### PR TITLE
[select] feat(QueryList): add `ref` to `ItemRendererProps`

### DIFF
--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { H5, Menu, MenuDivider, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
-import { isCreateNewItem, ItemListRendererProps, ListItemsProps } from "@blueprintjs/select";
+import { ItemListRendererProps } from "@blueprintjs/select";
 import { Film, FilmSelect, filterFilm, TOP_100_FILMS } from "@blueprintjs/select/examples";
 
 export interface ISelectExampleState {
@@ -95,7 +95,6 @@ export class SelectExample extends React.PureComponent<ExampleProps, ISelectExam
                     allowCreate={allowCreate}
                     createNewItemPosition={this.state.createFirst ? "first" : "last"}
                     disabled={disabled}
-                    getActiveElement={grouped ? this.getGroupedActiveElement : undefined}
                     itemDisabled={this.isItemDisabled}
                     itemListRenderer={grouped ? this.renderGroupedItemList : undefined}
                     itemListPredicate={grouped ? this.groupedItemListPredicate : undefined}
@@ -170,25 +169,6 @@ export class SelectExample extends React.PureComponent<ExampleProps, ISelectExam
         const firstLetter = item.title[0].toUpperCase();
         return /[0-9]/.test(firstLetter) ? "0-9" : firstLetter;
     }
-
-    private getGroupedActiveElement: ListItemsProps<Film>["getActiveElement"] = ({
-        activeItem,
-        filteredItems,
-        index,
-        itemsParent,
-    }) => {
-        if (itemsParent != null) {
-            if (isCreateNewItem(activeItem)) {
-                return itemsParent.children.item(index) as HTMLElement;
-            }
-
-            const group = this.getGroup(activeItem);
-            const groupedItems = this.getGroupedItems(filteredItems);
-            const groupIndex = groupedItems.findIndex(item => item.group === group);
-            return itemsParent.children.item(index + groupIndex + 1) as HTMLElement;
-        }
-        return undefined;
-    };
 
     private getGroupedItems = (filteredItems: Film[]) => {
         return filteredItems.reduce<Array<{ group: string; index: number; items: Film[]; key: number }>>(

--- a/packages/select/src/__examples__/films.tsx
+++ b/packages/select/src/__examples__/films.tsx
@@ -140,11 +140,12 @@ export const TOP_100_FILMS: Film[] = [
  */
 export function getFilmItemProps(
     film: Film,
-    { handleClick, handleFocus, modifiers, query }: ItemRendererProps,
+    { handleClick, handleFocus, modifiers, ref, query }: ItemRendererProps,
 ): MenuItemProps & React.Attributes & React.HTMLAttributes<HTMLAnchorElement> {
     return {
         active: modifiers.active,
         disabled: modifiers.disabled,
+        elementRef: ref,
         key: film.rank,
         label: film.year.toString(),
         onClick: handleClick,

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { MouseEventHandler } from "react";
+import { MouseEventHandler, Ref } from "react";
 
 /** @deprecated use ItemModifiers */
 export type IItemModifiers = ItemModifiers;
@@ -38,6 +38,9 @@ export type IItemRendererProps = ItemRendererProps;
  * An `itemRenderer` receives the item as its first argument, and this object as its second argument.
  */
 export interface ItemRendererProps {
+    /** A ref that receives the native HTML element rendered by this item. */
+    ref: Ref<any>;
+
     /** Click event handler to select this item. */
     handleClick: MouseEventHandler<HTMLElement>;
 

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -49,6 +49,7 @@ export interface ListItemsProps<T> extends Props {
     /** If provided, this function will be used in place of the default implementation. */
     getActiveElement?: (props: {
         activeItem: CreateNewItem | T | null;
+        filteredItems: T[];
         index: number;
         itemsParent: HTMLElement;
     }) => HTMLElement | undefined;

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -46,6 +46,13 @@ export interface ListItemsProps<T> extends Props {
      */
     activeItem?: T | CreateNewItem | null;
 
+    /** If provided, this function will be used in place of the default implementation. */
+    getActiveElement?: (props: {
+        activeItem: CreateNewItem | T | null;
+        index: number;
+        itemsParent: HTMLElement;
+    }) => HTMLElement | undefined;
+
     /** Array of items in the list. */
     items: T[];
 

--- a/packages/select/src/common/listItemsProps.ts
+++ b/packages/select/src/common/listItemsProps.ts
@@ -46,14 +46,6 @@ export interface ListItemsProps<T> extends Props {
      */
     activeItem?: T | CreateNewItem | null;
 
-    /** If provided, this function will be used in place of the default implementation. */
-    getActiveElement?: (props: {
-        activeItem: CreateNewItem | T | null;
-        filteredItems: T[];
-        index: number;
-        itemsParent: HTMLElement;
-    }) => HTMLElement | undefined;
-
     /** Array of items in the list. */
     items: T[];
 

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -34,12 +34,6 @@ import {
 export type QueryListProps<T> = IQueryListProps<T>;
 /** @deprecated use QueryListProps */
 export interface IQueryListProps<T> extends ListItemsProps<T> {
-    /** If provided, this function will be used in place of the default implementation. */
-    getActiveElement?: (props: {
-        activeItem: CreateNewItem | T | null;
-        index: number;
-        itemsParent: HTMLElement;
-    }) => HTMLElement | undefined;
     /**
      * Initial active item, useful if the parent component is controlling its selectedItem but
      * not activeItem.

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -415,21 +415,21 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
     };
 
     private getActiveElement() {
-        const { activeItem } = this.state;
+        const { activeItem, filteredItems } = this.state;
         if (this.itemsParentRef != null) {
             const { getActiveElement } = this.props;
             if (isCreateNewItem(activeItem)) {
-                const index = this.isCreateItemFirst() ? 0 : this.state.filteredItems.length;
+                const index = this.isCreateItemFirst() ? 0 : filteredItems.length;
                 if (typeof getActiveElement === "function") {
-                    return getActiveElement({ activeItem, index, itemsParent: this.itemsParentRef });
+                    return getActiveElement({ activeItem, filteredItems, index, itemsParent: this.itemsParentRef });
                 }
                 return this.itemsParentRef.children.item(index) as HTMLElement;
             } else {
-                const activeIndex = this.getActiveIndex();
+                const index = this.getActiveIndex();
                 if (typeof getActiveElement === "function") {
-                    return getActiveElement({ activeItem, index: activeIndex, itemsParent: this.itemsParentRef });
+                    return getActiveElement({ activeItem, filteredItems, index, itemsParent: this.itemsParentRef });
                 }
-                return this.itemsParentRef.children.item(activeIndex) as HTMLElement;
+                return this.itemsParentRef.children.item(index) as HTMLElement;
             }
         }
         return undefined;

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -34,6 +34,12 @@ import {
 export type QueryListProps<T> = IQueryListProps<T>;
 /** @deprecated use QueryListProps */
 export interface IQueryListProps<T> extends ListItemsProps<T> {
+    /** If provided, this function will be used in place of the default implementation. */
+    getActiveElement?: (props: {
+        activeItem: CreateNewItem | T | null;
+        index: number;
+        itemsParent: HTMLElement;
+    }) => HTMLElement | undefined;
     /**
      * Initial active item, useful if the parent component is controlling its selectedItem but
      * not activeItem.
@@ -417,11 +423,18 @@ export class QueryList<T> extends AbstractComponent2<QueryListProps<T>, IQueryLi
     private getActiveElement() {
         const { activeItem } = this.state;
         if (this.itemsParentRef != null) {
+            const { getActiveElement } = this.props;
             if (isCreateNewItem(activeItem)) {
                 const index = this.isCreateItemFirst() ? 0 : this.state.filteredItems.length;
+                if (typeof getActiveElement === "function") {
+                    return getActiveElement({ activeItem, index, itemsParent: this.itemsParentRef });
+                }
                 return this.itemsParentRef.children.item(index) as HTMLElement;
             } else {
                 const activeIndex = this.getActiveIndex();
+                if (typeof getActiveElement === "function") {
+                    return getActiveElement({ activeItem, index: activeIndex, itemsParent: this.itemsParentRef });
+                }
                 return this.itemsParentRef.children.item(activeIndex) as HTMLElement;
             }
         }


### PR DESCRIPTION
#### Fixes #3369

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

See https://github.com/palantir/blueprint/issues/3369#issuecomment-469887277

I didn't add any tests because it seems like there's no tests for scrolling, and I wasn't sure how to best write such a test:

https://github.com/palantir/blueprint/blob/b6c1518ea2f524accfba8045ce6f22cac7c5b56e/packages/select/test/queryListTests.tsx#L215-L217

#### Reviewers should focus on:

<!-- Fill this out. -->

`getActiveElement` being exposed as desired

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
