### PR TITLE
[core] docs: Button fill & alignText options; dropdown menus

### DIFF
--- a/packages/core/src/components/button/button.md
+++ b/packages/core/src/components/button/button.md
@@ -1,6 +1,6 @@
 @# Button
 
-Buttons trigger actions when clicked.
+Buttons trigger actions when clicked. You may render a button as either a `<button>` or `<a>` HTML element.
 
 @reactExample ButtonsExample
 

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -55,18 +55,22 @@ The `Menu` component by itself simply renders a list of items. To make a
 dropdown menu, compose a `Menu` as the `content` property of a `Popover`:
 
 ```tsx
-<Popover content={<Menu>...</Menu>} position={Position.RIGHT_TOP}>
-    <Button icon="share" text="Open in..." />
+<Popover content={<Menu>...</Menu>} placement="bottom">
+    <Button alignText="left" icon="applications" rightIcon="caret-down" text="Open with..." />
 </Popover>
 ```
 
-By default, the popover is automatically dismissed when the user clicks a menu
-item ([Popover docs](#core/components/popover.closing-on-click) have more
-details). If you want to opt out of this behavior, set
-`shouldDismissPopover={false}` on a `MenuItem`.
+Some tips for designing dropdown menus:
 
-In the example below, clicking the menu item labeled "Table" will not dismiss
-the `Popover`.
+* __Appearance__: it's often useful to style the target Button with `fill={true}`,
+  `alignText="left"`, and `rightIcon="caret-down"`. This makes it appear more like an
+  [HTML `<select>`](#core/components/html-select) dropdown.
+
+* __Interactions__: by default, the popover is automatically dismissed when the user clicks a menu
+  item ([Popover docs](#core/components/popover.closing-on-click) have more
+  details). If you want to opt out of this behavior, set
+  `shouldDismissPopover={false}` on a `MenuItem`. For example, clicking the "Table"
+  item in this dropdown menu will not dismiss the `Popover`:
 
 @reactExample DropdownMenuExample
 

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
+import classNames from "classnames";
 import * as React from "react";
 
-import { AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
+import { Alignment, AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
+import { AlignmentSelect } from "./common/alignmentSelect";
 import { IntentSelect } from "./common/intentSelect";
 import { Size, SizeSelect } from "./common/sizeSelect";
 
-export interface IButtonsExampleState {
+interface ButtonsExampleState {
     active: boolean;
+    alignText: Alignment | undefined;
     disabled: boolean;
+    fill: boolean;
     iconOnly: boolean;
     intent: Intent;
     loading: boolean;
@@ -34,10 +38,12 @@ export interface IButtonsExampleState {
     wiggling: boolean;
 }
 
-export class ButtonsExample extends React.PureComponent<ExampleProps, IButtonsExampleState> {
-    public state: IButtonsExampleState = {
+export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExampleState> {
+    public state: ButtonsExampleState = {
         active: false,
+        alignText: undefined,
         disabled: false,
+        fill: false,
         iconOnly: false,
         intent: Intent.NONE,
         loading: false,
@@ -49,7 +55,11 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, IButtonsEx
 
     private handleActiveChange = handleBooleanChange(active => this.setState({ active }));
 
+    private handleAlignTextChange = (alignText: Alignment) => this.setState({ alignText });
+
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
+
+    private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
 
     private handleIconOnlyChange = handleBooleanChange(iconOnly => this.setState({ iconOnly }));
 
@@ -80,6 +90,8 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, IButtonsEx
                 <Switch label="Loading" checked={this.state.loading} onChange={this.handleLoadingChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
+                <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
+                <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignTextChange} />
                 <SizeSelect size={this.state.size} onChange={this.handleSizeChange} />
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <H5>Example</H5>
@@ -89,7 +101,7 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, IButtonsEx
 
         return (
             <Example options={options} {...this.props}>
-                <div>
+                <div className={classNames({ "docs-flex-column": this.state.fill })}>
                     <p>
                         <Code>Button</Code>
                     </p>
@@ -104,7 +116,7 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, IButtonsEx
                         {!iconOnly && "Click to wiggle"}
                     </Button>
                 </div>
-                <div>
+                <div className={classNames({ "docs-flex-column": this.state.fill })}>
                     <p>
                         <Code>AnchorButton</Code>
                     </p>

--- a/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
@@ -18,14 +18,14 @@ import * as React from "react";
 
 import { Alignment, Button, ButtonGroup } from "@blueprintjs/core";
 
-export interface IAlignSelectProps {
+interface AlignmentSelectProps {
     align: Alignment | undefined;
     allowCenter?: boolean;
     label?: string;
     onChange: (align: Alignment) => void;
 }
 
-export class AlignmentSelect extends React.PureComponent<IAlignSelectProps> {
+export class AlignmentSelect extends React.PureComponent<AlignmentSelectProps> {
     public render() {
         const { align, allowCenter = true, label = "Align text" } = this.props;
         return (

--- a/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { Button, Card, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Popover2 } from "@blueprintjs/popover2";
 
@@ -27,7 +27,7 @@ export class DropdownMenuExample extends React.PureComponent<ExampleProps> {
                 <MenuItem icon="graph" text="Graph" />
                 <MenuItem icon="map" text="Map" />
                 <MenuItem icon="th" text="Table" shouldDismissPopover={false} />
-                <MenuItem icon="zoom-to-fit" text="Nucleus" disabled={true} />
+                <MenuItem icon="zoom-to-fit" text="Browser" disabled={true} />
                 <MenuDivider />
                 <MenuItem icon="cog" text="Settings...">
                     <MenuItem icon="add" text="Add new application" disabled={true} />
@@ -37,9 +37,17 @@ export class DropdownMenuExample extends React.PureComponent<ExampleProps> {
         );
         return (
             <Example options={false} {...this.props}>
-                <Popover2 content={exampleMenu} placement="right-end">
-                    <Button icon="share" text="Open in..." />
-                </Popover2>
+                <Card style={{ width: 250 }}>
+                    <Popover2 content={exampleMenu} fill={true} placement="bottom">
+                        <Button
+                            alignText="left"
+                            fill={true}
+                            icon="applications"
+                            rightIcon="caret-down"
+                            text="Open with..."
+                        />
+                    </Popover2>
+                </Card>
             </Example>
         );
     }

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -15,7 +15,15 @@
   @return '[data-example-id#{$comparator}"#{$ComponentName}Example"]';
 }
 
-// Specific example customizations
+// Common modifiers, incubating usage before they can be incorporated into @blueprintjs/docs-theme
+
+.docs-flex-column {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+// Example-specific customizations
 
 //
 // CORE
@@ -33,6 +41,19 @@
 }
 
 #{example("Buttons")} {
+  .docs-example {
+    flex-direction: column;
+    gap: $pt-grid-size * 3;
+
+    > * {
+      margin: 0;
+    }
+
+    p {
+      text-align: center;
+    }
+  }
+
   .docs-wiggle {
     animation: docs-wiggle-rotate $pt-transition-duration $pt-transition-ease infinite;
   }


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Update "Dropdowns" section of Menu docs to include styling advice for dropdown buttons
- Adjust layout of Buttons docs example, and add interactive options to show usage of the `fill` and `alignText` props

<img width="832" alt="image" src="https://user-images.githubusercontent.com/723999/210643361-4403a8b5-b2c6-4693-9ca4-6f1c8114f068.png">

<img width="352" alt="image" src="https://user-images.githubusercontent.com/723999/210643378-dd1303cc-be21-49a7-bf61-7de355cc4921.png">
