### PR TITLE
[datetime2] fix(DateInput2): display updated timezone immediately

### DIFF
--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -608,6 +608,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
             isTimezoneSelectHidden,
             placeholder,
             shouldShowErrorStyling,
+            timezoneValue,
             props.disabled,
             props.inputProps,
             props.rightElement,

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -479,7 +479,7 @@ describe("<DateInput2>", () => {
             assert.doesNotThrow(() => mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={null} />));
         });
 
-        describe.only("when changing timezone", () => {
+        describe("when changing timezone", () => {
             it("calls onChange with the updated ISO string", () => {
                 const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
                 clickTimezoneItem(wrapper, "Paris");

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -21,7 +21,7 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as sinon from "sinon";
 
-import { Classes as CoreClasses, InputGroup, Keys } from "@blueprintjs/core";
+import { Classes as CoreClasses, InputGroup, Keys, Tag } from "@blueprintjs/core";
 import { DatePicker, Classes as DatetimeClasses, Months, TimePrecision, TimeUnit } from "@blueprintjs/datetime";
 import { Popover2, Classes as Popover2Classes } from "@blueprintjs/popover2";
 
@@ -479,7 +479,7 @@ describe("<DateInput2>", () => {
             assert.doesNotThrow(() => mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} value={null} />));
         });
 
-        describe("when changing timezone", () => {
+        describe.only("when changing timezone", () => {
             it("calls onChange with the updated ISO string", () => {
                 const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
                 clickTimezoneItem(wrapper, "Paris");
@@ -494,6 +494,14 @@ describe("<DateInput2>", () => {
                 clickTimezoneItem(wrapper, "Paris");
                 assert.isTrue(onChange.calledOnce);
                 assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30+01:00");
+            });
+
+            it("updates the displayed timezone", () => {
+                const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_CONTROLLED} />);
+                clickTimezoneItem(wrapper, "New York");
+                const tzTag = wrapper.find(Tag);
+                // date-fns does not know about Daylight Saving Time in Node.js
+                assert.strictEqual(tzTag.text(), "EST");
             });
         });
 
@@ -725,13 +733,18 @@ describe("<DateInput2>", () => {
 
     function clickTimezoneItem(wrapper: ReactWrapper<DateInput2Props>, searchQuery: string) {
         wrapper.find(`.${Classes.TIMEZONE_SELECT}`).hostNodes().simulate("click");
-        wrapper
+        const tzItem = wrapper
             .find(`.${Classes.TIMEZONE_SELECT_POPOVER}`)
             .find(`.${CoreClasses.MENU_ITEM}`)
             .hostNodes()
             .findWhere(item => item.text().includes(searchQuery))
-            .first()
-            .simulate("click");
+            .first();
+
+        if (tzItem.exists()) {
+            tzItem.simulate("click");
+        } else {
+            assert.fail(`Could not find timezone option with query '${searchQuery}'`);
+        }
     }
 
     function clickCalendarDay(wrapper: ReactWrapper<DateInput2Props>, dayNumber: number) {


### PR DESCRIPTION
#### Fixes #5714 

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix `renderTarget` dependency list so that the timezone displayed inside DateInput2 is updated immediately after changing it via the TimezoneSelect.

The fact that we have to do this is a sign that React hooks are kind of lame. 

#### Reviewers should focus on:

No regressions

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
