### PR TITLE
Downgrade classnames dependency to 2.3.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
         "@blueprintjs/icons": "^4.8.0",
         "@juggle/resize-observer": "^3.4.0",
         "@types/dom4": "^2.0.2",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "dom4": "^2.1.5",
         "normalize.css": "^8.0.1",
         "popper.js": "^1.16.1",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -36,7 +36,7 @@
     },
     "dependencies": {
         "@blueprintjs/core": "^4.11.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "react-day-picker": "7.4.9",
         "tslib": "~2.3.1"
     },

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -39,7 +39,7 @@
         "@blueprintjs/datetime": "^4.4.4",
         "@blueprintjs/popover2": "^1.7.4",
         "@blueprintjs/select": "^4.8.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.4",
         "lodash": "^4.17.21",

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -23,7 +23,7 @@
         "@blueprintjs/select": "^4.8.4",
         "@blueprintjs/table": "^4.7.4",
         "@blueprintjs/timezone": "^4.5.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "core-js": "^3.25.5",
         "dom4": "^2.1.5",
         "lodash": "^4.17.21",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -29,7 +29,7 @@
         "@blueprintjs/timezone": "^4.5.4",
         "@documentalist/client": "^4.0.0",
         "chroma-js": "^2.1.0",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "core-js": "^3.25.5",
         "date-fns": "^2.28.0",
         "dom4": "^2.1.5",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -33,7 +33,7 @@
         "@blueprintjs/core": "^4.11.4",
         "@blueprintjs/select": "^4.8.4",
         "@documentalist/client": "^4.0.0",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "fuzzaldrin-plus": "^0.6.0",
         "tslib": "~2.3.1"
     },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "change-case": "^4.1.2",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "tslib": "~2.3.1"
     },
     "devDependencies": {

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -18,7 +18,7 @@
     "dependencies": {
         "@blueprintjs/core": "^4.11.4",
         "@blueprintjs/icons": "^4.8.0",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
     },

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -38,7 +38,7 @@
         "@blueprintjs/core": "^4.11.4",
         "@juggle/resize-observer": "^3.4.0",
         "@popperjs/core": "^2.11.6",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "dom4": "^2.1.5",
         "react-popper": "^2.2.4",
         "tslib": "~2.3.1"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@blueprintjs/core": "^4.11.4",
         "@blueprintjs/popover2": "^1.7.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "tslib": "~2.3.1"
     },
     "peerDependencies": {

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -19,7 +19,7 @@
         "@blueprintjs/core": "^4.11.4",
         "@blueprintjs/popover2": "^1.7.4",
         "@blueprintjs/table": "^4.7.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "dom4": "^2.1.5",
         "lodash": "^4.17.21",
         "normalize.css": "^8.0.1",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@blueprintjs/core": "^4.11.4",
         "@blueprintjs/popover2": "^1.7.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "prop-types": "^15.7.2",
         "react-innertext": "^1.1.5",
         "tslib": "~2.3.1"

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -37,7 +37,7 @@
     "dependencies": {
         "@blueprintjs/core": "^4.11.4",
         "@blueprintjs/select": "^4.8.4",
-        "classnames": "^2.3.2",
+        "classnames": "^2.3.1",
         "moment": "^2.29.0",
         "moment-timezone": "^0.5.31",
         "tslib": "~2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,9 +3251,9 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.3.2:
+classnames@^2.3.1:
   version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  resolved "https://artifactory.palantir.build/artifactory/api/npm/all-npm/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-stack@^2.0.0:


### PR DESCRIPTION
In 2.3.2, classnames changed their types to require esModuleInterop and/or changing to `import * as classNames from "classnames"`. This relaxes the dependency in blueprint so that consumers that are not ready to bump to 2.3.2 have the choice to stay on 2.3.1