### PR TITLE
[datetime2] feat(TimezoneSelect): support valueDisplayFormat

### DIFF
--- a/packages/datetime2/karma.conf.js
+++ b/packages/datetime2/karma.conf.js
@@ -10,6 +10,8 @@ module.exports = async function (config) {
             coverageExcludes: [
                 // HACKHACK: needs coverage
                 "src/components/date-range-input2/*",
+                // not worth coverage, fairly simple implementation
+                "src/common/timezoneDisplayFormat.ts",
             ],
         }),
     );

--- a/packages/datetime2/src/common/index.ts
+++ b/packages/datetime2/src/common/index.ts
@@ -19,3 +19,4 @@ import * as DateUtils from "./dateUtils";
 
 export { Classes, DateUtils };
 export { DateRange, NonNullDateRange } from "./dateRange";
+export { TimezoneDisplayFormat } from "./timezoneDisplayFormat";

--- a/packages/datetime2/src/common/timezoneDisplayFormat.ts
+++ b/packages/datetime2/src/common/timezoneDisplayFormat.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/datetime2/src/common/timezoneDisplayFormat.ts
+++ b/packages/datetime2/src/common/timezoneDisplayFormat.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TimezoneWithNames } from "./timezoneNameUtils";
+
+export type TimezoneDisplayFormat = "offset" | "abbreviation" | "name" | "composite" | "code" | "long-name";
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const TimezoneDisplayFormat = {
+    /**
+     * Short name format: "HST", "EDT", etc.
+     * Falls back to "GMT+/-offset" if there is no commonly used abbreviation.
+     */
+    ABBREVIATION: "abbreviation" as "abbreviation",
+
+    /**
+     * IANA timezone code: "Pacific/Honolulu", "America/New_York", etc.
+     */
+    CODE: "code" as "code",
+
+    /**
+     * Composite format: "Hawaii Time (HST) -10:00", "New York (EDT) -5:00", etc.
+     * Omits abbreviation if there is no short name (it is redundant with offset).
+     */
+    COMPOSITE: "composite" as "composite",
+
+    /**
+     * Long name format: "Hawaii-Aleutian Standard Time", "Eastern Daylight Time", "Coordinated Universal Time", etc.
+     */
+    LONG_NAME: "long-name" as "long-name",
+
+    /**
+     * @deprecated use {@link TimezoneDisplayFormat.CODE} instead
+     */
+    // eslint-disable-next-line deprecation/deprecation
+    NAME: "name" as "name",
+
+    /**
+     * Offset format: "-10:00", "-5:00", etc.
+     */
+    OFFSET: "offset" as "offset",
+};
+
+/**
+ * Formats a timezone according to the specified display format to show in the default `<Button>` rendered as the
+ * `<TimezoneSelect>` target element.
+ */
+export function formatTimezone(
+    timezone: TimezoneWithNames | undefined,
+    displayFormat: TimezoneDisplayFormat,
+): string | undefined {
+    if (timezone === undefined) {
+        return undefined;
+    }
+
+    switch (displayFormat) {
+        case TimezoneDisplayFormat.ABBREVIATION:
+            return timezone.shortName;
+        // eslint-disable-next-line deprecation/deprecation
+        case TimezoneDisplayFormat.NAME:
+            return timezone.ianaCode;
+        case TimezoneDisplayFormat.OFFSET:
+            return timezone.offset;
+        case TimezoneDisplayFormat.CODE:
+            return timezone.ianaCode;
+        case TimezoneDisplayFormat.LONG_NAME:
+            return timezone.longName;
+        case TimezoneDisplayFormat.COMPOSITE:
+            const { shortName } = timezone;
+            // if the short name is just an offset (contains + or -) or equal to the label, omit it
+            return /[-\+]/.test(shortName) || shortName === timezone.label
+                ? `${timezone.label} ${timezone.offset}`
+                : `${timezone.label} (${timezone.shortName}) ${timezone.offset}`;
+    }
+}

--- a/packages/datetime2/src/common/timezoneMetadata.ts
+++ b/packages/datetime2/src/common/timezoneMetadata.ts
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
-import * as Classes from "./classes";
-import * as DateUtils from "./dateUtils";
+import { TIMEZONE_ITEMS } from "./timezoneItems";
+import { getTimezoneNames, TimezoneWithNames } from "./timezoneNameUtils";
 
