### PR TITLE
[popover2] feat: export PopperModifierOverrides type

### DIFF
--- a/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2Example.tsx
@@ -46,7 +46,7 @@ import {
     PlacementOptions,
     Popover2,
     Popover2InteractionKind,
-    Popover2SharedProps,
+    PopperModifierOverrides,
     StrictModifierNames,
 } from "@blueprintjs/popover2";
 import { FilmSelect } from "@blueprintjs/select/examples";
@@ -72,7 +72,7 @@ export interface IPopover2ExampleState {
     isOpen?: boolean;
     matchTargetWidth: boolean;
     minimal?: boolean;
-    modifiers?: Popover2SharedProps<HTMLElement>["modifiers"];
+    modifiers?: PopperModifierOverrides;
     placement?: Placement;
     sliderValue?: number;
     usePortal?: boolean;

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -33,6 +33,7 @@ export {
     Popover2SharedProps,
     Popover2TargetProps,
     PopperBoundary,
+    PopperModifierOverrides,
     Placement,
     PlacementOptions,
     StrictModifierNames,

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -24,6 +24,15 @@ export { Boundary as PopperBoundary, Placement, placements as PlacementOptions }
 // copied from @popperjs/core, where it is not exported as public
 export type StrictModifierNames = NonNullable<StrictModifiers["name"]>;
 
+/**
+ * Configuration object for customizing popper.js v2 modifiers in Popover2 and Tooltip2.
+ *
+ * @see https://popper.js.org/docs/v2/modifiers/
+ */
+export type PopperModifierOverrides = Partial<{
+    [M in StrictModifierNames]: Partial<Omit<StrictModifier<M>, "name">>;
+}>;
+
 // eslint-disable-next-line deprecation/deprecation
 export type Popover2TargetProps = IPopover2TargetProps;
 /**
@@ -153,9 +162,7 @@ export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
      *
      * @see https://popper.js.org/docs/v2/modifiers/
      */
-    modifiers?: Partial<{
-        [M in StrictModifierNames]: Partial<Omit<StrictModifier<M>, "name">>;
-    }>;
+    modifiers?: PopperModifierOverrides;
 
     /**
      * Custom modifiers to add to the popper instance.


### PR DESCRIPTION
#### Changes proposed in this pull request:

Export `Popover2SharedProps["modifiers"]` as its own new type, `PopperModifierOverrides`.

This makes it easier for consumers to reference this type, particularly useful for source code transformations.

