### PR TITLE
[core] feat(Icon): new prop 'svgProps'

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -84,7 +84,7 @@ export interface IIconProps extends IntentProps, Props {
     style?: React.CSSProperties;
 
     /** Props to apply to the `SVG` element */
-    svgProps?: React.HTMLAttributes<SVGElement>
+    svgProps?: React.HTMLAttributes<SVGElement>;
 
     /**
      * HTML tag to use for the rendered element.

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -83,6 +83,7 @@ export interface IIconProps extends IntentProps, Props {
     /** CSS style properties. */
     style?: React.CSSProperties;
 
+    /** Props to apply to the `SVG` element */
     svgProps?: React.HTMLAttributes<SVGElement>
 
     /**

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -83,6 +83,8 @@ export interface IIconProps extends IntentProps, Props {
     /** CSS style properties. */
     style?: React.CSSProperties;
 
+    svgProps?: React.HTMLAttributes<SVGElement>
+
     /**
      * HTML tag to use for the rendered element.
      *
@@ -128,6 +130,7 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
             iconSize,
             intent,
             size = iconSize ?? IconSize.STANDARD,
+            svgProps,
             title,
             tagName = "span",
             ...htmlprops
@@ -159,6 +162,7 @@ export class Icon extends AbstractPureComponent2<IconProps & Omit<React.HTMLAttr
                 viewBox={viewBox}
                 aria-labelledby={title ? titleId : undefined}
                 role="img"
+                {...svgProps}
             >
                 {title && <title id={titleId}>{title}</title>}
                 {paths}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

allow passing of props to SVG element in the Icon.

#### Reviewers should focus on:

Example usage:

We are using an `Icon` as the target of a `Tooltip2`. So, we cannot use the `title` prop of the `Icon`, as this creates 2 visible tooltips when hovered (the `title` html tooltip, and the `Tooltip2` `content`). However, we still need the SVG to have an accessible label, so we want to be able to pass the `aria-label` prop to it (as opposed to a `title`). With this, will also override to set `aria-hidden=false` (as was given by https://github.com/palantir/blueprint/pull/5955)
