### PR TITLE
[v5] [core] fix: refactor button prop types

### DIFF
--- a/packages/core/src/components/button/buttonProps.ts
+++ b/packages/core/src/components/button/buttonProps.ts
@@ -14,28 +14,12 @@
  * limitations under the License.
  */
 
+import React from "react";
+
 import type { ActionProps, Alignment, MaybeElement } from "../../common";
 import type { IconName } from "../icon/icon";
 
-/**
- * Props interface for both the Button and AnchorButton components.
- *
- * Note that it is useful for the props for the two components to be assignable to each other, which we can allow
- * by omitting the `ref` prop as `DialogStepButton` does. This is mostly for backwards compatibility, but it is
- * a feature we like to preserve because the components are so similar and distinguishing between them in their event
- * handlers is usually unnecessary. For this reason, we extend `ActionProps<HTMLElement>` rather than `ActionProps<E>`.
- *
- * @see {@link ActionProps}
- */
-export type ButtonProps<E extends HTMLButtonElement | HTMLAnchorElement = HTMLButtonElement> =
-    ActionProps<HTMLElement> &
-        React.RefAttributes<E> &
-        (E extends HTMLButtonElement
-            ? React.ButtonHTMLAttributes<HTMLButtonElement>
-            : React.AnchorHTMLAttributes<HTMLAnchorElement>) &
-        ButtonSharedProps;
-
-interface ButtonSharedProps {
+export interface ButtonSharedProps extends ActionProps<HTMLElement> {
     /**
      * If set to `true`, the button will display in an active state.
      * This is equivalent to setting `className={Classes.ACTIVE}`.
@@ -92,3 +76,19 @@ interface ButtonSharedProps {
      */
     type?: "submit" | "reset" | "button";
 }
+
+/**
+ * Props interface assignable to both the Button and AnchorButton components.
+ *
+ * It is useful for the props for the two components to be assignable to each other because the components
+ * are so similar and distinguishing between them in their event handlers is usually unnecessary.
+ */
+export type ButtonSharedPropsAndAttributes = ButtonSharedProps & React.HTMLAttributes<HTMLElement>;
+
+export type ButtonProps = ButtonSharedProps &
+    React.ButtonHTMLAttributes<HTMLButtonElement> &
+    React.RefAttributes<HTMLButtonElement>;
+
+export type AnchorButtonProps = ButtonSharedProps &
+    React.AnchorHTMLAttributes<HTMLAnchorElement> &
+    React.RefAttributes<HTMLAnchorElement>;

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -24,11 +24,7 @@ import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { mergeRefs } from "../../common/refs";
 import { Icon } from "../icon/icon";
 import { Spinner } from "../spinner/spinner";
-import { ButtonProps } from "./buttonProps";
-
-export { ButtonProps };
-
-export type AnchorButtonProps = ButtonProps<HTMLAnchorElement>;
+import { AnchorButtonProps, ButtonProps } from "./buttonProps";
 
 /**
  * Button component.
@@ -75,7 +71,7 @@ AnchorButton.displayName = `${DISPLAYNAME_PREFIX}.AnchorButton`;
  * Most of the button logic lives in this shared hook.
  */
 function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonElement>(
-    props: ButtonProps<E>,
+    props: E extends HTMLAnchorElement ? AnchorButtonProps : ButtonProps,
     ref: React.Ref<E>,
 ) {
     const { active = false, alignText, fill, large, loading = false, outlined, minimal, small, tabIndex } = props;
@@ -159,7 +155,9 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
 /**
  * Shared rendering code for button contents.
  */
-function renderButtonContents<E extends HTMLAnchorElement | HTMLButtonElement>(props: ButtonProps<E>) {
+function renderButtonContents<E extends HTMLAnchorElement | HTMLButtonElement>(
+    props: E extends HTMLAnchorElement ? AnchorButtonProps : ButtonProps,
+) {
     const { children, icon, loading, rightIcon, text } = props;
     const hasTextContent = !Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children);
     return (

--- a/packages/core/src/components/dialog/dialogStepButton.tsx
+++ b/packages/core/src/components/dialog/dialogStepButton.tsx
@@ -16,20 +16,17 @@
 
 import React from "react";
 
-import { AnchorButton, ButtonProps } from "../button/buttons";
+import { ButtonSharedPropsAndAttributes } from "../button/buttonProps";
+import { AnchorButton } from "../button/buttons";
 import { Tooltip, TooltipProps } from "../tooltip/tooltip";
 
-// omit "ref", which is the only property with a different type in ButtonProps vs. AnchorButtonProps
-export type DialogStepButtonProps = Partial<Omit<ButtonProps, "ref">> & {
+export type DialogStepButtonProps = Partial<ButtonSharedPropsAndAttributes> & {
     /** If defined, the button will be wrapped with a tooltip with the specified content. */
     // eslint-disable-next-line deprecation/deprecation
     tooltipContent?: TooltipProps["content"];
 };
 
 export function DialogStepButton({ tooltipContent, ...props }: DialogStepButtonProps) {
-    // TODO(adahiya): MUST FIX FOR Blueprint v5 (tsc suppression)
-    // see https://github.com/palantir/blueprint/issues/6094
-    // @ts-ignore
     const button = <AnchorButton {...props} />;
 
     if (tooltipContent !== undefined) {

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -17,7 +17,13 @@
 export { Alert, AlertProps } from "./alert/alert";
 export { Breadcrumb, BreadcrumbProps } from "./breadcrumbs/breadcrumb";
 export { Breadcrumbs, BreadcrumbsProps } from "./breadcrumbs/breadcrumbs";
-export { AnchorButton, AnchorButtonProps, Button, ButtonProps } from "./button/buttons";
+export { AnchorButton, Button } from "./button/buttons";
+export type {
+    AnchorButtonProps,
+    ButtonProps,
+    ButtonSharedProps,
+    ButtonSharedPropsAndAttributes,
+} from "./button/buttonProps";
 export { ButtonGroup, ButtonGroupProps } from "./button/buttonGroup";
 export { Callout, CalloutProps } from "./callout/callout";
 export { Card, CardProps } from "./card/card";


### PR DESCRIPTION
Simplifying Button & AnchorButton prop types, while preserving assignability where it matters (DialogStepButton)