### PR TITLE
[table] docs(README): fix link to NPM package

### DIFF
--- a/packages/table/src/docs/table.md
+++ b/packages/table/src/docs/table.md
@@ -1,6 +1,6 @@
 @# Table
 
-The [__@blueprintjs/table__ package](https://www.npmjs.com/package/@blueprintjs/select) provides components
+The [__@blueprintjs/table__ package](https://www.npmjs.com/package/@blueprintjs/table) provides components
 to build a highly interactive table or spreadsheet UI.
 
 <div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">


### PR DESCRIPTION
Fixes a typo (previously linked to select package instead of table)