### PR TITLE
[popover2] feat(ContextMenu2): allow popover placement override

### DIFF
--- a/packages/popover2/src/contextMenu2Shared.ts
+++ b/packages/popover2/src/contextMenu2Shared.ts
@@ -25,6 +25,11 @@ export type Offset = {
 
 /**
  * A limited subset of props to forward along to the context menu popover overlay.
+ *
+ * Overriding `placement` is not recommended, as users expect context menus to open towards the bottom right
+ * of their cursor, which is the default placement. However, this option is provided to help with rare cases where
+ * the menu is triggered at the bottom and/or right edge of a window and the built-in popover flipping behavior does
+ * not work effectively.
  */
 export type ContextMenu2PopoverOptions = OverlayLifecycleProps &
-    Pick<Popover2Props, "popoverClassName" | "transitionDuration" | "popoverRef" | "rootBoundary">;
+    Pick<Popover2Props, "placement" | "popoverClassName" | "transitionDuration" | "popoverRef" | "rootBoundary">;


### PR DESCRIPTION
#### Fixes #6048

#### Changes proposed in this pull request:

Allow overriding context menu placement with `<ContextMenu2 popoverProps={{ placement }}>` or `showContextMenu({ placement })`

