### PR TITLE
Fix various issues with deprecated type references

### DIFF
--- a/packages/core/src/components/panel-stack/panelProps.ts
+++ b/packages/core/src/components/panel-stack/panelProps.ts
@@ -21,7 +21,7 @@ import * as React from "react";
 /**
  * An object describing a panel in a `PanelStack`.
  *
- * @deprecated use `Panel<T>`
+ * @deprecated use `Panel<T>` with PanelStack2
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface IPanel<P = {}> {
@@ -59,7 +59,7 @@ export interface IPanel<P = {}> {
  * export class SettingsPanel extends React.Component<IPanelProps & ISettingsPanelProps> {...}
  * ```
  *
- * @deprecated use `PanelActions<T>`
+ * @deprecated use `PanelActions<T>` with PanelStack2
  */
 export interface IPanelProps {
     /**

--- a/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
@@ -70,8 +70,9 @@ const DEPRECATED_TYPE_REFERENCES_BY_PACKAGE = {
         "IOverflowListProps",
         "IOverlayableProps",
         "IOverlayProps",
-        "IPanel",
-        "IPanelActions",
+        // N.B. Panel corresponds to PanelStack2, so it is not a direct replacement for IPanel
+        // "IPanel",
+        // "IPanelProps",
         "IPortalProps",
         "IProgressBarProps",
         "IResizeSensorProps",

--- a/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
@@ -122,6 +122,7 @@ const DEPRECATED_TYPE_REFERENCES_BY_PACKAGE = {
         "IMultiSelectProps",
         "IOmnibarProps",
         "IQueryListProps",
+        "IQueryListRendererProps",
         "ISelectProps",
         "ISuggestProps",
     ],

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -40,7 +40,7 @@ import {
 } from "@blueprintjs/core";
 
 import { Classes, ListItemsProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 // N.B. selectedItems should really be a required prop, but is left optional for backwards compatibility
 
@@ -157,7 +157,7 @@ export class MultiSelect<T> extends AbstractPureComponent2<MultiSelectProps<T>, 
         );
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         const { fill, tagInputProps = {}, popoverProps = {}, selectedItems = [], placeholder } = this.props;
         const { handlePaste, handleKeyDown, handleKeyUp } = listProps;
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -33,7 +33,7 @@ import {
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 export interface MultiSelect2Props<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
@@ -190,7 +190,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         );
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         const { disabled, popoverContentProps = {}, popoverProps = {} } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
 
@@ -230,7 +230,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
     // again after that state changes.
     private getPopoverTargetRenderer =
-        (listProps: IQueryListRendererProps<T>, isOpen: boolean) =>
+        (listProps: QueryListRendererProps<T>, isOpen: boolean) =>
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
@@ -355,7 +355,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     };
 
     private getTagInputAddHandler =
-        (listProps: IQueryListRendererProps<T>) => (values: any[], method: TagInputAddMethod) => {
+        (listProps: QueryListRendererProps<T>) => (values: any[], method: TagInputAddMethod) => {
             if (method === "paste") {
                 listProps.handlePaste(values);
             }

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { DISPLAYNAME_PREFIX, InputGroup, InputGroupProps2, Overlay, OverlayProps } from "@blueprintjs/core";
 
 import { Classes, ListItemsProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 // eslint-disable-next-line deprecation/deprecation
 export type OmnibarProps<T> = IOmnibarProps<T>;
@@ -72,7 +72,7 @@ export class Omnibar<T> extends React.PureComponent<OmnibarProps<T>> {
         return <this.TypedQueryList {...restProps} initialContent={initialContent} renderer={this.renderQueryList} />;
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         const { inputProps = {}, isOpen, overlayProps = {} } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
         const handlers = isOpen ? { onKeyDown: handleKeyDown, onKeyUp: handleKeyUp } : {};

--- a/packages/select/src/components/query-list/query-list.md
+++ b/packages/select/src/components/query-list/query-list.md
@@ -14,4 +14,4 @@ An object with the following properties will be passed to an `QueryList` `render
 
 This interface is generic, accepting a type parameter `<T>` for an item in the list.
 
-@interface IQueryListRendererProps
+@interface QueryListRendererProps

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -63,7 +63,7 @@ export interface IQueryListProps<T> extends ListItemsProps<T> {
      * Customize rendering of the component.
      * Receives an object with props that should be applied to elements as necessary.
      */
-    renderer: (listProps: IQueryListRendererProps<T>) => JSX.Element;
+    renderer: (listProps: QueryListRendererProps<T>) => JSX.Element;
 
     /**
      * Whether the list is disabled.
@@ -73,9 +73,13 @@ export interface IQueryListProps<T> extends ListItemsProps<T> {
     disabled?: boolean;
 }
 
+// eslint-disable-next-line deprecation/deprecation
+export type QueryListRendererProps<T> = IQueryListRendererProps<T>;
 /**
  * An object describing how to render a `QueryList`.
  * A `QueryList` `renderer` receives this object as its sole argument.
+ *
+ * @deprecated use QueryListRendererProps
  */
 export interface IQueryListRendererProps<T> // Omit `createNewItem`, because it's used strictly for internal tracking.
     extends Pick<IQueryListState<T>, "activeItem" | "filteredItems" | "query">,

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -39,7 +39,7 @@ import {
 } from "@blueprintjs/core";
 
 import { Classes, ListItemsProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 export type SelectProps<T> = ISelectProps<T>;
 /** @deprecated use SelectProps */
@@ -156,7 +156,7 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
         }
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
         const {
             fill,

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -34,7 +34,7 @@ import {
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 export interface Select2Props<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
@@ -151,7 +151,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         }
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
         const {
             filterable = true,
@@ -209,7 +209,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
     // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
     // again after that state changes.
     private getPopoverTargetRenderer =
-        (listProps: IQueryListRendererProps<T>, isOpen: boolean) =>
+        (listProps: QueryListRendererProps<T>, isOpen: boolean) =>
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -39,7 +39,7 @@ import {
 } from "@blueprintjs/core";
 
 import { Classes, ListItemsProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 export type SuggestProps<T> = ISuggestProps<T>;
 /** @deprecated use SuggestProps */
@@ -184,7 +184,7 @@ export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggest
         }
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         const { fill, inputProps = {}, popoverProps = {} } = this.props;
         const { isOpen, selectedItem } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -33,7 +33,7 @@ import {
 import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
-import { IQueryListRendererProps, QueryList } from "../query-list/queryList";
+import { QueryList, QueryListRendererProps } from "../query-list/queryList";
 
 export interface Suggest2Props<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
@@ -181,7 +181,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
         }
     }
 
-    private renderQueryList = (listProps: IQueryListRendererProps<T>) => {
+    private renderQueryList = (listProps: QueryListRendererProps<T>) => {
         const { popoverContentProps = {}, popoverProps = {}, popoverRef } = this.props;
         const { isOpen } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
@@ -216,7 +216,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
     // the "fill" prop. Note that we must take `isOpen` as an argument to force this render function to be called
     // again after that state changes.
     private getPopoverTargetRenderer =
-        (listProps: IQueryListRendererProps<T>, isOpen: boolean) =>
+        (listProps: QueryListRendererProps<T>, isOpen: boolean) =>
         // eslint-disable-next-line react/display-name
         ({
             // pull out `isOpen` so that it's not forwarded to the DOM

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -23,13 +23,13 @@ import { Menu } from "@blueprintjs/core";
 
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/common/films";
 import {
-    IQueryListRendererProps,
     IQueryListState,
     ItemListPredicate,
     ItemListRenderer,
     ItemPredicate,
     QueryList,
     QueryListProps,
+    QueryListRendererProps,
 } from "../src";
 
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
@@ -43,7 +43,7 @@ describe("<QueryList>", () => {
         items: TOP_100_FILMS.slice(0, 20),
         onActiveItemChange: sinon.spy(),
         onItemSelect: sinon.spy(),
-        renderer: sinon.spy((props: IQueryListRendererProps<IFilm>) => <div>{props.itemList}</div>),
+        renderer: sinon.spy((props: QueryListRendererProps<IFilm>) => <div>{props.itemList}</div>),
     };
 
     beforeEach(() => {
@@ -80,7 +80,7 @@ describe("<QueryList>", () => {
             shallow(<FilmQueryList {...testProps} itemPredicate={predicate} query="1994" />);
 
             assert.equal(predicate.callCount, testProps.items.length, "called once per item");
-            const { filteredItems } = testProps.renderer.args[0][0] as IQueryListRendererProps<IFilm>;
+            const { filteredItems } = testProps.renderer.args[0][0] as QueryListRendererProps<IFilm>;
             assert.lengthOf(filteredItems, 3, "returns only films from 1994");
         });
 
@@ -89,7 +89,7 @@ describe("<QueryList>", () => {
             shallow(<FilmQueryList {...testProps} itemListPredicate={predicate} query="1994" />);
 
             assert.equal(predicate.callCount, 1, "called once for entire list");
-            const { filteredItems } = testProps.renderer.args[0][0] as IQueryListRendererProps<IFilm>;
+            const { filteredItems } = testProps.renderer.args[0][0] as QueryListRendererProps<IFilm>;
             assert.lengthOf(filteredItems, 3, "returns only films from 1994");
         });
 
@@ -111,7 +111,7 @@ describe("<QueryList>", () => {
 
         it("omitting both predicate props is supported", () => {
             shallow(<FilmQueryList {...testProps} query="1980" />);
-            const { filteredItems } = testProps.renderer.args[0][0] as IQueryListRendererProps<IFilm>;
+            const { filteredItems } = testProps.renderer.args[0][0] as QueryListRendererProps<IFilm>;
             assert.lengthOf(filteredItems, testProps.items.length, "returns all films");
         });
 
@@ -232,7 +232,7 @@ describe("<QueryList>", () => {
                 ...testProps,
                 itemPredicate,
                 onItemsPaste,
-                renderer: sinon.spy((listItemsProps: IQueryListRendererProps<IFilm>) => {
+                renderer: sinon.spy((listItemsProps: QueryListRendererProps<IFilm>) => {
                     handlePaste = listItemsProps.handlePaste;
                     return testProps.renderer(listItemsProps);
                 }),
@@ -343,8 +343,8 @@ describe("<QueryList>", () => {
             let triggerInputQueryChange: ((e: any) => void) | undefined;
             const createNewItemFromQuerySpy = sinon.spy();
             const createNewItemRendererSpy = sinon.spy();
-            // we must supply our own renderer so that we can hook into IQueryListRendererProps#handleQueryChange
-            const renderer = sinon.spy((props: IQueryListRendererProps<IFilm>) => {
+            // we must supply our own renderer so that we can hook into QueryListRendererProps#handleQueryChange
+            const renderer = sinon.spy((props: QueryListRendererProps<IFilm>) => {
                 triggerInputQueryChange = props.handleQueryChange;
                 return <div>{props.itemList}</div>;
             });

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -82,6 +82,8 @@ export interface IColumnHeaderCellProps extends IHeaderCellProps, IColumnNamePro
      */
     menuIcon?: IconName | JSX.Element;
 }
+// eslint-disable-next-line deprecation/deprecation
+export type ColumnHeaderCellProps = IColumnHeaderCellProps;
 
 export interface IColumnHeaderCellState {
     isActive?: boolean;

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -69,7 +69,12 @@ export { ColumnHeaderRenderer, IColumnHeaderRenderer } from "./headers/columnHea
 
 export { RowHeaderRenderer } from "./headers/rowHeader";
 
-export { ColumnHeaderCell, IColumnHeaderCellProps, HorizontalCellDivider } from "./headers/columnHeaderCell";
+export {
+    ColumnHeaderCell,
+    ColumnHeaderCellProps,
+    IColumnHeaderCellProps,
+    HorizontalCellDivider,
+} from "./headers/columnHeaderCell";
 
 export { ColumnHeaderCell2, ColumnHeaderCell2Props } from "./headers/columnHeaderCell2";
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Add `ColumnHeaderCellProps` type alias, export it (this corresponds to what `@blueprintjs/no-deprecated-type-references` is suggesting/auto-fixing right now)
- Deprecate `IQueryListRendererProps`, add `QueryListRendererProps` type alias (I realized that this is actually being used outside this repo)
- Remove `IPanel` from `@bluprintjs/no-deprecated-type-references` since we cannot automatically migrate
- Remove `IPanelActions` from `@bluprintjs/no-deprecated-type-references` since that symbol does not exist

