### PR TITLE
[core] fix(InputGroup): omit invalid 'tagName' attr from DOM

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -177,6 +177,7 @@ const INVALID_PROPS = [
     "rightIcon",
     "round",
     "small",
+    "tagName",
     "text",
 ];
 


### PR DESCRIPTION
Regression introduced in #5713, where I forgot to omit the new `tagName` prop from DOM attributes.