### PR TITLE
Fixing Issue 2550 - DateInput handles blur and key down Enter on the input field differently.

### DIFF
--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -316,7 +316,17 @@ export class DateInput extends AbstractPureComponent2<DateInputProps, IDateInput
         } else {
             this.setState({ isInputFocused, isOpen });
         }
-        this.props.onChange?.(newDate, isUserChange);
+        if (didSubmitWithEnter) {
+            if (isNaN(newDate.valueOf())) {
+                this.props.onError?.(new Date(undefined));
+            } else if (!this.isDateInRange(newDate)) {
+                this.props.onError?.(newDate);
+            } else {
+                this.props.onChange?.(newDate, isUserChange);
+            }
+        } else {
+            this.props.onChange?.(newDate, isUserChange);
+        }
     };
 
     private hasMonthChanged(prevDate: Date | null, nextDate: Date | null) {

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -480,6 +480,28 @@ describe("<DateInput>", () => {
             assertDateEquals(onError.args[0][0], new Date(value));
         });
 
+        it("Typing in a date out of range displays the error message and calls onError with invalid date on enter keydown", () => {
+            const rangeMessage = "RANGE ERROR";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput
+                    {...DATE_FORMAT}
+                    defaultValue={new Date(2015, Months.MAY, 1)}
+                    minDate={new Date(2015, Months.MARCH, 1)}
+                    onError={onError}
+                    outOfRangeMessage={rangeMessage}
+                />,
+            );
+            const value = "2/1/2030";
+            wrapper.find("input").simulate("change", { target: { value } }).simulate("keydown", { which: Keys.ENTER });
+
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
+
+            assert.isTrue(onError.calledOnce);
+            assertDateEquals(onError.args[0][0], new Date(value));
+        });
+
         it("Typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {
             const invalidDateMessage = "INVALID DATE";
             const onError = sinon.spy();
@@ -495,6 +517,29 @@ describe("<DateInput>", () => {
                 .find("input")
                 .simulate("change", { target: { value: "not a date" } })
                 .simulate("blur");
+
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), invalidDateMessage);
+
+            assert.isTrue(onError.calledOnce);
+            assert.isNaN((onError.args[0][0] as Date).valueOf());
+        });
+
+        it("Typing in an invalid date displays the error message and calls onError with Date(undefined) on enter keydown", () => {
+            const invalidDateMessage = "INVALID DATE";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput
+                    {...DATE_FORMAT}
+                    defaultValue={new Date(2015, Months.MAY, 1)}
+                    onError={onError}
+                    invalidDateMessage={invalidDateMessage}
+                />,
+            );
+            wrapper
+                .find("input")
+                .simulate("change", { target: { value: "not a date" } })
+                .simulate("keydown", { which: Keys.ENTER });
 
             assert.strictEqual(wrapper.find(InputGroup).prop("intent"), Intent.DANGER);
             assert.strictEqual(wrapper.find(InputGroup).prop("value"), invalidDateMessage);


### PR DESCRIPTION
#### Fixes #2550

#### Checklist

- [x] Includes tests
- [ ] Update documentation - not required for this fix imho

#### Changes proposed in this pull request:

This change fixes an existing issue where if a user pressed enter after typing a date it would call onChange even if the date was invalid or out of range. The fix in this PR calls onError in those conditions instead and includes unit tests to capture this case.

#### Reviewers should focus on:

Is this logic added in the appropriate place with an appropriate pattern?

#### Screenshot

No new visual updates with this PR.
