### PR TITLE
fix: relax types for MenuItem and ItemRenderer handleClick

### DIFF
--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -41,7 +41,7 @@ required `text` prop for `MenuItem` content.
 
 @reactExample MenuItemExample
 
-@interface IMenuItemProps
+@interface MenuItemProps
 
 @## Menu divider
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -27,9 +27,9 @@ import { IPopoverProps, Popover, PopoverInteractionKind } from "../popover/popov
 import { Text } from "../text/text";
 import { Menu, MenuProps } from "./menu";
 
-export type MenuItemProps = IMenuItemProps;
 /** @deprecated use MenuItemProps */
-export interface IMenuItemProps extends ActionProps<HTMLAnchorElement>, LinkProps, IElementRefProps<HTMLLIElement> {
+export type IMenuItemProps = MenuItemProps;
+export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<HTMLLIElement> {
     /** Item text, required for usability. */
     text: React.ReactNode;
 

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -35,7 +35,7 @@ import * as Classes from "./classes";
 import { Popover2, Popover2Props } from "./popover2";
 
 // eslint-disable-next-line deprecation/deprecation
-export interface MenuItem2Props extends ActionProps<HTMLAnchorElement>, LinkProps, IElementRefProps<HTMLLIElement> {
+export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps<HTMLLIElement> {
     /** Item text, required for usability. */
     text: React.ReactNode;
 

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -40,10 +40,9 @@ export type IItemRendererProps = ItemRendererProps;
  * Make sure to forward the provided `ref` to the rendered element (usually via the `elementRef` prop on `MenuItem`/`MenuItem2`)
  * to ensure that scrolling to active items works correctly.
  *
- * @template T type of the DOM element to attach a ref to, usually the component's root container (defaults to MenuItem's HTMLLIElement)
- * @template U type of the DOM element to attach a click handler to, usually the component's root container (defaults to MenuItem's HTMLAnchorElement)
+ * @template T type of the DOM element rendered for this item to which we can attach a ref (defaults to MenuItem's HTMLLIElement)
  */
-export interface ItemRendererProps<T extends HTMLElement = HTMLLIElement, U extends HTMLElement = HTMLAnchorElement> {
+export interface ItemRendererProps<T extends HTMLElement = HTMLLIElement> {
     /**
      * A ref attached the native HTML element rendered by this item.
      *
@@ -52,7 +51,7 @@ export interface ItemRendererProps<T extends HTMLElement = HTMLLIElement, U exte
     ref?: React.Ref<T>;
 
     /** Click event handler to select this item. */
-    handleClick: React.MouseEventHandler<U>;
+    handleClick: React.MouseEventHandler<HTMLElement>;
 
     /**
      * Focus event handler to set this as the "active" item.


### PR DESCRIPTION
#### Changes proposed in this pull request:

- [core] fix(`MenuItem`): relax type definition of `onClick` prop, fixing a regression in v4.16.1
- [popover2] fix(`MenuItem2`): relax type definition of `onClick` prop, fixing a regression in v1.13.1
- [select] fix(`ItemRendererProps`): relax type definition of `onClick` prop, fixing a regression in v4.9.1

Fix another regression in overly-strict type definitions, this one caused by https://github.com/palantir/blueprint/pull/5944 where I tried to do too much in one PR 😢 

MenuItem's `handleClick` prop cannot be any more specific than it is now, otherwise we get compile errors for code like this:

```ts
const handleClick = useCallback((e: React.MouseEvent<HTMLElement>) => {
  // ...
}, []);

return (
  <MenuItem onClick={handleClick} />
);
```

