### PR TITLE
docs: update code sandbox template link

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -13,7 +13,7 @@ about: Something not working as expected?
 
 #### Code Sandbox
 
-Link to a minimal repro (fork [this code sandbox](https://codesandbox.io/s/blueprint-sandbox-et9xy)): <!-- here -->
+Link to a minimal repro (fork [this code sandbox](https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4)): <!-- here -->
 
 #### Steps to reproduce
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is optimized for building complex, data-dense web interfaces for _desktop app
 
 [**View the full documentation ▸**](http://blueprintjs.com/docs)
 
-[**Try it out on CodeSandbox ▸**](https://codesandbox.io/s/blueprint-sandbox-et9xy)
+[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4)
 
 [**Read frequently asked questions (FAQ) on the wiki ▸**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -25,7 +25,7 @@ export class Welcome extends React.PureComponent {
                 <WelcomeCard href="#blueprint/getting-started" icon="star" title="Getting started" sameTab={true} />
                 <WelcomeCard href="https://github.com/palantir/blueprint" icon="git-repo" title="Git repository" />
                 <WelcomeCard
-                    href="https://codesandbox.io/s/blueprint-sandbox-et9xy"
+                    href="https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4"
                     icon="code-block"
                     title="Code Sandbox"
                 />


### PR DESCRIPTION
New CodeSandbox environment: https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4

Previously, we were using the older version of CodeSandbox along with a deprecated [create-react-app-typescript boilerplate](https://github.com/wmonk/create-react-app-typescript).

The latest version of the CodeSandbox platform has a cloud-based option for more configurability and control over the build tasks.

I chose to base this new Blueprint template environment on one of the common modern templates which uses Vite for the build system. It seems to work well out of the box and requires little configuration. Also it's good to test that the published @blueprintjs packages are easy to consume with other bundlers that are not Webpack.

In the future, I could imagine this code living in this repo and being published as an NPM package named `@blueprintjs/codesandbox-template`. That way, it would get regularly updated without having to manually update the library version numbers in the CodeSandbox UI. Or it could live in a separate repo in the palantir org (this seems to be more in line with what CodeSandbox docs suggest).