### PR TITLE
[core] fix(Callout): link text color in primary intent callouts

### DIFF
--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -9,7 +9,7 @@ Callout
 Markup:
 <div class="#{$ns}-callout {{.modifier}}">
   <h5 class="#{$ns}-heading">Callout Heading</h5>
-  It's dangerous to go alone! Take this.
+  It's dangerous to go alone! Take <a href="#">this</a>.
 </div>
 
 .#{$ns}-intent-primary - Primary intent
@@ -21,7 +21,7 @@ Markup:
 Styleguide callout
 */
 
-$callout-padding:  $pt-grid-size * 1.5;
+$callout-padding: $pt-grid-size * 1.5;
 $callout-header-margin-top: $pt-grid-size * 0.2;
 
 .#{$ns}-callout {
@@ -104,6 +104,24 @@ $callout-header-margin-top: $pt-grid-size * 0.2;
         .#{$ns}-heading {
           color: map-get($pt-dark-intent-text-colors, $intent);
         }
+      }
+    }
+  }
+
+  &.#{$ns}-intent-primary {
+    // special case for links inside primary intent callouts, which would otherwise not have any indication
+    // that they are clickable links; see https://github.com/palantir/blueprint/issues/5853
+    a {
+      text-decoration: underline;
+
+      &:hover {
+        color: $blue1;
+      }
+    }
+
+    .#{$ns}-dark & {
+      a:hover {
+        color: $blue6;
       }
     }
   }

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -5,7 +5,11 @@ a title, an icon and content. Each intent has a default icon associated with it.
 
 @reactExample CalloutExample
 
-@## Props
+@## Props interface
+
+The `<Callout>` component is a simple wrapper around the CSS API that provides props for
+modifiers and an optional title element. Any additional HTML props will be spread to the
+rendered `<div>` element.
 
 @interface ICalloutProps
 

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -52,9 +52,9 @@ export class CalloutExample extends React.PureComponent<IDocsExampleProps, Callo
         return (
             <Example options={options} {...this.props}>
                 <Callout {...calloutProps} title={showHeader ? "Visually important content" : undefined}>
-                    Long-form information about the the important content. This text is styled as{" "}
-                    <a href="#core/typography.running-text">"Running text" typography</a>, so it may contain things like
-                    headers, links, lists, <Code>code</Code> etc.
+                    Long-form information about the important content. This text is styled as{" "}
+                    <a href="#core/typography.running-text">"Running text"</a>, so it may contain things like headers,
+                    links, lists, <Code>code</Code> etc.
                 </Callout>
             </Example>
         );

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -23,14 +23,14 @@ import { IconName } from "@blueprintjs/icons";
 import { IconSelect } from "./common/iconSelect";
 import { IntentSelect } from "./common/intentSelect";
 
-export interface ICalloutExampleState {
+interface CalloutExampleState {
     icon?: IconName;
     intent?: Intent;
     showHeader: boolean;
 }
 
-export class CalloutExample extends React.PureComponent<IDocsExampleProps, ICalloutExampleState> {
-    public state: ICalloutExampleState = { showHeader: true };
+export class CalloutExample extends React.PureComponent<IDocsExampleProps, CalloutExampleState> {
+    public state: CalloutExampleState = { showHeader: true };
 
     private handleHeaderChange = handleBooleanChange((showHeader: boolean) => this.setState({ showHeader }));
 
@@ -52,9 +52,9 @@ export class CalloutExample extends React.PureComponent<IDocsExampleProps, ICall
         return (
             <Example options={options} {...this.props}>
                 <Callout {...calloutProps} title={showHeader ? "Visually important content" : undefined}>
-                    The component is a simple wrapper around the CSS API that provides props for modifiers and optional
-                    title element. Any additional HTML props will be spread to the rendered <Code>{"<div>"}</Code>{" "}
-                    element.
+                    Long-form information about the the important content. This text is styled as{" "}
+                    <a href="#core/typography.running-text">"Running text" typography</a>, so it may contain things like
+                    headers, links, lists, <Code>code</Code> etc.
                 </Callout>
             </Example>
         );


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/5853

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Add special styling for links inside primary intent callouts to make them appear clickable
- Improve Callout docs example

#### Reviewers should focus on:

Visual design

#### Screenshot

![2023-01-30 16 34 37](https://user-images.githubusercontent.com/723999/215600216-7422fc68-ffee-46d6-97b4-83c6ef3cef45.gif)
