### PR TITLE
Smoothen Omnibar fadeout

### DIFF
--- a/packages/select/src/components/omnibar/_omnibar.scss
+++ b/packages/select/src/components/omnibar/_omnibar.scss
@@ -15,7 +15,7 @@ $omnibar-input-height: $pt-grid-size * 4 !default;
 .#{$ns}-omnibar {
   $omnibar-transition-props: (
     filter: (blur($pt-grid-size * 2), blur(0)),
-    opacity: (0.2, 1),
+    opacity: (0, 1),
   );
 
   @include react-transition(


### PR DESCRIPTION
#### Fixes #5419

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

It has always bothered me the way the Omnibar hiccups when it fades out before disappearing from screen. I always thought it was some slow reflow issue, but it's actually just because we don't fade down to 0 opacity. I've changed that behaviour here and think it looks and feels better.

#### Reviewers should focus on:

N/A

#### Screenshot

It's difficult to see the difference between before/after on these screen recordings, but is fairly tangible when interacting with the component "in real life".

before

https://user-images.githubusercontent.com/9415645/196694671-f300c01d-5f25-4d79-a5c7-c5d34765a828.mp4




after


https://user-images.githubusercontent.com/9415645/196694696-d525b273-5d3a-4b89-8304-5cf7bec9699a.mp4


