### PR TITLE
[eslint-plugin] chore: add mocha for better test output diffs

### DIFF
--- a/packages/eslint-plugin/.mocharc.json
+++ b/packages/eslint-plugin/.mocharc.json
@@ -1,0 +1,6 @@
+{
+    "require": "ts-node/register",
+    "extensions": ["ts", "tsx"],
+    "spec": ["test/*.test.*"],
+    "watch-files": ["src"]
+}

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -9,7 +9,7 @@
         "lint": "run-p lint:es",
         "lint:es": "es-lint",
         "lint-fix": "es-lint --fix",
-        "test": "ts-node test/index.ts"
+        "test": "mocha test/index.ts"
     },
     "dependencies": {
         "@typescript-eslint/utils": "^5.32.0",
@@ -19,6 +19,7 @@
         "@blueprintjs/node-build-scripts": "^5.1.0",
         "@types/dedent": "^0.7.0",
         "dedent": "^0.7.0",
+        "mocha": "^9.2.2",
         "ts-node": "^10.9.1",
         "typescript": "^4.6.2"
     },

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -32,7 +32,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing classes-constants rule...");
 ruleTester.run("classes-constants", classesConstantsRule, {
     invalid: [
         // literal string

--- a/packages/eslint-plugin/test/html-components.test.ts
+++ b/packages/eslint-plugin/test/html-components.test.ts
@@ -31,7 +31,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing html-components rule...");
 ruleTester.run("html-components", htmlComponentsRule, {
     invalid: [
         {

--- a/packages/eslint-plugin/test/icon-components.test.ts
+++ b/packages/eslint-plugin/test/icon-components.test.ts
@@ -29,7 +29,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing icon-components rule...");
 ruleTester.run("icon-components", iconComponentsRule, {
     invalid: [
         {

--- a/packages/eslint-plugin/test/no-deprecated-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-components.test.ts
@@ -32,7 +32,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing no-deprecated-components rule...");
 ruleTester.run("no-deprecated-components", noDeprecatedComponentsRule, {
     invalid: [
         {

--- a/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
@@ -32,7 +32,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing no-deprecated-core-components rule...");
 ruleTester.run("no-deprecated-core-components", noDeprecatedCoreComponentsRule, {
     // N.B. most other deprecated components are tested by no-deprecated-components.test.ts, this suite just tests
     // for more specific violations which involve certain deprecated props

--- a/packages/eslint-plugin/test/no-deprecated-select-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-select-components.test.ts
@@ -32,7 +32,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing no-deprecated-core-components rule...");
 ruleTester.run("no-deprecated-core-components", noDeprecatedSelectComponentsRule, {
     // N.B. most other deprecated components are tested by no-deprecated-components.test.ts, this suite just tests
     // for more specific violations which involve certain syntax

--- a/packages/eslint-plugin/test/no-deprecated-type-references.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-type-references.test.ts
@@ -32,7 +32,6 @@ const ruleTester = new TSESLint.RuleTester({
     },
 });
 
-console.info("Testing no-deprecated-type-references rule...");
 ruleTester.run("no-deprecated-type-references", noDeprecatedTypeReferencesRule, {
     invalid: [
         {


### PR DESCRIPTION

#### Changes proposed in this pull request:

Install `mocha` and configure it to run tests in packages/eslint-plugin.

This improves the test output with a pretty diff when the expected code from an auto-fixed rule doesn't match the actual code produced. See my discussion in https://github.com/eslint/eslint/discussions/16247.

#### Screenshot

<img width="433" alt="image" src="https://user-images.githubusercontent.com/723999/187978241-a8b681e1-9791-41cc-b0e8-398ff9252d37.png">
