### PR TITLE
[table] feat(ColumnHeaderCell2): support menu popover props

### DIFF
--- a/packages/table/src/headers/columnHeaderCell2.tsx
+++ b/packages/table/src/headers/columnHeaderCell2.tsx
@@ -17,17 +17,22 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent2, Utils as CoreUtils, DISPLAYNAME_PREFIX, Icon } from "@blueprintjs/core";
-import { Popover2 } from "@blueprintjs/popover2";
+import {
+    AbstractPureComponent2,
+    Utils as CoreUtils,
+    DISPLAYNAME_PREFIX,
+    Icon,
+    OverlayLifecycleProps,
+} from "@blueprintjs/core";
+import { Popover2, Popover2Props } from "@blueprintjs/popover2";
 
 import * as Classes from "../common/classes";
 import { LoadableContent } from "../common/loadableContent";
 import { CLASSNAME_EXCLUDED_FROM_TEXT_MEASUREMENT } from "../common/utils";
-import { HorizontalCellDivider, IColumnHeaderCellProps, IColumnHeaderCellState } from "./columnHeaderCell";
+import { ColumnHeaderCellProps, HorizontalCellDivider, IColumnHeaderCellState } from "./columnHeaderCell";
 import { HeaderCell2 } from "./headerCell2";
 
-// eslint-disable-next-line deprecation/deprecation
-export interface ColumnHeaderCell2Props extends IColumnHeaderCellProps {
+export interface ColumnHeaderCell2Props extends ColumnHeaderCellProps {
     /**
      * If `true`, adds an interaction bar on top of all column header cells, and
      * moves interaction triggers into it.
@@ -35,6 +40,12 @@ export interface ColumnHeaderCell2Props extends IColumnHeaderCellProps {
      * @default false
      */
     enableColumnInteractionBar?: boolean;
+
+    /**
+     * Optional props to forward to the dropdown menu popover.
+     * This has no effect if `menuRenderer` is undefined.
+     */
+    menuPopoverProps?: Omit<Popover2Props, "content" | keyof OverlayLifecycleProps>;
 
     /**
      * If `true`, clicks on the header menu target element will cause the column's
@@ -153,7 +164,7 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCell2P
     }
 
     private maybeRenderDropdownMenu() {
-        const { index, menuIcon, menuRenderer, selectCellsOnMenuClick } = this.props;
+        const { index, menuIcon, menuPopoverProps, menuRenderer, selectCellsOnMenuClick } = this.props;
 
         if (!CoreUtils.isFunction(menuRenderer)) {
             return undefined;
@@ -168,12 +179,13 @@ export class ColumnHeaderCell2 extends AbstractPureComponent2<ColumnHeaderCell2P
             <div className={classes}>
                 <div className={Classes.TABLE_TH_MENU_CONTAINER_BACKGROUND} />
                 <Popover2
-                    className={Classes.TABLE_TH_MENU}
+                    className={classNames(Classes.TABLE_TH_MENU, menuPopoverProps?.className)}
                     content={menuRenderer(index)}
                     onClosing={this.handlePopoverClosing}
                     onOpened={this.handlePopoverOpened}
                     placement="bottom"
                     rootBoundary="document"
+                    {...menuPopoverProps}
                 >
                     <Icon icon={menuIcon} />
                 </Popover2>


### PR DESCRIPTION
#### Fixes #6035

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add a new prop `menuPopoverProps` to `<ColumnHeaderCell2>` to allow overriding (most, not all) Popover2 props.
