### PR TITLE
break: migrate webpack + karma build scripts to ES modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const config = require("./packages/eslint-config");
 
 const xtends = ["./packages/eslint-config"];
@@ -38,13 +53,14 @@ module.exports = {
             },
         },
         {
-            files: ["**/webpack.config.js"],
+            files: ["**/webpack.config.{js,mjs}"],
             env: {
                 browser: false,
                 node: true,
             },
             rules: {
                 "prefer-object-spread": "off",
+                "import/no-default-export": "off",
                 "import/no-extraneous-dependencies": [
                     "error",
                     {

--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -2,35 +2,30 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            dirname: __dirname,
+            coverageExcludes: [
+                // not worth full coverage
+                "src/accessibility/*",
+                "src/common/abstractComponent*",
+                "src/common/abstractPureComponent*",
+                "src/compatibility/*",
 
-module.exports = function (config) {
-    const coverageExcludes = [
-        // not worth full coverage
-        "src/accessibility/*",
-        "src/common/abstractComponent*",
-        "src/common/abstractPureComponent*",
-        "src/compatibility/*",
+                // HACKHACK: for karma upgrade only
+                "src/common/refs.ts",
 
-        // HACKHACK: for karma upgrade only
-        "src/common/refs.ts",
+                // HACKHACK: need to add hotkeys v2 tests
+                "src/components/hotkeys/hotkeysDialog2.tsx",
+                "src/components/hotkeys/hotkeysTarget2.tsx",
+                "src/context/hotkeys/hotkeysProvider.tsx",
 
-        // HACKHACK: need to add hotkeys v2 tests
-        "src/components/hotkeys/hotkeysDialog2.tsx",
-        "src/components/hotkeys/hotkeysTarget2.tsx",
-        "src/context/hotkeys/hotkeysProvider.tsx",
-
-        // HACKHACK: see https://github.com/palantir/blueprint/issues/5511
-        "src/components/portal/portal2.tsx",
-        "src/context/portal/portalProvider.tsx",
-    ];
-
-    const baseConfig = createKarmaConfig({
-        dirname: __dirname,
-        coverageExcludes,
-    });
-    config.set(baseConfig);
-    config.set({
-        // overrides here
-    });
+                // HACKHACK: see https://github.com/palantir/blueprint/issues/5511
+                "src/components/portal/portal2.tsx",
+                "src/context/portal/portalProvider.tsx",
+            ],
+        }),
+    );
 };

--- a/packages/core/webpack.config.mjs
+++ b/packages/core/webpack.config.mjs
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +14,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        table: ["./src/index.ts"],
+        core: "./src/index.ts",
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Table"],
+        library: ["Blueprint", "Core"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/datetime/karma.conf.js
+++ b/packages/datetime/karma.conf.js
@@ -2,17 +2,11 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
-const path = require("path");
-const coreManifest = require("../core/package.json");
-const packageManifest = require("./package.json");
-
-module.exports = function (config) {
-    const baseConfig = createKarmaConfig({
-        dirname: __dirname,
-    });
-    config.set(baseConfig);
-    config.set({
-        // overrides here
-    });
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            dirname: __dirname,
+        }),
+    );
 };

--- a/packages/datetime/webpack.config.mjs
+++ b/packages/datetime/webpack.config.mjs
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        "docs-theme": ["./src/index.ts"],
+        datetime: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "DocsTheme"],
+        library: ["Blueprint", "Datetime"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/datetime2/karma.conf.js
+++ b/packages/datetime2/karma.conf.js
@@ -2,18 +2,15 @@
  * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
-
-module.exports = function (config) {
-    const baseConfig = createKarmaConfig({
-        dirname: __dirname,
-        coverageExcludes: [
-            // HACKHACK: needs coverage
-            "src/components/date-range-input2/*",
-        ],
-    });
-    config.set(baseConfig);
-    config.set({
-        // overrides here
-    });
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            dirname: __dirname,
+            coverageExcludes: [
+                // HACKHACK: needs coverage
+                "src/components/date-range-input2/*",
+            ],
+        }),
+    );
 };

