### PR TITLE
[webpack-build-scripts] fix: ProvidePlugin module path

### DIFF
--- a/packages/webpack-build-scripts/webpack.config.karma.mjs
+++ b/packages/webpack-build-scripts/webpack.config.karma.mjs
@@ -88,7 +88,7 @@ export default {
     plugins: [
         // HACKHACK: we should use an alternative to `process` in frontend code
         new webpack.ProvidePlugin({
-            process: "process/browser",
+            process: "process/browser.js",
         }),
 
         new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
the `process/browser` module was not getting resolved when using webpack-build-scripts outside this repo, and adding the `.js` file extension seemed to work. it will probably work for this repo too, so hopefully we can inline the fix to the module path this way.