### PR TITLE
[core] fix Less variable syntax

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -5,3 +5,4 @@ dist
 /docs
 generated
 coverage
+__tests__/__fixtures__

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ */
+
+@ns: bp4;
+@icons16-family: "blueprint-icons-16";
+@pt-font-family: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto",
+  "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue",
+  "blueprint-icons-16", sans-serif;
+@pt-border-radius: 2px;
+@black: #111418;
+@gray1: #5f6b7c;
+@white: #ffffff;
+@pt-divider-black: rgba(17, 20, 24, 0.15);
+@pt-border-shadow-opacity: 0.1;
+@pt-drop-shadow-opacity: 0.2;
+@pt-elevation-shadow-0: 0 0 0 1px rgba(17, 20, 24, 0.15);
+@pt-elevation-shadow-1: 0 0 0 1px rgba(17, 20, 24, 0.1),
+  0 1px 1px rgba(17, 20, 24, 0.2);
+@pt-text-color-disabled: rgba(95, 107, 124, 0.6);
+@pt-dark-divider-white: rgba(255, 255, 255, 0.2);
+@pt-dark-popover-border-color: hsl(215, 3%, 38%);
+@test-map: {
+  first: #111418;
+  second: #ffffff;
+};

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.scss
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.scss
@@ -19,3 +19,8 @@ $pt-elevation-shadow-1: 0 0 0 1px rgba(17, 20, 24, 0.1),
   0 1px 1px rgba(17, 20, 24, 0.2) !default;
 $pt-text-color-disabled: rgba(95, 107, 124, 0.6) !default;
 $pt-dark-divider-white: rgba(255, 255, 255, 0.2) !default;
+$pt-dark-popover-border-color: hsl(215deg, 3%, 38%) !default;
+$test-map: (
+  "first": #111418,
+  "second": #ffffff,
+) !default;

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/input/_variables.scss
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/input/_variables.scss
@@ -25,3 +25,8 @@ $pt-elevation-shadow-1: border-shadow($pt-border-shadow-opacity),
                         0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
 $pt-text-color-disabled: rgba($gray1, 0.6) !default;
 $pt-dark-divider-white: rgba($white, 0.2) !default;
+$pt-dark-popover-border-color: hsl(215deg, 3%, 38%) !default;
+$test-map: (
+  "first": $black,
+  "second": $white,
+) !default;

--- a/packages/node-build-scripts/src/__tests__/cssVariables.test.ts
+++ b/packages/node-build-scripts/src/__tests__/cssVariables.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from "@jest/globals";
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
-import { generateScssVariables, getParsedVars } from "../cssVariables.mjs";
+import { generateLessVariables, generateScssVariables, getParsedVars } from "../cssVariables.mjs";
 
 const FIXTURES_DIR = join(__dirname, "__fixtures__");
 const INPUT_DIR = resolve(FIXTURES_DIR, "input");
@@ -17,6 +17,15 @@ describe("generateScssVariables", () => {
         const parsedInput = await getParsedVars(INPUT_DIR, ["_variables.scss"]);
         const actualVariables = generateScssVariables(parsedInput, true);
         const expectedVariables = readFileSync(join(EXPECTED_DIR, "variables.scss"), { encoding: "utf8" });
+        expect(actualVariables).toStrictEqual(expectedVariables);
+    });
+});
+
+describe("generateLessVariables", () => {
+    test("produces expected output", async () => {
+        const parsedInput = await getParsedVars(INPUT_DIR, ["_variables.scss"]);
+        const actualVariables = generateLessVariables(parsedInput);
+        const expectedVariables = readFileSync(join(EXPECTED_DIR, "variables.less"), { encoding: "utf8" });
         expect(actualVariables).toStrictEqual(expectedVariables);
     });
 });


### PR DESCRIPTION
`variables.less` published in the latest release was empty: https://unpkg.com/browse/@blueprintjs/core@4.17.2/lib/less/variables.less

This PR fixes that, and adds regression tests for a few special bits of Less syntax like `hsl()` and map type values.