### PR TITLE
[v5] [table] fix: stop using findDOMNode in Draggable interactions

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -55,6 +55,14 @@ export interface EditableTextProps extends IntentProps, Props {
      */
     disabled?: boolean;
 
+    /**
+     * Ref to attach to the root element rendered by this component.
+     *
+     * N.B. this may be renamed to simply `ref` in a future major version of Blueprint, when this class component is
+     * refactored into a function.
+     */
+    elementRef?: React.RefObject<HTMLDivElement>;
+
     /** Whether the component is currently being edited. */
     isEditing?: boolean;
 
@@ -205,7 +213,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
     }
 
     public render() {
-        const { alwaysRenderInput, disabled, multiline, contentId } = this.props;
+        const { alwaysRenderInput, disabled, elementRef, multiline, contentId } = this.props;
         const value = this.props.value ?? this.state.value;
         const hasValue = value != null && value !== "";
 
@@ -247,7 +255,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
         const spanProps: React.HTMLProps<HTMLSpanElement> = contentId != null ? { id: contentId } : {};
 
         return (
-            <div className={classes} onFocus={this.handleFocus} tabIndex={tabIndex}>
+            <div className={classes} onFocus={this.handleFocus} tabIndex={tabIndex} ref={elementRef}>
                 {alwaysRenderInput || this.state.isEditing ? this.renderInput(value) : undefined}
                 {shouldHideContents ? undefined : (
                     <span

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -166,14 +166,20 @@ export class Popover<
      * DOM element that contains the popover.
      * When `usePortal={true}`, this element will be portaled outside the usual DOM flow,
      * so this reference can be very useful for testing.
+     *
+     * @public for testing
      */
     public popoverElement: HTMLElement | null = null;
 
     /** Popover ref handler */
     private popoverRef: React.Ref<HTMLDivElement> = refHandler(this, "popoverElement", this.props.popoverRef);
 
-    /** Target DOM element ref */
-    private targetRef = React.createRef<HTMLElement>();
+    /**
+     * Target DOM element ref.
+     *
+     * @public for testing
+     */
+    public targetRef = React.createRef<HTMLElement>();
 
     private cancelOpenTimeout?: () => void;
 

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -1,6 +1,6 @@
 @# Resize sensor
 
-ResizeSensor observes the DOM and provides a callback for `"resize"` events on a single child element.
+__ResizeSensor__ observes the DOM and provides a callback for `"resize"` events on a single child element.
 It is a thin wrapper around [`ResizeObserver`][resizeobserver] to provide React bindings.
 
 [resizeobserver]: https://developers.google.com/web/updates/2016/10/resizeobserver

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -17,7 +17,7 @@
 import { ResizeObserver, ResizeObserverEntry } from "@juggle/resize-observer";
 import * as React from "react";
 
-import { AbstractPureComponent, DISPLAYNAME_PREFIX, mergeRefs } from "../../common";
+import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
 /** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 export interface ResizeSensorProps {
@@ -55,7 +55,7 @@ export interface ResizeSensorProps {
      * If you attach a `ref` to the child yourself when rendering it, you must pass the
      * same value here (otherwise, ResizeSensor won't be able to attach its own).
      */
-    targetRef?: React.Ref<HTMLElement>;
+    targetRef?: React.RefObject<HTMLElement>;
 }
 
 /**
@@ -68,7 +68,7 @@ export interface ResizeSensorProps {
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
-    private targetRef = React.createRef<HTMLElement>();
+    private targetRef = this.props.targetRef ?? React.createRef<HTMLElement>();
 
     private prevElement: HTMLElement | undefined = undefined;
 
@@ -76,10 +76,13 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     public render() {
         const onlyChild = React.Children.only(this.props.children);
-        const ref =
-            this.props.targetRef === undefined ? this.targetRef : mergeRefs(this.targetRef, this.props.targetRef);
 
-        return React.cloneElement(onlyChild, { ref });
+        // if we're provided a ref to the child already, we don't need to attach one ourselves
+        if (this.props.targetRef !== undefined) {
+            return onlyChild;
+        }
+
+        return React.cloneElement(onlyChild, { ref: this.targetRef });
     }
 
     public componentDidMount() {

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -15,9 +15,9 @@
  */
 
 import { ResizeObserver, ResizeObserverEntry } from "@juggle/resize-observer";
-import React, { cloneElement, createRef } from "react";
+import * as React from "react";
 
-import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
+import { AbstractPureComponent, DISPLAYNAME_PREFIX, mergeRefs } from "../../common";
 
 /** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 export interface ResizeSensorProps {
@@ -55,7 +55,7 @@ export interface ResizeSensorProps {
      * If you attach a `ref` to the child yourself when rendering it, you must pass the
      * same value here (otherwise, ResizeSensor won't be able to attach its own).
      */
-    targetRef?: React.Ref<any>;
+    targetRef?: React.Ref<HTMLElement>;
 }
 
 /**
@@ -68,7 +68,7 @@ export interface ResizeSensorProps {
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
-    private targetRef = createRef<HTMLElement>();
+    private targetRef = React.createRef<HTMLElement>();
 
     private prevElement: HTMLElement | undefined = undefined;
 
@@ -76,13 +76,10 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     public render() {
         const onlyChild = React.Children.only(this.props.children);
+        const ref =
+            this.props.targetRef === undefined ? this.targetRef : mergeRefs(this.targetRef, this.props.targetRef);
 
-        // if we're provided a ref to the child already, we don't need to attach one ourselves
-        if (this.props.targetRef !== undefined) {
-            return onlyChild;
-        }
-
-        return cloneElement(onlyChild, { ref: this.targetRef });
+        return React.cloneElement(onlyChild, { ref });
     }
 
     public componentDidMount() {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -827,7 +827,7 @@ describe("<Popover>", () => {
 
         const instance = wrapper.instance() as Popover<React.HTMLProps<HTMLButtonElement>>;
         wrapper.popoverElement = instance.popoverElement!;
-        wrapper.targetElement = instance.targetElement!;
+        wrapper.targetElement = instance.targetRef.current!;
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {
             const actual = wrapper!.findClass(className);
             if (expected) {

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -70,7 +70,7 @@ export interface EditableCellProps extends CellProps {
     /**
      * Props that should be passed to the EditableText when it is used to edit
      */
-    editableTextProps?: EditableTextProps;
+    editableTextProps?: Omit<EditableTextProps, "elementRef">;
 }
 
 export interface EditableCellState {
@@ -90,13 +90,9 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
         wrapText: false,
     };
 
-    private cellRef: HTMLElement | null | undefined;
+    private cellRef = React.createRef<HTMLDivElement>();
 
-    private refHandlers = {
-        cell: (ref: HTMLElement | null) => {
-            this.cellRef = ref;
-        },
-    };
+    private contentsRef = React.createRef<HTMLDivElement>();
 
     public constructor(props: EditableCellProps) {
         super(props);
@@ -146,6 +142,7 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
                     {...editableTextProps}
                     isEditing={true}
                     className={classNames(Classes.TABLE_EDITABLE_TEXT, Classes.TABLE_EDITABLE_NAME, className)}
+                    elementRef={this.contentsRef}
                     intent={spreadableProps.intent}
                     minWidth={0}
                     onCancel={this.handleCancel}
@@ -163,7 +160,11 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
                 [Classes.TABLE_NO_WRAP_TEXT]: !wrapText,
             });
 
