### PR TITLE
[select] fix: allow popoverProps.disabled

### DIFF
--- a/packages/select/src/common/selectPopoverProps.ts
+++ b/packages/select/src/common/selectPopoverProps.ts
@@ -32,8 +32,11 @@ export interface SelectPopoverProps {
      * Note that `content` cannot be changed, but you may apply some props to the content wrapper element
      * with `popoverContentProps`. Likewise, `targetProps` is no longer supported as it was in Blueprint v4, but you
      * may use `popoverTargetProps` instead.
+     *
+     * N.B. `disabled` is supported here, as this can be distinct from disabling the entire select button / input
+     * control element. There are some cases where we only want to disable the popover interaction.
      */
-    popoverProps?: Partial<Omit<Popover2Props, "content" | "defaultIsOpen" | "disabled" | "fill" | "renderTarget">>;
+    popoverProps?: Partial<Omit<Popover2Props, "content" | "defaultIsOpen" | "fill" | "renderTarget">>;
 
     /**
      * Optional ref for the Popover2 component instance.


### PR DESCRIPTION

#### Changes proposed in this pull request:

Allow `<Select2 popoverProps={{ disabled }}>`, `<Suggest2 popoverProps={{ disabled }}>`, and `<MultiSelect2 popoverProps={{ disabled }}>` because there are legitimate use cases for only disabling the popover.

