### PR TITLE
fix(DateRangePicker): various layout issues, footerElement prop

### DIFF
--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -4,24 +4,13 @@
 @import "./common";
 
 // react-day-picker does not conform to our naming scheme
-
 /* stylelint-disable selector-class-pattern */
+
 .#{$ns}-daterangepicker {
   display: flex;
-  white-space: nowrap;
 
   .DayPicker-NavButton--interactionDisabled {
     display: none;
-  }
-
-  .#{$ns}-daterangepicker-timepickers {
-    display: flex;
-    justify-content: space-around;
-
-    .#{$ns}-timepicker-arrow-row:empty + .#{$ns}-timepicker-input-row {
-      // when timepicker arrows are not displayed in the daterangepicker, we need a bit of extra margin
-      margin: $datepicker-padding 0;
-    }
   }
 
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
@@ -110,6 +99,25 @@
         }
       }
     }
+  }
+}
+
+.#{$ns}-daterangepicker-calendars {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+}
+
+.#{$ns}-daterangepicker-timepickers {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+
+  .#{$ns}-timepicker-arrow-row:empty + .#{$ns}-timepicker-input-row {
+    // when timepicker arrows are not displayed in the daterangepicker, we need a bit of extra margin
+    margin: $datepicker-padding 0;
   }
 }
 

--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -103,17 +103,17 @@
 }
 
 .#{$ns}-daterangepicker-calendars {
-  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-evenly;
+  width: 100%;
 }
 
 .#{$ns}-daterangepicker-timepickers {
-  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+  width: 100%;
 
   .#{$ns}-timepicker-arrow-row:empty + .#{$ns}-timepicker-input-row {
     // when timepicker arrows are not displayed in the daterangepicker, we need a bit of extra margin

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -18,8 +18,8 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
   white-space: nowrap;
 
   .#{$ns}-timepicker-arrow-row {
-    width: $timepicker-row-width;
     padding: $timepicker-row-padding;
+    width: $timepicker-row-width;
   }
 
   .#{$ns}-timepicker-arrow-button {
@@ -44,10 +44,10 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     box-shadow: $pt-input-box-shadow;
     display: inline-block;
     height: $timepicker-input-row-height;
-    width: $timepicker-row-width;
     line-height: $timepicker-input-row-inner-height;
     padding: $timepicker-row-padding;
     vertical-align: middle;
+    width: $timepicker-row-width;
   }
 
   .#{$ns}-timepicker-divider-text {

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -6,6 +6,7 @@
 @import "./common";
 
 $timepicker-input-row-height: $pt-grid-size * 3 !default;
+$timepicker-row-width: $pt-grid-size * 8 !default;
 // subtract two because of inset shadow
 $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly
@@ -17,6 +18,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
   white-space: nowrap;
 
   .#{$ns}-timepicker-arrow-row {
+    width: $timepicker-row-width;
     padding: $timepicker-row-padding;
   }
 
@@ -42,6 +44,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     box-shadow: $pt-input-box-shadow;
     display: inline-block;
     height: $timepicker-input-row-height;
+    width: $timepicker-row-width;
     line-height: $timepicker-input-row-inner-height;
     padding: $timepicker-row-padding;
     vertical-align: middle;

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -41,6 +41,7 @@ export const DATEPICKER_NAVBUTTON = `DayPicker-NavButton`;
 export const DATEPICKER_TIMEPICKER_WRAPPER = `${DATEPICKER}-timepicker-wrapper`;
 
 export const DATERANGEPICKER = `${NS}-daterangepicker`;
+export const DATERANGEPICKER_CALENDARS = `${DATERANGEPICKER}-calendars`;
 export const DATERANGEPICKER_CONTIGUOUS = `${DATERANGEPICKER}-contiguous`;
 export const DATERANGEPICKER_SINGLE_MONTH = `${DATERANGEPICKER}-single-month`;
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = `${DATEPICKER_DAY}--selected-range`;

