### PR TITLE
[eslint-plugin] Fix type of `currentMatch`

### DIFF
--- a/packages/eslint-plugin/src/rules/classes-constants.ts
+++ b/packages/eslint-plugin/src/rules/classes-constants.ts
@@ -91,7 +91,7 @@ function create(
 
 function getAllMatches(className: string) {
     const ptMatches = [];
-    let currentMatch: RegExpMatchArray | null;
+    let currentMatch: RegExpExecArray | null;
     // eslint-disable-line no-cond-assign
     while ((currentMatch = BLUEPRINT_CLASSNAME_PATTERN.exec(className)) != null) {
         ptMatches.push({ match: currentMatch[1], index: currentMatch.index || 0 });


### PR DESCRIPTION
In TS 4.9 we made the types of exec and match more precise, so this is now correctly an error. Fixed to use the correct type.