### PR TITLE
[datetime2] feat(TimezoneSelect): allow filtering by short names

### DIFF
--- a/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
@@ -204,7 +204,14 @@ export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, 
         // using list predicate so only one RegExp instance is needed
         // escape bad regex characters, let spaces act as any separator
         const expr = new RegExp(query.replace(/([[()+*?])/g, "\\$1").replace(" ", "[ _/\\(\\)]+"), "i");
-        return items.filter(item => expr.test(item.ianaCode) || expr.test(item.label) || expr.test(item.longName));
+
+        return items.filter(
+            item =>
+                expr.test(item.ianaCode) ||
+                expr.test(item.label) ||
+                expr.test(item.longName) ||
+                expr.test(item.shortName),
+        );
     };
 
     private renderItem: ItemRenderer<TimezoneWithNames> = (item, { handleClick, modifiers }) => {


### PR DESCRIPTION
Partially fixes https://github.com/palantir/blueprint/issues/5531 by allowing you to search for the short name. This is locale specific and abbreviations may differ depending on your browser locale. 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

allow earching forabbreviations in `TimezonePicker` 

#### Reviewers should focus on:

- Whether we need to update any tests/documentation here. 

#### Screenshot

![Screenshot 2022-09-08 at 10 50 50](https://user-images.githubusercontent.com/9450684/189079101-de093d89-543a-49c4-a473-f1d56ac0575f.png)

