### PR TITLE
[webpack-build-scripts] fix: bump react-refresh-webpack-plugin

### DIFF
--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -6,7 +6,7 @@
         "test": "exit 0"
     },
     "dependencies": {
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.4",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
         "assert": "^2.0.0",
         "autoprefixer": "^10.4.4",
         "css-loader": "^6.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1351,10 +1351,10 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@pmmmwh/react-refresh-webpack-plugin@^0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.4.tgz#df0d0d855fc527db48aac93c218a0bf4ada41f99"
-  integrity sha512-zZbZeHQDnoTlt2AF+diQT0wsSXpvWiaIOZwBRdltNFhG1+I3ozyaw7U/nBiUwyJ0D+zwdXp0E3bWOl38Ag2BMw==
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz#58f8217ba70069cc6a73f5d7e05e85b458c150e2"
+  integrity sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==
   dependencies:
     ansi-html-community "^0.0.8"
     common-path-prefix "^3.0.0"


### PR DESCRIPTION
Fixes https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/565, which we hit after the react-refresh upgrade in https://github.com/palantir/blueprint/pull/5633