### PR TITLE
[datetime2] fix(DateInput2): allow changing tz before selecting date

### DIFF
--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -393,8 +393,8 @@ export const DateInput2: React.FC<DateInput2Props> = React.memo(function _DateIn
 
     const handleTimezoneChange = React.useCallback(
         (newTimezone: string) => {
-            if (valueAsDate !== null) {
-                setTimezoneValue(newTimezone);
+            setTimezoneValue(newTimezone);
+            if (valueAsDate != null) {
                 const newDateString = getIsoEquivalentWithUpdatedTimezone(valueAsDate, newTimezone, timePrecision);
                 props.onChange?.(newDateString, true);
             }


### PR DESCRIPTION
#### Fixes #6008

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix DateInput2 implementation to allow changing the selected timezone _before_ selecting a date in the picker.

#### Reviewers should focus on:

Test cases & demo in docs-app

#### Screenshot

![2023-03-13 13 49 37](https://user-images.githubusercontent.com/723999/224786020-fda1edca-d408-4b10-ac45-290f9d4f3fea.gif)

