### PR TITLE
[datetime] fix(DateRangePicker): accept controlled updates for start/end time

### DIFF
--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -39,8 +39,9 @@ export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange) {
     } else {
         const [start1, end1] = dateRange1;
         const [start2, end2] = dateRange2;
-        const areStartsEqual = (start1 == null && start2 == null) || areSameDay(start1, start2);
-        const areEndsEqual = (end1 == null && end2 == null) || areSameDay(end1, end2);
+        const areStartsEqual =
+            (start1 == null && start2 == null) || (areSameDay(start1, start2) && areSameTime(start1, start2));
+        const areEndsEqual = (end1 == null && end2 == null) || (areSameDay(end1, end2) && areSameTime(start1, start2));
         return areStartsEqual && areEndsEqual;
     }
 }

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -41,7 +41,7 @@ export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange) {
         const [start2, end2] = dateRange2;
         const areStartsEqual =
             (start1 == null && start2 == null) || (areSameDay(start1, start2) && areSameTime(start1, start2));
-        const areEndsEqual = (end1 == null && end2 == null) || (areSameDay(end1, end2) && areSameTime(start1, start2));
+        const areEndsEqual = (end1 == null && end2 == null) || (areSameDay(end1, end2) && areSameTime(end1, end2));
         return areStartsEqual && areEndsEqual;
     }
 }

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -27,11 +27,15 @@ describe("DateUtils", () => {
         const DATE_2 = new Date(2017, Months.JANUARY, 2);
         const DATE_3 = new Date(2017, Months.JANUARY, 3);
         const DATE_4 = new Date(2017, Months.JANUARY, 4);
+        const DATE_5 = new Date(2017, Months.JANUARY, 5);
+        const DATE_5_00 = new Date(2017, Months.JANUARY, 5, 0, 0, 0, 0);
+        const DATE_5_01 = new Date(2017, Months.JANUARY, 5, 1, 1, 1, 1);
 
         describe("returns true for", () => {
             runTest("null and null", null, null, true);
             runTest("[null, null] and [null, null]", [null, null], [null, null], true);
             runTest("[DATE_1, DATE_2] and [DATE_1, DATE_2]", [DATE_1, DATE_2], [DATE_1, DATE_2], true);
+            runTest("[DATE_1, DATE_5] and [DATE_1, DATE_5_00]", [DATE_1, DATE_5], [DATE_1, DATE_5_00], true);
         });
 
         describe("returns false for", () => {
@@ -41,6 +45,7 @@ describe("DateUtils", () => {
             runTest("[DATE_1, DATE_2] and [DATE_1, DATE_4]", [DATE_1, DATE_2], [DATE_1, DATE_4], false);
             runTest("[DATE_1, DATE_4] and [DATE_2, DATE_4]", [DATE_1, DATE_4], [DATE_2, DATE_4], false);
             runTest("[DATE_1, DATE_2] and [DATE_3, DATE_4]", [DATE_1, DATE_2], [DATE_3, DATE_4], false);
+            runTest("[DATE_1, DATE_5] and [DATE_1, DATE_5_01]", [DATE_1, DATE_5], [DATE_1, DATE_5_01], false);
         });
 
         function runTest(description: string, dateRange1: DateRange, dateRange2: DateRange, expectedResult: boolean) {


### PR DESCRIPTION
#### Fixes #5502

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- `areRangesEqual` is used to check value changes when the DateRangePicker component is controlled as hinted [here](https://github.com/palantir/blueprint/issues/3967#issuecomment-668111971). This function now ensures that both the day and time in the date object match.

#### Reviewers should focus on:

- Tests as proof that this now works. The current code passes updated tests, whereas older code failed:

```
DateUtils
    areRangesEqual
       returns false for
          [DATE_1, DATE_5] and [DATE_1, DATE_5_01]
             1) AssertionError: expected true to equal false
                at Context.<anonymous> (/var/folders/bf/99sjtr2d4_s2jzr5ct9nfb5x086lgg/T/_karma_webpack_575875/commons.js:169997:89)
```

#### Screenshot

N/A
