### PR TITLE
Bvandercar/fix enter keypress on non button components

### DIFF
--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -163,7 +163,7 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
 
     private renderLeftPanel() {
         return (
-            <div className={Classes.MULTISTEP_DIALOG_LEFT_PANEL}>
+            <div className={Classes.MULTISTEP_DIALOG_LEFT_PANEL} role="tablist" aria-label="steps">
                 {this.getDialogStepChildren().filter(isDialogStepElement).map(this.renderDialogStep)}
             </div>
         );
@@ -173,6 +173,8 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
         const stepNumber = index + 1;
         const hasBeenViewed = this.state.lastViewedIndex >= index;
         const currentlySelected = this.state.selectedIndex === index;
+        const handleClickDialogStep =
+            index > this.state.lastViewedIndex ? undefined : this.getDialogStepChangeHandler(index);
         return (
             <div
                 className={classNames(Classes.DIALOG_STEP_CONTAINER, {
@@ -180,11 +182,13 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
                     [Classes.DIALOG_STEP_VIEWED]: hasBeenViewed,
                 })}
                 key={index}
+                aria-selected={currentlySelected}
+                role="tab"
             >
                 <div
                     className={Classes.DIALOG_STEP}
-                    onClick={this.handleClickDialogStep(index)}
-                    tabIndex={this.handleClickDialogStep(index) ? 0 : -1}
+                    onClick={handleClickDialogStep}
+                    tabIndex={handleClickDialogStep ? 0 : -1}
                     onKeyDown={e =>
                         e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined }))
                     }
@@ -194,13 +198,6 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
                 </div>
             </div>
         );
