### PR TITLE
Fix#5825 DateRangeInput add defaultTimeValue to set start and end Time

### DIFF
--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -70,6 +70,13 @@ export interface IDateRangePickerProps extends DatePickerBaseProps, Props {
     contiguousCalendarMonths?: boolean;
 
     /**
+     * Initial time the `TimePicker` will display.
+     * This should not be set if `defaultValue` or `value` is set.
+     * This overrides `timePickerProps.defaultValue`
+     */
+    defaultTimeValue?: DateRange;
+
+    /**
      * Initial `DateRange` the calendar will display as selected.
      * This should not be set if `value` is set.
      */
@@ -196,7 +203,7 @@ export class DateRangePicker extends AbstractPureComponent2<DateRangePickerProps
     public constructor(props: DateRangePickerProps, context?: any) {
         super(props, context);
         const value = getInitialValue(props);
-        const time: DateRange = value;
+        const time: DateRange = getInitialTime(props);
         const initialMonth = getInitialMonth(props, value);
 
         // if the initial month is the last month of the picker's
@@ -793,6 +800,19 @@ function getInitialValue(props: DateRangePickerProps): DateRange | null {
     }
     if (props.defaultValue != null) {
         return props.defaultValue;
+    }
+    return [null, null];
+}
+
+function getInitialTime(props: DateRangePickerProps): DateRange | null {
+    if (props.value != null) {
+        return props.value;
+    }
+    if (props.defaultValue != null) {
+        return props.defaultValue;
+    }
+    if (props.defaultTimeValue != null) {
+        return props.defaultTimeValue;
     }
     return [null, null];
 }

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -1207,6 +1207,14 @@ describe("<DateRangePicker>", () => {
             assert.isTrue(wrapper.find(TimePicker).exists());
         });
 
+        it("use defaultTimeValue if set and defaultValue not set", () => {
+            render({ timePickerProps: {}, defaultTimeValue: defaultRange }).left.clickDay(19);
+            const cbHour = onChangeSpy.firstCall.args[0][0].getHours();
+            const cbMinutes = onChangeSpy.firstCall.args[0][0].getMinutes();
+            assert.strictEqual(cbHour, defaultRange[0].getHours());
+            assert.strictEqual(cbMinutes, defaultRange[0].getMinutes());
+        });
+
         it("onChange fired when the time is changed", () => {
             const { wrapper } = render({
                 defaultValue: defaultRange,


### PR DESCRIPTION
#### Fixes #5825

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Adding a `defaultTimeValue` prop to set the state of the TimePickers without a `defaultvalue` or `value`. 
It overrides `timePickerProps.defaultValue` and allows the start and end time to be set independently.

I tried reusing `timePickerProps.defaultValue`, but the type gets messy. 
<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->