### PR TITLE
[eslint-plugin] fix(no-deprecated-type-references): handle name conflicts with import aliases for new types

### DIFF
--- a/packages/eslint-plugin/src/rules/utils/getAllIdentifiersInFile.ts
+++ b/packages/eslint-plugin/src/rules/utils/getAllIdentifiersInFile.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AST_TOKEN_TYPES, TSESLint } from "@typescript-eslint/utils";
+
+/**
+ * Gets all identifier tokens in a source file.
+ */
+export function getAllIdentifiersInFile(source: TSESLint.SourceCode): string[] {
+    return source.ast.tokens.filter(token => token.type === AST_TOKEN_TYPES.Identifier).map(token => token.value);
+}

--- a/packages/eslint-plugin/src/rules/utils/replaceImportInFile.ts
+++ b/packages/eslint-plugin/src/rules/utils/replaceImportInFile.ts
@@ -17,35 +17,45 @@
 import { AST_NODE_TYPES, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 /**
- * Return a function which when provided with a fixer will produce a RuleFix to replace the
+ * Return a function which, when provided with a fixer, will produce a RuleFix to replace the
  * specified `fromImportName` with `toImportName` from the specified `packageName` at the top of the file.
  */
 export const replaceImportInFile =
     (
         program: TSESTree.Program,
-        fromImportName: string,
-        toImportName: string,
-        packageName: string,
+        options: {
+            fromName: string;
+            toName: string;
+            alias?: string;
+            moduleSpecifier: string;
+        },
     ): TSESLint.ReportFixFunction =>
     fixer => {
         const fileImports = program.body.filter(
             node => node.type === AST_NODE_TYPES.ImportDeclaration,
         ) as TSESTree.ImportDeclaration[];
-        const importToModify = fileImports.find(node => node.source.value === packageName);
+        const importToModify = fileImports.find(node => node.source.value === options.moduleSpecifier);
 
         if (importToModify === undefined) {
-            throw new Error(`Unable to find import from "${packageName}" while fixing lint error`);
+            throw new Error(`Unable to find import from "${options.moduleSpecifier}" while fixing lint error`);
         }
 
         const nodeToReplace = importToModify.specifiers.find(
-            specifier => specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.local.name === fromImportName,
-        );
+            specifier =>
+                specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.imported.name === options.fromName,
+        ) as TSESTree.ImportSpecifier;
 
         if (nodeToReplace === undefined) {
             throw new Error(
-                `Unable to find import { ${fromImportName} } from "${packageName}" while fixing lint error`,
+                `Unable to find import { ${options.fromName} } from "${options.moduleSpecifier}" while fixing lint error`,
+            );
+        } else if (options.alias !== undefined && nodeToReplace.local.name !== nodeToReplace.imported.name) {
+            throw new Error(
+                `Existing import '${nodeToReplace.imported.name}' is already aliased as '${nodeToReplace.local.name}', refusing to rename with new alias '${options.alias}'`,
             );
         }
 
-        return fixer.replaceText(nodeToReplace, toImportName);
+        const newText = options.alias !== undefined ? `${options.toName} as ${options.alias}` : options.toName;
+
+        return fixer.replaceText(nodeToReplace, newText);
     };

--- a/packages/eslint-plugin/test/no-deprecated-type-references.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-type-references.test.ts
@@ -200,6 +200,56 @@ ruleTester.run("no-deprecated-type-references", noDeprecatedTypeReferencesRule, 
                 const MyButton = (props: MyButtonProps) => <Button {...props} />;
             `,
         },
+
+        // dealing with name conflicts which require import aliases
+        {
+            code: dedent`
+                import { IProps } from "@blueprintjs/core";
+
+                export interface Props extends IProps {
+                    foo: string;
+                }
+            `,
+            errors: [
+                {
+                    messageId: "migration",
+                    data: { deprecatedTypeName: "IProps", newTypeName: "Props" },
+                },
+            ],
+            output: dedent`
+                import { Props as BlueprintProps } from "@blueprintjs/core";
+
+                export interface Props extends BlueprintProps {
+                    foo: string;
+                }
+            `,
+        },
+        {
+            code: dedent`
+                import { IProps } from "@blueprintjs/core";
+
+                export namespace MyComponent {
+                    export interface Props extends IProps {
+                        foo: string;
+                    }
+                }
+            `,
+            errors: [
+                {
+                    messageId: "migration",
+                    data: { deprecatedTypeName: "IProps", newTypeName: "Props" },
+                },
+            ],
+            output: dedent`
+                import { Props as BlueprintProps } from "@blueprintjs/core";
+
+                export namespace MyComponent {
+                    export interface Props extends BlueprintProps {
+                        foo: string;
+                    }
+                }
+            `,
+        },
     ],
     valid: [
         {


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Improve `@blueprintjs/no-deprecated-type-references` lint rule implementation to detect name conflicts for the new symbols. In these cases the rule will now alias the new type name with a "Blueprint" prefix, such as `{ Props as BlueprintProps }`.

#### Reviewers should focus on:

New test cases
