### PR TITLE
[core] feat(MultiStepDialog): allow multiple close buttons

### DIFF
--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -40,7 +40,7 @@ export interface IMultistepDialogProps extends DialogProps {
     children?: React.ReactNode;
 
     /**
-     * Props for the close button that appears in the footer when there is no title.
+     * Props for the close button that appears in the footer.
      */
     closeButtonProps?: DialogStepButtonProps;
 
@@ -79,9 +79,8 @@ export interface IMultistepDialogProps extends DialogProps {
     resetOnClose?: boolean;
 
     /**
-     * Whether the footer close button is shown. The button will only appear if
-     * `isCloseButtonShown` is `true`. The close button in the dialog title will
-     * not be shown when this is `true`.
+     * Whether the footer close button is shown. When this value is true, the button will appear
+     * regardless of the value of `isCloseButtonShown`.
      *
      * @default false
      */
@@ -121,13 +120,9 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
         const { className, navigationPosition, showCloseButtonInFooter, isCloseButtonShown, ...otherProps } =
             this.props;
 
-        // Only one close button should be displayed. If the footer close button
-        // is shown, we need to ensure the dialog close button is not displayed.
-        const isCloseButtonVisible = !showCloseButtonInFooter && isCloseButtonShown;
-
         return (
             <Dialog
-                isCloseButtonShown={isCloseButtonVisible}
+                isCloseButtonShown={isCloseButtonShown}
                 {...otherProps}
                 className={classNames(
                     {
@@ -211,9 +206,8 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
     }
 
     private renderFooter() {
-        const { closeButtonProps, isCloseButtonShown, showCloseButtonInFooter, onClose } = this.props;
-        const isFooterCloseButtonVisible = showCloseButtonInFooter && isCloseButtonShown;
-        const maybeCloseButton = !isFooterCloseButtonVisible ? undefined : (
+        const { closeButtonProps, showCloseButtonInFooter, onClose } = this.props;
+        const maybeCloseButton = !showCloseButtonInFooter ? undefined : (
             <DialogStepButton text="Close" onClick={onClose} {...closeButtonProps} />
         );
         return (


### PR DESCRIPTION
#### Fixes #5758

#### Checklist

- [ ] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

- `isCloseButtonShown` only affects the close button in the header
- `showCloseButtonInFooter` independently affects the close button in the footer (and now allows the exciting possibility of having a third custom button e.g. to skip the multiple steps of the dialog.
- Updated inline prop docs and omitted tests since there were none for close buttons previously

#### Reviewers should focus on:
- The separation of `isCloseButtonShown` and `showCloseButtonInFooter` and that it works as expected depending on the set props.

#### Screenshot

![Screen Shot 2022-11-19 at 3 40 15 PM](https://user-images.githubusercontent.com/24800495/202870827-823c6432-4ab7-47b1-96f4-919a778946ba.png)