### PR TITLE
[v5] [select] break(QueryList): index is always defined in itemRenderer

### DIFF
--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -54,7 +54,8 @@ export interface ItemRendererProps<T extends HTMLElement = HTMLLIElement> {
      */
     handleFocus?: () => void;
 
-    index?: number;
+    /** Index of the item in the QueryList items array. */
+    index: number;
 
     /** Modifiers that describe how to render this item, such as `active` or `disabled`. */
     modifiers: ItemModifiers;

--- a/packages/select/test/itemRendererTests.tsx
+++ b/packages/select/test/itemRendererTests.tsx
@@ -41,11 +41,12 @@ describe("ItemRenderer", () => {
         };
 
         it("without ref prop", () => {
-            function getItemProps(_item: Film): ItemRendererProps {
+            function getItemProps(_item: Film, index: number): ItemRendererProps {
                 return {
                     handleClick: (_event: React.MouseEvent<HTMLElement>) => {
                         /* noop */
                     },
+                    index,
                     modifiers: {
                         active: false,
                         disabled: false,
@@ -55,7 +56,9 @@ describe("ItemRenderer", () => {
                 };
             }
             const MyList: React.FC = () => {
-                return <Menu>{TOP_100_FILMS.map(item => myItemRenderer(item, getItemProps(item)))}</Menu>;
+                return (
+                    <Menu>{TOP_100_FILMS.map((item, index) => myItemRenderer(item, getItemProps(item, index)))}</Menu>
+                );
             };
             shallow(<MyList />);
         });


### PR DESCRIPTION

#### Changes proposed in this pull request:

Re-do of #5501 as a breaking change in v5

