### PR TITLE
[stylelint-plugin] feat: migrate from @import to @use statements

### DIFF
--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -52,7 +52,7 @@ Enforce usage of the color variables instead of color literals.
 -.my-class {
 -    border: 1px solid #137CBD;
 -}
-+ @use "@blueprintjs/core/lib/scss/variables" as bp;
++ @use "@blueprintjs/core/lib/scss/variables.scss" as bp;
 +
 +.my-class {
 +    border: 1px solid bp.$blue3;
@@ -83,9 +83,9 @@ The `@blueprintjs` package exports a `bp-ns` CSS variable which contains the pre
 -.bp3-button > div {
 -    border: 1px solid black;
 -}
-+ @use "@blueprintjs/core/lib/scss/variables" as bp;
++ @use "@blueprintjs/core/lib/scss/variables.scss" as bp;
 +
-+.#{bp.$bp-ns}-button > div {
++.#{bp.$ns}-button > div {
 +    border: 1px solid black;
 +}
 ```

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -52,10 +52,10 @@ Enforce usage of the color variables instead of color literals.
 -.my-class {
 -    border: 1px solid #137CBD;
 -}
-+ @import "~@blueprintjs/core/lib/scss/variables";
++ @use "@blueprintjs/core/lib/scss/variables" as bp;
 +
 +.my-class {
-+    border: 1px solid $blue3;
++    border: 1px solid bp.$blue3;
 +}
 ```
 
@@ -83,9 +83,9 @@ The `@blueprintjs` package exports a `bp-ns` CSS variable which contains the pre
 -.bp3-button > div {
 -    border: 1px solid black;
 -}
-+ @import "~@blueprintjs/core/lib/scss/variables";
++ @use "@blueprintjs/core/lib/scss/variables" as bp;
 +
-+.#{$bp-ns}-button > div {
++.#{bp.$bp-ns}-button > div {
 +    border: 1px solid black;
 +}
 ```

--- a/packages/stylelint-plugin/src/rules/no-color-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-color-literal.ts
@@ -21,6 +21,7 @@ import { Colors } from "@blueprintjs/colors";
 
 import { checkImportExists } from "../utils/checkImportExists";
 import {
+    BpSassNamespace,
     BpVariableImportMap,
     BpVariablePrefixMap,
     CssExtensionMap,
@@ -83,10 +84,15 @@ export default stylelint.createPlugin(
             const importPath = options?.variablesImportPath?.[cssSyntaxType] ?? BpVariableImportMap[cssSyntaxType];
             const extension = CssExtensionMap[cssSyntaxType];
             if (hasBpVariablesImport == null) {
-                hasBpVariablesImport = checkImportExists(root, [importPath, `${importPath}.${extension}`]);
+                hasBpVariablesImport = checkImportExists(
+                    cssSyntaxType,
+                    root,
+                    [importPath, `${importPath}.${extension}`],
+                    BpSassNamespace,
+                );
             }
             if (!hasBpVariablesImport) {
-                insertImport(root, context, importPath);
+                insertImport(cssSyntaxType, root, context, importPath, BpSassNamespace);
                 hasBpVariablesImport = true;
             }
         }
@@ -106,7 +112,7 @@ export default stylelint.createPlugin(
                 }
                 if (context.fix && !disableFix) {
                     assertBpVariablesImportExists(cssSyntax);
-                    node.value = cssVar;
+                    node.value = `${BpSassNamespace}.${cssVar}`;
                     needsFix = true;
                 } else {
                     const message =

--- a/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
@@ -21,6 +21,7 @@ import type { PluginContext, PostcssResult } from "stylelint";
 import { checkImportExists } from "../utils/checkImportExists";
 import {
     BpPrefixVariableMap,
+    BpSassNamespace,
     BpVariableImportMap,
     CssExtensionMap,
     CssSyntax,
@@ -83,10 +84,15 @@ export default stylelint.createPlugin(
             const importPath = options?.variablesImportPath?.[cssSyntaxType] ?? BpVariableImportMap[cssSyntaxType];
             const extension = CssExtensionMap[cssSyntaxType];
             if (hasBpVariablesImport == null) {
-                hasBpVariablesImport = checkImportExists(root, [importPath, `${importPath}.${extension}`]);
+                hasBpVariablesImport = checkImportExists(
+                    cssSyntaxType,
+                    root,
+                    [importPath, `${importPath}.${extension}`],
+                    BpSassNamespace,
+                );
             }
             if (!hasBpVariablesImport) {
-                insertImport(root, context, importPath);
+                insertImport(cssSyntaxType, root, context, importPath, BpSassNamespace);
                 hasBpVariablesImport = true;
             }
         }

--- a/packages/stylelint-plugin/src/utils/checkImportExists.ts
+++ b/packages/stylelint-plugin/src/utils/checkImportExists.ts
@@ -31,19 +31,11 @@ export function checkImportExists(
     const walkRegex = cssSyntaxType === CssSyntax.LESS ? /^import$/i : /^use$/i;
     root.walkAtRules(walkRegex, atRule => {
         for (const path of typeof importPath === "string" ? [importPath] : importPath) {
-            if (cssSyntaxType === CssSyntax.LESS) {
-                if (stripQuotes(stripLessReference(atRule.params)) === path) {
-                    hasBpVarsImport = true;
-                    return false; // Stop the iteration
-                }
-                continue;
+            if (stripQuotes(stripLessReference(atRule.params)) === path) {
+                hasBpVarsImport = true;
+                return false; // Stop the iteration
             }
-            if (namespace === undefined) {
-                if (stripQuotes(atRule.params)) {
-                    hasBpVarsImport = true;
-                    return false; // Stop the iteration
-                }
-            } else {
+            if (namespace !== undefined) {
                 const asText = ` as ${namespace}`;
                 if (
                     atRule.params.endsWith(asText) &&

--- a/packages/stylelint-plugin/src/utils/cssSyntax.ts
+++ b/packages/stylelint-plugin/src/utils/cssSyntax.ts
@@ -29,13 +29,15 @@ export const BpVariablePrefixMap: Record<Exclude<CssSyntax, CssSyntax.OTHER>, st
     [CssSyntax.LESS]: "@",
 };
 
+export const BpSassNamespace = "bp";
+
 export const BpPrefixVariableMap: Record<Exclude<CssSyntax, CssSyntax.OTHER>, string> = {
-    [CssSyntax.SASS]: "#{$bp-ns}",
+    [CssSyntax.SASS]: `#{${BpSassNamespace}.$bp-ns}`,
     [CssSyntax.LESS]: "@{bp-ns}",
 };
 
 export const BpVariableImportMap: Record<Exclude<CssSyntax, CssSyntax.OTHER>, string> = {
-    [CssSyntax.SASS]: "~@blueprintjs/core/lib/scss/variables",
+    [CssSyntax.SASS]: "@blueprintjs/core/lib/scss/variables.scss",
     [CssSyntax.LESS]: "~@blueprintjs/core/lib/less/variables",
 };
 

