### PR TITLE
[stylelint-plugin] feat: Improve copyright comment detection

### DIFF
--- a/packages/stylelint-plugin/test/insertImport.test.js
+++ b/packages/stylelint-plugin/test/insertImport.test.js
@@ -54,6 +54,24 @@ describe("insertImport", () => {
 .some-class { width: 10px }`);
     });
 
+    it("Inserts an import below a multi-line copyright header if no other imports exist", () => {
+        const root = postcss.parse(`
+/* copyright 2021
+ * and some additional licensing info here
+ */
+
+.some-class { width: 10px }`);
+        insertImport(CssSyntax.SASS, root, { newline: "\n" }, "some_path");
+        expect(root.toString()).to.be.eq(`
+/* copyright 2021
+ * and some additional licensing info here
+ */
+
+@use "some_path";
+
+.some-class { width: 10px }`);
+    });
+
     it("Inserts an import below other imports if the copyright header exists", () => {
         const root = postcss.parse(`
 /* copyright 2021 */


### PR DESCRIPTION
Adds support for comments like this:

```
// Copyright 2016 Palantir Technologies, Inc. All rights reserved.
<would add the import here before>
// Licensed under the Apache License, Version 2.0.
<adds the import here now>
```

Was not able to add a test for the `//` case since postcss doesn’t recognize these as comments by default.