### PR TITLE
[datetime2] fix(DateInput2): gracefully handle invalid timezones

### DIFF
--- a/packages/datetime2/src/common/errors.ts
+++ b/packages/datetime2/src/common/errors.ts
@@ -19,3 +19,5 @@ const ns = "[Blueprint]";
 export const DATERANGEINPUT_NULL_VALUE =
     `${ns} <DateRangeInput2> value cannot be null. Pass undefined to clear the value and operate in` +
     " uncontrolled mode, or pass [null, null] to clear the value and continue operating in controlled mode.";
+
+export const DATEINPUT_INVALID_DEFAULT_TIMEZONE = `${ns} <DateInput2> was provided an invalid defaultTimezone, defaulting to Etc/UTC instead`;

--- a/packages/datetime2/src/common/getTimezone.ts
+++ b/packages/datetime2/src/common/getTimezone.ts
@@ -22,7 +22,12 @@ import memoize from "lodash/memoize";
  */
 export const getCurrentTimezone: () => string = memoize(guessTimezone);
 
+/**
+ * Unsupported in IE, which newer Blueprint components do not support.
+ * In the unlikely case that the browser API returns undefined, we default to UTC.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions
+ */
 function guessTimezone(): string {
-    // N.B. getting time zone from the Intl api is not supported in IE (it returns undefined)
-    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "";
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "Etc/UTC";
 }

--- a/packages/datetime2/src/common/timezoneNameUtils.ts
+++ b/packages/datetime2/src/common/timezoneNameUtils.ts
@@ -28,6 +28,18 @@ const CURRENT_DATE = Date.now();
 const LONG_NAME_FORMAT_STR = "zzzz";
 const SHORT_NAME_FORMAT_STR = "zzz";
 
+export function isValidTimezone(timeZone: string | undefined): boolean {
+    if (timeZone === undefined) {
+        return false;
+    }
+    try {
+        Intl.DateTimeFormat(undefined, { timeZone });
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
 export function getTimezoneShortName(tzIanaCode: string, date: Date | undefined) {
     return formatInTimeZone(date ?? CURRENT_DATE, tzIanaCode, SHORT_NAME_FORMAT_STR);
 }

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -40,8 +40,9 @@ import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps } from "@blu
 import * as Classes from "../../common/classes";
 import { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import { isDateValid, isDayInRange } from "../../common/dateUtils";
+import * as Errors from "../../common/errors";
 import { getCurrentTimezone } from "../../common/getTimezone";
-import { getTimezoneShortName } from "../../common/timezoneNameUtils";
+import { getTimezoneShortName, isValidTimezone } from "../../common/timezoneNameUtils";
 import {
     convertLocalDateToTimezoneTime,
     getDateObjectFromIsoString,
@@ -214,7 +215,7 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
     // ------------------------------------------------------------------------
 
     const [isOpen, setIsOpen] = React.useState(false);
-    const [timezoneValue, setTimezoneValue] = React.useState(defaultTimezone ?? getCurrentTimezone());
+    const [timezoneValue, setTimezoneValue] = React.useState(getInitialTimezoneValue(props));
     const valueFromProps = React.useMemo(
         () => getDateObjectFromIsoString(value, timezoneValue),
         [timezoneValue, value],
@@ -640,6 +641,19 @@ DateInput2.defaultProps = {
     outOfRangeMessage: "Out of range",
     reverseMonthAndYearMenus: false,
 };
+
+function getInitialTimezoneValue({ defaultTimezone }: DateInput2Props) {
+    if (defaultTimezone === undefined) {
+        return getCurrentTimezone();
+    } else {
+        if (isValidTimezone(defaultTimezone)) {
+            return defaultTimezone;
+        } else {
+            console.error(Errors.DATEINPUT_INVALID_DEFAULT_TIMEZONE);
+            return "Etc/UTC";
+        }
+    }
+}
 
 function getRelatedTargetWithFallback(e: React.FocusEvent<HTMLElement>) {
     return (e.relatedTarget ?? Utils.getActiveElement(e.currentTarget)) as HTMLElement;

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -170,6 +170,10 @@ describe("<DateInput2>", () => {
             assert.strictEqual(popover.prop("usePortal"), false);
             assert.isTrue(onOpening.calledOnce);
         });
+
+        it("gracefully handles invalid defaultTimezone prop value", () => {
+            mount(<DateInput2 {...DEFAULT_PROPS} defaultTimezone="Foo/Bar" />);
+        });
     });
 
     describe("popover interaction", () => {
@@ -217,7 +221,6 @@ describe("<DateInput2>", () => {
             const wrapper = mount(<DateInput2 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
             clickTimezoneItem(wrapper, "New York");
             assert.isTrue(onChange.calledOnce);
-            console.info(onChange.firstCall.args);
             // New York is UTC-5
             assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30:00-05:00");
         });

--- a/packages/datetime2/test/components/dateRangeInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput2Tests.tsx
@@ -521,7 +521,7 @@ describe("<DateRangeInput2>", () => {
         it("accepts custom popoverProps", () => {
             const popoverProps: Partial<Popover2Props> = {
                 backdropProps: {},
-                position: Position.TOP_LEFT,
+                placement: "top-start",
                 usePortal: false,
             };
             const popover = wrap(<DateRangeInput2 {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover2);

--- a/packages/datetime2/test/components/dateRangeInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput2Tests.tsx
@@ -21,15 +21,7 @@ import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
-import {
-    Boundary,
-    HTMLDivProps,
-    HTMLInputProps,
-    InputGroup,
-    InputGroupProps2,
-    Keys,
-    Position,
-} from "@blueprintjs/core";
+import { Boundary, HTMLDivProps, HTMLInputProps, InputGroup, InputGroupProps2, Keys } from "@blueprintjs/core";
 import { DateRangePicker, Classes as DatetimeClasses, Months, TimePrecision } from "@blueprintjs/datetime";
 import { Popover2, Classes as Popover2Classes, Popover2Props } from "@blueprintjs/popover2";
 import { expectPropValidationError } from "@blueprintjs/test-commons";


### PR DESCRIPTION

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Improve logic used to set the initial `timezoneValue` in the DateInput2 component. If the user specified an invalid `defaultTimezone`, or if the `Intl.DateTimeFormat` API fails for some reason, we now default to "Etc/UTC" instead of throwing an unhandled error.

