### PR TITLE
Set default icon colour

### DIFF
--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -51,6 +51,7 @@ Styleguide select
   .#{$ns}-icon {
     @extend %pt-select-arrow;
     @include pt-icon-colors();
+    @include pt-icon-colors-hover();
   }
 
   &.#{$ns}-minimal select {

--- a/packages/core/src/components/icon/_icon-mixins.scss
+++ b/packages/core/src/components/icon/_icon-mixins.scss
@@ -23,13 +23,17 @@
 @mixin pt-icon-colors() {
   color: $pt-icon-color;
 
+  .#{$ns}-dark & {
+    color: $pt-dark-icon-color;
+  }
+}
+
+@mixin pt-icon-colors-hover() {
   &:hover {
     color: $pt-icon-color-hover;
   }
 
   .#{$ns}-dark & {
-    color: $pt-dark-icon-color;
-
     &:hover {
       color: $pt-dark-icon-color-hover;
     }

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -8,6 +8,8 @@
 
 // the icon class which will contain an SVG icon
 .#{$ns}-icon {
+  @include pt-icon-colors();
+
   // ensure icons sit inline with text & isolate svg from surrounding elements
   // (vertical alignment in flow is usually off due to svg - not an issue with flex.)
   display: inline-block;

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -107,6 +107,7 @@ $tree-intent-icon-colors: (
 
 .#{$ns}-tree-node-caret {
   @include pt-icon-colors();
+  @include pt-icon-colors-hover();
   cursor: pointer;
   padding: $tree-icon-spacing;
   transform: rotate(0deg);

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -22,6 +22,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
   .#{$ns}-timepicker-arrow-button {
     @include pt-icon-colors();
+    @include pt-icon-colors-hover();
     display: inline-block;
     padding: ($pt-grid-size * 0.4) 0;
     text-align: center;

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -32,6 +32,7 @@ $attribute-modifier-color: $violet5;
 
 .docs-anchor-link {
   @include pt-icon-colors();
+  @include pt-icon-colors-hover();
   left: 0;
   line-height: $pt-icon-size-standard;
   opacity: 0;


### PR DESCRIPTION
Currently, the icon default colour is not applied so it can inherit the text colour. It optimises for the "edge" case where text is "primary" or some other colour. On the flip side, most icons end-up not having their intended colour `$pt-icon-color` or `$pt-dark-icon-color` 

This is a breaking change.