### PR TITLE
[core] feat(Callout): visual modernisation

### DIFF
--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -8,7 +8,7 @@ Callout
 
 Markup:
 <div class="#{$ns}-callout {{.modifier}}">
-  <h4 class="#{$ns}-heading">Callout Heading</h4>
+  <h5 class="#{$ns}-heading">Callout Heading</h5>
   It's dangerous to go alone! Take this.
 </div>
 
@@ -25,20 +25,20 @@ Styleguide callout
   @include running-typography();
   background-color: rgba($gray3, 0.15);
   border-radius: $pt-border-radius;
-  padding: $pt-grid-size ($pt-grid-size * 1.2) ($pt-grid-size * 0.9);
+  padding: $pt-grid-size * 1.5;
   position: relative;
   width: 100%;
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: ($pt-grid-size * 2) + $pt-icon-size-large;
+    padding-left: ($pt-grid-size * 2) + $pt-icon-size-standard;
 
     &::before {
-      @include pt-icon($pt-icon-size-large);
+      @include pt-icon($pt-icon-size-standard);
       color: $pt-icon-color;
-      left: $pt-grid-size;
+      left: $pt-grid-size * 1.5;
       position: absolute;
-      top: $pt-grid-size;
+      top: $pt-grid-size * 1.5;
     }
   }
 
@@ -48,18 +48,18 @@ Styleguide callout
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: ($pt-grid-size * 2) + $pt-icon-size-large;
+    padding-left: ($pt-grid-size * 2) + $pt-icon-size-standard;
 
     > .#{$ns}-icon:first-child {
       color: $pt-icon-color;
-      left: $pt-grid-size;
+      left: $pt-grid-size * 1.5;
       position: absolute;
-      top: $pt-grid-size;
+      top: $pt-grid-size * 1.5;
     }
   }
 
   .#{$ns}-heading {
-    line-height: $pt-icon-size-large;
+    line-height: $pt-icon-size-standard;
     margin-bottom: $pt-grid-size * 0.5;
     margin-top: 0;
 
@@ -80,6 +80,7 @@ Styleguide callout
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
       background-color: rgba($color, 0.1);
+      color: map-get($pt-intent-text-colors, $intent);
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
         border: 1px solid $pt-high-contrast-mode-border-color;
@@ -93,6 +94,7 @@ Styleguide callout
 
       .#{$ns}-dark & {
         background-color: rgba($color, 0.2);
+        color: map-get($pt-dark-intent-text-colors, $intent);
 
         &[class*="#{$ns}-icon-"]::before,
         > .#{$ns}-icon:first-child,

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -28,7 +28,7 @@ $callout-header-margin-top: $pt-grid-size * 0.2;
   @include running-typography();
   background-color: rgba($gray3, 0.15);
   border-radius: $pt-border-radius;
-  padding: $pt-grid-size * 1.5;
+  padding: $callout-padding;
   position: relative;
   width: 100%;
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -31,14 +31,14 @@ Styleguide callout
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: ($pt-grid-size * 2) + $pt-icon-size-standard;
+    padding-left: ($pt-grid-size * 2.2) + $pt-icon-size-standard;
 
     &::before {
       @include pt-icon($pt-icon-size-standard);
       color: $pt-icon-color;
       left: $pt-grid-size * 1.5;
       position: absolute;
-      top: $pt-grid-size * 1.5;
+      top: $pt-grid-size * 1.7;
     }
   }
 
@@ -48,20 +48,20 @@ Styleguide callout
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: ($pt-grid-size * 2) + $pt-icon-size-standard;
+    padding-left: ($pt-grid-size * 2.2) + $pt-icon-size-standard;
 
     > .#{$ns}-icon:first-child {
       color: $pt-icon-color;
       left: $pt-grid-size * 1.5;
       position: absolute;
-      top: $pt-grid-size * 1.5;
+      top: $pt-grid-size * 1.7;
     }
   }
 
   .#{$ns}-heading {
     line-height: $pt-icon-size-standard;
     margin-bottom: $pt-grid-size * 0.5;
-    margin-top: 0;
+    margin-top: $pt-grid-size * 0.2;
 
     &:last-child {
       margin-bottom: 0;

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -21,6 +21,9 @@ Markup:
 Styleguide callout
 */
 
+$callout-padding:  $pt-grid-size * 1.5;
+$callout-header-margin-top: $pt-grid-size * 0.2;
+
 .#{$ns}-callout {
   @include running-typography();
   background-color: rgba($gray3, 0.15);
@@ -31,14 +34,14 @@ Styleguide callout
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: ($pt-grid-size * 2.2) + $pt-icon-size-standard;
+    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-grid-size * 0.7);
 
     &::before {
       @include pt-icon($pt-icon-size-standard);
       color: $pt-icon-color;
-      left: $pt-grid-size * 1.5;
+      left: $callout-padding;
       position: absolute;
-      top: $pt-grid-size * 1.7;
+      top: $callout-padding + $callout-header-margin-top;
     }
   }
 
