### PR TITLE
[v5] [core] feat: restore PanelStack & PanelStack2 APIs

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -242,6 +242,11 @@ export const PANEL_STACK_HEADER = `${PANEL_STACK}-header`;
 export const PANEL_STACK_HEADER_BACK = `${PANEL_STACK}-header-back`;
 export const PANEL_STACK_VIEW = `${PANEL_STACK}-view`;
 
+export const PANEL_STACK2 = `${NS}-panel-stack2`;
+export const PANEL_STACK2_HEADER = `${PANEL_STACK}-header`;
+export const PANEL_STACK2_HEADER_BACK = `${PANEL_STACK}-header-back`;
+export const PANEL_STACK2_VIEW = `${PANEL_STACK}-view`;
+
 export const POPOVER = `${NS}-popover`;
 export const POPOVER_ARROW = `${POPOVER}-arrow`;
 export const POPOVER_BACKDROP = `${POPOVER}-backdrop`;

--- a/packages/core/src/components/_index.scss
+++ b/packages/core/src/components/_index.scss
@@ -27,6 +27,7 @@
 @import "overflow-list/overflow-list";
 @import "overlay/overlay";
 @import "panel-stack/panel-stack";
+@import "panel-stack2/panel-stack2";
 @import "popover/popover";
 @import "portal/portal";
 @import "progress-bar/progress-bar";

--- a/packages/core/src/components/components.md
+++ b/packages/core/src/components/components.md
@@ -19,6 +19,7 @@
 @page non-ideal-state
 @page overflow-list
 @page panel-stack
+@page panel-stack2
 @page progress-bar
 @page resize-sensor
 @page skeleton

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -69,8 +69,12 @@ export { NonIdealState, NonIdealStateProps, NonIdealStateIconSize } from "./non-
 export { OverflowList, OverflowListProps } from "./overflow-list/overflowList";
 export { Overlay, OverlayLifecycleProps, OverlayProps, OverlayableProps } from "./overlay/overlay";
 export { Text, TextProps } from "./text/text";
+// eslint-disable-next-line deprecation/deprecation
 export { PanelStack, PanelStackProps } from "./panel-stack/panelStack";
-export { Panel, PanelProps } from "./panel-stack/panelTypes";
+// eslint-disable-next-line deprecation/deprecation
+export { IPanel, IPanelProps } from "./panel-stack/panelProps";
+export { PanelStack2, PanelStack2Props } from "./panel-stack2/panelStack2";
+export { Panel, PanelProps } from "./panel-stack2/panelTypes";
 export { PopoverProps, Popover, PopoverInteractionKind } from "./popover/popover";
 export {
     DefaultPopoverTargetHTMLProps,

--- a/packages/core/src/components/panel-stack/panel-stack.md
+++ b/packages/core/src/components/panel-stack/panel-stack.md
@@ -1,5 +1,18 @@
 @# Panel stack
 
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h5 class="@ns-heading">
+
+Deprecated: use [PanelStack2](#core/components/panel-stack2)
+
+</h5>
+
+This API is **deprecated since @blueprintjs/core v3.40.0** in favor of the new
+PanelStack2 component. You should migrate to the new API which will become the
+standard in a future major version of Blueprint.
+
+</div>
+
 `PanelStack` manages a stack of panels and displays only the topmost panel.
 
 Each panel appears with a header containing a "back" button to return to the
@@ -18,68 +31,47 @@ React trees mounted, change the `renderActivePanelOnly` prop.
 
 @## Panels
 
-Panels are supplied as `Panel` objects, where `renderPanel` and `props` are
-used to render the panel element and `title` will appear in the header and back
-button. This breakdown allows the component to avoid cloning elements. Note
-that each panel is only mounted when it is atop the stack and is unmounted when
-it is closed or when a panel opens above it.
+Panels are supplied as `IPanel` objects like `{ component, props, title }`,
+where `component` and `props` are used to render the panel element and `title`
+will appear in the header and back button. This breakdown allows the component
+to avoid cloning elements. Note that each panel is only mounted when it is atop
+the stack and is unmounted when it is closed or when a panel opens above it.
 
-`PanelStack` injects panel action callbacks into each panel renderer. These
-allow you to close the current panel or open a new one on top of it during the
-panel's lifecycle. For example:
+`PanelStack` injects its own `IPanelProps` into each panel (in addition to the
+`props` defined alongside the `component`), providing methods to imperatively
+close the current panel or open a new one on top of it.
 
 ```tsx
-import { Button, PanelProps } from "@blueprintjs/core";
+import { Button, IPanelProps, PanelStack } from "@blueprintjs/core";
 
-type SettingsPanelInfo = { /* ...  */ };
-type AccountSettingsPanelInfo = { /* ...  */ };
-type NotificationSettingsPanelInfo = { /* ...  */ };
+class MyPanel extends React.Component<IPanelProps> {
+    public render() {
+        return <Button onClick={this.openSettingsPanel} text="Settings" />
+    }
 
-const AccountSettingsPanel: React.FC<PanelProps<AccountSettingsPanelInfo>> = props => {
-    // implementation
-};
-
-const NotificationSettingsPanel: React.FC<PanelProps<NotificationSettingsPanelInfo>> = props => {
-    // implementation
-};
-
-const SettingsPanel: React.FC<PanelProps<SettingsPanelInfo>> = props => {
-    const { openPanel, closePanel, ...info } = props;
-
-    const openAccountSettings = () =>
-        openPanel({
-            props: {
-                /* ... */
-            },
-            renderPanel: AccountSettingsPanel,
-            title: "Account settings",
+    private openSettingsPanel() {
+        // openPanel (and closePanel) are injected by PanelStack
+        this.props.openPanel({
+            component: SettingsPanel, // <- class or stateless function type
+            props: { enabled: true }, // <- SettingsPanel props without IPanelProps
+            title: "Settings",        // <- appears in header and back button
         });
-    const openNotificationSettings = () =>
-        openPanel({
-            props: {
-                /* ... */
-            },
-            renderPanel: NotificationSettingsPanel,
-            title: "Notification settings",
-        });
-
-    return (
-        <>
-            <Button onClick={openAccountSettings} text="Account settings" />
-            <Button onClick={openNotificationSettings} text="Notification settings" />
-        </>
-    );
+    }
 }
+
+class SettingsPanel extends React.Component<IPanelProps & { enabled: boolean }> {
+    // ...
+}
+
+<PanelStack initialPanel={{ component: MyPanel, title: "Home" }} />
 ```
 
-@interface Panel
+@interface IPanel
 
-@interface PanelActions
+@interface IPanelProps
 
-@## Props
+@## Props interface
 
 PanelStack can be operated as a controlled or uncontrolled component.
 
-If controlled, panels should be added to and removed from the _end_ of the `stack` array.
-
-@interface PanelStackProps
+@interface IPanelStackProps

--- a/packages/core/src/components/panel-stack/panelProps.ts
+++ b/packages/core/src/components/panel-stack/panelProps.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+/* eslint-disable deprecation/deprecation */
+
+/**
+ * An object describing a panel in a `PanelStack`.
+ *
+ * @deprecated use `Panel<T>` with PanelStack2
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export interface IPanel<P = {}> {
+    /**
+     * The component type to render for this panel. This must be a reference to
+     * the component class or SFC, _not_ a JSX element, so it can be re-created
+     * dynamically when needed.
+     */
+    component: React.ComponentType<P & IPanelProps>;
+
+    /**
+     * HTML title to be passed to the <Text> component
+     */
+    htmlTitle?: string;
+
+    /**
+     * The props passed to the component type when it is rendered. The methods
+     * in `IPanelProps` will be injected by `PanelStack`.
+     */
+    props?: P;
+
+    /**
+     * The title to be displayed above this panel. It is also used as the text
+     * of the back button for any panel opened by this panel.
+     */
+    title?: React.ReactNode;
+}
+
+/**
+ * Include this interface in your panel component's props type to access these
+ * two functions which are injected by `PanelStack`.
+ *
+ * ```tsx
+ * import { IPanelProps } from "@blueprintjs/core";
+ * export class SettingsPanel extends React.Component<IPanelProps & ISettingsPanelProps> {...}
+ * ```
+ *
+ * @deprecated use `PanelActions<T>` with PanelStack2
+ */
+export interface IPanelProps {
+    /**
+     * Call this method to programatically close this panel. If this is the only
+     * panel on the stack then this method will do nothing.
+     *
+     * Remember that the panel header always contains a "back" button that
+     * closes this panel on click (unless there is only one panel on the stack).
+     */
+    closePanel(): void;
+
+    /**
+     * Call this method to open a new panel on the top of the stack.
+     */
+    openPanel<P>(panel: IPanel<P>): void;
+}

--- a/packages/core/src/components/panel-stack2/_panel-stack2.scss
+++ b/packages/core/src/components/panel-stack2/_panel-stack2.scss
@@ -1,15 +1,15 @@
-// Copyright 2018 Palantir Technologies, Inc. All rights reserved.
+// Copyright 2021 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
 @import "../../common/variables";
 @import "@blueprintjs/core/src/common/react-transition";
 
-.#{$ns}-panel-stack {
+.#{$ns}-panel-stack2 {
   overflow: hidden;
   position: relative;
 }
 
