### PR TITLE
[select] fix: set aria-disabled attribute on combobox elements

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -288,8 +288,8 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     "aria-controls": this.listboxId,
                     ...popoverTargetProps,
                     ...targetProps,
-                    "aria-expanded": isOpen,
                     "aria-disabled": disabled,
+                    "aria-expanded": isOpen,
                     // Note that we must set FILL here in addition to TagInput to get the wrapper element to full width
                     className: classNames(targetProps.className, popoverTargetProps.className, {
                         [CoreClasses.FILL]: fill,

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -289,11 +289,11 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     ...popoverTargetProps,
                     ...targetProps,
                     "aria-expanded": isOpen,
+                    "aria-disabled": disabled,
                     // Note that we must set FILL here in addition to TagInput to get the wrapper element to full width
                     className: classNames(targetProps.className, popoverTargetProps.className, {
                         [CoreClasses.FILL]: fill,
                     }),
-                    disabled,
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.

--- a/packages/select/src/components/multi-select/multiSelect2.tsx
+++ b/packages/select/src/components/multi-select/multiSelect2.tsx
@@ -293,6 +293,7 @@ export class MultiSelect2<T> extends AbstractPureComponent2<MultiSelect2Props<T>
                     className: classNames(targetProps.className, popoverTargetProps.className, {
                         [CoreClasses.FILL]: fill,
                     }),
+                    disabled,
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -223,12 +223,12 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                     "aria-controls": this.listboxId,
                     ...popoverTargetProps,
                     ...targetProps,
+                    "aria-disabled": disabled,
                     "aria-expanded": isOpen,
                     // Note that we must set FILL here in addition to children to get the wrapper element to full width
                     className: classNames(targetProps.className, popoverTargetProps?.className, {
                         [CoreClasses.FILL]: this.props.fill,
                     }),
-                    disabled,
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -214,7 +214,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         // since it may be stale (`renderTarget` is not re-invoked on this.state changes).
         // eslint-disable-next-line react/display-name
         ({ isOpen: _isOpen, ref, ...targetProps }: Popover2TargetProps & Popover2ClickTargetHandlers) => {
-            const { popoverProps = {}, popoverTargetProps } = this.props;
+            const { disabled, popoverProps = {}, popoverTargetProps } = this.props;
             const { handleKeyDown, handleKeyUp } = listProps;
             const { targetTagName = "div" } = popoverProps;
             return React.createElement(
@@ -228,6 +228,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
                     className: classNames(targetProps.className, popoverTargetProps?.className, {
                         [CoreClasses.FILL]: this.props.fill,
                     }),
+                    disabled,
                     // Normally, Popover2 would also need to attach its own `onKeyDown` handler via `targetProps`,
                     // but in our case we fully manage that interaction and listen for key events to open/close
                     // the popover, so we elide it from the DOM.


### PR DESCRIPTION
Disabled prop should be applied to the element that has `role="combobox"`, not just the `input`.
