### PR TITLE
[docs-theme] fix: remove monaco-editor dependency

### DIFF
--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -36,7 +36,6 @@
         "@documentalist/client": "^4.0.0",
         "classnames": "^2.3.1",
         "fuzzaldrin-plus": "^0.6.0",
-        "monaco-editor": "^0.34.1",
         "tslib": "~2.3.1"
     },
     "peerDependencies": {


### PR DESCRIPTION
It's not used in this package (at least yet).