### PR TITLE
[docs] fix(Popover2PlacementExample): layout jankiness

### DIFF
--- a/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPositionExample.tsx
@@ -27,9 +27,9 @@ import { Button, Classes, Code, Popover, Position } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 const EXAMPLE_CLASS = "docs-popover-position-example";
-
 const SIDE_LABEL_CLASS = "docs-popover-position-label-side";
 const ALIGNMENT_LABEL_CLASS = "docs-popover-position-label-alignment";
+const CONTENT_CLASS = `${EXAMPLE_CLASS}-content`;
 
 export class PopoverPositionExample extends React.PureComponent<ExampleProps> {
     public render() {
@@ -111,7 +111,7 @@ export class PopoverPositionExample extends React.PureComponent<ExampleProps> {
         );
 
         return (
-            <Popover content={content} position={position} usePortal={false}>
+            <Popover content={content} popoverClassName={CONTENT_CLASS} position={position}>
                 <Button className={Classes.MONOSPACE_TEXT}>{buttonLabel}</Button>
             </Popover>
         );

--- a/packages/docs-app/src/examples/popover2-examples/popover2PlacementExample.tsx
+++ b/packages/docs-app/src/examples/popover2-examples/popover2PlacementExample.tsx
@@ -16,13 +16,14 @@
 
 import * as React from "react";
 
-import { Button, Classes, Code } from "@blueprintjs/core";
+import { Button, Classes, Code, ControlGroup } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Placement, Popover2 } from "@blueprintjs/popover2";
 
 const EXAMPLE_CLASS = "docs-popover2-placement-example";
 const SIDE_LABEL_CLASS = "docs-popover2-placement-label-side";
 const ALIGNMENT_LABEL_CLASS = "docs-popover2-placement-label-alignment";
+const CONTENT_CLASS = `${EXAMPLE_CLASS}-content`;
 
 export class Popover2PlacementExample extends React.PureComponent<ExampleProps> {
     public static displayName = "Popover2PlacementExample";
@@ -30,46 +31,45 @@ export class Popover2PlacementExample extends React.PureComponent<ExampleProps> 
     public render() {
         return (
             <Example className={EXAMPLE_CLASS} options={false} {...this.props}>
-                {/* eslint-disable-next-line @blueprintjs/html-components */}
-                <table>
-                    <tbody>
-                        <tr>
-                            <td />
-                            <td>
-                                {this.renderPopover("bottom-start")}
-                                {this.renderPopover("bottom")}
-                                {this.renderPopover("bottom-end")}
-                            </td>
-                            <td />
-                        </tr>
-                        <tr>
-                            <td>
-                                {this.renderPopover("right-start")}
-                                {this.renderPopover("right")}
-                                {this.renderPopover("right-end")}
-                            </td>
-                            <td>
-                                <em className={Classes.TEXT_MUTED}>
-                                    Button positions are flipped here so that all popovers open inward.
-                                </em>
-                            </td>
-                            <td>
-                                {this.renderPopover("left-start")}
-                                {this.renderPopover("left")}
-                                {this.renderPopover("left-end")}
-                            </td>
-                        </tr>
-                        <tr>
-                            <td />
-                            <td>
-                                {this.renderPopover("top-start")}
-                                {this.renderPopover("top")}
-                                {this.renderPopover("top-end")}
-                            </td>
-                            <td />
-                        </tr>
-                    </tbody>
-                </table>
+                <div className="docs-example-grid">
+                    <div className="docs-example-grid-1-1" />
+                    <div className="docs-example-grid-1-2">
+                        <ControlGroup fill={true}>
+                            {this.renderPopover("bottom-start")}
+                            {this.renderPopover("bottom")}
+                            {this.renderPopover("bottom-end")}
+                        </ControlGroup>
+                    </div>
+                    <div className="docs-example-grid-1-3" />
+                    <div className="docs-example-grid-2-1">
+                        <ControlGroup vertical={true}>
+                            {this.renderPopover("right-start")}
+                            {this.renderPopover("right")}
+                            {this.renderPopover("right-end")}
+                        </ControlGroup>
+                    </div>
+                    <div className="docs-example-grid-2-2">
+                        <em className={Classes.TEXT_MUTED}>
+                            Button positions are flipped here so that all popovers open inward.
+                        </em>
+                    </div>
+                    <div className="docs-example-grid-2-3">
+                        <ControlGroup vertical={true}>
+                            {this.renderPopover("left-start")}
+                            {this.renderPopover("left")}
+                            {this.renderPopover("left-end")}
+                        </ControlGroup>
+                    </div>
+                    <div className="docs-example-grid-3-1" />
+                    <div className="docs-example-grid-3-2">
+                        <ControlGroup fill={true}>
+                            {this.renderPopover("top-start")}
+                            {this.renderPopover("top")}
+                            {this.renderPopover("top-end")}
+                        </ControlGroup>
+                    </div>
+                    <div className="docs-example-grid-3-3" />
+                </div>
             </Example>
         );
     }
@@ -110,7 +110,7 @@ export class Popover2PlacementExample extends React.PureComponent<ExampleProps> 
             <Popover2
                 content={content}
                 placement={placement}
-                usePortal={false}
+                popoverClassName={CONTENT_CLASS}
                 renderTarget={({ isOpen, ref, ...p }) => (
                     <Button
                         {...p}

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -1,9 +1,10 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@import "~@blueprintjs/icons/lib/scss/variables";
 @import "~@blueprintjs/core/src/common/react-transition";
+@import "~@blueprintjs/core/src/common/variables-extended";
 @import "~@blueprintjs/core/src/components/icon/icon-mixins";
+@import "~@blueprintjs/icons/lib/scss/variables";
 
 // Generate a selector for a page ID by reference
 @function page($ref, $comparator: "$=") {
@@ -355,19 +356,8 @@
   }
 }
 
-.docs-popover2-placement-example,
+// deprecated example layout
 .docs-popover-position-example {
-  em {
-    color: $pt-text-color-muted;
-    display: inline-block;
-    font-style: italic;
-    max-width: 25 * $pt-grid-size;
-
-    .#{$ns}-dark & {
-      color: $pt-dark-text-color-muted;
-    }
-  }
-
   td:nth-child(1) {
     align-items: flex-end;
     display: flex;
@@ -384,26 +374,80 @@
     flex-direction: column;
   }
 
-  .#{$ns}-popover-wrapper,
-  .#{$ns}-popover2-wrapper {
+  .#{$ns}-popover-wrapper {
     // Add a bit of space between borders of consecutive buttons.
     margin: $pt-grid-size * 0.5;
   }
+}
 
-  .#{$ns}-popover-content,
-  .#{$ns}-popover2-content {
-    align-items: center;
-    display: flex;
-    height: 7 * $pt-grid-size;
-    justify-content: center;
-    line-height: 2;
-    padding: $pt-grid-size * 2;
+.docs-popover2-placement-example {
+  .docs-example-grid {
+    display: grid;
+    gap: $pt-grid-size;
+    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-rows: 1fr 2fr 1fr;
+    justify-content: stretch;
+    margin: 0;
+  }
+
+  @each $row-line in (1, 2, 3) {
+    @each $col-line in (1, 2, 3) {
+      .docs-example-grid-#{$row-line}-#{$col-line} {
+        grid-column: #{$col-line}/#{$col-line + 1};
+        grid-row: #{$row-line}/#{$row-line + 1};
+      }
+    }
+  }
+
+  @each $line in (1, 2, 3) {
+    // top row and first col
+    .docs-example-grid-1-#{$line},
+    .docs-example-grid-#{$line}-1 {
+      align-self: end;
+    }
+
+    // middle row and middle col
+    .docs-example-grid-2-#{$line},
+    .docs-example-grid-#{$line}-2 {
+      align-self: stretch;
+    }
+
+    // last row and last col
+    .docs-example-grid-3-#{$line},
+    .docs-example-grid-#{$line}-3 {
+      align-self: start;
+    }
+  }
+
+  // middle area
+  .docs-example-grid-2-2 {
+    align-self: center;
     text-align: center;
-    // big enough to make the shifting arrow position noticeable
-    width: 20 * $pt-grid-size;
+  }
+}
 