-            cellContents = <div className={textClasses}>{savedValue}</div>;
+            cellContents = (
+                <div className={textClasses} ref={this.contentsRef}>
+                    {savedValue}
+                </div>
+            );
         }
 
         return (
@@ -172,7 +173,7 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
                 wrapText={wrapText}
                 truncated={false}
                 interactive={interactive}
-                cellRef={this.refHandlers.cell}
+                cellRef={this.cellRef}
                 onKeyPress={this.handleKeyPress}
             >
                 <Draggable
@@ -180,6 +181,7 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
                     onDoubleClick={this.handleCellDoubleClick}
                     preventDefault={false}
                     stopPropagation={interactive}
+                    targetRef={this.contentsRef}
                 >
                     {cellContents}
                 </Draggable>
@@ -206,7 +208,7 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
     private checkShouldFocus() {
         if (this.props.isFocused && !this.state.isEditing) {
             // don't focus if we're editing -- we'll lose the fact that we're editing
-            this.cellRef?.focus();
+            this.cellRef.current?.focus();
         }
     }
 

--- a/packages/table/src/cell/editableCell2.tsx
+++ b/packages/table/src/cell/editableCell2.tsx
@@ -70,7 +70,7 @@ export interface EditableCell2Props extends Omit<CellProps, "onKeyDown" | "onKey
     /**
      * Props that should be passed to the EditableText when it is used to edit
      */
-    editableTextProps?: EditableTextProps;
+    editableTextProps?: Omit<EditableTextProps, "elementRef">;
 }
 
 export interface EditableCell2State {
@@ -92,13 +92,9 @@ export class EditableCell2 extends React.Component<EditableCell2Props, EditableC
         wrapText: false,
     };
 
