### PR TITLE
[datetime] docs: formally mark DateInput as deprecated

### DIFF
--- a/packages/datetime/src/dateinput.md
+++ b/packages/datetime/src/dateinput.md
@@ -1,13 +1,16 @@
 @# Date input
 
-<div class="@ns-callout @ns-intent-success @ns-icon-star">
-    <h4 class="@ns-heading">Newer API available</h4>
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h4 class="@ns-heading">
 
-There is an updated version of this component available in the new
-[__@blueprintjs/datetime2__ package](#datetime2) called
-[DateInput2](#datetime2/date-input2). Its API is currently in development,
-but you are encouraged to try it out and provide feedback for the next
-version of the Blueprint date input.
+Deprecated: use [DateInput2](#datetime2/date-input2)
+
+</h4>
+
+This component is **deprecated since @blueprintjs/datetime v4.4.5** in favor of the new
+DateInput2 component available in the `@blueprintjs/datetime2` package, which uses
+Popover2 instead of Popover. You should migrate to the new API which will become the
+standard in Blueprint v5.
 
 </div>
 

--- a/packages/datetime2/src/components/date-input2/date-input2.md
+++ b/packages/datetime2/src/components/date-input2/date-input2.md
@@ -11,8 +11,7 @@ Migrating from [DateInput](#datetime/dateinput)?
 
 </h4>
 
-DateInput2 is a replacement for the [DateInput component](#datetime/dateinput) from
-[__@blueprintjs/datetime__ package](#datetime) and will replace it in Blueprint v5.
+DateInput2 is a replacement for DateInput and will replace it in Blueprint v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
 See the [migration guide](https://github.com/palantir/blueprint/wiki/datetime2-component-migration)
 on the wiki.


### PR DESCRIPTION
`<DateInput>` was marked as `@deprecated` in TS/JS, but the docs did not fully match this. Now the guidance is more clear.

Before:

<img width="837" alt="image" src="https://user-images.githubusercontent.com/723999/200090152-55efa974-8794-4095-915f-78cfe43596ab.png">

After:
<img width="825" alt="image" src="https://user-images.githubusercontent.com/723999/200090210-3dab15cf-3e9c-4dcb-9a89-ffb808fc03bc.png">
