### PR TITLE
feat(tag): always make remove button appear interactive on hover, even when tag itself not interactive

### DIFF
--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -168,7 +168,7 @@ export class Tag extends AbstractPureComponent2<TagProps> {
             <button
                 aria-label="Remove Tag"
                 type="button"
-                className={Classes.TAG_REMOVE}
+                className={classNames(Classes.TAG_REMOVE, Classes.INTERACTIVE)}
                 onClick={this.onRemoveClick}
                 tabIndex={tabIndex}
             >


### PR DESCRIPTION
…n when tag itself not interactive

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