-    private cellRef: HTMLElement | null | undefined;
+    private cellRef = React.createRef<HTMLDivElement>();
 
-    private refHandlers = {
-        cell: (ref: HTMLElement | null) => {
-            this.cellRef = ref;
-        },
-    };
+    private contentsRef = React.createRef<HTMLDivElement>();
 
     public state: EditableCell2State = {
         isEditing: false,
@@ -157,6 +153,7 @@ export class EditableCell2 extends React.Component<EditableCell2Props, EditableC
                     {...editableTextProps}
                     isEditing={true}
                     className={classNames(Classes.TABLE_EDITABLE_TEXT, Classes.TABLE_EDITABLE_NAME, className)}
+                    elementRef={this.contentsRef}
                     intent={spreadableProps.intent}
                     minWidth={0}
                     onCancel={this.handleCancel}
@@ -174,7 +171,11 @@ export class EditableCell2 extends React.Component<EditableCell2Props, EditableC
                 [Classes.TABLE_NO_WRAP_TEXT]: !wrapText,
             });
 
-            cellContents = <div className={textClasses}>{savedValue}</div>;
+            cellContents = (
+                <div className={textClasses} ref={this.contentsRef}>
+                    {savedValue}
+                </div>
+            );
         }
 
         return (
@@ -183,7 +184,7 @@ export class EditableCell2 extends React.Component<EditableCell2Props, EditableC
                 wrapText={wrapText}
                 truncated={false}
                 interactive={interactive}
-                cellRef={this.refHandlers.cell}
+                cellRef={this.cellRef}
                 onKeyDown={handleKeyDown}
                 onKeyPress={this.handleKeyPress}
                 onKeyUp={handleKeyUp}
@@ -194,6 +195,7 @@ export class EditableCell2 extends React.Component<EditableCell2Props, EditableC
                     onDoubleClick={this.handleCellDoubleClick}
                     preventDefault={false}
                     stopPropagation={interactive}
+                    targetRef={this.contentsRef}
                 >
                     {cellContents}
                 </Draggable>
@@ -204,7 +206,7 @@ export class EditableCell2 extends React.Component<EditableCell2Props, EditableC
     private checkShouldFocus() {
         if (this.props.isFocused && !this.state.isEditing) {
             // don't focus if we're editing -- we'll lose the fact that we're editing
-            this.cellRef?.focus();
+            this.cellRef.current?.focus();
         }
     }
 

--- a/packages/table/src/common/contextMenuTargetWrapper.tsx
+++ b/packages/table/src/common/contextMenuTargetWrapper.tsx
@@ -29,6 +29,7 @@ export interface ContextMenuTargetWrapperProps extends Props {
     children?: React.ReactNode;
     renderContextMenu: (e: React.MouseEvent<HTMLElement>) => JSX.Element | undefined;
     style: React.CSSProperties;
+    targetRef?: React.RefObject<HTMLDivElement>;
 }
 
 /**
@@ -40,9 +41,9 @@ export interface ContextMenuTargetWrapperProps extends Props {
 @ContextMenuTargetLegacy
 export class ContextMenuTargetWrapper extends React.PureComponent<ContextMenuTargetWrapperProps> {
     public render() {
-        const { className, children, style } = this.props;
+        const { className, children, targetRef, style } = this.props;
         return (
-            <div className={className} style={style}>
+            <div className={className} style={style} ref={targetRef}>
                 {children}
             </div>
         );

--- a/packages/table/src/deprecatedAliases.ts
+++ b/packages/table/src/deprecatedAliases.ts
@@ -18,12 +18,12 @@ export {
     /** @deprecated import ColumnHeaderCell instead */
     ColumnHeaderCell as ColumnHeaderCell2,
     /** @deprecated import ColumnHeaderCellProps instead */
-    ColumnHeaderCellProps as ColumnHeaderCellProps2,
+    type ColumnHeaderCellProps as ColumnHeaderCellProps2,
 } from "./headers/columnHeaderCell";
 
 export {
     /** @deprecated import RowHeaderCell instead */
     RowHeaderCell as RowHeaderCell2,
     /** @deprecated import RowHeaderCellProps instead */
-    RowHeaderCellProps as RowHeaderCellProps2,
+    type RowHeaderCellProps as RowHeaderCellProps2,
 } from "./headers/rowHeaderCell";

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -72,6 +72,11 @@ export interface HeaderCellProps extends Props {
      * CSS styles for the top level element.
      */
     style?: React.CSSProperties;
+
+    /**
+     * Required for Draggable to attach a DOM ref.
+     */
+    targetRef?: React.RefObject<HTMLElement>;
 }
 
 export interface InternalHeaderCellProps extends HeaderCellProps {
@@ -124,6 +129,7 @@ export class HeaderCell extends React.Component<InternalHeaderCellProps, HeaderC
                 content={this.props.menuRenderer?.(this.props.index)}
                 disabled={!hasMenu}
                 style={this.props.style}
+                ref={this.props.targetRef}
             >
                 {this.props.children}
             </ContextMenu>

--- a/packages/table/src/interactions/dragTypes.ts
+++ b/packages/table/src/interactions/dragTypes.ts
@@ -103,3 +103,34 @@ export interface DragHandler {
      */
     stopPropagation?: boolean;
 }
+
+export interface DraggableChildrenProps {
+    /**
+     * Single child, must be an element and not a string or fragment.
+     */
+    children: JSX.Element;
+
+    /**
+     * You must provide provide this ref so that Draggable can access its child DOM node if:
+     *
+     *  - You are already attaching your own `ref` to the child element
+     *  - The child element is not a native DOM element
+     *  - The child element _does not_ use React.forwardRef to allow refs to pass through to the DOM
+     *
+     * This may look something like:
+     *
+     *  ```tsx
+     *  import * as React from "react";
+     *
+     *  function MyDraggableComponent() {
+     *      const myRef = React.createRef<HTMLElement();
+     *      return (
+     *          <Draggable targetRef={myRef}>
+     *              <div ref={myRef} />
+     *          </Draggable>
+     *      );
+     *  }
+     *  ```
+     */
+    targetRef?: React.RefObject<HTMLElement>;
+}

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -19,14 +19,9 @@ import * as React from "react";
 import { Utils as CoreUtils, Props } from "@blueprintjs/core";
 
 import { DragEvents } from "./dragEvents";
-import { DragHandler } from "./dragTypes";
+import { DraggableChildrenProps, DragHandler } from "./dragTypes";
 
-export interface DraggableProps extends Props, DragHandler {
-    /**
-     * Single child, must be an element and not a string or fragment.
-     */
-    children: JSX.Element;
-}
+export type DraggableProps = Props & DragHandler & DraggableChildrenProps;
 
 const REATTACH_PROPS_KEYS = ["stopPropagation", "preventDefault"] as Array<keyof DraggableProps>;
 
@@ -65,10 +60,16 @@ export class Draggable extends React.PureComponent<DraggableProps> {
 
     private events = new DragEvents();
 
-    private targetRef = React.createRef<HTMLElement>();
+    private targetRef = this.props.targetRef ?? React.createRef<HTMLElement>();
 
     public render() {
         const onlyChild = React.Children.only(this.props.children);
+
+        // if we're provided a ref to the child already, we don't need to attach one ourselves
+        if (this.props.targetRef !== undefined) {
+            return onlyChild;
+        }
+
         return React.cloneElement(onlyChild, { ref: this.targetRef });
     }
 

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -22,7 +22,7 @@ import type { FocusedCellCoordinates } from "../common/cellTypes";
 import { Utils } from "../common/utils";
 import { Region, RegionCardinality, Regions } from "../regions";
 import { Draggable } from "./draggable";
-import { CoordinateData, DragHandler } from "./dragTypes";
+import { CoordinateData, DraggableChildrenProps, DragHandler } from "./dragTypes";
 
 export interface ReorderableProps {
     /**
@@ -64,12 +64,7 @@ export interface ReorderableProps {
     selectedRegions?: Region[];
 }
 
-export interface DragReorderable extends ReorderableProps {
-    /**
-     * Single child, must be an element and not a string or fragment.
-     */
-    children: JSX.Element;
-
+export interface DragReorderable extends ReorderableProps, DraggableChildrenProps {
     /**
      * Whether the reordering behavior is disabled.
      *
@@ -109,7 +104,7 @@ export class DragReorderable extends React.PureComponent<DragReorderable> {
     public render() {
         const draggableProps = this.getDraggableHandlers();
         return (
-            <Draggable {...draggableProps} preventDefault={false}>
+            <Draggable {...draggableProps} preventDefault={false} targetRef={this.props.targetRef}>
                 {this.props.children}
             </Draggable>
         );

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -21,8 +21,8 @@ import { Utils as CoreUtils } from "@blueprintjs/core";
 import type { FocusedCellCoordinates } from "../common/cellTypes";
 import { Utils } from "../common/utils";
 import { Region, RegionCardinality, Regions } from "../regions";
-import { Draggable, DraggableProps } from "./draggable";
-import { CoordinateData } from "./dragTypes";
+import { Draggable } from "./draggable";
+import { CoordinateData, DragHandler } from "./dragTypes";
 
 export interface ReorderableProps {
     /**
@@ -65,8 +65,10 @@ export interface ReorderableProps {
 }
 
 export interface DragReorderable extends ReorderableProps {
-    /** Element to drag & reorder. */
-    children?: React.ReactNode;
+    /**
+     * Single child, must be an element and not a string or fragment.
+     */
+    children: JSX.Element;
 
     /**
      * Whether the reordering behavior is disabled.
@@ -105,7 +107,7 @@ export class DragReorderable extends React.PureComponent<DragReorderable> {
     private selectedRegionLength: number = 0;
 
     public render() {
-        const draggableProps = this.getDraggableProps();
+        const draggableProps = this.getDraggableHandlers();
         return (
             <Draggable {...draggableProps} preventDefault={false}>
                 {this.props.children}
@@ -113,7 +115,7 @@ export class DragReorderable extends React.PureComponent<DragReorderable> {
         );
     }
 
-    private getDraggableProps(): DraggableProps {
+    private getDraggableHandlers(): DragHandler {
         return this.props.onReordered == null
             ? {}
             : {

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -100,6 +100,7 @@ export class ResizeHandle extends React.PureComponent<ResizeHandleProps, ResizeH
                 onDoubleClick={this.handleDoubleClick}
                 onDragEnd={this.handleDragEnd}
                 onDragMove={this.handleDragMove}
+                // N.B. no need to specify targetRef since the child is a native DOM element that accepts ref injection
             >
                 <div className={targetClasses}>
                     <div className={handleClasses} />

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -24,8 +24,8 @@ import * as PlatformUtils from "../common/internal/platformUtils";
 import { Utils } from "../common/utils";
 import { Region, Regions } from "../regions";
 import { DragEvents } from "./dragEvents";
-import { Draggable, DraggableProps } from "./draggable";
-import { CoordinateData } from "./dragTypes";
+import { Draggable } from "./draggable";
+import { CoordinateData, DragHandler } from "./dragTypes";
 
 export type SelectedRegionTransform = (
     region: Region,
@@ -88,8 +88,10 @@ export interface SelectableProps {
 }
 
 export interface DragSelectableProps extends SelectableProps {
-    /** Element to make interactive. */
-    children?: React.ReactNode;
+    /**
+     * Single child, must be an element and not a string or fragment.
+     */
+    children: JSX.Element;
 
     /**
      * A list of CSS selectors that should _not_ trigger selection when a `mousedown` occurs inside of them.
@@ -129,7 +131,7 @@ export class DragSelectable extends React.PureComponent<DragSelectableProps> {
     private lastEmittedSelectedRegions: Region[] | null = null;
 
     public render() {
-        const draggableProps = this.getDraggableProps();
+        const draggableProps = this.getDraggableHandlers();
         return (
             <Draggable {...draggableProps} preventDefault={false}>
                 {this.props.children}
@@ -137,7 +139,7 @@ export class DragSelectable extends React.PureComponent<DragSelectableProps> {
         );
     }
 
-    private getDraggableProps(): DraggableProps {
+    private getDraggableHandlers(): DragHandler {
         return this.props.onSelection == null
             ? {}
             : {

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -25,7 +25,7 @@ import { Utils } from "../common/utils";
 import { Region, Regions } from "../regions";
 import { DragEvents } from "./dragEvents";
 import { Draggable } from "./draggable";
-import { CoordinateData, DragHandler } from "./dragTypes";
+import { CoordinateData, DraggableChildrenProps, DragHandler } from "./dragTypes";
 
 export type SelectedRegionTransform = (
     region: Region,
@@ -87,12 +87,7 @@ export interface SelectableProps {
     selectedRegionTransform?: SelectedRegionTransform;
 }
 
-export interface DragSelectableProps extends SelectableProps {
-    /**
-     * Single child, must be an element and not a string or fragment.
-     */
-    children: JSX.Element;
-
+export interface DragSelectableProps extends SelectableProps, DraggableChildrenProps {
     /**
      * A list of CSS selectors that should _not_ trigger selection when a `mousedown` occurs inside of them.
      */
@@ -133,7 +128,7 @@ export class DragSelectable extends React.PureComponent<DragSelectableProps> {
     public render() {
         const draggableProps = this.getDraggableHandlers();
         return (
-            <Draggable {...draggableProps} preventDefault={false}>
+            <Draggable {...draggableProps} preventDefault={false} targetRef={this.props.targetRef}>
                 {this.props.children}
             </Draggable>
         );

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -64,6 +64,8 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
 
     private activationCell: CellCoordinates | null = null;
 
+    private wrapperRef = React.createRef<HTMLDivElement>();
+
     public shouldComponentUpdate(nextProps: TableBodyProps) {
         return (
             !CoreUtils.shallowCompareKeys(this.props, nextProps, { exclude: DEEP_COMPARE_KEYS }) ||
@@ -91,11 +93,13 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
                 onSelectionEnd={this.handleSelectionEnd}
                 selectedRegions={this.props.selectedRegions}
                 selectedRegionTransform={this.props.selectedRegionTransform}
+                targetRef={this.wrapperRef}
             >
                 <ContextMenuTargetWrapper
                     className={classNames(Classes.TABLE_BODY_VIRTUAL_CLIENT, Classes.TABLE_CELL_CLIENT)}
                     renderContextMenu={this.renderContextMenu}
                     style={style}
+                    targetRef={this.wrapperRef}
                 >
                     <TableBodyCells
                         cellRenderer={this.props.cellRenderer}

--- a/packages/table/src/tableBody2.tsx
+++ b/packages/table/src/tableBody2.tsx
@@ -39,6 +39,8 @@ export class TableBody2 extends AbstractComponent<TableBodyProps> {
 
     private activationCell: CellCoordinates | null = null;
 
+    private containerRef = React.createRef<HTMLDivElement>();
+
     public shouldComponentUpdate(nextProps: TableBodyProps) {
         return (
             !CoreUtils.shallowCompareKeys(this.props, nextProps, { exclude: DEEP_COMPARE_KEYS }) ||
@@ -66,12 +68,14 @@ export class TableBody2 extends AbstractComponent<TableBodyProps> {
                 onSelectionEnd={this.handleSelectionEnd}
                 selectedRegions={this.props.selectedRegions}
                 selectedRegionTransform={this.props.selectedRegionTransform}
+                targetRef={this.containerRef}
             >
                 <ContextMenu
                     className={classNames(Classes.TABLE_BODY_VIRTUAL_CLIENT, Classes.TABLE_CELL_CLIENT)}
                     content={this.renderContextMenu}
                     disabled={this.props.bodyContextMenuRenderer === undefined}
                     onContextMenu={this.handleContextMenu}
+                    ref={this.containerRef}
                     style={style}
                 >
                     <TableBodyCells


### PR DESCRIPTION
#### Fixes #3979

#### Changes proposed in this pull request:

Migrate away from `ReactDOM.findDOMNode()` in the `<Draggable>` component by borrowing an implementation from `<ResizeSensor>` which clones its single React child and injects its own DOM ref. ~It's even simpler here than in ResizeSensor because we don't have to deal with a prop ref sent to `<Draggable>`.~

#### @blueprintjs/core changelog

- fix(`ResizeSensor`): account for `props.targetRef` if specified (previously, this component would not actually take DOM measurements properly if this prop was specified)
  - :warning: break: the type of the `targetRef` prop is now more specific, it only allows ref objects and no ref callbacks. Before this change, this prop's usage broke the component completely, so it's extremely unlikely that this break will impact any users negatively.
- feat(`EditableText`): new prop `elementRef` allows users to pass through a DOM ref (useful for taking measurements or implementing interactions like `<Draggable>` in @blueprintjs/table)

#### @blueprintjs/table changelog

- fix: stop using `ReactDOM.findDOMNode()` to implement drag & drop interactions, which unblocks support for React strict mode

#### Reviewers should focus on:

No regressions in dragging behavior in Table component demos

#### Screenshot

Note that there are some delays in re-rendering cells (until you scroll around a bit in some cases), but these are bugs present on develop too:

![2023-05-09 15 08 36](https://github.com/palantir/blueprint/assets/723999/3d989402-00d8-4ce0-898b-d50b7d88d78a)
