### PR TITLE
[datetime2] fix(DateRangeInput2): input value when controlled

### DIFF
--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -687,7 +687,12 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
 
     private handleInputFocus = (_e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
         const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
-        const inputString = DatePickerUtils.getFormattedDateString(values.selectedValue, this.props, true);
+        const isValueControlled = this.isControlled();
+        const inputString = DatePickerUtils.getFormattedDateString(
+            isValueControlled ? values.controlledValue : values.selectedValue,
+            this.props,
+            true,
+        );
 
         // change the boundary only if the user explicitly focused in the field.
         // focus changes from hovering don't count; they're just temporary.

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -688,6 +688,9 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
     private handleInputFocus = (_e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
         const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
         const isValueControlled = this.isControlled();
+        // We may be reacting to a programmatic focus triggered by componentDidUpdate() at a point when
+        // values.selectedValue may not have been updated yet in controlled mode, so we must use values.controlledValue
+        // in that case.
         const inputString = DatePickerUtils.getFormattedDateString(
             isValueControlled ? values.controlledValue : values.selectedValue,
             this.props,

--- a/packages/datetime2/test/components/dateRangeInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput2Tests.tsx
@@ -60,6 +60,19 @@ type InvalidDateTestFunction = (
 DateRangeInput2.defaultProps.popoverProps = { usePortal: false };
 
 describe("<DateRangeInput2>", () => {
+    let containerElement: HTMLElement | undefined;
+
+    beforeEach(() => {
+        containerElement = document.createElement("div");
+        document.body.appendChild(containerElement);
+    });
+    afterEach(() => {
+        if (containerElement !== undefined) {
+            ReactDOM.unmountComponentAtNode(containerElement);
+            containerElement.remove();
+        }
+    });
+
     const START_DAY = 22;
     const START_DATE = new Date(2022, Months.JANUARY, START_DAY);
     const START_STR = DATE_FORMAT.formatDate(START_DATE);
@@ -145,14 +158,8 @@ describe("<DateRangeInput2>", () => {
     });
 
     describe("timePrecision prop", () => {
-        const testsContainerElement = document.createElement("div");
-        document.documentElement.appendChild(testsContainerElement);
-
         it("<TimePicker /> should not lose focus on increment/decrement with up/down arrows", () => {
-            const { root } = wrap(
-                <DateRangeInput2 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
-                testsContainerElement,
-            );
+            const { root } = wrap(<DateRangeInput2 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
             root.setState({ isOpen: true });
             expect(root.find(Popover2).prop("isOpen")).to.be.true;
@@ -165,7 +172,7 @@ describe("<DateRangeInput2>", () => {
         it("when timePrecision != null && closeOnSelection=true && <TimePicker /> values is changed popover should not close", () => {
             const { root, getDayElement } = wrap(
                 <DateRangeInput2 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
-                testsContainerElement,
+                true,
             );
 
             root.setState({ isOpen: true });
@@ -183,10 +190,7 @@ describe("<DateRangeInput2>", () => {
         });
 
         it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
-            const { root } = wrap(
-                <DateRangeInput2 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
-                testsContainerElement,
-            );
+            const { root } = wrap(<DateRangeInput2 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
             root.setState({ isOpen: true });
             keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, Keys.ARROW_UP);
@@ -194,10 +198,6 @@ describe("<DateRangeInput2>", () => {
             keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, Keys.ARROW_UP, 1);
             root.update();
             expect(root.find(Popover2).prop("isOpen")).to.be.true;
-        });
-
-        afterEach(() => {
-            ReactDOM.unmountComponentAtNode(testsContainerElement);
         });
 
         function keyDownOnInput(className: string, key: number, inputElementIndex: number = 0) {
@@ -365,19 +365,8 @@ describe("<DateRangeInput2>", () => {
     });
 
     describe("closeOnSelection", () => {
-        let containerElement: HTMLElement | undefined;
-
-        beforeEach(() => {
-            containerElement = document.createElement("div");
-            document.body.appendChild(containerElement);
-        });
-        afterEach(() => containerElement?.remove());
-
         it("if closeOnSelection=false, popover stays open when full date range is selected", () => {
-            const { root, getDayElement } = wrap(
-                <DateRangeInput2 {...DATE_FORMAT} closeOnSelection={false} />,
-                containerElement,
-            );
+            const { root, getDayElement } = wrap(<DateRangeInput2 {...DATE_FORMAT} closeOnSelection={false} />, true);
             root.setState({ isOpen: true });
             root.update();
             getDayElement(1).simulate("click");
@@ -387,7 +376,7 @@ describe("<DateRangeInput2>", () => {
         });
 
         it("if closeOnSelection=true, popover closes when full date range is selected", () => {
-            const { root, getDayElement } = wrap(<DateRangeInput2 {...DATE_FORMAT} />, containerElement);
+            const { root, getDayElement } = wrap(<DateRangeInput2 {...DATE_FORMAT} />, true);
             root.setState({ isOpen: true });
             root.update();
             getDayElement(1).simulate("click");
@@ -399,7 +388,7 @@ describe("<DateRangeInput2>", () => {
         it("if closeOnSelection=true && timePrecision != null, popover closes when full date range is selected", () => {
             const { root, getDayElement } = wrap(
                 <DateRangeInput2 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
-                containerElement,
+                true,
             );
             root.setState({ isOpen: true });
             root.update();
@@ -467,19 +456,8 @@ describe("<DateRangeInput2>", () => {
     });
 
     describe("selectAllOnFocus", () => {
-        let containerElement: HTMLElement | undefined;
-
-        beforeEach(() => {
-            containerElement = document.createElement("div");
-            document.body.appendChild(containerElement);
-        });
-        afterEach(() => containerElement?.remove());
-
         it("if false (the default), does not select any text on focus", () => {
-            const { root } = wrap(
-                <DateRangeInput2 {...DATE_FORMAT} defaultValue={[START_DATE, null]} />,
-                containerElement,
-            );
+            const { root } = wrap(<DateRangeInput2 {...DATE_FORMAT} defaultValue={[START_DATE, null]} />, true);
 
             const startInput = getStartInput(root);
             startInput.simulate("focus");
@@ -491,7 +469,7 @@ describe("<DateRangeInput2>", () => {
         it("if true, selects all text on focus", () => {
             const { root } = wrap(
                 <DateRangeInput2 {...DATE_FORMAT} defaultValue={[START_DATE, null]} selectAllOnFocus={true} />,
-                containerElement,
+                true,
             );
 
             const startInput = getStartInput(root);
@@ -505,7 +483,7 @@ describe("<DateRangeInput2>", () => {
         it.skip("if true, selects all text on day mouseenter in calendar", () => {
             const { root, getDayElement } = wrap(
                 <DateRangeInput2 {...DATE_FORMAT} defaultValue={[START_DATE, null]} selectAllOnFocus={true} />,
-                containerElement,
+                true,
             );
 
             root.setState({ isOpen: true });
@@ -2649,6 +2627,60 @@ describe("<DateRangeInput2>", () => {
             assertInputValuesEqual(root, START_STR, "");
         });
 
+        // Regression test for https://github.com/palantir/blueprint/issues/5791
+        it("Hovering and clicking on end date shows the new date in input, not a previously selected date", () => {
+            const DEC_1_DATE = new Date(2022, 11, 1);
+            const DEC_1_STR = DATE_FORMAT.formatDate(DEC_1_DATE);
+            const DEC_2_DATE = new Date(2022, 11, 2);
+            const DEC_2_STR = DATE_FORMAT.formatDate(DEC_2_DATE);
+            const DEC_6_DATE = new Date(2022, 11, 6);
+            const DEC_6_STR = DATE_FORMAT.formatDate(DEC_6_DATE);
+            const DEC_8_DATE = new Date(2022, 11, 8);
+            const DEC_8_STR = DATE_FORMAT.formatDate(DEC_8_DATE);
+
+            // eslint-disable-next-line prefer-const
+            let controlledRoot: WrappedComponentRoot;
+
+            const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });
+            const { root, getDayElement } = wrap(
+                <DateRangeInput2
+                    {...DATE_FORMAT}
+                    closeOnSelection={false}
+                    popoverProps={{ isOpen: true }}
+                    onChange={onChange}
+                    value={[DEC_6_DATE, DEC_8_DATE]}
+                />,
+                true,
+            );
+            controlledRoot = root;
+
+            // initial state
+            getStartInput(root).simulate("focus");
+            assertInputValuesEqual(root, DEC_6_STR, DEC_8_STR);
+
+            // hover over Dec 1
+            getDayElement(1).simulate("mouseenter");
+            assertInputValuesEqual(root, DEC_1_STR, DEC_8_STR);
+
+            // click to select Dec 1
+            getDayElement(1).simulate("click");
+            getDayElement(1).simulate("mouseleave");
+            assertInputValuesEqual(root, DEC_1_STR, DEC_8_STR);
+
+            // re-focus on start input to ensure the component doesn't think we're changing the end boundary
+            // (this mimics real UX, where the component-refocuses the start input after selecting a start date)
+            getStartInput(root).simulate("focus");
+
+            // hover over Dec 2
+            getDayElement(2).simulate("mouseenter");
+            assertInputValuesEqual(root, DEC_2_STR, DEC_8_STR);
+
+            // click to select Dec 2
+            getDayElement(2).simulate("click");
+            getDayElement(2).simulate("mouseleave");
+            assertInputValuesEqual(root, DEC_2_STR, DEC_8_STR);
+        });
+
         it.skip("Formats locale-specific format strings properly", () => {
             const { root } = wrap(<DateRangeInput2 {...DATE_FORMAT} locale="de" value={DATE_RANGE_2} />);
             assertInputValuesEqual(root, START_DE_STR_2, END_DE_STR_2);
@@ -2725,8 +2757,9 @@ describe("<DateRangeInput2>", () => {
         expect(actualEnd).to.equal(expectedEnd);
     }
 
-    function wrap(dateRangeInput: JSX.Element, attachTo?: HTMLElement) {
-        const wrapper = mount(dateRangeInput, { attachTo });
+    function wrap(dateRangeInput: JSX.Element, attachToDOM = false) {
+        const mountOptions = attachToDOM ? { attachTo: containerElement } : undefined;
+        const wrapper = mount(dateRangeInput, mountOptions);
         return {
             getDayElement: (dayNumber = 1, fromLeftMonth = true) => {
                 const monthElement = wrapper.find(".DayPicker-Month").at(fromLeftMonth ? 0 : 1);

--- a/packages/datetime2/test/index.ts
+++ b/packages/datetime2/test/index.ts
@@ -7,7 +7,9 @@ import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/datetime/lib/css/blueprint-datetime.css";
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css";
 // tslint:enable no-submodule-imports
+
 import "../lib/css/blueprint-datetime2.css";
+import "./test-debugging-styles.scss";
 
 import "@blueprintjs/test-commons/bootstrap";
 

--- a/packages/datetime2/test/test-debugging-styles.scss
+++ b/packages/datetime2/test/test-debugging-styles.scss
@@ -1,0 +1,11 @@
+// Copyright 2022 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "~@blueprintjs/colors/lib/scss/colors";
+@import "~@blueprintjs/core/src/common/variables";
+
+.#{$ns}-date-range-input-popover {
+  // popover does not position itself corectly in tests sometimes... we add this margin so that we can see
+  // the input while the popover is open when debugging tests
+  margin-top: 50px;
+}

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
@@ -119,6 +119,7 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
                 <DateRangeInput2
                     {...spreadProps}
                     {...format}
+                    value={range}
                     onChange={this.handleRangeChange}
                     footerElement={showFooterElement ? exampleFooterElement : undefined}
                     timePickerProps={

--- a/packages/webpack-build-scripts/webpack.config.karma.mjs
+++ b/packages/webpack-build-scripts/webpack.config.karma.mjs
@@ -58,6 +58,11 @@ export default {
                 },
             },
             {
+                // allow some custom styles to be written for tests (sometimes just for debugging purposes)
+                test: /\.scss$/,
+                use: [require.resolve("style-loader"), require.resolve("css-loader"), require.resolve("sass-loader")],
+            },
+            {
                 test: /\.(eot|ttf|woff|woff2|svg|png)$/,
                 type: "asset/resource",
                 generator: {


### PR DESCRIPTION
#### Fixes #5791

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

DateRangeInput2 input focus handler should read from the controlled value rather than the state value.

When a new date is selected the onChange callback is called which updates the controlled value. On the next render cycle componentDidUpdate syncs the state value with the controlled props value and also refocuses the boundary input at the same time. During this input focus the stale value from the state is read before it has been updated leading to the input display value showing the previous value.

#### Reviewers should focus on:

The input blur and input change handlers already special case controlled mode could it have been intentional to have this behaviour in the input focus handler for any reason?
<!-- Fill this out. -->

#### Screenshot

I tested this on the docs app locally by changing the example to be controlled:

```
@@ -120,6 +120,7 @@ export class DateRangeInput2Example extends React.PureComponent<ExampleProps, Da
                     {...spreadProps}
                     {...format}
                     onChange={this.handleRangeChange}
+                    value={range}
                     footerElement={showFooterElement ? exampleFooterElement : undefined}
                     timePickerProps={
                         enableTimePicker
```

| Before | After |
|-|-|
![controlled_before](https://user-images.githubusercontent.com/13809355/206512709-d8bebc8e-4bf4-487d-a65c-4377f49efc69.gif) | ![controlled_after](https://user-images.githubusercontent.com/13809355/206512752-50a92afd-230c-41d0-bd01-1b620d27f426.gif)

<!-- Include an image of the most relevant user-facing change, if any. -->
