### PR TITLE
[v5] fix: various compatibility fixes

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -260,6 +260,8 @@ export const POPOVER_POPPER_ESCAPED = `${POPOVER}-popper-escaped`;
 export const POPOVER_REFERENCE_HIDDEN = `${POPOVER}-reference-hidden`;
 export const POPOVER_TARGET = `${POPOVER}-target`;
 export const POPOVER_TRANSITION_CONTAINER = `${POPOVER}-transition-container`;
+/** @deprecated, no longer used in Blueprint v5.x */
+export const POPOVER_WRAPPER = `${POPOVER}-wrapper`;
 
 export const PROGRESS_BAR = `${NS}-progress-bar`;
 export const PROGRESS_METER = `${NS}-progress-meter`;

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -115,6 +115,7 @@ const INVALID_PROPS = [
     "asyncControl", // InputGroupProps
     "containerRef",
     "current",
+    "elementRef", // not used anymore in Blueprint v5.x, but kept for backcompat if consumers use this naming pattern
     "fill",
     "icon",
     "inputClassName",

--- a/packages/core/src/components/button/buttonProps.ts
+++ b/packages/core/src/components/button/buttonProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import * as React from "react";
 
 import type { ActionProps, Alignment, MaybeElement } from "../../common";
 import type { IconName } from "../icon/icon";

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef, useCallback, useRef, useState } from "react";
+import * as React from "react";
 
 import { IconSize } from "@blueprintjs/icons";
 
@@ -31,7 +31,7 @@ import { AnchorButtonProps, ButtonProps } from "./buttonProps";
  *
  * @see https://blueprintjs.com/docs/#core/components/button
  */
