### PR TITLE
[core] fix(Collapse): set `aria-hidden` correctly

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -208,7 +208,7 @@ export class Collapse extends AbstractPureComponent2<CollapseProps, ICollapseSta
                 className={Classes.COLLAPSE_BODY}
                 ref={this.contentsRefHandler}
                 style={contentsStyle}
-                aria-hidden={!shouldRenderChildren}
+                aria-hidden={!isContentVisible}
             >
                 {shouldRenderChildren ? this.props.children : null}
             </div>,


### PR DESCRIPTION
This fixes regression introduced in #5926 where if `keepChildrenMounted` is set, `aria-hidden` no longer updates correctly.

#### Fixes regression introduced in #5926

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
