### PR TITLE
[datetime2] fix: remove errant whitespace in timezones list

### DIFF
--- a/packages/datetime2/src/common/timezoneItems.ts
+++ b/packages/datetime2/src/common/timezoneItems.ts
@@ -33,7 +33,7 @@ export const TIMEZONE_ITEMS: Timezone[] = [
     { offset: "-09:00", label: "Gambier", ianaCode: "Pacific/Gambier" },
     { offset: "-08:00", label: "Los Angeles", ianaCode: "America/Los_Angeles" },
     { offset: "-08:00", label: "Tijuana", ianaCode: "America/Tijuana" },
-    { offset: "-08:00", label: " Vancouver", ianaCode: "America/Vancouver" },
+    { offset: "-08:00", label: "Vancouver", ianaCode: "America/Vancouver" },
     { offset: "-08:00", label: "Whitehorse", ianaCode: "America/Whitehorse" },
     { offset: "-08:00", label: "Pitcairn", ianaCode: "Pacific/Pitcairn" },
     { offset: "-07:00", label: "Denver", ianaCode: "America/Denver" },


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation
- [x] I am sorry 

#### Changes proposed in this pull request:

- Fixed a SUPER TINY typo in the dataset that MIGHT cause a bug, (tbh negligible but better be fixed!)

#### Reviewers should focus on:

- How petty I am to submit a single line PR (:smile:)
- Seriously, I feel guilty about this PR but hey I found something!
- Also one of my colleague and lots of lived in Vancouver and a lot of my friends still do so I've got that going for me, which is nice
- Aaand I had been in love with elegant design of blurprint.js since years ago and I still do. 

#### Screenshot

- None, since white-spaces are generally invisible inside ReactNode.
