### PR TITLE
[datetime2] fix: relax date-fns dependency constraint

### DIFF
--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -40,7 +40,7 @@
         "@blueprintjs/popover2": "^1.10.0",
         "@blueprintjs/select": "^4.8.10",
         "classnames": "^2.3.1",
-        "date-fns": "^2.29.3",
+        "date-fns": "^2.28.0",
         "date-fns-tz": "^1.3.4",
         "lodash": "^4.17.21",
         "tslib": "~2.3.1"

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -31,7 +31,7 @@
         "chroma-js": "^2.1.0",
         "classnames": "^2.3.1",
         "core-js": "^3.26.0",
-        "date-fns": "^2.29.3",
+        "date-fns": "^2.28.0",
         "dom4": "^2.1.5",
         "downloadjs": "^1.4.7",
         "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4012,7 +4012,7 @@ date-fns-tz@^1.3.4:
   resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.4.tgz#8b0e75beb771c7e9f1597aba467dc14431bb5403"
   integrity sha512-O47vEyz85F2ax/ZdhMBJo187RivZGjH6V0cPjPzpm/yi6YffJg4upD/8ibezO11ezZwP3QYlBHh/t4JhRNx0Ow==
 
-date-fns@^2.29.3:
+date-fns@^2.28.0:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==


### PR DESCRIPTION
date-fns v2.29.3 has a significant bundle size regression (https://github.com/date-fns/date-fns/issues/3208), so we need to allow consumers to install a wider version range of that library. We aren't using any features that require the latest version.