### PR TITLE
[v5] [select] feat: re-export v2 APIs

### DIFF
--- a/packages/select/src/components/deprecatedAliases.ts
+++ b/packages/select/src/components/deprecatedAliases.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+    /** @deprecated import "v1" API instead */
+    MultiSelect as MultiSelect2,
+    /** @deprecated import "v1" API instead */
+    MultiSelectProps as MultiSelect2Props,
+} from "./multi-select/multiSelect";
+
+export {
+    /** @deprecated import "v1" API instead */
+    Select as Select2,
+    /** @deprecated import "v1" API instead */
+    SelectProps as Select2Props,
+} from "./select/select";
+
+export {
+    /** @deprecated import "v1" API instead */
+    Suggest as Suggest2,
+    /** @deprecated import "v1" API instead */
+    SuggestProps as Suggest2Props,
+} from "./suggest/suggest";

--- a/packages/select/src/components/index.ts
+++ b/packages/select/src/components/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-export * from "./multi-select/multiSelect";
-export * from "./omnibar/omnibar";
-export * from "./query-list/queryList";
-export * from "./select/select";
-export * from "./suggest/suggest";
+export { MultiSelect, MultiSelectProps } from "./multi-select/multiSelect";
+export { Omnibar, OmnibarProps } from "./omnibar/omnibar";
+export { QueryList, QueryListProps, QueryListRendererProps } from "./query-list/queryList";
+export { Select, SelectProps } from "./select/select";
+export { Suggest, SuggestProps } from "./suggest/suggest";

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -119,6 +119,7 @@ export interface MultiSelectProps<T> extends ListItemsProps<T>, SelectPopoverPro
     tagRenderer: (item: T) => React.ReactNode;
 }
 
+/** Exported for testing, not part of public API */
 export interface MultiSelectState {
     isOpen: boolean;
 }

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -123,6 +123,7 @@ export interface QueryListRendererProps<T> // Omit `createNewItem`, because it's
     itemList: React.ReactNode;
 }
 
+/** Exported for testing, not part of public API */
 export interface QueryListState<T> {
     /** The currently focused item (for keyboard interactions). */
     activeItem: T | CreateNewItem | null;

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -89,6 +89,7 @@ export interface SelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
     resetOnClose?: boolean;
 }
 
+/** Exported for testing, not part of public API */
 export interface SelectState {
     isOpen: boolean;
 }

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -16,3 +16,4 @@
 
 export * from "./common";
 export * from "./components";
+export * from "./components/deprecatedAliases";

--- a/packages/select/test/isotest.js
+++ b/packages/select/test/isotest.js
@@ -25,6 +25,9 @@ describe("Select isomorphic rendering", () => {
         MultiSelect: {
             props: { items: [], query: "", selectedItems: [], tagRenderer: () => null },
         },
+        MultiSelect2: {
+            skip: true,
+        },
         QueryList: {
             // needs at least one handler or it returns undefined
             props: { renderer: () => null },
@@ -33,8 +36,14 @@ describe("Select isomorphic rendering", () => {
         Select: {
             props: { items: [] },
         },
+        Select2: {
+            skip: true,
+        },
         Suggest: {
             props: { items: [] },
+        },
+        Suggest2: {
+            skip: true,
         },
         Omnibar: {
             props: { items: [], isOpen: true, overlayProps: { usePortal: false } },

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -22,8 +22,9 @@ import sinon from "sinon";
 import { Classes as CoreClasses, Tag } from "@blueprintjs/core";
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
-import { ItemRendererProps, MultiSelect, MultiSelectProps, MultiSelectState } from "../src";
+import { ItemRendererProps, MultiSelect, MultiSelectProps } from "../src";
 import { Film, renderFilm, TOP_100_FILMS } from "../src/__examples__";
+import type { MultiSelectState } from "../src/components/multi-select/multiSelect";
 import { selectComponentSuite } from "./selectComponentSuite";
 
 describe("<MultiSelect>", () => {

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -28,9 +28,9 @@ import {
     QueryList,
     QueryListProps,
     QueryListRendererProps,
-    QueryListState,
 } from "../src";
 import { Film, renderFilm, TOP_100_FILMS } from "../src/__examples__";
+import type { QueryListState } from "../src/components/query-list/queryList";
 
 type FilmQueryListWrapper = ReactWrapper<QueryListProps<Film>, QueryListState<Film>>;
 

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -21,8 +21,9 @@ import * as sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup, MenuItem, Popover } from "@blueprintjs/core";
 
-import { ItemRendererProps, Select, SelectProps, SelectState } from "../src";
+import { ItemRendererProps, Select, SelectProps } from "../src";
 import { Film, renderFilm, TOP_100_FILMS } from "../src/__examples__";
+import type { SelectState } from "../src/components/select/select";
 import { selectComponentSuite } from "./selectComponentSuite";
 import { selectPopoverTestSuite } from "./selectPopoverTestSuite";
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

Re-export Select2, Suggest2, MultiSelect2 APIs from @blueprintjs/select package

