### PR TITLE
[core,select] chore: deprecate .ofType() helper methods

### DIFF
--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -126,9 +126,8 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
 
         const nodeItems = treeNodes.map((node, i) => {
             const elementPath = currentPath!.concat(i);
-            const TypedTreeNode = TreeNode.ofType<T>();
             return (
-                <TypedTreeNode
+                <TreeNode<T>
                     {...node}
                     key={node.id}
                     contentRef={this.handleContentRef}
@@ -143,7 +142,7 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
                     path={elementPath}
                 >
                     {this.renderNodes(node.childNodes, elementPath)}
-                </TypedTreeNode>
+                </TreeNode>
             );
         });
 

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -105,6 +105,7 @@ export interface ITreeNodeProps<T = {}> extends TreeNodeInfo<T> {
 export class TreeNode<T = {}> extends React.Component<ITreeNodeProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TreeNode`;
 
+    /** @deprecated no longer necessary now that the TypeScript parser supports type arguments on JSX element tags */
     public static ofType<U>() {
         return TreeNode as new (props: ITreeNodeProps<U>) => TreeNode<U>;
     }

--- a/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
@@ -117,8 +117,6 @@ export interface TimezoneSelectState {
     query: string;
 }
 
-const TypedSelect = Select2.ofType<TimezoneWithNames>();
-
 export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, TimezoneSelectState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TimezoneSelect`;
 
@@ -150,7 +148,7 @@ export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, 
         const { query } = this.state;
 
         return (
-            <TypedSelect
+            <Select2<TimezoneWithNames>
                 className={classNames(Classes.TIMEZONE_SELECT, className)}
                 disabled={disabled}
                 fill={fill}
@@ -172,7 +170,7 @@ export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, 
                 resetOnSelect={true}
             >
                 {children ?? this.renderButton()}
-            </TypedSelect>
+            </Select2>
         );
     }
 

