### PR TITLE
[popover2] docs(Tooltip2): add warning about disabled Buttons

### DIFF
--- a/packages/popover2/src/tooltip2.md
+++ b/packages/popover2/src/tooltip2.md
@@ -76,4 +76,14 @@ The **content** will be shown inside the tooltip itself. When opened, the toolti
 positioned on the page next to the target; the `position` prop determines its relative position (on
 which side of the target).
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h4 class="@ns-heading">Button targets</h4>
+
+Buttons make great tooltip targets, but the `disabled` attribute will prevent all
+events so the enclosing `Tooltip2` will not know when to respond.
+Use [`AnchorButton`](#core/components/button.anchor-button) instead;
+see the [callout here](#core/components/button.props) for more details.
+
+</div>
+
 @interface ITooltip2Props


### PR DESCRIPTION
Added the Button warning from deprecated Tooltip document

#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The documentation of the old Tooltip component has a warning about using the tooltip with Button component. The new document doesn't have this and it may confuse the users. I just copied that part.

#### Reviewers should focus on:

The warning in the Props section
