### PR TITLE
[core] fix(TagInput): remove extra element, allow placeholder to fill width

### DIFF
--- a/packages/core/src/components/tag-input/resizableInput.tsx
+++ b/packages/core/src/components/tag-input/resizableInput.tsx
@@ -4,7 +4,7 @@
 
 import React, { forwardRef, useEffect, useRef, useState } from "react";
 
-import { Classes, HTMLInputProps } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, HTMLInputProps } from "../../common";
 
 export type Ref = HTMLInputElement;
 
@@ -27,12 +27,13 @@ export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function Resizable
     };
 
     return (
-        <span>
+        <>
             <span ref={span} className={Classes.RESIZABLE_INPUT_SPAN}>
                 {/* Need to replace spaces with the html character for them to be preserved */}
                 {content.replace(/ /g, "\u00a0")}
             </span>
             <input {...otherProps} type="text" style={{ width }} onChange={handleInputChange} ref={ref} />
-        </span>
+        </>
     );
 });
+ResizableInput.displayName = `${DISPLAYNAME_PREFIX}.ResizableInput`;


### PR DESCRIPTION

#### Fixes regression in TagInput: https://github.com/palantir/blueprint/pull/5966#issuecomment-1448511660

#### Changes proposed in this pull request:

Remove extra wrapper element, reverting us to a DOM structure that did not have this bug

#### Screenshot

Before (with bug from #5966):

<img width="752" alt="Screenshot 2023-02-28 at 6 32 01 PM" src="https://user-images.githubusercontent.com/723999/222007019-9ba9b774-b057-493f-94ce-31262f995703.png">

After (fixed):

<img width="796" alt="Screenshot 2023-02-28 at 6 30 52 PM" src="https://user-images.githubusercontent.com/723999/222007030-9c202c25-d59f-462f-a41f-957dde1c7de5.png">


