### PR TITLE
[node-build-scripts] fix(generate-css-variables): whitespace in maps

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -141,7 +141,7 @@ $pt-dark-input-intent-box-shadow-colors: (
   "primary": $blue4,
   "success": $green4,
   "warning": $orange4,
-  "danger" : $red4,
+  "danger": $red4,
 ) !default;
 
 $pt-dark-dialog-box-shadow: $pt-dark-elevation-shadow-3 !default;

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
@@ -23,4 +23,5 @@
 @test-map: {
   first: #111418;
   second: #ffffff;
+  third: #5f6b7c;
 };

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.scss
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.scss
@@ -23,4 +23,5 @@ $pt-dark-popover-border-color: hsl(215deg, 3%, 38%) !default;
 $test-map: (
   "first": #111418,
   "second": #ffffff,
+  "third": #5f6b7c,
 ) !default;

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/input/_variables.scss
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/input/_variables.scss
@@ -27,6 +27,7 @@ $pt-text-color-disabled: rgba($gray1, 0.6) !default;
 $pt-dark-divider-white: rgba($white, 0.2) !default;
 $pt-dark-popover-border-color: hsl(215deg, 3%, 38%) !default;
 $test-map: (
-  "first": $black,
+  "first" : $black,
   "second": $white,
+  "third" : $gray1,
 ) !default;

--- a/packages/node-build-scripts/src/cssVariables.mjs
+++ b/packages/node-build-scripts/src/cssVariables.mjs
@@ -86,7 +86,7 @@ function printVariable(value, allVariables, outputType) {
                     } else if (line === ")") {
                         return "}";
                     } else {
-                        return line.replace(/"(\S+)": (.+),/, (_substr, key, value) => `${key}: ${value.trim()};`);
+                        return line.replace(/"(\S+)"\s*: (.+),/, (_substr, key, value) => `${key}: ${value.trim()};`);
                     }
                 })
                 .join("\n");
@@ -149,12 +149,12 @@ export function generateLessVariables(parsedInput) {
         const lessBlock = lessVariablesArray
             .join("\n")
             .replace(/rgba\((\$[\w-]+), ([\d\.]+)\)/g, (_match, color, opacity) => `fade(${color}, ${+opacity * 100}%)`)
-            // special case for hsl(), which supports a value like '270deg' in its first argument in Sass, but in Less we must omit the 'deg'
-            .replace(/hsl\(([0-9]+)deg, (.+)\)/g, (_match, degrees, rest) => `hsl(${degrees}, ${rest})`)
             .replace(
                 /rgba\((\$[\w-]+), (\$[\w-]+)\)/g,
                 (_match, color, variable) => `fade(${color}, ${variable} * 100%)`,
             )
+            // special case for hsl(), which supports a value like '270deg' in its first argument in Sass, but in Less we must omit the 'deg'
+            .replace(/hsl\(([0-9]+)deg, (.+)\)/g, (_match, degrees, rest) => `hsl(${degrees}, ${rest})`)
             .replace(/\$/g, "@");
 
         variablesLess = `${variablesLess}${lessBlock}\n\n`;


### PR DESCRIPTION

#### Checklist

- [x] Includes tests

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix another Less syntax error in [core v4.17.3 `variables.less`](https://unpkg.com/browse/@blueprintjs/core@4.17.3/lib/less/variables.less):

```less
@pt-dark-input-intent-box-shadow-colors: {
  primary: #4c90f0;
  success: #32a467;
  warning: #ec9a3c;
  "danger":#e76a6e, ;
};
```

should be instead (fixed):

```less
@pt-dark-input-intent-box-shadow-colors: {
  primary: #4c90f0;
  success: #32a467;
  warning: #ec9a3c;
  danger: #e76a6e;
};
```

#### Reviewers should focus on:

Regression test

