### PR TITLE
[icons] fix: adjust generated src path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,10 @@ jobs:
       - run: yarn compile
       - persist_to_workspace:
           root: "."
-          paths: [packages/*/lib, packages/*/src/generated]
+          paths:
+            - packages/*/lib
+            - packages/*/src/generated
+            - packages/icons/src/generated-icons
 
   format-check:
     docker: *docker-node-image

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -78,5 +78,14 @@ module.exports = {
             },
         },
     ],
-    ignorePatterns: ["node_modules", "dist", "lib", "fixtures", "coverage", "__snapshots__", "generated"],
+    ignorePatterns: [
+        "node_modules",
+        "dist",
+        "lib",
+        "fixtures",
+        "coverage",
+        "__snapshots__",
+        "generated",
+        "generated-icons",
+    ],
 };

--- a/.gitignore
+++ b/.gitignore
@@ -18,11 +18,12 @@ yarn-error.log
 .sass-cache/
 
 # Blueprint
-build
-dist
-lib
-generated
-coverage
+build/
+dist/
+lib/
+generated/
+generated-icons/
+coverage/
 /docs
 docs-static/**/*.d.ts
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules/
 generated/
+generated-icons/
 lib/
 dist/
 /site/

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -5,7 +5,7 @@
     "types": "src/index.d.ts",
     "private": true,
     "scripts": {
-        "clean": "rm -rf src/generated/*",
+        "clean": "rm -rf src/generated-icons/*",
         "compile": "node ./compile-docs-data.mjs",
         "test": "exit 0"
     },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -12,7 +12,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* && rm -rf lib/**/* && rm -rf src/generated/*",
+        "clean": "rm -rf dist/* && rm -rf lib/**/* && rm -rf src/generated-icons/*",
         "compile": "npm-run-all -s \"generate-icon-src\" -p \"compile:*\" -p \"copy:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",

--- a/packages/icons/scripts/common.mjs
+++ b/packages/icons/scripts/common.mjs
@@ -21,7 +21,7 @@ import { fileURLToPath } from "node:url";
 
 export const scriptsDir = fileURLToPath(new URL(".", import.meta.url));
 export const iconResourcesDir = resolve(scriptsDir, "../../../resources/icons");
-export const generatedSrcDir = resolve(scriptsDir, "../src/generated");
+export const generatedSrcDir = resolve(scriptsDir, "../src/generated-icons");
 export const NS = "bp4";
 
 /**

--- a/packages/icons/scripts/copy-fonts.sh
+++ b/packages/icons/scripts/copy-fonts.sh
@@ -4,7 +4,7 @@
 # Usage: copy-fonts
 #   set INPUT / OUTPUT env varibles to change directories
 
-INPUT="${INPUT:-src/generated}"
+INPUT="${INPUT:-src/generated-icons}"
 OUTPUT="${OUTPUT:-lib/css}"
 
 mkdir -p "$OUTPUT"

--- a/packages/icons/scripts/copy-scss.sh
+++ b/packages/icons/scripts/copy-scss.sh
@@ -8,7 +8,7 @@ INPUT="${INPUT:-src}"
 OUTPUT="${OUTPUT:-lib/scss}"
 
 mkdir -p "$OUTPUT"
-cp "$INPUT/generated/16px/_icon-variables.scss" "$OUTPUT/blueprint-icons-16.scss"
-cp "$INPUT/generated/20px/_icon-variables.scss" "$OUTPUT/blueprint-icons-20.scss"
+cp "$INPUT/generated-icons/16px/_icon-variables.scss" "$OUTPUT/blueprint-icons-16.scss"
+cp "$INPUT/generated-icons/20px/_icon-variables.scss" "$OUTPUT/blueprint-icons-20.scss"
 
 cp "$INPUT/templates/_lib_variables.scss" "$OUTPUT/variables.scss"

--- a/packages/icons/scripts/generate-icon-paths.mjs
+++ b/packages/icons/scripts/generate-icon-paths.mjs
@@ -16,7 +16,7 @@
 /**
  * @fileoverview Generates SVG paths used in <Icon> React components
  *
- * Important: we expect ../src/generated/ to contain SVG definitions of all the icons already before this script runs.
+ * Important: we expect ../src/generated-icons/ to contain SVG definitions of all the icons already before this script runs.
  */
 
 // @ts-check

--- a/packages/icons/src/blueprint-icons.scss
+++ b/packages/icons/src/blueprint-icons.scss
@@ -3,5 +3,5 @@ Copyright 2017-present Palantir Technologies, Inc. All rights reserved.
 Licensed under the Apache License, Version 2.0.
 */
 
-@import "generated/16px/blueprint-icons-16";
-@import "generated/20px/blueprint-icons-20";
+@import "generated-icons/16px/blueprint-icons-16";
+@import "generated-icons/20px/blueprint-icons-20";

--- a/packages/icons/src/iconCodepoints.ts
+++ b/packages/icons/src/iconCodepoints.ts
@@ -15,7 +15,7 @@
  */
 
 // The two icon sets are identical aside from SVG paths, so we only need to import info for the 16px set
-import { BLUEPRINT_ICONS_16_CODEPOINTS } from "./generated/16px/blueprint-icons-16";
+import { BLUEPRINT_ICONS_16_CODEPOINTS } from "./generated-icons/16px/blueprint-icons-16";
 import type { IconName } from "./iconNames";
 
 /**

--- a/packages/icons/src/iconNames.ts
+++ b/packages/icons/src/iconNames.ts
@@ -19,7 +19,7 @@
 import { pascalCase, snakeCase } from "change-case";
 
 // The two icon sets are identical aside from SVG paths, so we only need to import info for the 16px set
-import { BlueprintIcons_16, BlueprintIcons_16Id as IconName } from "./generated/16px/blueprint-icons-16";
+import { BlueprintIcons_16, BlueprintIcons_16Id as IconName } from "./generated-icons/16px/blueprint-icons-16";
 import type { PascalCase, ScreamingSnakeCase } from "./type-utils";
 
 export type { IconName };

--- a/packages/icons/src/iconSvgPaths.ts
+++ b/packages/icons/src/iconSvgPaths.ts
@@ -16,8 +16,8 @@
 
 import { pascalCase } from "change-case";
 
-import * as IconSvgPaths16 from "./generated/16px/paths";
-import * as IconSvgPaths20 from "./generated/20px/paths";
+import * as IconSvgPaths16 from "./generated-icons/16px/paths";
+import * as IconSvgPaths20 from "./generated-icons/20px/paths";
 import type { IconName } from "./iconNames";
 import type { PascalCase } from "./type-utils";
 

--- a/scripts/get-publishable-paths-from-semver-tags.mjs
+++ b/scripts/get-publishable-paths-from-semver-tags.mjs
@@ -46,7 +46,7 @@ exec(`git tag --points-at ${commitish}`, (err, stdout) => {
             const packagePath = join("packages", unscopedName);
             return {
                 // This will throw if the package name isn't also the path, which is desirable.
-                packageJson: loadJsonFile(packagePath, "package.json"),
+                packageJson: loadJsonFile("..", packagePath, "package.json"),
                 path: packagePath,
             };
         })


### PR DESCRIPTION
Attempt to fix https://github.com/palantir/blueprint/issues/5645 by using `src/generated-icons/` instead of `src/generated/` path 🤷🏽‍♂️ 

Also fixes a minor bug in the NPM publish script (I made this edit manually in https://app.circleci.com/pipelines/github/palantir/blueprint/3570/workflows/d2e47051-2cc1-4248-9442-b9711716d14a/jobs/65522 to get the last publish working).