### PR TITLE
Actually update aria-hidden in Collapse

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -208,7 +208,7 @@ export class Collapse extends AbstractPureComponent2<CollapseProps, ICollapseSta
                 className={Classes.COLLAPSE_BODY}
                 ref={this.contentsRefHandler}
                 style={contentsStyle}
-                aria-hidden={!isContentVisible && this.props.keepChildrenMounted}
+                aria-hidden={!shouldRenderChildren}
             >
                 {shouldRenderChildren ? this.props.children : null}
             </div>,


### PR DESCRIPTION
This is reproducible in the blueprint docs - if you open/close the collapse, aria-hidden doesn't actually change:

![image](https://user-images.githubusercontent.com/1143755/217054390-27b78dbd-a07e-4df0-ae3b-cde0e50d3dcd.png)

I think it's because `aria-hidden` should reflect whether we're actually hiding children or not?