### PR TITLE
[core] feat(Utils): elementIsTextInput utility function

### DIFF
--- a/packages/core/src/common/utils/domUtils.ts
+++ b/packages/core/src/common/utils/domUtils.ts
@@ -19,6 +19,42 @@ export function elementIsOrContains(element: HTMLElement, testElement: HTMLEleme
 }
 
 /**
+ * Checks whether the given element is inside something that looks like a text input.
+ * This is particularly useful to determine if a keyboard event inside this element should take priority over hotkey
+ * bindings / keyboard shortcut handlers.
+ *
+ * @returns true if the element is inside a text input
+ */
+export function elementIsTextInput(elem: HTMLElement) {
+    // we check these cases for unit testing, but this should not happen
+    // during normal operation
+    if (elem == null || elem.closest == null) {
+        return false;
+    }
+
+    const editable = elem.closest("input, textarea, [contenteditable=true]");
+
+    if (editable == null) {
+        return false;
+    }
+
+    // don't let checkboxes, switches, and radio buttons prevent hotkey behavior
+    if (editable.tagName.toLowerCase() === "input") {
+        const inputType = (editable as HTMLInputElement).type;
+        if (inputType === "checkbox" || inputType === "radio") {
+            return false;
+        }
+    }
+
+    // don't let read-only fields prevent hotkey behavior
+    if ((editable as HTMLInputElement).readOnly) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
  * Gets the active element in the document or shadow root (if an element is provided, and it's in the shadow DOM).
  */
 export function getActiveElement(element?: HTMLElement | null, options?: GetRootNodeOptions) {

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -15,7 +15,14 @@
  */
 
 export * from "./compareUtils";
-export * from "./domUtils";
+export {
+    elementIsOrContains,
+    elementIsTextInput,
+    getActiveElement,
+    throttle,
+    throttleEvent,
+    throttleReactEventCallback,
+} from "./domUtils";
 export * from "./functionUtils";
 export * from "./jsUtils";
 export * from "./reactUtils";

--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -17,6 +17,7 @@
 import * as React from "react";
 
 import { HOTKEYS_PROVIDER_NOT_FOUND } from "../../common/errors";
+import { elementIsTextInput } from "../../common/utils/domUtils";
 import { comboMatches, getKeyCombo, IKeyCombo, parseKeyCombo } from "../../components/hotkeys/hotkeyParser";
 import { HotkeysContext } from "../../context";
 import { HotkeyConfig } from "./hotkeyConfig";
@@ -93,7 +94,7 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
         callbackName: "onKeyDown" | "onKeyUp",
         e: KeyboardEvent,
     ) => {
-        const isTextInput = isTargetATextInput(e);
+        const isTextInput = elementIsTextInput(e.target as HTMLElement);
         for (const key of global ? globalKeys : localKeys) {
             const {
                 allowInInput = false,
@@ -120,7 +121,7 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
         (e: KeyboardEvent) => {
             // special case for global keydown: if '?' is pressed, open the hotkeys dialog
             const combo = getKeyCombo(e);
-            const isTextInput = isTargetATextInput(e);
+            const isTextInput = elementIsTextInput(e.target as HTMLElement);
             if (!isTextInput && comboMatches(parseKeyCombo(showDialogKeyCombo), combo)) {
                 dispatch({ type: "OPEN_DIALOG" });
             } else {
@@ -156,39 +157,6 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
     }, [handleGlobalKeyDown, handleGlobalKeyUp]);
 
     return { handleKeyDown: handleLocalKeyDown, handleKeyUp: handleLocalKeyUp };
-}
-
-/**
- * @returns true if the event target is a text input which should take priority over hotkey bindings
- */
-function isTargetATextInput(e: KeyboardEvent) {
-    const elem = e.target as HTMLElement;
-    // we check these cases for unit testing, but this should not happen
-    // during normal operation
-    if (elem == null || elem.closest == null) {
-        return false;
-    }
-
-    const editable = elem.closest("input, textarea, [contenteditable=true]");
-
-    if (editable == null) {
-        return false;
-    }
-
-    // don't let checkboxes, switches, and radio buttons prevent hotkey behavior
-    if (editable.tagName.toLowerCase() === "input") {
-        const inputType = (editable as HTMLInputElement).type;
-        if (inputType === "checkbox" || inputType === "radio") {
-            return false;
-        }
-    }
-
-    // don't let read-only fields prevent hotkey behavior
-    if ((editable as HTMLInputElement).readOnly) {
-        return false;
-    }
-
-    return true;
 }
 
 function getDefaultDocument(): Document | undefined {


### PR DESCRIPTION

#### Changes proposed in this pull request:

Add a new utility function to the public API. We found some use cases for it in our internal codebases, so I'd like to expose it:

```ts
import { Utils } from "@blueprintjs/core";

Utils.elementIsTextInput(...);
```

