### PR TITLE
[v5] [core] fix: add back HotkeysDialogLegacy functions to public API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,13 @@ export * from "./hooks";
 /* eslint-disable deprecation/deprecation */
 export {
     HotkeysTargetLegacy as HotkeysTarget,
-    HotkeysTargetLegacyComponent as IHotkeysTargetComponent,
+    type HotkeysTargetLegacyComponent as IHotkeysTargetComponent,
 } from "./legacy/hotkeysTargetLegacy";
+export {
+    isHotkeysDialogShowing,
+    setHotkeysDialogProps,
+    showHotkeysDialog,
+    hideHotkeysDialog,
+    hideHotkeysDialogAfterDelay,
+} from "./legacy/hotkeysDialogLegacy";
 export { ContextMenuTargetLegacy, ContextMenuTargetLegacyComponent } from "./legacy/contextMenuTargetLegacy";

--- a/packages/core/src/legacy/hotkeysDialogLegacy.tsx
+++ b/packages/core/src/legacy/hotkeysDialogLegacy.tsx
@@ -153,10 +153,12 @@ class HotkeysDialogLegacy {
 // singleton instance
 const HOTKEYS_DIALOG = new HotkeysDialogLegacy();
 
+/** @deprecated use HotkeysProvider */
 export function isHotkeysDialogShowing() {
     return HOTKEYS_DIALOG.isShowing();
 }
 
+/** @deprecated use HotkeysProvider */
 export function setHotkeysDialogProps(props: Partial<HotkeysDialogProps>) {
     for (const key in props) {
         if (props.hasOwnProperty(key)) {
@@ -165,10 +167,12 @@ export function setHotkeysDialogProps(props: Partial<HotkeysDialogProps>) {
     }
 }
 
+/** @deprecated use HotkeysProvider */
 export function showHotkeysDialog(hotkeys: HotkeyProps[]) {
     HOTKEYS_DIALOG.enqueueHotkeysForDisplay(hotkeys);
 }
 
+/** @deprecated use HotkeysProvider */
 export function hideHotkeysDialog() {
     HOTKEYS_DIALOG.hide();
 }
@@ -177,6 +181,8 @@ export function hideHotkeysDialog() {
  * Use this function instead of `hideHotkeysDialog` if you need to ensure that all hotkey listeners
  * have time to execute with the dialog in a consistent open state. This can avoid flickering the
  * dialog between open and closed states as successive listeners fire.
+ *
+ * @deprecated use HotkeysProvider
  */
 export function hideHotkeysDialogAfterDelay() {
     HOTKEYS_DIALOG.hideAfterDelay();

--- a/packages/core/src/legacy/hotkeysEvents.ts
+++ b/packages/core/src/legacy/hotkeysEvents.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to HotkeysDialog2 instead.
+ */
+
+/* eslint-disable deprecation/deprecation */
+
 import { Children, ReactNode } from "react";
 
 import { isElementOfType } from "../common/utils";


### PR DESCRIPTION
These functions were previously available on the public API. This change restores that support and adds `/** @deprecated */` flags.