### PR TITLE
[core] fix(TagInput): remove extraneous id attribute

### DIFF
--- a/packages/core/src/components/tag-input/resizableInput.tsx
+++ b/packages/core/src/components/tag-input/resizableInput.tsx
@@ -28,7 +28,7 @@ export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function Resizable
 
     return (
         <span>
-            <span id="hide" ref={span} className={Classes.RESIZABLE_INPUT_SPAN}>
+            <span ref={span} className={Classes.RESIZABLE_INPUT_SPAN}>
                 {/* Need to replace spaces with the html character for them to be preserved */}
                 {content.replace(/ /g, "\u00a0")}
             </span>


### PR DESCRIPTION
From what I can tell, this `id` prop is unused / useless. It is creating aXe a11y failures due to the fact that all `id` props on a page must be **unique**. 