--- a/packages/stylelint-plugin/src/utils/cssSyntax.ts
+++ b/packages/stylelint-plugin/src/utils/cssSyntax.ts
@@ -32,7 +32,7 @@ export const BpVariablePrefixMap: Record<Exclude<CssSyntax, CssSyntax.OTHER>, st
 export const BpSassNamespace = "bp";
 
 export const BpPrefixVariableMap: Record<Exclude<CssSyntax, CssSyntax.OTHER>, string> = {
-    [CssSyntax.SASS]: `#{${BpSassNamespace}.$bp-ns}`,
+    [CssSyntax.SASS]: `#{${BpSassNamespace}.$ns}`,
     [CssSyntax.LESS]: "@{bp-ns}",
 };
 

--- a/packages/stylelint-plugin/test/checkImportExists.test.js
+++ b/packages/stylelint-plugin/test/checkImportExists.test.js
@@ -18,11 +18,12 @@ const { expect } = require("chai");
 const postcss = require("postcss");
 
 const { checkImportExists } = require("../lib/utils/checkImportExists");
+const { CssSyntax } = require("../lib/utils/cssSyntax");
 
 describe("checkImportExists", () => {
     it("Returns false if no imports exist", () => {
         const root = postcss.parse(`.some-class { width: 10px }`);
-        expect(checkImportExists(root, "some_path")).to.be.false;
+        expect(checkImportExists(CssSyntax.LESS, root, "some_path")).to.be.false;
     });
 
     it("Returns false if imports exist but not the one we want", () => {
@@ -34,7 +35,7 @@ describe("checkImportExists", () => {
     width: 10px;
 }
     `);
-        expect(checkImportExists(root, "some_path")).to.be.false;
+        expect(checkImportExists(CssSyntax.LESS, root, "some_path")).to.be.false;
     });
 
     it("Returns true if our import exists", () => {
@@ -46,7 +47,7 @@ describe("checkImportExists", () => {
     width: 10px;
 }
     `);
-        expect(checkImportExists(root, "some_path")).to.be.true;
+        expect(checkImportExists(CssSyntax.LESS, root, "some_path")).to.be.true;
     });
 
     it("Returns true if our import exists, and works with single quotes", () => {
@@ -58,21 +59,33 @@ describe("checkImportExists", () => {
     width: 10px;
 }
     `);
-        expect(checkImportExists(root, "some_path")).to.be.true;
+        expect(checkImportExists(CssSyntax.LESS, root, "some_path")).to.be.true;
     });
 
-    it("Can match multiple paths", () => {
+    it("Returns true if our sass import exists, and works with single quotes", () => {
         const root = postcss.parse(`
-@import 'some_path.scss';
+@use 'some_path1';
+@use 'some_path2';
+@use 'some_path' as foo;
 .some-class {
     width: 10px;
 }
     `);
-        expect(checkImportExists(root, ["some_path", "some_path.scss"])).to.be.true;
+        expect(checkImportExists(CssSyntax.SASS, root, "some_path", "foo")).to.be.true;
+    });
+
+    it("Can match multiple paths", () => {
+        const root = postcss.parse(`
+@use 'some_path.scss';
+.some-class {
+    width: 10px;
+}
+    `);
+        expect(checkImportExists(CssSyntax.SASS, root, ["some_path", "some_path.scss"])).to.be.true;
     });
 
     it("Handles less references", () => {
         const root = postcss.parse(`@import (reference) "some_path";`);
-        expect(checkImportExists(root, "some_path")).to.be.true;
+        expect(checkImportExists(CssSyntax.LESS, root, "some_path")).to.be.true;
     });
 });

--- a/packages/stylelint-plugin/test/insertImport.test.js
+++ b/packages/stylelint-plugin/test/insertImport.test.js
@@ -17,12 +17,13 @@
 const { expect } = require("chai");
 const postcss = require("postcss");
 
+const { CssSyntax } = require("../lib/utils/cssSyntax");
 const { insertImport } = require("../lib/utils/insertImport");
 
 describe("insertImport", () => {
     it("Inserts an import at the top of the file when no imports are present", () => {
         const root = postcss.parse(`.some-class { width: 10px }`);
-        insertImport(root, { newline: "\n" }, "some_path");
+        insertImport(CssSyntax.LESS, root, { newline: "\n" }, "some_path");
         expect(root.toString()).to.be.eq(`@import "some_path";
 
 .some-class { width: 10px }`);
@@ -32,7 +33,7 @@ describe("insertImport", () => {
         const root = postcss.parse(`
 @import "some_path1";
 .some-class { width: 10px }`);
-        insertImport(root, { newline: "\n" }, "some_path2");
+        insertImport(CssSyntax.LESS, root, { newline: "\n" }, "some_path2");
         expect(root.toString()).to.be.eq(`
 @import "some_path1";
 @import "some_path2";
@@ -44,7 +45,7 @@ describe("insertImport", () => {
 /* copyright 2021 */
 
 .some-class { width: 10px }`);
-        insertImport(root, { newline: "\n" }, "some_path");
+        insertImport(CssSyntax.LESS, root, { newline: "\n" }, "some_path");
         expect(root.toString()).to.be.eq(`
 /* copyright 2021 */
 
@@ -61,13 +62,32 @@ describe("insertImport", () => {
 @import "some_path2";
 
 .some-class { width: 10px }`);
-        insertImport(root, { newline: "\n" }, "some_path3");
+        insertImport(CssSyntax.LESS, root, { newline: "\n" }, "some_path3");
         expect(root.toString()).to.be.eq(`
 /* copyright 2021 */
 
 @import "some_path1";
 @import "some_path2";
 @import "some_path3";
+
+.some-class { width: 10px }`);
+    });
+
+    it("Inserts a sass import below other sass imports if the copyright header exists", () => {
+        const root = postcss.parse(`
+/* copyright 2021 */
+
+@use "some_path1";
+@use "some_path2";
+
+.some-class { width: 10px }`);
+        insertImport(CssSyntax.SASS, root, { newline: "\n" }, "some_path3", "foo");
+        expect(root.toString()).to.be.eq(`
+/* copyright 2021 */
+
+@use "some_path1";
+@use "some_path2";
+@use "some_path3" as foo;
 
 .some-class { width: 10px }`);
     });
@@ -82,7 +102,7 @@ describe("insertImport", () => {
 
 .some-class { width: 10px }
     `);
-        insertImport(root, { newline: "\n" }, "some_path");
+        insertImport(CssSyntax.LESS, root, { newline: "\n" }, "some_path");
         expect(root.toString()).to.be.eq(`@import "some_path";
 
 @media only screen and (max-width: 600px) {

--- a/packages/stylelint-plugin/test/no-prefix-literal.test.js
+++ b/packages/stylelint-plugin/test/no-prefix-literal.test.js
@@ -198,8 +198,8 @@ describe("no-prefix-literal", () => {
             expect(warnings).lengthOf(0);
 
             const fixedSourceContents = fs.readFileSync(mutableFixturePath, { encoding: "utf-8" });
-            expect(fixedSourceContents).to.contain(`@import "~@blueprintjs/core/lib/scss/variables";`);
-            expect(fixedSourceContents).to.contain(".#{$bp-ns}-tag {");
+            expect(fixedSourceContents).to.contain(`@use "@blueprintjs/core/lib/scss/variables.scss" as bp;`);
+            expect(fixedSourceContents).to.contain(".#{bp.$bp-ns}-tag {");
         });
     });
 });

--- a/packages/stylelint-plugin/test/no-prefix-literal.test.js
+++ b/packages/stylelint-plugin/test/no-prefix-literal.test.js
@@ -199,7 +199,7 @@ describe("no-prefix-literal", () => {
 
             const fixedSourceContents = fs.readFileSync(mutableFixturePath, { encoding: "utf-8" });
             expect(fixedSourceContents).to.contain(`@use "@blueprintjs/core/lib/scss/variables.scss" as bp;`);
-            expect(fixedSourceContents).to.contain(".#{bp.$bp-ns}-tag {");
+            expect(fixedSourceContents).to.contain(".#{bp.$ns}-tag {");
         });
     });
 });


### PR DESCRIPTION
`@blueprintjs/stylelint-plugin`  now supports Sass `@use` and drops support for Sass `@import`. Less `@import` support remains.