### PR TITLE
[select,datetime2] support popoverProps.targetTagName

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -137,6 +137,13 @@ export interface IInputGroupProps2
     round?: boolean;
 
     /**
+     * Name of the HTML tag that contains the input group.
+     *
+     * @default "div"
+     */
+    tagName?: keyof JSX.IntrinsicElements;
+
+    /**
      * HTML `input` type attribute.
      *
      * @default "text"
@@ -164,7 +171,18 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
     };
 
     public render() {
-        const { asyncControl = false, className, disabled, fill, inputRef, intent, large, small, round } = this.props;
+        const {
+            asyncControl = false,
+            className,
+            disabled,
+            fill,
+            inputRef,
+            intent,
+            large,
+            round,
+            small,
+            tagName = "div",
+        } = this.props;
         const inputGroupClasses = classNames(
             Classes.INPUT_GROUP,
             Classes.intentClass(intent),
@@ -188,17 +206,18 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
             className: Classes.INPUT,
             style,
         };
+        const inputElement = asyncControl ? (
+            <AsyncControllableInput {...inputProps} inputRef={inputRef} />
+        ) : (
+            <input {...inputProps} ref={inputRef} />
+        );
 
-        return (
-            <div className={inputGroupClasses}>
-                {this.maybeRenderLeftElement()}
-                {asyncControl ? (
-                    <AsyncControllableInput {...inputProps} inputRef={inputRef} />
-                ) : (
-                    <input {...inputProps} ref={inputRef} />
-                )}
-                {this.maybeRenderRightElement()}
-            </div>
+        return React.createElement(
+            tagName,
+            { className: inputGroupClasses },
+            this.maybeRenderLeftElement(),
+            inputElement,
+            this.maybeRenderRightElement(),
         );
     }
 

--- a/packages/datetime2/src/common/datetimePopoverProps.ts
+++ b/packages/datetime2/src/common/datetimePopoverProps.ts
@@ -20,17 +20,16 @@ import type { Popover2, Popover2Props } from "@blueprintjs/popover2";
  * Reusable collection of props for components in this package which render a `Popover2`
  * and need to provide some degree of customization for that popover.
  */
