### PR TITLE
fix: widen versions allowed for @types/react peer dep

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -41,7 +41,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -46,7 +46,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -38,7 +38,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -44,7 +44,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -41,7 +41,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -43,7 +43,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -43,7 +43,7 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.2",
+        "@types/react": "^16.14.2 || 17 || 18",
         "react": "^16.8 || 17 || 18",
         "react-dom": "^16.8 || 17 || 18"
     },


### PR DESCRIPTION
based on feedback from https://github.com/palantir/blueprint/pull/5515#issuecomment-1228658796