### PR TITLE
[datetime2] fix(TimezoneSelect): items should dismiss popover

### DIFF
--- a/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
@@ -237,7 +237,6 @@ export class TimezoneSelect extends AbstractPureComponent2<TimezoneSelectProps, 
                 text={`${item.label}, ${item.longName}`}
                 onClick={handleClick}
                 label={item.shortName}
-                shouldDismissPopover={false}
             />
         );
     };


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/pull/6070#issuecomment-1515244820

#6070 surfaced some buggy behavior. We were specifying `shouldDismissPopover={false}` on these items, when we really shouldn't be.