-.#{$ns}-panel-stack-header {
+.#{$ns}-panel-stack2-header {
   align-items: center;
   box-shadow: 0 1px $pt-divider-black;
   display: flex;
@@ -33,7 +33,7 @@
   }
 }
 
-.#{$ns}-button.#{$ns}-panel-stack-header-back {
+.#{$ns}-button.#{$ns}-panel-stack2-header-back {
   margin-left: $pt-grid-size * 0.5;
   padding-left: 0;
   white-space: nowrap;
@@ -44,7 +44,7 @@
   }
 }
 
-.#{$ns}-panel-stack-view {
+.#{$ns}-panel-stack2-view {
   @include position-all(absolute, 0);
 
   background-color: $white;
@@ -67,16 +67,16 @@
 }
 
 // PUSH transition: enter from right (100%), existing panel moves off left.
-.#{$ns}-panel-stack-push {
+.#{$ns}-panel-stack2-push {
   @include react-transition-phase(
-    "#{$ns}-panel-stack",
+    "#{$ns}-panel-stack2",
     "enter",
     (transform: translateX(100%) translate(0%), opacity: 0 1),
     $easing: ease,
     $duration: $pt-transition-duration * 4
   );
   @include react-transition-phase(
-    "#{$ns}-panel-stack",
+    "#{$ns}-panel-stack2",
     "exit",
     (transform: translateX(-50%) translate(0%), opacity: 0 1),
     $easing: ease,
@@ -85,16 +85,16 @@
 }
 
 // POP transition: enter from left (-50%), existing panel moves off right.
