### PR TITLE
[select] fix(Suggest2): show non-empty query when popover closed

### DIFF
--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -247,7 +247,13 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
             const inputPlaceholder = isOpen && selectedItemText ? selectedItemText : placeholder;
             // value shows query when open, and query remains when closed if nothing is selected.
             // if resetOnClose is enabled, then hide query when not open. (see handlePopoverOpening)
-            const inputValue = isOpen ? listProps.query : (selectedItemText == "" ? (resetOnClose ? "" : listProps.query) : selectedItemText);
+            const inputValue = isOpen
+                ? listProps.query
+                : selectedItemText === ""
+                ? resetOnClose
+                    ? ""
+                    : listProps.query
+                : selectedItemText;
 
             return (
                 <InputGroup

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -247,7 +247,7 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
             const inputPlaceholder = isOpen && selectedItemText ? selectedItemText : placeholder;
             // value shows query when open, and query remains when closed if nothing is selected.
             // if resetOnClose is enabled, then hide query when not open. (see handlePopoverOpening)
-            const inputValue = isOpen ? listProps.query : selectedItemText ?? (resetOnClose ? "" : listProps.query);
+            const inputValue = isOpen ? listProps.query : (selectedItemText == "" ? (resetOnClose ? "" : listProps.query) : selectedItemText);
 
             return (
                 <InputGroup


### PR DESCRIPTION
Closes https://github.com/palantir/blueprint/issues/5804