### PR TITLE
fix(MenuItem,MenuItem2): Enter keypress should trigger onClick

### DIFF
--- a/packages/core/src/common/utils/domUtils.ts
+++ b/packages/core/src/common/utils/domUtils.ts
@@ -142,3 +142,8 @@ function throttleImpl<T extends Function>(
     };
     return func as any as T;
 }
+
+export function clickElementOnKeyPress(keys: string[]) {
+    return (e: React.KeyboardEvent) =>
+        keys.some(key => e.key === key) && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined }));
+}

--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -16,6 +16,7 @@
 
 export * from "./compareUtils";
 export {
+    clickElementOnKeyPress,
     elementIsOrContains,
     elementIsTextInput,
     getActiveElement,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -22,6 +22,7 @@ import * as React from "react";
 
 import { AbstractPureComponent2, Classes, Position } from "../../common";
 import { ActionProps, DISPLAYNAME_PREFIX, IElementRefProps, LinkProps } from "../../common/props";
+import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
 import { IPopoverProps, Popover, PopoverInteractionKind } from "../popover/popover";
 import { Text } from "../text/text";
@@ -228,9 +229,7 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
             tagName,
             {
                 // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
-                onKeyDown: (e: React.KeyboardEvent) =>
-                    (e.key === "Enter" || e.key === " ") &&
-                    e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
+                onKeyDown: clickElementOnKeyPress(["Enter", " "]),
                 role: targetRole,
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -229,7 +229,8 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
             {
                 // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
                 onKeyDown: (e: React.KeyboardEvent) =>
-                    e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
+                    (e.key === "Enter" || e.key === " ") &&
+                    e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
                 role: targetRole,
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -227,6 +227,9 @@ export class MenuItem extends AbstractPureComponent2<MenuItemProps & React.Ancho
         const target = React.createElement(
             tagName,
             {
+                // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
+                onKeyDown: (e: React.KeyboardEvent) =>
+                    e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
                 role: targetRole,
                 tabIndex: 0,
                 ...htmlProps,

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -116,13 +116,16 @@ describe("MenuItem", () => {
         assert.isTrue(onClick.calledOnce);
     });
 
-    it("pressing enter on MenuItem triggers onClick prop", () => {
+    it("pressing enter on MenuItem triggers onClick prop", done => {
         const onClick = spy();
         shallow(<MenuItem text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("focus")
             .simulate("keydown", { keyCode: Keys.ENTER });
-        assert.isTrue(onClick.calledOnce);
+        setTimeout(() => {
+            assert.isTrue(onClick.calledOnce);
+            done();
+        }, 200);
     });
 
     it("Clicking disabled MenuItem does not trigger onClick prop", () => {

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -19,13 +19,14 @@ import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
+import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
+
 import {
     Button,
     Classes,
     Icon,
     IMenuItemProps,
     IMenuProps,
-    Keys,
     MenuItem,
     Popover,
     PopoverInteractionKind,
@@ -116,16 +117,13 @@ describe("MenuItem", () => {
         assert.isTrue(onClick.calledOnce);
     });
 
-    it("pressing enter on MenuItem triggers onClick prop", done => {
+    it("pressing enter on MenuItem triggers onClick prop", () => {
+        const testsContainerElement = document.createElement("div");
+        document.documentElement.appendChild(testsContainerElement);
         const onClick = spy();
-        shallow(<MenuItem text="Graph" onClick={onClick} />)
-            .find("a")
-            .simulate("focus")
-            .simulate("keydown", { keyCode: Keys.ENTER });
-        setTimeout(() => {
-            assert.isTrue(onClick.calledOnce);
-            done();
-        }, 200);
+        const wrapper = mount(<MenuItem text="Graph" onClick={onClick} />, { attachTo: testsContainerElement });
+        dispatchTestKeyboardEvent(wrapper.find("a").getDOMNode(), "keydown", "Enter");
+        assert.isTrue(onClick.calledOnce);
     });
 
     it("Clicking disabled MenuItem does not trigger onClick prop", () => {

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -25,6 +25,7 @@ import {
     Icon,
     IMenuItemProps,
     IMenuProps,
+    Keys,
     MenuItem,
     Popover,
     PopoverInteractionKind,
@@ -112,6 +113,14 @@ describe("MenuItem", () => {
         shallow(<MenuItem text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("click");
+        assert.isTrue(onClick.calledOnce);
+    });
+
+    it("pressing enter on MenuItem triggers onClick prop", () => {
+        const onClick = spy();
+        shallow(<MenuItem text="Graph" onClick={onClick} />)
+            .find("a")
+            .simulate("keydown", Keys.ENTER);
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -120,7 +120,8 @@ describe("MenuItem", () => {
         const onClick = spy();
         shallow(<MenuItem text="Graph" onClick={onClick} />)
             .find("a")
-            .simulate("keydown", { which: Keys.ENTER });
+            .simulate("focus")
+            .simulate("keydown", { keyCode: Keys.ENTER });
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -120,7 +120,7 @@ describe("MenuItem", () => {
         const onClick = spy();
         shallow(<MenuItem text="Graph" onClick={onClick} />)
             .find("a")
-            .simulate("keydown", Keys.ENTER);
+            .simulate("keydown", { which: Keys.ENTER });
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -29,6 +29,7 @@ import {
     MenuProps,
     removeNonHTMLProps,
     Text,
+    Utils,
 } from "@blueprintjs/core";
 
 import * as Classes from "./classes";
@@ -261,9 +262,7 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
             tagName,
             {
                 // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
-                onKeyDown: (e: React.KeyboardEvent) =>
-                    (e.key === "Enter" || e.key === " ") &&
-                    e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
+                onKeyDown: Utils.clickElementOnKeyPress(["Enter", " "]),
                 // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
                 role: hasSubmenu ? "none" : targetRole,
                 tabIndex: hasSubmenu ? -1 : 0,

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -262,7 +262,8 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
             {
                 // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
                 onKeyDown: (e: React.KeyboardEvent) =>
-                    e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
+                    (e.key === "Enter" || e.key === " ") &&
+                    e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
                 // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
                 role: hasSubmenu ? "none" : targetRole,
                 tabIndex: hasSubmenu ? -1 : 0,

--- a/packages/popover2/src/menuItem2.tsx
+++ b/packages/popover2/src/menuItem2.tsx
@@ -260,6 +260,9 @@ export class MenuItem2 extends AbstractPureComponent2<MenuItem2Props & React.Anc
         const target = React.createElement(
             tagName,
             {
+                // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
+                onKeyDown: (e: React.KeyboardEvent) =>
+                    e.key === "Enter" && e.target.dispatchEvent(new MouseEvent("click", { ...e, view: undefined })),
                 // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
                 role: hasSubmenu ? "none" : targetRole,
                 tabIndex: hasSubmenu ? -1 : 0,

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -106,7 +106,8 @@ describe("MenuItem2", () => {
         const onClick = spy();
         shallow(<MenuItem2 text="Graph" onClick={onClick} />)
             .find("a")
-            .simulate("keydown", { which: Keys.ENTER });
+            .simulate("focus")
+            .simulate("keydown", { keyCode: Keys.ENTER });
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -19,7 +19,7 @@ import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { Button, Classes, Icon, MenuProps, Text } from "@blueprintjs/core";
+import { Button, Classes, Icon, Keys, MenuProps, Text } from "@blueprintjs/core";
 
 import { MenuItem2, MenuItem2Props, Popover2, Popover2InteractionKind } from "../src";
 
@@ -99,6 +99,14 @@ describe("MenuItem2", () => {
         shallow(<MenuItem2 text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("click");
+        assert.isTrue(onClick.calledOnce);
+    });
+
+    it("pressing enter on MenuItem2 triggers onClick prop", () => {
+        const onClick = spy();
+        shallow(<MenuItem2 text="Graph" onClick={onClick} />)
+            .find("a")
+            .simulate("keydown", Keys.ENTER);
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -102,13 +102,16 @@ describe("MenuItem2", () => {
         assert.isTrue(onClick.calledOnce);
     });
 
-    it("pressing enter on MenuItem2 triggers onClick prop", () => {
+    it("pressing enter on MenuItem2 triggers onClick prop", done => {
         const onClick = spy();
         shallow(<MenuItem2 text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("focus")
             .simulate("keydown", { keyCode: Keys.ENTER });
-        assert.isTrue(onClick.calledOnce);
+        setTimeout(() => {
+            assert.isTrue(onClick.calledOnce);
+            done();
+        }, 200);
     });
 
     it("clicking disabled MenuItem2 does not trigger onClick prop", () => {

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -106,7 +106,7 @@ describe("MenuItem2", () => {
         const onClick = spy();
         shallow(<MenuItem2 text="Graph" onClick={onClick} />)
             .find("a")
-            .simulate("keydown", Keys.ENTER);
+            .simulate("keydown", { which: Keys.ENTER });
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -20,6 +20,7 @@ import * as React from "react";
 import { spy } from "sinon";
 
 import { Button, Classes, Icon, Keys, MenuProps, Text } from "@blueprintjs/core";
+import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
 import { MenuItem2, MenuItem2Props, Popover2, Popover2InteractionKind } from "../src";
 
@@ -102,16 +103,13 @@ describe("MenuItem2", () => {
         assert.isTrue(onClick.calledOnce);
     });
 
-    it("pressing enter on MenuItem2 triggers onClick prop", done => {
+    it("pressing enter on MenuItem2 triggers onClick prop", () => {
+        const testsContainerElement = document.createElement("div");
+        document.documentElement.appendChild(testsContainerElement);
         const onClick = spy();
-        shallow(<MenuItem2 text="Graph" onClick={onClick} />)
-            .find("a")
-            .simulate("focus")
-            .simulate("keydown", { keyCode: Keys.ENTER });
-        setTimeout(() => {
-            assert.isTrue(onClick.calledOnce);
-            done();
-        }, 200);
+        const wrapper = mount(<MenuItem2 text="Graph" onClick={onClick} />, { attachTo: testsContainerElement });
+        dispatchTestKeyboardEvent(wrapper.find("a").getDOMNode(), "keydown", "Enter");
+        assert.isTrue(onClick.calledOnce);
     });
 
     it("clicking disabled MenuItem2 does not trigger onClick prop", () => {

--- a/packages/popover2/test/menuItem2Tests.tsx
+++ b/packages/popover2/test/menuItem2Tests.tsx
@@ -19,7 +19,7 @@ import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { Button, Classes, Icon, Keys, MenuProps, Text } from "@blueprintjs/core";
+import { Button, Classes, Icon, MenuProps, Text } from "@blueprintjs/core";
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
 import { MenuItem2, MenuItem2Props, Popover2, Popover2InteractionKind } from "../src";


### PR DESCRIPTION
#### Fixes #6056

#### Checklist

- [X] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Enable pressing enter on `menuitem` components. React does not apply `onClick` when enter is pressed on a `role="menuitem"` component like it does for a button, apply fix for this.
