### PR TITLE
[select] fix(Suggest2): popover max height & overflow styles

### DIFF
--- a/packages/select/src/components/_index.scss
+++ b/packages/select/src/components/_index.scss
@@ -4,3 +4,4 @@
 @import "multi-select/multi-select";
 @import "omnibar/omnibar";
 @import "select/select";
+@import "suggest/suggest";

--- a/packages/select/src/components/suggest/_suggest.scss
+++ b/packages/select/src/components/suggest/_suggest.scss
@@ -1,0 +1,21 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "../../common/variables";
+
+.#{$ns}-suggest-popover {
+  .#{$ns}-menu {
+    max-height: $select-popover-max-height;
+    max-width: $select-popover-max-width;
+    overflow: auto;
+  }
+
+  &.#{$ns}-popover2-match-target-width {
+    width: 100%;
+
+    .#{$ns}-menu {
+      max-width: none;
+      min-width: 0;
+    }
+  }
+}


### PR DESCRIPTION
#### Fixes #5664

#### Changes proposed in this pull request:

Add suggest component-specific CSS to get the popover styles lost in #5369 for Suggest2 dropdowns.

#### Screenshot

<img width="428" alt="image" src="https://user-images.githubusercontent.com/723999/194916988-835a8316-36b8-4e28-9d4e-e20c5f987338.png">