-export { Classes, DateUtils };
-export { DateRange, NonNullDateRange } from "./dateRange";
-export { TimezoneDisplayFormat } from "./timezoneDisplayFormat";
-export { TimezoneMetadata, getTimezoneMetadata } from "./timezoneMetadata";
+export type TimezoneMetadata = TimezoneWithNames;
+
+/**
+ * Given a timezone IANA code and an optional date object, retrieve additional metadata like its common name, offset,
+ * and abbreviation.
+ */
+export function getTimezoneMetadata(timezoneIanaCode: string, date?: Date): TimezoneMetadata | undefined {
+    const timezone = TIMEZONE_ITEMS.find(tz => tz.ianaCode === timezoneIanaCode);
+    if (timezone === undefined) {
+        return undefined;
+    }
+    return getTimezoneNames(timezone, date);
+}

--- a/packages/datetime2/src/common/timezoneNameUtils.ts
+++ b/packages/datetime2/src/common/timezoneNameUtils.ts
@@ -25,21 +25,30 @@ export interface TimezoneWithNames extends Timezone {
 }
 
 const CURRENT_DATE = Date.now();
+const LONG_NAME_FORMAT_STR = "zzzz";
+const SHORT_NAME_FORMAT_STR = "zzz";
 
-export const getTimezoneName = (date: Date | undefined, ianaCode: string, getLongName: boolean = true) =>
-    formatInTimeZone(date ?? CURRENT_DATE, ianaCode, getLongName ? "zzzz" : "zzz");
+export function getTimezoneShortName(tzIanaCode: string, date: Date | undefined) {
+    return formatInTimeZone(date ?? CURRENT_DATE, tzIanaCode, SHORT_NAME_FORMAT_STR);
+}
+
+/**
+ * Augments a simple {@link Timezone} metadata object with long and short names formatted by `date-fns-tz`.
+ */
+export function getTimezoneNames(tz: Timezone, date: Date | number | undefined = CURRENT_DATE): TimezoneWithNames {
+    return {
+        ...tz,
+        longName: formatInTimeZone(date, tz.ianaCode, LONG_NAME_FORMAT_STR),
+        shortName: formatInTimeZone(date, tz.ianaCode, SHORT_NAME_FORMAT_STR),
+    };
+}
 
 export const mapTimezonesWithNames = (
     date: Date | undefined,
     timezones: Timezone[] | TimezoneWithNames[],
-): TimezoneWithNames[] =>
-    timezones.map(tz => ({
-        ...tz,
-        longName: getTimezoneName(date, tz.ianaCode),
-        shortName: getTimezoneName(date, tz.ianaCode, false),
-    }));
+): TimezoneWithNames[] => timezones.map(tz => getTimezoneNames(tz, date));
 
