### PR TITLE
[datetime] fix(TimeInput): text color when disabled in dark mode

### DIFF
--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -100,7 +100,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     .#{$ns}-timepicker-divider-text {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
-      color: $input-color-disabled  !important;
+      color: $input-color-disabled !important;
       cursor: not-allowed;
     }
 
@@ -108,7 +108,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     .#{$ns}-timepicker-arrow-button:hover {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
-      color: $input-color-disabled  !important;
+      color: $input-color-disabled !important;
       cursor: not-allowed;
     }
   }

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -98,17 +98,13 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
     .#{$ns}-timepicker-input,
     .#{$ns}-timepicker-divider-text {
-      // disabled state always overrides over styles
-      /* stylelint-disable-next-line declaration-no-important */
-      color: $input-color-disabled !important;
+      color: $input-color-disabled;
       cursor: not-allowed;
     }
 
     .#{$ns}-timepicker-arrow-button,
     .#{$ns}-timepicker-arrow-button:hover {
-      // disabled state always overrides over styles
-      /* stylelint-disable-next-line declaration-no-important */
-      color: $input-color-disabled !important;
+      color: $input-color-disabled;
       cursor: not-allowed;
     }
   }
@@ -126,5 +122,14 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
   .#{$ns}-timepicker-input {
     color: $pt-dark-text-color;
+  }
+
+  &.#{$ns}-disabled {
+    .#{$ns}-timepicker-input,
+    .#{$ns}-timepicker-divider-text,
+    .#{$ns}-timepicker-arrow-button,
+    .#{$ns}-timepicker-arrow-button:hover {
+      color: $dark-input-color-disabled;
+    }
   }
 }

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -100,7 +100,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     .#{$ns}-timepicker-divider-text {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
-      color: $input-color-disableed  !important;
+      color: $input-color-disabled  !important;
       cursor: not-allowed;
     }
 

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -93,18 +93,22 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
   &.#{$ns}-disabled {
     .#{$ns}-timepicker-input-row {
-      @include pt-input-disabled();
+      @include pt-input-disabled() ;
     }
 
     .#{$ns}-timepicker-input,
     .#{$ns}-timepicker-divider-text {
-      color: $input-color-disabled;
+      // disabled state always overrides over styles
+      /* stylelint-disable-next-line declaration-no-important */
+      color: $input-color-disabled  !important;
       cursor: not-allowed;
     }
 
     .#{$ns}-timepicker-arrow-button,
     .#{$ns}-timepicker-arrow-button:hover {
-      color: $input-color-disabled;
+      // disabled state always overrides over styles
+      /* stylelint-disable-next-line declaration-no-important */
+      color: $input-color-disabled  !important;
       cursor: not-allowed;
     }
   }

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -100,7 +100,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
     .#{$ns}-timepicker-divider-text {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
-      color: $input-color-disabled  !important;
+      color: $input-color-disableed  !important;
       cursor: not-allowed;
     }
 

--- a/packages/datetime/src/_timepicker.scss
+++ b/packages/datetime/src/_timepicker.scss
@@ -93,7 +93,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
   &.#{$ns}-disabled {
     .#{$ns}-timepicker-input-row {
-      @include pt-input-disabled() ;
+      @include pt-input-disabled();
     }
 
     .#{$ns}-timepicker-input,


### PR DESCRIPTION
Bug fix:
TimeInput component currently does not visually look disabled when in dark mode.
Have confirmed this change is effective.