### PR TITLE
[core] fix(Slider): error if min/max are not finite

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -93,6 +93,8 @@ export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
 
 export const SLIDER_ZERO_STEP = ns + ` <Slider> stepSize must be greater than zero.`;
 export const SLIDER_ZERO_LABEL_STEP = ns + ` <Slider> labelStepSize must be greater than zero.`;
+export const SLIDER_MIN = ns + ` <Slider> min prop must be a finite number.`;
+export const SLIDER_MAX = ns + ` <Slider> max prop must be a finite number.`;
 export const RANGESLIDER_NULL_VALUE = ns + ` <RangeSlider> value prop must be an array of two non-null numbers.`;
 export const MULTISLIDER_INVALID_CHILD = ns + ` <MultiSlider> children must be <SliderHandle>s or <SliderTrackStop>s`;
 export const MULTISLIDER_WARN_LABEL_STEP_SIZE_LABEL_VALUES_MUTEX =

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -65,14 +65,14 @@ export interface ISliderBaseProps extends Props, IntentProps {
     labelPrecision?: number;
 
     /**
-     * Maximum value of the slider.
+     * Maximum value of the slider. Value must be a finite number.
      *
      * @default 10
      */
     max?: number;
 
     /**
-     * Minimum value of the slider.
+     * Minimum value of the slider. Value must be a finite number.
      *
      * @default 0
      */

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -228,6 +228,12 @@ export class MultiSlider extends AbstractPureComponent2<MultiSliderProps, ISlide
         if (props.labelStepSize !== undefined && props.labelStepSize! <= 0) {
             throw new Error(Errors.SLIDER_ZERO_LABEL_STEP);
         }
+        if (props.min !== undefined && !isFinite(props.min)) {
+            throw new Error(Errors.SLIDER_MIN);
+        }
+        if (props.max !== undefined && !isFinite(props.max)) {
+            throw new Error(Errors.SLIDER_MAX);
+        }
 
         let anyInvalidChildren = false;
         React.Children.forEach(props.children, child => {

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -334,6 +334,22 @@ describe("<MultiSlider>", () => {
                 expectPropValidationError(MultiSlider, { labelStepSize }, "greater than zero");
             });
         });
+
+        it("throws an error if the min value is not finite", () => {
+            expectPropValidationError(
+                MultiSlider,
+                { min: Number.NEGATIVE_INFINITY },
+                "min prop must be a finite number",
+            );
+        });
+
+        it("throws an error if the max value is not finite", () => {
+            expectPropValidationError(
+                MultiSlider,
+                { max: Number.POSITIVE_INFINITY },
+                "max prop must be a finite number",
+            );
+        });
     });
 
     function renderSlider(joinedProps: IMultiSliderProps & { values?: [number, number, number] } = {}) {


### PR DESCRIPTION
Enforcing min and max values to be finite
Added two unit tests

#### Fixes #5436

#### Checklist

- [X] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Added a prop validation that checks that the minimum value and maximum values are both finite.  If they're not, then throw an error.
#### Reviewers should focus on:

Constraints added to the MultiSlider (includes Slider + RangeSlider, since they're both implemented as MulitSliders under the hood) Component + Documentation
#### Screenshot

![image](https://user-images.githubusercontent.com/9396787/220192753-e48a0a2e-e61c-4774-b808-ffce6d223d43.png)
