### PR TITLE
[select] fix(Select2): check shouldDismissPopover on menu items

### DIFF
--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -300,8 +300,7 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
         // event.target.closest(Classes.MENU_ITEM)?.matches(Classes.POPOVER_DISMISS)
         const target = event?.target as HTMLElement;
         const shouldDismiss =
-            target?.closest(`.${CoreClasses.MENU_ITEM}`)?.classList?.contains(Popover2Classes.POPOVER2_DISMISS) ??
-            false;
+            target?.closest(`.${CoreClasses.MENU_ITEM}`)?.classList?.contains(Popover2Classes.POPOVER2_DISMISS) ?? true;
 
         this.setState({ isOpen: !shouldDismiss });
         this.props.onItemSelect?.(item, event);

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -297,7 +297,6 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
     };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
-        // event.target.closest(Classes.MENU_ITEM)?.matches(Classes.POPOVER_DISMISS)
         const target = event?.target as HTMLElement;
         const shouldDismiss =
             target?.closest(`.${CoreClasses.MENU_ITEM}`)?.classList?.contains(Popover2Classes.POPOVER2_DISMISS) ?? true;

--- a/packages/select/src/components/select/select2.tsx
+++ b/packages/select/src/components/select/select2.tsx
@@ -31,7 +31,13 @@ import {
     setRef,
     Utils,
 } from "@blueprintjs/core";
-import { Popover2, Popover2ClickTargetHandlers, Popover2TargetProps, PopupKind } from "@blueprintjs/popover2";
+import {
+    Popover2,
+    Classes as Popover2Classes,
+    Popover2ClickTargetHandlers,
+    Popover2TargetProps,
+    PopupKind,
+} from "@blueprintjs/popover2";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { QueryList, QueryListRendererProps } from "../query-list/queryList";
@@ -291,7 +297,13 @@ export class Select2<T> extends AbstractPureComponent2<Select2Props<T>, Select2S
     };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
-        this.setState({ isOpen: false });
+        // event.target.closest(Classes.MENU_ITEM)?.matches(Classes.POPOVER_DISMISS)
+        const target = event?.target as HTMLElement;
+        const shouldDismiss =
+            target?.closest(`.${CoreClasses.MENU_ITEM}`)?.classList?.contains(Popover2Classes.POPOVER2_DISMISS) ??
+            false;
+
+        this.setState({ isOpen: !shouldDismiss });
         this.props.onItemSelect?.(item, event);
     };
 

--- a/packages/select/test/select2Tests.tsx
+++ b/packages/select/test/select2Tests.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import * as sinon from "sinon";
 
 import { InputGroup, Keys, MenuItem } from "@blueprintjs/core";
-import { Popover2 } from "@blueprintjs/popover2";
+import { MenuItem2, Popover2 } from "@blueprintjs/popover2";
 
 import { ItemRendererProps, Select2, Select2Props, Select2State } from "../src";
 import { Film, renderFilm, TOP_100_FILMS } from "../src/__examples__";
@@ -126,6 +126,42 @@ describe("<Select2>", () => {
         const wrapper = select();
         wrapper.find(Popover2).find(MenuItem).first().simulate("click");
         assert.isTrue(handlers.onItemSelect.calledOnce);
+    });
+
+    it("closes the popover when selecting first MenuItem", () => {
+        const itemRenderer = (film: Film) => {
+            return <MenuItem2 text={`${film.rank}. ${film.title}`} shouldDismissPopover={true} />;
+        };
+        const wrapper = select({ itemRenderer, popoverProps: { usePortal: false } });
+
+        // popover should start close
+        assert.strictEqual(wrapper.find(Popover2).prop("isOpen"), false);
+
+        // popover should open after clicking the button
+        wrapper.find("[data-testid='target-button']").simulate("click");
+        assert.strictEqual(wrapper.find(Popover2).prop("isOpen"), true);
+
+        // and should close after the a menu item is clicked
+        wrapper.find(Popover2).find(".bp4-menu-item").first().simulate("click");
+        assert.strictEqual(wrapper.find(Popover2).prop("isOpen"), false);
+    });
+
+    it("does not close the popover when selecting a MenuItem with shouldDismissPopover", () => {
+        const itemRenderer = (film: Film) => {
+            return <MenuItem2 text={`${film.rank}. ${film.title}`} shouldDismissPopover={false} />;
+        };
+        const wrapper = select({ itemRenderer, popoverProps: { usePortal: false } });
+
+        // popover should start closed
+        assert.strictEqual(wrapper.find(Popover2).prop("isOpen"), false);
+
+        // popover should open after clicking the button
+        wrapper.find("[data-testid='target-button']").simulate("click");
+        assert.strictEqual(wrapper.find(Popover2).prop("isOpen"), true);
+
+        // and should not close after the a menu item is clicked
+        wrapper.find(Popover2).find(".bp4-menu-item").first().simulate("click");
+        assert.strictEqual(wrapper.find(Popover2).prop("isOpen"), true);
     });
 
     function select(props: Partial<Select2Props<Film>> = {}, query?: string) {


### PR DESCRIPTION
#### Fixes #4001

#### Checklist

- [X] Includes tests
- [ ] Update documentation
Don't see a need to update docs because it fixes a feature that should be working.
<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes problem where popover was closing on selection despite shouldDismissPopover being set to false on MenuItem2. 

#### Reviewers should focus on:

Ensuring popover open state is updated correctly

#### Screenshot
N/A