### PR TITLE
fix(menuDivider): role="separator"

### DIFF
--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -42,10 +42,16 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
 
     public render() {
         const { className, title } = this.props;
-        return (
-            <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
-                {title ? <H6>{title}</H6> : null}
-            </li>
-        );
+        if (title == null) {
+            // simple divider
+            return <li className={classNames(Classes.MENU_DIVIDER, className)} role="separator" />;
+        } else {
+            // section header with title
+            return (
+                <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
+                    <H6>{title}</H6>
+                </li>
+            );
+        }
     }
 }

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -42,16 +42,10 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
 
     public render() {
         const { className, title } = this.props;
-        if (title == null) {
-            // simple divider
-            return <li className={classNames(Classes.MENU_DIVIDER, className)} role="none" />;
-        } else {
-            // section header with title
-            return (
-                <li className={classNames(Classes.MENU_HEADER, className)} role="none">
-                    <H6>{title}</H6>
-                </li>
-            );
-        }
+        return (
+            <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
+                {title ? <H6>{title}</H6> : null}
+            </li>
+        );
     }
 }

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -24,6 +24,8 @@ describe("<MenuDivider>", () => {
     it("React renders MenuDivider", () => {
         const divider = shallow(<MenuDivider />);
         assert.isTrue(divider.hasClass(Classes.MENU_DIVIDER));
+        assert.isFalse(divider.hasClass(Classes.MENU_HEADER));
+        assert.isFalse(divider.find(H6).exists());
     });
 
     it("React renders MenuDivider with title", () => {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [X] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Change `menuDivider` `role` to `separator`: 

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role
