### PR TITLE
[core] fix dialog footer layout regression

### DIFF
--- a/packages/core/src/components/dialog/_dialog-footer.scss
+++ b/packages/core/src/components/dialog/_dialog-footer.scss
@@ -3,7 +3,10 @@
 
 .#{$ns}-dialog-footer {
   flex: 0 0 auto;
-  padding: $dialog-padding;
+  // We'd like to use padding instead of margin here to be consistent with the -dialog-footer-fixed class,
+  // but we need to keep this margin style for backwards-compatibility. This may change in a future major version.
+  // TODO(adahiya): migrate from margin to padding style (CSS breaking change)
+  margin: $dialog-padding;
 }
 
 .#{$ns}-dialog-footer-fixed {
@@ -14,6 +17,7 @@
   display: flex;
   gap: $dialog-padding;
   justify-content: space-between;
+  margin: 0;
   padding: $pt-grid-size $pt-grid-size $pt-grid-size $dialog-padding;
 
   .#{$ns}-dark & {

--- a/packages/core/test/drawer/drawerTests.tsx
+++ b/packages/core/test/drawer/drawerTests.tsx
@@ -270,7 +270,7 @@ describe("<Drawer>", () => {
                 </p>
             </div>,
             <div className={Classes.DRAWER_FOOTER} key={2}>
-                <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+                <div style={{ display: "flex", justifyContent: "flex-end", gap: "10px" }}>
                     <Button text="Secondary" />
                     <Button className={Classes.INTENT_PRIMARY} type="submit" text="Primary" />
                 </div>

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -36,6 +36,7 @@ describe("<MultistepDialog>", () => {
             Classes.MULTISTEP_DIALOG_PANELS,
             Classes.MULTISTEP_DIALOG_LEFT_PANEL,
             Classes.MULTISTEP_DIALOG_RIGHT_PANEL,
+            // eslint-disable-next-line deprecation/deprecation -- need to keep adding this class for backcompat, can be removed in next major version
             Classes.MULTISTEP_DIALOG_FOOTER,
             Classes.DIALOG_STEP,
             Classes.DIALOG_STEP_CONTAINER,


### PR DESCRIPTION
Similar to #5852, we also have to revert this `padding` -> `margin` change and only apply it for the new "fixed footer" class.

Before, with padding:

<img width="564" alt="image" src="https://user-images.githubusercontent.com/723999/213746637-19618296-e8b1-4893-a623-c588d9f6adad.png">

After, with margin:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/723999/213746686-0e638b9c-e284-4f47-8b80-d04672ebd496.png">

Staying with `margin` allows existing code which uses `<div className={Classes.DIALOG_FOOTER}>` and applies margin style overrides to keep working, which is part of our CSS API contract.