### PR TITLE
Multiselect2, TagInput: undefined remove, change handlers should not render tag-remove button

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -110,7 +110,8 @@ export interface ITagInputProps extends IntentProps, Props {
      *
      * This callback essentially implements basic `onAdd` and `onRemove` functionality and merges
      * the two handlers into one to simplify controlled usage.
-     * ```
+     *
+     * If both `onRemove` and `onChange` are not provided, rendered tag items will not have remove icons.
      */
     onChange?: (values: React.ReactNode[]) => boolean | void;
 
@@ -137,6 +138,8 @@ export interface ITagInputProps extends IntentProps, Props {
     /**
      * Callback invoked when the user clicks the X button on a tag.
      * Receives value and index of removed tag.
+     *
+     * If both `onRemove` and `onChange` are not provided, rendered tag items will not have remove icons.
      */
     onRemove?: (value: React.ReactNode, index: number) => void;
 
@@ -307,15 +310,16 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
         if (!tag) {
             return null;
         }
-        const { large, tagProps } = this.props;
+        const { large, tagProps, onRemove, onChange } = this.props;
         const props = Utils.isFunction(tagProps) ? tagProps(tag, index) : tagProps;
+        const canRemoveTag = onRemove != null || onChange != null;
         return (
             <Tag
                 active={index === this.state.activeIndex}
                 data-tag-index={index}
                 key={tag + "__" + index}
                 large={large}
-                onRemove={this.props.disabled ? undefined : this.handleRemoveTag}
+                onRemove={this.props.disabled || !canRemoveTag ? undefined : this.handleRemoveTag}
                 {...props}
             >
                 {tag}

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -421,6 +421,13 @@ describe("<TagInput>", () => {
         });
     });
 
+    it("when both onRemove or onChange are not supplied", () => {
+        const wrapper = mount(<TagInput values={VALUES} />);
+        wrapper.find(Tag).forEach(tag => {
+            assert.lengthOf(tag.find("." + Classes.TAG_REMOVE), 0, "tag should not have tag-remove button");
+        });
+    });
+
     describe("onKeyDown", () => {
         it("emits the active tag index on key down", () => {
             runKeyPressTest("onKeyDown", 1, 1);

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -39,6 +39,7 @@ const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Int
 
 export interface IMultiSelectExampleState {
     allowCreate: boolean;
+    allowRemove: boolean;
     createdItems: Film[];
     disabled: boolean;
     fill: boolean;
@@ -57,6 +58,7 @@ export interface IMultiSelectExampleState {
 export class MultiSelectExample extends React.PureComponent<ExampleProps, IMultiSelectExampleState> {
     public state: IMultiSelectExampleState = {
         allowCreate: false,
+        allowRemove: true,
         createdItems: [],
         disabled: false,
         fill: false,
@@ -75,6 +77,8 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
     private popoverRef: React.RefObject<Popover2<DefaultPopover2TargetHTMLProps>> = React.createRef();
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
+
+    private handleAllowRemoveChange = this.handleSwitchChange("allowRemove");
 
     private handleDisabledChange = this.handleSwitchChange("disabled");
 
@@ -129,7 +133,7 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
                     popoverRef={this.popoverRef}
                     tagRenderer={this.renderTag}
                     tagInputProps={{
-                        onRemove: this.handleTagRemove,
+                        onRemove: this.state.allowRemove ? this.handleTagRemove : undefined,
                         tagProps: getTagProps,
                     }}
                     selectedItems={this.state.films}
@@ -169,6 +173,20 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
                         label="Allow creating new films"
                         checked={this.state.allowCreate}
                         onChange={this.handleAllowCreateChange}
+                    />
+                </PropCodeTooltip>
+                <PropCodeTooltip
+                    content={
+                        <>
+                            <Code>onRemove</Code> or <Code>tagProps.onRemove</Code> is{" "}
+                            {this.state.allowRemove ? "defined" : "undefined"}
+                        </>
+                    }
+                >
+                    <Switch
+                        label="Allow deselecting films from tags"
+                        checked={this.state.allowRemove}
+                        onChange={this.handleAllowRemoveChange}
                     />
                 </PropCodeTooltip>
                 <PropCodeTooltip

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -67,6 +67,9 @@ export interface MultiSelect2Props<T> extends ListItemsProps<T>, SelectPopoverPr
      * the value's rendered `ReactNode` tag.
      *
      * It is not recommended to supply _both_ this prop and `tagInputProps.onRemove`.
+     *
+     * If none of `tagInputProps.onRemove` and `tagInputProps.onChange`, and `onRemove` are provided,
+     * rendered tag items will not have remove icons.
      */
     onRemove?: (value: T, index: number) => void;
 
@@ -110,6 +113,10 @@ export interface MultiSelect2Props<T> extends ListItemsProps<T>, SelectPopoverPr
      * - you are responsible for disabling any elements you may render here when the overall `MultiSelect2` is disabled
      * - if the `onClear` prop is defined, this element will override/replace the default rightElement,
      *   which is a "clear" button that removes all items from the current selection.
+     *
+     * Notes for `tagInputProps.onRemove` and `tagInputProps.onChange`:
+     * - if none of `tagInputProps.onRemove` and `tagInputProps.onChange`, and `onRemove` are provided,
+     *   rendered tag items will not have remove icons.
      */
     tagInputProps?: Partial<Omit<TagInputProps, "inputValue" | "onInputChange">>;
 
@@ -244,6 +251,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 disabled,
                 fill,
                 onClear,
+                onRemove,
                 placeholder,
                 popoverProps = {},
                 popoverTargetProps = {},
@@ -281,6 +289,8 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
             const { targetTagName = "div" } = popoverProps;
 
+            const canRemoveTag = onRemove != null || tagInputProps?.onRemove != null;
+
             return React.createElement(
                 targetTagName,
                 {
@@ -311,7 +321,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     inputValue={listProps.query}
                     onAdd={this.getTagInputAddHandler(listProps)}
                     onInputChange={listProps.handleQueryChange}
-                    onRemove={this.handleTagRemove}
+                    onRemove={canRemoveTag ? this.handleTagRemove : undefined}
                     values={selectedItems.map(this.props.tagRenderer)}
                 />,
             );

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -289,7 +289,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
             const { targetTagName = "div" } = popoverProps;
 
-            const canRemoveTag = onRemove != null || tagInputProps?.onRemove != null;
+            const canRemoveTag = onRemove != null || tagInputProps?.onRemove != null || tagInputProps?.onChange != null;
 
             return React.createElement(
                 targetTagName,

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -97,8 +97,10 @@ describe("<MultiSelect2>", () => {
 
     it("only triggers QueryList key up events when focus is on TagInput's <input>", () => {
         const itemSelectSpy = sinon.spy();
+        const handleRemove = sinon.spy();
         const wrapper = multiselect({
             onItemSelect: itemSelectSpy,
+            onRemove: handleRemove,
             selectedItems: [TOP_100_FILMS[1]],
         });
 

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -111,14 +111,26 @@ describe("<MultiSelect2>", () => {
         assert.isFalse(itemSelectSpy.calledWith(TOP_100_FILMS[0]));
     });
 
-    it("triggers onRemove", () => {
+    it("triggers onRemove if provided", () => {
         const handleRemove = sinon.spy();
         const wrapper = multiselect({
             onRemove: handleRemove,
             selectedItems: [TOP_100_FILMS[2], TOP_100_FILMS[3], TOP_100_FILMS[4]],
         });
+        wrapper.find(Tag).forEach(tag => {
+            assert.lengthOf(tag.find(`.${CoreClasses.TAG_REMOVE}`), 1, "tag should have tag-remove button");
+        });
         wrapper.find(`.${CoreClasses.TAG_REMOVE}`).at(1).simulate("click");
         assert.isTrue(handleRemove.calledOnceWithExactly(TOP_100_FILMS[3], 1));
+    });
+
+    it("does not render tag-remove button if both onRemove and tagInputProps.onRemove are not provided", () => {
+        const wrapper = multiselect({
+            selectedItems: [TOP_100_FILMS[2], TOP_100_FILMS[3], TOP_100_FILMS[4]],
+        });
+        wrapper.find(Tag).forEach(tag => {
+            assert.lengthOf(tag.find(`.${CoreClasses.TAG_REMOVE}`), 0, "tag should not have tag-remove button");
+        });
     });
 
     function multiselect(props: Partial<MultiSelect2Props<Film>> = {}, query?: string) {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/5897

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Updating `<MultiSelect2 />` and `<TagInput />` components to handle cases where their respective `onRemove` or `onChange` handlers not provided.

1. For `TagInput` when passing `onRemove` handler to `<Tag />`, we check if either of `onRemove` or `onChange` props is supplied to `TagInput`. If not, we pass `undefined` – this makes sure we don't render tag-remove button when no handlers are defined.

2. For `MultiSelect2` when passing `onRemove` prop to `<TagInput />`, we check if any of `onRemove` or `tagInputProps.onRemove` or `tagInputProps.onChange` is defined. If not, we do not pass any remove handlers down to `TagInput`.

#### Reviewers should focus on:

Making sure this does not break any components that depend on `TagInput`.

#### Screenshot

![Screenshot 2023-01-30 at 14 51 47](https://user-images.githubusercontent.com/26179019/215510596-e4cbedfe-23fb-4304-8d5c-ef3bcb8bdff5.png)
