### PR TITLE
docs: fix callout heading markup

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -1,11 +1,11 @@
 @# Breadcrumbs
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Breadcrumbs2](#popover2-package/breadcrumbs2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/core v4.7.0** in favor of the new
 Breadcrumbs2 component, which uses Popover2 instead of Popover under the hood.

--- a/packages/core/src/components/button/button.md
+++ b/packages/core/src/components/button/button.md
@@ -21,10 +21,10 @@ Buttons trigger actions when clicked. You may render a button as either a `<butt
 ```
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Disabled `Button` prevents all interaction
-</h4>
+</h5>
 
 Use `AnchorButton` if you need mouse interaction events (such as hovering) on a disabled button.
 

--- a/packages/core/src/components/collapsible-list/collapsible-list.md
+++ b/packages/core/src/components/collapsible-list/collapsible-list.md
@@ -7,10 +7,10 @@ customizing the appearance of visible items, using the props from the `MenuItem`
 children.
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Overflow list](#core/components/overflow-list)
-</h4>
+</h5>
 
 This component is **deprecated since 3.0.0** with the introduction of
 [`OverflowList`](#core/components/overflow-list) which provides a similar

--- a/packages/core/src/components/context-menu/context-menu.md
+++ b/packages/core/src/components/context-menu/context-menu.md
@@ -1,11 +1,11 @@
 @# Context menu
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [ContextMenu2](#popover2-package/context-menu2)
 
-</h4>
+</h5>
 
 This API is **deprecated since @blueprintjs/core v3.39.0** in favor of the new
 ContextMenu2 component available in the `@blueprintjs/popover2` package. You should migrate

--- a/packages/core/src/components/dialog/dialog.md
+++ b/packages/core/src/components/dialog/dialog.md
@@ -3,7 +3,7 @@
 Dialogs present content overlaid over other parts of the UI.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Terminology note</h4>
+    <h5 class="@ns-heading">Terminology note</h5>
 
 The term "modal" is sometimes used to mean "dialog," but this is a misnomer.
 _Modal_ is an adjective that describes parts of a UI.

--- a/packages/core/src/components/editable-text/editable-text.md
+++ b/packages/core/src/components/editable-text/editable-text.md
@@ -14,7 +14,7 @@ You should not use `EditableText` when a static always-editable `<input>` or
 @reactExample EditableTextExample
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">Centering the component</h4>
+    <h5 class="@ns-heading">Centering the component</h5>
 
 **Do not center this component** using `text-align: center`, as it will cause an infinite loop
 in the browser ([more details](https://github.com/JedWatson/react-select/issues/540)). Instead,

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -5,7 +5,7 @@ between elements. It supports any number of buttons, text inputs, input groups, 
 inputs, and HTML selects as direct children.
 
 <div class="@ns-callout @ns-intent-success @ns-icon-comparison">
-    <h4 class="@ns-heading">Control group vs. input group</h4>
+    <h5 class="@ns-heading">Control group vs. input group</h5>
 
 Both components group multiple elements into a single unit, but their usage patterns are
 quite different.

--- a/packages/core/src/components/forms/file-input.md
+++ b/packages/core/src/components/forms/file-input.md
@@ -10,7 +10,7 @@ which contain an `<input type="file">`. It supports the full range of HTML `<lab
 Use `inputProps` to apply props to the `<input>` element.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Static file name</h4>
+    <h5 class="@ns-heading">Static file name</h5>
 
 File name does not update on file selection. To get this behavior,
 you must implement it separately in JS.

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -7,7 +7,7 @@ where the user can click to activate the control. Notice how in the examples
 below, clicking a label focuses its `<input>`.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Prefer form groups over labels</h4>
+    <h5 class="@ns-heading">Prefer form groups over labels</h5>
 
 The [React `FormGroup` component](#core/components/form-group) provides
 additional functionality such as helper text and modifier props as well as

--- a/packages/core/src/components/forms/text-inputs.md
+++ b/packages/core/src/components/forms/text-inputs.md
@@ -46,7 +46,7 @@ vice versa. You do not need to apply sizing classes to the children&mdash;they i
 the parent input.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Icons only</h4>
+    <h5 class="@ns-heading">Icons only</h5>
 
 You cannot use buttons with text in the CSS API for input groups. The padding for text inputs
 in CSS cannot accommodate buttons whose width varies due to text content. You should use icons on

--- a/packages/core/src/components/hotkeys/hotkeys-target2.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target2.md
@@ -5,11 +5,11 @@ tag: new
 @# HotkeysTarget2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [HotkeysTarget](#core/components/hotkeys)?
 
-</h4>
+</h5>
 
 HotkeysTarget2 is a replacement for HotkeysTarget. You are encouraged to use this new API, or
 the `useHotkeys` hook directly in your function components, as they will become the standard

--- a/packages/core/src/components/hotkeys/hotkeys.md
+++ b/packages/core/src/components/hotkeys/hotkeys.md
@@ -1,11 +1,11 @@
 @# Hotkeys
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [useHotkeys](#core/hooks/use-hotkeys)
 
-</h4>
+</h5>
 
 This API is **deprecated since @blueprintjs/core v3.39.0** in favor of the new
 [`useHotkeys` hook](#core/hooks/use-hotkeys) and

--- a/packages/core/src/components/html-table/html-table.md
+++ b/packages/core/src/components/html-table/html-table.md
@@ -3,7 +3,7 @@
 This component provides Blueprint styling to native HTML tables.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">This is not @blueprintjs/table</h4>
+    <h5 class="@ns-heading">This is not @blueprintjs/table</h5>
 
 This table component is a simple CSS-only skin for HTML `<table>` elements.
 It is ideal for basic static tables. If you're looking for more complex

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -88,7 +88,7 @@ Icon classes also support the four `.@ns-intent-*` modifiers to color the image.
 ```
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Non-standard sizes</h4>
+    <h5 class="@ns-heading">Non-standard sizes</h5>
 
 Generally, font icons should only be used at either 16px or 20px. However, if a non-standard size is
 necessary, set a `font-size` that is whole multiple of 16 or 20 with the relevant size class.

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -91,11 +91,11 @@ there is not enough room to the right.
 ```
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated prop `popoverProps`: use [MenuItem2](#popover2-package/menu-item2)
 
-</h4>
+</h5>
 
 Usage of `<MenuItem popoverProps={...}>` is **deprecated since @blueprintjs/core v4.7.0**
 in favor of the new MenuItem2 component, which uses Popover2 instead of Popover under the hood.

--- a/packages/core/src/components/navbar/navbar.md
+++ b/packages/core/src/components/navbar/navbar.md
@@ -13,7 +13,7 @@ stays at the top of the screen as the user scrolls through the document.
 This modifier is not illustrated here because it breaks the document flow.
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">Body padding required</h4>
+    <h5 class="@ns-heading">Body padding required</h5>
 
 The fixed navbar will lie on top of your other content unless you add padding to the top of the
 `<body>` element equal to the height of the navbar. Use the `$pt-navbar-height` Sass variable.

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -43,7 +43,7 @@ for text, which is enclosed in a `.@ns-non-ideal-state-text` wrapper element). T
 constraint ensures proper spacing between each child.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Limited CSS API support</h4>
+    <h5 class="@ns-heading">Limited CSS API support</h5>
 
 Note that you are required to set the `font-size` and `line-height` styles for
 the icon element to render it properly.

--- a/packages/core/src/components/overlay/overlay.md
+++ b/packages/core/src/components/overlay/overlay.md
@@ -43,7 +43,7 @@ to close, but your application is responsible for updating the state that
 actually closes the overlay.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">A note about overlay content positioning</h4>
+    <h5 class="@ns-heading">A note about overlay content positioning</h5>
 
 When rendered inline, content will automatically be set to `position: absolute` to respect
 document flow. Otherwise, content will be set to `position: fixed` to cover the entire viewport.

--- a/packages/core/src/components/panel-stack/panel-stack.md
+++ b/packages/core/src/components/panel-stack/panel-stack.md
@@ -1,11 +1,11 @@
 @# Panel stack
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [PanelStack2](#core/components/panel-stack2)
 
-</h4>
+</h5>
 
 This API is **deprecated since @blueprintjs/core v3.40.0** in favor of the new
 PanelStack2 component. You should migrate to the new API which will become the

--- a/packages/core/src/components/panel-stack2/panel-stack2.md
+++ b/packages/core/src/components/panel-stack2/panel-stack2.md
@@ -5,11 +5,11 @@ tag: new
 @# Panel stack (v2)
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [PanelStack](#core/components/panel-stack)?
 
-</h4>
+</h5>
 
 PanelStack2 is a replacement for PanelStack. It will become the standard
 API in a future major version of Blueprint. You are encouraged to use this

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -1,11 +1,11 @@
 @# Popover
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Popover2](#popover2-package/popover2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/core v3.38.0** in favor of the new
 Popover2 component available in the `@blueprintjs/popover2` package. You should migrate
@@ -89,7 +89,7 @@ wrapped in a single element when rendering
 ```
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Button targets</h4>
+    <h5 class="@ns-heading">Button targets</h5>
 
 Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
 events, which interferes with the popover functioning. If you need to disable a button that
@@ -211,7 +211,7 @@ in your application logic whether you should care about a particular invocation 
 if the `nextOpenState` is not the same as the `Popover`'s current state).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Disabling controlled popovers</h4>
+    <h5 class="@ns-heading">Disabling controlled popovers</h5>
 
 If `disabled={true}`, a controlled popover will remain closed even if `isOpen={true}`.
 The popover will re-open when `disabled` is set to `false`.
@@ -278,7 +278,7 @@ The following example demonstrates the various interaction kinds (note: these Po
 @reactExample PopoverInteractionKindExample
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Conditionally styling popover targets</h4>
+    <h5 class="@ns-heading">Conditionally styling popover targets</h5>
 
 When a popover is open, `Classes.POPOVER_OPEN` is applied to the target.
 You can use this to style the target differently when the popover is open.
@@ -358,7 +358,7 @@ a translucent background color, like the backdrop for the [`Dialog`](#core/compo
 The backdrop element has the same opacity-fade transition as the `Dialog` backdrop.
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">Dangerous edge case</h4>
+    <h5 class="@ns-heading">Dangerous edge case</h5>
 
 Rendering a `<Popover isOpen={true} hasBackdrop={true}>` outside the viewport bounds can easily break
 your application by covering the UI with an invisible non-interactive backdrop. This edge case

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -10,11 +10,11 @@ For the most part, Portal is a thin wrapper around [`ReactDOM.createPortal`](htt
 @## React context (legacy)
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 React legacy API
 
-</h4>
+</h5>
 
 This feature uses React's legacy context API. Support for the
 [newer React context API](https://reactjs.org/docs/context.html) will be coming soon
@@ -46,7 +46,7 @@ Portal is used inside [Overlay](#core/components/overlay) to actually overlay th
 application.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-move">
-    <h4 class="@ns-heading">A note about responsive layouts</h4>
+    <h5 class="@ns-heading">A note about responsive layouts</h5>
 
 For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal`
 may take up extra whitespace and cause the window to undesirably scroll. To fix this, instead

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -21,7 +21,7 @@ function handleResize(entries: IResizeEntry[]) {
 @## Props
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Asynchronous behavior</h4>
+    <h5 class="@ns-heading">Asynchronous behavior</h5>
 
 The `onResize` callback is invoked asynchronously after a resize is detected
 and typically happens at the end of a frame (after layout, before paint).

--- a/packages/core/src/components/skeleton/skeleton.md
+++ b/packages/core/src/components/skeleton/skeleton.md
@@ -15,7 +15,7 @@ Apply the class `.@ns-skeleton` to elements that you would like to cover up with
 a loading animation.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Manually disable focusable elements</h4>
+    <h5 class="@ns-heading">Manually disable focusable elements</h5>
 
 When using the `.@ns-skeleton` class on focusable elements such as inputs
 and buttons, be sure to disable the element, via either the `disabled` or

--- a/packages/core/src/components/spinner/spinner.md
+++ b/packages/core/src/components/spinner/spinner.md
@@ -22,7 +22,7 @@ by including `Classes.SMALL` or `Classes.LARGE` in `className` instead of the
 `size` prop (this prevents an API break when upgrading to 3.x).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">IE11 compatibility note</h4>
+    <h5 class="@ns-heading">IE11 compatibility note</h5>
 
 IE11 [does not support CSS transitions on SVG elements][msdn-css-svg] so spinners with known
 `value` will not smoothly transition as `value` changes. Indeterminate spinners still animate

--- a/packages/core/src/components/tag-input/tag-input.md
+++ b/packages/core/src/components/tag-input/tag-input.md
@@ -8,7 +8,7 @@ on the container will focus the text input for seamless interaction.
 @reactExample TagInputExample
 
 <div class="@ns-callout @ns-intent-success @ns-icon-info-sign">
-    <h4 class="@ns-heading">Looking for a dropdown menu?</h4>
+    <h5 class="@ns-heading">Looking for a dropdown menu?</h5>
 
 [`MultiSelect` in the **@blueprintjs/select** package](#select/multi-select)
 composes this component with a dropdown menu of suggestions.
@@ -46,7 +46,7 @@ The `<input>` element can be controlled directly via the `inputValue` and
 be applied to the input via `inputProps`.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Handling long words</h4>
+    <h5 class="@ns-heading">Handling long words</h5>
 
 Set an explicit `width` on the container element to cause long tags to wrap onto multiple lines.
 Either supply a specific pixel value, or use `<TagInput className={Classes.FILL}>`
@@ -55,7 +55,7 @@ to fill its container's width (try this in the example above).
 </div>
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Disabling a tag input</h4>
+    <h5 class="@ns-heading">Disabling a tag input</h5>
 
 Disabling this component requires setting the `disabled` prop to `true`
 and separately disabling the component's `rightElement` as appropriate

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -35,7 +35,7 @@ There are three ways to use the `Toaster` component:
 1. `<Toaster ref={ref => ref.show({ ...toast })} />`: Render a `<Toaster>` element and use the `ref` prop to access its instance methods.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Working with multiple toasters</h4>
+    <h5 class="@ns-heading">Working with multiple toasters</h5>
 
 You can have multiple toasters in a single application, but you must ensure that each has a unique
 `position` to prevent overlap.
@@ -43,7 +43,7 @@ You can have multiple toasters in a single application, but you must ensure that
 </div>
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Toaster focus</h4>
+    <h5 class="@ns-heading">Toaster focus</h5>
 
 `Toaster` always disables `Overlay`'s `enforceFocus` behavior (meaning that you're not blocked
 from accessing other parts of the application while a toast is active), and by default also
@@ -73,7 +73,7 @@ methods detailed below. It can be thought of as `Toaster` minus the `React.Compo
 because the `Toaster` should not be treated as a normal React component.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">React 16 usage</h4>
+    <h5 class="@ns-heading">React 16 usage</h5>
 
 `Toaster.create()` will throw an error if invoked inside a component lifecycle method in React 16, as `ReactDOM.render()` will return
 `null` resulting in an inaccessible toaster instance. See the second bullet point on the [React 16 release notes](https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes) for more information.

--- a/packages/core/src/components/tooltip/tooltip.md
+++ b/packages/core/src/components/tooltip/tooltip.md
@@ -1,11 +1,11 @@
 @# Tooltip
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Tooltip2](#popover2-package/tooltip2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/core v3.38.0** in favor of the new
 Tooltip2 component available in the `@blueprintjs/popover2` package. You should migrate
@@ -56,7 +56,7 @@ When creating a tooltip, you must specify both:
 The content will appear in a contrasting popover when the target is hovered.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Button targets</h4>
+    <h5 class="@ns-heading">Button targets</h5>
 
 Buttons make great tooltip targets, but the `disabled` attribute will prevent all
 events so the enclosing `Tooltip` will not know when to respond.

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -5,11 +5,11 @@ tag: new
 @# HotkeysProvider
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [HotkeysTarget](#core/components/hotkeys)?
 
-</h4>
+</h5>
 
 HotkeysProvider and `useHotkeys`, used together, are a replacement for HotkeysTarget.
 You are encouraged to use this new API, as it will become the standard APIs in a future major version of Blueprint.

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -5,11 +5,11 @@ tag: new
 @# useHotkeys
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [HotkeysTarget](#core/components/hotkeys)?
 
-</h4>
+</h5>
 
 `useHotkeys` is a replacement for HotkeysTarget. You are encouraged to use this new API in your function
 components, or the [HotkeysTarget2 component](#core/components/hotkeys-target2) in your component classes,

--- a/packages/datetime/src/dateinput.md
+++ b/packages/datetime/src/dateinput.md
@@ -1,11 +1,11 @@
 @# Date input
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [DateInput2](#datetime2/date-input2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/datetime v4.4.5** in favor of the new
 DateInput2 component available in the `@blueprintjs/datetime2` package, which uses

--- a/packages/datetime/src/daterangeinput.md
+++ b/packages/datetime/src/daterangeinput.md
@@ -1,7 +1,7 @@
 @# Date range input
 
 <div class="@ns-callout @ns-intent-success @ns-icon-star">
-    <h4 class="@ns-heading">Newer API available</h4>
+    <h5 class="@ns-heading">Newer API available</h5>
 
 There is an updated version of this component available in the new
 [__@blueprintjs/datetime2__ package](#datetime2) called

--- a/packages/datetime/src/datetimepicker.md
+++ b/packages/datetime/src/datetimepicker.md
@@ -4,10 +4,10 @@
 and a [`TimePicker`](#datetime/timepicker) into one container.
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Date picker](#datetime/datepicker)
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/datetime v3.2.0** with the addition
 of `<DatePicker>` `timePrecision` and `timePickerProps` props to trivially

--- a/packages/datetime2/src/components/date-input2/date-input2.md
+++ b/packages/datetime2/src/components/date-input2/date-input2.md
@@ -5,11 +5,11 @@ tag: new
 @# DateInput2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [DateInput](#datetime/dateinput)?
 
-</h4>
+</h5>
 
 DateInput2 is a replacement for DateInput and will replace it in Blueprint v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.

--- a/packages/datetime2/src/components/date-range-input2/date-range-input2.md
+++ b/packages/datetime2/src/components/date-range-input2/date-range-input2.md
@@ -5,11 +5,11 @@ tag: new
 @# DateRangeInput2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [DateRangeInput](#datetime/daterangeinput)?
 
-</h4>
+</h5>
 
 DateRangeInput2 is a replacement for the [DateRangeInput component](#datetime/daterangeinput) from
 [__@blueprintjs/datetime__ package](#datetime) and will replace it in Blueprint v5.

--- a/packages/datetime2/src/components/timezone-select/timezone-select.md
+++ b/packages/datetime2/src/components/timezone-select/timezone-select.md
@@ -5,11 +5,11 @@ tag: new
 @# TimezoneSelect
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [TimezonePicker](#timezone/timezone-picker)?
 
-</h4>
+</h5>
 
 TimezoneSelect is a replacement for [TimezonePicker component](#timezone/timezone-picker) from
 the [__@blueprintjs/timezone__ package](#timezone) and will replace it in Blueprint v5.
@@ -62,7 +62,7 @@ in this case, all button-specific props will be ignored:
 ```
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Local timezone detection</h4>
+    <h5 class="@ns-heading">Local timezone detection</h5>
 
 We detect the local timezone using the
 [i18n API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions)

--- a/packages/datetime2/src/index.md
+++ b/packages/datetime2/src/index.md
@@ -5,7 +5,7 @@ reference: datetime2
 @# Datetime2
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Incubating component library</h4>
+    <h5 class="@ns-heading">Incubating component library</h5>
     <p>This package is currently in the v0.x version range, which means its API is unstable.</p>
 </div>
 
@@ -52,7 +52,7 @@ Import the package stylesheet (for example, in Sass):
 ```
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Additional CSS required</h4>
+    <h5 class="@ns-heading">Additional CSS required</h5>
 
 This library relies on some components from other Blueprint packages, so you will need to pull in those
 packages' CSS files as well (if you are not doing this already):

--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -7,7 +7,7 @@ It is optimized for building complex data-dense interfaces for desktop applicati
 @reactDocs Welcome
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-star">
-<h4 class="@ns-heading">Blueprint v5 is coming soon</h4>
+<h5 class="@ns-heading">Blueprint v5 is coming soon</h5>
 
 [Check out the new features and migration guides to upgrade from v4.x &rarr;](https://github.com/palantir/blueprint/wiki/Blueprint-5.0)
 

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -52,7 +52,7 @@ The `main` module exports all symbols from all modules so you don't have to impo
     ```
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">CDN-only usage</h4>
+    <h5 class="@ns-heading">CDN-only usage</h5>
 
 Blueprint can instead be quickly added to a page using the Unpkg CDN.
 [See below for instructions](#blueprint/getting-started.cdn-consumption).

--- a/packages/popover2/src/breadcrumbs2.md
+++ b/packages/popover2/src/breadcrumbs2.md
@@ -5,11 +5,11 @@ tag: new
 @# Breadcrumbs2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [Breadcrumbs](#core/components/breadcrumbs)?
 
-</h4>
+</h5>
 
 Breadcrumbs2 is a replacement for Breadcrumbs and will replace it in Blueprint core v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.

--- a/packages/popover2/src/context-menu2.md
+++ b/packages/popover2/src/context-menu2.md
@@ -1,11 +1,11 @@
 @# ContextMenu2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [ContextMenu](#core/components/context-menu)?
 
-</h4>
+</h5>
 
 ContextMenu2 is a replacement for ContextMenu + ContextMenuTarget. It will become the standard
 context menu API in Blueprint core v5. You are encouraged to use this new API now to ease the

--- a/packages/popover2/src/menu-item2.md
+++ b/packages/popover2/src/menu-item2.md
@@ -5,11 +5,11 @@ tag: new
 @# MenuItem2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [MenuItem](#core/components/menu.menu-item)?
 
-</h4>
+</h5>
 
 MenuItem2 is a replacement for MenuItem. It uses Popover2 instead of Popover for its submenus.
 You are encouraged to migrate to MenuItem2 now in the rare case where you customize submenu layout

--- a/packages/popover2/src/popover2.md
+++ b/packages/popover2/src/popover2.md
@@ -1,11 +1,11 @@
 @# Popover2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [Popover](#core/components/popover)?
 
-</h4>
+</h5>
 
 Popover2 is a replacement for Popover and will become the standard Popover API in Blueprint core v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
@@ -69,7 +69,7 @@ positioned on the page next to the target; the `placement` prop determines its r
 which side of the target).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Button targets</h4>
+    <h5 class="@ns-heading">Button targets</h5>
 
 Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
 events, which interferes with the popover functioning. If you need to disable a button which
@@ -160,7 +160,7 @@ modifier name and its options object, respectively. See the [Popper.js modifiers
 for more info.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Auto placement requires flip modifier</h4>
+    <h5 class="@ns-heading">Auto placement requires flip modifier</h5>
 
 Be careful when disabling the "flip" modifier, since the default "auto" placement relies on it. If you _do_ decide
 to disable this modifier, be sure to also specify a placement which is not "auto".
@@ -186,7 +186,7 @@ in your application logic whether you should care about a particular invocation 
 if the `nextOpenState` is not the same as the `Popover2`'s current state).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Disabling controlled popovers</h4>
+    <h5 class="@ns-heading">Disabling controlled popovers</h5>
 
 If `disabled={true}`, a controlled popover will remain closed even if `isOpen={true}`.
 The popover will re-open when `disabled` is set to `false`.
@@ -252,7 +252,7 @@ The following example demonstrates the various interaction kinds (note: these Po
 @reactExample Popover2InteractionKindExample
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Conditionally styling popover targets</h4>
+    <h5 class="@ns-heading">Conditionally styling popover targets</h5>
 
 When a popover is open, `Classes.POPOVER2_OPEN` is applied to the target.
 You can use this to style the target differently when the popover is open.
@@ -332,7 +332,7 @@ a translucent background color, like the backdrop for the [`Dialog`](#core/compo
 The backdrop element has the same opacity-fade transition as the `Dialog` backdrop.
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">Dangerous edge case</h4>
+    <h5 class="@ns-heading">Dangerous edge case</h5>
 
 Rendering a `<Popover2 isOpen={true} hasBackdrop={true}>` outside the viewport bounds can easily break
 your application by covering the UI with an invisible non-interactive backdrop. This edge case

--- a/packages/popover2/src/resize-sensor2.md
+++ b/packages/popover2/src/resize-sensor2.md
@@ -29,7 +29,7 @@ function handleResize(entries: ResizeEntry[]) {
 @## Props
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Asynchronous behavior</h4>
+    <h5 class="@ns-heading">Asynchronous behavior</h5>
 
 The `onResize` callback is invoked asynchronously after a resize is detected
 and typically happens at the end of a frame (after layout, before paint).

--- a/packages/popover2/src/tooltip2.md
+++ b/packages/popover2/src/tooltip2.md
@@ -1,11 +1,11 @@
 @# Tooltip2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [Tooltip](#core/components/tooltip)?
 
-</h4>
+</h5>
 
 Tooltip2 is a replacement for Tooltip and will become the standard Popover API in Blueprint core v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
@@ -71,7 +71,7 @@ positioned on the page next to the target; the `placement` prop determines its r
 which side of the target).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Button targets</h4>
+    <h5 class="@ns-heading">Button targets</h5>
 
 Buttons make great tooltip targets, but the `disabled` attribute will prevent all
 events so the enclosing `Tooltip2` will not know when to respond.

--- a/packages/select/src/components/multi-select/multi-select.md
+++ b/packages/select/src/components/multi-select/multi-select.md
@@ -1,11 +1,11 @@
 @# MultiSelect
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [MultiSelect2](#select/multi-select2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/select v4.3.0** in favor of the new
 MultiSelect2 component, which uses Popover2 instead of Popover under the hood.

--- a/packages/select/src/components/multi-select/multi-select2.md
+++ b/packages/select/src/components/multi-select/multi-select2.md
@@ -5,11 +5,11 @@ tag: new
 @# MultiSelect2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [MultiSelect](#select/multi-select)?
 
-</h4>
+</h5>
 
 MultiSelect2 is a replacement for MultiSelect and will replace it in Blueprint core v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
@@ -28,7 +28,7 @@ You may react to user interactions with the `onItemSelect` and `onRemove` callba
 @reactExample MultiSelectExample
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">Generic components and custom filtering</h4>
+    <h5 class="@ns-heading">Generic components and custom filtering</h5>
 
 For more information on controlled usage, generic components, creating new items, and custom filtering,
 please visit the documentation for [Select2](#select/select2).

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -1,11 +1,11 @@
 @# Select
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Select2](#select/select2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/select v4.3.0** in favor of the new
 Select2 component, which uses Popover2 instead of Popover under the hood.

--- a/packages/select/src/components/select/select2.md
+++ b/packages/select/src/components/select/select2.md
@@ -5,11 +5,11 @@ tag: new
 @# Select2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [Select](#select/select-component)?
 
-</h4>
+</h5>
 
 Select2 is a replacement for Select and will replace it in Blueprint core v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
@@ -171,7 +171,7 @@ in the list, based on the current query string. Use `createNewItemFromQuery` and
     will invoke `onItemSelect` with the item returned from `createNewItemFromQuery`.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-info-sign">
-    <h4 class="@ns-heading">Avoiding type conflicts</h4>
+    <h5 class="@ns-heading">Avoiding type conflicts</h5>
 
 The "Create Item" option is represented by the reserved type `CreateNewItem`
 exported from this package. It is exceedingly unlikely but technically possible

--- a/packages/select/src/components/suggest/suggest.md
+++ b/packages/select/src/components/suggest/suggest.md
@@ -1,11 +1,11 @@
 @# Suggest
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [Suggest2](#select/suggest2)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/select v4.3.0** in favor of the new
 Suggest2 component, which uses Popover2 instead of Popover under the hood.

--- a/packages/select/src/components/suggest/suggest2.md
+++ b/packages/select/src/components/suggest/suggest2.md
@@ -5,11 +5,11 @@ tag: new
 @# Suggest2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Migrating from [Suggest](#select/suggest)?
 
-</h4>
+</h5>
 
 Suggest2 is a replacement for Suggest and will replace it in Blueprint core v5.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.

--- a/packages/table/src/docs/table-api.md
+++ b/packages/table/src/docs/table-api.md
@@ -64,7 +64,7 @@ name, you can supply a `nameRenderer` prop to the `ColumnHeaderCell2`.
 
 <div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
 
-<h4 class="@ns-heading">Additional CSS required</h4>
+<h5 class="@ns-heading">Additional CSS required</h5>
 
 __ColumnHeaderCell2__ depends on @blueprintjs/popover2 styles, so you must remember to import
 that package's stylesheet in your application in addition to `table.css`:
@@ -100,7 +100,7 @@ In order to use this API, supply a custom renderer function which returns a `Row
 
 <div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
 
-<h4 class="@ns-heading">Additional CSS required</h4>
+<h5 class="@ns-heading">Additional CSS required</h5>
 
 __RowHeaderCell2__ depends on @blueprintjs/popover2 styles, so you must remember to import
 that package's stylesheet in your application in addition to `table.css`:

--- a/packages/table/src/docs/table-features.md
+++ b/packages/table/src/docs/table-features.md
@@ -162,7 +162,7 @@ and a `<JSONFormat2 detectTruncation={true}>` component to show the timezone inf
 
 <div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
 
-<h4 class="@ns-heading">Additional CSS required</h4>
+<h5 class="@ns-heading">Additional CSS required</h5>
 
 These cell formatting components depend on @blueprintjs/popover2 styles, so you must remember to import
 that package's stylesheet in your application in addition to `table.css`:

--- a/packages/table/src/docs/table.md
+++ b/packages/table/src/docs/table.md
@@ -23,7 +23,7 @@ Do not forget to include `table.css` on your page:
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
 
-<h4 class="@ns-heading">Additional CSS required</h4>
+<h5 class="@ns-heading">Additional CSS required</h5>
 
 __ColumnHeaderCell2__, __JSONFormat2__, and __TruncatedFormat2__ (available since @blueprintjs/table v4.6.0)
 depend on @blueprintjs/popover2 styles, so you must also import this CSS file for those components

--- a/packages/timezone/src/components/timezone-picker/timezone-picker.md
+++ b/packages/timezone/src/components/timezone-picker/timezone-picker.md
@@ -1,11 +1,11 @@
 @# TimezonePicker
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error">
-    <h4 class="@ns-heading">
+    <h5 class="@ns-heading">
 
 Deprecated: use [TimezoneSelect](#datetime2/timezone-select)
 
-</h4>
+</h5>
 
 This component is **deprecated since @blueprintjs/timezone v4.3.0** in favor of the new
 TimezoneSelect component, which uses Popover2 instead of Popover under the hood, and
@@ -49,7 +49,7 @@ all button-specific props will be ignored:
 ```
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h4 class="@ns-heading">Local timezone detection</h4>
+    <h5 class="@ns-heading">Local timezone detection</h5>
 
 We detect the local timezone when the `showLocalTimezone` prop is enabled and cannot guarantee correctness in all browsers.
 In supported browsers, the [i18n API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions) is used.


### PR DESCRIPTION
This change updates static markup in our markdown docs to use smaller headings inside Callouts to match the visual changes made in https://github.com/palantir/blueprint/pull/5834.