### PR TITLE
[core] fix(TagInput): make sure ResizableInput span is invisible

### DIFF
--- a/packages/core/src/components/tag-input/_resizable-input.scss
+++ b/packages/core/src/components/tag-input/_resizable-input.scss
@@ -5,9 +5,9 @@
   max-height: 0;
   max-width: 100%;
   min-width: $pt-grid-size * 8;
+  opacity: 0;
+  overflow: hidden;
   position: absolute;
   white-space: nowrap;
   z-index: -1;
-  opacity: 0;
-  overflow: hidden;
 }

--- a/packages/core/src/components/tag-input/_resizable-input.scss
+++ b/packages/core/src/components/tag-input/_resizable-input.scss
@@ -8,4 +8,6 @@
   position: absolute;
   white-space: nowrap;
   z-index: -1;
+  opacity: 0;
+  overflow: hidden;
 }


### PR DESCRIPTION
#### Checklist

- [ N/A] Includes tests
- [ N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

In some scenarios, other styles might clash making the supposedly hidden span not invisible...

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

Example of it broken:
<img width="670" alt="Screenshot 2023-03-06 at 17 53 53" src="https://user-images.githubusercontent.com/33576267/223180994-32f10c80-a431-4bcf-a159-9eb6370eb2dd.png">

<!-- Include an image of the most relevant user-facing change, if any. -->
