### PR TITLE
Fix Nx task dependencies for test/dev tasks

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -54,11 +54,14 @@
             "dependsOn": ["^dist:bundle"],
             "outputs": ["{projectRoot}/dist"]
         },
-        "test:karma": {
+        "test": {
             "dependsOn": ["^compile"]
         },
+        "test:karma": {
+            "dependsOn": []
+        },
         "test:karma:debug": {
-            "dependsOn": ["^compile"]
+            "dependsOn": []
         },
         "bundle": {
             "dependsOn": ["^bundle"],

--- a/nx.json
+++ b/nx.json
@@ -40,7 +40,7 @@
             "outputs": ["{projectRoot}/lib/css"]
         },
         "dev": {
-            "dependsOn": ["^dev"]
+            "dependsOn": ["^compile"]
         },
         "compile:cjs": {
             "dependsOn": ["^compile:cjs"],
@@ -55,10 +55,10 @@
             "outputs": ["{projectRoot}/dist"]
         },
         "test:karma": {
-            "dependsOn": ["^test:karma"]
+            "dependsOn": ["^compile"]
         },
         "test:karma:debug": {
-            "dependsOn": ["^test:karma:debug"]
+            "dependsOn": ["^compile"]
         },
         "bundle": {
             "dependsOn": ["^bundle"],


### PR DESCRIPTION
Before this change, the `test:karma` task in CI was running `test:karma` for its dependencies every time, which is not our intention.