### PR TITLE
[core] fix(MenuDivider): handle escape key to close popover

### DIFF
--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -51,7 +51,7 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
         } else {
             // section header with title
             return (
-                <li className={classNames(Classes.MENU_HEADER, className)} role="separator" tabIndex={0}>
+                <li className={classNames(Classes.MENU_HEADER, className)} role="separator" tabIndex={-1}>
                     <H6 id={titleId}>{title}</H6>
                 </li>
             );

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -51,7 +51,7 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
         } else {
             // section header with title
             return (
-                <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
+                <li className={classNames(Classes.MENU_HEADER, className)} role="separator" tabIndex={0}>
                     <H6 id={titleId}>{title}</H6>
                 </li>
             );


### PR DESCRIPTION
#### Fixes #6054

#### Changes proposed in this pull request:

Previously MenuDivider did not handle escape key to close popover. This should fix that.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
