### PR TITLE
[core] fix(Button): icon a11y fix when there is no text

### DIFF
--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -213,7 +213,7 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         const maybeHasText = !Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children);
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={IconSize.LARGE} />,
-            <Icon key="leftIcon" icon={icon}/>,
+            <Icon key="leftIcon" icon={icon} />,
             maybeHasText && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}

--- a/packages/core/src/components/button/abstractButton.tsx
+++ b/packages/core/src/components/button/abstractButton.tsx
@@ -213,8 +213,7 @@ export abstract class AbstractButton<E extends HTMLButtonElement | HTMLAnchorEle
         const maybeHasText = !Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children);
         return [
             loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={IconSize.LARGE} />,
-            // The icon is purely decorative if text is provided
-            <Icon key="leftIcon" icon={icon} aria-hidden={maybeHasText} tabIndex={maybeHasText ? -1 : undefined} />,
+            <Icon key="leftIcon" icon={icon}/>,
             maybeHasText && (
                 <span key="text" className={Classes.BUTTON_TEXT}>
                     {text}


### PR DESCRIPTION
the `Icon` in any `button` should have `aria-hidden=true` since the `<button` wrapper itself is what would have `aria-label`/`aria-labelledby`, in cases where there is no button text.