### PR TITLE
[DRAFT] feat(TagInput, MultiSelect2): readOnly prop

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -113,7 +113,8 @@ $control-group-stack: (
     padding-left: $pt-grid-size;
   }
 
-  &[readonly] {
+  &[readonly],
+  &.#{$ns}-read-only {
     box-shadow: inset 0 0 0 1px $pt-divider-black;
   }
 

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -206,6 +206,7 @@ export class InputGroup extends AbstractPureComponent2<InputGroupProps2, IInputG
             Classes.intentClass(intent),
             {
                 [Classes.DISABLED]: disabled,
+                // N.B. this 'read-only' class does not apply any styles, but may be useful as a CSS selector
                 [Classes.READ_ONLY]: readOnly,
                 [Classes.FILL]: fill,
                 [Classes.LARGE]: large,

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -110,7 +110,8 @@ export interface ITagInputProps extends IntentProps, Props {
      *
      * This callback essentially implements basic `onAdd` and `onRemove` functionality and merges
      * the two handlers into one to simplify controlled usage.
-     * ```
+     *
+     * If both `onRemove` and `onChange` are not provided, rendered tag items will not have remove icons.
      */
     onChange?: (values: React.ReactNode[]) => boolean | void;
 
@@ -137,6 +138,8 @@ export interface ITagInputProps extends IntentProps, Props {
     /**
      * Callback invoked when the user clicks the X button on a tag.
      * Receives value and index of removed tag.
+     *
+     * If both `onRemove` and `onChange` are not provided, rendered tag items will not have remove icons.
      */
     onRemove?: (value: React.ReactNode, index: number) => void;
 
@@ -307,15 +310,16 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
         if (!tag) {
             return null;
         }
-        const { large, tagProps } = this.props;
+        const { large, tagProps, onRemove, onChange } = this.props;
         const props = Utils.isFunction(tagProps) ? tagProps(tag, index) : tagProps;
+        const canRemoveTag = onRemove != null || onChange != null;
         return (
             <Tag
                 active={index === this.state.activeIndex}
                 data-tag-index={index}
                 key={tag + "__" + index}
                 large={large}
-                onRemove={this.props.disabled ? undefined : this.handleRemoveTag}
+                onRemove={this.props.disabled || !canRemoveTag ? undefined : this.handleRemoveTag}
                 {...props}
             >
                 {tag}

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -122,6 +122,11 @@ export interface ITagInputProps extends IntentProps, Props {
     onChange?: (values: React.ReactNode[]) => boolean | void;
 
     /**
+     * Callback invoked when the user clicks on the tag input.
+     */
+    onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+
+    /**
      * Callback invoked when the value of `<input>` element is changed.
      * This is shorthand for `inputProps={{ onChange }}`.
      */
@@ -383,11 +388,12 @@ export class TagInput extends AbstractPureComponent2<TagInputProps, ITagInputSta
             .filter(val => val.length > 0);
     }
 
-    private handleContainerClick = () => {
-        if (this.props.readOnly) {
-            return;
+    private handleContainerClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        this.props.onClick?.(event);
+
+        if (!this.props.readOnly) {
+            this.inputElement?.focus();
         }
-        this.inputElement?.focus();
     };
 
     private handleContainerBlur = ({ currentTarget }: React.FocusEvent<HTMLDivElement>) => {

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -421,6 +421,13 @@ describe("<TagInput>", () => {
         });
     });
 
+    it("when both onRemove or onChange are not supplied", () => {
+        const wrapper = mount(<TagInput values={VALUES} />);
+        wrapper.find(Tag).forEach(tag => {
+            assert.lengthOf(tag.find("." + Classes.TAG_REMOVE), 0, "tag should not have tag-remove button");
+        });
+    });
+
     describe("onKeyDown", () => {
         it("emits the active tag index on key down", () => {
             runKeyPressTest("onKeyDown", 1, 1);

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -34,9 +34,9 @@ import { Popover2, Tooltip2 } from "@blueprintjs/popover2";
 
 export interface IInputGroupExampleState {
     disabled: boolean;
-    readOnly: boolean;
     filterValue: string;
     large: boolean;
+    readOnly: boolean;
     small: boolean;
     showPassword: boolean;
     tagValue: string;
@@ -55,8 +55,6 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, IInputG
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
 
-    private handleReadOnlyChange = handleBooleanChange(readOnly => this.setState({ readOnly }));
-
     private handleLargeChange = handleBooleanChange(large => this.setState({ large, ...(large && { small: false }) }));
 
     private handleSmallChange = handleBooleanChange(small => this.setState({ small, ...(small && { large: false }) }));
@@ -64,6 +62,8 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, IInputG
     private handleFilterChange = handleStringChange(filterValue =>
         window.setTimeout(() => this.setState({ filterValue }), 10),
     );
+
+    private handleReadOnlyChange = handleBooleanChange(readOnly => this.setState({ readOnly }));
 
     private handleTagChange = handleStringChange(tagValue => this.setState({ tagValue }));
 

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -44,6 +44,7 @@ export interface ITagInputExampleState {
     leftIcon: boolean;
     tagIntents: boolean;
     tagMinimal: boolean;
+    readOnly: boolean;
     values: React.ReactNode[];
 }
 
@@ -56,6 +57,7 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
         intent: "none",
         large: false,
         leftIcon: true,
+        readOnly: false,
         tagIntents: false,
         tagMinimal: false,
         values: VALUES,
@@ -75,6 +77,8 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
 
     private handleLeftIconChange = handleBooleanChange(leftIcon => this.setState({ leftIcon }));
 
+    private handleReadOnlyChange = handleBooleanChange(readOnly => this.setState({ readOnly }));
+
     private handleTagIntentsChange = handleBooleanChange(tagIntents => this.setState({ tagIntents }));
 
     private handleTagMinimalChange = handleBooleanChange(tagMinimal => this.setState({ tagMinimal }));
@@ -82,7 +86,7 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
     public render() {
         const { tagIntents, tagMinimal, values, ...props } = this.state;
 
-        const clearButton = (
+        const maybeClearButton = props.readOnly ? undefined : (
             <Button
                 disabled={props.disabled}
                 icon={values.length > 1 ? "cross" : "refresh"}
@@ -107,7 +111,7 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
                     leftIcon={this.state.leftIcon ? "user" : undefined}
                     onChange={this.handleChange}
                     placeholder="Separate values with commas..."
-                    rightElement={clearButton}
+                    rightElement={maybeClearButton}
                     tagProps={getTagProps}
                     values={values}
                 />
@@ -121,6 +125,7 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
                 <H5>Props</H5>
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
+                <Switch label="Read-only" checked={this.state.readOnly} onChange={this.handleReadOnlyChange} />
                 <Switch label="Left icon" checked={this.state.leftIcon} onChange={this.handleLeftIconChange} />
                 <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />
                 <Switch label="Add on paste" checked={this.state.addOnPaste} onChange={this.handleAddOnPasteChange} />

--- a/packages/docs-app/src/examples/select-examples/index.ts
+++ b/packages/docs-app/src/examples/select-examples/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from "./multiSelectExample";
+export * from "./multiSelectEditableOnClickExample";
 export * from "./omnibarExample";
 export * from "./selectExample";
 export * from "./suggestExample";

--- a/packages/docs-app/src/examples/select-examples/multiSelectEditableOnClickExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectEditableOnClickExample.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { MenuItem } from "@blueprintjs/core";
+import { Example, ExampleProps } from "@blueprintjs/docs-theme";
+import { ItemRenderer, MultiSelect2 } from "@blueprintjs/select";
+import { areFilmsEqual, Film, filterFilm, getFilmItemProps, TOP_100_FILMS } from "@blueprintjs/select/examples";
+
+interface ExampleState {
+    hasFocus: boolean;
+    items: Film[];
+    selectedItems: Film[];
+}
+
+export class MultiSelectEditableOnClickExample extends React.PureComponent<ExampleProps, ExampleState> {
+    public state: ExampleState = {
+        hasFocus: false,
+        items: TOP_100_FILMS,
+        selectedItems: [],
+    };
+
+    public render() {
+        return (
+            <Example {...this.props}>
+                <MultiSelect2<Film>
+                    itemPredicate={filterFilm}
+                    itemRenderer={this.renderFilm}
+                    items={this.state.items}
+                    itemsEqual={areFilmsEqual}
+                    menuProps={{ "aria-label": "films" }}
+                    noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
+                    onClear={this.handleClear}
+                    onItemSelect={this.handleFilmSelect}
+                    onItemsPaste={this.handleFilmsPaste}
+                    popoverProps={{
+                        onClosed: this.handlePopoverClosed,
+                    }}
+                    readOnly={!this.state.hasFocus}
+                    tagRenderer={this.renderTag}
+                    tagInputProps={{
+                        onClick: this.handleTagInputClick,
+                        onRemove: this.handleTagRemove,
+                    }}
+                    selectedItems={this.state.selectedItems}
+                />
+            </Example>
+        );
+    }
+
+    private renderTag = (film: Film) => film.title;
+
+    private renderFilm: ItemRenderer<Film> = (film, props) => {
+        if (!props.modifiers.matchesPredicate) {
+            return null;
+        }
+
+        return (
+            <MenuItem
+                {...getFilmItemProps(film, props)}
+                selected={this.isFilmSelected(film)}
+                shouldDismissPopover={false}
+                text={`${film.rank}. ${film.title}`}
+            />
+        );
+    };
+
+    private handlePopoverClosed = () => {
+        this.setState({ hasFocus: false });
+    };
+
+    private handleTagInputClick = () => {
+        this.setState({ hasFocus: true });
+    };
+
+    private handleTagRemove = (_tag: React.ReactNode, index: number) => {
+        this.deselectFilm(index);
+    };
+
+    private getSelectedFilmIndex(film: Film) {
+        return this.state.selectedItems.indexOf(film);
+    }
+
+    private isFilmSelected(film: Film) {
+        return this.getSelectedFilmIndex(film) !== -1;
+    }
+
+    private selectFilm(film: Film) {
+        this.selectFilms([film]);
+    }
+
+    private selectFilms(selectedItems: Film[]) {
+        this.setState({ selectedItems });
+    }
+
+    private deselectFilm(index: number) {
+        this.setState(({ selectedItems }) => ({
+            selectedItems: selectedItems.filter((_film, i) => i !== index),
+        }));
+    }
+
+    private handleFilmSelect = (film: Film) => {
+        if (!this.isFilmSelected(film)) {
+            this.selectFilm(film);
+        } else {
+            this.deselectFilm(this.getSelectedFilmIndex(film));
+        }
+    };
+
+    private handleFilmsPaste = (films: Film[]) => {
+        // On paste, don't bother with deselecting already selected values, just
+        // add the new ones.
+        this.selectFilms(films);
+    };
+
+    private handleClear = () => {
+        this.setState({ selectedItems: [] });
+    };
+}

--- a/packages/docs-app/src/examples/select-examples/multiSelectEditableOnClickExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectEditableOnClickExample.tsx
@@ -48,7 +48,9 @@ export class MultiSelectEditableOnClickExample extends React.PureComponent<Examp
                     onItemSelect={this.handleFilmSelect}
                     onItemsPaste={this.handleFilmsPaste}
                     popoverProps={{
+                        minimal: true,
                         onClosed: this.handlePopoverClosed,
+                        placement: "bottom",
                     }}
                     readOnly={!this.state.hasFocus}
                     tagRenderer={this.renderTag}

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -39,6 +39,7 @@ const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Int
 
 export interface IMultiSelectExampleState {
     allowCreate: boolean;
+    allowRemove: boolean;
     createdItems: Film[];
     disabled: boolean;
     fill: boolean;
@@ -57,6 +58,7 @@ export interface IMultiSelectExampleState {
 export class MultiSelectExample extends React.PureComponent<ExampleProps, IMultiSelectExampleState> {
     public state: IMultiSelectExampleState = {
         allowCreate: false,
+        allowRemove: true,
         createdItems: [],
         disabled: false,
         fill: false,
@@ -75,6 +77,8 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
     private popoverRef: React.RefObject<Popover2<DefaultPopover2TargetHTMLProps>> = React.createRef();
 
     private handleAllowCreateChange = this.handleSwitchChange("allowCreate");
+
+    private handleAllowRemoveChange = this.handleSwitchChange("allowRemove");
 
     private handleDisabledChange = this.handleSwitchChange("disabled");
 
@@ -129,7 +133,7 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
                     popoverRef={this.popoverRef}
                     tagRenderer={this.renderTag}
                     tagInputProps={{
-                        onRemove: this.handleTagRemove,
+                        onRemove: this.state.allowRemove ? this.handleTagRemove : undefined,
                         tagProps: getTagProps,
                     }}
                     selectedItems={this.state.films}
@@ -169,6 +173,20 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
                         label="Allow creating new films"
                         checked={this.state.allowCreate}
                         onChange={this.handleAllowCreateChange}
+                    />
+                </PropCodeTooltip>
+                <PropCodeTooltip
+                    content={
+                        <>
+                            <Code>onRemove</Code> or <Code>tagProps.onRemove</Code> is{" "}
+                            {this.state.allowRemove ? "defined" : "undefined"}
+                        </>
+                    }
+                >
+                    <Switch
+                        label="Allow deselecting films from tags"
+                        checked={this.state.allowRemove}
+                        onChange={this.handleAllowRemoveChange}
                     />
                 </PropCodeTooltip>
                 <PropCodeTooltip

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -50,6 +50,7 @@ export interface IMultiSelectExampleState {
     matchTargetWidth: boolean;
     openOnKeyDown: boolean;
     popoverMinimal: boolean;
+    readOnly: boolean;
     resetOnSelect: boolean;
     showClearButton: boolean;
     tagMinimal: boolean;
@@ -69,6 +70,7 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
         matchTargetWidth: false,
         openOnKeyDown: false,
         popoverMinimal: true,
+        readOnly: false,
         resetOnSelect: true,
         showClearButton: true,
         tagMinimal: false,
@@ -93,6 +95,8 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
     private handleMatchTargetWidthChange = this.handleSwitchChange("matchTargetWidth");
 
     private handlePopoverMinimalChange = this.handleSwitchChange("popoverMinimal");
+
+    private handleReadOnlyChange = this.handleSwitchChange("readOnly");
 
     private handleResetChange = this.handleSwitchChange("resetOnSelect");
 
@@ -208,6 +212,9 @@ export class MultiSelectExample extends React.PureComponent<ExampleProps, IMulti
                 </PropCodeTooltip>
                 <PropCodeTooltip snippet={`fill={${this.state.fill.toString()}}`}>
                     <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
+                </PropCodeTooltip>
+                <PropCodeTooltip snippet={`readOnly={${this.state.readOnly.toString()}}`}>
+                    <Switch label="Read-only" checked={this.state.readOnly} onChange={this.handleReadOnlyChange} />
                 </PropCodeTooltip>
                 <H5>Tag props</H5>
                 <Switch

--- a/packages/select/src/components/multi-select/multi-select2.md
+++ b/packages/select/src/components/multi-select/multi-select2.md
@@ -37,3 +37,15 @@ please visit the documentation for [Select2](#select/select2).
 @## Props interface
 
 @interface MultiSelect2Props
+
+@## Editable on click
+
+It's possible to make a MultiSelect2 behave like [EditableText](#core/components/editable-text) where its contents
+are read-only until a user clicks on the component.
+
+To do this, set the `readOnly` prop:
+
+- `true` after handling `tagInputProps.onClick`
+- `false` after handling `popoverProps.onClosed`
+
+@reactExample MultiSelectEditableOnClickExample

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -67,6 +67,9 @@ export interface MultiSelect2Props<T> extends ListItemsProps<T>, SelectPopoverPr
      * the value's rendered `ReactNode` tag.
      *
      * It is not recommended to supply _both_ this prop and `tagInputProps.onRemove`.
+     *
+     * If none of `tagInputProps.onRemove` and `tagInputProps.onChange`, and `onRemove` are provided,
+     * rendered tag items will not have remove icons.
      */
     onRemove?: (value: T, index: number) => void;
 
@@ -110,6 +113,10 @@ export interface MultiSelect2Props<T> extends ListItemsProps<T>, SelectPopoverPr
      * - you are responsible for disabling any elements you may render here when the overall `MultiSelect2` is disabled
      * - if the `onClear` prop is defined, this element will override/replace the default rightElement,
      *   which is a "clear" button that removes all items from the current selection.
+     *
+     * Notes for `tagInputProps.onRemove` and `tagInputProps.onChange`:
+     * - if none of `tagInputProps.onRemove` and `tagInputProps.onChange`, and `onRemove` are provided,
+     *   rendered tag items will not have remove icons.
      */
     tagInputProps?: Partial<Omit<TagInputProps, "inputValue" | "onInputChange">>;
 
@@ -244,6 +251,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                 disabled,
                 fill,
                 onClear,
+                onRemove,
                 placeholder,
                 popoverProps = {},
                 popoverTargetProps = {},
@@ -281,6 +289,8 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
             const { targetTagName = "div" } = popoverProps;
 
+            const canRemoveTag = onRemove != null || tagInputProps?.onRemove != null;
+
             return React.createElement(
                 targetTagName,
                 {
@@ -311,7 +321,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     inputValue={listProps.query}
                     onAdd={this.getTagInputAddHandler(listProps)}
                     onInputChange={listProps.handleQueryChange}
-                    onRemove={this.handleTagRemove}
+                    onRemove={canRemoveTag ? this.handleTagRemove : undefined}
                     values={selectedItems.map(this.props.tagRenderer)}
                 />,
             );

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -289,7 +289,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
 
             const { targetTagName = "div" } = popoverProps;
 
-            const canRemoveTag = onRemove != null || tagInputProps?.onRemove != null;
+            const canRemoveTag = onRemove != null || tagInputProps?.onRemove != null || tagInputProps?.onChange != null;
 
             return React.createElement(
                 targetTagName,

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -97,8 +97,10 @@ describe("<MultiSelect2>", () => {
 
     it("only triggers QueryList key up events when focus is on TagInput's <input>", () => {
         const itemSelectSpy = sinon.spy();
+        const handleRemove = sinon.spy();
         const wrapper = multiselect({
             onItemSelect: itemSelectSpy,
+            onRemove: handleRemove,
             selectedItems: [TOP_100_FILMS[1]],
         });
 

--- a/packages/select/test/multiSelect2Tests.tsx
+++ b/packages/select/test/multiSelect2Tests.tsx
@@ -111,14 +111,26 @@ describe("<MultiSelect2>", () => {
         assert.isFalse(itemSelectSpy.calledWith(TOP_100_FILMS[0]));
     });
 
-    it("triggers onRemove", () => {
+    it("triggers onRemove if provided", () => {
         const handleRemove = sinon.spy();
         const wrapper = multiselect({
             onRemove: handleRemove,
             selectedItems: [TOP_100_FILMS[2], TOP_100_FILMS[3], TOP_100_FILMS[4]],
         });
+        wrapper.find(Tag).forEach(tag => {
+            assert.lengthOf(tag.find(`.${CoreClasses.TAG_REMOVE}`), 1, "tag should have tag-remove button");
+        });
         wrapper.find(`.${CoreClasses.TAG_REMOVE}`).at(1).simulate("click");
         assert.isTrue(handleRemove.calledOnceWithExactly(TOP_100_FILMS[3], 1));
+    });
+
+    it("does not render tag-remove button if both onRemove and tagInputProps.onRemove are not provided", () => {
+        const wrapper = multiselect({
+            selectedItems: [TOP_100_FILMS[2], TOP_100_FILMS[3], TOP_100_FILMS[4]],
+        });
+        wrapper.find(Tag).forEach(tag => {
+            assert.lengthOf(tag.find(`.${CoreClasses.TAG_REMOVE}`), 0, "tag should not have tag-remove button");
+        });
     });
 
     function multiselect(props: Partial<MultiSelect2Props<Film>> = {}, query?: string) {


### PR DESCRIPTION
Currently based on top of https://github.com/palantir/blueprint/pull/5903

Semantically building off @CPerinet's work to add `<InpuGroup readOnly={true} />` in https://github.com/palantir/blueprint/pull/5839


<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Add support for a new `readOnly` prop to both `TagInput` and `MultiSelect2` components.
- Demo usage of the new prop in the interactive docs examples.

#### Screenshot

<img width="612" alt="image" src="https://user-images.githubusercontent.com/723999/217045800-4acfad9c-7a6c-4af4-a535-5d63861b343b.png">


#### Reviewers should focus on:

What should be done about @nurseiit's use case where they want to make a multi-select interactive only on click/focus, like EditableText?

I've demonstrated one approach to this in this PR, where we use `tagInputProps.onClick` and `popoverProps.onClosed` to set the value of the `readOnly` prop, but the UX is not very smooth - it requires two clicks to open the MultiSelect2:

![2023-02-06 12 03 28](https://user-images.githubusercontent.com/723999/217036736-391f67a4-4104-464b-bb20-164d9a9cc789.gif)

Note that the visual affordance of EditableText is missing here, too:

![2023-02-06 12 06 40](https://user-images.githubusercontent.com/723999/217037237-e203f32b-ddac-4749-b6c0-2ffdbb009893.gif)


#### Checklist

- [ ] Includes tests
- [x] Update documentation