### PR TITLE
[v5] [core] docs(Portal): clarify legacy context support

### DIFF
--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -22,9 +22,6 @@ module.exports = async function (config) {
                 // HACKHACK: need to add hotkeys tests
                 "src/components/hotkeys/*",
                 "src/context/hotkeys/hotkeysProvider.tsx",
-
-                // HACKHACK: see https://github.com/palantir/blueprint/issues/5511
-                "src/context/portal/portalProvider.tsx",
             ],
             coverageOverrides: {
                 "src/components/editable-text/editableText.tsx": {

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -26,7 +26,7 @@ apply `position: absolute` to the `<body>` tag.
 
 @interface PortalProps
 
-@## Portal context options
+@## React context options
 
 __Portal__ supports some customization through [React context](https://reactjs.org/docs/context.html).
 Using this API can be helpful if you need to apply some custom styling or logic to _all_ Blueprint
@@ -53,14 +53,14 @@ ReactDOM.render(
 
 @## Legacy context options
 
-<div class="@ns-callout @ns-intent-error @ns-icon-danger">
-    <h5 class="@ns-heading">React legacy API</h5>
+<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+    <h5 class="@ns-heading">Legacy React API</h5>
 
 This feature uses React's legacy context API. Support for this API will be removed in Blueprint v6.0.
 
 </div>
 
-__Portal__ supports the following options on its [React (legacy) context](https://reactjs.org/docs/legacy-context.html).
+__Portal__ supports the following options via the [React legacy context API](https://reactjs.org/docs/legacy-context.html).
 To use them, supply a child context to a subtree that contains the Portals you want to customize.
 
 @interface PortalLegacyContext

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -1,16 +1,38 @@
 @# Portal
 
-The Portal component renders its children into a new "subtree" outside of the current component
-hierarchy. It is an essential piece of [Overlay](#core/components/overlay), responsible for ensuring that
-the overlay contents cover the application below. In most cases you do not need to use a Portal
-directly; this documentation is provided simply for reference.
+The __Portal__ component renders its children into a new DOM "subtree" outside of the current component
+hierarchy. It is an essential piece of the [Overlay](#core/components/overlay) component, responsible for
+ensuring that the overlay contents appear above the rest of the application. In most cases, you do not
+need to use a Portal directly; this documentation is provided simply for reference.
+
+@## DOM Behavior
+
+__Portal__ component functions like a declarative `appendChild()`, or jQuery's
+`$.fn.appendTo()`. The children of a __Portal__ are inserted into a new child of the document `<body>`.
+
+__Portal__ is used inside [Overlay](#core/components/overlay) to actually overlay the content on the
+application.
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-move">
+    <h5 class="@ns-heading">A note about responsive layouts</h5>
+
+For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal`
+may take up extra whitespace and cause the window to undesirably scroll. To fix this, instead
+apply `position: absolute` to the `<body>` tag.
+
+</div>
+
+@## Props interface
+
+@interface PortalProps
 
 @## Portal context options
 
-`Portal` supports some customization through [React context](https://reactjs.org/docs/context.html).
+__Portal__ supports some customization through [React context](https://reactjs.org/docs/context.html).
 Using this API can be helpful if you need to apply some custom styling or logic to _all_ Blueprint
 components which use portals (popovers, tooltips, dialogs, etc.). You can do so by rendering a
-`<PortalProvider>` in your React tree (usually, this should be done near the root of your application).
+[PortalProvider](#core/context/portal/portal-provider) in your React tree
+(usually, this should be done near the root of your application).
 
 ```tsx
 import { Button, Popover, PortalProvider } from "@blueprintjs/core";
@@ -27,24 +49,18 @@ ReactDOM.render(
 );
 ```
 
-@interface PortalProviderProps
+@interface PortalContextOptions
 
-@## Props
+@## Legacy context options
 
-The Portal component functions like a declarative `appendChild()`, or jQuery's
-`$.fn.appendTo()`. The children of a `Portal` component are inserted into a new
-child of the `<body>`.
+<div class="@ns-callout @ns-intent-error @ns-icon-danger">
+    <h5 class="@ns-heading">React legacy API</h5>
 
-Portal is used inside [Overlay](#core/components/overlay) to actually overlay the content on the
-application.
-
-<div class="@ns-callout @ns-intent-warning @ns-icon-move">
-    <h5 class="@ns-heading">A note about responsive layouts</h5>
-
-For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal`
-may take up extra whitespace and cause the window to undesirably scroll. To fix this, instead
-apply `position: absolute` to the `<body>` tag.
+This feature uses React's legacy context API. Support for this API will be removed in Blueprint v6.0.
 
 </div>
 
-@interface PortalProps
+__Portal__ supports the following options on its [React (legacy) context](https://reactjs.org/docs/legacy-context.html).
+To use them, supply a child context to a subtree that contains the Portals you want to customize.
+
+@interface PortalLegacyContext

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * Portal supports both the newer React context API and the legacy context API. Support for the legacy context API
- * will be removed in Blueprint v6.0.
- */
-
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
@@ -50,7 +45,8 @@ export interface PortalLegacyContext {
     blueprintPortalClassName?: string;
 }
 
-const REACT_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
+/** @deprecated will be removed in Blueprint v6.0 */
+const PORTAL_LEGACY_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
     blueprintPortalClassName: (obj: PortalLegacyContext, key: keyof PortalLegacyContext) => {
         if (obj[key] != null && typeof obj[key] !== "string") {
             return new Error(Errors.PORTAL_CONTEXT_CLASS_NAME_STRING);
@@ -66,6 +62,9 @@ const REACT_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
  * Use it when you need to circumvent DOM z-stacking (for dialogs, popovers, etc.).
  * Any class names passed to this element will be propagated to the new container element on document.body.
  *
+ * Portal supports both the newer React context API and the legacy context API.
+ * Support for the legacy context API will be removed in Blueprint v6.0.
+ *
  * @see https://blueprintjs.com/docs/#core/components/portal
  */
 export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = {}) {
@@ -80,6 +79,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
         maybeAddClass(container.classList, props.className); // directly added to this portal element
         maybeAddClass(container.classList, context.portalClassName); // added via PortalProvider context
 
+        // TODO: remove legacy context support in Blueprint v6.0
         const { blueprintPortalClassName } = legacyContext;
         if (blueprintPortalClassName != null && blueprintPortalClassName !== "") {
             console.error(Errors.PORTAL_LEGACY_CONTEXT_API);
@@ -135,7 +135,8 @@ Portal.defaultProps = {
     container: typeof document !== "undefined" ? document.body : undefined,
 };
 Portal.displayName = `${DISPLAYNAME_PREFIX}.Portal`;
-Portal.contextTypes = REACT_CONTEXT_TYPES;
+// eslint-disable-next-line deprecation/deprecation
+Portal.contextTypes = PORTAL_LEGACY_CONTEXT_TYPES;
 
 function maybeRemoveClass(classList: DOMTokenList, className?: string) {
     if (className != null && className !== "") {

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -15,6 +15,11 @@
 
 import "@blueprintjs/test-commons/bootstrap";
 
+// common
+import "./common/propsTests";
+import "./common/utils/compareUtilsTests";
+import "./common/utilsTests";
+
 // components
 import "./alert/alertTests";
 import "./breadcrumbs/breadcrumbsTests";
@@ -23,9 +28,6 @@ import "./buttons/buttonTests";
 import "./callout/calloutTests";
 import "./card/cardTests";
 import "./collapse/collapseTests";
-import "./common/propsTests";
-import "./common/utils/compareUtilsTests";
-import "./common/utilsTests";
 import "./context-menu/contextMenuTests";
 import "./context-menu/contextMenuSingletonTests";
 import "./controls/controlsTests";

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -133,4 +133,18 @@ describe("<Portal>", () => {
             { attachTo: rootElement },
         );
     });
+
+    // TODO: remove legacy context support in Blueprint v6.0
+    it("respects blueprintPortalClassName on legacy context", () => {
+        const CLASS_TO_TEST = "bp-test-klass bp-other-class";
+        portal = mount(
+            <Portal>
+                <p>test</p>
+            </Portal>,
+            { attachTo: rootElement, context: { blueprintPortalClassName: CLASS_TO_TEST } },
+        );
+
+        const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);
+        assert.isTrue(portalElement?.classList.contains(Classes.PORTAL));
+    });
 });


### PR DESCRIPTION
#### Fixes #5511

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Update Portal docs to mention legacy context support (it will be removed in v6.0)
- Re-enable test coverage for PortalProvider, since it's being tested in the Portal test suite

#### Reviewers should focus on:

Portal docs page

