### PR TITLE
[datetime] fix layout of TimePicker with second/ms precision

### DIFF
--- a/packages/datetime/src/_daterangepicker.scss
+++ b/packages/datetime/src/_daterangepicker.scss
@@ -105,7 +105,7 @@
 .#{$ns}-daterangepicker-calendars {
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
+  justify-content: space-around;
   width: 100%;
 }
 

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -6,7 +6,6 @@
 @import "./common";
 
 $timepicker-input-row-height: $pt-grid-size * 3 !default;
-$timepicker-row-width: $pt-grid-size * 8 !default;
 // subtract two because of inset shadow
 $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly
@@ -19,7 +18,6 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
   .#{$ns}-timepicker-arrow-row {
     padding: $timepicker-row-padding;
-    width: $timepicker-row-width;
   }
 
   .#{$ns}-timepicker-arrow-button {
@@ -47,7 +45,6 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     line-height: $timepicker-input-row-inner-height;
     padding: $timepicker-row-padding;
     vertical-align: middle;
-    width: $timepicker-row-width;
   }
 
   .#{$ns}-timepicker-divider-text {

--- a/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
@@ -14,12 +14,20 @@
  * limitations under the License.
  */
 
+import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, HTMLSelect } from "@blueprintjs/core";
 import { TimePrecision } from "@blueprintjs/datetime";
 
 export interface PrecisionSelectProps {
+    /**
+     * Whether the select is disabled.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
     /**
      * The precision-string option to display as selected.
      */
@@ -44,9 +52,9 @@ export interface PrecisionSelectProps {
 }
 
 export const PrecisionSelect: React.FC<PrecisionSelectProps> = props => (
-    <label className={Classes.LABEL}>
-        {props.label ?? "Precision"}
-        <HTMLSelect value={props.value} onChange={props.onChange}>
+    <label className={classNames(Classes.LABEL, { [Classes.DISABLED]: props.disabled })}>
+        {props.label}
+        <HTMLSelect value={props.value} onChange={props.onChange} disabled={props.disabled}>
             {props.allowNone && <option value="none">None</option>}
             <option value={TimePrecision.MINUTE}>Minute</option>
             <option value={TimePrecision.SECOND}>Second</option>
@@ -54,3 +62,7 @@ export const PrecisionSelect: React.FC<PrecisionSelectProps> = props => (
         </HTMLSelect>
     </label>
 );
+PrecisionSelect.defaultProps = {
+    disabled: false,
+    label: "Precision",
+};

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
@@ -19,8 +19,9 @@ import * as React from "react";
 import { Callout, Code, H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangeInput2 } from "@blueprintjs/datetime2";
-import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
+import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { DateFnsDateRange } from "./dateFnsDate";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "./dateFnsFormatSelector";
 
@@ -45,6 +46,7 @@ export interface DateRangeInput2ExampleState {
     showFooterElement: boolean;
     showTimeArrowButtons: boolean;
     singleMonthOnly: boolean;
+    timePrecision: TimePrecision | undefined;
 }
 
 export class DateRangeInput2Example extends React.PureComponent<ExampleProps, DateRangeInput2ExampleState> {
@@ -62,6 +64,7 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
         showFooterElement: false,
         showTimeArrowButtons: false,
         singleMonthOnly: false,
+        timePrecision: TimePrecision.MINUTE,
     };
 
     private toggleContiguous = handleBooleanChange(contiguous => {
@@ -92,8 +95,20 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
         this.setState({ showTimeArrowButtons }),
     );
 
+    private handleTimePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
+        this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
+    );
+
     public render() {
-        const { enableTimePicker, format, range, showFooterElement, showTimeArrowButtons, ...spreadProps } = this.state;
+        const {
+            enableTimePicker,
+            format,
+            range,
+            showFooterElement,
+            showTimeArrowButtons,
+            timePrecision,
+            ...spreadProps
+        } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <DateRangeInput2
@@ -103,7 +118,7 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
                     footerElement={showFooterElement ? exampleFooterElement : undefined}
                     timePickerProps={
                         enableTimePicker
-                            ? { precision: TimePrecision.MINUTE, showArrowButtons: showTimeArrowButtons }
+                            ? { precision: timePrecision, showArrowButtons: showTimeArrowButtons }
                             : undefined
                     }
                 />
@@ -163,6 +178,13 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
                     checked={this.state.showTimeArrowButtons}
                     label="Show timepicker arrow buttons"
                     onChange={this.toggleTimepickerArrowButtons}
+                />
+                <PrecisionSelect
+                    allowNone={false}
+                    disabled={!this.state.enableTimePicker}
+                    label="Time precision"
+                    onChange={this.handleTimePrecisionChange}
+                    value={this.state.timePrecision}
                 />
                 <DateFnsFormatSelector key="Format" format={this.state.format} onChange={this.handleFormatChange} />
             </>


### PR DESCRIPTION
#### Fixes a regression in `<TimePicker>` CSS layout introduced by #5539 

#### Before this PR

<img width="360" alt="Screen Shot 2022-09-23 at 3 15 04 PM" src="https://user-images.githubusercontent.com/723999/192041141-2810cb9a-6ccf-4e03-9912-6c33ccdc2dbf.png">


#### After this PR

<img width="402" alt="Screen Shot 2022-09-23 at 3 11 55 PM" src="https://user-images.githubusercontent.com/723999/192041184-516d8fa8-2b88-4122-b641-51714abe1fa9.png">
<img width="657" alt="Screen Shot 2022-09-23 at 3 11 14 PM" src="https://user-images.githubusercontent.com/723999/192041190-2e285125-d1e4-422b-b3d1-55006893fec9.png">
<img width="949" alt="Screen Shot 2022-09-23 at 3 01 14 PM" src="https://user-images.githubusercontent.com/723999/192041193-56962db1-9914-41c0-b8ad-a6e431420b3d.png">