--- a/packages/datetime2/test/components/timezoneSelectTests.tsx
+++ b/packages/datetime2/test/components/timezoneSelectTests.tsx
@@ -169,11 +169,11 @@ describe("<TimezoneSelect>", () => {
     }
 
     function findSelect(timezoneSelect: ReactWrapper<TimezoneSelect>) {
-        return timezoneSelect.find(Select2.ofType<TimezoneWithNames>());
+        return timezoneSelect.find<Select2<TimezoneWithNames>>(Select2);
     }
 
     function findQueryList(timezoneSelect: ReactWrapper<TimezoneSelect>) {
-        return findSelect(timezoneSelect).find(QueryList.ofType<TimezoneWithNames>());
+        return findSelect(timezoneSelect).find<QueryList<TimezoneWithNames>>(QueryList);
     }
 
     function findPopover(timezoneSelect: ReactWrapper<TimezoneSelect>) {

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -31,15 +31,13 @@ export interface IIconSelectProps {
     onChange: (iconName?: IconName) => void;
 }
 
-const TypedSelect = Select2.ofType<IconNameOrNone>();
-
 export class IconSelect extends React.PureComponent<IIconSelectProps> {
     public render() {
         const { disabled, iconName } = this.props;
         return (
             <label className={classNames(Classes.LABEL, { [Classes.DISABLED]: disabled })}>
                 Icon
-                <TypedSelect
+                <Select2<IconNameOrNone>
                     disabled={disabled}
                     items={ICON_NAMES}
                     itemPredicate={this.filterIconName}
@@ -57,7 +55,7 @@ export class IconSelect extends React.PureComponent<IIconSelectProps> {
                         text={iconName || NONE}
                         rightIcon="caret-down"
                     />
-                </TypedSelect>
+                </Select2>
             </label>
         );
     }

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -35,8 +35,6 @@ import {
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
-const FilmMultiSelect = MultiSelect2.ofType<Film>();
-
 const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Intent.WARNING];
 
 export interface IMultiSelectExampleState {
@@ -113,7 +111,7 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
 
         return (
             <Example options={this.renderOptions()} {...this.props}>
-                <FilmMultiSelect
+                <MultiSelect2<Film>
                     {...flags}
                     createNewItemFromQuery={allowCreate ? createFilms : undefined}
                     createNewItemRenderer={allowCreate ? renderCreateFilmsMenuItem : null}

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -27,8 +27,6 @@ import {
     TOP_100_FILMS,
 } from "@blueprintjs/select/examples";
 
-const FilmOmnibar = Omnibar.ofType<Film>();
-
 export interface IOmnibarExampleState {
     allowCreate: boolean;
     isOpen: boolean;
@@ -78,7 +76,7 @@ export class OmnibarExample extends React.PureComponent<ExampleProps, IOmnibarEx
                         <KeyCombo combo="shift + o" />
                     </span>
 
-                    <FilmOmnibar
+                    <Omnibar<Film>
                         {...this.state}
                         createNewItemFromQuery={maybeCreateNewItemFromQuery}
                         createNewItemRenderer={maybeCreateNewItemRenderer}

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -46,7 +46,6 @@ export interface INavigationSection {
     title: string;
 }
 
-const NavOmnibar = Omnibar.ofType<INavigationSection>();
 export class Navigator extends React.PureComponent<INavigatorProps> {
     private sections: INavigationSection[];
 
@@ -68,7 +67,7 @@ export class Navigator extends React.PureComponent<INavigatorProps> {
             return null;
         }
         return (
-            <NavOmnibar
+            <Omnibar<INavigationSection>
                 className="docs-navigator-menu"
                 inputProps={{ placeholder: "Search documentation pages and sections..." }}
                 itemListPredicate={this.filterMatches}

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -120,8 +120,6 @@ export class MultiSelect<T> extends AbstractPureComponent2<MultiSelectProps<T>, 
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
     };
 
-    private TypedQueryList = QueryList.ofType<T>();
-
     public input: HTMLInputElement | null = null;
 
     public queryList: QueryList<T> | null = null;
@@ -147,7 +145,7 @@ export class MultiSelect<T> extends AbstractPureComponent2<MultiSelectProps<T>, 
         const { openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         return (
-            <this.TypedQueryList
+            <QueryList<T>
                 {...restProps}
                 onItemSelect={this.handleItemSelect}
                 onQueryChange={this.handleQueryChange}

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -131,6 +131,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         placeholder: "Search...",
     };
 
+    /** @deprecated no longer necessary now that the TypeScript parser supports type arguments on JSX element tags */
     public static ofType<U>() {
         return MultiSelect2 as new (props: MultiSelect2Props<U>) => MultiSelect2<U>;
     }
@@ -138,8 +139,6 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
     public state: MultiSelect2State = {
         isOpen: (this.props.popoverProps && this.props.popoverProps.isOpen) || false,
     };
-
-    private TypedQueryList = QueryList.ofType<T>();
 
     public input: HTMLInputElement | null = null;
 
@@ -174,7 +173,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         const { menuProps, openOnKeyDown, popoverProps, tagInputProps, ...restProps } = this.props;
 
         return (
-            <this.TypedQueryList
+            <QueryList<T>
                 {...restProps}
                 menuProps={{
                     "aria-label": "selectable options",

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -62,14 +62,12 @@ export class Omnibar<T> extends React.PureComponent<OmnibarProps<T>> {
         return Omnibar as new (props: OmnibarProps<U>) => Omnibar<U>;
     }
 
-    private TypedQueryList = QueryList.ofType<T>();
-
     public render() {
         // omit props specific to this component, spread the rest.
         const { isOpen, inputProps, overlayProps, ...restProps } = this.props;
         const initialContent = "initialContent" in this.props ? this.props.initialContent : null;
 
-        return <this.TypedQueryList {...restProps} initialContent={initialContent} renderer={this.renderQueryList} />;
+        return <QueryList<T> {...restProps} initialContent={initialContent} renderer={this.renderQueryList} />;
     }
 
     private renderQueryList = (listProps: QueryListRendererProps<T>) => {

--- a/packages/select/src/components/query-list/query-list.md
+++ b/packages/select/src/components/query-list/query-list.md
@@ -2,7 +2,7 @@
 
 `QueryList<T>` is a higher-order component that provides interactions between a query string and a list of items. Specifically, it implements the two predicate props described above and provides keyboard selection. It does not render anything on its own, instead deferring to a `renderer` prop to perform the actual composition of components.
 
-`QueryList<T>` is a generic component where `<T>` represents the type of one item in the array of `items`. The static method `QueryList.ofType<T>()` is available to simplify the TypeScript usage.
+`QueryList<T>` is a generic component where `<T>` represents the type of one item in the array of `items`.
 
 If the `Select` interactions are not sufficient for your use case, you can use `QueryList` directly to render your own components while leveraging basic interactions for keyboard selection and filtering. The `Select` source code is a great place to start when implementing a custom `QueryList` `renderer`.
 

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -157,6 +157,7 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
         resetOnQuery: true,
     };
 
+    /** @deprecated no longer necessary now that the TypeScript parser supports type arguments on JSX element tags */
     public static ofType<U>() {
         return QueryList as new (props: QueryListProps<U>) => QueryList<U>;
     }

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -114,8 +114,6 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
 
     public state: ISelectState = { isOpen: false };
 
-    private TypedQueryList = QueryList.ofType<T>();
-
     public inputElement: HTMLInputElement | null = null;
 
     private queryList: QueryList<T> | null = null;
@@ -135,7 +133,7 @@ export class Select<T> extends AbstractPureComponent2<SelectProps<T>, ISelectSta
         const { filterable, inputProps, popoverProps, ...restProps } = this.props;
 
         return (
-            <this.TypedQueryList
+            <QueryList<T>
                 {...restProps}
                 onItemSelect={this.handleItemSelect}
                 ref={this.handleQueryListRef}

--- a/packages/select/src/components/select/select2.md
+++ b/packages/select/src/components/select/select2.md
@@ -91,7 +91,7 @@ const FilmSelect: React.FC = () => {
 ReactDOM.render(<FilmSelect /> document.querySelector("#root"));
 ```
 
-In TypeScript, `Select2<T>` is a _generic component_ so you must define a local type that specifies `<T>`, the type of one item in `items`. The props on this local type will now operate on your data type (speak your language) so you can easily define handlers without transformation steps, but most props are required as a result. The static `Select2.ofType<T>()` method is available to streamline this process. (Note that this has no effect on JavaScript usage: the `Select2` export is a perfectly valid React component class.)
+In TypeScript, `Select2<T>` is a _generic component_ so you must define a local type that specifies `<T>`, the type of one item in `items`. The props on this local type will now operate on your data type so you can easily define handlers without transformation steps, but most props are required as a result.
 
 @## Querying
 
@@ -112,13 +112,11 @@ Since Select2 accepts arbitrary children, disabling a Select2 componet requires 
 _and also_ disabling its children. For example:
 
 ```tsx
-const FilmSelect = Select2.ofType<Films.Film>();
-
-// many props omitted here for brevity
-return (
-    <FilmSelect disabled={true}>
+const FilmSelect: React.FC = () => (
+    // many props omitted here for brevity
+    <Select2<Film> disabled={true}>
         <Button disabled={true}>
-    </FilmSelect>
+    </Select2>
 );
 ```
 
@@ -137,17 +135,19 @@ The input value can be controlled with the `query` and `onQueryChange` props. _D
 The focused item (for keyboard interactions) can be controlled with the `activeItem` and `onActiveItemChange` props.
 
 ```tsx
-<FilmSelect
-    items={myFilter(ALL_ITEMS, this.state.myQuery)}
-    itemRenderer={...}
-    onItemSelect={...}
-    // controlled active item
-    activeItem={this.state.myActiveItem}
-    onActiveItemChange={this.handleActiveItemChange}
-    // controlled query
-    query={this.state.myQuery}
-    onQueryChange={this.handleQueryChange}
-/>
+const FilmSelect: React.FC = () => (
+    <Select2<Film>
+        items={myFilter(ALL_ITEMS, this.state.myQuery)}
+        itemRenderer={...}
+        onItemSelect={...}
+        // controlled active item
+        activeItem={this.state.myActiveItem}
+        onActiveItemChange={this.handleActiveItemChange}
+        // controlled query
+        query={this.state.myQuery}
+        onQueryChange={this.handleQueryChange}
+    />
+);
 ```
 
 This controlled usage allows you to implement all sorts of advanced behavior on
@@ -207,8 +207,8 @@ function renderCreateFilmOption(
     )
 }
 
-ReactDOM.render(
-    <FilmSelect
+const FilmSelect: React.FC = () => (
+    <Select2<Film>
         createNewItemFromQuery={createFilm}
         createNewItemRenderer={renderCreateFilmOption}
         items={Films.items}
@@ -216,8 +216,7 @@ ReactDOM.render(
         itemRenderer={Films.itemRenderer}
         noResults={<MenuItem disabled={true} text="No results."  roleStructure="listoption" />}
         onItemSelect={...}
-    />,
-    document.querySelector("#root")
+    />
 );
 ```
 
@@ -261,15 +260,14 @@ function getActiveItem() {
     return isCreateNewItemActive ? getCreateNewItem() : currentActiveItem;
 }
 
-ReactDOM.render(
-    <FilmSelect
+const FilmSelect: React.FC = () => (
+    <Select2<Film>
         {...} // Other required props (see previous examples).
         activeItem={getActiveItem()}
         createNewItemFromQuery={...}
         createNewItemRenderer={...}
         onActiveItemChange={handleActiveItemChange}
-    />,
-    document.querySelector("#root")
+    />
 );
 ```
 
@@ -287,8 +285,6 @@ to rendering this item in this frame. The renderer is called for all items, so d
 import { Classes } from "@blueprintjs/core";
 import { MenuItem } from "@blueprintjs/popover2";
 import { ItemRenderer, ItemPredicate, Select2 } from "@blueprintjs/select";
-
-const FilmSelect = Select2.ofType<Film>();
 
 const filterFilm: ItemPredicate<Film> = (query, film) => {
     return film.title.toLowerCase().indexOf(query.toLowerCase()) >= 0;
@@ -311,7 +307,14 @@ const renderFilm: ItemRenderer<Film> = (film, { handleClick, handleFocus, modifi
     );
 };
 
-<FilmSelect itemPredicate={filterFilm} itemRenderer={renderFilm} items={...} onItemSelect={...} />
+const FilmSelect: React.FC = () => (
+    <Select2<Film>
+        itemPredicate={filterFilm}
+        itemRenderer={renderFilm}
+        items={...}
+        onItemSelect={...}
+    />
+);
 ```
 
 @interface ItemRendererProps
@@ -337,13 +340,15 @@ const renderMenu: ItemListRenderer<Film> = ({ items, itemsParentRef, query, rend
     );
 };
 
-<FilmSelect
-    itemListRenderer={renderMenu}
-    itemPredicate={filterFilm}
-    itemRenderer={renderFilm}
-    items={...}
-    onItemSelect={...}
-/>
+const FilmSelect: React.FC = () => (
+    <Select2<Film>
+        itemListRenderer={renderMenu}
+        itemPredicate={filterFilm}
+        itemRenderer={renderFilm}
+        items={...}
+        onItemSelect={...}
+    />
+);
 ```
 
 @interface ItemListRendererProps

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -100,6 +100,7 @@ export interface Select2State {
 export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Select2`;
 
+    /** @deprecated no longer necessary now that the TypeScript parser supports type arguments on JSX element tags */
     public static ofType<U>() {
         return Select2 as new (props: Select2Props<U>) => Select2<U>;
     }
@@ -107,8 +108,6 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
     public state: Select2State = { isOpen: false };
 
     public inputElement: HTMLInputElement | null = null;
-
-    private TypedQueryList = QueryList.ofType<T>();
 
     private queryList: QueryList<T> | null = null;
 
@@ -129,7 +128,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         const { filterable, inputProps, menuProps, popoverProps, ...restProps } = this.props;
 
         return (
-            <this.TypedQueryList
+            <QueryList<T>
                 {...restProps}
                 menuProps={{ "aria-label": "selectable options", ...menuProps, id: this.listboxId }}
                 onItemSelect={this.handleItemSelect}

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -132,8 +132,6 @@ export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggest
         selectedItem: this.getInitialSelectedItem(),
     };
 
-    private TypedQueryList = QueryList.ofType<T>();
-
     public inputElement: HTMLInputElement | null = null;
 
     private queryList: QueryList<T> | null = null;
@@ -150,7 +148,7 @@ export class Suggest<T> extends AbstractPureComponent2<SuggestProps<T>, ISuggest
         // omit props specific to this component, spread the rest.
         const { disabled, inputProps, popoverProps, ...restProps } = this.props;
         return (
-            <this.TypedQueryList
+            <QueryList<T>
                 {...restProps}
                 initialActiveItem={this.props.selectedItem ?? undefined}
                 onItemSelect={this.handleItemSelect}

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -115,6 +115,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
         resetOnClose: false,
     };
 
+    /** @deprecated no longer necessary now that the TypeScript parser supports type arguments on JSX element tags */
     public static ofType<U>() {
         return Suggest2 as new (props: Suggest2Props<U>) => Suggest2<U>;
     }
@@ -123,8 +124,6 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
         isOpen: (this.props.popoverProps != null && this.props.popoverProps.isOpen) || false,
         selectedItem: this.getInitialSelectedItem(),
     };
-
-    private TypedQueryList = QueryList.ofType<T>();
 
     public inputElement: HTMLInputElement | null = null;
 
@@ -145,7 +144,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
         const { disabled, inputProps, menuProps, popoverProps, ...restProps } = this.props;
 
         return (
-            <this.TypedQueryList
+            <QueryList<T>
                 {...restProps}
                 menuProps={{ "aria-label": "selectable options", ...menuProps, id: this.listboxId }}
                 initialActiveItem={this.props.selectedItem ?? undefined}

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -28,7 +28,6 @@ import { selectComponentSuite } from "./selectComponentSuite";
 import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
 describe("<MultiSelect2>", () => {
-    const FilmMultiSelect = MultiSelect2.ofType<Film>();
     const defaultProps = {
         items: TOP_100_FILMS,
         popoverProps: { isOpen: true, usePortal: false },
@@ -124,9 +123,9 @@ describe("<MultiSelect2>", () => {
 
     function multiselect(props: Partial<MultiSelect2Props<Film>> = {}, query?: string) {
         const wrapper = mount(
-            <FilmMultiSelect {...defaultProps} {...handlers} {...props}>
+            <MultiSelect2<Film> {...defaultProps} {...handlers} {...props}>
                 <article />
-            </FilmMultiSelect>,
+            </MultiSelect2>,
         );
         if (query !== undefined) {
             wrapper.setState({ query });

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -34,7 +34,6 @@ import { Film, renderFilm, TOP_100_FILMS } from "../src/__examples__";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<MultiSelect>", () => {
-    const FilmMultiSelect = MultiSelect.ofType<Film>();
     const defaultProps = {
         items: TOP_100_FILMS,
         popoverProps: { isOpen: true, usePortal: false },
@@ -116,9 +115,9 @@ describe("<MultiSelect>", () => {
 
     function multiselect(props: Partial<IMultiSelectProps<Film>> = {}, query?: string) {
         const wrapper = mount(
-            <FilmMultiSelect {...defaultProps} {...handlers} {...props}>
+            <MultiSelect<Film> {...defaultProps} {...handlers} {...props}>
                 <article />
-            </FilmMultiSelect>,
+            </MultiSelect>,
         );
         if (query !== undefined) {
             wrapper.setState({ query });

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -35,7 +35,6 @@ import { Film, renderFilm, TOP_100_FILMS } from "../src/__examples__";
 type FilmQueryListWrapper = ReactWrapper<QueryListProps<Film>, IQueryListState<Film>>;
 
 describe("<QueryList>", () => {
-    const FilmQueryList = QueryList.ofType<Film>();
     const testProps = {
         itemRenderer: sinon.spy(renderFilm),
         items: TOP_100_FILMS.slice(0, 20),
@@ -53,7 +52,7 @@ describe("<QueryList>", () => {
 
     describe("items", () => {
         it("handles controlled changes to the whole items list", () => {
-            const wrapper = shallow(<FilmQueryList {...testProps} />);
+            const wrapper = shallow(<QueryList<Film> {...testProps} />);
             const newItems = TOP_100_FILMS.slice(0, 1);
             wrapper.setProps({ items: newItems });
             assert.deepEqual(wrapper.state("filteredItems"), newItems);
@@ -66,7 +65,7 @@ describe("<QueryList>", () => {
         );
 
         it("renderItem calls itemRenderer", () => {
-            const wrapper = shallow(<FilmQueryList {...testProps} itemListRenderer={itemListRenderer} />);
+            const wrapper = shallow(<QueryList<Film> {...testProps} itemListRenderer={itemListRenderer} />);
             assert.lengthOf(wrapper.find("ul.foo"), 1, "should find element");
             assert.equal(testProps.itemRenderer.callCount, 20);
         });
@@ -75,7 +74,7 @@ describe("<QueryList>", () => {
     describe("filtering", () => {
         it("itemPredicate filters each item by query", () => {
             const predicate = sinon.spy((query: string, film: Film) => film.year === +query);
-            shallow(<FilmQueryList {...testProps} itemPredicate={predicate} query="1994" />);
+            shallow(<QueryList<Film> {...testProps} itemPredicate={predicate} query="1994" />);
 
             assert.equal(predicate.callCount, testProps.items.length, "called once per item");
             const { filteredItems } = testProps.renderer.args[0][0] as QueryListRendererProps<Film>;
@@ -84,7 +83,7 @@ describe("<QueryList>", () => {
 
         it("itemListPredicate filters entire list by query", () => {
             const predicate = sinon.spy((query: string, films: Film[]) => films.filter(f => f.year === +query));
-            shallow(<FilmQueryList {...testProps} itemListPredicate={predicate} query="1994" />);
+            shallow(<QueryList<Film> {...testProps} itemListPredicate={predicate} query="1994" />);
 
             assert.equal(predicate.callCount, 1, "called once for entire list");
             const { filteredItems } = testProps.renderer.args[0][0] as QueryListRendererProps<Film>;
@@ -96,7 +95,7 @@ describe("<QueryList>", () => {
             const listPredicate: ItemListPredicate<any> = (_q, items) => items;
             const listPredicateSpy = sinon.spy(listPredicate);
             shallow(
-                <FilmQueryList
+                <QueryList<Film>
                     {...testProps}
                     itemPredicate={predicate}
                     itemListPredicate={listPredicateSpy}
@@ -108,14 +107,16 @@ describe("<QueryList>", () => {
         });
 
         it("omitting both predicate props is supported", () => {
-            shallow(<FilmQueryList {...testProps} query="1980" />);
+            shallow(<QueryList<Film> {...testProps} query="1980" />);
             const { filteredItems } = testProps.renderer.args[0][0] as QueryListRendererProps<Film>;
             assert.lengthOf(filteredItems, testProps.items.length, "returns all films");
         });
 
         it("ensure onActiveItemChange is not called with undefined and empty list", () => {
             const myItem = { title: "Toy Story 3", year: 2010, rank: 1 };
-            const filmQueryList = mount(<FilmQueryList {...testProps} items={[myItem]} activeItem={myItem} query="" />);
+            const filmQueryList = mount(
+                <QueryList<Film> {...testProps} items={[myItem]} activeItem={myItem} query="" />,
+            );
             filmQueryList.setState({ query: "query" });
             filmQueryList.setState({ activeItem: undefined });
             assert.equal(testProps.onActiveItemChange.callCount, 0);
@@ -129,7 +130,7 @@ describe("<QueryList>", () => {
                 items: [myItem],
                 query: "",
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             filmQueryList.setProps(props);
             assert.equal(testProps.onActiveItemChange.callCount, 0);
         });
@@ -140,7 +141,7 @@ describe("<QueryList>", () => {
                 items: [TOP_100_FILMS[0]],
                 query: "abc",
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
             filmQueryList.setProps({
                 items: [TOP_100_FILMS[1]],
@@ -155,7 +156,7 @@ describe("<QueryList>", () => {
                 items: [TOP_100_FILMS[0]],
                 query: "abc",
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
             filmQueryList.setProps({
                 items: [TOP_100_FILMS[1]],
@@ -173,7 +174,7 @@ describe("<QueryList>", () => {
                 itemPredicate: (_query, item) => item === TOP_100_FILMS[11],
                 query: "123",
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             assert(filmQueryList.state().activeItem === TOP_100_FILMS[11]);
         });
 
@@ -183,7 +184,7 @@ describe("<QueryList>", () => {
                 // List is not filtered, and item at index 11 is explicitly chosen as activeItem
                 activeItem: TOP_100_FILMS[11],
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             assert(filmQueryList.state().activeItem === TOP_100_FILMS[11]);
         });
 
@@ -192,7 +193,7 @@ describe("<QueryList>", () => {
                 ...testProps,
                 activeItem: null,
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             assert(filmQueryList.state().activeItem === null);
         });
 
@@ -204,7 +205,7 @@ describe("<QueryList>", () => {
                 items: TOP_100_FILMS.slice(0, 4),
                 query: "the",
             };
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             assert(filmQueryList.find(Menu).children().children().last().is("article"));
             filmQueryList.setProps({ createNewItemPosition: "first" });
             assert(filmQueryList.find(Menu).children().children().first().is("article"));
@@ -237,7 +238,7 @@ describe("<QueryList>", () => {
                 ...overrideProps,
             };
 
-            const filmQueryList: FilmQueryListWrapper = mount(<FilmQueryList {...props} />);
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
             // `handlePaste` will have been set by now, because `props.renderer`
             // will have been called.
             return { filmQueryList, handlePaste: handlePaste! };
@@ -347,7 +348,7 @@ describe("<QueryList>", () => {
                 return <div>{props.itemList}</div>;
             });
             shallow(
-                <FilmQueryList
+                <QueryList<Film>
                     {...testProps}
                     renderer={renderer}
                     createNewItemFromQuery={createNewItemFromQuerySpy}
@@ -385,7 +386,7 @@ describe("<QueryList>", () => {
                 },
             );
             const queryList = shallow(
-                <FilmQueryList
+                <QueryList<Film>
                     {...testProps}
                     // Must return something in order for item creation to work.
                     createNewItemFromQuery={() => ({ title: "irrelevant", rank: 0, year: 0 })}

--- a/packages/select/test/suggest2Tests.tsx
+++ b/packages/select/test/suggest2Tests.tsx
@@ -29,7 +29,6 @@ import { selectComponentSuite } from "./selectComponentSuite";
 import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 
 describe("Suggest2", () => {
-    const FilmSuggest = Suggest2.ofType<Film>();
     const defaultProps = {
         items: TOP_100_FILMS,
         popoverProps: { isOpen: true, usePortal: false },
@@ -339,12 +338,8 @@ describe("Suggest2", () => {
         });
     });
 
-    function suggest(props: Partial<Suggest2Props<Film>> = {}, query?: string) {
-        const wrapper = mount<typeof FilmSuggest>(<FilmSuggest {...defaultProps} {...handlers} {...props} />);
-        if (query !== undefined) {
-            wrapper.setState({ query });
-        }
-        return wrapper;
+    function suggest(props: Partial<Suggest2Props<Film>> = {}) {
+        return mount<Suggest2<Film>>(<Suggest2<Film> {...defaultProps} {...handlers} {...props} />);
     }
 });
 

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -34,7 +34,6 @@ import { ISuggestProps, ISuggestState, Suggest } from "../src/components/suggest
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("Suggest", () => {
-    const FilmSuggest = Suggest.ofType<Film>();
     const defaultProps = {
         items: TOP_100_FILMS,
         popoverProps: { isOpen: true, usePortal: false },
@@ -331,11 +330,8 @@ describe("Suggest", () => {
         });
     });
 
-    function suggest(props: Partial<ISuggestProps<Film>> = {}, query?: string) {
-        const wrapper = mount<typeof FilmSuggest>(<FilmSuggest {...defaultProps} {...handlers} {...props} />);
-        if (query !== undefined) {
-            wrapper.setState({ query });
-        }
+    function suggest(props: Partial<ISuggestProps<Film>> = {}) {
+        const wrapper = mount<Suggest<Film>>(<Suggest<Film> {...defaultProps} {...handlers} {...props} />);
         return wrapper;
     }
 });


### PR DESCRIPTION

#### Changes proposed in this pull request:

core:

- ❌ deprecation: `TreeNode.ofType<T>()` is no longer necessary
  - we recommend specifying the type parameter in JSX syntax directly, e.g. `<TreeNode<T>>`

select:

- :x: deprecation: `Select2.ofType<T>()`, `Suggest2.ofType<T>()`, and `MultiSelect2.ofType<T>()` are no longer necessary
  - we recommend specifying the type parameter in JSX syntax directly, e.g. `<Select2<T>>`

