### PR TITLE
chore: upgrade to Typescript 4.8

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.6.2",
+    "version": "4.8.4",
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
         "declaration": true,

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "sinon": "^15.0.1",
         "stylelint-config-palantir": "^6.0.1",
         "stylelint-scss": "^4.4.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "yargs": "^17.6.0",
         "yarn-deduplicate": "^6.0.1"
     },

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -19,7 +19,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^7.0.3",
         "mocha": "^10.2.0",
-        "typescript": "~4.6.2"
+        "typescript": "~4.8.4"
     },
     "repository": {
         "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/core/src/common/utils/compareUtils.ts
+++ b/packages/core/src/common/utils/compareUtils.ts
@@ -155,7 +155,7 @@ function isSimplePrimitiveType(value: any) {
     return typeof value === "number" || typeof value === "string" || typeof value === "boolean";
 }
 
-function filterKeys<T>(objA: T, objB: T, keys: KeyDenylist<T> | KeyAllowlist<T>) {
+function filterKeys<T extends object>(objA: T, objB: T, keys: KeyDenylist<T> | KeyAllowlist<T>) {
     if (isAllowlist(keys)) {
         return keys.include;
     } else if (isDenylist(keys)) {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -62,7 +62,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -68,7 +68,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -54,7 +54,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -100,5 +100,5 @@ function assertFunctionProp<T>(obj: T, key: keyof T) {
     if (obj[key] != null && Utils.isFunction(obj[key])) {
         return null;
     }
-    return new Error(`[Blueprint] Documentation context ${key} must be function.`);
+    return new Error(`[Blueprint] Documentation context ${key.toString()} must be function.`);
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -51,7 +51,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/monaco-editor-theme/package.json
+++ b/packages/monaco-editor-theme/package.json
@@ -28,7 +28,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^7.0.3",
         "npm-run-all": "^4.1.5",
-        "typescript": "~4.6.2"
+        "typescript": "~4.8.4"
     },
     "repository": {
         "type": "git",

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -37,14 +37,13 @@
         "postcss-simple-vars": "^7.0.1",
         "prettier": "~2.8.3",
         "sass": "^1.58.3",
-        "sass-extended-importer": "^0.4.2",
         "source-map-js": "^1.0.2",
         "strip-css-comments": "^5.0.0",
         "stylelint": "~14.16.0",
         "stylelint-junit-formatter": "^0.2.2",
         "svgo": "^1.3.2",
         "ts-node": "^10.9.1",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "yargs": "^17.6.0"
     },
     "devDependencies": {

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -65,7 +65,7 @@
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.13.1",
         "sass-inline-svg": "^1.2.3",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -60,7 +60,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -64,7 +64,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack": "^5.75.0"
     },
     "repository": {

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -25,7 +25,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^7.0.3",
         "react": "^16.13.1",
-        "typescript": "~4.6.2"
+        "typescript": "~4.8.4"
     },
     "repository": {
         "type": "git",

--- a/packages/timezone/package.json
+++ b/packages/timezone/package.json
@@ -62,7 +62,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.6.2",
+        "typescript": "~4.8.4",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,15 +1660,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.1.tgz#2f4f65bb08bc368ac39c96da7b2f09140b26851b"
   integrity sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==
 
-"@types/node@*", "@types/node@16.10.4", "@types/node@>=10.0.0":
+"@types/node@*", "@types/node@>=10.0.0":
   version "16.10.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.4.tgz#592f12b0b5f357533ddc3310b0176d42ea3e45d1"
   integrity sha512-EITwVTX5B4nDjXjGeQAfXOrm+Jn+qNjDmyDRtWoD+wZsl/RDPRTFRKivs4Mt74iOFlLOrE5+Kf+p5yjyhm3+cA==
-
-"@types/node@^15.9.0":
-  version "15.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
-  integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1734,11 +1729,6 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
-
-"@types/resolve@1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.1.tgz#3727e48042fda81e374f5d5cf2fa92288bf698f8"
-  integrity sha512-Ku5+GPFa12S3W26Uwtw+xyrtIpaZsGYHH6zxNbZlstmlvMYSZRzOwzwsXbxlVUbHyUucctSyuFtu6bNxwYomIw==
 
 "@types/retry@0.12.0":
   version "0.12.0"
@@ -3713,13 +3703,6 @@ cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
-
-crosspath@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/crosspath/-/crosspath-0.0.9.tgz#2ac42b39b3b83eeb25851a4058ccd0722baea520"
-  integrity sha512-lhDiWhqHk1IQ0BiGN9/Ji7qEr9LwCG8taDCTgihII/6b91my+GvTNXDB7eKh/FySz488tkt2IboqBJTSZtc4Fw==
-  dependencies:
-    "@types/node" "^15.9.0"
 
 css-declaration-sorter@^6.3.1:
   version "6.3.1"
@@ -7936,13 +7919,6 @@ minimalistic-assert@^1.0.0:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@5.0.1, minimatch@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
@@ -10135,17 +10111,6 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-extended-importer@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/sass-extended-importer/-/sass-extended-importer-0.4.2.tgz#58f86b8118d0739ba6e60797fa4f2744b6e0b3ee"
-  integrity sha512-3e9+iVB1vvoGS6ohq7OG2MiYvcwESkZqwV8g0uCDGvHeTt4kEt0E/T8eav18J03fvNFK1/mV47592E1tx1izgQ==
-  dependencies:
-    "@types/node" "16.10.4"
-    "@types/resolve" "1.20.1"
-    crosspath "0.0.9"
-    minimatch "3.0.4"
-    resolve "^1.20.0"
-
 sass-inline-svg@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/sass-inline-svg/-/sass-inline-svg-1.2.3.tgz#3dedfff55c13f1a96aac07740413be61f871c4bc"
@@ -11502,10 +11467,15 @@ typedoc@~0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-"typescript@^3 || ^4", typescript@^4.6.2, typescript@~4.6.2:
+"typescript@^3 || ^4", typescript@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
   integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
+typescript@~4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11467,12 +11467,7 @@ typedoc@~0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-"typescript@^3 || ^4", typescript@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
-
-typescript@~4.8.4:
+"typescript@^3 || ^4", typescript@^4.6.2, typescript@~4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION

#### Changes proposed in this pull request:

Upgrade to TypeScript v4.8.

I had issues with TypeScript v4.9 due to https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1368. We can probably work around that if we migrate to PNPM.