-export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezone: boolean) {
+export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezone: boolean): TimezoneWithNames[] {
     const systemTimezone = getCurrentTimezone();
     const localTimezone = showLocalTimezone
         ? TIMEZONE_ITEMS.find(timezone => timezone.ianaCode === systemTimezone)
@@ -49,7 +58,7 @@ export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezon
             ? {
                   ...localTimezone,
                   longName: "Current timezone",
-                  shortName: getTimezoneName(date, localTimezone.ianaCode, false),
+                  shortName: formatInTimeZone(date ?? CURRENT_DATE, localTimezone.ianaCode, SHORT_NAME_FORMAT_STR),
               }
             : undefined;
     const minimalTimezoneItemsWithNames = mapTimezonesWithNames(date, MINIMAL_TIMEZONE_ITEMS).filter(

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -40,7 +40,7 @@ import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popov
 import * as Classes from "../../common/classes";
 import { isDateValid, isDayInRange } from "../../common/dateUtils";
 import { getCurrentTimezone } from "../../common/getTimezone";
-import { getTimezoneName } from "../../common/timezoneNameUtils";
+import { getTimezoneShortName } from "../../common/timezoneNameUtils";
 import {
     convertLocalDateToTimezoneTime,
     getDateObjectFromIsoString,
@@ -420,7 +420,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                 interactive={!isTimezoneSelectDisabled}
                 minimal={true}
             >
-                {getTimezoneName(tzSelectDate, timezoneValue, false)}
+                {getTimezoneShortName(timezoneValue, tzSelectDate)}
             </Tag>
         </TimezoneSelect>
     );

--- a/packages/datetime2/src/components/timezone-select/timezone-select.md
+++ b/packages/datetime2/src/components/timezone-select/timezone-select.md
@@ -19,24 +19,41 @@ on the wiki.
 
 </div>
 
-`TimezoneSelect` allows the user to select from a list of timezones. The list is coded into the library itself, so it does not depend on any external packages for the list of timezones.
+`TimezoneSelect` allows the user to select from a list of timezones. The list is coded into the library itself, so it
+does not depend on any external packages for the list of timezones. It uses [date-fns-tz](https://github.com/marnusw/date-fns-tz)
+for display formatting.
 
 @reactExample TimezoneSelectExample
 
-@## Props
+@## Usage
 
-This component only supports controlled usage.
-Control the selected timezone with the `value` prop.
-Use the `onChange` prop to listen for changes to the selected timezone.
+This component only supports __controlled__ usage.
 
-The `date` prop is used to determine the timezone offsets.
-This is because a timezone usually has more than one offset from UTC due to daylight saving time.
+Control the selected timezone with the `value` prop and use the `onChange` prop callback to listen for changes to the
+selected timezone.
 
-By default, the component will show a clickable button target,
-which will display the selected timezone formatted according to `valueDisplayFormat`.
-The button can also be managed via `disabled`, `placeholder`, and more generally via `buttonProps`.
-You can show a custom element instead of the default button by passing a single-element child; in this case,
-all button-specific props will be ignored:
+```tsx
+import { TimezoneSelect } from "@blueprintjs/datetime2";
+import React, { useState } from "react";
+
+function TimezoneExample() {
+    const [timezone, setTimezone] = useState("");
+    return (
+        <TimezoneSelect value={timezone} onChange={setTimezone} />
+    );
+}
+```
+
+The optional `date` prop is used to determine the timezone offsets.
+This is useful to disambiguate timezones which have more than one offset from UTC due to
+[Daylight saving time](https://en.wikipedia.org/wiki/Daylight_saving_time).
+
+By default, the component will show a clickable button target which displays the selected timezone formatted according
+to the `valueDisplayFormat` prop. The button can be customized via `disabled`, `placeholder`, and more generally via
+`buttonProps`.
+
+You can show a custom element instead of the default button by passing a single-element child to `<TimezoneSelect>`;
+in this case, all button-specific props will be ignored:
 
 ```tsx
 <TimezoneSelect value={...} onChange={...}>
@@ -49,22 +66,9 @@ all button-specific props will be ignored:
 
 We detect the local timezone using the
 [i18n API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions)
-when the `showLocalTimezone` prop is enabled and cannot guarantee correctness
-in all browsers.
+when the `showLocalTimezone` prop is enabled and cannot guarantee correctness in all browsers.
 </div>
 
-```tsx
-import { TimezoneSelect } from "@blueprintjs/datetime2";
-
-export class TimezoneExample extends React.PureComponent<{}, { timezone: string; }> {
-    public state = { timezone: "" };
-
-    public render() {
-        return <TimezoneSelect value={this.state.timezone} onChange={this.handleTimezoneChange} />;
-    }
-
-    private handleTimezoneChange = (timezone: string) => this.setState({ timezone });
-}
-```
+@## Props interface
 
 @interface TimezoneSelectProps

--- a/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import { formatInTimeZone } from "date-fns-tz";
 import * as React from "react";
 
 import {
@@ -31,6 +30,7 @@ import {
 import { ItemListPredicate, ItemRenderer, Select2, SelectPopoverProps } from "@blueprintjs/select";
 
 import * as Classes from "../../common/classes";
+import { formatTimezone, TimezoneDisplayFormat } from "../../common/timezoneDisplayFormat";
 import { TIMEZONE_ITEMS } from "../../common/timezoneItems";
 import { getInitialTimezoneItems, mapTimezonesWithNames, TimezoneWithNames } from "../../common/timezoneNameUtils";
 
@@ -111,6 +111,14 @@ export interface TimezoneSelectProps extends Props {
 
     /** Props to spread to `Popover2`. Note that `content` cannot be changed. */
     popoverProps?: SelectPopoverProps["popoverProps"];
+
+    /**
+     * Format to use when displaying the selected (or default) timezone within the target element.
+     * This prop will be ignored if `children` is provided.
+     *
+     * @default TimezoneDisplayFormat.COMPOSITE
+     */
+    valueDisplayFormat?: TimezoneDisplayFormat;
 }
 
 export interface TimezoneSelectState {
@@ -188,13 +196,14 @@ export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, 
     }
 
     private renderButton() {
-        const { buttonProps = {}, disabled, fill, placeholder, value } = this.props;
+        const { buttonProps = {}, disabled, fill, placeholder, value, valueDisplayFormat } = this.props;
         const selectedTimezone = this.timezoneItems.find(tz => tz.ianaCode === value);
-        const buttonContent = selectedTimezone ? (
-            `${selectedTimezone.label} ${formatInTimeZone(this.props.date!, selectedTimezone.ianaCode, "xxx")}`
-        ) : (
-            <span className={CoreClasses.TEXT_MUTED}>{placeholder}</span>
-        );
+        const buttonContent =
+            selectedTimezone !== undefined ? (
+                formatTimezone(selectedTimezone, valueDisplayFormat ?? TimezoneDisplayFormat.COMPOSITE)
+            ) : (
+                <span className={CoreClasses.TEXT_MUTED}>{placeholder}</span>
+            );
         return <Button rightIcon="caret-down" disabled={disabled} text={buttonContent} fill={fill} {...buttonProps} />;
     }
 

--- a/packages/datetime2/test/common/timezoneMetadataTests.ts
+++ b/packages/datetime2/test/common/timezoneMetadataTests.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai";
+
+import { getTimezoneMetadata } from "../../src/common/timezoneMetadata";
+
+const UTC_TIME = "Etc/UTC";
+const LONDON_TIME = "Europe/London";
+const NEW_YORK = "America/New_York";
+
+describe("getTimezoneMetadata", () => {
+    it("Returns valid metadata for common timezones", () => {
+        for (const tzCode of [UTC_TIME, LONDON_TIME, NEW_YORK]) {
+            const metadata = getTimezoneMetadata(tzCode);
+            expect(metadata).not.to.be.undefined;
+            expect(metadata?.label).to.exist;
+            expect(metadata?.longName).to.exist;
+            expect(metadata?.ianaCode).to.be(tzCode);
+        }
+    });
+});

--- a/packages/datetime2/test/common/timezoneMetadataTests.ts
+++ b/packages/datetime2/test/common/timezoneMetadataTests.ts
@@ -29,7 +29,7 @@ describe("getTimezoneMetadata", () => {
             expect(metadata).not.to.be.undefined;
             expect(metadata?.label).to.exist;
             expect(metadata?.longName).to.exist;
-            expect(metadata?.ianaCode).to.be(tzCode);
+            expect(metadata?.ianaCode).to.equal(tzCode);
         }
     });
 });

--- a/packages/datetime2/test/index.ts
+++ b/packages/datetime2/test/index.ts
@@ -13,6 +13,8 @@ import "@blueprintjs/test-commons/bootstrap";
 
 import "./common/dateUtilsTests";
 import "./common/timezoneUtilsTest";
+import "./common/timezoneMetadataTests";
+
 import "./components/dateInput2Tests";
 import "./components/dateInput2MigrationUtilsTests";
 import "./components/dateRangeInput2Tests";

--- a/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
@@ -16,12 +16,13 @@
 
 import * as React from "react";
 
-import { H5, Position, Switch } from "@blueprintjs/core";
-import { TimezoneSelect } from "@blueprintjs/datetime2";
-import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import { TimezoneDisplayFormat, TimezoneSelect } from "@blueprintjs/datetime2";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 export interface TimezoneSelectExampleState {
     disabled: boolean;
+    displayFormat: TimezoneDisplayFormat;
     fill: boolean;
     showCustomTarget: boolean;
     showLocalTimezone: boolean;
@@ -31,6 +32,7 @@ export interface TimezoneSelectExampleState {
 export class TimezoneSelectExample extends React.PureComponent<ExampleProps, TimezoneSelectExampleState> {
     public state: TimezoneSelectExampleState = {
         disabled: false,
+        displayFormat: TimezoneDisplayFormat.COMPOSITE,
         fill: false,
         showCustomTarget: false,
         showLocalTimezone: true,
@@ -39,12 +41,16 @@ export class TimezoneSelectExample extends React.PureComponent<ExampleProps, Tim
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
 
+    private handleDisplayFormatChange = handleValueChange((displayFormat: TimezoneDisplayFormat) =>
+        this.setState({ displayFormat }),
+    );
+
     private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
 
     private handleShowLocalChange = handleBooleanChange(showLocalTimezone => this.setState({ showLocalTimezone }));
 
     public render() {
-        const { timezone, disabled, fill, showLocalTimezone } = this.state;
+        const { timezone, disabled, displayFormat, fill, showLocalTimezone } = this.state;
 
         const options = (
             <>
@@ -52,6 +58,17 @@ export class TimezoneSelectExample extends React.PureComponent<ExampleProps, Tim
                 <Switch checked={showLocalTimezone} label="Show local timezone" onChange={this.handleShowLocalChange} />
                 <Switch checked={disabled} label="Disabled" onChange={this.handleDisabledChange} />
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
+                <RadioGroup
+                    label="Display format"
+                    onChange={this.handleDisplayFormatChange}
+                    selectedValue={this.state.displayFormat}
+                >
+                    <Radio label="Composite" value={TimezoneDisplayFormat.COMPOSITE} />
+                    <Radio label="Abbreviation" value={TimezoneDisplayFormat.ABBREVIATION} />
+                    <Radio label="Long Name" value={TimezoneDisplayFormat.LONG_NAME} />
+                    <Radio label="IANA Code" value={TimezoneDisplayFormat.CODE} />
+                    <Radio label="Offset" value={TimezoneDisplayFormat.OFFSET} />
+                </RadioGroup>
             </>
         );
 
@@ -64,6 +81,7 @@ export class TimezoneSelectExample extends React.PureComponent<ExampleProps, Tim
                     popoverProps={{ position: Position.BOTTOM }}
                     showLocalTimezone={showLocalTimezone}
                     value={timezone}
+                    valueDisplayFormat={displayFormat}
                 />
             </Example>
         );

--- a/packages/timezone/src/components/timezone-picker/timezoneDisplayFormat.ts
+++ b/packages/timezone/src/components/timezone-picker/timezoneDisplayFormat.ts
@@ -14,10 +14,18 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview These APIs are DEPRECATED and the code is frozen.
+ * All changes & bugfixes should be made to @blueprintjs/datetime2 instead.
+ */
+
+/* eslint-disable deprecation/deprecation */
+
 import * as moment from "moment-timezone";
 
 import { getTimezoneMetadata } from "./timezoneMetadata";
 
+/** @deprecated use @blueprintjs/datetime2 */
 export type TimezoneDisplayFormat = "offset" | "abbreviation" | "name" | "composite";
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TimezoneDisplayFormat = {
@@ -31,6 +39,7 @@ export const TimezoneDisplayFormat = {
     OFFSET: "offset" as "offset",
 };
 
+/** @deprecated use @blueprintjs/datetime2 */
 export function formatTimezone(timezone: string, date: Date, displayFormat: TimezoneDisplayFormat): string | undefined {
     if (!timezone || !moment.tz.zone(timezone)) {
         return undefined;


### PR DESCRIPTION
#### Fixes #5676

#### Checklist

- [x] Includes tests
- [x] Update documentation
- [x] Update [migration guide](https://github.com/palantir/blueprint/wiki/datetime2-component-migration#timezoneselect)

#### Changes proposed in this pull request:

- feat(`TimezoneSelect`): support `valueDisplayFormat` to achieve feature parity with `TimezonePicker`
  - Note: this now has slightly different semantics, see the migration guide for full details
- feat: add `TimezoneMetadata` and `getTimezoneMetadata` to the public API to achieve partial API parity with @blueprintjs/timezone
  - Note: the available metadata has changed slightly to reflect the shift from moment-timezone to date-fns-tz, see the migration guide for full details

#### Reviewers should focus on:

Code correctness

#### Screenshot

![2022-10-18 13 49 40](https://user-images.githubusercontent.com/723999/196506750-97acbb82-fa46-4c93-b4b3-dbd02575f50c.gif)