-    code {
-      font-weight: 600;
+.docs-popover2-placement-example-content,
+.docs-popover-position-example-content {
+  .#{$ns}-popover2-content,
+  .#{$ns}-popover-content {
+    line-height: 2;
+    padding: $pt-grid-size ($pt-grid-size * 2);
+    text-align: center;
+  }
+
+  code {
+    font-weight: 600;
+  }
+}
+
+.docs-popover2-placement-example,
+.docs-popover-position-example {
+  em {
+    display: inline-block;
+    max-width: 25 * $pt-grid-size;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-text-color-muted;
     }
   }
 }

--- a/packages/popover2/src/popover2.md
+++ b/packages/popover2/src/popover2.md
@@ -122,8 +122,8 @@ each consist of two attributes:
 
 These two attributes can be expressed with a single value having the following structure:
 
-<pre class="docs-popover-placement-value-code-block">
-    <span class="docs-popover-placement-label-side">[SIDE]</span>-<span class="docs-popover-placement-label-alignment">[ALIGNMENT]</span>
+<pre class="docs-popover2-placement-value-code-block">
+<span class="docs-popover2-placement-label-side">[SIDE]</span>-<span class="docs-popover2-placement-label-alignment">[ALIGNMENT]</span>
 </pre>
 
 @reactExample Popover2PlacementExample


### PR DESCRIPTION
#### Fixes #5177

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Switch to using CSS Grid in Popover2 placement example
- Switch to `usePortal={true}` for Popover position & Popover2 placement examples
- Improve popover content styles for both examples


#### Screenshot

Popover2:

![2023-01-31 11 20 06](https://user-images.githubusercontent.com/723999/215818738-55c37fd7-3fd5-43b7-92cc-ce77cd0f6d08.gif)

Popover:

![2023-01-31 11 20 36](https://user-images.githubusercontent.com/723999/215818880-bbe9edb8-5966-4031-a917-d7be3558dcdb.gif)

