### PR TITLE
[datetime] fix: reduce react peer dep range

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -41,9 +41,9 @@
         "tslib": "~2.3.1"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.32 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^16.14.32 || 17",
+        "react": "^16.8 || 17",
+        "react-dom": "^16.8 || 17"
     },
     "peerDependenciesMeta": {
         "@types/react": {


### PR DESCRIPTION
react-day-picker v7 is not compatible with React 18, so until we upgrade to v8, we can't declare compatibility with that version ourselves.

Related to https://github.com/palantir/blueprint/issues/5699
