### PR TITLE
docs: add banner to link to v5 pre-release docs

### DIFF
--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -7,9 +7,10 @@ It is optimized for building complex data-dense interfaces for desktop applicati
 @reactDocs Welcome
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-star">
-<h5 class="@ns-heading">Blueprint v5 is coming soon</h5>
+<h5 class="@ns-heading">Blueprint v5.0 is coming soon</h5>
 
-[Check out the new features and migration guides to upgrade from v4.x &rarr;](https://github.com/palantir/blueprint/wiki/Blueprint-5.0)
+Check out the [migration guides to upgrade from v4.x](https://github.com/palantir/blueprint/wiki/Blueprint-5.0)
+and [v5.0 pre-release documentation](https://blueprintjs.com/docs/versions/5) &rarr;
 
 </div>
 
@@ -25,14 +26,15 @@ Install it with your Node.js package manager of choice ([Yarn](https://yarnpkg.c
 yarn add @blueprintjs/core react react-dom
 ```
 
-Additional UI components and APIs live in:
-- [**@blueprintjs/icons**](https://www.npmjs.com/package/@blueprintjs/icons),
-- [**@blueprintjs/datetime**](https://www.npmjs.com/package/@blueprintjs/datetime),
-- [**@blueprintjs/select**](https://www.npmjs.com/package/@blueprintjs/select),
-- [**@blueprintjs/table**](https://www.npmjs.com/package/@blueprintjs/table),
+Additional UI components and APIs are available in:
+- [**@blueprintjs/icons**](https://www.npmjs.com/package/@blueprintjs/icons)
+- [**@blueprintjs/datetime**](https://www.npmjs.com/package/@blueprintjs/datetime)
+- [**@blueprintjs/popover2**](https://www.npmjs.com/package/@blueprintjs/popover2)
+- [**@blueprintjs/select**](https://www.npmjs.com/package/@blueprintjs/select)
+- [**@blueprintjs/table**](https://www.npmjs.com/package/@blueprintjs/table)
 
-and more &mdash; the navigation sidebar lists them all. They are separated by use case and significant dependencies.
-All have peer dependencies on **react** and **react-dom**, so these two packages must be installed alongside Blueprint.
+The navigation sidebar lists all the available packages, separated by use case and significant dependencies.
+All have peer dependencies on **react** and **react-dom**.
 
 ### Import
 

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 
 import { AnchorButton, Classes, HotkeysProvider, Tag } from "@blueprintjs/core";
 import { IDocsCompleteData } from "@blueprintjs/docs-data";
-import { Documentation, IDocumentationProps, NavMenuItem, NavMenuItemProps } from "@blueprintjs/docs-theme";
+import { Banner, Documentation, IDocumentationProps, NavMenuItem, NavMenuItemProps } from "@blueprintjs/docs-theme";
 
 import { highlightCodeBlocks } from "../styles/syntaxHighlighting";
 import { NavHeader } from "./navHeader";
@@ -38,8 +38,12 @@ const NPM_URL = "https://www.npmjs.com/package";
 const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
 const CONTEXT_PATTERN = /\/context(\.[\w-]+)?$/;
 const HOOKS_PATTERN = /\/hooks(\.[\w-]+)?$/;
+const LEGACY_PATTERN = /\/legacy(\.[\w-]+)?$/;
 const isNavSection = ({ route }: IHeadingNode) =>
-    COMPONENTS_PATTERN.test(route) || CONTEXT_PATTERN.test(route) || HOOKS_PATTERN.test(route);
+    COMPONENTS_PATTERN.test(route) ||
+    CONTEXT_PATTERN.test(route) ||
+    HOOKS_PATTERN.test(route) ||
+    LEGACY_PATTERN.test(route);
 
 /** Return the current theme className. */
 export function getTheme(): string {
@@ -63,6 +67,11 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
     public state = { themeName: getTheme() };
 
     public render() {
+        const banner = (
+            <Banner href="https://blueprintjs.com/docs/versions/5" intent="success">
+                Blueprint v5.0 is coming soon. Click here to visit the pre-release documentation &rarr;
+            </Banner>
+        );
         const footer = (
             <small className={classNames("docs-copyright", Classes.TEXT_MUTED)}>
                 &copy; {new Date().getFullYear()}
@@ -87,6 +96,7 @@ export class BlueprintDocs extends React.Component<IBlueprintDocsProps, { themeN
                 <Documentation
                     {...this.props}
                     className={this.state.themeName}
+                    banner={banner}
                     footer={footer}
                     header={header}
                     navigatorExclude={isNavSection}


### PR DESCRIPTION

#### Changes proposed in this pull request:

Add banner linking to v5 pre-release docs

#### Screenshot

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/723999/236491048-6663c1cd-baa4-485a-9f2d-19383e5b3dba.png">