### PR TITLE
[core] feat(InputGroup, NumericInput): inputClassName prop

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -160,6 +160,7 @@ const INVALID_PROPS = [
     "elementRef",
     "fill",
     "icon",
+    "inputClassName",
     "inputRef",
     "intent",
     "inline",

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -192,6 +192,7 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
             className,
             disabled,
             fill,
+            inputClassName,
             inputRef,
             intent,
             large,
@@ -221,7 +222,7 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
         const inputProps = {
             type: "text",
             ...removeNonHTMLProps(this.props),
-            className: Classes.INPUT,
+            className: classNames(Classes.INPUT, inputClassName),
             style,
         };
         const inputElement = asyncControl ? (

--- a/packages/core/src/components/forms/inputSharedProps.ts
+++ b/packages/core/src/components/forms/inputSharedProps.ts
@@ -37,6 +37,11 @@ export interface InputSharedProps extends IntentProps, Props {
     fill?: boolean;
 
     /**
+     * Class name to apply to the `<input>` element (not the InputGroup container).
+     */
+    inputClassName?: string;
+
+    /**
      * Ref attached to the HTML `<input>` element backing this component.
      */
     inputRef?: React.Ref<HTMLInputElement>;

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -438,6 +438,7 @@ export class NumericInput extends AbstractPureComponent2<HTMLInputProps & Numeri
                 aria-valuemin={this.props.min}
                 aria-valuenow={valueAsNumber}
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
+                inputClassName={this.props.inputClassName}
                 inputRef={this.inputRef}
                 large={this.props.large}
                 leftElement={this.props.leftElement}


### PR DESCRIPTION
#### Fixes #5860

#### Changes proposed in this pull request:

Add `inputClassName` to `InputSharedProps` and implement support for it in both `<InputGroup>` and `<NumericInput>`.

