### PR TITLE
[v5] [popover2] restore package with re-exports from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "dev:select": "lerna run dev --scope \"@blueprintjs/{select,docs-app}\"",
         "dev:table": "lerna run dev --scope \"@blueprintjs/{table,table-dev-app}\"",
         "dist": "run-s dist:libs dist:apps",
-        "dist:libs": "lerna run dist --scope \"@blueprintjs/{colors,core,datetime,datetime2,docs-theme,icons,select,table}\"",
+        "dist:libs": "lerna run dist --scope \"@blueprintjs/{colors,core,datetime,datetime2,docs-theme,icons,popover2,select,table}\"",
         "dist:apps": "lerna run dist --scope \"@blueprintjs/{docs-app,landing-app,table-dev-app,demo-app}\"",
         "docs-data": "lerna run compile --scope \"@blueprintjs/docs-data\"",
         "format": "prettier --write \"./**/*.{ts,tsx,json}\"",

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -79,6 +79,7 @@ export {
     PopoverClickTargetHandlers,
     PopoverHoverTargetHandlers,
     PopperBoundary,
+    PopperCustomModifier,
     PopperModifierOverrides,
     Placement,
     PopperPlacements,

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -48,7 +48,7 @@ export type PopperModifierOverrides = Partial<{
  *
  * @see https://popper.js.org/docs/v2/modifiers/#custom-modifiers
  */
-export type PopperCustomModifer = Partial<Modifier<any, object>>;
+export type PopperCustomModifier = Partial<Modifier<any, object>>;
 
 /**
  * Default props interface for the Popover target element.
@@ -207,7 +207,7 @@ export interface PopoverSharedProps<TProps extends DefaultPopoverTargetHTMLProps
      *
      * @see https://popper.js.org/docs/v2/modifiers/#custom-modifiers
      */
-    modifiersCustom?: readonly PopperCustomModifer[];
+    modifiersCustom?: readonly PopperCustomModifier[];
 
     /**
      * Callback invoked in controlled mode when the popover open state *would*

--- a/packages/popover2/.npmignore
+++ b/packages/popover2/.npmignore
@@ -1,0 +1,5 @@
+coverage/
+test/
+webpack.config.js
+karma.conf.js
+.npmrc

--- a/packages/popover2/LICENSE
+++ b/packages/popover2/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/packages/popover2/README.md
+++ b/packages/popover2/README.md
@@ -1,0 +1,18 @@
+<img height="204" src="https://cloud.githubusercontent.com/assets/464822/20228152/d3f36dc2-a804-11e6-80ff-51ada2d13ea7.png">
+
+# [Blueprint](http://blueprintjs.com/) Popover2 & Tooltip2 Components
+
+Blueprint is a React UI toolkit for the web.
+
+This package contains re-exports of popover-related components from @blueprintjs/core. These "V2" components were
+previously available in @blueprintjs/popover v4.x, but they were promoted to the standard "V1" components in
+@blueprintjs/core v5.x.
+
+Once you upgrade to Blueprint v5.0, you should migrate your imports to the @blueprintjs/core package.
+
+```diff
+- import { Popover2 } from "@blueprintjs/popover2";
++ import { Popover } from "@blueprintjs/core";
+```
+
+### [Full Documentation](http://blueprintjs.com/docs) | [Source Code](https://github.com/palantir/blueprint)

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -1,0 +1,67 @@
+{
+    "name": "@blueprintjs/popover2",
+    "version": "1.14.1",
+    "description": "Re-exports of popover-related components from @blueprintjs/core",
+    "main": "lib/cjs/index.js",
+    "module": "lib/esm/index.js",
+    "esnext": "lib/esnext/index.js",
+    "typings": "lib/esm/index.d.ts",
+    "style": "lib/css/blueprint-popover2.css",
+    "sideEffects": [
+        "**/*.css"
+    ],
+    "scripts": {
+        "clean": "rm -rf dist/* && rm -rf lib/*",
+        "compile": "run-p \"compile:*\"",
+        "compile:esm": "tsc -p ./src",
+        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
+        "compile:css": "sass-compile ./src",
+        "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
+        "dist": "run-s \"dist:*\"",
+        "dist:css": "css-dist lib/css/*.css",
+        "dist:verify": "assert-package-layout",
+        "lint": "run-p lint:scss lint:es",
+        "lint:scss": "sass-lint",
+        "lint:es": "es-lint",
+        "lint-fix": "es-lint --fix && sass-lint --fix",
+        "test": "exit 0",
+        "verify": "npm-run-all compile -p dist test lint"
+    },
+    "dependencies": {
+        "@blueprintjs/core": "^4.18.0",
+        "tslib": "~2.5.0"
+    },
+    "peerDependencies": {
+        "@types/react": "^16.14.32 || 17 || 18",
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
+    },
+    "peerDependenciesMeta": {
+        "@types/react": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@blueprintjs/node-build-scripts": "^7.1.1",
+        "npm-run-all": "^4.1.5",
+        "react": "^16.14.0",
+        "react-dom": "^16.14.0",
+        "typescript": "~4.8.4"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:palantir/blueprint.git",
+        "directory": "packages/popover2"
+    },
+    "keywords": [
+        "palantir",
+        "blueprint",
+        "components",
+        "styles",
+        "theme",
+        "ui"
+    ],
+    "author": "Palantir Technologies",
+    "license": "Apache-2.0"
+}

