### PR TITLE
[core] fix(TagInput): left padding when no icon or tags

### DIFF
--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -42,9 +42,15 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
 
     // use the larger, conventional input padding when there are no tags and no left icon present.
     // see: https://github.com/palantir/blueprint/issues/2872
-    &:first-child .#{$ns}-input-ghost:first-child {
-      // recall that some padding-left is already applied on the root component.
-      padding-left: $input-padding-horizontal - $tag-input-padding;
+    &:first-child {
+      .#{$ns}-tag ~ .#{$ns}-input-ghost {
+        padding-left: 0;
+      }
+
+      .#{$ns}-input-ghost {
+        // some padding-left is already applied on the root component, so we should subtract that
+        padding-left: $input-padding-horizontal - $tag-input-padding;
+      }
     }
 
     > * {


### PR DESCRIPTION
#### Fixes #5998

#### Changes proposed in this pull request:

Fix left padding in TagInput ghost input when there is no left icon or tags. This got broken in #5966 when the DOM changed but some CSS was relying on a specific outdated DOM structure

#### Reviewers should focus on:

Fixes the linked bug

#### Screenshot

Before:

<img width="518" alt="Screenshot 2023-03-06 at 2 52 28 PM" src="https://user-images.githubusercontent.com/723999/223216551-fd054394-c6c6-4d5f-a83e-a43ca51c75a4.png">

After:

<img width="521" alt="Screenshot 2023-03-06 at 2 52 14 PM" src="https://user-images.githubusercontent.com/723999/223216649-c19d7cb9-68f2-41cc-9433-9694a4543006.png">


Padding with tags is unchanged:

<img width="511" alt="Screenshot 2023-03-06 at 2 52 19 PM" src="https://user-images.githubusercontent.com/723999/223216663-e8fa308c-577e-47d4-955f-5e42867e4568.png">


