### PR TITLE
[popover2] feat(Popover2, Tooltip2): make component type param optional

### DIFF
--- a/packages/datetime2/src/common/datetimePopoverProps.ts
+++ b/packages/datetime2/src/common/datetimePopoverProps.ts
@@ -22,7 +22,7 @@ import type { Popover2, Popover2Props } from "@blueprintjs/popover2";
  */
 export interface DatetimePopoverProps {
     /**
-     * Props to spread to `Popover2`.
+     * Props to spread to Popover2.
      */
     popoverProps?: Partial<
         Omit<
@@ -35,5 +35,5 @@ export interface DatetimePopoverProps {
      * Optional ref for the Popover2 component instance.
      * This is sometimes useful to reposition the popover.
      */
-    popoverRef?: React.RefObject<Popover2<React.HTMLProps<unknown>>>;
+    popoverRef?: React.RefObject<Popover2>;
 }

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -373,7 +373,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
     // We use the renderTarget API to flatten the rendered DOM.
     private renderTarget =
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
-        ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<unknown>) => {
+        ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLElement>) => {
             const { fill, popoverProps = {} } = this.props;
             const { targetTagName = "div" } = popoverProps;
             return React.createElement(

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -72,7 +72,7 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
         tagMinimal: false,
     };
 
-    private popoverRef: React.RefObject<Popover2<any>> = React.createRef();
+    private popoverRef: React.RefObject<Popover2> = React.createRef();
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
 

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -129,9 +129,12 @@ export interface IPopover2State {
 }
 
 /**
- * @template T target element props interface
+ * @template T target element props interface. Defaults to `React.HTMLProps<HTMLElement>`.
  */
-export class Popover2<T> extends AbstractPureComponent2<Popover2Props<T>, IPopover2State> {
+export class Popover2<T = React.HTMLProps<HTMLElement>> extends AbstractPureComponent2<
+    Popover2Props<T>,
+    IPopover2State
+> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover2`;
 
     public static defaultProps: Popover2Props = {

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -75,7 +75,10 @@ export interface ITooltip2Props<TProps = React.HTMLProps<HTMLElement>>
     transitionDuration?: number;
 }
 
-export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
+/**
+ * @template T target element props interface. Defaults to `React.HTMLProps<HTMLElement>`.
+ */
+export class Tooltip2<T = React.HTMLProps<HTMLElement>> extends React.PureComponent<Tooltip2Props<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tooltip2`;
 
     public static defaultProps: Partial<Tooltip2Props> = {

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -23,14 +23,14 @@ import { Classes as CoreClasses, Menu, MenuItem, Overlay, Portal } from "@bluepr
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 
 import { Classes, Errors } from "../src";
-import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind } from "../src/popover2";
+import { IPopover2State, Popover2, Popover2InteractionKind, Popover2Props } from "../src/popover2";
 import { Popover2Arrow } from "../src/popover2Arrow";
 import { PopupKind } from "../src/popupKind";
 import { Tooltip2 } from "../src/tooltip2";
 
 describe("<Popover2>", () => {
     let testsContainerElement: HTMLElement;
-    let wrapper: IPopover2Wrapper | undefined;
+    let wrapper: Popover2Wrapper | undefined;
     const onInteractionSpy = sinon.spy();
 
     beforeEach(() => {
@@ -366,7 +366,7 @@ describe("<Popover2>", () => {
             assert.equal(wrapper.state("isOpen"), isOpen);
         }
 
-        function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<IPopover2Props>) {
+        function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<Popover2Props>) {
             wrapper = renderPopover({ ...popoverProps, usePortal: true });
             const targetElement = wrapper.find("[data-testid='target-button']").getDOMNode();
 
@@ -790,7 +790,7 @@ describe("<Popover2>", () => {
         });
     });
 
-    interface IPopover2Wrapper extends ReactWrapper<IPopover2Props, IPopover2State> {
+    interface Popover2Wrapper extends ReactWrapper<Popover2Props, IPopover2State> {
         popoverElement: HTMLElement;
         targetElement: HTMLElement;
         assertFindClass(className: string, expected?: boolean, msg?: string): this;
@@ -799,10 +799,10 @@ describe("<Popover2>", () => {
         simulateTarget(eventName: string): this;
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
         sendEscapeKey(): this;
-        then(next: (wrap: IPopover2Wrapper) => void, done: Mocha.Done): this;
+        then(next: (wrap: Popover2Wrapper) => void, done: Mocha.Done): this;
     }
 
-    function renderPopover(props: Partial<IPopover2Props> = {}, content?: any) {
+    function renderPopover(props: Partial<Popover2Props> = {}, content?: any) {
         wrapper = mount(
             <Popover2
                 usePortal={false}
@@ -814,9 +814,9 @@ describe("<Popover2>", () => {
                 <button data-testid="target-button">Target</button>
             </Popover2>,
             { attachTo: testsContainerElement },
-        ) as IPopover2Wrapper;
+        ) as Popover2Wrapper;
 
-        const instance = wrapper.instance() as Popover2<React.HTMLProps<HTMLButtonElement>>;
+        const instance = wrapper.instance() as Popover2;
         wrapper.popoverElement = instance.popoverElement!;
         wrapper.targetElement = instance.targetElement!;
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {

--- a/packages/select/src/common/selectPopoverProps.ts
+++ b/packages/select/src/common/selectPopoverProps.ts
@@ -39,7 +39,7 @@ export interface SelectPopoverProps {
      * Optional ref for the Popover2 component instance.
      * This is sometimes useful to reposition the popover.
      */
-    popoverRef?: React.RefObject<Popover2<React.HTMLProps<unknown>>>;
+    popoverRef?: React.RefObject<Popover2>;
 
     /**
      * HTML attributes to add to the popover target element.

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -147,7 +147,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     private refHandlers: {
         input: React.RefCallback<HTMLInputElement>;
-        popover: React.RefObject<Popover2<React.HTMLProps<HTMLDivElement>>>;
+        popover: React.RefObject<Popover2>;
         queryList: React.RefCallback<QueryList<T>>;
     } = {
         input: refHandler(this, "input", this.props.tagInputProps?.inputRef),


### PR DESCRIPTION

#### Changes proposed in this pull request:

It turns out https://github.com/palantir/blueprint/pull/5713 also had a typings regression for the `popoverRef` prop on datetime2 & select components, specifically the bit with `React.HTMLProps<unknown>`. In trying to improve this type definition, I found myself writing `React.HTMLProps<HtmlElement>` in a lot of places, since that's the default assumed in the definition of `Popover2Props<T = ...>`. It seems like we can actually just define this as the default in the `Popover2` class definition and avoid specifying the type param in most cases. I'm not exactly sure why this wasn't the case before (`T` was required if referencing `Popover2` as a type), but this will make these type references a lot simpler in our codebase and for consumers.