--- a/packages/datetime/src/datePickerCore.tsx
+++ b/packages/datetime/src/datePickerCore.tsx
@@ -52,7 +52,7 @@ export interface DatePickerBaseProps {
     dayPickerProps?: DayPickerProps;
 
     /**
-     * An additional element to show below the date picker
+     * An additional element to show below the date picker.
      */
     footerElement?: JSX.Element;
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -18,7 +18,15 @@ import classNames from "classnames";
 import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
 
-import { AbstractPureComponent2, Boundary, DISPLAYNAME_PREFIX, Divider, Props } from "@blueprintjs/core";
+import {
+    AbstractPureComponent2,
+    Boundary,
+    Button,
+    ButtonGroup,
+    DISPLAYNAME_PREFIX,
+    Divider,
+    Props,
+} from "@blueprintjs/core";
 
 import * as DateClasses from "./common/classes";
 import { DateRange } from "./common/dateRange";
@@ -225,7 +233,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     }
 
     public render() {
-        const { className, contiguousCalendarMonths, singleMonthOnly } = this.props;
+        const { className, contiguousCalendarMonths, singleMonthOnly, footerElement } = this.props;
         const isShowingOneMonth = singleMonthOnly || DateUtils.areSameMonth(this.props.minDate, this.props.maxDate);
 
         const classes = classNames(DateClasses.DATEPICKER, DateClasses.DATERANGEPICKER, className, {
@@ -237,9 +245,12 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
         return (
             <div className={classes}>
                 {this.maybeRenderShortcuts()}
-                <div>
-                    {this.renderCalendars(isShowingOneMonth)}
-                    {this.maybeRenderTimePickers()}
+                <div className={DateClasses.DATEPICKER_CONTENT}>
+                    <div>
+                        {this.renderCalendars(isShowingOneMonth)}
+                        {this.maybeRenderTimePickers()}
+                    </div>
+                    {footerElement}
                 </div>
             </div>
         );
@@ -395,7 +406,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     };
 
     private renderCalendars(isShowingOneMonth: boolean) {
-        const { dayPickerProps, locale, localeUtils, maxDate, minDate } = this.props;
+        const { dayPickerProps, locale, localeUtils, maxDate, minDate, footerElement } = this.props;
         const dayPickerBaseProps: DayPickerProps = {
             locale,
             localeUtils,

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -238,10 +238,8 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
             <div className={classes}>
                 {this.maybeRenderShortcuts()}
                 <div className={DateClasses.DATEPICKER_CONTENT}>
-                    <div>
-                        {this.renderCalendars(isShowingOneMonth)}
-                        {this.maybeRenderTimePickers()}
-                    </div>
+                    {this.renderCalendars(isShowingOneMonth)}
+                    {this.maybeRenderTimePickers(isShowingOneMonth)}
                     {footerElement}
                 </div>
             </div>
@@ -350,27 +348,39 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
         ];
     }
 
-    private maybeRenderTimePickers() {
+    private maybeRenderTimePickers(isShowingOneMonth: boolean) {
         const { timePrecision, timePickerProps } = this.props;
         if (timePrecision == null && timePickerProps === DateRangePicker.defaultProps.timePickerProps) {
             return null;
         }
-        return (
-            <div className={DateClasses.DATERANGEPICKER_TIMEPICKERS}>
+
+        if (isShowingOneMonth) {
+            return (
                 <TimePicker
                     precision={timePrecision}
                     {...timePickerProps}
                     onChange={this.handleTimeChangeLeftCalendar}
                     value={this.state.time[0]}
                 />
-                <TimePicker
-                    precision={timePrecision}
-                    {...timePickerProps}
-                    onChange={this.handleTimeChangeRightCalendar}
-                    value={this.state.time[1]}
-                />
-            </div>
-        );
+            );
+        } else {
+            return (
+                <div className={DateClasses.DATERANGEPICKER_TIMEPICKERS}>
+                    <TimePicker
+                        precision={timePrecision}
+                        {...timePickerProps}
+                        onChange={this.handleTimeChangeLeftCalendar}
+                        value={this.state.time[0]}
+                    />
+                    <TimePicker
+                        precision={timePrecision}
+                        {...timePickerProps}
+                        onChange={this.handleTimeChangeRightCalendar}
+                        value={this.state.time[1]}
+                    />
+                </div>
+            );
+        }
     }
 
     private handleTimeChange = (newTime: Date, dateIndex: number) => {
@@ -427,34 +437,36 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
                 />
             );
         } else {
-            return [
-                <DayPicker
-                    key="left"
-                    {...dayPickerBaseProps}
-                    canChangeMonth={true}
-                    captionElement={this.renderLeftCaption}
-                    navbarElement={this.renderLeftNavbar}
-                    fromMonth={minDate}
-                    month={this.state.leftView.getFullDate()}
-                    numberOfMonths={1}
-                    onMonthChange={this.handleLeftMonthChange}
-                    toMonth={DateUtils.getDatePreviousMonth(maxDate)}
-                    renderDay={dayPickerProps?.renderDay ?? this.renderDay}
-                />,
-                <DayPicker
-                    key="right"
-                    {...dayPickerBaseProps}
-                    canChangeMonth={true}
-                    captionElement={this.renderRightCaption}
-                    navbarElement={this.renderRightNavbar}
-                    fromMonth={DateUtils.getDateNextMonth(minDate)}
-                    month={this.state.rightView.getFullDate()}
-                    numberOfMonths={1}
-                    onMonthChange={this.handleRightMonthChange}
-                    toMonth={maxDate}
-                    renderDay={dayPickerProps?.renderDay ?? this.renderDay}
-                />,
-            ];
+            return (
+                <div className={DateClasses.DATERANGEPICKER_CALENDARS}>
+                    <DayPicker
+                        key="left"
+                        {...dayPickerBaseProps}
+                        canChangeMonth={true}
+                        captionElement={this.renderLeftCaption}
+                        navbarElement={this.renderLeftNavbar}
+                        fromMonth={minDate}
+                        month={this.state.leftView.getFullDate()}
+                        numberOfMonths={1}
+                        onMonthChange={this.handleLeftMonthChange}
+                        toMonth={DateUtils.getDatePreviousMonth(maxDate)}
+                        renderDay={dayPickerProps?.renderDay ?? this.renderDay}
+                    />
+                    <DayPicker
+                        key="right"
+                        {...dayPickerBaseProps}
+                        canChangeMonth={true}
+                        captionElement={this.renderRightCaption}
+                        navbarElement={this.renderRightNavbar}
+                        fromMonth={DateUtils.getDateNextMonth(minDate)}
+                        month={this.state.rightView.getFullDate()}
+                        numberOfMonths={1}
+                        onMonthChange={this.handleRightMonthChange}
+                        toMonth={maxDate}
+                        renderDay={dayPickerProps?.renderDay ?? this.renderDay}
+                    />
+                </div>
+            );
         }
     }
 

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -18,15 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
 
-import {
-    AbstractPureComponent2,
-    Boundary,
-    Button,
-    ButtonGroup,
-    DISPLAYNAME_PREFIX,
-    Divider,
-    Props,
-} from "@blueprintjs/core";
+import { AbstractPureComponent2, Boundary, DISPLAYNAME_PREFIX, Divider, Props } from "@blueprintjs/core";
 
 import * as DateClasses from "./common/classes";
 import { DateRange } from "./common/dateRange";
@@ -406,7 +398,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     };
 
     private renderCalendars(isShowingOneMonth: boolean) {
-        const { dayPickerProps, locale, localeUtils, maxDate, minDate, footerElement } = this.props;
+        const { dayPickerProps, locale, localeUtils, maxDate, minDate } = this.props;
         const dayPickerBaseProps: DayPickerProps = {
             locale,
             localeUtils,

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -54,12 +54,7 @@ export class DatePickerExample extends React.PureComponent<ExampleProps, IDatePi
 
     private toggleActionsBar = handleBooleanChange(showActionsBar => this.setState({ showActionsBar }));
 
-    private toggleShowFooterElement = () => {
-        this.setState(prevState => {
-            const showFooterElement = !prevState.showFooterElement;
-            return { showFooterElement };
-        });
-    };
+    private toggleShowFooterElement = handleBooleanChange(showFooterElement => this.setState({ showFooterElement }));
 
     private toggleShortcuts = handleBooleanChange(shortcuts => this.setState({ shortcuts }));
 

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
@@ -16,13 +16,20 @@
 
 import * as React from "react";
 
-import { H5, Switch } from "@blueprintjs/core";
+import { Callout, Code, H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangeInput2 } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { DateFnsDateRange } from "./dateFnsDate";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "./dateFnsFormatSelector";
+
+const exampleFooterElement = (
+    <Callout style={{ maxWidth: 460 }}>
+        A custom footer element may be displayed below the date range picker calendars using the{" "}
+        <Code>footerElement</Code> prop.
+    </Callout>
+);
 
 export interface DateRangeInput2ExampleState {
     allowSingleDayRange: boolean;
@@ -35,8 +42,9 @@ export interface DateRangeInput2ExampleState {
     reverseMonthAndYearMenus: boolean;
     selectAllOnFocus: boolean;
     shortcuts: boolean;
-    singleMonthOnly: boolean;
+    showFooterElement: boolean;
     showTimeArrowButtons: boolean;
+    singleMonthOnly: boolean;
 }
 
 export class DateRangeInput2Example extends React.PureComponent<ExampleProps, DateRangeInput2ExampleState> {
@@ -51,6 +59,7 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
         reverseMonthAndYearMenus: false,
         selectAllOnFocus: false,
         shortcuts: true,
+        showFooterElement: false,
         showTimeArrowButtons: false,
         singleMonthOnly: false,
     };
@@ -69,6 +78,8 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
 
     private toggleSelectAllOnFocus = handleBooleanChange(selectAllOnFocus => this.setState({ selectAllOnFocus }));
 
+    private toggleShowFooterElement = handleBooleanChange(showFooterElement => this.setState({ showFooterElement }));
+
     private toggleSingleDay = handleBooleanChange(allowSingleDayRange => this.setState({ allowSingleDayRange }));
 
     private toggleSingleMonth = handleBooleanChange(singleMonthOnly => this.setState({ singleMonthOnly }));
@@ -82,13 +93,14 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
     );
 
     public render() {
-        const { enableTimePicker, format, range, showTimeArrowButtons, ...spreadProps } = this.state;
+        const { enableTimePicker, format, range, showFooterElement, showTimeArrowButtons, ...spreadProps } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <DateRangeInput2
                     {...spreadProps}
                     {...format}
                     onChange={this.handleRangeChange}
+                    footerElement={showFooterElement ? exampleFooterElement : undefined}
                     timePickerProps={
                         enableTimePicker
                             ? { precision: TimePrecision.MINUTE, showArrowButtons: showTimeArrowButtons }
@@ -135,6 +147,11 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
                     checked={this.state.reverseMonthAndYearMenus}
                     label="Reverse month and year menus"
                     onChange={this.toggleReverseMonthAndYearMenus}
+                />
+                <Switch
+                    checked={this.state.showFooterElement}
+                    label="Show custom footer element"
+                    onChange={this.toggleShowFooterElement}
                 />
                 <Switch
                     checked={this.state.enableTimePicker}


### PR DESCRIPTION
#### Fixes #5537

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Fix DateRangePicker (and transitively, DateRangeInput & DateRangeInput2) to render `footerElement` correctly
- Fix a bug in DateRangePicker where it would render both time pickers with `showSingleMonthOnly={true}` and time pickers enabled

  <img width="418" alt="Screen Shot 2022-09-13 at 4 28 18 PM" src="https://user-images.githubusercontent.com/723999/190004218-6b83936a-f8ba-4a94-903a-ff34a6c83d96.png">

#### Reviewers should focus on:

Making a custom `footerElement` work in the popover layout required adjusting the DOM structure of DRP somewhat to ensure that the calendars and time pickers get aligned correctly even when there is a very wide footer element that expands the width of the popover and creates extra whitespace. There are some new flexbox container elements. See the screenshot below.

#### Screenshot

<img width="644" alt="image" src="https://user-images.githubusercontent.com/723999/190004489-58bb4612-b1fe-4d38-a27c-a9e827083f13.png">

<img width="439" alt="Screen Shot 2022-09-13 at 4 29 56 PM" src="https://user-images.githubusercontent.com/723999/190004661-05567578-99d3-4766-8258-55e1f8f044d1.png">
