### PR TITLE
fix: declare @types/react as optional peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,8 +59,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^3.1.1",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -41,8 +41,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/colors": "^4.1.5",

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -46,8 +46,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/colors": "^4.1.5",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -38,8 +38,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^5.1.0",

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -44,8 +44,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^3.1.1",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -41,8 +41,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/karma-build-scripts": "^3.1.1",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -43,8 +43,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/colors": "^4.1.5",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -43,8 +43,14 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
+        "@types/react": "^16.14.2",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^5.1.0",


### PR DESCRIPTION
#### Changes proposed in this pull request:

Add `@types/react` as an optional peer dependency in package.json for each package that depends on those types in its generated `.d.ts` files.

This is in line with the approach taken by other modern OSS React UI library packages like [@mui/material](https://github.com/mui/material-ui/blob/64e5dc1656e2c70e1b692618a5121ff67c645e78/packages/mui-material/package.json#L47) and [react-bootstrap](https://github.com/react-bootstrap/react-bootstrap/blob/5dc9ed4cd991a50da14b7e004a3d4e7bb0709bc6/package.json#L149).

#### Reviewers should focus on:

If this actually fixes the problem we've been having in PNPM installs, where sometimes `@types/react` is not available to `@blueprintjs/core` to compile with `tsc` with `skipLibCheck: false`.

