### PR TITLE
[node-build-scripts] fix(sass-compile): relative path to mjs script

### DIFF
--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
+set -e
+set -o pipefail
+
 if [ $# -eq 0 ]; then
   echo "Usage: [OUTPUT=dir] sass-compile <directory> [...args]"
   exit 1
 fi
 
+node_build_scripts_dir="$( dirname "$(readlink -f "$0")" )"
+
 # set OUTPUT env varible to change output directory
 OUTPUT="${OUTPUT:-lib/css/}"
 
 # the `dart-sass` CLI doesn't support custom functions or importers, but the JS API does, so delegate to node
-node ../node-build-scripts/sass-compile.mjs --output $OUTPUT $@
+node $node_build_scripts_dir/sass-compile.mjs --output $OUTPUT $@


### PR DESCRIPTION

#### Changes proposed in this pull request:

Adjust `sass-compile.sh` so that it gets the path to the `node-build-scripts` folder correctly and is thus usable outside of this repo.

#### Reviewers should focus on:

N/A - if it passes the build, it should be g2g

