### PR TITLE
[core] fix: improve contrast for disabled inputs in iOS

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -142,11 +142,6 @@ $control-group-stack: (
   cursor: not-allowed;
   resize: none;
 
-  @supports (-webkit-touch-callout: none) {
-    opacity: 1;
-    -webkit-text-fill-color: $input-color-disabled;
-  }
-
   &::placeholder {
     color: $input-color-disabled;
   }

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -142,6 +142,11 @@ $control-group-stack: (
   cursor: not-allowed;
   resize: none;
 
+  @supports (-webkit-touch-callout: none) {
+    opacity: 1;
+    -webkit-text-fill-color: $input-color-disabled;
+  }
+
   &::placeholder {
     color: $input-color-disabled;
   }

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -58,6 +58,16 @@ Styleguide input
   }
 }
 
+@supports (-webkit-touch-callout: none) {
+  input.#{$ns}-input {
+    &:disabled,
+    &.#{$ns}-disabled {
+      opacity: 1;
+      -webkit-text-fill-color: $input-color-disabled;
+    }
+  }
+}
+
 /*
 Search inputs
 

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -58,15 +58,22 @@ Styleguide input
   }
 }
 
+// for iOS support
 @supports (-webkit-touch-callout: none) {
+  // only html input elements require a fix on iOS
   input.#{$ns}-input {
     &:disabled,
     &.#{$ns}-disabled {
       opacity: 1;
       -webkit-text-fill-color: $input-color-disabled;
+
+      .#{$ns}-dark & {
+        -webkit-text-fill-color: $dark-input-color-disabled;
+      }
     }
   }
 }
+
 
 /*
 Search inputs


### PR DESCRIPTION
#### Checklist

No additional documentation/tests necessary

#### Changes proposed in this pull request:

Fix or iOS specific styling, based on:
https://stackoverflow.com/questions/262158/disabled-input-text-color-on-ios
and:
https://stackoverflow.com/questions/30102792/css-media-query-to-target-only-ios-devices

#### Reviewers should focus on:

#### Screenshot

##### Before

<img width="481" alt="Screenshot 2022-10-04 at 12 06 38" src="https://user-images.githubusercontent.com/2834839/193803204-e74f5036-afab-477f-b25e-286ca4490a25.png">

<img width="482" alt="Screenshot 2022-10-04 at 12 05 21" src="https://user-images.githubusercontent.com/2834839/193803318-f9dbcdc5-c19b-42ee-af15-e18c5e93a85f.png">

##### After

<img width="1208" alt="Screenshot 2022-10-04 at 12 07 42" src="https://user-images.githubusercontent.com/2834839/193803402-f3b60b0a-113e-4449-9999-de04034f7094.png">

<img width="471" alt="Screenshot 2022-10-04 at 12 02 13" src="https://user-images.githubusercontent.com/2834839/193803441-cb523353-eaf4-420c-984e-152fc24357cc.png">
