### PR TITLE
[v5] [core] feat(ButtonGroup, ControlGroup, MenuItem): use forwardRef

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -83,7 +83,7 @@ export interface LinkProps {
     href?: string;
 
     /** Link target attribute. Use `"_blank"` to open in a new window. */
-    target?: string;
+    target?: React.HTMLAttributeAnchorTarget;
 }
 
 /**

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -17,12 +17,10 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Alignment, Classes } from "../../common";
+import { Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
-// TODO(adahiya): MUST FIX FOR BLUEPRINT v5.0, add back `ref` prop support by migrating to function component, using React.RefAttributes<HTMLLIElement>
-// see https://github.com/palantir/blueprint/issues/6094
-export interface ButtonGroupProps extends Props, HTMLDivProps {
+export interface ButtonGroupProps extends Props, HTMLDivProps, React.RefAttributes<HTMLDivElement> {
     /**
      * Text alignment within button. By default, icons and text will be centered
      * within the button. Passing `"left"` or `"right"` will align the button
@@ -70,11 +68,9 @@ export interface ButtonGroupProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/button-group
  */
-export class ButtonGroup extends AbstractPureComponent<ButtonGroupProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.ButtonGroup`;
-
-    public render() {
-        const { alignText, className, fill, minimal, large, vertical, ...htmlProps } = this.props;
+export const ButtonGroup: React.FC<ButtonGroupProps> = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
+    (props, ref) => {
+        const { alignText, className, fill, minimal, large, vertical, ...htmlProps } = props;
         const buttonGroupClasses = classNames(
             Classes.BUTTON_GROUP,
             {
@@ -87,9 +83,10 @@ export class ButtonGroup extends AbstractPureComponent<ButtonGroupProps> {
             className,
         );
         return (
-            <div {...htmlProps} className={buttonGroupClasses}>
-                {this.props.children}
+            <div {...htmlProps} ref={ref} className={buttonGroupClasses}>
+                {props.children}
             </div>
         );
-    }
-}
+    },
+);
+ButtonGroup.displayName = `${DISPLAYNAME_PREFIX}.ButtonGroup`;

--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -18,10 +18,9 @@ import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
-export interface AsyncControllableInputProps
-    extends React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement> {
-    inputRef?: React.LegacyRef<HTMLInputElement>;
-}
+export type AsyncControllableInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+    inputRef?: React.Ref<HTMLInputElement>;
+};
 
 type InputValue = AsyncControllableInputProps["value"];
 

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -17,12 +17,10 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes } from "../../common";
+import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
-// TODO(adahiya): MUST FIX FOR BLUEPRINT v5.0, add back `ref` prop support by migrating to function component, using React.RefAttributes<HTMLLIElement>
-// see https://github.com/palantir/blueprint/issues/6094
-export interface ControlGroupProps extends Props, HTMLDivProps {
+export interface ControlGroupProps extends Props, HTMLDivProps, React.RefAttributes<HTMLDivElement> {
     /** Group contents. */
     children?: React.ReactNode;
 
@@ -48,11 +46,9 @@ export interface ControlGroupProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/control-group
  */
-export class ControlGroup extends AbstractPureComponent<ControlGroupProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.ControlGroup`;
-
-    public render() {
-        const { children, className, fill, vertical, ...htmlProps } = this.props;
+export const ControlGroup: React.FC<ControlGroupProps> = React.forwardRef<HTMLDivElement, ControlGroupProps>(
+    (props, ref) => {
+        const { children, className, fill, vertical, ...htmlProps } = props;
 
         const rootClasses = classNames(
             Classes.CONTROL_GROUP,
@@ -64,9 +60,10 @@ export class ControlGroup extends AbstractPureComponent<ControlGroupProps> {
         );
 
         return (
-            <div {...htmlProps} className={rootClasses}>
+            <div {...htmlProps} ref={ref} className={rootClasses}>
                 {children}
             </div>
         );
-    }
-}
+    },
+);
+ControlGroup.displayName = `${DISPLAYNAME_PREFIX}.ControlGroup`;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -20,7 +20,7 @@ import React, { forwardRef, useCallback, useEffect, useRef, useState } from "rea
 import { Alignment, Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, Props } from "../../common/props";
 
