### PR TITLE
Revert "[select] fix(QueryList): index is always defined in itemRenderer"

### DIFF
--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -48,8 +48,7 @@ export interface ItemRendererProps {
      */
     handleFocus?: () => void;
 
-    /** Index of the item in the QueryList items array. */
-    index: number;
+    index?: number;
 
     /** Modifiers that describe how to render this item, such as `active` or `disabled`. */
     modifiers: ItemModifiers;


### PR DESCRIPTION
Reverts palantir/blueprint#5501

This caused unnecessary breaking type changes downstream. We can defer this until Blueprint v5.0.