### PR TITLE
feat(MenuItem, MenuItem2): roleStructure="listitem"

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -93,7 +93,7 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
      * `<li role=undefined`
      *     `<a role=undefined`
      *
-     *  which can be used if this item is within a `list` parent
+     *  which can be used if this item is within a basic `<ul/>` (or `role="list"`) parent.
      *
      * @default "menuitem"
      */

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -88,9 +88,16 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
      *
      *  which is proper role structure for a `<ul role="listbox"` parent, or a `<select>` parent.
      *
+     *  If `none`, role structure becomes:
+     *
+     * `<li role=undefined`
+     *     `<a role=undefined`
+     *
+     *  which can be used if this item is not within a `menu`,`listbox`, etc.
+     *
      * @default "menuitem"
      */
-    roleStructure?: "menuitem" | "listoption";
+    roleStructure?: "menuitem" | "listoption" | "none";
 
     /**
      * Whether the text should be allowed to wrap to multiple lines.
@@ -204,7 +211,9 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const [liRole, targetRole, ariaSelected] =
             roleStructure === "listoption"
                 ? ["option", undefined, active || selected] // parent has listbox role, or is a <select>
-                : ["none", "menuitem", undefined]; // parent has menu role
+                : roleStructure === "menuitem"
+                ? ["none", "menuitem", undefined] // parent has menu role
+                : [undefined, undefined, active || selected];
 
         const target = React.createElement(
             tagName,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -88,16 +88,9 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
      *
      *  which is proper role structure for a `<ul role="listbox"` parent, or a `<select>` parent.
      *
-     *  If `none`, role structure becomes:
-     *
-     * `<li role=undefined`
-     *     `<a role=undefined`
-     *
-     *  which can be used if this item is not within a `menu`,`listbox`, etc.
-     *
      * @default "menuitem"
      */
-    roleStructure?: "menuitem" | "listoption" | "none";
+    roleStructure?: "menuitem" | "listoption";
 
     /**
      * Whether the text should be allowed to wrap to multiple lines.
@@ -211,9 +204,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const [liRole, targetRole, ariaSelected] =
             roleStructure === "listoption"
                 ? ["option", undefined, active || selected] // parent has listbox role, or is a <select>
-                : roleStructure === "menuitem"
-                ? ["none", "menuitem", undefined] // parent has menu role
-                : [undefined, undefined, active || selected];
+                : ["none", "menuitem", undefined]; // parent has menu role
 
         const target = React.createElement(
             tagName,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -88,9 +88,16 @@ export interface IMenuItemProps extends ActionProps, LinkProps {
      *
      *  which is proper role structure for a `<ul role="listbox"` parent, or a `<select>` parent.
      *
+     * If `listitem`, role structure becomes:
+     *
+     * `<li role=undefined`
+     *     `<a role=undefined`
+     *
+     *  which can be used if this item is within a `list` parent
+     *
      * @default "menuitem"
      */
-    roleStructure?: "menuitem" | "listoption";
+    roleStructure?: "menuitem" | "listoption" | "listitem";
 
     /**
      * Whether the text should be allowed to wrap to multiple lines.
@@ -204,7 +211,9 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const [liRole, targetRole, ariaSelected] =
             roleStructure === "listoption"
                 ? ["option", undefined, active || selected] // parent has listbox role, or is a <select>
-                : ["none", "menuitem", undefined]; // parent has menu role
+                : roleStructure === "menuitem"
+                ? ["none", "menuitem", undefined] // parent has menu role
+                : [undefined, undefined, undefined]; // roleStructure === "listitem"-- needs no role prop, li is listitem by default
 
         const target = React.createElement(
             tagName,

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -71,6 +71,12 @@ describe("MenuItem", () => {
         assert.equal(wrapper.find("a").prop("role"), undefined);
     });
 
+    it("can set roleStructure to change role prop structure to that of a list item", () => {
+        const wrapper = mount(<MenuItem text="Roles" roleStructure="listitem" />);
+        assert.equal(wrapper.find("li").prop("role"), undefined);
+        assert.equal(wrapper.find("a").prop("role"), undefined);
+    });
+
     it("disabled MenuItem will not show its submenu", () => {
         const wrapper = shallow(
             <MenuItem disabled={true} icon="style" text="Style">

--- a/packages/popover2/src/menu-item2.md
+++ b/packages/popover2/src/menu-item2.md
@@ -38,6 +38,8 @@ depending on the `role` attribute of its parent `<ul>` list:
 - `roleStructure="listoption"` is appropriate for a `<ul role="listbox">` parent, such as
     those found in Select2, Suggest2, and MultiSelect2 components. The item will render with
     `<li role="option">` and `<a>` (anchor role undefined).
+- `roleStructure="listitem"` is appropriate for a `<ul>` parent (no role defined). The item will
+    render with `<li>` and `<a>` (roles undefined).
 
 @## Selection state
 

--- a/packages/popover2/src/menu-item2.md
+++ b/packages/popover2/src/menu-item2.md
@@ -38,8 +38,8 @@ depending on the `role` attribute of its parent `<ul>` list:
 - `roleStructure="listoption"` is appropriate for a `<ul role="listbox">` parent, such as
     those found in Select2, Suggest2, and MultiSelect2 components. The item will render with
     `<li role="option">` and `<a>` (anchor role undefined).
-- `roleStructure="listitem"` is appropriate for a `<ul>` parent (no role defined). The item will
-    render with `<li>` and `<a>` (roles undefined).
+- `roleStructure="listitem"` is appropriate for a `<ul>` (no role defined) or a `<ul role="list">` parent. The
+    item will render with `<li>` and `<a>` (roles undefined).
 
 @## Selection state
 

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -93,9 +93,16 @@ export interface MenuItem2Props extends ActionProps, LinkProps {
      *
      *  which is proper role structure for a `<ul role="listbox"` parent, or a `<select>` parent.
      *
+     * If `listitem`, role structure becomes:
+     *
+     * `<li role=undefined`
+     *     `<a role=undefined`
+     *
+     *  which can be used if this item is within a `list` parent
+     *
      * @default "menuitem"
      */