-export interface ControlProps extends Props, HTMLInputProps, React.RefAttributes<any> {
+export interface ControlProps extends Props, HTMLInputProps, React.RefAttributes<HTMLInputElement> {
     // NOTE: HTML props are duplicated here to provide control-specific documentation
 
     /**
@@ -41,9 +41,6 @@ export interface ControlProps extends Props, HTMLInputProps, React.RefAttributes
 
     /** Whether the control is non-interactive. */
     disabled?: boolean;
-
-    /** Ref handler that receives HTML `<input>` element backing this component. */
-    inputRef?: React.Ref<HTMLInputElement>;
 
     /** Whether the control should appear as an inline element. */
     inline?: boolean;
@@ -94,14 +91,13 @@ interface ControlInternalProps extends ControlProps {
  * Renders common control elements, with additional props to customize appearance.
  * This function is not exported and is only used within this module for `Checkbox`, `Radio`, and `Switch` below.
  */
-function renderControl(props: ControlInternalProps, ref: React.Ref<any>) {
+function renderControl(props: ControlInternalProps, ref: React.Ref<HTMLInputElement>) {
     const {
         alignIndicator,
         children,
         className,
         indicatorChildren,
         inline,
-        inputRef,
         label,
         labelElement,
         large,
@@ -126,7 +122,7 @@ function renderControl(props: ControlInternalProps, ref: React.Ref<any>) {
     return React.createElement(
         tagName,
         { className: classes, style, ref },
-        <input {...htmlProps} ref={inputRef} type={type} />,
+        <input {...htmlProps} ref={ref} type={type} />,
         <span className={Classes.CONTROL_INDICATOR}>{indicatorChildren}</span>,
         label,
         labelElement,
@@ -233,9 +229,9 @@ export interface CheckboxProps extends ControlProps {
  * @see https://blueprintjs.com/docs/#core/components/checkbox
  */
 export const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
-    const { defaultIndeterminate, indeterminate, inputRef: inputRefProp, onChange, ...controlProps } = props;
+    const { defaultIndeterminate, indeterminate, onChange, ...controlProps } = props;
     const [isIndeterminate, setIsIndeterminate] = useState<boolean>(indeterminate || defaultIndeterminate || false);
-    const inputRefLocal = useRef<HTMLInputElement>(null);
+    const localRef = useRef<HTMLInputElement>(null);
     const handleChange = useCallback(
         (evt: React.ChangeEvent<HTMLInputElement>) => {
             // update state immediately only if uncontrolled
@@ -255,20 +251,19 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
     }, [indeterminate]);
 
     useEffect(() => {
-        if (inputRefLocal.current != null) {
-            inputRefLocal.current.indeterminate = isIndeterminate;
+        if (localRef.current != null) {
+            localRef.current.indeterminate = isIndeterminate;
         }
-    }, [inputRefLocal, isIndeterminate]);
+    }, [localRef, isIndeterminate]);
 
     return renderControl(
         {
             ...controlProps,
-            inputRef: inputRefProp === undefined ? inputRefLocal : mergeRefs(inputRefLocal, inputRefProp),
             onChange: handleChange,
             type: "checkbox",
             typeClassName: Classes.CHECKBOX,
         },
-        ref,
+        mergeRefs(ref, localRef),
     );
 });
 Checkbox.displayName = `${DISPLAYNAME_PREFIX}.Checkbox`;

--- a/packages/core/src/components/hotkeys/hotkeys-target.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target.md
@@ -44,7 +44,7 @@ export default class extends React.PureComponent {
                 {({ handleKeyDown, handleKeyUp }) => (
                     <div tabIndex={0} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                         Press "R" to refresh data, "F" to focus the input...
-                        <InputGroup ref={this.inputRef} />
+                        <InputGroup inputRef={this.inputRef} />
                     </div>
                 )}
             </HotkeysTarget>

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -19,17 +19,23 @@ import * as React from "react";
 
 import { CaretRight } from "@blueprintjs/icons";
 
-import { AbstractPureComponent, Classes } from "../../common";
-import { ActionProps, DISPLAYNAME_PREFIX, LinkProps, removeNonHTMLProps } from "../../common/props";
+import { Classes } from "../../common";
+import { ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
 import { Popover, PopoverProps } from "../popover/popover";
 import { Text } from "../text/text";
 import { Menu, MenuProps } from "./menu";
 
-// TODO(adahiya): MUST FIX FOR BLUEPRINT v5.0, add back `ref` prop support by migrating to function component, using React.RefAttributes<HTMLLIElement>
-// see https://github.com/palantir/blueprint/issues/6094
-export interface MenuItemProps extends ActionProps, LinkProps {
+/**
+ * Note that the HTML attributes supported by this component are spread to the nested `<a>` element, while the
+ * `ref` is attached to the root `<li>` element. This is an unfortunate quirk in the API which we keep around
+ * for backwards-compatibility.
+ */
+export interface MenuItemProps
+    extends ActionProps<HTMLAnchorElement>,
+        React.AnchorHTMLAttributes<HTMLAnchorElement>,
+        React.RefAttributes<HTMLLIElement> {
     /** Item text, required for usability. */
     text: React.ReactNode;
 
@@ -168,166 +174,147 @@ export interface MenuItemProps extends ActionProps, LinkProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/menu.menu-item
  */
-export class MenuItem extends AbstractPureComponent<MenuItemProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> {
-    public static defaultProps: MenuItemProps = {
-        active: false,
-        disabled: false,
-        multiline: false,
-        popoverProps: {},
-        selected: undefined,
-        shouldDismissPopover: true,
-        text: "",
-    };
+export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => {
+    const {
+        active,
+        className,
+        children,
+        disabled,
+        intent,
+        labelClassName,
+        labelElement,
+        multiline,
+        popoverProps,
+        roleStructure = "menuitem",
+        selected,
+        shouldDismissPopover,
+        submenuProps,
+        text,
+        textClassName,
+        tagName = "a",
+        htmlTitle,
+        ...htmlProps
+    } = props;
 
-    public static displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;
+    const [liRole, targetRole, icon, ariaSelected] =
+        roleStructure === "listoption" // "listoption": parent has listbox role, or is a <select>
+            ? [
+                  "option",
+                  undefined, // target should have no role
+                  props.icon ?? (selected === undefined ? undefined : selected ? "small-tick" : "blank"),
+                  Boolean(selected), // aria-selected prop
+              ]
+            : roleStructure === "menuitem" // "menuitem": parent has menu role
+            ? [
+                  "none",
+                  "menuitem",
+                  props.icon,
+                  undefined, // don't set aria-selected prop
+              ]
+            : roleStructure === "none" // "none": allows wrapping MenuItem in custom <li>
+            ? [
+                  "none",
+                  undefined, // target should have no role
+                  props.icon,
+                  undefined, // don't set aria-selected prop
+              ]
+            : // roleStructure === "listitem"
+              [
+                  undefined, // needs no role prop, li is listitem by default
+                  undefined,
+                  props.icon,
+                  undefined, // don't set aria-selected prop
+              ];
 
-    public render() {
-        const {
-            active,
-            className,
-            children,
-            disabled,
-            intent,
-            labelClassName,
-            labelElement,
-            multiline,
-            popoverProps,
-            roleStructure = "menuitem",
-            selected,
-            shouldDismissPopover,
-            submenuProps,
-            text,
-            textClassName,
-            tagName = "a",
-            htmlTitle,
-            ...htmlProps
-        } = this.props;
+    const hasIcon = icon != null;
+    const hasSubmenu = children != null;
 
-        const [liRole, targetRole, icon, ariaSelected] =
-            roleStructure === "listoption" // "listoption": parent has listbox role, or is a <select>
-                ? [
-                      "option",
-                      undefined, // target should have no role
-                      this.props.icon ?? (selected === undefined ? undefined : selected ? "small-tick" : "blank"),
-                      Boolean(selected), // aria-selected prop
-                  ]
-                : roleStructure === "menuitem" // "menuitem": parent has menu role
-                ? [
-                      "none",
-                      "menuitem",
-                      this.props.icon,
-                      undefined, // don't set aria-selected prop
-                  ]
-                : roleStructure === "none" // "none": allows wrapping MenuItem in custom <li>
-                ? [
-                      "none",
-                      undefined, // target should have no role
-                      this.props.icon,
-                      undefined, // don't set aria-selected prop
-                  ]
-                : // roleStructure === "listitem"
-                  [
-                      undefined, // needs no role prop, li is listitem by default
-                      undefined,
-                      this.props.icon,
-                      undefined, // don't set aria-selected prop
-                  ];
+    const intentClass = Classes.intentClass(intent);
+    const anchorClasses = classNames(
+        Classes.MENU_ITEM,
+        intentClass,
+        {
+            [Classes.ACTIVE]: active,
+            [Classes.DISABLED]: disabled,
+            // prevent popover from closing when clicking on submenu trigger or disabled item
+            [Classes.POPOVER_DISMISS]: shouldDismissPopover && !disabled && !hasSubmenu,
+            [Classes.SELECTED]: active && intentClass === undefined,
+        },
+        className,
+    );
 
-        const hasIcon = icon != null;
-        const hasSubmenu = children != null;
-
-        const intentClass = Classes.intentClass(intent);
-        const anchorClasses = classNames(
-            Classes.MENU_ITEM,
-            intentClass,
-            {
-                [Classes.ACTIVE]: active,
-                [Classes.DISABLED]: disabled,
-                // prevent popover from closing when clicking on submenu trigger or disabled item
-                [Classes.POPOVER_DISMISS]: shouldDismissPopover && !disabled && !hasSubmenu,
-                [Classes.SELECTED]: active && intentClass === undefined,
-            },
-            className,
-        );
-
-        const target = React.createElement(
-            tagName,
-            {
-                // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
-                onKeyDown: clickElementOnKeyPress(["Enter", " "]),
-                // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
-                role: hasSubmenu ? "none" : targetRole,
-                tabIndex: hasSubmenu ? -1 : 0,
-                ...removeNonHTMLProps(htmlProps),
-                ...(disabled ? DISABLED_PROPS : {}),
-                className: anchorClasses,
-            },
-            hasIcon ? (
-                // wrap icon in a <span> in case `icon` is a custom element rather than a built-in icon identifier,
-                // so that we always render this class
-                <span className={Classes.MENU_ITEM_ICON}>
-                    <Icon icon={icon} aria-hidden={true} tabIndex={-1} />
-                </span>
-            ) : undefined,
-            <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>
-                {text}
-            </Text>,
-            this.maybeRenderLabel(labelElement),
-            hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" /> : undefined,
-        );
-
-        const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });
-        return (
-            <li className={liClasses} role={liRole} aria-selected={ariaSelected}>
-                {this.maybeRenderPopover(target, { role: targetRole, tabIndex: 0 }, children)}
-            </li>
-        );
-    }
-
-    private maybeRenderLabel(labelElement?: React.ReactNode) {
-        const { label, labelClassName } = this.props;
-        if (label == null && labelElement == null) {
-            return null;
-        }
-        return (
+    const maybeLabel =
+        props.label == null && labelElement == null ? null : (
             <span className={classNames(Classes.MENU_ITEM_LABEL, labelClassName)}>
-                {label}
+                {props.label}
                 {labelElement}
             </span>
         );
-    }
 
-    private maybeRenderPopover(
-        target: JSX.Element,
-        popoverTargetProps: PopoverProps["targetProps"],
-        children?: React.ReactNode,
-    ) {
-        if (children == null) {
-            return target;
-        }
-        const { disabled, popoverProps, submenuProps } = this.props;
-        return (
-            <Popover
-                autoFocus={false}
-                captureDismiss={false}
-                disabled={disabled}
-                enforceFocus={false}
-                hoverCloseDelay={0}
-                interactionKind="hover"
-                modifiers={SUBMENU_POPOVER_MODIFIERS}
-                targetProps={popoverTargetProps}
-                placement="right-start"
-                usePortal={false}
-                {...popoverProps}
-                content={<Menu {...submenuProps}>{children}</Menu>}
-                minimal={true}
-                popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
-            >
-                {target}
-            </Popover>
-        );
-    }
-}
+    const target = React.createElement(
+        tagName,
+        {
+            // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
+            onKeyDown: clickElementOnKeyPress(["Enter", " "]),
+            // if hasSubmenu, must apply correct role and tabIndex to the outer Popover2 target <span> instead of this target element
+            role: hasSubmenu ? "none" : targetRole,
+            tabIndex: hasSubmenu ? -1 : 0,
+            ...removeNonHTMLProps(htmlProps),
+            ...(disabled ? DISABLED_PROPS : {}),
+            className: anchorClasses,
+        },
+        hasIcon ? (
+            // wrap icon in a <span> in case `icon` is a custom element rather than a built-in icon identifier,
+            // so that we always render this class
+            <span className={Classes.MENU_ITEM_ICON}>
+                <Icon icon={icon} aria-hidden={true} tabIndex={-1} />
+            </span>
+        ) : undefined,
+        <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>
+            {text}
+        </Text>,
+        maybeLabel,
+        hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" /> : undefined,
+    );
+
+    const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });
+    return (
+        <li className={liClasses} ref={ref} role={liRole} aria-selected={ariaSelected}>
+            {children == null ? (
+                target
+            ) : (
+                <Popover
+                    autoFocus={false}
+                    captureDismiss={false}
+                    disabled={disabled}
+                    enforceFocus={false}
+                    hoverCloseDelay={0}
+                    interactionKind="hover"
+                    modifiers={SUBMENU_POPOVER_MODIFIERS}
+                    targetProps={{ role: targetRole, tabIndex: 0 }}
+                    placement="right-start"
+                    usePortal={false}
+                    {...popoverProps}
+                    content={<Menu {...submenuProps}>{children}</Menu>}
+                    minimal={true}
+                    popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
+                >
+                    {target}
+                </Popover>
+            )}
+        </li>
+    );
+});
+MenuItem.defaultProps = {
+    active: false,
+    disabled: false,
+    multiline: false,
+    popoverProps: {},
+    selected: undefined,
+    shouldDismissPopover: true,
+    text: "",
+};
+MenuItem.displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;
 
 const SUBMENU_POPOVER_MODIFIERS: PopoverProps["modifiers"] = {
     // 20px padding - scrollbar width + a bit

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -58,7 +58,7 @@ export default function() {
     return (
         <div tabIndex={0} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
             Press <KeyCombo combo="R" /> to refresh data, <KeyCombo combo="F" /> to focus the input...
-            <InputGroup ref={inputRef} />
+            <InputGroup inputRef={inputRef} />
         </div>
     );
 }

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -26,17 +26,16 @@ type ControlType = typeof Checkbox | typeof Radio | typeof Switch;
 describe("Controls:", () => {
     controlsTests(Checkbox, "checkbox", Classes.CHECKBOX, () => {
         describe("indeterminate", () => {
-            let input: HTMLInputElement | null = null;
-            const handleInputRef = (ref: HTMLInputElement | null) => (input = ref);
+            const inputRef = React.createRef<HTMLInputElement>();
 
             it("prop sets element state", () => {
-                mount(<Checkbox indeterminate={true} inputRef={handleInputRef} />);
-                assert.isTrue(input?.indeterminate);
+                mount(<Checkbox indeterminate={true} ref={inputRef} />);
+                assert.isTrue(inputRef.current?.indeterminate);
             });
 
             it("default prop sets element state", () => {
-                mount(<Checkbox defaultIndeterminate={true} inputRef={handleInputRef} />);
-                assert.isTrue(input?.indeterminate);
+                mount(<Checkbox defaultIndeterminate={true} ref={inputRef} />);
+                assert.isTrue(inputRef.current?.indeterminate);
             });
         });
     });

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -294,18 +294,18 @@ describe("<Overlay>", () => {
         });
 
         it("returns focus to overlay if enforceFocus=true", done => {
-            let buttonRef: HTMLElement | null = null;
-            let inputRef: HTMLElement | null = null;
+            const buttonRef = React.createRef<HTMLButtonElement>();
+            const inputRef = React.createRef<HTMLInputElement>();
             mountWrapper(
                 <div>
-                    <button ref={ref => (buttonRef = ref)} />
+                    <button ref={buttonRef} />
                     <Overlay className={overlayClassName} enforceFocus={true} isOpen={true} usePortal={true}>
-                        <input autoFocus={true} ref={ref => (inputRef = ref)} />
+                        <input autoFocus={true} ref={inputRef} />
                     </Overlay>
                 </div>,
             );
-            assert.strictEqual(document.activeElement, inputRef);
-            buttonRef!.focus();
+            assert.strictEqual(document.activeElement, inputRef.current);
+            buttonRef.current?.focus();
             assertFocusIsInOverlayWithTimeout(done);
         });
 

--- a/packages/datetime/test/dateInputTests.tsx
+++ b/packages/datetime/test/dateInputTests.tsx
@@ -71,9 +71,9 @@ describe("<DateInput>", () => {
     });
 
     it("supports inputProps.inputRef", () => {
-        let input: HTMLInputElement | null = null;
-        mount(<DateInput {...DATE_FORMAT} inputProps={{ inputRef: ref => (input = ref) }} />);
-        assert.instanceOf(input, HTMLInputElement);
+        const inputRef = React.createRef<HTMLInputElement>();
+        mount(<DateInput {...DATE_FORMAT} inputProps={{ inputRef }} />);
+        assert.instanceOf(inputRef.current, HTMLInputElement);
     });
 
     it("Popover opens on input focus", () => {

--- a/packages/datetime2/test/components/dateInput2Tests.tsx
+++ b/packages/datetime2/test/components/dateInput2Tests.tsx
@@ -103,9 +103,9 @@ describe("<DateInput2>", () => {
         });
 
         it("supports inputProps.inputRef", () => {
-            let input: HTMLInputElement | null = null;
-            mount(<DateInput2 {...DEFAULT_PROPS} inputProps={{ inputRef: ref => (input = ref) }} />);
-            assert.instanceOf(input, HTMLInputElement);
+            const inputRef = React.createRef<HTMLInputElement>();
+            mount(<DateInput2 {...DEFAULT_PROPS} inputProps={{ inputRef }} />);
+            assert.instanceOf(inputRef.current, HTMLInputElement);
         });
 
         it("does not render a TimezoneSelect if timePrecision is undefined", () => {

--- a/packages/select/src/__examples__/films.tsx
+++ b/packages/select/src/__examples__/films.tsx
@@ -140,7 +140,7 @@ export const TOP_100_FILMS: Film[] = [
  */
 export function getFilmItemProps(
     film: Film,
-    { handleClick, handleFocus, modifiers, query }: ItemRendererProps,
+    { handleClick, handleFocus, modifiers, query, ref }: ItemRendererProps,
 ): MenuItemProps & React.Attributes {
     return {
         active: modifiers.active,
@@ -149,8 +149,7 @@ export function getFilmItemProps(
         label: film.year.toString(),
         onClick: handleClick,
         onFocus: handleFocus,
-        // TODO(adahiya): MUST FIX FOR BLUEPRINT v5.0, add back `ref` prop support
-        // see https://github.com/palantir/blueprint/issues/6094
+        ref,
         roleStructure: "listoption",
         text: highlightText(`${film.rank}. ${film.title}`, query),
     };

--- a/packages/select/test/itemRendererTests.tsx
+++ b/packages/select/test/itemRendererTests.tsx
@@ -26,15 +26,14 @@ describe("ItemRenderer", () => {
     // N.B. don't use `renderFilm` here from the src/__examples__ directory, since we are specifically trying to
     // test the ergonomics and type definitions of the item renderer API by defining custom renderers.
     describe("allows defining basic item renderers", () => {
-        const myItemRenderer: ItemRenderer<Film> = (item, { modifiers, handleClick, handleFocus }) => {
+        const myItemRenderer: ItemRenderer<Film> = (item, { modifiers, handleClick, handleFocus, ref }) => {
             return (
                 <MenuItem
                     active={modifiers.active}
                     key={item.title}
                     onClick={handleClick}
                     onFocus={handleFocus}
-                    // TODO(adahiya): MUST FIX FOR BLUEPRINT v5.0, add back `ref` prop support
-                    // see https://github.com/palantir/blueprint/issues/6094
+                    ref={ref}
                     text={item.title}
                 />
             );

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -23,7 +23,7 @@ import { TABLE_COPY_FAILED } from "../../common/errors";
 import { Regions } from "../../regions";
 import { MenuContext } from "./menuContext";
 
-export interface CopyCellsMenuItemProps extends MenuItemProps {
+export interface CopyCellsMenuItemProps extends Omit<MenuItemProps, "onCopy"> {
     /**
      * The `MenuContext` that launched the menu.
      */


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Remove a bunch of TODO "MUST FIX" comments I recently added to the v5 branch
- Standardize usage of `ref` prop in various components where it's straightforward to do so:
  - ButtonGroup
  - ControlGroup
  - MenuItem
  - Radio
  - Checkbox
  - Switch
- Use `React.createRef()` in a few more places in test suites (instead of ref callbacks)

#### Not done in this PR:

Migrate from `inputRef` to `ref` in input-based components as suggested in https://github.com/palantir/blueprint/issues/4763. This is going to require a bit of work, and I'm not sure it's worth doing this right now for v5.0. We can punt it to v6.0.

