### PR TITLE
[popover2] fix(ContextMenu2Popover): support overrides correctly

### DIFF
--- a/packages/popover2/src/contextMenu2Popover.tsx
+++ b/packages/popover2/src/contextMenu2Popover.tsx
@@ -71,6 +71,9 @@ export const ContextMenu2Popover = React.memo(function _ContextMenu2Popover(prop
 
     return (
         <Popover2
+            placement="right-start"
+            rootBoundary={rootBoundary}
+            transitionDuration={transitionDuration}
             {...popoverProps}
             content={
                 // this prevents right-clicking inside our context menu
@@ -87,11 +90,8 @@ export const ContextMenu2Popover = React.memo(function _ContextMenu2Popover(prop
             popoverClassName={classNames(Classes.CONTEXT_MENU2_POPOVER2, popoverClassName, {
                 [CoreClasses.DARK]: isDarkTheme,
             })}
-            placement="right-start"
             positioningStrategy="fixed"
-            rootBoundary={rootBoundary}
             renderTarget={renderTarget}
-            transitionDuration={transitionDuration}
         />
     );
 });

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -116,6 +116,20 @@ describe("ContextMenu2", () => {
             assert.isFalse(wrapperClickSpy.called, "ctx menu wrapper click handler should not be called");
         });
 
+        it("allows overrding some Popover2 props", () => {
+            const placement = "top";
+            const popoverClassName = "test-popover-class";
+            const ctxMenu = mountTestMenu({ popoverProps: { placement, popoverClassName } });
+            openCtxMenu(ctxMenu);
+            const popoverWithTopPlacement = document.querySelector(
+                `.${popoverClassName}.${Classes.POPOVER2_CONTENT_PLACEMENT}-${placement}`,
+            );
+            assert.exists(
+                popoverWithTopPlacement,
+                `popover element with custom class '${popoverClassName}' and '${placement}' placement should exist`,
+            );
+        });
+
         function mountTestMenu(props: Partial<ContextMenu2Props> = {}) {
             return mount(
                 <ContextMenu2 content={MENU} popoverProps={{ transitionDuration: 0 }} {...props}>


### PR DESCRIPTION

#### Changes proposed in this pull request:

Actually implement the behavior change intended in https://github.com/palantir/blueprint/pull/6078. ContextMenu2Popover now allows some of its Popover2 props to be overridden. Added a unit test.

