### PR TITLE
[datetime2] fix: non-nullable onChange adapter

### DIFF
--- a/packages/datetime2/src/components/date-input2/dateInput2MigrationUtils.ts
+++ b/packages/datetime2/src/components/date-input2/dateInput2MigrationUtils.ts
@@ -21,12 +21,17 @@ import { getDateObjectFromIsoString, getIsoEquivalentWithUpdatedTimezone } from 
 import type { DateInput2Props } from "./dateInput2";
 
 /**
- * Adapter for automated DateInput -> DateInput2 migrations.
+ * `onChange` prop adapter for automated DateInput -> DateInput2 migrations.
+ *
+ * Note that we exclude `undefined` from the input & output types since we expect the callback to be defined
+ * if this adapter is used.
  *
  * @param handler DateInput onChange handler
  * @returns DateInput2 onChange handler
  */
-export function onChangeAdapter(handler: DateInputProps["onChange"]): DateInput2Props["onChange"] {
+export function onChangeAdapter(
+    handler: NonNullable<DateInputProps["onChange"]>,
+): NonNullable<DateInput2Props["onChange"]> {
     if (handler === undefined) {
         return noOp;
     }
@@ -36,7 +41,7 @@ export function onChangeAdapter(handler: DateInputProps["onChange"]): DateInput2
 }
 
 /**
- * Adapter for automated DateInput -> DateInput2 migrations.
+ * `value` prop adapter for automated DateInput -> DateInput2 migrations.
  *
  * @param value DateInput value
  * @param timePrecision (optional) DateInput timePrecision

--- a/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
@@ -93,4 +93,21 @@ describe("DateInput2MigrationUtils", () => {
             />,
         );
     });
+
+    it("Adapters work in common usage pattern with React.useCallback + React.useMemo", () => {
+        function TestComponent() {
+            const handleChange = React.useCallback(
+                DateInput2MigrationUtils.onChangeAdapter(controlledDateInputProps.onChange),
+                [controlledDateInputProps.onChange],
+            );
+            const value = React.useMemo(
+                () => DateInput2MigrationUtils.valueAdapter(controlledDateInputProps.value),
+                [controlledDateInputProps.value],
+            );
+
+            return <DateInput2 {...dateFormattingProps} onChange={handleChange} value={value} />;
+        }
+
+        mount(<TestComponent />);
+    });
 });


### PR DESCRIPTION
#### Changes proposed in this pull request:

It's common to see code like this in a function component using DateInput:

```ts
const handleChange = React.useCallback((newDate: Date) => {
    // ...
}, [/* some dependencies */]);
return <DateInput2 onChange={handleChange} />;
```

When this gets migrated to DateInput2 using our automated codemods, it becomes:

```ts
const handleChange = React.useCallback((newDate: Date) => {
    // ...
}, [/* some dependencies */]);
return <DateInput2 onChange={DateInput2MigrationUtils.onChangeAdapter(handleChange)} />;
```

... which nullifies the benefits of `useCallback` since a new function is being created every time. A better pattern would be:

```ts
const handleChange = React.useCallback(
    DateInput2MigrationUtils.onChangeAdapter((newDate: Date) => {
        // ...
    }),
    [/* some dependencies */]
);
return <DateInput2 onChange={handleChange)} />;
```

... but that did not type check before this PR because of the loose input/output types for the adapter which included `undefined`.

This change fixes the type of `DateInput2MigrationUtils.onChangeAdapter` so the last code example works.