### PR TITLE
[core] feat: deprecate ref types, use React.Ref instead

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -19,7 +19,6 @@ import * as React from "react";
 import type { IconName } from "@blueprintjs/icons";
 
 import { Intent } from "./intent";
-import { IRef } from "./refs";
 
 export const DISPLAYNAME_PREFIX = "Blueprint4";
 
@@ -129,7 +128,7 @@ export type ControlledProps2 = IControlledProps2;
  */
 export interface IElementRefProps<E extends HTMLElement> {
     /** A ref handler or a ref object that receives the native HTML element rendered by this component. */
-    elementRef?: IRef<E>;
+    elementRef?: React.Ref<E>;
 }
 
 /**

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -20,7 +20,7 @@
 import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
-import { IRef, refHandler, setRef } from "../../common/refs";
+import { refHandler, setRef } from "../../common/refs";
 import { AbstractButton, AnchorButtonProps, ButtonProps, IAnchorButtonProps, IButtonProps } from "./abstractButton";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -32,7 +32,7 @@ export class Button extends AbstractButton<HTMLButtonElement> {
     // need to keep this ref so that we can access it in AbstractButton#handleKeyUp
     public buttonRef: HTMLButtonElement | null = null;
 
-    protected handleRef: IRef<HTMLButtonElement> = refHandler(this, "buttonRef", this.props.elementRef);
+    protected handleRef: React.Ref<HTMLButtonElement> = refHandler(this, "buttonRef", this.props.elementRef);
 
     public render() {
         return (
@@ -62,7 +62,7 @@ export class AnchorButton extends AbstractButton<HTMLAnchorElement> {
     // need to keep this ref so that we can access it in AbstractButton#handleKeyUp
     public buttonRef: HTMLAnchorElement | null = null;
 
-    protected handleRef: IRef<HTMLAnchorElement> = refHandler(this, "buttonRef", this.props.elementRef);
+    protected handleRef: React.Ref<HTMLAnchorElement> = refHandler(this, "buttonRef", this.props.elementRef);
 
     public render() {
         const { href, tabIndex = 0 } = this.props;

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Classes, IRef } from "../../common";
+import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, MaybeElement, Props } from "../../common/props";
 import { uniqueId } from "../../common/utils";
@@ -83,7 +83,7 @@ export interface IDialogProps extends OverlayableProps, IBackdropProps, Props {
     /**
      * Ref supplied to the `Classes.DIALOG_CONTAINER` element.
      */
-    containerRef?: IRef<HTMLDivElement>;
+    containerRef?: React.Ref<HTMLDivElement>;
 
     /**
      * ID of the element that contains title or label text for this dialog.

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -21,7 +21,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Alignment, Classes, IRef, refHandler, setRef } from "../../common";
+import { AbstractPureComponent2, Alignment, Classes, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, Props } from "../../common/props";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -50,7 +50,7 @@ export interface IControlProps extends Props, HTMLInputProps {
     disabled?: boolean;
 
     /** Ref handler that receives HTML `<input>` element backing this component. */
-    inputRef?: IRef<HTMLInputElement>;
+    inputRef?: React.Ref<HTMLInputElement>;
 
     /** Whether the control should appear as an inline element. */
     inline?: boolean;
@@ -255,7 +255,7 @@ export class Checkbox extends AbstractPureComponent2<CheckboxProps, ICheckboxSta
     // must maintain internal reference for `indeterminate` support
     public input: HTMLInputElement | null = null;
 