-    };
-
-    private handleClickDialogStep = (index: number) => {
-        if (index > this.state.lastViewedIndex) {
-            return;
-        }
-        return this.getDialogStepChangeHandler(index);
     };
 
     private maybeRenderRightPanel() {

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -68,7 +68,7 @@ export interface IMultistepDialogProps extends DialogProps {
     onChange?(
         newDialogStepId: DialogStepId,
         prevDialogStepId: DialogStepId | undefined,
-        event: React.MouseEvent<HTMLElement>,
+        event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
     ): void;
 
     /**
@@ -173,6 +173,8 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
         const stepNumber = index + 1;
         const hasBeenViewed = this.state.lastViewedIndex >= index;
         const currentlySelected = this.state.selectedIndex === index;
+        const handleClickDialogStep =
+            index > this.state.lastViewedIndex ? undefined : this.getDialogStepChangeHandler(index);
         return (
             <div
                 className={classNames(Classes.DIALOG_STEP_CONTAINER, {
@@ -181,19 +183,17 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
                 })}
                 key={index}
             >
-                <div className={Classes.DIALOG_STEP} onClick={this.handleClickDialogStep(index)}>
+                <div
+                    className={Classes.DIALOG_STEP}
+                    onClick={handleClickDialogStep}
+                    tabIndex={handleClickDialogStep ? 0 : -1}
+                    onKeyDown={e => e.key === "Enter" && handleClickDialogStep && handleClickDialogStep(e)}
+                >
                     <div className={Classes.DIALOG_STEP_ICON}>{stepNumber}</div>
                     <div className={Classes.DIALOG_STEP_TITLE}>{step.props.title}</div>
                 </div>
             </div>
         );
-    };
-
-    private handleClickDialogStep = (index: number) => {
-        if (index > this.state.lastViewedIndex) {
-            return;
-        }
-        return this.getDialogStepChangeHandler(index);
     };
 
     private maybeRenderRightPanel() {
@@ -262,7 +262,7 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
     }
 
     private getDialogStepChangeHandler(index: number) {
-        return (event: React.MouseEvent<HTMLElement>) => {
+        return (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
             if (this.props.onChange !== undefined) {
                 const steps = this.getDialogStepChildren();
                 const prevStepId = steps[this.state.selectedIndex].props.id;

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -68,7 +68,7 @@ export interface IMultistepDialogProps extends DialogProps {
     onChange?(
         newDialogStepId: DialogStepId,
         prevDialogStepId: DialogStepId | undefined,
-        event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
+        event: React.MouseEvent<HTMLElement>,
     ): void;
 
     /**
@@ -173,8 +173,6 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
         const stepNumber = index + 1;
         const hasBeenViewed = this.state.lastViewedIndex >= index;
         const currentlySelected = this.state.selectedIndex === index;
-        const handleClickDialogStep =
-            index > this.state.lastViewedIndex ? undefined : this.getDialogStepChangeHandler(index);
         return (
             <div
                 className={classNames(Classes.DIALOG_STEP_CONTAINER, {
@@ -185,15 +183,24 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
             >
                 <div
                     className={Classes.DIALOG_STEP}
-                    onClick={handleClickDialogStep}
-                    tabIndex={handleClickDialogStep ? 0 : -1}
-                    onKeyDown={e => e.key === "Enter" && handleClickDialogStep && handleClickDialogStep(e)}
+                    onClick={this.handleClickDialogStep(index)}
+                    tabIndex={this.handleClickDialogStep(index) ? 0 : -1}
+                    onKeyDown={e =>
+                        e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined }))
+                    }
                 >
                     <div className={Classes.DIALOG_STEP_ICON}>{stepNumber}</div>
                     <div className={Classes.DIALOG_STEP_TITLE}>{step.props.title}</div>
                 </div>
             </div>
         );
+    };
+
+    private handleClickDialogStep = (index: number) => {
+        if (index > this.state.lastViewedIndex) {
+            return;
+        }
+        return this.getDialogStepChangeHandler(index);
     };
 
     private maybeRenderRightPanel() {
@@ -262,7 +269,7 @@ export class MultistepDialog extends AbstractPureComponent2<MultistepDialogProps
     }
 
     private getDialogStepChangeHandler(index: number) {
-        return (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+        return (event: React.MouseEvent<HTMLElement>) => {
             if (this.props.onChange !== undefined) {
                 const steps = this.getDialogStepChildren();
                 const prevStepId = steps[this.state.selectedIndex].props.id;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -102,7 +102,8 @@ export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
-     * NOTE: if `listoption` or `none`, need to specify `onKeyDown` for enter key press to take effect.
+     * NOTE: if not `listoption`, need to specify `onKeyDown` or similar for enter key press
+     * to take effect.
      *
      * @default "menuitem"
      */

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -115,6 +115,11 @@ export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<
     multiline?: boolean;
 
     /**
+     * Called on click, and on enter keydown (unless `onKeyDown` manually overriden)
+     */
+    onClick?: (e: React.MouseEvent | React.KeyboardEvent) => void;
+
+    /**
      * Props to spread to `Popover`. Note that `content` and `minimal` cannot be
      * changed and `usePortal` defaults to `false` so all submenus will live in
      * the same container.
@@ -186,6 +191,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
             labelClassName,
             labelElement,
             multiline,
+            onClick,
             popoverProps,
             roleStructure = "menuitem",
             selected,
@@ -227,6 +233,8 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
+                onClick,
+                onKeyDown: e => (e.key === "Enter" && onClick ? onClick(e) : undefined),
                 role: targetRole,
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -102,9 +102,6 @@ export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
-     * NOTE: if not `listoption`, need to specify `onKeyDown` or similar for enter key press
-     * to take effect.
-     *
      * @default "menuitem"
      */
     roleStructure?: "menuitem" | "listoption" | "listitem" | "none";
@@ -230,6 +227,9 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
+                // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
+                onKeyDown: (e: React.KeyboardEvent) =>
+                    e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
                 role: targetRole,
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -102,6 +102,8 @@ export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
+     * NOTE: if `listoption` or `none`, need to specift `onKeyDown` for enter key press to take effect.
+     *
      * @default "menuitem"
      */
     roleStructure?: "menuitem" | "listoption" | "listitem" | "none";
@@ -113,11 +115,6 @@ export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<
      * @default false
      */
     multiline?: boolean;
-
-    /**
-     * Called on click, and on enter keydown (unless `onKeyDown` manually overriden)
-     */
-    onClick?: (e: React.MouseEvent | React.KeyboardEvent) => void;
 
     /**
      * Props to spread to `Popover`. Note that `content` and `minimal` cannot be
@@ -191,7 +188,6 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
             labelClassName,
             labelElement,
             multiline,
-            onClick,
             popoverProps,
             roleStructure = "menuitem",
             selected,
@@ -233,8 +229,6 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
-                onClick,
-                onKeyDown: e => (e.key === "Enter" && onClick ? onClick(e) : undefined),
                 role: targetRole,
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -102,7 +102,7 @@ export interface MenuItemProps extends ActionProps, LinkProps, IElementRefProps<
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
-     * NOTE: if `listoption` or `none`, need to specift `onKeyDown` for enter key press to take effect.
+     * NOTE: if `listoption` or `none`, need to specify `onKeyDown` for enter key press to take effect.
      *
      * @default "menuitem"
      */

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -71,7 +71,7 @@ export class TabTitle extends AbstractPureComponent2<TabTitleProps> {
                 id={generateTabTitleId(parentId, id)}
                 onClick={disabled ? undefined : this.handleClick}
                 role="tab"
-                tabIndex={disabled ? undefined : selected ? 0 : -1}
+                tabIndex={disabled ? undefined : selected ? -1 : 0}
             >
                 {icon != null && <Icon icon={icon} intent={intent} className={Classes.TAB_ICON} />}
                 {title}

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -25,6 +25,7 @@ import {
     Icon,
     IMenuItemProps,
     IMenuProps,
+    Keys,
     MenuItem,
     Popover,
     PopoverInteractionKind,
@@ -112,6 +113,14 @@ describe("MenuItem", () => {
         shallow(<MenuItem text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("click");
+        assert.isTrue(onClick.calledOnce);
+    });
+
+    it("pressing enter on MenuItem triggers onClick prop", () => {
+        const onClick = spy();
+        shallow(<MenuItem text="Graph" onClick={onClick} />)
+            .find("a")
+            .simulate("keydown", Keys.ENTER);
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -100,6 +100,7 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
                 disabled={!this.isShortcutInRange(shortcut.dateRange)}
                 key={index}
                 onClick={this.getShorcutClickHandler(shortcut, index)}
+                onKeyDown={this.getShorcutKeyDownHandler(shortcut, index)}
                 shouldDismissPopover={false}
                 text={shortcut.label}
             />
@@ -112,11 +113,11 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
         );
     }
 
-    private getShorcutClickHandler = (shortcut: DateRangeShortcut, index: number) => () => {
-        const { onShortcutClick } = this.props;
+    private getShorcutClickHandler = (shortcut: DateRangeShortcut, index: number) => () =>
+        this.props.onShortcutClick(shortcut, index);
 
-        onShortcutClick(shortcut, index);
-    };
+    private getShorcutKeyDownHandler = (shortcut: DateRangeShortcut, index: number) => (e: React.KeyboardEvent) =>
+        e.key === "Enter" && this.props.onShortcutClick(shortcut, index);
 
     private isShortcutInRange = (shortcutDateRange: DateRange) => {
         const { minDate, maxDate } = this.props;

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -100,7 +100,6 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
                 disabled={!this.isShortcutInRange(shortcut.dateRange)}
                 key={index}
                 onClick={this.getShorcutClickHandler(shortcut, index)}
-                onKeyDown={this.getShorcutKeyDownHandler(shortcut, index)}
                 shouldDismissPopover={false}
                 text={shortcut.label}
             />
@@ -113,11 +112,11 @@ export class Shortcuts extends React.PureComponent<IShortcutsProps> {
         );
     }
 
-    private getShorcutClickHandler = (shortcut: DateRangeShortcut, index: number) => () =>
-        this.props.onShortcutClick(shortcut, index);
+    private getShorcutClickHandler = (shortcut: DateRangeShortcut, index: number) => () => {
+        const { onShortcutClick } = this.props;
 
-    private getShorcutKeyDownHandler = (shortcut: DateRangeShortcut, index: number) => (e: React.KeyboardEvent) =>
-        e.key === "Enter" && this.props.onShortcutClick(shortcut, index);
+        onShortcutClick(shortcut, index);
+    };
 
     private isShortcutInRange = (shortcutDateRange: DateRange) => {
         const { minDate, maxDate } = this.props;

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -110,9 +110,6 @@ export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
-     * NOTE: if not `listoption`, need to specify `onKeyDown` or similar for enter key press
-     * to take effect.
-     *
      * @default "menuitem"
      */
     roleStructure?: "menuitem" | "listoption" | "listitem" | "none";
@@ -263,6 +260,9 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
         const target = React.createElement(
             tagName,
             {
+                // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
+                onKeyDown: (e: React.KeyboardEvent) =>
+                    e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
                 // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
                 role: hasSubmenu ? "none" : targetRole,
                 tabIndex: hasSubmenu ? -1 : 0,

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -110,7 +110,7 @@ export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
-     * NOTE: if `listoption` or `none`, need to specift `onKeyDown` for enter key press to take effect.
+     * NOTE: if `listoption` or `none`, need to specify `onKeyDown` for enter key press to take effect.
      *
      * @default "menuitem"
      */

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -110,7 +110,8 @@ export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
-     * NOTE: if `listoption` or `none`, need to specify `onKeyDown` for enter key press to take effect.
+     * NOTE: if not `listoption`, need to specify `onKeyDown` or similar for enter key press
+     * to take effect.
      *
      * @default "menuitem"
      */

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -110,6 +110,8 @@ export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps
      *
      * which can be used if wrapping this item in a custom `<li>` parent.
      *
+     * NOTE: if `listoption` or `none`, need to specift `onKeyDown` for enter key press to take effect.
+     *
      * @default "menuitem"
      */
     roleStructure?: "menuitem" | "listoption" | "listitem" | "none";
@@ -121,11 +123,6 @@ export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps
      * @default false
      */
     multiline?: boolean;
-
-    /**
-     * Called on click, and on enter keydown (unless `onKeyDown` manually overriden)
-     */
-    onClick?: (e: React.MouseEvent | React.KeyboardEvent) => void;
 
     /**
      * Props to spread to the submenu popover. Note that `content` and `minimal` cannot be
@@ -203,7 +200,6 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
             labelClassName,
             labelElement,
             multiline,
-            onClick,
             popoverProps,
             roleStructure = "menuitem",
             selected,
@@ -266,8 +262,6 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
         const target = React.createElement(
             tagName,
             {
-                onClick,
-                onKeyDown: e => (e.key === "Enter" && onClick ? onClick(e) : undefined),
                 // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
                 role: hasSubmenu ? "none" : targetRole,
                 tabIndex: hasSubmenu ? -1 : 0,

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -123,6 +123,11 @@ export interface MenuItem2Props extends ActionProps, LinkProps, IElementRefProps
     multiline?: boolean;
 
     /**
+     * Called on click, and on enter keydown (unless `onKeyDown` manually overriden)
+     */
+    onClick?: (e: React.MouseEvent | React.KeyboardEvent) => void;
+
+    /**
      * Props to spread to the submenu popover. Note that `content` and `minimal` cannot be
      * changed and `usePortal` defaults to `false` so all submenus will live in
      * the same container.
@@ -198,6 +203,7 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
             labelClassName,
             labelElement,
             multiline,
+            onClick,
             popoverProps,
             roleStructure = "menuitem",
             selected,
@@ -260,6 +266,8 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
         const target = React.createElement(
             tagName,
             {
+                onClick,
+                onKeyDown: e => (e.key === "Enter" && onClick ? onClick(e) : undefined),
                 // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
                 role: hasSubmenu ? "none" : targetRole,
                 tabIndex: hasSubmenu ? -1 : 0,

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -19,7 +19,7 @@ import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { Button, Classes, Icon, MenuProps, Text } from "@blueprintjs/core";
+import { Button, Classes, Icon, Keys, MenuProps, Text } from "@blueprintjs/core";
 
 import { MenuItem2, MenuItem2Props, Popover2, Popover2InteractionKind } from "../src";
 
@@ -99,6 +99,14 @@ describe("MenuItem2", () => {
         shallow(<MenuItem2 text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("click");
+        assert.isTrue(onClick.calledOnce);
+    });
+
+    it("pressing enter on MenuItem2 triggers onClick prop", () => {
+        const onClick = spy();
+        shallow(<MenuItem2 text="Graph" onClick={onClick} />)
+            .find("a")
+            .simulate("keydown", Keys.ENTER);
         assert.isTrue(onClick.calledOnce);
     });
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [X] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Enable pressing enter on `menuitem` components. React does not apply `onClick` when enter is pressed on a `role="menuitem"` component like it does for a `button`, apply fix for this.