-    roleStructure?: "menuitem" | "listoption";
+    roleStructure?: "menuitem" | "listoption" | "listitem";
 
     /**
      * Whether the text should be allowed to wrap to multiple lines.
@@ -193,18 +200,24 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
         } = this.props;
 
         const [liRole, targetRole, icon, ariaSelected] =
-            roleStructure === "listoption"
-                ? // "listoption": parent has listbox role, or is a <select>
-                  [
+            roleStructure === "listoption" // "listoption": parent has listbox role, or is a <select>
+                ? [
                       "option",
                       undefined, // target should have no role
                       this.props.icon ?? (selected === undefined ? undefined : selected ? "small-tick" : "blank"),
                       Boolean(selected), // aria-selected prop
                   ]
-                : // "menuitem": parent has menu role
-                  [
+                : roleStructure === "menuitem" // "menuitem": parent has menu role
+                ? [
                       "none",
                       "menuitem",
+                      this.props.icon,
+                      undefined, // don't set aria-selected prop
+                  ]
+                : // roleStructure === "listitem"
+                  [
+                      undefined, // needs no role prop, li is listitem by default
+                      undefined,
                       this.props.icon,
                       undefined, // don't set aria-selected prop
                   ];

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -98,7 +98,7 @@ export interface MenuItem2Props extends ActionProps, LinkProps {
      * `<li role=undefined`
      *     `<a role=undefined`
      *
-     *  which can be used if this item is within a `list` parent
+     *  which can be used if this item is within a basic `<ul/>` (or `role="list"`) parent.
      *
      * @default "menuitem"
      */

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -62,6 +62,12 @@ describe("MenuItem2", () => {
         assert.equal(wrapper.find("a").prop("role"), undefined);
     });
 
+    it("can set roleStructure to change role prop structure to that of a list item", () => {
+        const wrapper = mount(<MenuItem2 text="Roles" roleStructure="listitem" />);
+        assert.equal(wrapper.find("li").prop("role"), undefined);
+        assert.equal(wrapper.find("a").prop("role"), undefined);
+    });
+
     it("disabled MenuItem2 will not show its submenu", () => {
         const wrapper = shallow(
             <MenuItem2 disabled={true} icon="style" text="Style">

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -62,12 +62,6 @@ describe("MenuItem2", () => {
         assert.equal(wrapper.find("a").prop("role"), undefined);
     });
 
-    it("can set roleStructure to change role prop structure to have no roles", () => {
-        const wrapper = mount(<MenuItem2 text="Roles" roleStructure="none" />);
-        assert.equal(wrapper.find("li").prop("role"), undefined);
-        assert.equal(wrapper.find("a").prop("role"), undefined);
-    });
-
     it("disabled MenuItem2 will not show its submenu", () => {
         const wrapper = shallow(
             <MenuItem2 disabled={true} icon="style" text="Style">

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -62,6 +62,12 @@ describe("MenuItem2", () => {
         assert.equal(wrapper.find("a").prop("role"), undefined);
     });
 
+    it("can set roleStructure to change role prop structure to have no roles", () => {
+        const wrapper = mount(<MenuItem2 text="Roles" roleStructure="none" />);
+        assert.equal(wrapper.find("li").prop("role"), undefined);
+        assert.equal(wrapper.find("a").prop("role"), undefined);
+    });
+
     it("disabled MenuItem2 will not show its submenu", () => {
         const wrapper = shallow(
             <MenuItem2 disabled={true} icon="style" text="Style">


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [X] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

using `roleStructure` prop of `MenuItem2`, allow a configuration where the components have no assigned roles.