### PR TITLE
[core] feat(Overlay, Portal): allow portal to stop event propagation

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -110,11 +110,13 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
     portalContainer?: HTMLElement;
 
     /**
-     * A list of DOM events to pass to the portal to stop propagation on.
+     * A list of DOM events which should be stopped from propagating through the Portal.
      * This prop is ignored if `usePortal` is `false`.
-     * Stopgap resolution for https://github.com/facebook/react/issues/11387
+     *
+     * @see https://legacy.reactjs.org/docs/portals.html#event-bubbling-through-portals
+     * @see https://github.com/palantir/blueprint/issues/6124
      */
-    stopPropagationEvents?: Array<keyof HTMLElementEventMap>;
+    portalStopPropagationEvents?: Array<keyof HTMLElementEventMap>;
 
     /**
      * A callback that is invoked when user interaction causes the overlay to close, such as
@@ -328,7 +330,7 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
                 <Portal
                     className={this.props.portalClassName}
                     container={this.props.portalContainer}
-                    stopPropagationEvents={this.props.stopPropagationEvents}
+                    stopPropagationEvents={this.props.portalStopPropagationEvents}
                 >
                     {transitionGroup}
                 </Portal>

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -110,6 +110,13 @@ export interface IOverlayableProps extends IOverlayLifecycleProps {
     portalContainer?: HTMLElement;
 
     /**
+     * A list of DOM events to pass to the portal to stop propagation on.
+     * This prop is ignored if `usePortal` is `false`.
+     * Stopgap resolution for https://github.com/facebook/react/issues/11387
+     */
+    stopPropagationEvents?: Array<keyof HTMLElementEventMap>;
+
+    /**
      * A callback that is invoked when user interaction causes the overlay to close, such as
      * clicking on the overlay or pressing the `esc` key (if enabled).
      *
@@ -318,7 +325,11 @@ export class Overlay extends AbstractPureComponent2<OverlayProps, IOverlayState>
         );
         if (usePortal) {
             return (
-                <Portal className={this.props.portalClassName} container={this.props.portalContainer}>
+                <Portal
+                    className={this.props.portalClassName}
+                    container={this.props.portalContainer}
+                    stopPropagationEvents={this.props.stopPropagationEvents}
+                >
                     {transitionGroup}
                 </Portal>
             );

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -42,8 +42,10 @@ export interface IPortalProps extends Props {
     container?: HTMLElement;
 
     /**
-     * A list of DOM events to stop propagation on.
-     * Stopgap resolution for https://github.com/facebook/react/issues/11387
+     * A list of DOM events which should be stopped from propagating through this portal element.
+     *
+     * @see https://legacy.reactjs.org/docs/portals.html#event-bubbling-through-portals
+     * @see https://github.com/palantir/blueprint/issues/6124
      */
     stopPropagationEvents?: Array<keyof HTMLElementEventMap>;
 }
@@ -109,7 +111,7 @@ export class Portal extends React.Component<PortalProps, IPortalState> {
         }
         this.portalElement = this.createContainerElement();
         this.props.container.appendChild(this.portalElement);
-        this.addEventListeners(this.props.stopPropagationEvents);
+        this.addStopPropagationListeners(this.props.stopPropagationEvents);
         /* eslint-disable-next-line react/no-did-mount-set-state */
         this.setState({ hasMounted: true }, this.props.onChildrenMount);
     }
@@ -120,14 +122,15 @@ export class Portal extends React.Component<PortalProps, IPortalState> {
             maybeRemoveClass(this.portalElement.classList, prevProps.className);
             maybeAddClass(this.portalElement.classList, this.props.className);
         }
-        if(this.portalElement != null && prevProps.stopPropagationEvents !== this.props.stopPropagationEvents) {
-            this.removeEventListeners(prevProps.stopPropagationEvents);
-            this.addEventListeners(this.props.stopPropagationEvents);
+
+        if (this.portalElement != null && prevProps.stopPropagationEvents !== this.props.stopPropagationEvents) {
+            this.removeStopPropagationListeners(prevProps.stopPropagationEvents);
+            this.addStopPropagationListeners(this.props.stopPropagationEvents);
         }
     }
 
     public componentWillUnmount() {
-        this.removeEventListeners(this.props.stopPropagationEvents);
+        this.removeStopPropagationListeners(this.props.stopPropagationEvents);
         this.portalElement?.remove();
     }
 
@@ -141,18 +144,12 @@ export class Portal extends React.Component<PortalProps, IPortalState> {
         return container;
     }
 
-    private addEventListeners(events?: Array<keyof HTMLElementEventMap>) {
-        if (events == null || events.length === 0) {
-            return;
-        }
-        events.map(event => this.portalElement?.addEventListener(event, handleStopProgation));
+    private addStopPropagationListeners(eventNames?: Array<keyof HTMLElementEventMap>) {
+        eventNames?.forEach(event => this.portalElement?.addEventListener(event, handleStopProgation));
     }
 
-    private removeEventListeners(events?: Array<keyof HTMLElementEventMap>) {
-        if (events == null || events.length === 0) {
-            return;
-        }
-        events.map(event => this.portalElement?.removeEventListener(event, handleStopProgation));
+    private removeStopPropagationListeners(events?: Array<keyof HTMLElementEventMap>) {
+        events?.forEach(event => this.portalElement?.removeEventListener(event, handleStopProgation));
     }
 }
 


### PR DESCRIPTION
#### Works around https://github.com/facebook/react/issues/11387
#### Fixes https://github.com/palantir/blueprint/issues/6124

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Currently react have a [longstanding issue](https://github.com/facebook/react/issues/11387) where portals propagate events up the react tree. This PR allows a list of events to be passed in to prevent propagation through the portal on.

#### Reviewers should focus on:
Whether or not this should be configurable, or if we should always stopPropagation on events on the portal element.

#### Screenshot

No user facing changes.