-export const Button: React.FC<ButtonProps> = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+export const Button: React.FC<ButtonProps> = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     const commonAttributes = useSharedButtonAttributes(props, ref);
 
     return (
@@ -47,7 +47,7 @@ Button.displayName = `${DISPLAYNAME_PREFIX}.Button`;
  *
  * @see https://blueprintjs.com/docs/#core/components/button
  */
-export const AnchorButton: React.FC<AnchorButtonProps> = forwardRef<HTMLAnchorElement, AnchorButtonProps>(
+export const AnchorButton: React.FC<AnchorButtonProps> = React.forwardRef<HTMLAnchorElement, AnchorButtonProps>(
     (props, ref) => {
         const { href, tabIndex = 0 } = props;
         const commonProps = useSharedButtonAttributes(props, ref);
@@ -78,13 +78,13 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
     const disabled = props.disabled || loading;
 
     // the current key being pressed
-    const [currentKeyPressed, setCurrentKeyPressed] = useState<string | undefined>();
+    const [currentKeyPressed, setCurrentKeyPressed] = React.useState<string | undefined>();
     // whether the button is in "active" state
-    const [isActive, setIsActive] = useState(false);
+    const [isActive, setIsActive] = React.useState(false);
     // our local ref for the button element, merged with the consumer's own ref (if supplied) in this hook's return value
-    const buttonRef = useRef<E | null>(null);
+    const buttonRef = React.useRef<E | null>(null);
 
-    const handleBlur = useCallback(
+    const handleBlur = React.useCallback(
         (e: React.FocusEvent<any>) => {
             if (isActive) {
                 setIsActive(false);
@@ -93,7 +93,7 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
         },
         [isActive, props.onBlur],
     );
-    const handleKeyDown = useCallback(
+    const handleKeyDown = React.useCallback(
         (e: React.KeyboardEvent<any>) => {
             if (Utils.isKeyboardClick(e)) {
                 e.preventDefault();
@@ -106,7 +106,7 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
         },
         [currentKeyPressed, props.onKeyDown],
     );
-    const handleKeyUp = useCallback(
+    const handleKeyUp = React.useCallback(
         (e: React.KeyboardEvent<any>) => {
             if (Utils.isKeyboardClick(e)) {
                 setIsActive(false);

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import * as React from "react";
 
 import { Alignment, Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLInputProps, Props } from "../../common/props";
@@ -155,30 +155,32 @@ export interface SwitchProps extends ControlProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/switch
  */
-export const Switch: React.FC<SwitchProps> = forwardRef(({ innerLabelChecked, innerLabel, ...controlProps }, ref) => {
-    const switchLabels =
-        innerLabel || innerLabelChecked
-            ? [
-                  <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
-                      <div className={Classes.SWITCH_INNER_TEXT}>
-                          {innerLabelChecked ? innerLabelChecked : innerLabel}
-                      </div>
-                  </div>,
-                  <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>
-                      <div className={Classes.SWITCH_INNER_TEXT}>{innerLabel}</div>
-                  </div>,
-              ]
-            : null;
-    return renderControl(
-        {
-            ...controlProps,
-            indicatorChildren: switchLabels,
-            type: "checkbox",
-            typeClassName: Classes.SWITCH,
-        },
-        ref,
-    );
-});
+export const Switch: React.FC<SwitchProps> = React.forwardRef(
+    ({ innerLabelChecked, innerLabel, ...controlProps }, ref) => {
+        const switchLabels =
+            innerLabel || innerLabelChecked
+                ? [
+                      <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
+                          <div className={Classes.SWITCH_INNER_TEXT}>
+                              {innerLabelChecked ? innerLabelChecked : innerLabel}
+                          </div>
+                      </div>,
+                      <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>
+                          <div className={Classes.SWITCH_INNER_TEXT}>{innerLabel}</div>
+                      </div>,
+                  ]
+                : null;
+        return renderControl(
+            {
+                ...controlProps,
+                indicatorChildren: switchLabels,
+                type: "checkbox",
+                typeClassName: Classes.SWITCH,
+            },
+            ref,
+        );
+    },
+);
 Switch.displayName = `${DISPLAYNAME_PREFIX}.Switch`;
 
 //
@@ -192,7 +194,7 @@ export type RadioProps = ControlProps;
  *
  * @see https://blueprintjs.com/docs/#core/components/radio
  */
-export const Radio: React.FC<RadioProps> = forwardRef((props, ref) =>
+export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) =>
     renderControl(
         {
             ...props,
@@ -228,11 +230,13 @@ export interface CheckboxProps extends ControlProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/checkbox
  */
-export const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
+export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) => {
     const { defaultIndeterminate, indeterminate, onChange, ...controlProps } = props;
-    const [isIndeterminate, setIsIndeterminate] = useState<boolean>(indeterminate || defaultIndeterminate || false);
-    const localRef = useRef<HTMLInputElement>(null);
-    const handleChange = useCallback(
+    const [isIndeterminate, setIsIndeterminate] = React.useState<boolean>(
+        indeterminate || defaultIndeterminate || false,
+    );
+    const localRef = React.useRef<HTMLInputElement>(null);
+    const handleChange = React.useCallback(
         (evt: React.ChangeEvent<HTMLInputElement>) => {
             // update state immediately only if uncontrolled
             if (indeterminate === undefined) {
@@ -244,13 +248,13 @@ export const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
         [onChange],
     );
 
-    useEffect(() => {
+    React.useEffect(() => {
         if (indeterminate !== undefined) {
             setIsIndeterminate(indeterminate);
         }
     }, [indeterminate]);
 
-    useEffect(() => {
+    React.useEffect(() => {
         if (localRef.current != null) {
             localRef.current.indeterminate = isIndeterminate;
         }

--- a/packages/core/src/components/hotkeys/hotkeysTarget2.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect } from "react";
+import * as React from "react";
 
 import * as Errors from "../../common/errors";
 import { isNodeEnv } from "../../common/utils";
@@ -48,7 +48,7 @@ export const HotkeysTarget2 = ({ children, hotkeys, options }: HotkeysTarget2Pro
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys, options);
 
     // run props validation
-    useEffect(() => {
+    React.useEffect(() => {
         if (!isNodeEnv("production")) {
             if (typeof children !== "function" && hotkeys.some(h => !h.global)) {
                 console.error(Errors.HOTKEYS_TARGET_CHILDREN_LOCAL_HOTKEYS);

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef } from "react";
+import * as React from "react";
 
 import { DoubleCaretVertical, SVGIconProps } from "@blueprintjs/icons";
 
@@ -66,7 +66,7 @@ export interface HTMLSelectProps
  *
  * @see https://blueprintjs.com/docs/#core/components/html-select
  */
-export const HTMLSelect: React.FC<HTMLSelectProps> = forwardRef((props, ref) => {
+export const HTMLSelect: React.FC<HTMLSelectProps> = React.forwardRef((props, ref) => {
     const { className, children, disabled, fill, iconProps, large, minimal, options = [], value, ...htmlProps } = props;
     const classes = classNames(
         HTML_SELECT,

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef } from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 
@@ -42,7 +42,7 @@ export interface HTMLTableProps
  *
  * @see https://blueprintjs.com/docs/#core/components/html-table
  */
-export const HTMLTable: React.FC<HTMLTableProps> = forwardRef((props, ref) => {
+export const HTMLTable: React.FC<HTMLTableProps> = React.forwardRef((props, ref) => {
     const { bordered, className, compact, interactive, striped, ...htmlProps } = props;
     const classes = classNames(
         Classes.HTML_TABLE,

--- a/packages/core/src/components/html/html.tsx
+++ b/packages/core/src/components/html/html.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef } from "react";
+import * as React from "react";
 
 import { BLOCKQUOTE, CODE, CODE_BLOCK, HEADING, LABEL, LIST } from "../../common/classes";
 
@@ -24,7 +24,7 @@ function htmlElement<E extends HTMLElement>(
     tagClassName: string,
 ): React.FC<React.HTMLAttributes<E> & React.RefAttributes<E>> {
     /* eslint-disable-next-line react/display-name */
-    return forwardRef<E, React.HTMLAttributes<E>>((props, ref) => {
+    return React.forwardRef<E, React.HTMLAttributes<E>>((props, ref) => {
         const { className, children, ...htmlProps } = props;
         return React.createElement(
             tagName,

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef, useEffect, useState } from "react";
+import * as React from "react";
 
 import { IconComponent, IconName, Icons, IconSize, SVGIconProps } from "@blueprintjs/icons";
 
@@ -58,90 +58,91 @@ export interface IconProps extends IntentProps, Props, SVGIconProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/icon
  */
-export const Icon: React.FC<IconProps & Omit<React.HTMLAttributes<HTMLElement>, "title">> = forwardRef<any, IconProps>(
-    (props, ref) => {
-        const { icon } = props;
-        if (icon == null || typeof icon === "boolean") {
-            return null;
-        } else if (typeof icon !== "string") {
-            return icon;
-        }
+export const Icon: React.FC<IconProps & Omit<React.HTMLAttributes<HTMLElement>, "title">> = React.forwardRef<
+    any,
+    IconProps
+>((props, ref) => {
+    const { icon } = props;
+    if (icon == null || typeof icon === "boolean") {
+        return null;
+    } else if (typeof icon !== "string") {
+        return icon;
+    }
 
-        const {
-            autoLoad,
-            className,
-            color,
-            size,
-            icon: _icon,
-            intent,
-            tagName,
-            svgProps,
-            title,
-            htmlTitle,
-            ...htmlProps
-        } = props;
-        const [Component, setIconComponent] = useState<IconComponent>();
+    const {
+        autoLoad,
+        className,
+        color,
+        size,
+        icon: _icon,
+        intent,
+        tagName,
+        svgProps,
+        title,
+        htmlTitle,
+        ...htmlProps
+    } = props;
+    const [Component, setIconComponent] = React.useState<IconComponent>();
 
-        useEffect(() => {
-            let shouldCancelIconLoading = false;
-            if (typeof icon === "string") {
-                if (autoLoad) {
-                    // load the module to get the component (it will be cached if it's the same icon)
-                    Icons.load(icon).then(() => {
-                        // if this effect expired by the time icon loaded, then don't set state
-                        if (!shouldCancelIconLoading) {
-                            setIconComponent(Icons.getComponent(icon));
-                        }
-                    });
-                } else {
-                    setIconComponent(Icons.getComponent(icon));
-                }
+    React.useEffect(() => {
+        let shouldCancelIconLoading = false;
+        if (typeof icon === "string") {
+            if (autoLoad) {
+                // load the module to get the component (it will be cached if it's the same icon)
+                Icons.load(icon).then(() => {
+                    // if this effect expired by the time icon loaded, then don't set state
+                    if (!shouldCancelIconLoading) {
+                        setIconComponent(Icons.getComponent(icon));
+                    }
+                });
+            } else {
+                setIconComponent(Icons.getComponent(icon));
             }
-            return () => {
-                shouldCancelIconLoading = true;
-            };
-        }, [autoLoad, icon]);
-
-        if (Component == null) {
-            // fall back to icon font if unloaded or unable to load SVG implementation
-            const sizeClass =
-                size === IconSize.STANDARD
-                    ? Classes.ICON_STANDARD
-                    : size === IconSize.LARGE
-                    ? Classes.ICON_LARGE
-                    : undefined;
-            return React.createElement(tagName!, {
-                ...htmlProps,
-                "aria-hidden": title ? undefined : true,
-                className: classNames(
-                    Classes.ICON,
-                    sizeClass,
-                    Classes.iconClass(icon),
-                    Classes.intentClass(intent),
-                    className,
-                ),
-                "data-icon": icon,
-                ref,
-                title: htmlTitle,
-            });
-        } else {
-            return (
-                <Component
-                    // don't forward Classes.iconClass(icon) here, since the component template will render that class
-                    className={classNames(Classes.intentClass(intent), className)}
-                    color={color}
-                    size={size}
-                    tagName={tagName}
-                    title={title}
-                    htmlTitle={htmlTitle}
-                    ref={ref}
-                    svgProps={svgProps}
-                    {...htmlProps}
-                />
-            );
         }
-    },
-);
+        return () => {
+            shouldCancelIconLoading = true;
+        };
+    }, [autoLoad, icon]);
+
+    if (Component == null) {
+        // fall back to icon font if unloaded or unable to load SVG implementation
+        const sizeClass =
+            size === IconSize.STANDARD
+                ? Classes.ICON_STANDARD
+                : size === IconSize.LARGE
+                ? Classes.ICON_LARGE
+                : undefined;
+        return React.createElement(tagName!, {
+            ...htmlProps,
+            "aria-hidden": title ? undefined : true,
+            className: classNames(
+                Classes.ICON,
+                sizeClass,
+                Classes.iconClass(icon),
+                Classes.intentClass(intent),
+                className,
+            ),
+            "data-icon": icon,
+            ref,
+            title: htmlTitle,
+        });
+    } else {
+        return (
+            <Component
+                // don't forward Classes.iconClass(icon) here, since the component template will render that class
+                className={classNames(Classes.intentClass(intent), className)}
+                color={color}
+                size={size}
+                tagName={tagName}
+                title={title}
+                htmlTitle={htmlTitle}
+                ref={ref}
+                svgProps={svgProps}
+                {...htmlProps}
+            />
+        );
+    }
+});
 Icon.defaultProps = {
     autoLoad: true,
     size: IconSize.STANDARD,

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { cloneElement, createRef } from "react";
+import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { AbstractPureComponent, Classes } from "../../common";
@@ -242,13 +242,13 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
     };
 
     /** Ref for container element, containing all children and the backdrop */
-    public containerElement = createRef<HTMLDivElement>();
+    public containerElement = React.createRef<HTMLDivElement>();
 
     // An empty, keyboard-focusable div at the beginning of the Overlay content
-    private startFocusTrapElement = createRef<HTMLDivElement>();
+    private startFocusTrapElement = React.createRef<HTMLDivElement>();
 
     // An empty, keyboard-focusable div at the end of the Overlay content
-    private endFocusTrapElement = createRef<HTMLDivElement>();
+    private endFocusTrapElement = React.createRef<HTMLDivElement>();
 
     public render() {
         // oh snap! no reason to render anything at all if we're being truly lazy
@@ -378,7 +378,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
         const tabIndex = this.props.enforceFocus || this.props.autoFocus ? 0 : undefined;
         const decoratedChild =
             typeof child === "object" ? (
-                cloneElement(child as React.ReactElement, {
+                React.cloneElement(child as React.ReactElement, {
                     className: classNames((child as React.ReactElement).props.className, Classes.OVERLAY_CONTENT),
                     tabIndex,
                 })

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -2,15 +2,15 @@
 
 Popovers display floating content next to a target element.
 
-`Popover` is built on top of the [**Popper.js**](https://popper.js.org) library.
+The __Popover__ component is built on top of the [**Popper.js**](https://popper.js.org) library.
 Popper.js is a small library that offers a powerful, customizable
 positioning engine and operates at blazing speed (`~60fps`).
 
 @reactExample PopoverExample
 
-@## Props
+@## Usage
 
-`Popover` supports controlled and uncontrolled usage through `isOpen` and
+__Popover__ supports controlled and uncontrolled usage through `isOpen` and
 `defaultIsOpen`, respectively. Use `onInteraction` in controlled mode to respond
 to changes in the `isOpen` state.
 
@@ -18,7 +18,9 @@ Supported user interactions are dictated by the `interactionKind` prop.
 
 This component is quite powerful and has a wide range of features. Explore the
 [**Concepts**](#core/components/popover.concepts) section below for more advanced
-guides.
+usage guides.
+
+@## Props interface
 
 @interface PopoverProps
 
@@ -34,10 +36,10 @@ as the trigger for the popover; user interaction will show the popover based on 
 In Popper.js terms, this is the popper "reference". There are two ways to render a Popover target, resulting
 in different DOM layout depending on your application's needs:
 
--   The simplest way is with `children`, an API unchanged from `<Popover>`. Provide a single React child to
+-   The simplest way to specify a target is via `children`. Provide a single React child to
     `<Popover>` and the component will render that child wrapped in a `@ns-popover-target` HTML element.
     This wrapper is configured with event handling logic necessary for the Popover to function. Its tag name
-    (e.g. `div`, `span`) can be customized with the `targetTagName` prop.
+    (e.g. `div`, `span`) and props can be customized with the `targetTagName` and `targetProps` props, respectively.
 
 -   A more advanced API is available through the `renderTarget` prop. Here, Popover provides you with all the
     information necessary to render a functional popover with a [render prop](https://reactjs.org/docs/render-props.html).
@@ -142,7 +144,7 @@ automatically by enabling the modifiers `flip` and `preventOverflow`.
 
 @### Modifiers
 
-Modifiers allow us to customize Popper.js's positioning behavior. `Popover` configures several of Popper.js's built-in modifiers
+Modifiers allow us to customize Popper.js's positioning behavior. __Popover__ configures several of Popper.js's built-in modifiers
 to handle things such as flipping, preventing overflow from a boundary element, and positioning the arrow.
 
 You may override the default modifiers with the `modifiers` prop, which is an object with key-value pairs representing the
@@ -173,7 +175,7 @@ user interaction under the current `interactionKind`.
 Note that there are cases where `onInteraction` is invoked with an unchanged open state.
 It is important to pay attention to the value of the `nextOpenState` parameter and determine
 in your application logic whether you should care about a particular invocation (for instance,
-if the `nextOpenState` is not the same as the `Popover`'s current state).
+if the `nextOpenState` is not the same as the __Popover__'s current state).
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h5 class="@ns-heading">Disabling controlled popovers</h5>
@@ -347,15 +349,15 @@ everything else on the page without needing to manually adjust z-indices, and Po
 
 @### Dark theme
 
-`Popover` automatically detects whether its trigger is nested inside a `.@ns-dark` container and applies the
+__Popover__ automatically detects whether its trigger is nested inside a `.@ns-dark` container and applies the
 same class to itself. You can also explicitly apply the dark theme to the React component by providing the prop
 `popoverClassName="@ns-dark"`.
 
-As a result, any component that you place inside a `Popover` (such as a `Menu`) automatically
-inherits the dark theme styles. Note that [`Tooltip`](#core/components/tooltip) uses `Popover` internally,
+As a result, any component that you place inside a __Popover__ (such as a `Menu`) automatically
+inherits the dark theme styles. Note that [`Tooltip`](#core/components/tooltip) uses __Popover__ internally,
 so it also benefits from this behavior.
 
-This behavior can be disabled (if the `Popover` uses a `Portal`) via the `inheritDarkTheme` prop.
+This behavior can be disabled (if the __Popover__ uses a `Portal`) via the `inheritDarkTheme` prop.
 
 @### Sizing
 
@@ -402,7 +404,7 @@ Your best resource for strategies in popover testing is
 
 #### Animation delays
 
-`Popover` can be difficult to test because it uses `Portal` to inject its contents elsewhere in the
+__Popover__ can be difficult to test because it uses `Portal` to inject its contents elsewhere in the
 DOM (outside the usual flow); this can be simplified by setting `usePortal={false}` in tests.
 Hover interactions can also be tricky due to delays and transitions; this can be resolved by
 zeroing the default hover delays.
@@ -415,7 +417,7 @@ zeroing the default hover delays.
 
 #### Rendering delays
 
-`Popover` delays rendering updates triggered on `mouseleave`, because the mouse might have moved from the popover to the target,
+__Popover__ delays rendering updates triggered on `mouseleave`, because the mouse might have moved from the popover to the target,
 which may require special handling depending on the current [`interactionKind`](#core/components/popover.interactions).
 Popper.js also throttles rendering updates to improve performance. If your components are not updating in a synchronous fashion
 as expected, you may need to introduce a `setTimeout` to wait for asynchronous Popover rendering to catch up:
@@ -447,7 +449,7 @@ setTimeout(() => {
 
 #### Element refs
 
-If `usePortal={false}` rendering is not an option, `Popover` instances expose `popoverElement` and
+If `usePortal={false}` rendering is not an option, __Popover__ instances expose `popoverElement` and
 `targetElement` refs of the actual DOM elements. Importantly, `popoverElement` points to the
 `.@ns-popover` element inside the `Portal` so you can use it to easily query popover contents without
 knowing precisely where they are in the DOM. These properties exist primarily to simplify testing;

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -15,7 +15,7 @@
  */
 
 import { ResizeObserver, ResizeObserverEntry } from "@juggle/resize-observer";
-import React, { cloneElement, createRef } from "react";
+import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
@@ -68,7 +68,7 @@ export interface ResizeSensorProps {
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
-    private targetRef = createRef<HTMLElement>();
+    private targetRef = React.createRef<HTMLElement>();
 
     private prevElement: HTMLElement | undefined = undefined;
 
@@ -82,7 +82,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
             return onlyChild;
         }
 
-        return cloneElement(onlyChild, { ref: this.targetRef });
+        return React.cloneElement(onlyChild, { ref: this.targetRef });
     }
 
     public componentDidMount() {

--- a/packages/core/src/components/tag-input/resizableInput.tsx
+++ b/packages/core/src/components/tag-input/resizableInput.tsx
@@ -2,18 +2,18 @@
  * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  */
 
-import React, { forwardRef, useEffect, useRef, useState } from "react";
+import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, HTMLInputProps } from "../../common";
 
 export type Ref = HTMLInputElement;
 
-export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function ResizableInput(props, ref) {
-    const [content, setContent] = useState("");
-    const [width, setWidth] = useState(0);
-    const span = useRef<HTMLSpanElement>(null);
+export const ResizableInput = React.forwardRef<Ref, HTMLInputProps>(function ResizableInput(props, ref) {
+    const [content, setContent] = React.useState("");
+    const [width, setWidth] = React.useState(0);
+    const span = React.useRef<HTMLSpanElement>(null);
 
-    useEffect(() => {
+    React.useEffect(() => {
         if (span.current != null) {
             setWidth(span.current.offsetWidth);
         }

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef } from "react";
+import * as React from "react";
 
 import { IconName, IconSize, SmallCross } from "@blueprintjs/icons";
 
@@ -115,7 +115,7 @@ export interface TagProps
  *
  * @see https://blueprintjs.com/docs/#core/components/tag
  */
-export const Tag: React.FC<TagProps> = forwardRef((props, ref) => {
+export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
     const {
         active,
         children,

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { useLayoutEffect, useRef, useState } from "react";
+import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, Props } from "../../common/props";
@@ -57,13 +57,13 @@ export const Text: React.FC<TextProps & Omit<React.HTMLAttributes<HTMLElement>, 
     ellipsize,
     ...htmlProps
 }) => {
-    const textRef = useRef<HTMLElement>();
-    const [textContent, setTextContent] = useState<string>("");
-    const [isContentOverflowing, setIsContentOverflowing] = useState<boolean>();
+    const textRef = React.useRef<HTMLElement>();
+    const [textContent, setTextContent] = React.useState<string>("");
+    const [isContentOverflowing, setIsContentOverflowing] = React.useState<boolean>();
 
     // try to be conservative about running this effect, since querying scrollWidth causes the browser to reflow / recalculate styles,
     // which can be very expensive for long lists (for example, in long Menus)
-    useLayoutEffect(() => {
+    React.useLayoutEffect(() => {
         if (textRef.current?.textContent != null) {
             setIsContentOverflowing(ellipsize! && textRef.current.scrollWidth > textRef.current.clientWidth);
             setTextContent(textRef.current.textContent);

--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { createContext } from "react";
+import * as React from "react";
 
 import { shallowCompareKeys } from "../../common/utils";
 import { HotkeysDialog2, HotkeysDialogProps } from "../../components/hotkeys/hotkeysDialog2";
@@ -54,7 +54,7 @@ const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
  *
  * For more information, see the [HotkeysProvider documentation](https://blueprintjs.com/docs/#core/context/hotkeys-provider).
  */
-export const HotkeysContext = createContext<HotkeysContextInstance>([initialHotkeysState, noOpDispatch]);
+export const HotkeysContext = React.createContext<HotkeysContextInstance>([initialHotkeysState, noOpDispatch]);
 
 const hotkeysReducer = (state: HotkeysContextState, action: HotkeysAction) => {
     switch (action.type) {

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import React, { useMemo } from "react";
+import * as React from "react";
 import { SinonStub, spy, stub } from "sinon";
 
 // N.B. { fireEvent } from "@testing-library/react" does not generate "real" enough events which
@@ -38,7 +38,7 @@ interface TestComponentContainerProps {
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputReadOnly, onKeyA, onKeyB }) => {
-    const hotkeys = useMemo(() => {
+    const hotkeys = React.useMemo(() => {
         const keys = [
             {
                 combo: "A",

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef, useCallback, useRef, useState } from "react";
+import * as React from "react";
 
 import { HTMLDivProps, Props, removeNonHTMLProps } from "@blueprintjs/core";
 import { createKeyEventHandler } from "@blueprintjs/docs-theme";
@@ -44,18 +44,18 @@ export interface ClickToCopyProps extends Props, React.RefAttributes<any>, HTMLD
  *  - `[data-copied-message="<message>"]` will be shown when the element has been copied.
  * The message is reset to default when the user mouses off the element after copying it.
  */
-export const ClickToCopy: React.FC<ClickToCopyProps> = forwardRef<any, ClickToCopyProps>((props, ref) => {
+export const ClickToCopy: React.FC<ClickToCopyProps> = React.forwardRef<any, ClickToCopyProps>((props, ref) => {
     const { className, children, copiedClassName, value } = props;
-    const [hasCopied, setHasCopied] = useState(false);
-    const inputRef = useRef<HTMLInputElement>();
+    const [hasCopied, setHasCopied] = React.useState(false);
+    const inputRef = React.useRef<HTMLInputElement>();
 
-    const copy = useCallback(async () => {
+    const copy = React.useCallback(async () => {
         inputRef.current?.select();
         await navigator.clipboard.writeText(inputRef.current.value);
         setHasCopied(true);
     }, [inputRef]);
 
-    const handleClick = useCallback(
+    const handleClick = React.useCallback(
         async (e: React.MouseEvent<HTMLDivElement>) => {
             await copy();
             props.onClick?.(e);
@@ -63,7 +63,7 @@ export const ClickToCopy: React.FC<ClickToCopyProps> = forwardRef<any, ClickToCo
         [copy, props.onClick],
     );
 
-    const handleMouseLeave = useCallback(
+    const handleMouseLeave = React.useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
             setHasCopied(false);
             props.onMouseLeave?.(e);
@@ -71,11 +71,11 @@ export const ClickToCopy: React.FC<ClickToCopyProps> = forwardRef<any, ClickToCo
         [props.onMouseLeave],
     );
 
-    const handleInputBlur = useCallback(() => {
+    const handleInputBlur = React.useCallback(() => {
         setHasCopied(false);
     }, []);
 
-    const handleKeyDown = useCallback(
+    const handleKeyDown = React.useCallback(
         createKeyEventHandler(
             {
                 Enter: copy,

--- a/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
+++ b/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import React, { useEffect, useState } from "react";
+import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -31,10 +31,10 @@ interface PianoKeyProps {
 }
 
 export const PianoKey: React.FC<PianoKeyProps> = ({ context, hotkey, note, pressed }) => {
-    const [envelope, setEnvelope] = useState<Envelope>();
+    const [envelope, setEnvelope] = React.useState<Envelope>();
 
     // only create oscillator and envelop once on mount
-    useEffect(() => {
+    React.useEffect(() => {
         if (context !== undefined) {
             const oscillator = new Oscillator(context, Scale[note]);
             const newEnvelope = new Envelope(context);
@@ -45,7 +45,7 @@ export const PianoKey: React.FC<PianoKeyProps> = ({ context, hotkey, note, press
     }, [context]);
 
     // start/stop envelope when this key is pressed down/up
-    useEffect(() => {
+    React.useEffect(() => {
         if (pressed) {
             envelope?.on();
         } else {

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import cloneDeep from "lodash/cloneDeep";
-import React, { useCallback, useReducer } from "react";
+import * as React from "react";
 
 import { Classes, ContextMenu, Icon, Intent, Tooltip, Tree, TreeNodeInfo } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
@@ -62,27 +62,30 @@ function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
 }
 
 export const TreeExample: React.FC<ExampleProps> = props => {
-    const [nodes, dispatch] = useReducer(treeExampleReducer, INITIAL_STATE);
+    const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
 
-    const handleNodeClick = useCallback((node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
-        const originallySelected = node.isSelected;
-        if (!e.shiftKey) {
-            dispatch({ type: "DESELECT_ALL" });
-        }
-        dispatch({
-            payload: { path: nodePath, isSelected: originallySelected == null ? true : !originallySelected },
-            type: "SET_IS_SELECTED",
-        });
-    }, []);
+    const handleNodeClick = React.useCallback(
+        (node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
+            const originallySelected = node.isSelected;
+            if (!e.shiftKey) {
+                dispatch({ type: "DESELECT_ALL" });
+            }
+            dispatch({
+                payload: { path: nodePath, isSelected: originallySelected == null ? true : !originallySelected },
+                type: "SET_IS_SELECTED",
+            });
+        },
+        [],
+    );
 
-    const handleNodeCollapse = useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
+    const handleNodeCollapse = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { path: nodePath, isExpanded: false },
             type: "SET_IS_EXPANDED",
         });
     }, []);
 
-    const handleNodeExpand = useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
+    const handleNodeExpand = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { path: nodePath, isExpanded: true },
             type: "SET_IS_EXPANDED",

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import * as React from "react";
 
 import { useHotkeys } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
@@ -22,10 +22,10 @@ import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 import { PianoKey } from "./audio";
 
 export const UseHotkeysExample: React.FC<ExampleProps> = props => {
-    const [audioContext, setAudioContext] = useState<AudioContext>();
+    const [audioContext, setAudioContext] = React.useState<AudioContext>();
 
-    const pianoRef = useRef<HTMLDivElement>();
-    const focusPiano = useCallback(() => {
+    const pianoRef = React.useRef<HTMLDivElement>();
+    const focusPiano = React.useCallback(() => {
         pianoRef?.current.focus();
         if (typeof window.AudioContext !== "undefined" && audioContext === undefined) {
             setAudioContext(new AudioContext());
@@ -34,13 +34,13 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
 
     // create a dictionary of key states and updater functions
     const keys = Array.apply(null, Array(24))
-        .map(() => useState(() => false), [])
+        .map(() => React.useState(() => false), [])
         .map(([pressed, setPressed]) => ({
             pressed,
             setPressed,
         }));
 
-    const hotkeys = useMemo(
+    const hotkeys = React.useMemo(
         () => [
             {
                 combo: "shift + P",

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -6,10 +6,9 @@ Blueprint is available as a collection of NPM packages under the `@blueprintjs`
 scope. Each package appears at the top level of the sidebar to the left, along
 with its current version.
 
-Each package contains a CSS file and a collection of CommonJS modules exposing React components.
-The `main` module exports all symbols from all modules so you don't have to import individual files
-(though you can if you want to). The JavaScript components are stable and their APIs adhere to
-[semantic versioning](http://semver.org/).
+Each package contains a CSS file and a collection of ES modules exposing React components (CommonJS modules are
+also available, for backwards-compatibility). The `main` module exports all symbols that are considered public API.
+The JavaScript components are stable and their APIs adhere to [semantic versioning](http://semver.org/).
 
 1.  Install the core package and its peer dependencies with an NPM client like
     `npm` or `yarn`, pulling in all relevant dependencies:

--- a/packages/docs-app/src/principles.md
+++ b/packages/docs-app/src/principles.md
@@ -2,11 +2,9 @@
 
 @## Browser support
 
-**Blueprint supports Chrome, Firefox, Safari, IE 11, and Microsoft Edge.**
+**Blueprint supports Chrome, Firefox, Safari, and Microsoft Edge.**
 
-You may experience degraded visuals in IE.
-IE 10 and below are unsupported due to their lack of support for CSS Flexbox Layout.
-These browsers were deprecated by Microsoft (end of support) in [January 2016](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support).
+Internet Explorer (IE) is no longer supported as of Blueprint v5.0 (its support was ended by Microsoft in June 2022).
 
 @## API Contract
 

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -22,7 +22,7 @@ import {
     ITsDocBase,
     ITypescriptPluginData,
 } from "@documentalist/client";
-import React, { createContext } from "react";
+import * as React from "react";
 
 /* eslint-disable @typescript-eslint/ban-types */
 /** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
@@ -68,7 +68,7 @@ export interface DocumentationContextApi {
     showApiDocs: (name: string) => void;
 }
 
-export const DocumentationContext = createContext<DocumentationContextApi>({
+export const DocumentationContext = React.createContext<DocumentationContextApi>({
     getDocsData: () => ({} as DocsData),
     renderBlock: (_block: IBlock) => undefined,
     renderType: (type: string) => type,

--- a/packages/docs-theme/src/components/typescript/apiHeader.tsx
+++ b/packages/docs-theme/src/components/typescript/apiHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import { isTsClass, isTsInterface, ITsDocBase } from "@documentalist/client";
-import React, { useContext } from "react";
+import * as React from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
 import { DocumentationContext } from "../../common/context";
@@ -25,7 +25,7 @@ interface ApiHeaderProps extends ITsDocBase {
 }
 
 export const ApiHeader: React.FC<ApiHeaderProps> = props => {
-    const { renderType, renderViewSourceLinkText } = useContext(DocumentationContext);
+    const { renderType, renderViewSourceLinkText } = React.useContext(DocumentationContext);
     let inheritance: React.ReactNode = "";
 
     if (isTsClass(props) || isTsInterface(props)) {

--- a/packages/docs-theme/src/components/typescript/apiLink.tsx
+++ b/packages/docs-theme/src/components/typescript/apiLink.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useCallback, useContext } from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 
@@ -30,8 +30,8 @@ export interface ApiLinkProps extends Props {
  * Renders a link to open a symbol in the API Browser.
  */
 export const ApiLink: React.FC<ApiLinkProps> = ({ className, name }) => {
-    const { showApiDocs } = useContext(DocumentationContext);
-    const handleClick = useCallback((evt: React.MouseEvent<HTMLAnchorElement>) => {
+    const { showApiDocs } = React.useContext(DocumentationContext);
+    const handleClick = React.useCallback((evt: React.MouseEvent<HTMLAnchorElement>) => {
         evt.preventDefault();
         showApiDocs(name);
     }, []);

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -16,7 +16,7 @@
 
 import { ITsEnum, ITsEnumMember } from "@documentalist/client";
 import classNames from "classnames";
-import React, { useCallback, useContext } from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 
@@ -33,9 +33,9 @@ export interface EnumTableProps extends Props {
 }
 
 export const EnumTable: React.FC<EnumTableProps> = props => {
-    const { renderBlock } = useContext(DocumentationContext);
+    const { renderBlock } = React.useContext(DocumentationContext);
 
-    const renderPropRow = useCallback(
+    const renderPropRow = React.useCallback(
         (entry: ITsEnumMember) => {
             const {
                 flags: { isDeprecated, isExternal },

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -24,7 +24,7 @@ import {
     ITsSignature,
 } from "@documentalist/client";
 import classNames from "classnames";
-import React, { useCallback, useContext } from "react";
+import * as React from "react";
 
 import { Classes, Intent, Props, Tag } from "@blueprintjs/core";
 
@@ -45,9 +45,9 @@ export interface InterfaceTableProps extends Props {
 /* eslint-disable @blueprintjs/html-components */
 
 export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data, title }) => {
-    const { renderBlock, renderType } = useContext(DocumentationContext);
+    const { renderBlock, renderType } = React.useContext(DocumentationContext);
 
-    const renderPropRow = useCallback((entry: ITsProperty | ITsMethod) => {
+    const renderPropRow = React.useCallback((entry: ITsProperty | ITsMethod) => {
         const {
             flags: { isDeprecated, isExternal, isOptional },
             name,
@@ -103,7 +103,7 @@ export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data,
         );
     }, []);
 
-    const renderIndexSignature = useCallback((entry?: ITsSignature) => {
+    const renderIndexSignature = React.useCallback((entry?: ITsSignature) => {
         if (entry == null) {
             return null;
         }

--- a/packages/docs-theme/src/components/typescript/methodTable.tsx
+++ b/packages/docs-theme/src/components/typescript/methodTable.tsx
@@ -16,7 +16,7 @@
 
 import { isTag, ITsMethod, ITsParameter, ITsSignature } from "@documentalist/client";
 import classNames from "classnames";
-import React, { useCallback, useContext } from "react";
+import * as React from "react";
 
 import { Code, Intent, Props, Tag } from "@blueprintjs/core";
 
@@ -33,9 +33,9 @@ export interface MethodTableProps extends Props {
 }
 
 export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => {
-    const { renderBlock, renderType } = useContext(DocumentationContext);
+    const { renderBlock, renderType } = React.useContext(DocumentationContext);
 
-    const renderPropRow = useCallback((parameter: ITsParameter) => {
+    const renderPropRow = React.useCallback((parameter: ITsParameter) => {
         const {
             flags: { isDeprecated, isExternal, isOptional },
             name,
@@ -80,7 +80,7 @@ export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => 
         );
     }, []);
 
-    const renderReturnSignature = useCallback((entry?: ITsSignature) => {
+    const renderReturnSignature = React.useCallback((entry?: ITsSignature) => {
         if (entry == null) {
             return null;
         }

--- a/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
+++ b/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
@@ -16,7 +16,7 @@
 
 import { ITsTypeAlias } from "@documentalist/client";
 import classNames from "classnames";
-import React, { useContext } from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 
@@ -29,7 +29,7 @@ export interface TypeAliasTableProps extends Props {
 }
 
 export const TypeAliasTable: React.FC<TypeAliasTableProps> = ({ className, data }) => {
-    const { renderBlock, renderType } = useContext(DocumentationContext);
+    const { renderBlock, renderType } = React.useContext(DocumentationContext);
     const aliases = data.type.split(" | ").map((type, i) => (
         <div key={i}>
             {i === 0 ? "=" : "|"} {renderType(type)}

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -16,7 +16,7 @@
 
 import { IKssPluginData, ITag } from "@documentalist/client";
 import classNames from "classnames";
-import React, { useCallback, useContext, useState } from "react";
+import * as React from "react";
 
 import { Checkbox, Classes, Code } from "@blueprintjs/core";
 
@@ -28,8 +28,8 @@ const MODIFIER_ATTR_REGEXP = /\{\{:modifier}}/g;
 const MODIFIER_CLASS_REGEXP = /\{\{\.modifier}}/g;
 
 export const CssExample: React.FC<ITag> = ({ value }) => {
-    const { getDocsData } = useContext(DocumentationContext);
-    const [activeModifiers, setActiveModifiers] = useState<Set<string>>(new Set());
+    const { getDocsData } = React.useContext(DocumentationContext);
+    const [activeModifiers, setActiveModifiers] = React.useState<Set<string>>(new Set());
 
     const getModifierToggleHandler = (modifier: string) => {
         return () => {
@@ -60,7 +60,7 @@ export const CssExample: React.FC<ITag> = ({ value }) => {
         </Checkbox>
     ));
 
-    const getModifiers = useCallback(
+    const getModifiers = React.useCallback(
         (prefix: "." | ":") => {
             return Array.from(activeModifiers.keys())
                 .filter(mod => mod.charAt(0) === prefix)

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -15,7 +15,7 @@
  */
 
 import { isTsClass, isTsMethod, ITag, ITsClass, ITypescriptPluginData } from "@documentalist/client";
-import React, { useContext } from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 
@@ -24,7 +24,7 @@ import { DocumentationContext } from "../common/context";
 import { MethodTable } from "../components/typescript/methodTable";
 
 export const Method: React.FC<ITag & Props> = ({ className, value }) => {
-    const { getDocsData } = useContext(DocumentationContext);
+    const { getDocsData } = React.useContext(DocumentationContext);
     const { typescript } = getDocsData() as ITypescriptPluginData;
     const member = typescript[value];
 

--- a/packages/docs-theme/src/tags/see.tsx
+++ b/packages/docs-theme/src/tags/see.tsx
@@ -15,13 +15,13 @@
  */
 
 import { ITag } from "@documentalist/client";
-import React, { useContext } from "react";
+import * as React from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 import { DocumentationContext } from "../common/context";
 
 export const SeeTag: React.FC<ITag> = ({ value }) => {
-    const { renderType } = useContext(DocumentationContext);
+    const { renderType } = React.useContext(DocumentationContext);
     return <p>See: {renderType(value)}</p>;
 };
 SeeTag.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.SeeTag`;

--- a/packages/docs-theme/src/tags/typescript.tsx
+++ b/packages/docs-theme/src/tags/typescript.tsx
@@ -15,7 +15,7 @@
  */
 
 import { isTsClass, isTsEnum, isTsInterface, isTsTypeAlias, ITag, ITypescriptPluginData } from "@documentalist/client";
-import React, { useContext } from "react";
+import * as React from "react";
 
 import { Props } from "@blueprintjs/core";
 
@@ -26,7 +26,7 @@ import { InterfaceTable } from "../components/typescript/interfaceTable";
 import { TypeAliasTable } from "../components/typescript/typeAliasTable";
 
 export const TypescriptExample: React.FC<ITag & Props> = ({ className, value }) => {
-    const { getDocsData } = useContext(DocumentationContext);
+    const { getDocsData } = React.useContext(DocumentationContext);
     const { typescript } = getDocsData() as ITypescriptPluginData;
     if (typescript == null || typescript[value] == null) {
         return null;

--- a/packages/icons/scripts/iconComponent.tsx.hbs
+++ b/packages/icons/scripts/iconComponent.tsx.hbs
@@ -14,13 +14,13 @@
  */
 
 import classNames from "classnames";
-import React, { forwardRef } from "react";
+import * as React from "react";
 import type { SVGIconProps } from "../../svgIconProps";
 import { IconSize } from "../../iconSize";
 import * as Classes from "../../classes";
 import { uniqueId } from "../../jsUtils";
 
-export const {{pascalCase iconName}}: React.FC<SVGIconProps> = forwardRef<any, SVGIconProps>(({
+export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>(({
     className,
     color,
     size = IconSize.STANDARD,


### PR DESCRIPTION

#### Changes proposed in this pull request:

- fix(build): remove all remaining usage of default import from "react" (`import React from "react"`)
- fix(`removeNonHTMLProps`): restore `elementRef` back to the list of props filtered by this utility function (for backcompat)
- fix(`Classes`): restore no-op CSS class `Classes.POPOVER_WRAPPER`
- docs(`Popopver`): fix some language referencing Popover v1
- docs: remove IE11 from list of supported browsers