--- a/packages/datetime2/webpack.config.mjs
+++ b/packages/datetime2/webpack.config.mjs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +13,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        datetime: ["./src/index.ts"],
+        datetime2: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Datetime"],
+        library: ["Blueprint", "Datetime2"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -4,9 +4,9 @@
     "description": "Blueprint Demo App",
     "private": true,
     "scripts": {
-        "bundle": "webpack --config ./webpack.config.js",
+        "bundle": "webpack",
         "clean": "rm -rf dist/*",
-        "dev": "webpack-dev-server --config ./webpack.config.js --host 0.0.0.0",
+        "dev": "webpack-dev-server",
         "dist": "cross-env NODE_ENV=production yarn bundle",
         "lint": "run-p lint:scss lint:es",
         "lint:scss": "sass-lint",

--- a/packages/demo-app/webpack.config.mjs
+++ b/packages/demo-app/webpack.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,27 +13,29 @@
  * limitations under the License.
  */
 
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const path = require("path");
+// @ts-check
 
-const { baseConfig } = require("@blueprintjs/webpack-build-scripts");
+import CopyWebpackPlugin from "copy-webpack-plugin";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        "docs-app": [
+        "demo-app": [
             // environment polyfills
             "dom4",
             "./polyfill.js",
             // bundle entry points
             "./src/index.tsx",
-            "./src/index.scss",
         ],
     },
 
     output: {
         filename: "[name].js",
         publicPath: "",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 
     plugins: baseConfig.plugins.concat([

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -4,9 +4,9 @@
     "description": "Blueprint Documentation Site",
     "private": true,
     "scripts": {
-        "bundle": "webpack --config ./webpack.config.js",
+        "bundle": "webpack",
         "clean": "rm -rf dist/*",
-        "dev": "webpack-dev-server --config ./webpack.config.js --host 0.0.0.0",
+        "dev": "webpack-dev-server",
         "dist": "cross-env NODE_ENV=production yarn bundle",
         "lint": "run-p lint:scss lint:es",
         "lint:scss": "sass-lint",

--- a/packages/docs-app/webpack.config.mjs
+++ b/packages/docs-app/webpack.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +13,30 @@
  * limitations under the License.
  */
 
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const path = require("path");
+// @ts-check
 
-const { baseConfig } = require("@blueprintjs/webpack-build-scripts");
+import CopyWebpackPlugin from "copy-webpack-plugin";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        features: ["./src/index.scss", "./src/features.tsx"],
-        index: ["./src/index.scss", "./src/index.tsx"],
+        "docs-app": [
+            // environment polyfills
+            "dom4",
+            "./polyfill.js",
+            // bundle entry points
+            "./src/index.tsx",
+            "./src/index.scss",
+        ],
     },
 
     output: {
-        filename: "[name].bundle.js",
+        filename: "[name].js",
         publicPath: "",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 
     plugins: baseConfig.plugins.concat([
@@ -35,7 +44,7 @@ module.exports = Object.assign({}, baseConfig, {
             patterns: [
                 // to: is relative to dist/
                 { from: "src/index.html", to: "." },
-                { from: "src/features.html", to: "." },
+                { from: "src/assets/favicon.png", to: "assets" },
             ],
         }),
     ]),

--- a/packages/docs-theme/webpack.config.mjs
+++ b/packages/docs-theme/webpack.config.mjs
@@ -13,26 +13,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        icons: ["./src/index.ts"],
+        "docs-theme": ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Icons"],
+        library: ["Blueprint", "DocsTheme"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
-    },
-
-    performance: {
-        maxAssetSize: 500000,
-        maxEntrypointSize: 500000,
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -14,9 +14,10 @@
  */
 
 const path = require("path");
-const tsEslintRules = require("./typescript-eslint-rules.json");
+
 const eslintBuiltinRules = require("./eslint-builtin-rules.json");
 const eslintPluginRules = require("./eslint-plugin-rules.json");
+const tsEslintRules = require("./typescript-eslint-rules.json");
 
 /**
  * Enable @blueprintjs/eslint-plugin.
@@ -25,7 +26,7 @@ const eslintPluginRules = require("./eslint-plugin-rules.json");
 module.exports = {
     plugins: ["@blueprintjs", "header", "import", "jsdoc", "react"],
     extends: ["plugin:@blueprintjs/recommended", "plugin:import/typescript"],
-    parserOptions: { ecmaVersion: 2017 },
+    parserOptions: { ecmaVersion: 2022 },
     settings: {
         "import/internal-regex": "^@blueprintjs",
     },
@@ -37,14 +38,16 @@ module.exports = {
     },
     overrides: [
         {
-            files: ["*.js", "*.mjs"],
+            files: ["**/*.{js,mjs}"],
             env: {
                 node: true,
-                es6: true,
             },
             parserOptions: {
                 ecmaVersion: 2022,
                 sourceType: "module",
+            },
+            rules: {
+                "import/no-default-export": "off",
             },
         },
         {

--- a/packages/icons/webpack.config.mjs
+++ b/packages/icons/webpack.config.mjs
@@ -1,5 +1,5 @@
-/**
- * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,21 +13,29 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "path";
+import { cwd } from "process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        datetime2: ["./src/index.ts"],
+        icons: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Datetime2"],
+        library: ["Blueprint", "Icons"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
+    },
+
+    performance: {
+        maxAssetSize: 500000,
+        maxEntrypointSize: 500000,
     },
 });

--- a/packages/karma-build-scripts/index.js
+++ b/packages/karma-build-scripts/index.js
@@ -1,9 +1,0 @@
-/*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
- */
-
-const createKarmaConfig = require("./createKarmaConfig");
-
-module.exports = {
-    createKarmaConfig,
-};

--- a/packages/karma-build-scripts/index.mjs
+++ b/packages/karma-build-scripts/index.mjs
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ */
+
+// @ts-check
+
+export { default as createKarmaConfig } from "./createKarmaConfig.mjs";

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -2,6 +2,7 @@
     "name": "@blueprintjs/karma-build-scripts",
     "version": "3.1.1",
     "description": "Karma build scripts for @blueprintjs packages",
+    "type": "module",
     "main": "index.mjs",
     "scripts": {
         "test": "exit 0"

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -2,6 +2,7 @@
     "name": "@blueprintjs/karma-build-scripts",
     "version": "3.1.1",
     "description": "Karma build scripts for @blueprintjs packages",
+    "main": "index.mjs",
     "scripts": {
         "test": "exit 0"
     },

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -4,9 +4,9 @@
     "description": "Blueprint landing page",
     "private": true,
     "scripts": {
-        "bundle": "webpack --config ./webpack.config.js",
+        "bundle": "webpack",
         "clean": "rm -rf dist/*",
-        "dev": "webpack-dev-server --config ./webpack.config.js",
+        "dev": "webpack-dev-server",
         "dist": "cross-env NODE_ENV=production yarn bundle",
         "lint": "run-p lint:scss lint:es",
         "lint:scss": "sass-lint",

--- a/packages/landing-app/webpack.config.mjs
+++ b/packages/landing-app/webpack.config.mjs
@@ -13,12 +13,15 @@
  * limitations under the License.
  */
 
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const path = require("path");
+// @ts-check
 
-const { baseConfig } = require("@blueprintjs/webpack-build-scripts");
+import CopyWebpackPlugin from "copy-webpack-plugin";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
         "blueprint-landing": ["./src/index.tsx", "./src/index.scss"],
     },
@@ -39,7 +42,7 @@ module.exports = Object.assign({}, baseConfig, {
     output: {
         filename: "[name].js",
         publicPath: "",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 
     plugins: baseConfig.plugins.concat([

--- a/packages/popover2/karma.conf.js
+++ b/packages/popover2/karma.conf.js
@@ -2,21 +2,18 @@
  * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
-
-module.exports = function (config) {
-    const baseConfig = createKarmaConfig({
-        dirname: __dirname,
-        coverageExcludes: ["src/popover2Arrow.tsx"],
-        coverageOverrides: {
-            "src/customModifiers.ts": {
-                lines: 66,
-                statements: 66,
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            dirname: __dirname,
+            coverageExcludes: ["src/popover2Arrow.tsx"],
+            coverageOverrides: {
+                "src/customModifiers.ts": {
+                    lines: 66,
+                    statements: 66,
+                },
             },
-        },
-    });
-    config.set(baseConfig);
-    config.set({
-        // overrides here
-    });
+        }),
+    );
 };

--- a/packages/popover2/webpack.config.mjs
+++ b/packages/popover2/webpack.config.mjs
@@ -1,5 +1,6 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,12 +14,24 @@
  * limitations under the License.
  */
 
-const COMMON_EXTERNALS = require("./externals");
-const baseConfig = require("./webpack.config.base");
-const karmaConfig = require("./webpack.config.karma");
+// @ts-check
 
-module.exports = {
-    baseConfig,
-    karmaConfig,
-    COMMON_EXTERNALS,
-};
+import { resolve } from "node:path";
+import { cwd } from "node:process";
+
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
+    entry: {
+        popover2: "./src/index.ts",
+    },
+
+    externals: COMMON_EXTERNALS,
+
+    output: {
+        filename: "[name].bundle.js",
+        library: ["Blueprint", "Popover2"],
+        libraryTarget: "umd",
+        path: resolve(cwd(), "./dist"),
+    },
+});

--- a/packages/select/karma.conf.js
+++ b/packages/select/karma.conf.js
@@ -2,12 +2,12 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
-
-module.exports = function (config) {
-    const baseConfig = createKarmaConfig({
-        dirname: __dirname,
-        coverageExcludes: ["src/__examples__/*"],
-    });
-    config.set(baseConfig);
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            dirname: __dirname,
+            coverageExcludes: ["src/__examples__/*"],
+        }),
+    );
 };

--- a/packages/select/webpack.config.mjs
+++ b/packages/select/webpack.config.mjs
@@ -13,21 +13,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        timezone: ["./src/index.ts"],
+        select: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Timezone"],
+        library: ["Blueprint", "Select"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -4,9 +4,9 @@
     "description": "Dev application for @blueprintjs/table",
     "private": true,
     "scripts": {
-        "bundle": "webpack --config ./webpack.config.js",
+        "bundle": "webpack",
         "clean": "rm -rf dist/*",
-        "dev": "webpack-dev-server --config ./webpack.config.js",
+        "dev": "webpack-dev-server",
         "dist": "cross-env NODE_ENV=production yarn bundle",
         "lint": "npm-run-all -p lint:scss lint:es",
         "lint:scss": "sass-lint",

--- a/packages/table-dev-app/webpack.config.mjs
+++ b/packages/table-dev-app/webpack.config.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -13,26 +13,24 @@
  * limitations under the License.
  */
 
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const path = require("path");
+// @ts-check
 
-const { baseConfig } = require("@blueprintjs/webpack-build-scripts");
+import CopyWebpackPlugin from "copy-webpack-plugin";
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        "demo-app": [
-            // environment polyfills
-            "dom4",
-            "./polyfill.js",
-            // bundle entry points
-            "./src/index.tsx",
-        ],
+        features: ["./src/index.scss", "./src/features.tsx"],
+        index: ["./src/index.scss", "./src/index.tsx"],
     },
 
     output: {
-        filename: "[name].js",
+        filename: "[name].bundle.js",
         publicPath: "",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 
     plugins: baseConfig.plugins.concat([
@@ -40,7 +38,7 @@ module.exports = Object.assign({}, baseConfig, {
             patterns: [
                 // to: is relative to dist/
                 { from: "src/index.html", to: "." },
-                { from: "src/assets/favicon.png", to: "assets" },
+                { from: "src/features.html", to: "." },
             ],
         }),
     ]),

--- a/packages/table/karma.conf.js
+++ b/packages/table/karma.conf.js
@@ -2,34 +2,32 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
-
 const REACT = process.env.REACT || "16";
 
-module.exports = function (config) {
-    const baseConfig = createKarmaConfig({
-        dirname: __dirname,
-        coverageOverrides: {
-            "src/cell/cell*": {
-                lines: 70,
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            dirname: __dirname,
+            coverageOverrides: {
+                "src/cell/cell*": {
+                    lines: 70,
+                },
+                "src/common/clipboard*": {
+                    lines: 0,
+                    statements: 0,
+                },
+                "src/headers/headerCell*": {
+                    lines: 70,
+                    statements: 70,
+                },
+                "src/tableHotkeys*": {
+                    lines: 70,
+                    statements: 70,
+                },
             },
-            "src/common/clipboard*": {
-                lines: 0,
-                statements: 0,
-            },
-            "src/headers/headerCell*": {
-                lines: 70,
-                statements: 70,
-            },
-            "src/tableHotkeys*": {
-                lines: 70,
-                statements: 70,
-            },
-        },
-        coverageExcludes: REACT === "15" ? ["src/table2.tsx", "src/table2Utils.ts", "src/cell/editableCell2.tsx"] : [],
-    });
-    config.set(baseConfig);
-    config.set({
-        // overrides here
-    });
+            coverageExcludes:
+                REACT === "15" ? ["src/table2.tsx", "src/table2Utils.ts", "src/cell/editableCell2.tsx"] : [],
+        }),
+    );
 };

--- a/packages/table/webpack.config.mjs
+++ b/packages/table/webpack.config.mjs
@@ -1,6 +1,5 @@
 /*
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,21 +13,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        core: "./src/index.ts",
+        table: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Core"],
+        library: ["Blueprint", "Table"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/timezone/karma.conf.js
+++ b/packages/timezone/karma.conf.js
@@ -2,15 +2,12 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const { createKarmaConfig } = require("@blueprintjs/karma-build-scripts");
-const path = require("path");
-const coreManifest = require("../core/package.json");
-const packageManifest = require("./package.json");
-
-module.exports = function (config) {
-    const baseConfig = createKarmaConfig({
-        coverage: false,
-        dirname: __dirname,
-    });
-    config.set(baseConfig);
+module.exports = async function (config) {
+    const { createKarmaConfig } = await import("@blueprintjs/karma-build-scripts");
+    config.set(
+        createKarmaConfig({
+            coverage: false,
+            dirname: __dirname,
+        }),
+    );
 };

--- a/packages/timezone/webpack.config.mjs
+++ b/packages/timezone/webpack.config.mjs
@@ -13,21 +13,24 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
+import { resolve } from "node:path";
+import { cwd } from "node:process";
 
-module.exports = Object.assign({}, baseConfig, {
+import { baseConfig, COMMON_EXTERNALS } from "@blueprintjs/webpack-build-scripts";
+
+export default Object.assign({}, baseConfig, {
     entry: {
-        select: ["./src/index.ts"],
+        timezone: ["./src/index.ts"],
     },
 
     externals: COMMON_EXTERNALS,
 
     output: {
         filename: "[name].bundle.js",
-        library: ["Blueprint", "Select"],
+        library: ["Blueprint", "Timezone"],
         libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
+        path: resolve(cwd(), "./dist"),
     },
 });

--- a/packages/webpack-build-scripts/externals.mjs
+++ b/packages/webpack-build-scripts/externals.mjs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-module.exports = externalize({
+export const COMMON_EXTERNALS = externalize({
     "@blueprintjs/core": ["Blueprint", "Core"],
     "@blueprintjs/icons": ["Blueprint", "Icons"],
     "@blueprintjs/datetime": ["Blueprint", "Datetime"],

--- a/packages/webpack-build-scripts/index.mjs
+++ b/packages/webpack-build-scripts/index.mjs
@@ -1,6 +1,5 @@
 /*
- * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
- *
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,21 +13,8 @@
  * limitations under the License.
  */
 
-const path = require("path");
+// @ts-check
 
-const { baseConfig, COMMON_EXTERNALS } = require("@blueprintjs/webpack-build-scripts");
-
-module.exports = Object.assign({}, baseConfig, {
-    entry: {
-        popover2: "./src/index.ts",
-    },
-
-    externals: COMMON_EXTERNALS,
-
-    output: {
-        filename: "[name].bundle.js",
-        library: ["Blueprint", "Popover2"],
-        libraryTarget: "umd",
-        path: path.resolve(__dirname, "./dist"),
-    },
-});
+export { COMMON_EXTERNALS } from "./externals.mjs";
+export { default as baseConfig } from "./webpack.config.base.mjs";
+export { default as karmaConfig } from "./webpack.config.karma.mjs";

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -2,6 +2,7 @@
     "name": "@blueprintjs/webpack-build-scripts",
     "version": "3.2.1",
     "description": "Webpack build scripts for @blueprintjs packages",
+    "main": "index.mjs",
     "scripts": {
         "test": "exit 0"
     },
@@ -19,6 +20,7 @@
         "postcss-loader": "^7.0.1",
         "process": "^0.11.10",
         "react-refresh": "^0.14.0",
+        "react-refresh-typescript": "^2.0.7",
         "sass": "^1.55.0",
         "sass-loader": "^13.0.2",
         "source-map-loader": "^4.0.0",

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -2,6 +2,7 @@
     "name": "@blueprintjs/webpack-build-scripts",
     "version": "3.2.1",
     "description": "Webpack build scripts for @blueprintjs packages",
+    "type": "module",
     "main": "index.mjs",
     "scripts": {
         "test": "exit 0"

--- a/packages/webpack-build-scripts/utils.mjs
+++ b/packages/webpack-build-scripts/utils.mjs
@@ -2,15 +2,18 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const path = require("path");
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { cwd } from "node:process";
 
 /**
  * Read a package name from package.json.
  */
-function getPackageName() {
+export function getPackageName() {
+    const require = createRequire(import.meta.url);
     let name;
     try {
-        name = require(path.join(process.cwd(), "package.json")).name;
+        name = require(join(cwd(), "package.json")).name;
         // strip NPM scope, if possible
         const nameSplit = name.split("/");
         if (nameSplit.length > 1) {
@@ -21,7 +24,3 @@ function getPackageName() {
     }
     return name;
 }
-
-module.exports = {
-    getPackageName,
-};

--- a/packages/webpack-build-scripts/webpack.config.base.mjs
+++ b/packages/webpack-build-scripts/webpack.config.base.mjs
@@ -129,7 +129,7 @@ export default {
         },
         historyApiFallback: true,
         https: false,
-        host: "local-ip",
+        host: "0.0.0.0",
         hot: true,
         open: false,
         port: DEV_PORT,

--- a/packages/webpack-build-scripts/webpack.config.base.mjs
+++ b/packages/webpack-build-scripts/webpack.config.base.mjs
@@ -13,32 +13,40 @@
  * limitations under the License.
  */
 
-const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
-const ForkTsCheckerNotifierWebpackPlugin = require("fork-ts-checker-notifier-webpack-plugin");
-const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
-const path = require("path");
-const webpack = require("webpack");
-const WebpackNotifierPlugin = require("webpack-notifier");
+// @ts-check
 
-const { getPackageName } = require("./utils");
+import ReactRefreshPlugin from "@pmmmwh/react-refresh-webpack-plugin";
+import autoprefixer from "autoprefixer";
+import cssnanoPlugin from "cssnano";
+import ForkTsCheckerNotifierPlugin from "fork-ts-checker-notifier-webpack-plugin";
+import ForkTsCheckerPlugin from "fork-ts-checker-webpack-plugin";
+import MiniCssExtractPlugin from "mini-css-extract-plugin";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { cwd, env } from "node:process";
+import ReactRefreshTypeScript from "react-refresh-typescript";
+import webpack from "webpack";
+import WebpackNotifierPlugin from "webpack-notifier";
+
+import { getPackageName } from "./utils.mjs";
 
 // globals
-const IS_PRODUCTION = process.env.NODE_ENV === "production";
-const DEV_PORT = process.env.PORT || 9000;
+const IS_PRODUCTION = env.NODE_ENV === "production";
+const DEV_PORT = env.PORT || 9001;
 const PACKAGE_NAME = getPackageName();
 
 /**
  * Configure plugins loaded based on environment.
+ *
+ * @type {webpack.WebpackPluginInstance[]}
  */
 const plugins = [
-    new ForkTsCheckerWebpackPlugin(
+    new ForkTsCheckerPlugin(
         IS_PRODUCTION
             ? {
                   async: false,
                   typescript: {
                       configFile: "src/tsconfig.json",
-                      useTypescriptIncrementalApi: true,
                       memoryLimit: 4096,
                   },
               }
@@ -63,11 +71,15 @@ const plugins = [
 
 if (!IS_PRODUCTION) {
     plugins.push(
-        new ReactRefreshWebpackPlugin(),
-        new ForkTsCheckerNotifierWebpackPlugin({ title: `${PACKAGE_NAME}: typescript`, excludeWarnings: false }),
+        new ReactRefreshPlugin(),
+        new ForkTsCheckerNotifierPlugin({ title: `${PACKAGE_NAME}: typescript`, excludeWarnings: false }),
         new WebpackNotifierPlugin({ title: `${PACKAGE_NAME}: webpack` }),
     );
 }
+
+// import.meta.resolve is still experimental under a CLI flag, so we create a require fn instead
+// see https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaresolvespecifier-parent
+const require = createRequire(import.meta.url);
 
 // Module loaders for .scss files, used in reverse order:
 // compile Sass, apply PostCSS, interpret CSS as modules.
@@ -89,16 +101,16 @@ const scssLoaders = [
         loader: require.resolve("postcss-loader"),
         options: {
             postcssOptions: {
-                plugins: [require("autoprefixer"), require("cssnano")({ preset: "default" })],
+                plugins: [autoprefixer, cssnanoPlugin({ preset: "default" })],
             },
         },
     },
     require.resolve("sass-loader"),
 ];
 
-module.exports = {
+export default {
     // to automatically find tsconfig.json
-    context: process.cwd(),
+    context: cwd(),
 
     devtool: IS_PRODUCTION ? false : "inline-source-map",
 
@@ -112,16 +124,17 @@ module.exports = {
             progress: true,
         },
         devMiddleware: {
-            index: path.resolve(process.cwd(), "src/index.html"),
+            index: resolve(cwd(), "src/index.html"),
             stats: "errors-only",
         },
         historyApiFallback: true,
         https: false,
+        host: "local-ip",
         hot: true,
         open: false,
         port: DEV_PORT,
         static: {
-            directory: path.resolve(process.cwd(), "src"),
+            directory: resolve(cwd(), "src"),
         },
     },
 
@@ -138,7 +151,10 @@ module.exports = {
                 loader: require.resolve("ts-loader"),
                 options: {
                     configFile: "src/tsconfig.json",
-                    transpileOnly: true,
+                    getCustomTransformers: () => ({
+                        before: IS_PRODUCTION ? [] : [ReactRefreshTypeScript()],
+                    }),
+                    transpileOnly: !IS_PRODUCTION,
                 },
             },
             {
@@ -160,7 +176,4 @@ module.exports = {
     resolve: {
         extensions: [".js", ".jsx", ".ts", ".tsx", ".scss"],
     },
-
-    // add support for IE11 (otherwise, webpack 5 uses some ES2015 syntax by default)
-    target: ["web", "es5"],
 };

--- a/packages/webpack-build-scripts/webpack.config.karma.mjs
+++ b/packages/webpack-build-scripts/webpack.config.karma.mjs
@@ -2,15 +2,23 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
-const webpack = require("webpack");
+// @ts-check
+
+import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
+import { createRequire } from "node:module";
+import { cwd } from "node:process";
+import webpack from "webpack";
+
+// import.meta.resolve is still experimental under a CLI flag, so we create a require fn instead
+// see https://nodejs.org/docs/latest-v16.x/api/esm.html#importmetaresolvespecifier-parent
+const require = createRequire(import.meta.url);
 
 /**
  * This differs significantly from the base webpack config, so we don't even end up extending from it.
  */
-module.exports = {
+export default {
     bail: true,
-    context: process.cwd(),
+    context: cwd(),
     devtool: "inline-source-map",
     mode: "development",
 
@@ -60,6 +68,7 @@ module.exports = {
     },
 
     plugins: [
+        // HACKHACK: we should use an alternative to `process` in frontend code
         new webpack.ProvidePlugin({
             process: "process/browser",
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -9894,6 +9894,11 @@ react-popper@^2.2.4:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
+react-refresh-typescript@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-refresh-typescript/-/react-refresh-typescript-2.0.7.tgz#ba91be2da4f1e86bba8629f1df0d4b9ff87b9970"
+  integrity sha512-KbuW57FauO11e6a9gU836sCm3M3z0b2+J2qPhUudg0QplOfz0eAF3gMeshcUC/ChfNLJCK1SZxvYmUtRxiZE5A==
+
 react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"


### PR DESCRIPTION
#### Changes proposed in this pull request:

- [webpack-build-scripts] break: migrate config scripts to ES modules
  - :warning: this package's API has not changed in shape, but it can no longer be imported using `require()` - you must use `await import()` or an ES import instead
- [webpack-build-scripts] break: change default dev server port to `9001`
- [webpack-build-scripts] fix(dev-server): add `host: "0.0.0.0"` option by default to obviate need for `--host 0.0.0.0` CLI argument
- [webpack-build-scripts] fix(dev-server): add `react-refresh-typescript` for HMR 
- [karma-build-scripts] break: migrate config scripts to ES modules
  - :warning: this package's API has not changed in shape, but it can no longer be imported using `require()` - you must use `await import()` or an ES import instead
- [eslint-config] fix: while linting `.js` or `.mjs` files, assume ES 2022 syntax in parser and allow ES default exports by disabling `import/no-default-export `rule

See [docs for webpack-dev-server migration to v4](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md).
