### PR TITLE
[core] fix(DialogFooter): remove invalid role "dialogfooter"

### DIFF
--- a/packages/core/src/components/dialog/dialogFooter.tsx
+++ b/packages/core/src/components/dialog/dialogFooter.tsx
@@ -63,7 +63,6 @@ export class DialogFooter extends AbstractPureComponent2<DialogFooterProps> {
                 className={classNames(Classes.DIALOG_FOOTER, this.props.className, {
                     [Classes.DIALOG_FOOTER_FIXED]: !this.props.minimal,
                 })}
-                role="dialogfooter"
             >
                 {this.renderMainSection()}
                 {this.maybeRenderActionsSection()}


### PR DESCRIPTION
"dialogfooter" is not a valid aria role. 

If we really do want to label this, could make it `role="region" aria-label="dialog footer"`. Otherwise, just remove, doesn't provide anything.