### PR TITLE
docs: fix deprecated Hotkeys example

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeys.md
+++ b/packages/core/src/components/hotkeys/hotkeys.md
@@ -171,4 +171,4 @@ Below is a little widget to quickly help you try out hotkey combos and see how
 they will look in the dialog. See the key combos section above for more about
 specifying key combo props.
 
-@reactExample HotkeyTester
+@reactExample HotkeyTesterExample

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -178,7 +178,7 @@
   }
 }
 
-#{example("HotkeyTester")} {
+#{example("HotkeyTesterExample")} {
   .docs-hotkey-tester {
     @include pt-flex-container(column, $pt-grid-size);
     align-items: center;


### PR DESCRIPTION
Missed some renames in #5715 when this React component was renamed. This fixes the deprecated Hotkeys documentation page runtime errors.