### PR TITLE
[datetime2] feat: DateInput2MigrationUtils

### DIFF
--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -113,7 +113,7 @@ export interface DateInput2Props extends DatePickerBaseProps, DateFormatProps, P
      * @param isUserChange `true` if the user clicked on a date in the calendar, changed the input value,
      *     or cleared the selection; `false` if the date was changed by changing the month or year.
      */
-    onChange?: (newDate: string | null, isUserChange?: boolean) => void;
+    onChange?: (newDate: string | null, isUserChange: boolean) => void;
 
     /**
      * Called when the user finishes typing in a new date and the date causes an error state.
@@ -400,7 +400,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             if (valueAsDate !== null) {
                 setTimezoneValue(newTimezone);
                 const newDateString = getIsoEquivalentWithUpdatedTimezone(valueAsDate, newTimezone, timePrecision);
-                props.onChange?.(newDateString);
+                props.onChange?.(newDateString, true);
             }
         },
         [props.onChange, valueAsDate, timePrecision],

--- a/packages/datetime2/src/components/date-input2/dateInput2MigrationUtils.ts
+++ b/packages/datetime2/src/components/date-input2/dateInput2MigrationUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DateInputProps, TimePrecision } from "@blueprintjs/datetime";
+import { DateInputProps, TimePrecision } from "@blueprintjs/datetime";
 
 import { getCurrentTimezone } from "../../common/getTimezone";
 import { getDateObjectFromIsoString, getIsoEquivalentWithUpdatedTimezone } from "../../common/timezoneUtils";
@@ -43,8 +43,21 @@ export function onChangeAdapter(handler: DateInputProps["onChange"]): DateInput2
  * @returns DateInput2 value
  */
 export function valueAdapter(value: DateInputProps["value"], timePrecision?: TimePrecision): DateInput2Props["value"] {
+    if (value == null) {
+        return null;
+    }
+
     const tz = getCurrentTimezone();
-    return value == null ? null : getIsoEquivalentWithUpdatedTimezone(value, tz, timePrecision);
+    const inferredTimePrecision =
+        value.getMilliseconds() !== 0
+            ? TimePrecision.MILLISECOND
+            : value.getSeconds() !== 0
+            ? TimePrecision.SECOND
+            : value.getMinutes() !== 0
+            ? TimePrecision.MINUTE
+            : undefined;
+
+    return getIsoEquivalentWithUpdatedTimezone(value, tz, timePrecision ?? inferredTimePrecision);
 }
 
 function noOp() {

--- a/packages/datetime2/src/components/date-input2/dateInput2MigrationUtils.ts
+++ b/packages/datetime2/src/components/date-input2/dateInput2MigrationUtils.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DateInputProps, TimePrecision } from "@blueprintjs/datetime";
+
+import { getCurrentTimezone } from "../../common/getTimezone";
+import { getDateObjectFromIsoString, getIsoEquivalentWithUpdatedTimezone } from "../../common/timezoneUtils";
+import type { DateInput2Props } from "./dateInput2";
+
+/**
+ * Adapter for automated DateInput -> DateInput2 migrations.
+ *
+ * @param handler DateInput onChange handler
+ * @returns DateInput2 onChange handler
+ */
+export function onChangeAdapter(handler: DateInputProps["onChange"]): DateInput2Props["onChange"] {
+    if (handler === undefined) {
+        return noOp;
+    }
+    const tz = getCurrentTimezone();
+    return (newDate: string | null, isUserChange: boolean) =>
+        handler(getDateObjectFromIsoString(newDate, tz) ?? null, isUserChange);
+}
+
+/**
+ * Adapter for automated DateInput -> DateInput2 migrations.
+ *
+ * @param value DateInput value
+ * @param timePrecision (optional) DateInput timePrecision
+ * @returns DateInput2 value
+ */
+export function valueAdapter(value: DateInputProps["value"], timePrecision?: TimePrecision): DateInput2Props["value"] {
+    const tz = getCurrentTimezone();
+    return value == null ? null : getIsoEquivalentWithUpdatedTimezone(value, tz, timePrecision);
+}
+
+function noOp() {
+    // nothing
+}

--- a/packages/datetime2/src/components/index.ts
+++ b/packages/datetime2/src/components/index.ts
@@ -17,5 +17,6 @@
 export type { DateFormatProps } from "@blueprintjs/datetime";
 
 export { DateInput2, DateInput2Props } from "./date-input2/dateInput2";
+export * as DateInput2MigrationUtils from "./date-input2/dateInput2MigrationUtils";
 export { DateRangeInput2, DateRangeInput2Props } from "./date-range-input2/dateRangeInput2";
 export { TimezoneSelect, TimezoneSelectProps } from "./timezone-select/timezoneSelect";

