### PR TITLE
[table-dev-app] feat: Add copy option to body context menu

### DIFF
--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -39,6 +39,7 @@ import {
     Cell,
     Column,
     ColumnHeaderCell2,
+    CopyCellsMenuItem,
     EditableCell2,
     EditableName,
     FocusedCellCoordinates,
@@ -55,6 +56,7 @@ import {
     TruncatedPopoverMode,
     Utils,
 } from "@blueprintjs/table";
+import { IMenuContext } from "@blueprintjs/table/src";
 import type { ColumnIndices, RowIndices } from "@blueprintjs/table/src/common/grid";
 
 import { DenseGridMutableStore } from "./denseGridMutableStore";
@@ -1044,9 +1046,10 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         return handleStringChange(value => this.setState({ [stateKey]: value }));
     };
 
-    private renderBodyContextMenu = () => {
+    private renderBodyContextMenu = (context: IMenuContext) => {
         const menu = (
             <Menu>
+                <CopyCellsMenuItem context={context} icon="clipboard" getCellData={this.getCellValue} text="Copy" />
                 <MenuItem icon="search-around" text="Item 1" />
                 <MenuItem icon="search" text="Item 2" />
                 <MenuItem icon="graph-remove" text="Item 3" />


### PR DESCRIPTION
#### Fixes: No issue, noticed it while trying to add paste feature

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add copy option to body context menu when it's enabled.

#### Screenshot

![ScreenShot Tool -20221106090605](https://user-images.githubusercontent.com/57423623/200178808-f1a403ec-47ca-498c-8811-d4980e24fce6.png)
