### PR TITLE
[v5] fix: revert React synthetic default import

### DIFF
--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { isNodeEnv } from "./utils";
 

--- a/packages/core/src/common/abstractPureComponent.ts
+++ b/packages/core/src/common/abstractPureComponent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { isNodeEnv } from "./utils";
 

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import type { IconName } from "@blueprintjs/icons";
 

--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export function isRefObject<T>(value: React.Ref<T> | undefined): value is React.RefObject<T> {
     return value != null && typeof value !== "function";

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 /**
  * Returns true if `node` is null/undefined, false, empty string, or an array

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Intent, MaybeElement, Props } from "../../common";
 import {

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { ActionProps, Classes, LinkProps } from "../../common";
 import { Icon } from "../icon/icon";

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -15,7 +15,7 @@ breadcrumbs that do not fit in the available space.
 
 ```tsx
 import { Breadcrumbs, BreadcrumbProps, Icon } from "@blueprintjs/core";
-import React from "react";
+import * as React from "react";
 
 const BREADCRUMBS: BreadcrumbProps[] = [
     { href: "/users", icon: "folder-close", text: "Users" },

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Boundary, Classes, Props, removeNonHTMLProps } from "../../common";
 import { Menu } from "../menu/menu";

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { IconName } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, Elevation } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Props, Utils } from "../../common";
 import { TooltipContext, TooltipProvider } from "../popover/tooltipContext";

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Popover } from "../popover/popover";

--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { Classes } from "../../common";
 import { ContextMenuPopover, ContextMenuPopoverProps } from "./contextMenuPopover";

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { IconName, IconSize, SmallCross } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/dialog/dialogBody.tsx
+++ b/packages/core/src/components/dialog/dialogBody.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { Props } from "../../common/props";

--- a/packages/core/src/components/dialog/dialogFooter.tsx
+++ b/packages/core/src/components/dialog/dialogFooter.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { Props } from "../../common/props";

--- a/packages/core/src/components/dialog/dialogStep.tsx
+++ b/packages/core/src/components/dialog/dialogStep.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/dialog/dialogStepButton.tsx
+++ b/packages/core/src/components/dialog/dialogStepButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AnchorButton, ButtonProps } from "../button/buttons";
 import { Tooltip, TooltipProps } from "../tooltip/tooltip";

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, Position, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent } from "../../common";
 import { DIVIDER } from "../../common/classes";

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { IconName, IconSize, SmallCross } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";

--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import * as Errors from "../../common/errors";

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { ChevronDown, ChevronUp } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, OptionProps, Props } from "../../common";
 import * as Errors from "../../common/errors";

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { HotkeyConfig } from "../../hooks";

--- a/packages/core/src/components/hotkeys/hotkeys-target.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target.md
@@ -17,7 +17,7 @@ React application.
 Then, to register hotkeys and generate the relevant event handlers, use the component like so:
 
 ```tsx
-import React from "react";
+import * as React from "react";
 import { HotkeysTarget, InputGroup } from "@blueprintjs/core";
 
 export default class extends React.PureComponent {

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";

--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "../../common";
 import { HotkeyConfig } from "../../hooks";

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { Icon, IconName } from "../icon/icon";

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { H6 } from "../html/html";

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { CaretRight } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { IconName, IconSize } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Boundary, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Button } from "../button/buttons";

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -16,7 +16,7 @@
 
 import { State as PopperState, PositioningStrategy } from "@popperjs/core";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import { Manager, Modifier, Popper, PopperChildrenProps, Reference, ReferenceChildrenProps } from "react-popper";
 
 import {

--- a/packages/core/src/components/popover/popoverArrow.tsx
+++ b/packages/core/src/components/popover/popoverArrow.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Placement } from "@popperjs/core";
-import React from "react";
+import * as React from "react";
 import { PopperArrowProps } from "react-popper";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -15,7 +15,7 @@
  */
 
 import { Boundary, Modifier, Placement, placements, RootBoundary, StrictModifiers } from "@popperjs/core";
-import React from "react";
+import * as React from "react";
 import { StrictModifier } from "react-popper";
 
 import { Position, Props } from "../../common";

--- a/packages/core/src/components/popover/tooltipContext.tsx
+++ b/packages/core/src/components/popover/tooltipContext.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export interface TooltipContextState {
     forceDisabled?: boolean;

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -14,8 +14,8 @@ components which use portals (popovers, tooltips, dialogs, etc.). You can do so 
 
 ```tsx
 import { Button, Popover, PortalProvider } from "@blueprintjs/core";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 ReactDOM.render(
     <PortalProvider portalClassName="my-custom-class">

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -19,8 +19,8 @@
  * will be removed in Blueprint v6.0.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { ValidationMap } from "../../common/context";

--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, Keys } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Intent, IntentProps, Props, Utils } from "../../common";
 import * as Errors from "../../common/errors";

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, Intent } from "../../common";
 import * as Errors from "../../common/errors";

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { IconName } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Keys, Props, Utils } from "../../common";
 import { Tab, TabId, TabProps } from "./tab";

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { IconName, IconSize } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -15,8 +15,8 @@
  */
 
 import classNames from "classnames";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { AbstractPureComponent, Classes, Position } from "../../common";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID, TOASTER_WARN_INLINE } from "../../common/errors";

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -99,7 +99,7 @@ export const AppToaster = OverlayToaster.create({
 
 ```tsx
 import { Button } from "@blueprintjs/core";
-import React from "react";
+import * as React from "react";
 import { AppToaster } from "./toaster";
 
 export class App extends React.PureComponent {
@@ -125,7 +125,7 @@ optionally attach a `ref` handler to access the instance methods, but we strongl
 
 ```tsx
 import { Button, Position, Toast, OverlayToaster, Toaster } from "@blueprintjs/core";
-import React from "react";
+import * as React from "react";
 
 class MyComponent extends React.PureComponent {
     public state = { toasts: [ /* ToastProps[] */ ] }

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Cross } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, IntentProps } from "../../common";
 import * as Classes from "../../common/classes";

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { TreeNode } from "./treeNode";

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Collapse } from "../collapse/collapse";

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -24,8 +24,8 @@ by navigating around and triggering the dialog with the <kbd>?</kbd> key.
 
 ```tsx
 import { HotkeysProvider } from "@blueprintjs/core";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 ReactDOM.render(
     <HotkeysProvider>
@@ -51,7 +51,7 @@ import {
     HotkeysTarget2
 } from "@blueprintjs/core";
 import React, { useContext, useEffect, useRef } from "react";
-import ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom";
 
 function App() {
     const appHotkeys: HotkeyConfig[] = [

--- a/packages/core/src/context/portal/portal-provider.md
+++ b/packages/core/src/context/portal/portal-provider.md
@@ -11,8 +11,8 @@ options. It uses the [React context API](https://reactjs.org/docs/context.html).
 
 ```tsx
 import { PortalProvider, Dialog } from "@blueprintjs/core";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 ReactDOM.render(
     <PortalProvider portalClassName="my-portal">

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export interface PortalContextOptions {
     /** Additional CSS classes to add to all `Portal` elements in this React context. */

--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { HOTKEYS_PROVIDER_NOT_FOUND } from "../../common/errors";
 import { elementIsTextInput } from "../../common/utils/domUtils";

--- a/packages/core/src/hooks/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export function usePrevious<T>(value: T) {
     const ref = React.useRef<T>();

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, shallow, ShallowWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { SinonStub, spy, stub } from "sinon";
 
 import { WarningSign } from "@blueprintjs/icons";

--- a/packages/core/test/breadcrumbs/breadcrumbTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { FolderClose } from "@blueprintjs/icons";

--- a/packages/core/test/breadcrumbs/breadcrumbsTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbsTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes } from "../../src/common";

--- a/packages/core/test/buttons/abstractButtonTests.tsx
+++ b/packages/core/test/buttons/abstractButtonTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Alignment, AnchorButton, Button } from "../../src";
 

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { AnchorButton, Button, ButtonProps, Classes, Icon, Keys, Spinner } from "../../src";

--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Callout, Classes, H5, Icon, Intent } from "../../src";
 

--- a/packages/core/test/card/cardTests.tsx
+++ b/packages/core/test/card/cardTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Card, Classes, H4 } from "../../src";

--- a/packages/core/test/collapse/collapseTests.tsx
+++ b/packages/core/test/collapse/collapseTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, MenuItem } from "../../src";
 import { AnimationStates, Collapse } from "../../src/components/collapse/collapse";

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import React from "react";
+import * as React from "react";
 import { SinonSpy, spy } from "sinon";
 
 import * as Utils from "../../src/common/utils";

--- a/packages/core/test/context-menu/contextMenuSingletonTests.tsx
+++ b/packages/core/test/context-menu/contextMenuSingletonTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -17,8 +17,8 @@
 import { assert } from "chai";
 import classNames from "classnames";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { spy } from "sinon";
 
 import {

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "../../src";
 import { Checkbox, ControlProps, Radio, Switch } from "../../src/components/forms/controls";

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes, Icon, InputGroup } from "../../src";

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -21,7 +21,7 @@ import {
     mount as untypedMount,
     shallow as untypedShallow,
 } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { SinonStub, spy, stub } from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { EnzymePropSelector, mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy, stub } from "sinon";
 
 import { OptionProps, Radio, RadioGroup } from "../../src";

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Button, Classes, Dialog, DialogBody, DialogFooter, DialogProps } from "../../src";

--- a/packages/core/test/drawer/drawerTests.tsx
+++ b/packages/core/test/drawer/drawerTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Button, Classes, Drawer, DrawerProps, Position } from "../../src";

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { EditableText, Keys } from "../../src";

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -18,7 +18,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 // this component is not part of the public API, but we want to test its implementation in isolation

--- a/packages/core/test/forms/fileInputTests.tsx
+++ b/packages/core/test/forms/fileInputTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, FileInput } from "../../src";

--- a/packages/core/test/forms/formGroupTests.tsx
+++ b/packages/core/test/forms/formGroupTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, FormGroup, Intent } from "../../src";
 

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -16,8 +16,8 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { TextArea } from "../../src";
 

--- a/packages/core/test/hotkeys/hotkey.tsx
+++ b/packages/core/test/hotkeys/hotkey.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 import { SinonStub, stub } from "sinon";
 
 import { Hotkey } from "../../src/components/hotkeys";

--- a/packages/core/test/hotkeys/keyComboTagTests.tsx
+++ b/packages/core/test/hotkeys/keyComboTagTests.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { KeyComboTag } from "../../src/components/hotkeys";
 

--- a/packages/core/test/html-select/htmlSelectTests.tsx
+++ b/packages/core/test/html-select/htmlSelectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { HTMLSelect, OptionProps } from "../../src";
 

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import Sinon, { stub } from "sinon";
 
 import { Add, Airplane, Calendar, Graph, IconName, Icons, IconSize } from "@blueprintjs/icons";

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow, ShallowWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, H6, Menu, MenuDivider, MenuItem } from "../../src";
 

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 

--- a/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
+++ b/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, H4, NonIdealState } from "../../src";
 

--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { OverflowList, OverflowListProps, OverflowListState } from "../../src/components/overflow-list/overflowList";

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes, NumericInput, Panel, PanelProps, PanelStack, PanelStackProps } from "../../src";

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Portal, PortalProps, PortalProvider } from "../../src";
 

--- a/packages/core/test/progress/progressBarTests.tsx
+++ b/packages/core/test/progress/progressBarTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, ProgressBar } from "../../src";
 

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { ResizeSensor, ResizeSensorProps } from "../../src/components/resize-sensor/resizeSensor";

--- a/packages/core/test/slider/handleTests.tsx
+++ b/packages/core/test/slider/handleTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { ARROW_DOWN, ARROW_UP } from "../../src/common/keys";

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -16,8 +16,8 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";

--- a/packages/core/test/slider/rangeSliderTests.tsx
+++ b/packages/core/test/slider/rangeSliderTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, Slider } from "../../src";

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { stub } from "sinon";
 
 import { Classes, Spinner, SpinnerSize } from "../../src";

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -15,7 +15,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes } from "../../src/common";

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert, expect } from "chai";
 import { MountRendererProps, ReactWrapper, mount as untypedMount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Button, Classes, Intent, Keys, Tag, TagInput, TagInputProps } from "../../src";

--- a/packages/core/test/tag/tagTests.tsx
+++ b/packages/core/test/tag/tagTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes, Icon, Tag, Text } from "../../src";

--- a/packages/core/test/text/textTests.tsx
+++ b/packages/core/test/text/textTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Text } from "../../src";
 

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -16,8 +16,8 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { SinonSpy, spy } from "sinon";
 
 import { AnchorButton, Button, Toast } from "../../src";

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import { spy, stub } from "sinon";
 
 import { Classes } from "../../src/common";

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -16,8 +16,8 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import { spy } from "sinon";
 
 import { Classes, Tree, TreeNodeInfo, TreeProps } from "../../src";

--- a/packages/datetime/src/dateInput.tsx
+++ b/packages/datetime/src/dateInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import type { DayPickerProps } from "react-day-picker";
 
 import {

--- a/packages/datetime/src/datePicker.tsx
+++ b/packages/datetime/src/datePicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, NavbarElementProps } from "react-day-picker";
 
 import { AbstractPureComponent, Button, DISPLAYNAME_PREFIX, Divider, Props } from "@blueprintjs/core";

--- a/packages/datetime/src/datePickerCaption.tsx
+++ b/packages/datetime/src/datePickerCaption.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 import { CaptionElementProps } from "react-day-picker";
 
 import { AbstractPureComponent, Divider, HTMLSelect, OptionProps } from "@blueprintjs/core";

--- a/packages/datetime/src/datePickerNavbar.tsx
+++ b/packages/datetime/src/datePickerNavbar.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import { NavbarElementProps } from "react-day-picker";
 
 import { Button } from "@blueprintjs/core";

--- a/packages/datetime/src/dateRangeInput.tsx
+++ b/packages/datetime/src/dateRangeInput.tsx
@@ -23,7 +23,7 @@
 /* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import DayPicker from "react-day-picker";
 
 import {

--- a/packages/datetime/src/dateRangePicker.tsx
+++ b/packages/datetime/src/dateRangePicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import DayPicker, { CaptionElementProps, DayModifiers, DayPickerProps, NavbarElementProps } from "react-day-picker";
 
 import { AbstractPureComponent, Boundary, DISPLAYNAME_PREFIX, Divider, Props } from "@blueprintjs/core";

--- a/packages/datetime/src/shortcuts.tsx
+++ b/packages/datetime/src/shortcuts.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 

--- a/packages/datetime/src/timePicker.tsx
+++ b/packages/datetime/src/timePicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     Classes as CoreClasses,

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -24,7 +24,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup, Intent, Keys, Popover } from "@blueprintjs/core";

--- a/packages/datetime/test/datePickerCaptionTests.tsx
+++ b/packages/datetime/test/datePickerCaptionTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { HTMLSelect } from "@blueprintjs/core";

--- a/packages/datetime/test/datePickerTests.tsx
+++ b/packages/datetime/test/datePickerTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import ReactDayPicker from "react-day-picker";
 import sinon from "sinon";
 

--- a/packages/datetime/test/dateRangeInputTests.tsx
+++ b/packages/datetime/test/dateRangeInputTests.tsx
@@ -24,8 +24,8 @@
 
 import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 

--- a/packages/datetime/test/dateRangePickerTests.tsx
+++ b/packages/datetime/test/dateRangePickerTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import ReactDayPicker from "react-day-picker";
 import sinon from "sinon";
 

--- a/packages/datetime/test/timePickerTests.tsx
+++ b/packages/datetime/test/timePickerTests.tsx
@@ -16,8 +16,8 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 

--- a/packages/datetime2/src/components/date-input2/dateInput2.tsx
+++ b/packages/datetime2/src/components/date-input2/dateInput2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import type { DayPickerProps } from "react-day-picker";
 
 import {

--- a/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
+++ b/packages/datetime2/src/components/date-range-input2/dateRangeInput2.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 import { isSameDay, isValid } from "date-fns";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime2/src/components/timezone-select/timezoneSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/components/dateInput2MigrationUtilsTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { DateInputProps, TimePrecision } from "@blueprintjs/datetime";
 

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -18,7 +18,7 @@ import { assert } from "chai";
 import { intlFormat, isEqual, parseISO } from "date-fns";
 import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup, Keys, Popover, Tag } from "@blueprintjs/core";

--- a/packages/datetime2/test/components/dateRangeInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput2Tests.tsx
@@ -16,8 +16,8 @@
 
 import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 

--- a/packages/datetime2/test/components/timezoneSelectTests.tsx
+++ b/packages/datetime2/test/components/timezoneSelectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { Button, ButtonProps, InputGroup, InputGroupProps, MenuItem, Popover, PopoverProps } from "@blueprintjs/core";

--- a/packages/demo-app/src/examples/BreadcrumbExample.tsx
+++ b/packages/demo-app/src/examples/BreadcrumbExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { BreadcrumbProps, Breadcrumbs } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/ButtonExample.tsx
+++ b/packages/demo-app/src/examples/ButtonExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Intent } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/ButtonGroupExample.tsx
+++ b/packages/demo-app/src/examples/ButtonGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ButtonGroup, Intent } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/CalloutExample.tsx
+++ b/packages/demo-app/src/examples/CalloutExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Callout, Intent } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/CheckboxRadioExample.tsx
+++ b/packages/demo-app/src/examples/CheckboxRadioExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Checkbox, Radio } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/DatePickerExample.tsx
+++ b/packages/demo-app/src/examples/DatePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { DatePicker } from "@blueprintjs/datetime";

--- a/packages/demo-app/src/examples/DateRangePickerExample.tsx
+++ b/packages/demo-app/src/examples/DateRangePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { DateRangePicker } from "@blueprintjs/datetime";

--- a/packages/demo-app/src/examples/DialogExample.tsx
+++ b/packages/demo-app/src/examples/DialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Dialog, DialogBody } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/EditableTextExample.tsx
+++ b/packages/demo-app/src/examples/EditableTextExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { EditableText, H1 } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/ExampleCard.tsx
+++ b/packages/demo-app/src/examples/ExampleCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Card, Classes, H4, H5 } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/Examples.tsx
+++ b/packages/demo-app/src/examples/Examples.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/HtmlCodeExample.tsx
+++ b/packages/demo-app/src/examples/HtmlCodeExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Code } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/HtmlTableExample.tsx
+++ b/packages/demo-app/src/examples/HtmlTableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, HTMLTable } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/IconExample.tsx
+++ b/packages/demo-app/src/examples/IconExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Icon, Intent } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/InputExample.tsx
+++ b/packages/demo-app/src/examples/InputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { InputGroup, Intent, NumericInput } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/MenuExample.tsx
+++ b/packages/demo-app/src/examples/MenuExample.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable deprecation/deprecation */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, Intent, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/NonIdealStateExample.tsx
+++ b/packages/demo-app/src/examples/NonIdealStateExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, NonIdealState } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Classes, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/SliderExample.tsx
+++ b/packages/demo-app/src/examples/SliderExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Slider } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/SwitchExample.tsx
+++ b/packages/demo-app/src/examples/SwitchExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/TableExample.tsx
+++ b/packages/demo-app/src/examples/TableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Cell, Column, ColumnHeaderCell2, Table2 } from "@blueprintjs/table";
 

--- a/packages/demo-app/src/examples/TabsExample.tsx
+++ b/packages/demo-app/src/examples/TabsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Tab, Tabs } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/TagExample.tsx
+++ b/packages/demo-app/src/examples/TagExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Intent, Tag } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/TagInputExample.tsx
+++ b/packages/demo-app/src/examples/TagInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Intent, TagInput, TagProps } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/TextExample.tsx
+++ b/packages/demo-app/src/examples/TextExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Intent, Text } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/ToastExample.tsx
+++ b/packages/demo-app/src/examples/ToastExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Intent, Toast } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/TooltipExample.tsx
+++ b/packages/demo-app/src/examples/TooltipExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, Icon, Tooltip } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/TreeExample.tsx
+++ b/packages/demo-app/src/examples/TreeExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import cloneDeep from "lodash/cloneDeep";
-import React from "react";
+import * as React from "react";
 
 import { Classes, ContextMenu, Icon, Intent, Tooltip, Tree, TreeNodeInfo } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { FocusStyleManager } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/common/dateFormatSelector.tsx
+++ b/packages/docs-app/src/common/dateFormatSelector.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Radio, RadioGroup } from "@blueprintjs/core";
 import { DateFormatProps } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/common/propCodeTooltip.tsx
+++ b/packages/docs-app/src/common/propCodeTooltip.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Code, Tooltip, TooltipProps } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -16,7 +16,7 @@
 
 import { IHeadingNode, IPageData, isPageNode, ITsDocBase } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AnchorButton, Classes, HotkeysProvider, Tag } from "@blueprintjs/core";
 import { DocsCompleteData } from "@blueprintjs/docs-data";

--- a/packages/docs-app/src/components/colorPalettes.tsx
+++ b/packages/docs-app/src/components/colorPalettes.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Colors, Pre } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/components/colorSchemes.tsx
+++ b/packages/docs-app/src/components/colorSchemes.tsx
@@ -16,7 +16,7 @@
 
 import chroma from "chroma-js";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Keys, RadioGroup } from "@blueprintjs/core";
 import { createKeyEventHandler, handleNumberChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 import download from "downloadjs";
-import React from "react";
+import * as React from "react";
 
 import { Classes, ContextMenu, Icon, IconName, Menu, MenuItem } from "@blueprintjs/core";
 import { IconSize } from "@blueprintjs/icons";

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, H3, InputGroup, NonIdealState } from "@blueprintjs/core";
 import { smartSearch } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/components/logo.tsx
+++ b/packages/docs-app/src/components/logo.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export const Logo: React.FC = () => (
     <svg width="65" height="76" xmlns="http://www.w3.org/2000/svg">

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import { INpmPackage } from "@documentalist/client";
-import React from "react";
+import * as React from "react";
 
 import { Classes, HotkeysTarget, Intent, Menu, MenuItem, NavbarHeading, Popover, Tag } from "@blueprintjs/core";
 import { NavButton } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/components/navIcons.tsx
+++ b/packages/docs-app/src/components/navIcons.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export const NavIcon: React.FC<{ route: string }> = ({ route }) => {
     return (

--- a/packages/docs-app/src/components/resources.tsx
+++ b/packages/docs-app/src/components/resources.tsx
@@ -15,7 +15,7 @@
  */
 
 import download from "downloadjs";
-import React from "react";
+import * as React from "react";
 
 import { Callout, Card } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Card, H4, Icon, IconName } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Alert, Button, H5, Intent, OverlayToaster, Switch, Toaster } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Boundary,

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Alignment,

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Alignment, Button, ButtonGroup, H5, IconName, Popover, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Alignment, AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/buttonsIconsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsIconsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Icon } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Callout, Code, H5, Intent, Switch } from "@blueprintjs/core";
 import { DocsExampleProps, Example, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/cardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Card, Classes, Elevation, H5, Label, Slider, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Alignment, Checkbox, H5, Label, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/collapseExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapseExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Collapse, H5, Pre, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Alignment, Button, ButtonGroup } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ButtonGroup, Code, Label } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Menu, MenuDivider, MenuItem, Props } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Alignment, Button, Classes, MenuItem } from "@blueprintjs/core";
 import { IconName } from "@blueprintjs/icons";

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ControlGroup, HTMLSelect, Intent, Label } from "@blueprintjs/core";
 import { handleValueChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ButtonGroup, Label } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ButtonGroup, Label } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     Classes,

--- a/packages/docs-app/src/examples/core-examples/contextMenuPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuPopoverExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, hideContextMenu, Menu, MenuDivider, MenuItem, showContextMenu } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ControlGroup, HTMLSelect, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     AnchorButton,

--- a/packages/docs-app/src/examples/core-examples/dividerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dividerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ButtonGroup, Divider, H5, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Card, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, EditableText, FormGroup, H1, H5, Intent, NumericInput, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { FileInput, FormGroup, H5, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/focusExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/focusExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Classes, FocusStyleManager, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { FormGroup, H5, InputGroup, Intent, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Code, getKeyComboString, KeyComboTag } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/hotkeysTargetExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeysTargetExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { HotkeyProps, HotkeysTarget } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Icon, Intent, Label, Slider } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, Icon, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, Code, H5, HTMLSelect, Intent, Label, Menu, MenuItem, MenuItemProps, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, HandleInteractionKind, Intent, MultiSlider, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/core-examples/navbarExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/navbarExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Alignment,

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/core-examples/numericInputExtendedExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputExtendedExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Keys, NumericInput } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Button, Classes, Code, H3, H5, Intent, Overlay, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -21,7 +21,7 @@
  * Panel1 renders either a new Panel2 or Panel3. Panel2 and Panel3 both render a new Panel1.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, H5, Intent, NumericInput, Panel, PanelProps, PanelStack, Switch, UL } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Callout, Classes, Popover, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     AnchorButton,

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Intent, Popover, PopoverInteractionKind } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Intent, Popover, PopoverProps } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Classes, Code, ControlGroup, Placement, Popover } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Code, H5, Popover, PopoverProps, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Popover } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/progressExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/progressExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Intent, ProgressBar, Slider, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/radioExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/radioExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Radio, RadioGroup } from "@blueprintjs/core";
 import { Example, handleStringChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, NumberRange, RangeSlider, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Slider, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Intent, Label, Slider, Spinner, SpinnerSize, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Code, Label, Switch } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Alignment, Classes, Divider, H4, H5, InputGroup, Navbar, Switch, Tab, TabId, Tabs } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, H5, Intent, Switch, Tag } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, H5, Intent, Switch, TagInput, TagProps } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, Menu, MenuItem, Popover, Text, TextArea } from "@blueprintjs/core";
 import { Example, ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, ButtonGroup, Classes, Code, H1, Popover, Switch, Tooltip } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/momentDate.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 import moment from "moment";
-import React from "react";
+import * as React from "react";
 
 import { Icon, Intent, Props, Tag } from "@blueprintjs/core";
 import { DateRange } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/common/momentFormats.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/momentFormats.tsx
@@ -15,7 +15,7 @@
  */
 
 import moment from "moment";
-import React from "react";
+import * as React from "react";
 
 import { DateFormatProps } from "@blueprintjs/datetime";
 

--- a/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, HTMLSelect } from "@blueprintjs/core";
 import { TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateInput, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Callout, Classes, H5, Switch } from "@blueprintjs/core";
 import { DatePicker, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, DateRangeInput, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import moment from "moment";
-import React from "react";
+import * as React from "react";
 
 import { Classes, H5, HTMLSelect, Label, Switch } from "@blueprintjs/core";
 import { DateRange, DateRangePicker, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { TimePicker, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime2-examples/dateFnsDate.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateFnsDate.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 import { format, isValid } from "date-fns";
-import React from "react";
+import * as React from "react";
 
 import { Icon, Intent, Props, Tag } from "@blueprintjs/core";
 import { DateRange } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime2-examples/dateFnsFormatSelector.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateFnsFormatSelector.tsx
@@ -15,7 +15,7 @@
  */
 
 import { format, Locale, parse } from "date-fns";
-import React from "react";
+import * as React from "react";
 
 import { DateFormatProps } from "@blueprintjs/datetime";
 

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput2Example.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Code, H5, Icon, Switch, Tag } from "@blueprintjs/core";
 import { DateFormatProps, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput2Example.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Callout, Code, H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/timezoneSelectExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { TimezoneDisplayFormat, TimezoneSelect } from "@blueprintjs/datetime2";

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Code, H5, Intent, MenuItem, Popover, Switch, TagProps } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, Menu, MenuDivider, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { H5, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { RadioGroup } from "@blueprintjs/core";
 import { Example, ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { HTMLSelect, Label } from "@blueprintjs/core";
 import { Example, ExampleProps, handleNumberChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Intent } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, JSONFormat, Table2, TruncatedFormat } from "@blueprintjs/table";

--- a/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table2, Utils } from "@blueprintjs/table";

--- a/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable max-classes-per-file */
 
-import React from "react";
+import * as React from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { docsData } from "@blueprintjs/docs-data";
 import { createDefaultRenderers, ReactDocsTagRenderer, ReactExampleTagRenderer } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { ExampleMap, ExampleProps } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-theme/src/components/banner.tsx
+++ b/packages/docs-theme/src/components/banner.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Intent, Props } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -16,7 +16,7 @@
 
 import { IBlock } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Code, H3 } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -16,7 +16,7 @@
 
 import { IHeadingNode, IPageData, IPageNode, isPageNode, ITsDocBase, linkify } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Drawer, FocusStyleManager, HotkeysTarget, Props } from "@blueprintjs/core";
 import { Search } from "@blueprintjs/icons";

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, HTMLTable } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/navButton.tsx
+++ b/packages/docs-theme/src/components/navButton.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Icon, KeyComboTag } from "@blueprintjs/core";
 import { IconName } from "@blueprintjs/icons";

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -16,7 +16,7 @@
 
 import { IHeadingNode, IPageNode, isPageNode } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes, Props } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -16,7 +16,7 @@
 
 import { IHeadingNode, IPageNode } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -16,7 +16,7 @@
 
 import { IHeadingNode, IPageNode } from "@documentalist/client";
 import { filter } from "fuzzaldrin-plus";
-import React from "react";
+import * as React from "react";
 
 import { Classes, MenuItem } from "@blueprintjs/core";
 import { CaretRight } from "@blueprintjs/icons";

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -15,7 +15,7 @@
  */
 
 import { IPageData } from "@documentalist/client";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
+++ b/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Intent, Tag } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -15,7 +15,7 @@
  */
 
 import { ITag } from "@documentalist/client";
-import React from "react";
+import * as React from "react";
 
 import { CssExample } from "./css";
 import { Heading } from "./heading";

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -16,7 +16,7 @@
 
 import { IHeadingTag } from "@documentalist/client";
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { Link } from "@blueprintjs/icons";

--- a/packages/docs-theme/src/tags/reactDocs.tsx
+++ b/packages/docs-theme/src/tags/reactDocs.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ITag } from "@documentalist/client";
-import React from "react";
+import * as React from "react";
 
 export interface DocsMap {
     [name: string]: React.ComponentClass;

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ITag } from "@documentalist/client";
-import React from "react";
+import * as React from "react";
 
 import { AnchorButton, Intent } from "@blueprintjs/core";
 import { Code } from "@blueprintjs/icons";

--- a/packages/icons/src/iconLoader.ts
+++ b/packages/icons/src/iconLoader.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { IconName, IconNames } from "./iconNames";
 import { wrapWithTimer } from "./loaderUtils";

--- a/packages/icons/src/loading-icons.md
+++ b/packages/icons/src/loading-icons.md
@@ -17,7 +17,7 @@ from the icons package.
 ```tsx
 import { Button } from "@blueprintjs/core";
 import { Download } from "@blueprintjs/icons";
-import ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom";
 
 ReactDOM.render(
     <Button text="Download" icon={<Download size={16} />} />,
@@ -42,7 +42,7 @@ It looks like this in your render code path:
 
 ```tsx
 import { Button } from "@blueprintjs/core";
-import ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom";
 
 ReactDOM.render(
     <Button text="Download" icon="download" />,

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export interface SVGIconProps extends React.RefAttributes<any> {
     /** A space-delimited list of class names to pass along to the SVG element. */

--- a/packages/select/src/__examples__/filmSelect.tsx
+++ b/packages/select/src/__examples__/filmSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Button, MenuItem } from "@blueprintjs/core";
 

--- a/packages/select/src/__examples__/films.tsx
+++ b/packages/select/src/__examples__/films.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { MenuItem, MenuItemProps } from "@blueprintjs/core";
 

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export interface ItemModifiers {
     /** Whether this is the "active" (focused) item, meaning keyboard interactions will act upon it. */

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, InputGroup, InputGroupProps, Overlay, OverlayProps } from "@blueprintjs/core";
 import { Search } from "@blueprintjs/icons";

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractComponent, DISPLAYNAME_PREFIX, Keys, Menu, Props, Utils } from "@blueprintjs/core";
 

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -11,8 +11,8 @@ You may provide a predicate to customize the filtering algorithm. The value of a
 ```tsx
 import { Button, MenuItem } from "@blueprintjs/core";
 import { ItemPredicate, ItemRenderer, Select } from "@blueprintjs/select";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 export interface Film {
     title: string;

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes as CoreClasses, Keys, Tag } from "@blueprintjs/core";

--- a/packages/select/test/omnibarTests.tsx
+++ b/packages/select/test/omnibarTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 
 import { Omnibar } from "../src";
 import { selectComponentSuite } from "./selectComponentSuite";

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Menu } from "@blueprintjs/core";

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { ItemListRendererProps, renderFilteredItems } from "../src";

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, HTMLInputProps, Keys } from "@blueprintjs/core";

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup, Keys, MenuItem, Popover } from "@blueprintjs/core";

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { InputGroup, Keys, MenuItem, Popover, PopoverProps } from "@blueprintjs/core";

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -17,8 +17,8 @@
 // tslint:disable object-literal-sort-keys
 /* eslint-disable max-classes-per-file, react/display-name, react/jsx-no-bind, react/no-did-mount-set-state */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { Button, Classes, H4, Intent, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import {

--- a/packages/table-dev-app/src/index.tsx
+++ b/packages/table-dev-app/src/index.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { MutableTable } from "./mutableTable";
 import { Nav } from "./nav";

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -17,7 +17,7 @@
 /* eslint-disable react/jsx-no-bind */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     Button,

--- a/packages/table-dev-app/src/nav.tsx
+++ b/packages/table-dev-app/src/nav.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Alignment, AnchorButton, Classes, Navbar, Switch } from "@blueprintjs/core";
 

--- a/packages/table-dev-app/src/slowLayoutStack.tsx
+++ b/packages/table-dev-app/src/slowLayoutStack.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Utils } from "@blueprintjs/table/src";
 

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Classes as CoreClasses, Utils as CoreUtils, DISPLAYNAME_PREFIX, IntentProps, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     Utils as CoreUtils,

--- a/packages/table/src/cell/editableCell2.tsx
+++ b/packages/table/src/cell/editableCell2.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     Utils as CoreUtils,

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
 

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, Popover, Props } from "@blueprintjs/core";
 import { More } from "@blueprintjs/icons";

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { DISPLAYNAME_PREFIX, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/common/context.ts
+++ b/packages/table/src/common/context.ts
@@ -14,7 +14,7 @@
  */
 
 import * as PropTypes from "prop-types";
-import React from "react";
+import * as React from "react";
 
 export interface ColumnInteractionBarContextTypes {
     enableColumnInteractionBar: boolean | null | undefined;

--- a/packages/table/src/common/contextMenuTargetWrapper.tsx
+++ b/packages/table/src/common/contextMenuTargetWrapper.tsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable deprecation/deprecation */
 
-import React from "react";
+import * as React from "react";
 
 import { ContextMenuTargetLegacy, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/common/loadableContent.tsx
+++ b/packages/table/src/common/loadableContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/table/src/common/rect.ts
+++ b/packages/table/src/common/rect.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 export type AnyRect = Rect | DOMRect;
 

--- a/packages/table/src/docs/table2.md
+++ b/packages/table/src/docs/table2.md
@@ -14,8 +14,8 @@ configure a [HotkeysProvider](#core/context/hotkeys-provider) in your applicatio
 ```tsx
 import { HotkeysProvider } from "@blueprintjs/core";
 import { Column, Table2 } from "@blueprintjs/table";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 ReactDOM.render(
     <HotkeysProvider>

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import * as Classes from "../common/classes";
 import { ColumnIndices } from "../common/grid";

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/table/src/headers/columnHeaderCell2.tsx
+++ b/packages/table/src/headers/columnHeaderCell2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { EditableText, IntentProps, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
 import { DragHandleVertical } from "@blueprintjs/icons";

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { ContextMenu, Classes as CoreClasses, Utils as CoreUtils, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/headers/headerCell2.tsx
+++ b/packages/table/src/headers/headerCell2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { ContextMenu, Classes as CoreClasses, Utils as CoreUtils, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import * as Classes from "../common/classes";
 import { RowIndices } from "../common/grid";

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/headers/rowHeaderCell2.tsx
+++ b/packages/table/src/headers/rowHeaderCell2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent } from "@blueprintjs/core";
 

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { Utils as CoreUtils, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { MenuItem, MenuItemProps } from "@blueprintjs/core";
 

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
 

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
 

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Utils as CoreUtils, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { Utils as CoreUtils, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractComponent, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { AbstractComponent, Utils as CoreUtils, Props, setRef } from "@blueprintjs/core";
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import innerText from "react-innertext";
 
 import {

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 import innerText from "react-innertext";
 
 import {

--- a/packages/table/src/table2Utils.ts
+++ b/packages/table/src/table2Utils.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { HotkeyConfig } from "@blueprintjs/core";
 

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractComponent, Utils as CoreUtils } from "@blueprintjs/core";
 

--- a/packages/table/src/tableBody2.tsx
+++ b/packages/table/src/tableBody2.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractComponent, ContextMenu, ContextMenuContentProps, Utils as CoreUtils } from "@blueprintjs/core";
 

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React from "react";
+import * as React from "react";
 
 import { AbstractComponent, Utils as CoreUtils, Props } from "@blueprintjs/core";
 

--- a/packages/table/src/tableHotkeys.ts
+++ b/packages/table/src/tableHotkeys.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import type { FocusedCellCoordinates } from "./common/cellTypes";
 import { Clipboard } from "./common/clipboard";

--- a/packages/table/src/tableUtils.ts
+++ b/packages/table/src/tableUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Utils } from "./common/utils";
 import type { TablePropsWithDefaults } from "./tableProps";

--- a/packages/table/test/cellTests.tsx
+++ b/packages/table/test/cellTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { Classes as CoreClasses, Intent } from "@blueprintjs/core";
 

--- a/packages/table/test/columnHeaderCell2Tests.tsx
+++ b/packages/table/test/columnHeaderCell2Tests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes as CoreClasses, H4, Menu, MenuItem } from "@blueprintjs/core";

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -23,7 +23,7 @@
 
 import { expect } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { H4, Menu, MenuItem } from "@blueprintjs/core";

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { Cell, Column, ColumnLoadingOption, Table2 } from "../src";
 import * as Classes from "../src/common/classes";

--- a/packages/table/test/common/internal/scrollUtilsTests.tsx
+++ b/packages/table/test/common/internal/scrollUtilsTests.tsx
@@ -15,8 +15,8 @@
  */
 
 import { expect } from "chai";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import * as ScrollUtils from "../../../src/common/internal/scrollUtils";
 import { Region, Regions } from "../../../src/regions";

--- a/packages/table/test/editableCell2Tests.tsx
+++ b/packages/table/test/editableCell2Tests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -21,7 +21,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";

--- a/packages/table/test/editableNameTests.tsx
+++ b/packages/table/test/editableNameTests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { EditableText } from "@blueprintjs/core";

--- a/packages/table/test/formats/jsonFormatTests.tsx
+++ b/packages/table/test/formats/jsonFormatTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { JSONFormat } from "../../src/cell/formats/jsonFormat";
 import { TruncatedPopoverMode } from "../../src/cell/formats/truncatedFormat";

--- a/packages/table/test/formats/truncatedFormatTests.tsx
+++ b/packages/table/test/formats/truncatedFormatTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { TruncatedFormat, TruncatedPopoverMode } from "../../src/cell/formats/truncatedFormat";
 import * as Classes from "../../src/common/classes";

--- a/packages/table/test/guidesTests.tsx
+++ b/packages/table/test/guidesTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import * as Classes from "../src/common/classes";
 import { GuideLayer } from "../src/layers/guides";

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -16,8 +16,8 @@
 
 /* eslint-disable  max-classes-per-file */
 
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 export type MouseEventType = "click" | "mousedown" | "mouseup" | "mousemove" | "mouseenter" | "mouseleave";
 export type KeyboardEventType = "keypress" | "keydown" | "keyup";

--- a/packages/table/test/loadableContentTests.tsx
+++ b/packages/table/test/loadableContentTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/table/test/loadingOptionsTests.tsx
+++ b/packages/table/test/loadingOptionsTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import {
     Cell,

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -15,8 +15,8 @@
  */
 
 import { expect } from "chai";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 
 import { Utils } from "../src";
 import { Grid } from "../src/common/grid";

--- a/packages/table/test/menusTests.tsx
+++ b/packages/table/test/menusTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, Menu } from "@blueprintjs/core";

--- a/packages/table/test/mocks/table.tsx
+++ b/packages/table/test/mocks/table.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import { Cell, Column, ColumnProps, RenderMode, Table, TableProps, Utils } from "../../src";
 

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -16,8 +16,8 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 

--- a/packages/table/test/quadrants/tableQuadrantTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantTests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import * as Classes from "../../src/common/classes";

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Regions } from "../src/";

--- a/packages/table/test/resizableTests.tsx
+++ b/packages/table/test/resizableTests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import * as Classes from "../src/common/classes";

--- a/packages/table/test/rowHeaderCell2Tests.tsx
+++ b/packages/table/test/rowHeaderCell2Tests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import * as sinon from "sinon";
 
 import { H4 } from "@blueprintjs/core";

--- a/packages/table/test/rowHeaderCellTests.tsx
+++ b/packages/table/test/rowHeaderCellTests.tsx
@@ -23,7 +23,7 @@
 
 import { expect } from "chai";
 import { shallow } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { H4 } from "@blueprintjs/core";

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import type { FocusedCellCoordinates } from "../src/common/cellTypes";

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -16,8 +16,8 @@
 
 import { expect } from "chai";
 import { MountRendererProps, ReactWrapper, mount as untypedMount } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import sinon from "sinon";
 
 import { Utils as CoreUtils, Keys } from "@blueprintjs/core";

--- a/packages/table/test/tableBody2Tests.tsx
+++ b/packages/table/test/tableBody2Tests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Cell } from "../src/cell/cell";

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -23,7 +23,7 @@
 
 import { expect } from "chai";
 import { mount, ReactWrapper } from "enzyme";
-import React from "react";
+import * as React from "react";
 import sinon from "sinon";
 
 import { Cell } from "../src/cell/cell";

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -16,8 +16,8 @@
 
 import { expect } from "chai";
 import { MountRendererProps, ReactWrapper, mount as untypedMount } from "enzyme";
-import React from "react";
-import ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
 import sinon from "sinon";
 
 import { Utils as CoreUtils, Keys } from "@blueprintjs/core";

--- a/packages/test-commons/src/generateIsomorphicTests.ts
+++ b/packages/test-commons/src/generateIsomorphicTests.ts
@@ -6,7 +6,7 @@
 
 import { strictEqual } from "assert";
 import Enzyme from "enzyme";
-import React from "react";
+import * as React from "react";
 
 function isReactClass(Component: any): Component is React.ComponentClass<any> {
     return (

--- a/packages/test-commons/src/testErrorBoundary.tsx
+++ b/packages/test-commons/src/testErrorBoundary.tsx
@@ -14,7 +14,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 export interface TestErrorBoundaryProps {
     children?: React.ReactNode;

--- a/packages/test-commons/src/utils.ts
+++ b/packages/test-commons/src/utils.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect } from "chai";
-import React from "react";
+import * as React from "react";
 
 /**
  * Dispatch a native KeyBoardEvent on the target element with the given type


### PR DESCRIPTION




#### Changes proposed in this pull request:

Revert the consumer-facing part of #4544, which caused unnecessary tsc errors downstream for users who had not enabled synthetic default imports. There's no need to include this break in v5.0.