--- a/packages/popover2/src/blueprint-popover2.scss
+++ b/packages/popover2/src/blueprint-popover2.scss
@@ -1,0 +1,8 @@
+/*
+
+Copyright 2021-present Palantir Technologies, Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0.
+
+*/
+
+// this file intentionally left empty

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -1,0 +1,44 @@
+/* !
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Classes as CoreClasses } from "@blueprintjs/core";
+
+/** @deprecated import from @blueprintjs/core instead */
+export const Classes = {
+    CONTEXT_MENU2: CoreClasses.CONTEXT_MENU,
+    CONTEXT_MENU2_BACKDROP: CoreClasses.CONTEXT_MENU_BACKDROP,
+    CONTEXT_MENU2_POPOVER2: CoreClasses.CONTEXT_MENU_POPOVER,
+    CONTEXT_MENU2_VIRTUAL_TARGET: CoreClasses.CONTEXT_MENU_VIRTUAL_TARGET,
+
+    POPOVER2: CoreClasses.POPOVER,
+    POPOVER2_ARROW: CoreClasses.POPOVER_ARROW,
+    POPOVER2_BACKDROP: CoreClasses.POPOVER_BACKDROP,
+    POPOVER2_CAPTURING_DISMISS: CoreClasses.POPOVER_CAPTURING_DISMISS,
+    POPOVER2_CONTENT: CoreClasses.POPOVER_CONTENT,
+    POPOVER2_CONTENT_PLACEMENT: CoreClasses.POPOVER_CONTENT_PLACEMENT,
+    POPOVER2_CONTENT_SIZING: CoreClasses.POPOVER_CONTENT_SIZING,
+    POPOVER2_DISMISS: CoreClasses.POPOVER_DISMISS,
+    POPOVER2_DISMISS_OVERRIDE: CoreClasses.POPOVER_DISMISS_OVERRIDE,
+    POPOVER2_MATCH_TARGET_WIDTH: CoreClasses.POPOVER_MATCH_TARGET_WIDTH,
+    POPOVER2_OPEN: CoreClasses.POPOVER_OPEN,
+    POPOVER2_POPPER_ESCAPED: CoreClasses.POPOVER_POPPER_ESCAPED,
+    POPOVER2_REFERENCE_HIDDEN: CoreClasses.POPOVER_REFERENCE_HIDDEN,
+    POPOVER2_TARGET: CoreClasses.POPOVER_TARGET,
+    POPOVER2_TRANSITION_CONTAINER: CoreClasses.POPOVER_TRANSITION_CONTAINER,
+
+    TOOLTIP2: CoreClasses.TOOLTIP,
+    TOOLTIP2_INDICATOR: CoreClasses.TOOLTIP_INDICATOR,
+};

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable deprecation/deprecation */
+
+export {
+    /** @deprecated import from @blueprintjs/core instead */
+    BreadcrumbProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    Breadcrumbs as Breadcrumbs2,
+    /** @deprecated import from @blueprintjs/core instead */
+    BreadcrumbsProps as Breadcrumbs2Props,
+
+    /** @deprecated import from @blueprintjs/core instead */
+    ContextMenu as ContextMenu2,
+    /** @deprecated import from @blueprintjs/core instead */
+    ContextMenuChildrenProps as ContextMenu2ChildrenProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    ContextMenuContentProps as ContextMenu2ContentProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    ContextMenuPopover as ContextMenu2Popover,
+    /** @deprecated import from @blueprintjs/core instead */
+    ContextMenuPopoverProps as ContextMenu2PopoverProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    ContextMenuProps as ContextMenu2Props,
+    /** @deprecated import from @blueprintjs/core instead */
+    hideContextMenu,
+    /** @deprecated import from @blueprintjs/core instead */
+    showContextMenu,
+
+    /** @deprecated import from @blueprintjs/core instead */
+    MenuItem as MenuItem2,
+    /** @deprecated import from @blueprintjs/core instead */
+    MenuItemProps as MenuItem2Props,
+
+    /** @deprecated import from @blueprintjs/core instead */
+    DefaultPopoverTargetHTMLProps as DefaultPopover2TargetHTMLProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    Placement,
+    /** @deprecated import from @blueprintjs/core instead */
+    Popover as Popover2,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopoverClickTargetHandlers as Popover2ClickTargetHandlers,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopoverHoverTargetHandlers as Popover2HoverTargetHandlers,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopoverInteractionKind as Popover2InteractionKind,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopoverProps as Popover2Props,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopoverSharedProps as Popover2SharedProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopoverTargetProps as Popover2TargetProps,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopperBoundary,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopperCustomModifier,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopperModifierOverrides,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopperPlacements as PlacementOptions,
+    /** @deprecated import from @blueprintjs/core instead */
+    PopupKind,
+    /** @deprecated import from @blueprintjs/core instead */
+    StrictModifierNames,
+
+    /** @deprecated import from @blueprintjs/core instead */
+    ResizeSensor as ResizeSensor2,
+    /** @deprecated import from @blueprintjs/core instead */
+    ResizeSensorProps as ResizeSensor2Props,
+
+    /** @deprecated import from @blueprintjs/core instead */
+    Tooltip as Tooltip2,
+    /** @deprecated import from @blueprintjs/core instead */
+    TooltipProps as Tooltip2Props,
+} from "@blueprintjs/core";
+
+export { Classes } from "./classes";

--- a/packages/popover2/src/tsconfig.json
+++ b/packages/popover2/src/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../../config/tsconfig.base",
+    "compilerOptions": {
+        "outDir": "../lib/esm"
+    }
+}


### PR DESCRIPTION
Re-export APIs from @blueprintjs/core so that consumers can minimize their code diff during the v5.0.0 upgrade