### PR TITLE
[core] fix(variables): revert change to text-selection-color

### DIFF
--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -31,7 +31,7 @@ $pt-dark-text-color-disabled: rgba($gray4, 0.6) !default;
 $pt-dark-heading-color: $pt-dark-text-color !default;
 $pt-dark-link-color: $blue5 !default;
 // Default text selection color using #7dbcff with 60% opacity
-$pt-text-selection-color: rgba(125, 188, 255, 0.6) !default;
+$pt-text-selection-color: rgba(125, 188, 255, 60%) !default;
 
 $pt-icon-color: $pt-text-color-muted !default;
 $pt-icon-color-hover: $pt-text-color !default;

--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -30,8 +30,8 @@ $pt-dark-text-color-muted: $gray4 !default;
 $pt-dark-text-color-disabled: rgba($gray4, 0.6) !default;
 $pt-dark-heading-color: $pt-dark-text-color !default;
 $pt-dark-link-color: $blue5 !default;
-// Default text selection color using #7dbcff
-$pt-text-selection-color: rgba(125, 188, 255, 60%) !default;
+// Default text selection color using #7dbcff with 60% opacity
+$pt-text-selection-color: rgba(125, 188, 255, 0.6) !default;
 
 $pt-icon-color: $pt-text-color-muted !default;
 $pt-icon-color-hover: $pt-text-color !default;

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
@@ -25,3 +25,4 @@
   second: #ffffff;
   third: #5f6b7c;
 };
+@pt-text-selection-color: rgba(125, 188, 255, 0.6);

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.scss
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.scss
@@ -25,3 +25,4 @@ $test-map: (
   "second": #ffffff,
   "third": #5f6b7c,
 ) !default;
+$pt-text-selection-color: rgba(125, 188, 255, 0.6) !default;

--- a/packages/node-build-scripts/src/__tests__/__fixtures__/input/_variables.scss
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/input/_variables.scss
@@ -31,3 +31,4 @@ $test-map: (
   "second": $white,
   "third" : $gray1,
 ) !default;
+$pt-text-selection-color: rgba(125, 188, 255, 0.6) !default;

--- a/packages/node-build-scripts/src/cssVariables.mjs
+++ b/packages/node-build-scripts/src/cssVariables.mjs
@@ -172,6 +172,11 @@ export function generateLessVariables(parsedInput) {
  * @returns {string}
  */
 function evaluateRgbaInitializerColor(variableInitializer, allVariables) {
+    if (variableInitializer.match(/rgba\(([0-9]+), ([0-9]+), ([0-9]+), (.+)\)/)) {
+        // do nothing if the color is specified in full rgba(r, g, b, a) syntax, since this _is_ supported in Less
+        return variableInitializer;
+    }
+
     return variableInitializer.replace(
         /rgba\((.+)\, (.+)\)/g,
         (_, colorHexCode, opacity) => `rgba(${colorHexToRgb(colorHexCode)}, ${opacity})`,


### PR DESCRIPTION
#### Fixes #6015

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

In node-build-scripts, fix(`generate-css-variables`) to not alter/transform variable initializers with the syntax `rgba(r, g, b, a)`

In core, fix the regression in the value of the `$pt-text-selection-color` variable

#### Reviewers should focus on:

Snapshot test update