-    private handleInputRef: IRef<HTMLInputElement> = refHandler(this, "input", this.props.inputRef);
+    private handleInputRef: React.Ref<HTMLInputElement> = refHandler(this, "input", this.props.inputRef);
 
     public render() {
         const { defaultIndeterminate, indeterminate, ...controlProps } = this.props;

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Classes, IRef } from "../../common";
+import { AbstractPureComponent2, Classes } from "../../common";
 import * as Errors from "../../common/errors";
 import {
     ControlledProps2,
@@ -70,7 +70,7 @@ export interface IInputGroupProps
     fill?: boolean;
 
     /** Ref handler or a ref object that receives HTML `<input>` element backing this component. */
-    inputRef?: IRef<HTMLInputElement>;
+    inputRef?: React.Ref<HTMLInputElement>;
 
     /**
      * Element to render on the left side of input.  This prop is mutually exclusive

--- a/packages/core/src/components/forms/inputSharedProps.ts
+++ b/packages/core/src/components/forms/inputSharedProps.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { IRef } from "../../common";
 import type { IntentProps, MaybeElement, Props } from "../../common/props";
 import type { IconName } from "../icon/icon";
 
@@ -40,7 +39,7 @@ export interface InputSharedProps extends IntentProps, Props {
     /**
      * Ref attached to the HTML `<input>` element backing this component.
      */
-    inputRef?: IRef<HTMLInputElement>;
+    inputRef?: React.Ref<HTMLInputElement>;
 
     /**
      * Element to render on the left side of input.

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -23,7 +23,6 @@ import {
     DISPLAYNAME_PREFIX,
     HTMLInputProps,
     Intent,
-    IRef,
     Keys,
     Position,
     refHandler,
@@ -290,7 +289,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
 
     public inputElement: HTMLInputElement | null = null;
 
-    private inputRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputRef);
+    private inputRef: React.Ref<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputRef);
 
     private intervalId?: number;
 

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Classes, IRef, IRefCallback, refHandler, setRef } from "../../common";
+import { AbstractPureComponent2, Classes, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -47,7 +47,7 @@ export interface ITextAreaProps extends IntentProps, Props, React.TextareaHTMLAt
     /**
      * Ref handler that receives HTML `<textarea>` element backing this component.
      */
-    inputRef?: IRef<HTMLTextAreaElement>;
+    inputRef?: React.Ref<HTMLTextAreaElement>;
 }
 
 export interface ITextAreaState {
@@ -64,7 +64,11 @@ export class TextArea extends AbstractPureComponent2<TextAreaProps, ITextAreaSta
     // used to measure and set the height of the component on first mount
     public textareaElement: HTMLTextAreaElement | null = null;
 
-    private handleRef: IRefCallback<HTMLTextAreaElement> = refHandler(this, "textareaElement", this.props.inputRef);
+    private handleRef: React.RefCallback<HTMLTextAreaElement> = refHandler(
+        this,
+        "textareaElement",
+        this.props.inputRef,
+    );
 
     public componentDidMount() {
         if (this.props.growVertically && this.textareaElement !== null) {

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Classes, IRef } from "../../common";
+import { AbstractPureComponent2, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
 
 // eslint-disable-next-line deprecation/deprecation
@@ -31,7 +31,7 @@ export interface IMenuProps extends Props, React.HTMLAttributes<HTMLUListElement
     large?: boolean;
 
     /** Ref handler that receives the HTML `<ul>` element backing this component. */
-    ulRef?: IRef<HTMLUListElement>;
+    ulRef?: React.Ref<HTMLUListElement>;
 }
 
 export class Menu extends AbstractPureComponent2<MenuProps> {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -19,7 +19,7 @@ import { ModifierFn } from "popper.js";
 import * as React from "react";
 import { Manager, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from "react-popper";
 
-import { AbstractPureComponent2, Classes, IRef, refHandler, setRef } from "../../common";
+import { AbstractPureComponent2, Classes, refHandler, setRef } from "../../common";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX, HTMLDivProps } from "../../common/props";
 import * as Utils from "../../common/utils";
@@ -94,7 +94,7 @@ export interface IPopoverProps extends IPopoverSharedProps {
     /**
      * Ref supplied to the `Classes.POPOVER` element.
      */
-    popoverRef?: IRef<HTMLElement>;
+    popoverRef?: React.Ref<HTMLElement>;
 
     /**
      * The target to which the popover content is attached. This can instead be
@@ -169,7 +169,7 @@ export class Popover extends AbstractPureComponent2<IPopoverProps, IPopoverState
     // Reference to the Poppper.scheduleUpdate() function, this changes every time the popper is mounted
     private popperScheduleUpdate?: () => void;
 
-    private handlePopoverRef: IRef<HTMLElement> = refHandler(this, "popoverElement", this.props.popoverRef);
+    private handlePopoverRef: React.Ref<HTMLElement> = refHandler(this, "popoverElement", this.props.popoverRef);
 
     private handleTargetRef = (ref: HTMLElement | null) => (this.targetElement = ref);
 

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Classes, IRef, Keys, refHandler, setRef, Utils } from "../../common";
+import { AbstractPureComponent2, Classes, Keys, refHandler, setRef, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, IntentProps, MaybeElement, Props } from "../../common/props";
 import { getActiveElement } from "../../common/utils";
 import { Icon, IconName, IconSize } from "../icon/icon";
@@ -79,7 +79,7 @@ export interface ITagInputProps extends IntentProps, Props {
     inputProps?: HTMLInputProps;
 
     /** Ref handler for the `<input>` element. */
-    inputRef?: IRef<HTMLInputElement>;
+    inputRef?: React.Ref<HTMLInputElement>;
 
     /** Controlled value of the `<input>` element. This is shorthand for `inputProps={{ value }}`. */
     inputValue?: string;
@@ -224,7 +224,7 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
 
     public inputElement: HTMLInputElement | null = null;
 
-    private handleRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputRef);
+    private handleRef: React.Ref<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputRef);
 
     public render() {
         const { className, disabled, fill, inputProps, intent, large, leftIcon, placeholder, values } = this.props;

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -33,7 +33,6 @@ import {
     InputGroupProps2,
     Intent,
     IPopoverProps,
-    IRef,
     Keys,
     Popover,
     Props,
@@ -200,7 +199,7 @@ export class DateInput extends AbstractPureComponent2<DateInputProps, IDateInput
         this.props.inputProps?.inputRef,
     );
 
-    private handlePopoverContentRef: IRef<HTMLDivElement> = refHandler(this, "popoverContentElement");
+    private handlePopoverContentRef: React.Ref<HTMLDivElement> = refHandler(this, "popoverContentElement");
 
     public render() {
         const { value, valueString } = this.state;

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -18,7 +18,7 @@ import { Boundary, Modifier, Placement, placements, RootBoundary, StrictModifier
 import * as React from "react";
 import { StrictModifier } from "react-popper";
 
-import { IRef, OverlayableProps, PopoverPosition, Props } from "@blueprintjs/core";
+import { OverlayableProps, PopoverPosition, Props } from "@blueprintjs/core";
 
 export { Boundary as PopperBoundary, Placement, placements as PlacementOptions };
 // copied from @popperjs/core, where it is not exported as public
@@ -185,7 +185,7 @@ export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
     /**
      * Ref supplied to the `Classes.POPOVER` element.
      */
-    popoverRef?: IRef<HTMLElement>;
+    popoverRef?: React.Ref<HTMLElement>;
 
     /**
      * Target renderer which receives props injected by Popover2 which should be spread onto

--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { IRef } from "@blueprintjs/core";
-
-import { CreateNewItem } from "./listItemsUtils";
+import type { CreateNewItem } from "./listItemsUtils";
 
 /** @deprecated use ItemListRendererProps */
 export type IItemListRendererProps<T> = ItemListRendererProps<T>;
@@ -57,7 +55,7 @@ export interface ItemListRendererProps<T> {
      * A ref handler that should be attached to the parent HTML element of the menu items.
      * This is required for the active item to scroll into view automatically.
      */
-    itemsParentRef: IRef<HTMLUListElement>;
+    itemsParentRef: React.Ref<HTMLUListElement>;
 
     /**
      * Props to apply to the `Menu` created within the `itemListRenderer`

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -31,7 +31,6 @@ import {
     InputGroup,
     InputGroupProps2,
     IPopoverProps,
-    IRef,
     Keys,
     Popover,
     Position,
@@ -123,7 +122,11 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
 
     private previousFocusedElement: HTMLElement | undefined;
 
-    private handleInputRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputProps?.inputRef);
+    private handleInputRef: React.Ref<HTMLInputElement> = refHandler(
+        this,
+        "inputElement",
+        this.props.inputProps?.inputRef,
+    );
 
     private handleQueryListRef = (ref: QueryList<T> | null) => (this.queryList = ref);
 

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -26,7 +26,6 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     InputGroupProps2,
-    IRef,
     Keys,
     refHandler,
     setRef,
@@ -115,7 +114,11 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
 
     private previousFocusedElement: HTMLElement | undefined;
 
-    private handleInputRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputProps?.inputRef);
+    private handleInputRef: React.Ref<HTMLInputElement> = refHandler(
+        this,
+        "inputElement",
+        this.props.inputProps?.inputRef,
+    );
 
     private handleQueryListRef = (ref: QueryList<T> | null) => (this.queryList = ref);
 

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -30,7 +30,6 @@ import {
     InputGroup,
     InputGroupProps2,
     IPopoverProps,
-    IRef,
     Keys,
     Popover,
     PopoverInteractionKind,
@@ -139,7 +138,11 @@ export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggest
 
     private queryList: QueryList<T> | null = null;
 
-    private handleInputRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputProps?.inputRef);
+    private handleInputRef: React.Ref<HTMLInputElement> = refHandler(
+        this,
+        "inputElement",
+        this.props.inputProps?.inputRef,
+    );
 
     private handleQueryListRef = (ref: QueryList<T> | null) => (this.queryList = ref);
 

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -24,7 +24,6 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     InputGroupProps2,
-    IRef,
     Keys,
     mergeRefs,
     refHandler,
@@ -131,7 +130,11 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
     private queryList: QueryList<T> | null = null;
 
-    private handleInputRef: IRef<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputProps?.inputRef);
+    private handleInputRef: React.Ref<HTMLInputElement> = refHandler(
+        this,
+        "inputElement",
+        this.props.inputProps?.inputRef,
+    );
 
     private handleQueryListRef = (ref: QueryList<T> | null) => (this.queryList = ref);
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -16,14 +16,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import {
-    Classes as CoreClasses,
-    Utils as CoreUtils,
-    DISPLAYNAME_PREFIX,
-    IntentProps,
-    IRef,
-    Props,
-} from "@blueprintjs/core";
+import { Classes as CoreClasses, Utils as CoreUtils, DISPLAYNAME_PREFIX, IntentProps, Props } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
@@ -112,7 +105,7 @@ export interface ICellProps extends IntentProps, Props {
     /**
      * A ref handle to capture the outer div of this cell. Used internally.
      */
-    cellRef?: IRef<HTMLDivElement>;
+    cellRef?: React.Ref<HTMLDivElement>;
 }
 
 /** @deprecated use CellRenderer */

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -17,8 +17,6 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IRef } from "@blueprintjs/core";
-
 import * as Classes from "../common/classes";
 import { ColumnIndices } from "../common/grid";
 import { Utils } from "../common/index";
@@ -53,7 +51,7 @@ export interface IColumnHeaderProps extends IHeaderProps, IColumnWidths, ColumnI
      * Ref handler that receives the HTML element that should be measured to
      * indicate the fluid height of the column header.
      */
-    measurableElementRef?: IRef<HTMLDivElement>;
+    measurableElementRef?: React.Ref<HTMLDivElement>;
 
     /**
      * A callback invoked when user is done resizing the column

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractComponent2, IRef, Props } from "@blueprintjs/core";
+import { AbstractComponent2, Props } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import * as Errors from "../common/errors";
@@ -51,7 +51,7 @@ export interface ITableQuadrantProps extends Props {
      * A callback that receives a `ref` to the quadrant's body-wrapping element. Will need to be
      * provided only for the MAIN quadrant, because that quadrant contains the main table body.
      */
-    bodyRef?: IRef<HTMLDivElement>;
+    bodyRef?: React.Ref<HTMLDivElement>;
 
     /**
      * The grid computes sizes of cells, rows, or columns from the
@@ -83,7 +83,7 @@ export interface ITableQuadrantProps extends Props {
     /**
      * A callback that receives a `ref` to the quadrant's outermost element.
      */
-    quadrantRef?: IRef<HTMLDivElement>;
+    quadrantRef?: React.Ref<HTMLDivElement>;
 
     /**
      * The quadrant type. Informs the values of the parameters that will be passed to the
@@ -118,7 +118,7 @@ export interface ITableQuadrantProps extends Props {
     /**
      * A callback that receives a `ref` to the quadrant's scroll-container element.
      */
-    scrollContainerRef?: IRef<HTMLDivElement>;
+    scrollContainerRef?: React.Ref<HTMLDivElement>;
 
     /**
      * CSS styles to apply to the quadrant's outermost element.

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { AbstractComponent2, Utils as CoreUtils, IRef, Props, setRef } from "@blueprintjs/core";
+import { AbstractComponent2, Utils as CoreUtils, Props, setRef } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";
 import { Grid } from "../common/grid";
@@ -34,7 +34,7 @@ interface QuadrantRefMap<T> {
     scrollContainer?: T;
 }
 
-type QuadrantRefHandler = IRef<HTMLDivElement>;
+type QuadrantRefHandler = React.Ref<HTMLDivElement>;
 type QuadrantRefs = QuadrantRefMap<HTMLDivElement | null>;
 type QuadrantRefHandlers = QuadrantRefMap<QuadrantRefHandler>;
 
@@ -42,12 +42,12 @@ export interface ITableQuadrantStackProps extends Props {
     /**
      * A callback that receives a `ref` to the main quadrant's table-body element.
      */
-    bodyRef?: IRef<HTMLDivElement>;
+    bodyRef?: React.Ref<HTMLDivElement>;
 
     /**
      * A callback that receives a `ref` to the main quadrant's column-header container.
      */
-    columnHeaderRef?: IRef<HTMLDivElement>;
+    columnHeaderRef?: React.Ref<HTMLDivElement>;
 
     /**
      * The grid computes sizes of cells, rows, or columns from the
@@ -151,7 +151,7 @@ export interface ITableQuadrantStackProps extends Props {
     /**
      * A callback that receives a `ref` to the main-quadrant element.
      */
-    quadrantRef?: IRef<HTMLDivElement>;
+    quadrantRef?: React.Ref<HTMLDivElement>;
 
     /**
      * A callback that renders either all of or just frozen sections of the table body.
@@ -168,7 +168,7 @@ export interface ITableQuadrantStackProps extends Props {
      * May return undefined if the table is not attached to the DOM yet.
      */
     columnHeaderRenderer?: (
-        refHandler: IRef<HTMLDivElement>,
+        refHandler: React.Ref<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
         showFrozenColumnsOnly?: boolean,
@@ -177,14 +177,14 @@ export interface ITableQuadrantStackProps extends Props {
     /**
      * A callback that renders the table menu (the rectangle in the top-left corner).
      */
-    menuRenderer?: (refHandler: IRef<HTMLDivElement> | undefined) => JSX.Element;
+    menuRenderer?: (refHandler: React.Ref<HTMLDivElement> | undefined) => JSX.Element;
 
     /**
      * A callback that renders either all of or just the frozen section of the row header.
      * May return undefined if the table is not attached to the DOM yet.
      */
     rowHeaderRenderer?: (
-        refHandler: IRef<HTMLDivElement>,
+        refHandler: React.Ref<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
         showFrozenRowsOnly?: boolean,
@@ -193,12 +193,12 @@ export interface ITableQuadrantStackProps extends Props {
     /**
      * A callback that receives a `ref` to the main quadrant's row-header container.
      */
-    rowHeaderRef?: IRef<HTMLDivElement>;
+    rowHeaderRef?: React.Ref<HTMLDivElement>;
 
     /**
      * A callback that receives a `ref` to the main quadrant's scroll-container element.
      */
-    scrollContainerRef?: IRef<HTMLDivElement>;
+    scrollContainerRef?: React.Ref<HTMLDivElement>;
 
     /**
      * Whether "scroll" and "wheel" events should be throttled using

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -32,7 +32,6 @@ import {
     Hotkey,
     Hotkeys,
     HotkeysTarget,
-    IRef,
 } from "@blueprintjs/core";
 
 import { CellRenderer } from "./cell/cell";
@@ -832,7 +831,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
         return areGhostColumnsVisible && (isViewportUnscrolledHorizontally || areColumnHeadersLoading);
     }
 
-    private renderMenu = (refHandler: IRef<HTMLDivElement> | undefined) => {
+    private renderMenu = (refHandler: React.Ref<HTMLDivElement> | undefined) => {
         const classes = classNames(Classes.TABLE_MENU, {
             [Classes.TABLE_SELECTION_ENABLED]: Table.isSelectionModeEnabled(
                 this.props as TablePropsWithDefaults,
@@ -904,7 +903,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
     };
 
     private renderColumnHeader = (
-        refHandler: IRef<HTMLDivElement>,
+        refHandler: React.Ref<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
         showFrozenColumnsOnly: boolean = false,
@@ -973,7 +972,7 @@ export class Table extends AbstractComponent2<TableProps, TableState, TableSnaps
     };
 
     private renderRowHeader = (
-        refHandler: IRef<HTMLDivElement>,
+        refHandler: React.Ref<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
         showFrozenRowsOnly: boolean = false,

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -23,7 +23,6 @@ import {
     DISPLAYNAME_PREFIX,
     HotkeyConfig,
     HotkeysTarget2,
-    IRef,
     UseHotkeysReturnValue,
 } from "@blueprintjs/core";
 
@@ -700,7 +699,7 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
         return areGhostColumnsVisible && (isViewportUnscrolledHorizontally || areColumnHeadersLoading);
     }
 
-    private renderMenu = (refHandler: IRef<HTMLDivElement> | undefined) => {
+    private renderMenu = (refHandler: React.Ref<HTMLDivElement> | undefined) => {
         const classes = classNames(Classes.TABLE_MENU, {
             [Classes.TABLE_SELECTION_ENABLED]: isSelectionModeEnabled(
                 this.props as TablePropsWithDefaults,
@@ -774,7 +773,7 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
     };
 
     private renderColumnHeader = (
-        refHandler: IRef<HTMLDivElement>,
+        refHandler: React.Ref<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
         showFrozenColumnsOnly: boolean = false,
@@ -856,7 +855,7 @@ export class Table2 extends AbstractComponent2<Table2Props, TableState, TableSna
     };
 
     private renderRowHeader = (
-        refHandler: IRef<HTMLDivElement>,
+        refHandler: React.Ref<HTMLDivElement>,
         resizeHandler: (verticalGuides: number[] | null) => void,
         reorderingHandler: (oldIndex: number, newIndex: number, length: number) => void,
         showFrozenRowsOnly: boolean = false,

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -21,8 +21,6 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
-import { IRef } from "@blueprintjs/core";
-
 import * as Classes from "../../src/common/classes";
 import { Grid } from "../../src/common/grid";
 import * as ScrollUtils from "../../src/common/internal/scrollUtils";
@@ -65,10 +63,10 @@ describe("TableQuadrantStack", () => {
         const columnHeaderRef = sinon.spy();
         const scrollContainerRef = sinon.spy();
 
-        const columnHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
+        const columnHeaderRenderer = (refHandler: React.Ref<HTMLDivElement>) => {
             return <div ref={refHandler} />;
         };
-        const rendeRowHeader = (refHandler: IRef<HTMLDivElement>) => {
+        const rendeRowHeader = (refHandler: React.Ref<HTMLDivElement>) => {
             return <div ref={refHandler} />;
         };
 
@@ -418,7 +416,7 @@ describe("TableQuadrantStack", () => {
         });
 
         function assertDefaultQuadrantSizesCorrect(numFrozenRows: number, numFrozenColumns: number) {
-            const rowHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
+            const rowHeaderRenderer = (refHandler: React.Ref<HTMLDivElement>) => {
                 // need to set the width on a child so the header maintains its size
                 // when the component measures the "desired" row-header width (by
                 // setting width:auto on the parent here).
@@ -428,7 +426,7 @@ describe("TableQuadrantStack", () => {
                     </div>
                 );
             };
-            const columnHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
+            const columnHeaderRenderer = (refHandler: React.Ref<HTMLDivElement>) => {
                 return <div ref={refHandler} style={{ height: COLUMN_HEADER_HEIGHT, width: "100%" }} />;
             };
 
@@ -455,7 +453,7 @@ describe("TableQuadrantStack", () => {
         }
 
         function assertQuadrantSizesCorrectIfRowHeadersHidden(numFrozenRows: number, numFrozenColumns: number) {
-            const columnHeaderRenderer = (refHandler: IRef<HTMLDivElement>) => {
+            const columnHeaderRenderer = (refHandler: React.Ref<HTMLDivElement>) => {
                 return <div ref={refHandler} style={{ height: COLUMN_HEADER_HEIGHT, width: "100%" }} />;
             };
 


### PR DESCRIPTION
- :x: DEPRECATION of `IRef`, `IRefObject`, and `IRefCallback` types
  - use `React.Ref`, `React.RefObject`, and `React.RefCallback` types instead