### PR TITLE
[core] feat(Toast): new prop isCloseButtonShown

### DIFF
--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -38,6 +38,13 @@ export interface ToastProps extends Props, IntentProps {
     /** Name of a Blueprint UI icon (or an icon element) to render before the message. */
     icon?: IconName | MaybeElement;
 
+    /**
+     * Whether to show the close button in the toast.
+     *
+     * @default true
+     */
+    isCloseButtonShown?: boolean;
+
     /** Message to display in the body of the toast. */
     message: React.ReactNode;
 
@@ -59,6 +66,7 @@ export interface ToastProps extends Props, IntentProps {
 export class Toast extends AbstractPureComponent2<ToastProps> {
     public static defaultProps: ToastProps = {
         className: "",
+        isCloseButtonShown: true,
         message: "",
         timeout: 5000,
     };
@@ -66,7 +74,7 @@ export class Toast extends AbstractPureComponent2<ToastProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Toast`;
 
     public render(): JSX.Element {
-        const { className, icon, intent, message } = this.props;
+        const { className, icon, intent, message, isCloseButtonShown } = this.props;
         return (
             <div
                 className={classNames(Classes.TOAST, Classes.intentClass(intent), className)}
@@ -82,7 +90,7 @@ export class Toast extends AbstractPureComponent2<ToastProps> {
                 </span>
                 <ButtonGroup minimal={true}>
                     {this.maybeRenderActionButton()}
-                    <Button aria-label="Close" icon="cross" onClick={this.handleCloseClick} />
+                    {isCloseButtonShown && <Button aria-label="Close" icon="cross" onClick={this.handleCloseClick} />}
                 </ButtonGroup>
             </div>
         );

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -108,6 +108,22 @@ export class ToastExample extends React.PureComponent<ExampleProps<IBlueprintExa
             intent: Intent.WARNING,
             message: "Goodbye, old friend.",
         },
+        {
+            action: {
+                onClick: () =>
+                    this.addToast({
+                        icon: "ban-circle",
+                        intent: Intent.DANGER,
+                        message: "You can't cancel what's been done!",
+                    }),
+                text: "Cancel",
+            },
+            button: "Start loading",
+            icon: "hand",
+            intent: Intent.PRIMARY,
+            isCloseButtonShown: false,
+            message: "Loading...",
+        },
     ];
 
     private toaster: Toaster;


### PR DESCRIPTION
#### Fixes #5508

#### Checklist
- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:
- added new prop, ```isCloseButtonShown```, following name conventions in ``` <Dialog>```
- conditionally renders the close button on a toast with this new prop
- added new example that uses the new prop 

#### Reviewers should focus on:
- maybe a better example? tried to use the use case provided in the issue, lmk if you have any better ideas! 

#### Testing / Screenrecording
https://user-images.githubusercontent.com/64056046/189474766-36334c36-bf72-4fc7-9a30-57293924e079.mov


