### PR TITLE
[core] feat(HTMLTable): use 'compact' instead of 'condensed'

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -28,6 +28,7 @@ if (typeof process !== "undefined") {
 export const ACTIVE = `${NS}-active`;
 export const ALIGN_LEFT = `${NS}-align-left`;
 export const ALIGN_RIGHT = `${NS}-align-right`;
+export const COMPACT = `${NS}-compact`;
 export const DARK = `${NS}-dark`;
 export const DISABLED = `${NS}-disabled`;
 export const FILL = `${NS}-fill`;
@@ -148,6 +149,7 @@ export const SELECT = `${NS}-select`;
 
 export const HTML_TABLE = `${NS}-html-table`;
 export const HTML_TABLE_BORDERED = `${HTML_TABLE}-bordered`;
+/** @deprecated prefer `COMPACT` */
 export const HTML_TABLE_CONDENSED = `${HTML_TABLE}-condensed`;
 export const HTML_TABLE_STRIPED = `${HTML_TABLE}-striped`;
 

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -44,8 +44,9 @@ Markup:
   </tfoot>
 </table>
 
+.#{$ns}-compact - Compact appearance
 .#{$ns}-html-table-bordered - Bordered appearance
-.#{$ns}-html-table-condensed - Condensed smaller appearance
+.#{$ns}-html-table-condensed - Condensed smaller appearance (DEPRECATED, use compact instead)
 .#{$ns}-html-table-striped - Striped appearance
 .#{$ns}-interactive - Enables hover styles on rows
 
@@ -112,6 +113,7 @@ $dark-table-border-color: $pt-dark-divider-white !default;
 table.#{$ns}-html-table {
   @extend %html-table;
 
+  &.#{$ns}-compact,
   &.#{$ns}-html-table-condensed {
     $small-vertical-padding: centered-text($table-row-height-small);
 

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -26,16 +26,23 @@ export interface IHTMLTableProps
     extends React.TableHTMLAttributes<HTMLTableElement>,
         // eslint-disable-next-line deprecation/deprecation
         IElementRefProps<HTMLTableElement> {
-    /** Enables borders between rows and cells. */
+    /** Enable borders between rows and cells. */
     bordered?: boolean;
 
-    /** Use small, condensed appearance. */
+    /** Use compact appearance with less padding. */
+    compact?: boolean;
+
+    /**
+     * Use small, condensed appearance.
+     *
+     * @deprecated use `compact` instead
+     */
     condensed?: boolean;
 
-    /** Enables hover styles on row. */
+    /** Enable hover styles on rows. */
     interactive?: boolean;
 
-    /** Use an alternate background color on odd rows. */
+    /** Use an alternate background color on odd-numbered rows. */
     striped?: boolean;
 }
 
@@ -49,11 +56,13 @@ export interface IHTMLTableProps
 export class HTMLTable extends AbstractPureComponent2<HTMLTableProps> {
     public render() {
         // eslint-disable-next-line deprecation/deprecation
-        const { bordered, className, condensed, elementRef, interactive, striped, ...htmlProps } = this.props;
+        const { bordered, className, compact, condensed, elementRef, interactive, striped, ...htmlProps } = this.props;
         const classes = classNames(
             Classes.HTML_TABLE,
             {
+                [Classes.COMPACT]: compact,
                 [Classes.HTML_TABLE_BORDERED]: bordered,
+                // eslint-disable-next-line deprecation/deprecation
                 [Classes.HTML_TABLE_CONDENSED]: condensed,
                 [Classes.HTML_TABLE_STRIPED]: striped,
                 [Classes.INTERACTIVE]: interactive,


### PR DESCRIPTION
#### Changes proposed in this pull request:

Add `.bp4-compact` modifier class support to HTMLTable, to replace `.bp4-html-table-condensed` (which is now deprecated). This matches the new terminology added in https://github.com/palantir/blueprint/pull/5822 for compact popovers & tooltips.

I feel like "compact" is slightly more appropriate than "condensed" in this context, and this name change aligns with other libraries like [Semantic UI](https://semantic-ui.com/collections/table.html#compact).

<img width="807" alt="image" src="https://user-images.githubusercontent.com/723999/210633498-eff8904c-f0ac-4228-99ba-0c038c7c3bdb.png">