-export interface SelectPopoverProps {
-    /** Props to spread to `Popover2` content wrapper eleemnt. */
-    popoverContentProps?: React.HTMLAttributes<HTMLDivElement>;
-
+export interface DatetimePopoverProps {
     /**
      * Props to spread to `Popover2`.
-     *
-     * Note that `content` cannot be changed, but you may apply some props to the content wrapper element
-     * with `popoverContentProps`.
      */
-    popoverProps?: Partial<Omit<Popover2Props, "content" | "defaultIsOpen" | "disabled" | "fill" | "renderTarget">>;
+    popoverProps?: Partial<
+        Omit<
+            Popover2Props,
+            "autoFocus" | "content" | "defaultIsOpen" | "disabled" | "enforceFocus" | "fill" | "renderTarget"
+        >
+    >;
 
     /**
      * Optional ref for the Popover2 component instance.

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -35,7 +35,7 @@ import {
     DatePickerShortcut,
     DatePickerUtils,
 } from "@blueprintjs/datetime";
-import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popover2";
+import { Popover2, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import * as Classes from "../../common/classes";
 import { DatetimePopoverProps } from "../../common/datetimePopoverProps";

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -38,6 +38,7 @@ import {
 import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import * as Classes from "../../common/classes";
+import { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import { isDateValid, isDayInRange } from "../../common/dateUtils";
 import { getCurrentTimezone } from "../../common/getTimezone";
 import { getTimezoneShortName } from "../../common/timezoneNameUtils";
@@ -48,7 +49,7 @@ import {
 } from "../../common/timezoneUtils";
 import { TimezoneSelect } from "../timezone-select/timezoneSelect";
 
-export interface DateInput2Props extends DatePickerBaseProps, DateFormatProps, Props {
+export interface DateInput2Props extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      * Passed to `DatePicker` component.
@@ -100,11 +101,16 @@ export interface DateInput2Props extends DatePickerBaseProps, DateFormatProps, P
     fill?: boolean;
 
     /**
-     * Props to pass to the [input group](#core/components/text-inputs.input-group).
-     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
-     * `type` is fixed to "text".
+     * Props to pass to the [InputGroup component](#core/components/text-inputs.input-group).
+     *
+     * Some properties are unavailable:
+     * - `inputProps.value`: use `value` instead
+     * - `inputProps.disabled`: use `disabled` instead
+     * - `inputProps.type`: cannot be customized, always set to "text"
+     *
+     * Note that `inputProps.tagName` will override `popoverProps.targetTagName`.
      */
-    inputProps?: Omit<InputGroupProps2, "disabled" | "type" | "value">;
+    inputProps?: Partial<Omit<InputGroupProps2, "disabled" | "type" | "value">>;
 
     /**
      * Callback invoked whenever the date or timezone has changed.
@@ -121,23 +127,6 @@ export interface DateInput2Props extends DatePickerBaseProps, DateFormatProps, P
      * the out of range date will be returned (`onChange` is not called in this case).
      */
     onError?: (errorDate: Date) => void;
-
-    /**
-     * The props to pass to the popover.
-     */
-    popoverProps?: Partial<
-        Omit<
-            Popover2Props,
-            | "autoFocus"
-            | "content"
-            | "defaultIsOpen"
-            | "disabled"
-            | "enforceFocus"
-            | "fill"
-            | "renderTarget"
-            | "targetTagName"
-        >
-    >;
 
     /**
      * Element to render on right side of input.
@@ -203,6 +192,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
         minDate = DEFAULT_MIN_DATE,
         placeholder,
         popoverProps = {},
+        popoverRef,
         showTimezoneSelect,
         timePrecision,
         value,
@@ -592,6 +582,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
                             {props.rightElement}
                         </>
                     }
+                    tagName={popoverProps.targetTagName}
                     type="text"
                     {...targetProps}
                     {...inputProps}
@@ -634,6 +625,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             enforceFocus={false}
             onClose={handlePopoverClose}
             popoverClassName={classNames(Classes.DATE_INPUT_POPOVER, popoverProps.popoverClassName)}
+            ref={popoverRef}
             renderTarget={renderTarget}
         />
     );

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -39,9 +39,10 @@ import {
     DateRangePicker,
     DateRangeShortcut,
 } from "@blueprintjs/datetime";
-import { Popover2, Popover2Props, Popover2TargetProps } from "@blueprintjs/popover2";
+import { Popover2, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import { Classes, DateRange, NonNullDateRange } from "../../common";
+import { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import { isDayInRange, isSameTime } from "../../common/dateUtils";
 import * as Errors from "../../common/errors";
 
@@ -53,7 +54,7 @@ type InputEvent =
     | React.FocusEvent<HTMLInputElement>
     | React.ChangeEvent<HTMLInputElement>;
 
-export interface DateRangeInput2Props extends DatePickerBaseProps, DateFormatProps, Props {
+export interface DateRangeInput2Props extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.
@@ -122,23 +123,6 @@ export interface DateRangeInput2Props extends DatePickerBaseProps, DateFormatPro
      * @default "Overlapping dates"
      */
     overlappingDatesMessage?: string;
-
-    /**
-     * The props to pass to the popover.
-     */
-    popoverProps?: Partial<
-        Omit<
-            Popover2Props,
-            | "autoFocus"
-            | "content"
-            | "defaultIsOpen"
-            | "disabled"
-            | "enforceFocus"
-            | "fill"
-            | "renderTarget"
-            | "targetTagName"
-        >
-    >;
 
     /**
      * Whether the entire text field should be selected on focus.
@@ -340,7 +324,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
 
     public render() {
         const { selectedShortcutIndex } = this.state;
-        const { popoverProps = {} } = this.props;
+        const { popoverProps = {}, popoverRef } = this.props;
 
         const popoverContent = (
             <DateRangePicker
@@ -367,6 +351,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
                 enforceFocus={false}
                 onClose={this.handlePopoverClose}
                 popoverClassName={classNames(Classes.DATE_RANGE_INPUT_POPOVER, popoverProps.popoverClassName)}
+                ref={popoverRef}
                 renderTarget={this.renderTarget}
             />
         );
@@ -383,12 +368,17 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
     // We use the renderTarget API to flatten the rendered DOM.
     private renderTarget =
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
-        ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
-            return (
-                <div {...targetProps} className={classNames(CoreClasses.CONTROL_GROUP, targetProps.className)}>
-                    {this.renderInputGroup(Boundary.START)}
-                    {this.renderInputGroup(Boundary.END)}
-                </div>
+        ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<unknown>) => {
+            const { popoverProps = {} } = this.props;
+            const { targetTagName = "div" } = popoverProps;
+            return React.createElement(
+                targetTagName,
+                {
+                    ...targetProps,
+                    className: classNames(CoreClasses.CONTROL_GROUP, targetProps.className),
+                },
+                this.renderInputGroup(Boundary.START),
+                this.renderInputGroup(Boundary.END),
             );
         };
 

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -129,7 +129,7 @@ export interface IPopover2State {
 }
 
 /**
- * @template T target component props interface
+ * @template T target element props interface
  */
 export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopover2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover2`;
@@ -151,7 +151,7 @@ export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopov
         // N.B. we don't set a default for `placement` or `position` here because that would trigger
         // a warning in validateProps if the other prop is specified by a user of this component
         positioningStrategy: "absolute",
-        renderTarget: undefined as any,
+        renderTarget: undefined,
         shouldReturnFocusOnClose: false,
         targetTagName: "span",
         transitionDuration: 300,

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -254,9 +254,16 @@ export interface IPopover2SharedProps<TProps> extends OverlayableProps, Props {
      * By default, a `<span>` tag is used so popovers appear as inline-block
      * elements and can be nested in text. Use `<div>` tag for a block element.
      *
-     * Mutually exclusive with renderTarget.
+     * If `fill` is set to `true`, this prop's default value will become `"div"`
+     * instead of `"span"`.
      *
-     * @default "span" ("div" if fill={true})
+     * Note that _not all HTML tags are supported_; you will need to make sure
+     * the tag you choose supports the HTML attributes Popover2 applies to the
+     * target element.
+     *
+     * This prop is mutually exclusive with the `renderTarget` API.
+     *
+     * @default "span" ("div" if `fill={true}`)
      */
     targetTagName?: keyof JSX.IntrinsicElements;
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -239,6 +239,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 fill,
                 onClear,
                 placeholder,
+                popoverProps = {},
                 popoverTargetProps = {},
                 selectedItems,
                 tagInputProps = {},
@@ -272,39 +273,41 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     />
                 ) : undefined;
 
-            return (
-                <div
-                    aria-autocomplete="list"
-                    aria-controls={this.listboxId}
-                    {...popoverTargetProps}
-                    {...targetProps}
-                    aria-expanded={isOpen}
+            const { targetTagName = "div" } = popoverProps;
+
+            return React.createElement(
+                targetTagName,
+                {
+                    "aria-autocomplete": "list",
+                    "aria-controls": this.listboxId,
+                    ...popoverTargetProps,
+                    ...targetProps,
+                    "aria-expanded": isOpen,
                     // Note that we must set FILL here in addition to TagInput to get the wrapper element to full width
-                    className={classNames(targetProps.className, popoverTargetProps.className, {
+                    className: classNames(targetProps.className, popoverTargetProps.className, {
                         [CoreClasses.FILL]: fill,
-                    })}
+                    }),
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.
-                    onKeyDown={this.getTagInputKeyDownHandler(handleKeyDown)}
-                    onKeyUp={this.getTagInputKeyUpHandler(handleKeyUp)}
-                    ref={ref}
-                    role="combobox"
-                >
-                    <TagInput
-                        placeholder={placeholder}
-                        rightElement={maybeClearButton}
-                        {...tagInputProps}
-                        className={classNames(Classes.MULTISELECT, tagInputProps.className)}
-                        inputRef={this.refHandlers.input}
-                        inputProps={inputProps}
-                        inputValue={listProps.query}
-                        onAdd={this.getTagInputAddHandler(listProps)}
-                        onInputChange={listProps.handleQueryChange}
-                        onRemove={this.handleTagRemove}
-                        values={selectedItems.map(this.props.tagRenderer)}
-                    />
-                </div>
+                    onKeyDown: this.getTagInputKeyDownHandler(handleKeyDown),
+                    onKeyUp: this.getTagInputKeyUpHandler(handleKeyUp),
+                    ref,
+                    role: "combobox",
+                },
+                <TagInput
+                    placeholder={placeholder}
+                    rightElement={maybeClearButton}
+                    {...tagInputProps}
+                    className={classNames(Classes.MULTISELECT, tagInputProps.className)}
+                    inputRef={this.refHandlers.input}
+                    inputProps={inputProps}
+                    inputValue={listProps.query}
+                    onAdd={this.getTagInputAddHandler(listProps)}
+                    onInputChange={listProps.handleQueryChange}
+                    onRemove={this.handleTagRemove}
+                    values={selectedItems.map(this.props.tagRenderer)}
+                />,
             );
         };
 

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -213,28 +213,29 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
         ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
-            const { popoverTargetProps } = this.props;
+            const { popoverProps = {}, popoverTargetProps } = this.props;
             const { handleKeyDown, handleKeyUp } = listProps;
-            return (
-                <div
-                    aria-controls={this.listboxId}
-                    {...popoverTargetProps}
-                    {...targetProps}
-                    aria-expanded={isOpen}
+            const { targetTagName = "div" } = popoverProps;
+            return React.createElement(
+                targetTagName,
+                {
+                    "aria-controls": this.listboxId,
+                    ...popoverTargetProps,
+                    ...targetProps,
+                    "aria-expanded": isOpen,
                     // Note that we must set FILL here in addition to children to get the wrapper element to full width
-                    className={classNames(targetProps.className, popoverTargetProps?.className, {
+                    className: classNames(targetProps.className, popoverTargetProps?.className, {
                         [CoreClasses.FILL]: this.props.fill,
-                    })}
+                    }),
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.
-                    onKeyDown={isOpen ? handleKeyDown : this.handleTargetKeyDown}
-                    onKeyUp={isOpen ? handleKeyUp : undefined}
-                    ref={ref}
-                    role="combobox"
-                >
-                    {this.props.children}
-                </div>
+                    onKeyDown: isOpen ? handleKeyDown : this.handleTargetKeyDown,
+                    onKeyUp: isOpen ? handleKeyUp : undefined,
+                    ref,
+                    role: "combobox",
+                },
+                this.props.children,
             );
         };
 

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -53,11 +53,16 @@ export interface Suggest2Props<T> extends ListItemsProps<T>, SelectPopoverProps 
     fill?: boolean;
 
     /**
-     * Props to spread to the query `InputGroup`. To control this input, use
-     * `query` and `onQueryChange` instead of `inputProps.value` and
-     * `inputProps.onChange`.
+     * Props to pass to the query [InputGroup component](#core/components/text-inputs.input-group).
+     *
+     * Some properties are unavailable:
+     * - `inputProps.value`: use `query` instead
+     * - `inputProps.onChange`: use `onQueryChange` instead
+     * - `inputProps.disabled`: use `disabled` instead
+     *
+     * Note that `inputProps.tagName` will override `popoverProps.targetTagName`.
      */
-    inputProps?: InputGroupProps2;
+    inputProps?: Partial<Omit<InputGroupProps2, "disabled" | "value" | "onChange">>;
 
     /** Custom renderer to transform an item into a string for the input value. */
     inputValueRenderer: (item: T) => string;
@@ -225,7 +230,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
             ref,
             ...targetProps
         }: Popover2TargetProps & React.HTMLProps<HTMLInputElement>) => {
-            const { disabled, fill, inputProps = {}, inputValueRenderer, resetOnClose } = this.props;
+            const { disabled, fill, inputProps = {}, inputValueRenderer, popoverProps = {}, resetOnClose } = this.props;
             const { selectedItem } = this.state;
             const { handleKeyDown, handleKeyUp } = listProps;
 
@@ -239,9 +244,10 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
 
             return (
                 <InputGroup
+                    aria-controls={this.listboxId}
                     autoComplete={autoComplete}
                     disabled={disabled}
-                    aria-controls={this.listboxId}
+                    tagName={popoverProps.targetTagName}
                     {...targetProps}
                     {...inputProps}
                     aria-autocomplete="list"

--- a/packages/select/test/selectPopoverTestSuite.tsx
+++ b/packages/select/test/selectPopoverTestSuite.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import { ReactWrapper } from "enzyme";
+import type { ReactWrapper } from "enzyme";
 import * as sinon from "sinon";
 
 import { Classes as Popover2Classes } from "@blueprintjs/popover2";
@@ -23,17 +23,17 @@ import { Classes as Popover2Classes } from "@blueprintjs/popover2";
 import { ListItemsProps, SelectPopoverProps } from "../src";
 import { areFilmsEqual, Film, filterFilm, renderFilm, TOP_100_FILMS } from "../src/__examples__";
 
+type EnzymeLocator<P, S> = (wrapper: ReactWrapper<P, S>) => ReactWrapper;
+
 /**
- * Common tests for popover functionality in select components which use Popover2.
+ * Common tests for popover functionality in `@blueprintjs/select` components which use Popover2.
  *
- * render() should ensure the component is attached to a DOM node so that we can get accurate DOM measurements.
+ * @param render should ensure the component is attached to a DOM node so that we can get accurate DOM measurements.
  */
 export function selectPopoverTestSuite<P extends ListItemsProps<Film>, S>(
     render: (props: ListItemsProps<Film> & SelectPopoverProps) => ReactWrapper<P, S>,
-    findPopover: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper =>
-        wrapper.find(`.${Popover2Classes.POPOVER2}`),
-    findTarget: (wrapper: ReactWrapper<P, S>) => ReactWrapper = wrapper =>
-        wrapper.find(`.${Popover2Classes.POPOVER2_TARGET}`),
+    findPopover: EnzymeLocator<P, S> = wrapper => wrapper.find(`.${Popover2Classes.POPOVER2}`),
+    findTarget: EnzymeLocator<P, S> = wrapper => wrapper.find(`.${Popover2Classes.POPOVER2_TARGET}`),
 ) {
     const defaultProps = {
         itemPredicate: filterFilm,
@@ -50,7 +50,7 @@ export function selectPopoverTestSuite<P extends ListItemsProps<Film>, S>(
         usePortal: false,
     };
 
-    describe("popover", () => {
+    describe("popoverProps functionality", () => {
         it("matchTargetWidth: true makes popover same width as target", () => {
             const wrapper = render({
                 ...defaultProps,
@@ -61,6 +61,20 @@ export function selectPopoverTestSuite<P extends ListItemsProps<Film>, S>(
             assert.notEqual(popoverWidth, 0, "popover width should be > 0");
             assert.notEqual(targetWidth, 0, "target width should be > 0");
             assert.closeTo(targetWidth, popoverWidth, 1, "popover width should be close to target width");
+            wrapper.detach();
+        });
+
+        it("targetTagName allows customizing the target element", () => {
+            const targetTagName = "a";
+            const wrapper = render({
+                ...defaultProps,
+                popoverProps: { ...defaultPopoverProps, targetTagName },
+            });
+            const anchorElement = wrapper.find(`${targetTagName}.${Popover2Classes.POPOVER2_TARGET}`);
+            assert.isTrue(
+                anchorElement.exists(),
+                `Expected to find popover target element with tag name '${targetTagName}'`,
+            );
             wrapper.detach();
         });
     });

--- a/packages/select/test/suggest2Tests.tsx
+++ b/packages/select/test/suggest2Tests.tsx
@@ -194,6 +194,7 @@ describe("Suggest2", () => {
             const value = "nailed it";
             const onChange = sinon.spy();
 
+            // @ts-expect-error - value and onChange are now omitted from the props type
             const input = suggest({ inputProps: { value, onChange } }).find("input");
             assert.notStrictEqual(input.prop("onChange"), onChange);
             assert.notStrictEqual(input.prop("value"), value);


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

While migrating a large codebase to Popover2, I noticed some v2 components no longer supported `popoverProps.targetTagName` like they did with Popover. Although this use case is rare, I think we can continue supporting it in Popover2.

This PR does a few things:
- 🌟 feat(`InputGroup`): new prop `tagName` allows customizing the tag name of the HTML element that contains the input group
- 🔧 fix(`Select2`, `Suggest2`, `MultiSelect2`): restore support for `popoverProps={{ targetTagName }}`, which was previously available in the v1 components with `<Popover>`
- 🔧 fix(`DateInput2`, `DateRangeInput2`): restore support for `popoverProps={{ targetTagName }}`, which was previously available in the v1 components with `<Popover>`
- 🌟 feat(`DateInput2`, `DateRangeInput2`): new prop `popoverRef` allows access to the Popover2 instance, sometimes useful for repositioning the popover

#### Reviewers should focus on:

No regressions

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