-.#{$ns}-panel-stack-pop {
+.#{$ns}-panel-stack2-pop {
   @include react-transition-phase(
-    "#{$ns}-panel-stack",
+    "#{$ns}-panel-stack2",
     "enter",
     (transform: translateX(-50%) translate(0%), opacity: 0 1),
     $easing: ease,
     $duration: $pt-transition-duration * 4
   );
   @include react-transition-phase(
-    "#{$ns}-panel-stack",
+    "#{$ns}-panel-stack2",
     "exit",
     (transform: translateX(100%) translate(0%), opacity: 0 1),
     $easing: ease,

--- a/packages/core/src/components/panel-stack2/panel-stack2.md
+++ b/packages/core/src/components/panel-stack2/panel-stack2.md
@@ -1,0 +1,100 @@
+@# Panel stack (v2)
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+    <h5 class="@ns-heading">
+
+Migrating from [PanelStack](#core/components/panel-stack)?
+
+</h5>
+
+PanelStack2 is a replacement for PanelStack. It will become the standard
+API in a future major version of Blueprint. You are encouraged to use this
+new API now for forwards-compatibility. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/PanelStack2-migration) on the wiki.
+
+</div>
+
+
+`PanelStack2` manages a stack of panels and displays only the topmost panel.
+
+Each panel appears with a header containing a "back" button to return to the
+previous panel. The bottom-most `initialPanel` cannot be closed or removed from
+the stack. Panels use
+[`CSSTransition`](http://reactcommunity.org/react-transition-group/css-transition)
+for seamless transitions.
+
+By default, only the currently active panel is rendered to the DOM. This means
+that other panels are unmounted and can lose their component state as a user
+transitions between the panels. You can notice this in the example below as
+the numeric counter is reset. To render all panels to the DOM and keep their
+React trees mounted, change the `renderActivePanelOnly` prop.
+
+@reactExample PanelStack2Example
+
+@## Panels
+
+Panels are supplied as `Panel<T>` objects, where `renderPanel` and `props` are
+used to render the panel element and `title` will appear in the header and back button.
+This breakdown allows the component to avoid cloning elements.
+Note that each panel is only mounted when it is atop the stack and is unmounted when
+it is closed or when a panel opens above it.
+
+`PanelStack2` injects panel action callbacks into each panel renderer in addition to
+the `props` defined by `Panel<T>`. These allow you to close the current panel or open a
+new one on top of it during the panel's lifecycle. For example:
+
+```tsx
+import { Button, PanelProps } from "@blueprintjs/core";
+
+type SettingsPanelInfo = { /* ...  */ };
+type AccountSettingsPanelInfo = { /* ...  */ };
+type NotificationSettingsPanelInfo = { /* ...  */ };
+
+const AccountSettingsPanel: React.FC<PanelProps<AccountSettingsPanelInfo>> = props => {
+    // implementation
+};
+
+const NotificationSettingsPanel: React.FC<PanelProps<NotificationSettingsPanelInfo>> = props => {
+    // implementation
+};
+
+const SettingsPanel: React.FC<PanelProps<SettingsPanelInfo>> = props => {
+    const { openPanel, closePanel, ...info } = props;
+
+    const openAccountSettings = () =>
+        openPanel({
+            props: {
+                /* ... */
+            },
+            renderPanel: AccountSettingsPanel,
+            title: "Account settings",
+        });
+    const openNotificationSettings = () =>
+        openPanel({
+            props: {
+                /* ... */
+            },
+            renderPanel: NotificationSettingsPanel,
+            title: "Notification settings",
+        });
+
+    return (
+        <>
+            <Button onClick={openAccountSettings} text="Account settings" />
+            <Button onClick={openNotificationSettings} text="Notification settings" />
+        </>
+    );
+}
+```
+
+@interface Panel
+
+@interface PanelActions
+
+@## Props interface
+
+PanelStack2 can be operated as a controlled or uncontrolled component.
+
+If controlled, panels should be added to and removed from the _end_ of the `stack` array.
+
+@interface PanelStack2Props

--- a/packages/core/src/components/panel-stack2/panelStack2.tsx
+++ b/packages/core/src/components/panel-stack2/panelStack2.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+import { CSSTransition, TransitionGroup } from "react-transition-group";
+
+import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
+import { Panel } from "./panelTypes";
+import { PanelView2 } from "./panelView2";
+
+/**
+ * @template T type union of all possible panels in this stack
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export interface PanelStack2Props<T extends Panel<object>> extends Props {
+    /**
+     * The initial panel to show on mount. This panel cannot be removed from the
+     * stack and will appear when the stack is empty.
+     * This prop is only used in uncontrolled mode and is thus mutually
+     * exclusive with the `stack` prop.
+     */
+    initialPanel?: T;
+
+    /**
+     * Callback invoked when the user presses the back button or a panel
+     * closes itself with a `closePanel()` action.
+     */
+    onClose?: (removedPanel: T) => void;
+
+    /**
+     * Callback invoked when a panel opens a new panel with an `openPanel(panel)`
+     * action.
+     */
+    onOpen?: (addedPanel: T) => void;
+
+    /**
+     * If false, PanelStack will render all panels in the stack to the DOM, allowing their
+     * React component trees to maintain state as a user navigates through the stack.
+     * Panels other than the currently active one will be invisible.
+     *
+     * @default true
+     */
+    renderActivePanelOnly?: boolean;
+
+    /**
+     * Whether to show the header with the "back" button in each panel.
+     *
+     * @default true
+     */
+    showPanelHeader?: boolean;
+
+    /**
+     * The full stack of panels in controlled mode. The last panel in the stack
+     * will be displayed.
+     */
+    stack?: readonly T[];
+}
+
+interface PanelStack2Component {
+    /**
+     * @template T type union of all possible panels in this stack
+     */
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    <T extends Panel<object>>(props: PanelStack2Props<T>): JSX.Element | null;
+    displayName: string;
+}
+
+/**
+ * Panel stack (v2) component.
+ *
+ * @see https://blueprintjs.com/docs/#core/components/panel-stack2
+ * @template T type union of all possible panels in this stack
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const PanelStack2: PanelStack2Component = <T extends Panel<object>>(props: PanelStack2Props<T>) => {
+    const { renderActivePanelOnly = true, showPanelHeader = true, stack: propsStack } = props;
+    const [direction, setDirection] = React.useState("push");
+
+    const [localStack, setLocalStack] = React.useState<T[]>(
+        props.initialPanel !== undefined ? [props.initialPanel] : [],
+    );
+    const stack = React.useMemo(
+        () => (propsStack != null ? propsStack.slice().reverse() : localStack),
+        [localStack, propsStack],
+    );
+    const stackLength = React.useRef<number>(stack.length);
+    React.useEffect(() => {
+        if (stack.length !== stackLength.current) {
+            // Adjust the direction in case the stack size has changed, controlled or uncontrolled
+            setDirection(stack.length - stackLength.current < 0 ? "pop" : "push");
+        }
+        stackLength.current = stack.length;
+    }, [stack]);
+
+    const handlePanelOpen = React.useCallback(
+        (panel: T) => {
+            props.onOpen?.(panel);
+            if (props.stack == null) {
+                setLocalStack(prevStack => [panel, ...prevStack]);
+            }
+        },
+        [props.onOpen],
+    );
+    const handlePanelClose = React.useCallback(
+        (panel: T) => {
+            // only remove this panel if it is at the top and not the only one.
+            if (stack[0] !== panel || stack.length <= 1) {
+                return;
+            }
+            props.onClose?.(panel);
+            if (props.stack == null) {
+                setLocalStack(prevStack => prevStack.slice(1));
+            }
+        },
+        [stack, props.onClose],
+    );
+
+    // early return, after all hooks are called
+    if (stack.length === 0) {
+        return null;
+    }
+
+    const panelsToRender = renderActivePanelOnly ? [stack[0]] : stack;
+    const panels = panelsToRender
+        .map((panel: T, index: number) => {
+            // With renderActivePanelOnly={false} we would keep all the CSSTransitions rendered,
+            // therefore they would not trigger the "enter" transition event as they were entered.
+            // To force the enter event, we want to change the key, but stack.length is not enough
+            // and a single panel should not rerender as long as it's hidden.
+            // This key contains two parts: first one, stack.length - index is constant (and unique) for each panel,
+            // second one, active changes only when the panel becomes or stops being active.
+            const layer = stack.length - index;
+            const key = renderActivePanelOnly ? stack.length : layer;
+
+            return (
+                <CSSTransition classNames={Classes.PANEL_STACK2} key={key} timeout={400}>
+                    <PanelView2<T>
+                        onClose={handlePanelClose}
+                        onOpen={handlePanelOpen}
+                        panel={panel}
+                        previousPanel={stack[index + 1]}
+                        showHeader={showPanelHeader}
+                    />
+                </CSSTransition>
+            );
+        })
+        .reverse();
+
+    const classes = classNames(Classes.PANEL_STACK2, `${Classes.PANEL_STACK2}-${direction}`, props.className);
+
+    return (
+        <TransitionGroup className={classes} component="div">
+            {panels}
+        </TransitionGroup>
+    );
+};
+PanelStack2.displayName = `${DISPLAYNAME_PREFIX}.PanelStack2`;

--- a/packages/core/src/components/panel-stack2/panelTypes.ts
+++ b/packages/core/src/components/panel-stack2/panelTypes.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * An object describing a panel in a `PanelStack`.
+ * An object describing a panel in a `PanelStack2`.
  */
 export interface Panel<P> {
     /**
@@ -30,7 +30,7 @@ export interface Panel<P> {
 
     /**
      * The props passed to the component type when it is rendered. The methods
-     * in `PanelActions` will be injected by `PanelStack`.
+     * in `PanelActions` will be injected by `PanelStack2`.
      */
     props?: P;
 
@@ -59,7 +59,7 @@ export interface PanelActions {
 
 /**
  * Use this interface in your panel component's props type to access these
- * panel action callbacks which are injected by `PanelStack`.
+ * panel action callbacks which are injected by `PanelStack2`.
  *
  * See the code example in the docs website.
  *

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { Classes, DISPLAYNAME_PREFIX } from "../../common";
+import { Button } from "../button/buttons";
+import { Text } from "../text/text";
+import { Panel, PanelProps } from "./panelTypes";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export interface PanelView2Props<T extends Panel<object>> {
+    /**
+     * Callback invoked when the user presses the back button or a panel invokes
+     * the `closePanel()` injected prop method.
+     */
+    onClose: (removedPanel: T) => void;
+
+    /**
+     * Callback invoked when a panel invokes the `openPanel(panel)` injected
+     * prop method.
+     */
+    onOpen: (addedPanel: T) => void;
+
+    /** The panel to be displayed. */
+    panel: T;
+
+    /** The previous panel in the stack, for rendering the "back" button. */
+    previousPanel?: T;
+
+    /** Whether to show the header with the "back" button. */
+    showHeader: boolean;
+}
+
+interface PanelView2Component {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    <T extends Panel<object>>(props: PanelView2Props<T>): JSX.Element | null;
+    displayName: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export const PanelView2: PanelView2Component = <T extends Panel<object>>(props: PanelView2Props<T>) => {
+    const handleClose = React.useCallback(() => props.onClose(props.panel), [props.onClose, props.panel]);
+
+    const maybeBackButton =
+        props.previousPanel === undefined ? null : (
+            <Button
+                aria-label="Back"
+                className={Classes.PANEL_STACK_HEADER_BACK}
+                icon="chevron-left"
+                minimal={true}
+                onClick={handleClose}
+                small={true}
+                text={props.previousPanel.title}
+                title={props.previousPanel.htmlTitle}
+            />
+        );
+
+    // `props.panel.renderPanel` is simply a function that returns a JSX.Element. It may be an FC which
+    // uses hooks. In order to avoid React errors due to inconsistent hook calls, we must encapsulate
+    // those hooks with their own lifecycle through a very simple wrapper component.
+    const PanelWrapper: React.FC = React.useMemo(
+        () => () =>
+            // N.B. A type cast is required because of error TS2345, where technically `panel.props` could be
+            // instantiated with a type unrelated to our generic constraint `T` here. We know
+            // we're sending the right values here though, and it makes the consumer API for this
+            // component type safe, so it's ok to do this...
+            props.panel.renderPanel({
+                closePanel: handleClose,
+                openPanel: props.onOpen,
+                ...props.panel.props,
+            } as PanelProps<T>),
+        [props.panel, props.onOpen],
+    );
+
+    return (
+        <div className={Classes.PANEL_STACK2_VIEW}>
+            {props.showHeader && (
+                <div className={Classes.PANEL_STACK2_HEADER}>
+                    {/* two <span> tags here ensure title is centered as long as possible, with `flex: 1` styling */}
+                    <span>{maybeBackButton}</span>
+                    <Text className={Classes.HEADING} ellipsize={true} title={props.panel.htmlTitle}>
+                        {props.panel.title}
+                    </Text>
+                    <span />
+                </div>
+            )}
+            <PanelWrapper />
+        </div>
+    );
+};
+PanelView2.displayName = `${DISPLAYNAME_PREFIX}.PanelView2`;

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -50,6 +50,7 @@ import "./non-ideal-state/nonIdealStateTests";
 import "./overflow-list/overflowListTests";
 import "./overlay/overlayTests";
 import "./panel-stack/panelStackTests";
+import "./panel-stack/panelStack2Tests";
 import "./popover/popoverTests";
 import "./popover/popperUtilTests";
 import "./portal/portalTests";

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -50,7 +50,7 @@ import "./non-ideal-state/nonIdealStateTests";
 import "./overflow-list/overflowListTests";
 import "./overlay/overlayTests";
 import "./panel-stack/panelStackTests";
-import "./panel-stack/panelStack2Tests";
+import "./panel-stack2/panelStack2Tests";
 import "./popover/popoverTests";
 import "./popover/popperUtilTests";
 import "./portal/portalTests";

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,40 +19,36 @@ import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
-import { Classes, NumericInput, Panel, PanelProps, PanelStack, PanelStackProps } from "../../src";
+import { Classes, IPanel, IPanelProps, PanelStack, PanelStackProps } from "../../src";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type TestPanelInfo = {};
-type TestPanelType = Panel<TestPanelInfo>;
+/* eslint-disable deprecation/deprecation */
 
-const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
-    const [counter, setCounter] = React.useState(0);
-    const newPanel = { renderPanel: TestPanel, title: "New Panel 1" };
+export class TestPanel extends React.Component<IPanelProps> {
+    public render() {
+        return (
+            <div>
+                <button id="new-panel-button" onClick={this.openPanel} />
+                <button id="close-panel-button" onClick={this.props.closePanel} />
+            </div>
+        );
+    }
 
-    return (
-        <div>
-            <button id="new-panel-button" onClick={() => props.openPanel(newPanel)} />
-            {/* eslint-disable-next-line @typescript-eslint/unbound-method */}
-            <button id="close-panel-button" onClick={props.closePanel} />
-            <span aria-label="counter value">{counter}</span>
-            <NumericInput value={counter} stepSize={1} onValueChange={setCounter} />
-        </div>
-    );
-};
+    private openPanel = () => this.props.openPanel({ component: TestPanel, title: "New Panel 1" });
+}
 
 describe("<PanelStack>", () => {
     let testsContainerElement: HTMLElement;
-    let panelStackWrapper: PanelStackWrapper<TestPanelType>;
+    let panelStackWrapper: PanelStackWrapper;
 
-    const initialPanel: Panel<TestPanelInfo> = {
+    const initialPanel: IPanel = {
+        component: TestPanel,
         props: {},
-        renderPanel: TestPanel,
         title: "Test Title",
     };
 
-    const emptyTitleInitialPanel: Panel<TestPanelInfo> = {
+    const emptyTitleInitialPanel: IPanel = {
+        component: TestPanel,
         props: {},
-        renderPanel: TestPanel,
     };
 
     beforeEach(() => {
@@ -66,260 +62,217 @@ describe("<PanelStack>", () => {
         testsContainerElement.remove();
     });
 
-    describe("uncontrolled mode", () => {
-        it("renders a basic panel and allows opening and closing", () => {
-            panelStackWrapper = renderPanelStack({ initialPanel });
-            assert.exists(panelStackWrapper);
+    it("renders a basic panel and allows opening and closing", () => {
+        panelStackWrapper = renderPanelStack({ initialPanel });
+        assert.exists(panelStackWrapper);
 
-            const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
-            newPanelButton.simulate("click");
+        const newPanelButton = panelStackWrapper.find("#new-panel-button");
+        assert.exists(newPanelButton);
+        newPanelButton.simulate("click");
 
-            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(newPanelHeader);
-            assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
+        const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(newPanelHeader);
+        assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
 
-            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.exists(backButton);
-            backButton.simulate("click");
+        const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
+        assert.exists(backButton);
+        backButton.simulate("click");
 
-            const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(oldPanelHeader);
-            assert.equal(oldPanelHeader.at(1).text(), "Test Title");
-        });
-
-        it("renders a panel stack without header and allows opening and closing", () => {
-            panelStackWrapper = renderPanelStack({ initialPanel, showPanelHeader: false });
-            assert.exists(panelStackWrapper);
-
-            const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
-            newPanelButton.simulate("click");
-
-            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.lengthOf(newPanelHeader, 0);
-
-            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.lengthOf(backButton, 0);
-
-            const closePanel = panelStackWrapper.find("#close-panel-button");
-            assert.exists(closePanel);
-            closePanel.last().simulate("click");
-
-            const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.lengthOf(oldPanelHeader, 0);
-        });
-
-        it("does not call the callback handler onClose when there is only a single panel on the stack", () => {
-            const onClose = spy();
-            panelStackWrapper = renderPanelStack({ initialPanel, onClose });
-
-            const closePanel = panelStackWrapper.find("#close-panel-button");
-            assert.exists(closePanel);
-
-            closePanel.simulate("click");
-            assert.equal(onClose.callCount, 0);
-        });
-
-        it("calls the callback handlers onOpen and onClose", () => {
-            const onOpen = spy();
-            const onClose = spy();
-            panelStackWrapper = renderPanelStack({ initialPanel, onClose, onOpen });
-
-            const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
-            newPanelButton.simulate("click");
-            assert.isTrue(onOpen.calledOnce);
-            assert.isFalse(onClose.calledOnce);
-
-            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.exists(backButton);
-            backButton.simulate("click");
-            assert.isTrue(onClose.calledOnce);
-            assert.isTrue(onOpen.calledOnce);
-        });
-
-        it("does not have the back button when only a single panel is on the stack", () => {
-            panelStackWrapper = renderPanelStack({ initialPanel });
-            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.equal(backButton.length, 0);
-        });
-
-        it("assigns the class to TransitionGroup", () => {
-            const TEST_CLASS_NAME = "TEST_CLASS_NAME";
-            panelStackWrapper = renderPanelStack({ initialPanel, className: TEST_CLASS_NAME });
-            assert.isTrue(panelStackWrapper.hasClass(TEST_CLASS_NAME));
-
-            const transitionGroupClassName = panelStackWrapper.findClass(TEST_CLASS_NAME).props().className;
-            assert.exists(transitionGroupClassName);
-            assert.equal(transitionGroupClassName!.indexOf(Classes.PANEL_STACK), 0);
-        });
-
-        it("can render a panel without a title", () => {
-            panelStackWrapper = renderPanelStack({ initialPanel: emptyTitleInitialPanel });
-            assert.exists(panelStackWrapper);
-
-            const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
-            newPanelButton.simulate("click");
-
-            const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.equal(
-                backButtonWithoutTitle.prop("aria-label"),
-                "Back",
-                "expected icon-only back button to have accessible label",
-            );
-
-            const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
-            assert.exists(newPanelButtonOnNotEmpty);
-            newPanelButtonOnNotEmpty.simulate("click");
-
-            const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK).hostNodes().at(1);
-            assert.equal(
-                backButtonWithTitle.prop("aria-label"),
-                "Back",
-                "expected icon-only back button to have accessible label",
-            );
-        });
+        const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(oldPanelHeader);
+        assert.equal(oldPanelHeader.at(1).text(), "Test Title");
     });
 
-    describe("controlled mode", () => {
-        it("can render a panel stack in controlled mode", () => {
-            const stack = [initialPanel];
-            panelStackWrapper = renderPanelStack({ stack });
-            assert.exists(panelStackWrapper);
+    it("renders a panel stack without header and allows opening and closing", () => {
+        panelStackWrapper = renderPanelStack({ initialPanel, showPanelHeader: false });
+        assert.exists(panelStackWrapper);
 
-            const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
-            newPanelButton.simulate("click");
+        const newPanelButton = panelStackWrapper.find("#new-panel-button");
+        assert.exists(newPanelButton);
+        newPanelButton.simulate("click");
 
-            // Expect the same panel as before since onOpen is not handled
-            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(newPanelHeader);
-            assert.equal(newPanelHeader.at(0).text(), "Test Title");
-        });
+        const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.lengthOf(newPanelHeader, 0);
 
-        it("can open a panel in controlled mode", () => {
-            let stack = [initialPanel];
-            panelStackWrapper = renderPanelStack({
-                onOpen: panel => {
-                    stack = [...stack, panel];
-                },
-                stack,
-            });
-            assert.exists(panelStackWrapper);
+        const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
+        assert.lengthOf(backButton, 0);
 
-            const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
-            newPanelButton.simulate("click");
-            panelStackWrapper.setProps({ stack });
+        const closePanel = panelStackWrapper.find("#close-panel-button");
+        assert.exists(closePanel);
+        closePanel.last().simulate("click");
 
-            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(newPanelHeader);
-            assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
-        });
-
-        it("can render a panel stack with multiple initial panels and close one", () => {
-            let stack: Array<Panel<TestPanelInfo>> = [initialPanel, { renderPanel: TestPanel, title: "New Panel 1" }];
-            panelStackWrapper = renderPanelStack({
-                onClose: () => {
-                    stack = stack.slice(0, -1);
-                },
-                stack,
-            });
-            assert.exists(panelStackWrapper);
-
-            const panelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(panelHeader);
-            assert.equal(panelHeader.at(0).text(), "New Panel 1");
-
-            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.exists(backButton);
-            backButton.simulate("click");
-            panelStackWrapper.setProps({ stack });
-
-            const firstPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(firstPanelHeader);
-            assert.equal(firstPanelHeader.at(0).text(), "Test Title");
-        });
-
-        it("renders only one panel by default", () => {
-            const stack = [
-                { renderPanel: TestPanel, title: "Panel A" },
-                { renderPanel: TestPanel, title: "Panel B" },
-            ];
-            panelStackWrapper = renderPanelStack({ stack });
-
-            const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(panelHeaders);
-            assert.equal(panelHeaders.length, 1);
-            assert.equal(panelHeaders.at(0).text(), stack[1].title);
-        });
-
-        describe("with renderActivePanelOnly={false}", () => {
-            it("renders all panels", () => {
-                const stack = [
-                    { renderPanel: TestPanel, title: "Panel A" },
-                    { renderPanel: TestPanel, title: "Panel B" },
-                ];
-                panelStackWrapper = renderPanelStack({ renderActivePanelOnly: false, stack });
-
-                const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
-                assert.exists(panelHeaders);
-                assert.equal(panelHeaders.length, 2);
-                assert.equal(panelHeaders.at(0).text(), stack[0].title);
-                assert.equal(panelHeaders.at(1).text(), stack[1].title);
-            });
-
-            it("keeps panels mounted", () => {
-                let stack = [initialPanel];
-                panelStackWrapper = renderPanelStack({
-                    onClose: () => {
-                        stack = stack.slice(0, -1);
-                    },
-                    onOpen: panel => {
-                        stack = [...stack, panel];
-                    },
-                    renderActivePanelOnly: false,
-                    stack,
-                });
-
-                const incrementButton = panelStackWrapper.find(`[aria-label="increment"]`);
-                assert.exists(incrementButton);
-                incrementButton.hostNodes().simulate("mousedown");
-                assert.equal(getFirstPanelCounterValue(), 1, "clicking increment button should increase counter");
-
-                const newPanelButton = panelStackWrapper.find("#new-panel-button");
-                newPanelButton.hostNodes().simulate("click");
-                panelStackWrapper.setProps({ stack });
-
-                const backButton = panelStackWrapper.find(`[aria-label="Back"]`);
-                backButton.hostNodes().simulate("click");
-                panelStackWrapper.setProps({ stack });
-                assert.equal(
-                    getFirstPanelCounterValue(),
-                    1,
-                    "first panel should retain its counter state when we return to it",
-                );
-            });
-
-            function getFirstPanelCounterValue() {
-                const counterValue = panelStackWrapper.find(`[aria-label="counter value"]`);
-                assert.exists(counterValue);
-                return parseInt(counterValue.hostNodes().first().text().trim(), 10);
-            }
-        });
+        const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.lengthOf(oldPanelHeader, 0);
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    interface PanelStackWrapper<T extends Panel<object>> extends ReactWrapper<PanelStackProps<T>, any> {
+    it("does not call the callback handler onClose when there is only a single panel on the stack", () => {
+        const onClose = spy();
+        panelStackWrapper = renderPanelStack({ initialPanel, onClose });
+
+        const closePanel = panelStackWrapper.find("#close-panel-button");
+        assert.exists(closePanel);
+
+        closePanel.simulate("click");
+        assert.equal(onClose.callCount, 0);
+    });
+
+    it("calls the callback handlers onOpen and onClose", () => {
+        const onOpen = spy();
+        const onClose = spy();
+        panelStackWrapper = renderPanelStack({ initialPanel, onClose, onOpen });
+
+        const newPanelButton = panelStackWrapper.find("#new-panel-button");
+        assert.exists(newPanelButton);
+        newPanelButton.simulate("click");
+        assert.isTrue(onOpen.calledOnce);
+        assert.isFalse(onClose.calledOnce);
+
+        const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
+        assert.exists(backButton);
+        backButton.simulate("click");
+        assert.isTrue(onClose.calledOnce);
+        assert.isTrue(onOpen.calledOnce);
+    });
+
+    it("does not have the back button when only a single panel is on the stack", () => {
+        panelStackWrapper = renderPanelStack({ initialPanel });
+        const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
+        assert.equal(backButton.length, 0);
+    });
+
+    it("assigns the class to TransitionGroup", () => {
+        const TEST_CLASS_NAME = "TEST_CLASS_NAME";
+        panelStackWrapper = renderPanelStack({ initialPanel, className: TEST_CLASS_NAME });
+        assert.isTrue(panelStackWrapper.hasClass(TEST_CLASS_NAME));
+
+        const transitionGroupClassName = panelStackWrapper.findClass(TEST_CLASS_NAME).props().className;
+        assert.exists(transitionGroupClassName);
+        assert.equal(transitionGroupClassName!.indexOf(Classes.PANEL_STACK), 0);
+    });
+
+    it("can render a panel without a title", () => {
+        panelStackWrapper = renderPanelStack({ initialPanel: emptyTitleInitialPanel });
+        assert.exists(panelStackWrapper);
+
+        const newPanelButton = panelStackWrapper.find("#new-panel-button");
+        assert.exists(newPanelButton);
+        newPanelButton.simulate("click");
+
+        const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
+        assert.equal(
+            backButtonWithoutTitle.prop("aria-label"),
+            "Back",
+            "expected icon-only back button to have accessible label",
+        );
+
+        const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
+        assert.exists(newPanelButtonOnNotEmpty);
+        newPanelButtonOnNotEmpty.simulate("click");
+
+        const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK).hostNodes().at(1);
+        assert.equal(
+            backButtonWithTitle.prop("aria-label"),
+            "Back",
+            "expected icon-only back button to have accessible label",
+        );
+    });
+
+    it("can render a panel stack in controlled mode", () => {
+        const stack = [initialPanel];
+        panelStackWrapper = renderPanelStack({ stack });
+        assert.exists(panelStackWrapper);
+
+        const newPanelButton = panelStackWrapper.find("#new-panel-button");
+        assert.exists(newPanelButton);
+        newPanelButton.simulate("click");
+
+        // Expect the same panel as before since onOpen is not handled
+        const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(newPanelHeader);
+        assert.equal(newPanelHeader.at(0).text(), "Test Title");
+    });
+
+    it("can open a panel in controlled mode", () => {
+        let stack = [initialPanel];
+        panelStackWrapper = renderPanelStack({
+            onOpen: panel => (stack = [...stack, panel]),
+            stack,
+        });
+        assert.exists(panelStackWrapper);
+
+        const newPanelButton = panelStackWrapper.find("#new-panel-button");
+        assert.exists(newPanelButton);
+        newPanelButton.simulate("click");
+        panelStackWrapper.setProps({ stack });
+        panelStackWrapper.update();
+
+        const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(newPanelHeader);
+        assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
+    });
+
+    it("can render a panel stack with multiple initial panels and close one", () => {
+        let stack: Array<IPanel<any>> = [initialPanel, { component: TestPanel, title: "New Panel 1" }];
+        panelStackWrapper = renderPanelStack({
+            onClose: () => {
+                const newStack = stack.slice();
+                newStack.pop();
+                stack = newStack;
+            },
+            stack,
+        });
+        assert.exists(panelStackWrapper);
+
+        const panelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(panelHeader);
+        assert.equal(panelHeader.at(0).text(), "New Panel 1");
+
+        const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
+        assert.exists(backButton);
+        backButton.simulate("click");
+        panelStackWrapper.setProps({ stack });
+        panelStackWrapper.update();
+
+        const firstPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(firstPanelHeader);
+        assert.equal(firstPanelHeader.at(0).text(), "Test Title");
+    });
+
+    it("renders only one panel by default", () => {
+        const stack = [
+            { component: TestPanel, title: "Panel A" },
+            { component: TestPanel, title: "Panel B" },
+        ];
+        panelStackWrapper = renderPanelStack({ stack });
+
+        const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(panelHeaders);
+        assert.equal(panelHeaders.length, 1);
+        assert.equal(panelHeaders.at(0).text(), stack[1].title);
+    });
+
+    it("renders all panels with renderActivePanelOnly disabled", () => {
+        const stack = [
+            { component: TestPanel, title: "Panel A" },
+            { component: TestPanel, title: "Panel B" },
+        ];
+        panelStackWrapper = renderPanelStack({ renderActivePanelOnly: false, stack });
+
+        const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
+        assert.exists(panelHeaders);
+        assert.equal(panelHeaders.length, 2);
+        assert.equal(panelHeaders.at(0).text(), stack[0].title);
+        assert.equal(panelHeaders.at(1).text(), stack[1].title);
+    });
+
+    interface PanelStackWrapper extends ReactWrapper<PanelStackProps, any> {
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
     }
 
-    function renderPanelStack(props: PanelStackProps<TestPanelType>): PanelStackWrapper<TestPanelType> {
+    function renderPanelStack(props: PanelStackProps): PanelStackWrapper {
         panelStackWrapper = mount(<PanelStack {...props} />, {
             attachTo: testsContainerElement,
-        }) as PanelStackWrapper<TestPanelType>;
+        }) as PanelStackWrapper;
         panelStackWrapper.findClass = (className: string) => panelStackWrapper.find(`.${className}`).hostNodes();
         return panelStackWrapper;
     }

--- a/packages/core/test/panel-stack2/panelStack2Tests.tsx
+++ b/packages/core/test/panel-stack2/panelStack2Tests.tsx
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { mount, ReactWrapper } from "enzyme";
+import * as React from "react";
+import { spy } from "sinon";
+
+import { Classes, NumericInput, Panel, PanelProps, PanelStack2, PanelStack2Props } from "../../src";
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type TestPanelInfo = {};
+type TestPanelType = Panel<TestPanelInfo>;
+
+const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
+    const [counter, setCounter] = React.useState(0);
+    const newPanel = { renderPanel: TestPanel, title: "New Panel 1" };
+
+    return (
+        <div>
+            <button id="new-panel-button" onClick={() => props.openPanel(newPanel)} />
+            {/* eslint-disable-next-line @typescript-eslint/unbound-method */}
+            <button id="close-panel-button" onClick={props.closePanel} />
+            <span aria-label="counter value">{counter}</span>
+            <NumericInput value={counter} stepSize={1} onValueChange={setCounter} />
+        </div>
+    );
+};
+
+describe("<PanelStack2>", () => {
+    let testsContainerElement: HTMLElement;
+    let panelStackWrapper: PanelStack2Wrapper<TestPanelType>;
+
+    const initialPanel: Panel<TestPanelInfo> = {
+        props: {},
+        renderPanel: TestPanel,
+        title: "Test Title",
+    };
+
+    const emptyTitleInitialPanel: Panel<TestPanelInfo> = {
+        props: {},
+        renderPanel: TestPanel,
+    };
+
+    beforeEach(() => {
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        panelStackWrapper?.unmount();
+        panelStackWrapper?.detach();
+        testsContainerElement.remove();
+    });
+
+    describe("uncontrolled mode", () => {
+        it("renders a basic panel and allows opening and closing", () => {
+            panelStackWrapper = renderPanelStack({ initialPanel });
+            assert.exists(panelStackWrapper);
+
+            const newPanelButton = panelStackWrapper.find("#new-panel-button");
+            assert.exists(newPanelButton);
+            newPanelButton.simulate("click");
+
+            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(newPanelHeader);
+            assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
+
+            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
+            assert.exists(backButton);
+            backButton.simulate("click");
+
+            const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(oldPanelHeader);
+            assert.equal(oldPanelHeader.at(1).text(), "Test Title");
+        });
+
+        it("renders a panel stack without header and allows opening and closing", () => {
+            panelStackWrapper = renderPanelStack({ initialPanel, showPanelHeader: false });
+            assert.exists(panelStackWrapper);
+
+            const newPanelButton = panelStackWrapper.find("#new-panel-button");
+            assert.exists(newPanelButton);
+            newPanelButton.simulate("click");
+
+            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.lengthOf(newPanelHeader, 0);
+
+            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
+            assert.lengthOf(backButton, 0);
+
+            const closePanel = panelStackWrapper.find("#close-panel-button");
+            assert.exists(closePanel);
+            closePanel.last().simulate("click");
+
+            const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.lengthOf(oldPanelHeader, 0);
+        });
+
+        it("does not call the callback handler onClose when there is only a single panel on the stack", () => {
+            const onClose = spy();
+            panelStackWrapper = renderPanelStack({ initialPanel, onClose });
+
+            const closePanel = panelStackWrapper.find("#close-panel-button");
+            assert.exists(closePanel);
+
+            closePanel.simulate("click");
+            assert.equal(onClose.callCount, 0);
+        });
+
+        it("calls the callback handlers onOpen and onClose", () => {
+            const onOpen = spy();
+            const onClose = spy();
+            panelStackWrapper = renderPanelStack({ initialPanel, onClose, onOpen });
+
+            const newPanelButton = panelStackWrapper.find("#new-panel-button");
+            assert.exists(newPanelButton);
+            newPanelButton.simulate("click");
+            assert.isTrue(onOpen.calledOnce);
+            assert.isFalse(onClose.calledOnce);
+
+            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
+            assert.exists(backButton);
+            backButton.simulate("click");
+            assert.isTrue(onClose.calledOnce);
+            assert.isTrue(onOpen.calledOnce);
+        });
+
+        it("does not have the back button when only a single panel is on the stack", () => {
+            panelStackWrapper = renderPanelStack({ initialPanel });
+            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
+            assert.equal(backButton.length, 0);
+        });
+
+        it("assigns the class to TransitionGroup", () => {
+            const TEST_CLASS_NAME = "TEST_CLASS_NAME";
+            panelStackWrapper = renderPanelStack({ initialPanel, className: TEST_CLASS_NAME });
+            assert.isTrue(panelStackWrapper.hasClass(TEST_CLASS_NAME));
+
+            const transitionGroupClassName = panelStackWrapper.findClass(TEST_CLASS_NAME).props().className;
+            assert.exists(transitionGroupClassName);
+            assert.equal(transitionGroupClassName!.indexOf(Classes.PANEL_STACK2), 0);
+        });
+
+        it("can render a panel without a title", () => {
+            panelStackWrapper = renderPanelStack({ initialPanel: emptyTitleInitialPanel });
+            assert.exists(panelStackWrapper);
+
+            const newPanelButton = panelStackWrapper.find("#new-panel-button");
+            assert.exists(newPanelButton);
+            newPanelButton.simulate("click");
+
+            const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
+            assert.equal(
+                backButtonWithoutTitle.prop("aria-label"),
+                "Back",
+                "expected icon-only back button to have accessible label",
+            );
+
+            const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
+            assert.exists(newPanelButtonOnNotEmpty);
+            newPanelButtonOnNotEmpty.simulate("click");
+
+            const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK).hostNodes().at(1);
+            assert.equal(
+                backButtonWithTitle.prop("aria-label"),
+                "Back",
+                "expected icon-only back button to have accessible label",
+            );
+        });
+    });
+
+    describe("controlled mode", () => {
+        it("can render a panel stack in controlled mode", () => {
+            const stack = [initialPanel];
+            panelStackWrapper = renderPanelStack({ stack });
+            assert.exists(panelStackWrapper);
+
+            const newPanelButton = panelStackWrapper.find("#new-panel-button");
+            assert.exists(newPanelButton);
+            newPanelButton.simulate("click");
+
+            // Expect the same panel as before since onOpen is not handled
+            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(newPanelHeader);
+            assert.equal(newPanelHeader.at(0).text(), "Test Title");
+        });
+
+        it("can open a panel in controlled mode", () => {
+            let stack = [initialPanel];
+            panelStackWrapper = renderPanelStack({
+                onOpen: panel => {
+                    stack = [...stack, panel];
+                },
+                stack,
+            });
+            assert.exists(panelStackWrapper);
+
+            const newPanelButton = panelStackWrapper.find("#new-panel-button");
+            assert.exists(newPanelButton);
+            newPanelButton.simulate("click");
+            panelStackWrapper.setProps({ stack });
+
+            const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(newPanelHeader);
+            assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
+        });
+
+        it("can render a panel stack with multiple initial panels and close one", () => {
+            let stack: Array<Panel<TestPanelInfo>> = [initialPanel, { renderPanel: TestPanel, title: "New Panel 1" }];
+            panelStackWrapper = renderPanelStack({
+                onClose: () => {
+                    stack = stack.slice(0, -1);
+                },
+                stack,
+            });
+            assert.exists(panelStackWrapper);
+
+            const panelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(panelHeader);
+            assert.equal(panelHeader.at(0).text(), "New Panel 1");
+
+            const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK2_HEADER_BACK);
+            assert.exists(backButton);
+            backButton.simulate("click");
+            panelStackWrapper.setProps({ stack });
+
+            const firstPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(firstPanelHeader);
+            assert.equal(firstPanelHeader.at(0).text(), "Test Title");
+        });
+
+        it("renders only one panel by default", () => {
+            const stack = [
+                { renderPanel: TestPanel, title: "Panel A" },
+                { renderPanel: TestPanel, title: "Panel B" },
+            ];
+            panelStackWrapper = renderPanelStack({ stack });
+
+            const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
+            assert.exists(panelHeaders);
+            assert.equal(panelHeaders.length, 1);
+            assert.equal(panelHeaders.at(0).text(), stack[1].title);
+        });
+
+        describe("with renderActivePanelOnly={false}", () => {
+            it("renders all panels", () => {
+                const stack = [
+                    { renderPanel: TestPanel, title: "Panel A" },
+                    { renderPanel: TestPanel, title: "Panel B" },
+                ];
+                panelStackWrapper = renderPanelStack({ renderActivePanelOnly: false, stack });
+
+                const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
+                assert.exists(panelHeaders);
+                assert.equal(panelHeaders.length, 2);
+                assert.equal(panelHeaders.at(0).text(), stack[0].title);
+                assert.equal(panelHeaders.at(1).text(), stack[1].title);
+            });
+
+            it("keeps panels mounted", () => {
+                let stack = [initialPanel];
+                panelStackWrapper = renderPanelStack({
+                    onClose: () => {
+                        stack = stack.slice(0, -1);
+                    },
+                    onOpen: panel => {
+                        stack = [...stack, panel];
+                    },
+                    renderActivePanelOnly: false,
+                    stack,
+                });
+
+                const incrementButton = panelStackWrapper.find(`[aria-label="increment"]`);
+                assert.exists(incrementButton);
+                incrementButton.hostNodes().simulate("mousedown");
+                assert.equal(getFirstPanelCounterValue(), 1, "clicking increment button should increase counter");
+
+                const newPanelButton = panelStackWrapper.find("#new-panel-button");
+                newPanelButton.hostNodes().simulate("click");
+                panelStackWrapper.setProps({ stack });
+
+                const backButton = panelStackWrapper.find(`[aria-label="Back"]`);
+                backButton.hostNodes().simulate("click");
+                panelStackWrapper.setProps({ stack });
+                assert.equal(
+                    getFirstPanelCounterValue(),
+                    1,
+                    "first panel should retain its counter state when we return to it",
+                );
+            });
+
+            function getFirstPanelCounterValue() {
+                const counterValue = panelStackWrapper.find(`[aria-label="counter value"]`);
+                assert.exists(counterValue);
+                return parseInt(counterValue.hostNodes().first().text().trim(), 10);
+            }
+        });
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    interface PanelStack2Wrapper<T extends Panel<object>> extends ReactWrapper<PanelStack2Props<T>, any> {
+        findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
+    }
+
+    function renderPanelStack(props: PanelStack2Props<TestPanelType>): PanelStack2Wrapper<TestPanelType> {
+        panelStackWrapper = mount(<PanelStack2 {...props} />, {
+            attachTo: testsContainerElement,
+        }) as PanelStack2Wrapper<TestPanelType>;
+        panelStackWrapper.findClass = (className: string) => panelStackWrapper.find(`.${className}`).hostNodes();
+        return panelStackWrapper;
+    }
+});

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -49,6 +49,7 @@ export * from "./nonIdealStateExample";
 export * from "./overflowListExample";
 export * from "./overlayExample";
 export { PanelStackExample } from "./panelStackExample";
+export { PanelStack2Example } from "./panelStack2Example";
 export * from "./popoverDismissExample";
 export * from "./popoverExample";
 export * from "./popoverInteractionKindExample";

--- a/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Panel stacks typically have heterogenous panels, each with different information and actions,
+ * so it's important to represent that kind of use case in the docs example. Here, we have 3 panel types.
+ * Panel1 renders either a new Panel2 or Panel3. Panel2 and Panel3 both render a new Panel1.
+ */
+
+import * as React from "react";
+
+import { Button, H5, Intent, NumericInput, Panel, PanelProps, PanelStack2, Switch, UL } from "@blueprintjs/core";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface Panel1Info {
+    // empty
+}
+
+const Panel1: React.FC<PanelProps<Panel1Info>> = props => {
+    const [counter, setCounter] = React.useState(0);
+    const shouldOpenPanelType2 = counter % 2 === 0;
+
+    const openNewPanel = () => {
+        if (shouldOpenPanelType2) {
+            props.openPanel({
+                props: { counter },
+                renderPanel: Panel2,
+                title: `Panel 2`,
+            });
+        } else {
+            props.openPanel({
+                props: { intent: counter % 3 === 0 ? Intent.SUCCESS : Intent.WARNING },
+                renderPanel: Panel3,
+                title: `Panel 3`,
+            });
+        }
+    };
+
+    return (
+        <div className="docs-panel-stack-contents-example">
+            <Button
+                intent={Intent.PRIMARY}
+                onClick={openNewPanel}
+                text={`Open panel type ${shouldOpenPanelType2 ? 2 : 3}`}
+            />
+            <NumericInput value={counter} stepSize={1} onValueChange={setCounter} />
+        </div>
+    );
+};
+
+interface Panel2Info {
+    counter: number;
+}
+
+const Panel2: React.FC<PanelProps<Panel2Info>> = props => {
+    const openNewPanel = () => {
+        props.openPanel({
+            props: {},
+            renderPanel: Panel1,
+            title: `Panel 1`,
+        });
+    };
+
+    return (
+        <div className="docs-panel-stack-contents-example">
+            <H5>Parent counter was {props.counter}</H5>
+            <Button intent={Intent.PRIMARY} onClick={openNewPanel} text="Open panel type 1" />
+        </div>
+    );
+};
+
+interface Panel3Info {
+    intent: Intent;
+}
+
+const Panel3: React.FC<PanelProps<Panel3Info>> = props => {
+    const openNewPanel = () => {
+        props.openPanel({
+            props: {},
+            renderPanel: Panel1,
+            title: `Panel 1`,
+        });
+    };
+
+    return (
+        <div className="docs-panel-stack-contents-example">
+            <Button intent={props.intent} onClick={openNewPanel} text="Open panel type 1" />
+        </div>
+    );
+};
+
+const initialPanel: Panel<Panel1Info> = {
+    props: {
+        panelNumber: 1,
+    },
+    renderPanel: Panel1,
+    title: "Panel 1",
+};
+
+export const PanelStack2Example: React.FC<ExampleProps> = props => {
+    const [activePanelOnly, setActivePanelOnly] = React.useState(false);
+    const [showHeader, setShowHeader] = React.useState(true);
+    const [currentPanelStack, setCurrentPanelStack] = React.useState<
+        Array<Panel<Panel1Info | Panel2Info | Panel3Info>>
+    >([initialPanel]);
+
+    const toggleActiveOnly = React.useCallback(handleBooleanChange(setActivePanelOnly), []);
+    const toggleShowHeader = React.useCallback(handleBooleanChange(setShowHeader), []);
+    const addToPanelStack = React.useCallback(
+        (newPanel: Panel<Panel1Info | Panel2Info | Panel3Info>) => setCurrentPanelStack(stack => [...stack, newPanel]),
+        [],
+    );
+    const removeFromPanelStack = React.useCallback(() => setCurrentPanelStack(stack => stack.slice(0, -1)), []);
+
+    const stackList = (
+        <>
+            <Switch checked={activePanelOnly} label="Render active panel only" onChange={toggleActiveOnly} />
+            <Switch checked={showHeader} label="Show panel header" onChange={toggleShowHeader} />
+            <H5>Current stack</H5>
+            <UL>
+                {currentPanelStack.map((p, i) => (
+                    <li key={i}>{p.title}</li>
+                ))}
+            </UL>
+        </>
+    );
+    return (
+        <Example options={stackList} {...props}>
+            <PanelStack2
+                className="docs-panel-stack-example"
+                onOpen={addToPanelStack}
+                onClose={removeFromPanelStack}
+                renderActivePanelOnly={activePanelOnly}
+                showPanelHeader={showHeader}
+                stack={currentPanelStack}
+            />
+        </Example>
+    );
+};

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2018 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,140 +15,119 @@
  */
 
 /**
- * @fileoverview
- * Panel stacks typically have heterogenous panels, each with different information and actions,
- * so it's important to represent that kind of use case in the docs example. Here, we have 3 panel types.
- * Panel1 renders either a new Panel2 or Panel3. Panel2 and Panel3 both render a new Panel1.
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to PanelStack2 instead.
  */
+
+/* eslint-disable deprecation/deprecation, max-classes-per-file, @blueprintjs/no-deprecated-components */
 
 import * as React from "react";
 
-import { Button, H5, Intent, NumericInput, Panel, PanelProps, PanelStack, Switch, UL } from "@blueprintjs/core";
+import { Button, H5, Intent, IPanel, IPanelProps, NumericInput, PanelStack, Switch, UL } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface Panel1Info {
-    // empty
+export interface IPanelStackExampleState {
+    activePanelOnly: boolean;
+    currentPanelStack: Array<IPanel<IPanelExampleProps>>;
+    showHeader: boolean;
 }
 
-const Panel1: React.FC<PanelProps<Panel1Info>> = props => {
-    const [counter, setCounter] = React.useState(0);
-    const shouldOpenPanelType2 = counter % 2 === 0;
-
-    const openNewPanel = () => {
-        if (shouldOpenPanelType2) {
-            props.openPanel({
-                props: { counter },
-                renderPanel: Panel2,
-                title: `Panel 2`,
-            });
-        } else {
-            props.openPanel({
-                props: { intent: counter % 3 === 0 ? Intent.SUCCESS : Intent.WARNING },
-                renderPanel: Panel3,
-                title: `Panel 3`,
-            });
-        }
+export class PanelStackExample extends React.PureComponent<ExampleProps, IPanelStackExampleState> {
+    public initialPanel: IPanel<IPanelExampleProps> = {
+        component: PanelExample,
+        props: {
+            panelNumber: 1,
+        },
+        title: "Panel 1",
     };
 
-    return (
-        <div className="docs-panel-stack-contents-example">
-            <Button
-                intent={Intent.PRIMARY}
-                onClick={openNewPanel}
-                text={`Open panel type ${shouldOpenPanelType2 ? 2 : 3}`}
-            />
-            <NumericInput value={counter} stepSize={1} onValueChange={setCounter} />
-        </div>
-    );
-};
+    public state = {
+        activePanelOnly: true,
+        currentPanelStack: [this.initialPanel],
+        showHeader: true,
+    };
 
-interface Panel2Info {
+    private toggleActiveOnly = handleBooleanChange((activePanelOnly: boolean) => this.setState({ activePanelOnly }));
+
+    private handleHeaderChange = handleBooleanChange((showHeader: boolean) => this.setState({ showHeader }));
+
+    public render() {
+        const stackList = (
+            <>
+                <Switch
+                    checked={this.state.activePanelOnly}
+                    label="Render active panel only"
+                    onChange={this.toggleActiveOnly}
+                />
+                <Switch checked={this.state.showHeader} label="Show panel header" onChange={this.handleHeaderChange} />
+                <H5>Current stack</H5>
+                <UL>
+                    {this.state.currentPanelStack.map((p, i) => (
+                        <li key={i}>{p.title}</li>
+                    ))}
+                </UL>
+            </>
+        );
+        return (
+            <Example options={stackList} {...this.props}>
+                <PanelStack
+                    className="docs-panel-stack-example"
+                    initialPanel={this.state.currentPanelStack[0]}
+                    onOpen={this.addToPanelStack}
+                    onClose={this.removeFromPanelStack}
+                    renderActivePanelOnly={this.state.activePanelOnly}
+                    showPanelHeader={this.state.showHeader}
+                />
+            </Example>
+        );
+    }
+
+    private addToPanelStack = (newPanel: IPanel) => {
+        this.setState(state => ({
+            // HACKHACK: https://github.com/palantir/blueprint/issues/4272
+            currentPanelStack: [newPanel as unknown as IPanel<IPanelExampleProps>, ...state.currentPanelStack],
+        }));
+    };
+
+    private removeFromPanelStack = (_lastPanel: IPanel) => {
+        // In this example, the last panel is always the one closed.
+        // Using `this.props.closePanel()` is one way to violate this.
+        this.setState(state => ({ currentPanelStack: state.currentPanelStack.slice(1) }));
+    };
+}
+
+interface IPanelExampleProps {
+    panelNumber: number;
+}
+
+interface IPanelExampleState {
     counter: number;
 }
 
-const Panel2: React.FC<PanelProps<Panel2Info>> = props => {
-    const openNewPanel = () => {
-        props.openPanel({
-            props: {},
-            renderPanel: Panel1,
-            title: `Panel 1`,
+class PanelExample extends React.PureComponent<IPanelExampleProps & IPanelProps> {
+    public state: IPanelExampleState = {
+        counter: 0,
+    };
+
+    public render() {
+        return (
+            <div className="docs-panel-stack-contents-example">
+                <Button intent={Intent.PRIMARY} onClick={this.openNewPanel} text="Open new panel" />
+                <NumericInput value={this.state.counter} stepSize={1} onValueChange={this.updateCounter} />
+            </div>
+        );
+    }
+
+    private openNewPanel = () => {
+        const panelNumber = this.props.panelNumber + 1;
+        this.props.openPanel({
+            component: PanelExample,
+            props: { panelNumber },
+            title: `Panel ${panelNumber}`,
         });
     };
 
-    return (
-        <div className="docs-panel-stack-contents-example">
-            <H5>Parent counter was {props.counter}</H5>
-            <Button intent={Intent.PRIMARY} onClick={openNewPanel} text="Open panel type 1" />
-        </div>
-    );
-};
-
-interface Panel3Info {
-    intent: Intent;
+    private updateCounter = (counter: number) => {
+        this.setState({ counter });
+    };
 }
-
-const Panel3: React.FC<PanelProps<Panel3Info>> = props => {
-    const openNewPanel = () => {
-        props.openPanel({
-            props: {},
-            renderPanel: Panel1,
-            title: `Panel 1`,
-        });
-    };
-
-    return (
-        <div className="docs-panel-stack-contents-example">
-            <Button intent={props.intent} onClick={openNewPanel} text="Open panel type 1" />
-        </div>
-    );
-};
-
-const initialPanel: Panel<Panel1Info> = {
-    props: {
-        panelNumber: 1,
-    },
-    renderPanel: Panel1,
-    title: "Panel 1",
-};
-
-export const PanelStackExample: React.FC<ExampleProps> = props => {
-    const [activePanelOnly, setActivePanelOnly] = React.useState(false);
-    const [showHeader, setShowHeader] = React.useState(true);
-    const [currentPanelStack, setCurrentPanelStack] = React.useState<
-        Array<Panel<Panel1Info | Panel2Info | Panel3Info>>
-    >([initialPanel]);
-
-    const toggleActiveOnly = React.useCallback(handleBooleanChange(setActivePanelOnly), []);
-    const toggleShowHeader = React.useCallback(handleBooleanChange(setShowHeader), []);
-    const addToPanelStack = React.useCallback(
-        (newPanel: Panel<Panel1Info | Panel2Info | Panel3Info>) => setCurrentPanelStack(stack => [...stack, newPanel]),
-        [],
-    );
-    const removeFromPanelStack = React.useCallback(() => setCurrentPanelStack(stack => stack.slice(0, -1)), []);
-
-    const stackList = (
-        <>
-            <Switch checked={activePanelOnly} label="Render active panel only" onChange={toggleActiveOnly} />
-            <Switch checked={showHeader} label="Show panel header" onChange={toggleShowHeader} />
-            <H5>Current stack</H5>
-            <UL>
-                {currentPanelStack.map((p, i) => (
-                    <li key={i}>{p.title}</li>
-                ))}
-            </UL>
-        </>
-    );
-    return (
-        <Example options={stackList} {...props}>
-            <PanelStack
-                className="docs-panel-stack-example"
-                onOpen={addToPanelStack}
-                onClose={removeFromPanelStack}
-                renderActivePanelOnly={activePanelOnly}
-                showPanelHeader={showHeader}
-                stack={currentPanelStack}
-            />
-        </Example>
-    );
-};

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -329,6 +329,7 @@
   }
 }
 
+#{example("PanelStack2")},
 #{example("PanelStack")} {
   .docs-panel-stack-example {
     box-shadow: $pt-elevation-shadow-0;


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Restore PanelStack and PanelStack2 component implementations just as they exist on the develop branch. The only changes are renames:
- `AbstractPureComponent2` -> `AbstractPureComponent`, same API, just renamed in v5
- `IPanelStackProps` -> `PanelStackProps`, this is a ⚠️ breaking change for v5
  - we can't drop the `I` prefix in `IPanelProps` and `IPanel` right now 😢 since the unprefixed interfaces are used by `PanelStack2`

#### Reviewers should focus on:

docs should look just like they do on develop

#### Screenshot

<img width="820" alt="image" src="https://user-images.githubusercontent.com/723999/235952618-9d184314-a48d-487f-974c-7663b729a1d4.png">

