### PR TITLE
[core] chore: remove checks for React.createRef undefined

### DIFF
--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -116,18 +116,16 @@ function buttonTestSuite(component: React.ComponentClass<any>, tagName: string) 
             checkClickTriggeredOnKeyUp(done, {}, { which: Keys.SPACE });
         });
 
-        if (typeof React.createRef !== "undefined") {
-            it("matches buttonRef with elementRef.current using createRef", done => {
-                const elementRef = React.createRef<HTMLButtonElement>();
-                const wrapper = button({ elementRef }, true);
+        it("matches buttonRef with elementRef.current using createRef", done => {
+            const elementRef = React.createRef<HTMLButtonElement>();
+            const wrapper = button({ elementRef }, true);
 
-                // wait for the whole lifecycle to run
-                setTimeout(() => {
-                    assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef);
-                    done();
-                }, 0);
-            });
-        }
+            // wait for the whole lifecycle to run
+            setTimeout(() => {
+                assert.equal(elementRef.current, (wrapper.instance() as any).buttonRef);
+                done();
+            }, 0);
+        });
 
         it("matches buttonRef with elementRef using callback", done => {
             let elementRef: HTMLElement | null = null;

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -93,17 +93,15 @@ describe("<TextArea>", () => {
         assert.instanceOf(textAreaNew, HTMLTextAreaElement);
     });
 
-    if (typeof React.createRef !== "undefined") {
-        it("accepts object refs created with React.createRef and updates on change", () => {
-            const textAreaRef = React.createRef<HTMLTextAreaElement>();
-            const textAreaNewRef = React.createRef<HTMLTextAreaElement>();
+    it("accepts object refs created with React.createRef and updates on change", () => {
+        const textAreaRef = React.createRef<HTMLTextAreaElement>();
+        const textAreaNewRef = React.createRef<HTMLTextAreaElement>();
 
-            const textAreawrapper = mount(<TextArea id="textarea" inputRef={textAreaRef} />);
-            assert.instanceOf(textAreaRef.current, HTMLTextAreaElement);
+        const textAreawrapper = mount(<TextArea id="textarea" inputRef={textAreaRef} />);
+        assert.instanceOf(textAreaRef.current, HTMLTextAreaElement);
 
-            textAreawrapper.setProps({ inputRef: textAreaNewRef });
-            assert.isNull(textAreaRef.current);
-            assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
-        });
-    }
+        textAreawrapper.setProps({ inputRef: textAreaNewRef });
+        assert.isNull(textAreaRef.current);
+        assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
+    });
 });

--- a/packages/core/test/tag/tagTests.tsx
+++ b/packages/core/test/tag/tagTests.tsx
@@ -80,16 +80,14 @@ describe("<Tag>", () => {
         assert.deepEqual(handleRemove.args[0][1][DATA_ATTR_FOO], tagProps[DATA_ATTR_FOO]);
     });
 
-    if (typeof React.createRef !== "undefined") {
-        it("supports ref objects", done => {
-            const elementRef = React.createRef<HTMLSpanElement>();
-            const wrapper = mount(<Tag elementRef={elementRef}>Hello</Tag>);
+    it("supports ref objects", done => {
+        const elementRef = React.createRef<HTMLSpanElement>();
+        const wrapper = mount(<Tag elementRef={elementRef}>Hello</Tag>);
 
-            // wait for the whole lifecycle to run
-            setTimeout(() => {
-                assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
-                done();
-            }, 0);
-        });
-    }
+        // wait for the whole lifecycle to run
+        setTimeout(() => {
+            assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
+            done();
+        }, 0);
+    });
 });


### PR DESCRIPTION
These checks in test code are not necessary since we dropped React <v16.8 a while ago.