### PR TITLE
[core] fix(TagInput): disable new autoResize behavior by default

### DIFF
--- a/packages/core/src/components/tag-input/resizableInput.tsx
+++ b/packages/core/src/components/tag-input/resizableInput.tsx
@@ -19,7 +19,7 @@ export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function Resizable
         }
     }, [content]);
 
-    const { onChange, ...otherProps } = props;
+    const { onChange, style, ...otherProps } = props;
 
     const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = evt => {
         onChange?.(evt);
@@ -32,7 +32,7 @@ export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function Resizable
                 {/* Need to replace spaces with the html character for them to be preserved */}
                 {content.replace(/ /g, "\u00a0")}
             </span>
-            <input {...otherProps} type="text" style={{ width }} onChange={handleInputChange} ref={ref} />
+            <input {...otherProps} type="text" style={{ ...style, width }} onChange={handleInputChange} ref={ref} />
         </>
     );
 });

--- a/packages/core/src/components/tag-input/resizableInput.tsx
+++ b/packages/core/src/components/tag-input/resizableInput.tsx
@@ -28,7 +28,7 @@ export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function Resizable
 
     return (
         <>
-            <span ref={span} className={Classes.RESIZABLE_INPUT_SPAN}>
+            <span ref={span} className={Classes.RESIZABLE_INPUT_SPAN} aria-hidden={true}>
                 {/* Need to replace spaces with the html character for them to be preserved */}
                 {content.replace(/ /g, "\u00a0")}
             </span>

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -565,6 +565,25 @@ describe("<TagInput>", () => {
         });
     });
 
+    describe("when autoResize={true}", () => {
+        it("passes inputProps to input element", () => {
+            const onBlur = sinon.spy();
+            const input = mount(
+                <TagInput autoResize={true} values={VALUES} inputProps={{ autoFocus: true, onBlur }} />,
+            ).find("input");
+            assert.isTrue(input.prop("autoFocus"));
+            // check that event handler is proxied
+            const fakeEvent = { flag: "yes" };
+            input.prop("onBlur")?.(fakeEvent as any);
+            assert.strictEqual(onBlur.args[0][0], fakeEvent);
+        });
+
+        it("renders a Tag for each value", () => {
+            const wrapper = mount(<TagInput autoResize={true} values={VALUES} />);
+            assert.lengthOf(wrapper.find(Tag), VALUES.length);
+        });
+    });
+
     function pressEnterInInput(wrapper: ReactWrapper<any, any>, value: string) {
         wrapper.find("input").prop("onKeyDown")?.(createInputKeydownEventMetadata(value, Keys.ENTER) as any);
     }

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -37,6 +37,7 @@ const VALUES = [
 export interface ITagInputExampleState {
     addOnBlur: boolean;
     addOnPaste: boolean;
+    autoResize: boolean;
     disabled: boolean;
     fill: boolean;
     intent: Intent;
@@ -51,6 +52,7 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
     public state: ITagInputExampleState = {
         addOnBlur: false,
         addOnPaste: true,
+        autoResize: false,
         disabled: false,
         fill: false,
         intent: "none",
@@ -64,6 +66,8 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
     private handleAddOnBlurChange = handleBooleanChange(addOnBlur => this.setState({ addOnBlur }));
 
     private handleAddOnPasteChange = handleBooleanChange(addOnPaste => this.setState({ addOnPaste }));
+
+    private handleAutoResizeChange = handleBooleanChange(autoResize => this.setState({ autoResize }));
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
 
@@ -118,14 +122,16 @@ export class TagInputExample extends React.PureComponent<ExampleProps, ITagInput
     private renderOptions() {
         return (
             <>
-                <H5>Props</H5>
+                <H5>Appearance props</H5>
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Left icon" checked={this.state.leftIcon} onChange={this.handleLeftIconChange} />
-                <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />
-                <Switch label="Add on paste" checked={this.state.addOnPaste} onChange={this.handleAddOnPasteChange} />
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
+                <H5>Behavior props</H5>
+                <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />
+                <Switch label="Add on paste" checked={this.state.addOnPaste} onChange={this.handleAddOnPasteChange} />
+                <Switch label="Auto resize" checked={this.state.autoResize} onChange={this.handleAutoResizeChange} />
                 <H5>Tag props</H5>
                 <Switch
                     label="Use minimal tags"


### PR DESCRIPTION
Fixes some TagInput-related issues we've been seeing recently as a result of #5966, which enabled the new "auto-resizing" behavior by default for all TagInputs.

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Move the functionality of #5966 behind a new prop `autoResize`, which is disabled by default.
- Don't clobber `inputProps.style` when `autoResize={true}`
- Add `aria-hidden={true}` to the new resizable-input-span element so that it's ignored by screen readers

#### Reviewers should focus on:

New behavior still works when `autoResize` is enabled. Also naming of the new prop.

#### Screenshot

![2023-03-07 11 12 59](https://user-images.githubusercontent.com/723999/223480919-5bd691b9-561b-4545-aec6-40c4b5cf9548.gif)

