### PR TITLE
[popover2] fix(Popover2): get correct click target in shadow DOM

### DIFF
--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -685,7 +685,8 @@ export class Popover2<T extends DefaultPopover2TargetHTMLProps> extends Abstract
             return;
         }
 
-        const eventTarget = e.target as HTMLElement;
+        const event = (e.nativeEvent ?? e) as Event;
+        const eventTarget = (event.composed ? event.composedPath()[0] : event.target) as HTMLElement;
         // if click was in target, target event listener will handle things, so don't close
         if (!Utils.elementIsOrContains(this.targetElement, eventTarget) || e.nativeEvent instanceof KeyboardEvent) {
             this.setOpenState(false, e);


### PR DESCRIPTION
#### Fixes #5908

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Get the actual click target. The same way it was done in "overlay.tsx" in function "handleDocumentClick"