@@ -48,20 +51,20 @@ Styleguide callout
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: ($pt-grid-size * 2.2) + $pt-icon-size-standard;
+    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-grid-size * 0.7);
 
     > .#{$ns}-icon:first-child {
       color: $pt-icon-color;
-      left: $pt-grid-size * 1.5;
+      left: $callout-padding;
       position: absolute;
-      top: $pt-grid-size * 1.7;
+      top: $callout-padding + $callout-header-margin-top;
     }
   }
 
   .#{$ns}-heading {
     line-height: $pt-icon-size-standard;
     margin-bottom: $pt-grid-size * 0.5;
-    margin-top: $pt-grid-size * 0.2;
+    margin-top: $callout-header-margin-top;
 
     &:last-child {
       margin-bottom: 0;

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -12,6 +12,6 @@ a title, an icon and content. Each intent has a default icon associated with it.
 @## CSS
 
 Callouts use the same visual intent modifier classes as buttons. If you need a
-heading, use the `<h4>` element with a `.@ns-heading` class.
+heading, use the `<h5>` element with a `.@ns-heading` class.
 
 @css callout

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -27,8 +27,8 @@ import {
     MaybeElement,
     Props,
 } from "../../common";
-import { H4 } from "../html/html";
-import { Icon, IconName, IconSize } from "../icon/icon";
+import { H5 } from "../html/html";
+import { Icon, IconName } from "../icon/icon";
 
 // eslint-disable-next-line deprecation/deprecation
 export type CalloutProps = ICalloutProps;
@@ -78,8 +78,8 @@ export class Callout extends AbstractPureComponent2<CalloutProps> {
 
         return (
             <div className={classes} {...htmlProps}>
-                {iconName && <Icon icon={iconName} size={IconSize.LARGE} aria-hidden={true} tabIndex={-1} />}
-                {title && <H4>{title}</H4>}
+                {iconName && <Icon icon={iconName} aria-hidden={true} tabIndex={-1} />}
+                {title && <H5>{title}</H5>}
                 {children}
             </div>
         );

--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -18,12 +18,12 @@ import { assert } from "chai";
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { Callout, Classes, H4, Icon, Intent } from "../../src";
+import { Callout, Classes, H5, Icon, Intent } from "../../src";
 
 describe("<Callout>", () => {
     it("supports className", () => {
         const wrapper = shallow(<Callout className="foo" />);
-        assert.isFalse(wrapper.find(H4).exists(), "expected no H4");
+        assert.isFalse(wrapper.find(H5).exists(), "expected no H5");
         assert.isTrue(wrapper.hasClass(Classes.CALLOUT));
         assert.isTrue(wrapper.hasClass("foo"));
     });
@@ -50,7 +50,7 @@ describe("<Callout>", () => {
 
     it("renders optional title element", () => {
         const wrapper = shallow(<Callout title="title" />);
-        assert.isTrue(wrapper.find(H4).exists());
+        assert.isTrue(wrapper.find(H5).exists());
         // NOTE: JSX cannot be passed through `title` prop due to conflict with HTML props
         // shallow(<Callout title={<em>typings fail</em>} />);
     });


### PR DESCRIPTION
Proposition for modernisation of callouts. Reduce unnecessary visual drag while retaining prominence.
- More consistent and slightly increased spacings
- Reduce header size from `h4` to `h5`
- Reduce icon size from `20px` to `16px`
- Use intent colour as default text colour.


| Before | After |
|---|---|
|![Screenshot 2023-01-10 at 12 08 42](https://user-images.githubusercontent.com/6755553/211548131-56b5ffe6-60ac-4b5a-b40e-75ed51e7ab5c.png)|![Screenshot 2023-01-10 at 12 08 23](https://user-images.githubusercontent.com/6755553/211548184-683a8e03-59de-4ed4-9046-7a0d982a2aa5.png)|
|![Screenshot 2023-01-10 at 12 11 02](https://user-images.githubusercontent.com/6755553/211548433-9965a252-227a-451c-9cd4-1d4c18671294.png)|![Screenshot 2023-01-10 at 12 10 51](https://user-images.githubusercontent.com/6755553/211548454-31d63754-a64d-458d-b33e-b027a07ec428.png)|


### Accessibility checks

Given background colours uses opacity, I chose to evaluate accessibility with the callout on a `$white` / `$light-gray5` background for light theme and `$dark-gray1` / `$dark-gray2` for dark theme. 

| Theme | Intent | WCAG Normal Text |
|---|---|---|
| Light | Default | AA |
| Light | Primary | AA |
| Light | Success | AA |
| Light | Warning | AA |
| Light | Danger | AA |
| Dark | Default | AA |
| Dark | Primary | AA |
| Dark | Success | AA |
| Dark | Warning | AA |
| Dark | Danger | AA |
 