### PR TITLE
Add prop to allow opening a column header menu without selecting the column's cells

### DIFF
--- a/packages/table/src/common/classes.ts
+++ b/packages/table/src/common/classes.ts
@@ -95,6 +95,7 @@ export const TABLE_TH_MENU = `${NS}-table-th-menu`;
 export const TABLE_TH_MENU_CONTAINER = `${NS}-table-th-menu-container`;
 export const TABLE_TH_MENU_CONTAINER_BACKGROUND = `${NS}-table-th-menu-container-background`;
 export const TABLE_TH_MENU_OPEN = `${NS}-table-th-menu-open`;
+export const TABLE_TH_MENU_SELECT_CELLS = `${NS}-table-th-menu-select-cells`;
 export const TABLE_THEAD = `${NS}-table-thead`;
 export const TABLE_TOP_CONTAINER = `${NS}-table-top-container`;
 export const TABLE_TRUNCATED_CELL = `${NS}-table-truncated-cell`;

--- a/packages/table/src/headers/columnHeaderCell2.tsx
+++ b/packages/table/src/headers/columnHeaderCell2.tsx
@@ -35,6 +35,14 @@ export interface ColumnHeaderCell2Props extends IColumnHeaderCellProps {
      * @default false
      */
     enableColumnInteractionBar?: boolean;
+
+    /**
+     * If `true`, clicks on the header menu target element will cause the column's
+     * cells to be selected.
+     *
+     * @default true
+     */
+    selectCellsOnMenuClick?: boolean;
 }
 
 /**
@@ -49,6 +57,7 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCell2P
         enableColumnInteractionBar: false,
         isActive: false,
         menuIcon: "chevron-down",
+        selectCellsOnMenuClick: true,
     };
 
     /**
@@ -144,7 +153,7 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCell2P
     }
 
     private maybeRenderDropdownMenu() {
-        const { index, menuIcon, menuRenderer } = this.props;
+        const { index, menuIcon, menuRenderer, selectCellsOnMenuClick } = this.props;
 
         if (!CoreUtils.isFunction(menuRenderer)) {
             return undefined;
@@ -152,6 +161,7 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCell2P
 
         const classes = classNames(Classes.TABLE_TH_MENU_CONTAINER, CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT, {
             [Classes.TABLE_TH_MENU_OPEN]: this.state.isActive,
+            [Classes.TABLE_TH_MENU_SELECT_CELLS]: selectCellsOnMenuClick,
         });
 
         return (

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -276,6 +276,12 @@ export class Header extends React.Component<IInternalHeaderProps, IHeaderState> 
     };
 
     private locateClick = (event: MouseEvent): Region => {
+        const menuContainer = (event.target as HTMLElement).closest(`.${Classes.TABLE_TH_MENU_CONTAINER}`);
+
+        if (menuContainer && !menuContainer.classList.contains(Classes.TABLE_TH_MENU_SELECT_CELLS)) {
+            return this.props.toRegion(-1);
+        }
+
         this.activationIndex = this.convertEventToIndex(event);
         return this.props.toRegion(this.activationIndex);
     };


### PR DESCRIPTION
#### Fixes #5929

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Add a prop to determine whether clicking the column header menu should select the column's cells. Default `true` to preserve the current behaviour.

#### Screenshot

With prop set to false, opening the column header menu does not cause the column's cells to be selected:

<img width="407" alt="image" src="https://user-images.githubusercontent.com/33153339/219510079-460f2548-2bc5-4bae-a626-1638404e97ee.png">