--- a/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { DateInputProps, TimePrecision } from "@blueprintjs/datetime";
+
+import { DateInput2, DateInput2MigrationUtils } from "../../src";
+
+const dateFormattingProps = {
+    formatDate: (date: Date | null | undefined) =>
+        date == null ? "" : [date.getMonth() + 1, date.getDate(), date.getFullYear()].join("/"),
+    parseDate: (str: string) => new Date(str),
+};
+
+const controlledDateInputProps: Required<Pick<DateInputProps, "value" | "onChange">> = {
+    onChange: (_newDate: Date | null, _isUserChange: boolean) => {
+        // nothing
+    },
+    value: new Date(),
+};
+
+describe("DateInput2MigrationUtils", () => {
+    let containerElement: HTMLElement | undefined;
+
+    beforeEach(() => {
+        containerElement = document.createElement("div");
+        document.body.appendChild(containerElement);
+    });
+    afterEach(() => {
+        containerElement?.remove();
+    });
+
+    it("Applying onChange + value adapters renders DateInput2 without error", () => {
+        mount(
+            <DateInput2
+                {...dateFormattingProps}
+                onChange={DateInput2MigrationUtils.onChangeAdapter(controlledDateInputProps.onChange)}
+                value={DateInput2MigrationUtils.valueAdapter(controlledDateInputProps.value)}
+            />,
+        );
+    });
+
+    it("Value adpater accepts time precision", () => {
+        const precision = TimePrecision.MINUTE;
+        mount(
+            <DateInput2
+                {...dateFormattingProps}
+                timePrecision={precision}
+                onChange={DateInput2MigrationUtils.onChangeAdapter(controlledDateInputProps.onChange)}
+                value={DateInput2MigrationUtils.valueAdapter(controlledDateInputProps.value, precision)}
+            />,
+        );
+    });
+});

--- a/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
 
@@ -55,7 +56,7 @@ describe("DateInput2MigrationUtils", () => {
         );
     });
 
-    it("Value adpater accepts time precision", () => {
+    it("Value adapter accepts time precision", () => {
         const precision = TimePrecision.MINUTE;
         mount(
             <DateInput2
@@ -65,5 +66,19 @@ describe("DateInput2MigrationUtils", () => {
                 value={DateInput2MigrationUtils.valueAdapter(controlledDateInputProps.value, precision)}
             />,
         );
+    });
+
+    it("Value adapter infers time precision from Date object", () => {
+        const date = new Date();
+
+        // TimePrecision.SECOND forces the string to exclude the date's milliseconds value
+        date.setHours(0, 0, 10, 100);
+        const valueWithExplicitPrecision = DateInput2MigrationUtils.valueAdapter(date, TimePrecision.SECOND);
+
+        date.setHours(0, 0, 10, 0);
+        assert.strictEqual(DateInput2MigrationUtils.valueAdapter(date), valueWithExplicitPrecision);
+
+        date.setHours(0, 0, 10, 100);
+        assert.notStrictEqual(DateInput2MigrationUtils.valueAdapter(date), valueWithExplicitPrecision);
     });
 });

--- a/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
@@ -36,16 +36,6 @@ const controlledDateInputProps: Required<Pick<DateInputProps, "value" | "onChang
 };
 
 describe("DateInput2MigrationUtils", () => {
-    let containerElement: HTMLElement | undefined;
-
-    beforeEach(() => {
-        containerElement = document.createElement("div");
-        document.body.appendChild(containerElement);
-    });
-    afterEach(() => {
-        containerElement?.remove();
-    });
-
     it("Applying onChange + value adapters renders DateInput2 without error", () => {
         mount(
             <DateInput2

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -484,7 +484,7 @@ describe("<DateInput2>", () => {
                 const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
                 clickTimezoneItem(wrapper, "Paris");
                 assert.isTrue(onChange.calledOnce);
-                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30:00+01:00"]);
+                assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30:00+01:00");
             });
 
             it("formats the returned ISO string according to timePrecision", () => {
@@ -493,7 +493,7 @@ describe("<DateInput2>", () => {
                 );
                 clickTimezoneItem(wrapper, "Paris");
                 assert.isTrue(onChange.calledOnce);
-                assert.deepEqual(onChange.firstCall.args, ["2021-11-29T10:30+01:00"]);
+                assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30+01:00");
             });
         });
 

--- a/packages/datetime2/test/index.ts
+++ b/packages/datetime2/test/index.ts
@@ -14,5 +14,6 @@ import "@blueprintjs/test-commons/bootstrap";
 import "./common/dateUtilsTests";
 import "./common/timezoneUtilsTest";
 import "./components/dateInput2Tests";
+import "./components/dateInput2MigrationUtilsTests";
 import "./components/dateRangeInput2Tests";
 import "./components/timezoneSelectTests";


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation - not adding to main docs, just to [datetime2 migration guide](https://github.com/palantir/blueprint/wiki/datetime2-component-migration#migration-utilities)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- fix(`DateInput2`): fix `onChange` prop callback type to match DateInput
- feat: add `DateInput2MigrationUtils` adapter functions to help with automated code migrations from DateInput &rarr; DateInput2

#### Reviewers should focus on:

Accuracy of adapter logic
