### PR TITLE
[popover2] fix(Popover2): renderTarget typedef regression

### DIFF
--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -35,7 +35,7 @@ import {
     DatePickerShortcut,
     DatePickerUtils,
 } from "@blueprintjs/datetime";
-import { Popover2, Popover2TargetProps } from "@blueprintjs/popover2";
+import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import * as Classes from "../../common/classes";
 import { DatetimePopoverProps } from "../../common/datetimePopoverProps";
@@ -568,13 +568,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
 
     // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like the "fill" prop.
     const renderTarget = React.useCallback(
-        // N.B. pull out `defaultValue` so that it's not forwarded to the DOM.
-        ({
-            defaultValue: _defaultValue,
-            isOpen: targetIsOpen,
-            ref,
-            ...targetProps
-        }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+        ({ isOpen: targetIsOpen, ref, ...targetProps }: Popover2TargetProps & Popover2ClickTargetHandlers) => {
             return (
                 <InputGroup
                     autoComplete="off"

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -39,7 +39,7 @@ import {
     DateRangePicker,
     DateRangeShortcut,
 } from "@blueprintjs/datetime";
-import { Popover2, Popover2TargetProps } from "@blueprintjs/popover2";
+import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps } from "@blueprintjs/popover2";
 
 import { Classes, DateRange, NonNullDateRange } from "../../common";
 import { DatetimePopoverProps } from "../../common/datetimePopoverProps";
@@ -378,7 +378,7 @@ export class DateRangeInput2 extends AbstractPureComponent2<DateRangeInput2Props
     // We use the renderTarget API to flatten the rendered DOM.
     private renderTarget =
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
-        ({ isOpen, ...targetProps }: Popover2TargetProps & React.HTMLProps<unknown>) => {
+        ({ isOpen, ...targetProps }: Popover2TargetProps & Popover2ClickTargetHandlers) => {
             const { fill, popoverProps = {} } = this.props;
             const { targetTagName = "div" } = popoverProps;
             return React.createElement(

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Code, H5, Intent, MenuItem, Switch, TagProps } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
-import { DefaultPopover2TargetHTMLProps, Popover2 } from "@blueprintjs/popover2";
+import { Popover2 } from "@blueprintjs/popover2";
 import { ItemRenderer, MultiSelect2 } from "@blueprintjs/select";
 import {
     areFilmsEqual,
@@ -72,7 +72,7 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
         tagMinimal: false,
     };
 
-    private popoverRef: React.RefObject<Popover2<DefaultPopover2TargetHTMLProps>> = React.createRef();
+    private popoverRef: React.RefObject<Popover2> = React.createRef();
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
 

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -138,16 +138,14 @@ export interface IPopover2State {
 /**
  * Popover (v2) component, used to display a floating UI next to and tethered to a target element.
  *
- * @template T target element props interface. Note that we cannot assign a default value for this type param because it
- * makes the type of the props supplied to `renderTarget()` cumbersome to work with when that API is used. Consumers
- * wishing to stay in sync with Blueprint's default target HTML props interface should use the
- * `DefaultPopover2TargetHTMLProps` type exported from @blueprintjs/popover2.
+ * @template T target element props interface. Consumers wishing to stay in sync with Blueprint's default target HTML
+ * props interface should use the `DefaultPopover2TargetHTMLProps` type (although this is already the default type for
+ * this type param).
  * @see https://blueprintjs.com/docs/#popover2-package/popover2
  */
-export class Popover2<T extends DefaultPopover2TargetHTMLProps> extends AbstractPureComponent2<
-    Popover2Props<T>,
-    IPopover2State
-> {
+export class Popover2<
+    T extends DefaultPopover2TargetHTMLProps = DefaultPopover2TargetHTMLProps,
+> extends AbstractPureComponent2<Popover2Props<T>, IPopover2State> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Popover2`;
 
     public static defaultProps: Popover2Props = {

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -57,10 +57,12 @@ export const Popover2InteractionKind = {
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Popover2InteractionKind = (typeof Popover2InteractionKind)[keyof typeof Popover2InteractionKind];
 
-// eslint-disable-next-line deprecation/deprecation
-export type Popover2Props<TProps = DefaultPopover2TargetHTMLProps> = IPopover2Props<TProps>;
+export type Popover2Props<TProps extends DefaultPopover2TargetHTMLProps = DefaultPopover2TargetHTMLProps> =
+    // eslint-disable-next-line deprecation/deprecation
+    IPopover2Props<TProps>;
 /** @deprecated use Popover2Props */
-export interface IPopover2Props<TProps = DefaultPopover2TargetHTMLProps> extends Popover2SharedProps<TProps> {
+export interface IPopover2Props<TProps extends DefaultPopover2TargetHTMLProps = DefaultPopover2TargetHTMLProps>
+    extends Popover2SharedProps<TProps> {
     /**
      * Whether the popover/tooltip should acquire application focus when it first opens.
      *

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -239,7 +239,13 @@ export interface IPopover2SharedProps<TProps extends DefaultPopover2TargetHTMLPr
      * Mutually exclusive with `children` and `targetTagName` props.
      */
     renderTarget?: (
-        props: Popover2TargetProps & (Popover2HoverTargetHandlers<TProps> | Popover2ClickTargetHandlers<TProps>),
+        // N.B. we would like to discriminate between "hover" and "click" popovers here, so that we can be clear
+        // about exactly which event handlers are passed here to be rendered on the target element, but unfortunately
+        // we can't do that without breaking backwards-compatibility in the renderTarget API. Besides, that kind of
+        // improvement would be better implemented if we added another type param to Popover2, something like
+        // Popover2<TProps, "click" | "hover">. Instead of discriminating, we union the different possible event handlers
+        // that may be passed (they are all optional properties anyway).
+        props: Popover2TargetProps & (Popover2HoverTargetHandlers<TProps> & Popover2ClickTargetHandlers<TProps>),
     ) => JSX.Element;
 
     /**

--- a/packages/popover2/src/popover2SharedProps.ts
+++ b/packages/popover2/src/popover2SharedProps.ts
@@ -245,7 +245,7 @@ export interface IPopover2SharedProps<TProps extends DefaultPopover2TargetHTMLPr
         // improvement would be better implemented if we added another type param to Popover2, something like
         // Popover2<TProps, "click" | "hover">. Instead of discriminating, we union the different possible event handlers
         // that may be passed (they are all optional properties anyway).
-        props: Popover2TargetProps & (Popover2HoverTargetHandlers<TProps> & Popover2ClickTargetHandlers<TProps>),
+        props: Popover2TargetProps & Popover2HoverTargetHandlers<TProps> & Popover2ClickTargetHandlers<TProps>,
     ) => JSX.Element;
 
     /**

--- a/packages/popover2/src/tooltip2.tsx
+++ b/packages/popover2/src/tooltip2.tsx
@@ -26,10 +26,12 @@ import { TOOLTIP_ARROW_SVG_SIZE } from "./popover2Arrow";
 import { DefaultPopover2TargetHTMLProps, Popover2SharedProps } from "./popover2SharedProps";
 import { Tooltip2Context, Tooltip2ContextState, Tooltip2Provider } from "./tooltip2Context";
 
-// eslint-disable-next-line deprecation/deprecation
-export type Tooltip2Props<TProps = DefaultPopover2TargetHTMLProps> = ITooltip2Props<TProps>;
+export type Tooltip2Props<TProps extends DefaultPopover2TargetHTMLProps = DefaultPopover2TargetHTMLProps> =
+    // eslint-disable-next-line deprecation/deprecation
+    ITooltip2Props<TProps>;
+
 /** @deprecated use Tooltip2Props */
-export interface ITooltip2Props<TProps = DefaultPopover2TargetHTMLProps>
+export interface ITooltip2Props<TProps extends DefaultPopover2TargetHTMLProps = DefaultPopover2TargetHTMLProps>
     extends Omit<Popover2SharedProps<TProps>, "shouldReturnFocusOnClose">,
         IntentProps {
     /**
@@ -88,7 +90,9 @@ export interface ITooltip2Props<TProps = DefaultPopover2TargetHTMLProps>
  *
  * @see https://blueprintjs.com/docs/#popover2-package/tooltip2
  */
-export class Tooltip2<T> extends React.PureComponent<Tooltip2Props<T>> {
+export class Tooltip2<
+    T extends DefaultPopover2TargetHTMLProps = DefaultPopover2TargetHTMLProps,
+> extends React.PureComponent<Tooltip2Props<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tooltip2`;
 
     public static defaultProps: Partial<Tooltip2Props> = {

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -22,7 +22,7 @@ import * as sinon from "sinon";
 import { Classes as CoreClasses, Menu, MenuItem, Overlay, Portal } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 
-import { Classes, Errors, Popover2TargetProps } from "../src";
+import { Classes, Errors } from "../src";
 import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind } from "../src/popover2";
 import { Popover2Arrow } from "../src/popover2Arrow";
 import { PopupKind } from "../src/popupKind";

--- a/packages/popover2/test/popover2Tests.tsx
+++ b/packages/popover2/test/popover2Tests.tsx
@@ -22,7 +22,7 @@ import * as sinon from "sinon";
 import { Classes as CoreClasses, Menu, MenuItem, Overlay, Portal } from "@blueprintjs/core";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 
-import { Classes, Errors } from "../src";
+import { Classes, Errors, Popover2TargetProps } from "../src";
 import { IPopover2Props, IPopover2State, Popover2, Popover2InteractionKind } from "../src/popover2";
 import { Popover2Arrow } from "../src/popover2Arrow";
 import { PopupKind } from "../src/popupKind";
@@ -780,8 +780,8 @@ describe("<Popover2>", () => {
         });
     });
 
-    // these tests can be removed once Popover2 is merged into core in v5.0
     describe("compatibility", () => {
+        // this test can be removed once Popover2 is merged into core in v5.0
         it("MenuItem from core package is able to dismiss open Popover2", () => {
             wrapper = renderPopover(
                 { defaultIsOpen: true, usePortal: false },
@@ -792,6 +792,23 @@ describe("<Popover2>", () => {
             );
             wrapper.find(`.${CoreClasses.MENU_ITEM}`).simulate("click");
             wrapper.assertIsOpen(false);
+        });
+
+        it("renderTarget type definition allows sending props to child components", () => {
+            mount(
+                <Popover2
+                    usePortal={false}
+                    hoverCloseDelay={0}
+                    hoverOpenDelay={0}
+                    content="content"
+                    renderTarget={({ isOpen, ref, ...props }) => (
+                        <button data-testid="target-button" ref={ref} onClick={props.onClick} {...props}>
+                            Target
+                        </button>
+                    )}
+                />,
+                { attachTo: testsContainerElement },
+            );
         });
     });
 

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -30,7 +30,7 @@ import {
     TagInputProps,
     Utils,
 } from "@blueprintjs/core";
-import { DefaultPopover2TargetHTMLProps, Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
+import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { QueryList, QueryListRendererProps } from "../query-list/queryList";
@@ -152,7 +152,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
     private refHandlers: {
         input: React.RefCallback<HTMLInputElement>;
-        popover: React.RefObject<Popover2<DefaultPopover2TargetHTMLProps>>;
+        popover: React.RefObject<Popover2>;
         queryList: React.RefCallback<QueryList<T>>;
     } = {
         input: refHandler(this, "input", this.props.tagInputProps?.inputRef),
@@ -239,7 +239,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
-        ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+        ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & Popover2ClickTargetHandlers) => {
             const {
                 disabled,
                 fill,

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -31,7 +31,7 @@ import {
     setRef,
     Utils,
 } from "@blueprintjs/core";
-import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
+import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { QueryList, QueryListRendererProps } from "../query-list/queryList";
@@ -213,7 +213,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         // N.B. pull out `isOpen` so that it's not forwarded to the DOM, but remember not to use it directly
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
-        ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & React.HTMLProps<HTMLDivElement>) => {
+        ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & Popover2ClickTargetHandlers) => {
             const { popoverProps = {}, popoverTargetProps } = this.props;
             const { handleKeyDown, handleKeyUp } = listProps;
             const { targetTagName = "div" } = popoverProps;

--- a/packages/select/src/components/suggest/suggest2.tsx
+++ b/packages/select/src/components/suggest/suggest2.tsx
@@ -30,7 +30,7 @@ import {
     setRef,
     Utils,
 } from "@blueprintjs/core";
-import { Popover2, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
+import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { QueryList, QueryListRendererProps } from "../query-list/queryList";
@@ -232,11 +232,9 @@ export class Suggest2<T> extends AbstractPureComponent2<Suggest2Props<T>, Sugges
         ({
             // pull out `isOpen` so that it's not forwarded to the DOM
             isOpen: _isOpen,
-            // pull out `defaultValue` due to type incompatibility with InputGroup
-            defaultValue,
             ref,
             ...targetProps
-        }: Popover2TargetProps & React.HTMLProps<HTMLInputElement>) => {
+        }: Popover2TargetProps & Popover2ClickTargetHandlers) => {
             const { disabled, fill, inputProps = {}, inputValueRenderer, popoverProps = {}, resetOnClose } = this.props;
             const { selectedItem } = this.state;
             const { handleKeyDown, handleKeyUp } = listProps;


### PR DESCRIPTION
#### Fixes #5889

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Use AND `&` type union instead of OR `|` to allow access to common props passed to `renderTarget`
- Add type param constraints to `Tooltip2` (this should fix the linked issue)

#### Reviewers should focus on:

No regressions, and the new unit test is appropriate
