### PR TITLE
[core] deprecate KeyCombo, add KeyComboTag alias

### DIFF
--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { AbstractPureComponent2, Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { HotkeyConfig } from "../../hooks";
-import { KeyCombo } from "./keyCombo";
+import { KeyComboTag } from "./keyComboTag";
 
 export type IHotkeyProps = Props & HotkeyConfig;
 
@@ -46,7 +46,7 @@ export class Hotkey extends AbstractPureComponent2<IHotkeyProps> {
         return (
             <div className={rootClasses}>
                 <div className={Classes.HOTKEY_LABEL}>{label}</div>
-                <KeyCombo {...spreadableProps} />
+                <KeyComboTag {...spreadableProps} />
             </div>
         );
     }

--- a/packages/core/src/components/hotkeys/index.ts
+++ b/packages/core/src/components/hotkeys/index.ts
@@ -19,7 +19,7 @@
 export * from "./hotkeysTypes";
 export * from "./hotkeys";
 export { Hotkey, IHotkeyProps } from "./hotkey";
-export { KeyCombo, KeyComboTagProps, IKeyComboProps } from "./keyCombo";
+export { KeyCombo, KeyComboTag, KeyComboTagProps, IKeyComboProps } from "./keyComboTag";
 // eslint-disable-next-line import/no-cycle
 export { HotkeysTarget, IHotkeysTargetComponent } from "./hotkeysTarget";
 export { IKeyCombo, comboMatches, getKeyCombo, getKeyComboString, parseKeyCombo } from "./hotkeyParser";

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -52,8 +52,8 @@ export interface IKeyComboProps extends Props {
     minimal?: boolean;
 }
 
-export class KeyCombo extends AbstractPureComponent2<KeyComboTagProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.KeyCombo`;
+export class KeyComboTag extends AbstractPureComponent2<KeyComboTagProps> {
+    public static displayName = `${DISPLAYNAME_PREFIX}.KeyComboTag`;
 
     public render() {
         const { className, combo, minimal } = this.props;
@@ -79,3 +79,8 @@ export class KeyCombo extends AbstractPureComponent2<KeyComboTagProps> {
         return icon == null ? key : <Icon icon={icon.icon} title={icon.iconTitle} key={`key-${index}`} />;
     };
 }
+
+/** @deprecated use the new, more specific component name `KeyComboTag` instead (forwards-compatible with v5) */
+export const KeyCombo = KeyComboTag;
+// eslint-disable-next-line deprecation/deprecation
+KeyCombo.displayName = `${DISPLAYNAME_PREFIX}.KeyCombo`;

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -34,7 +34,7 @@ React application.
 Then, to register hotkeys and generate the relevant event handlers, use the hook like so:
 
 ```tsx
-import { InputGroup, KeyCombo, useHotkeys } from "@blueprintjs/core";
+import { InputGroup, KeyComboTag, useHotkeys } from "@blueprintjs/core";
 import React, { createRef, useCallback, useMemo } from "react";
 
 export default function() {
@@ -61,7 +61,7 @@ export default function() {
 
     return (
         <div tabIndex={0} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
-            Press <KeyCombo combo="R" /> to refresh data, <KeyCombo combo="F" /> to focus the input...
+            Press <KeyComboTag combo="R" /> to refresh data, <KeyComboTag combo="F" /> to focus the input...
             <InputGroup inputRef={inputRef} />
         </div>
     );

--- a/packages/core/test/isotest.js
+++ b/packages/core/test/isotest.js
@@ -61,6 +61,9 @@ describe("Core isomorphic rendering", () => {
         KeyCombo: {
             props: { combo: "?" },
         },
+        KeyComboTag: {
+            props: { combo: "?" },
+        },
         OverflowList: {
             props: { items: [], overflowRenderer: () => null, visibleItemRenderer: () => null },
         },

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Code, getKeyComboString, KeyCombo } from "@blueprintjs/core";
+import { Code, getKeyComboString, KeyComboTag } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface HotkeyTesterState {
@@ -50,7 +50,7 @@ export class HotkeyTesterExample extends React.PureComponent<ExampleProps, Hotke
         } else {
             return (
                 <>
-                    <KeyCombo combo={combo} />
+                    <KeyComboTag combo={combo} />
                     <Code>{combo}</Code>
                 </>
             );

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -14,7 +14,7 @@
 
 import * as React from "react";
 
-import { Button, H5, HotkeysTarget2, KeyCombo, MenuItem, Position, Switch, Toaster } from "@blueprintjs/core";
+import { Button, H5, HotkeysTarget2, KeyComboTag, MenuItem, Position, Switch, Toaster } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Omnibar } from "@blueprintjs/select";
 import {
@@ -73,7 +73,7 @@ export class OmnibarExample extends React.PureComponent<ExampleProps, IOmnibarEx
                     <span>
                         <Button text="Click to show Omnibar" onClick={this.handleClick} />
                         {" or press "}
-                        <KeyCombo combo="shift + o" />
+                        <KeyComboTag combo="shift + o" />
                     </span>
 
                     <Omnibar<Film>

--- a/packages/docs-theme/src/components/navButton.tsx
+++ b/packages/docs-theme/src/components/navButton.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Icon, IconName, KeyCombo } from "@blueprintjs/core";
+import { Classes, Icon, IconName, KeyComboTag } from "@blueprintjs/core";
 
 export interface INavButtonProps {
     icon: IconName;
@@ -31,7 +31,7 @@ export const NavButton: React.FC<INavButtonProps> = props => (
         <Icon icon={props.icon} />
         <span className={Classes.FILL}>{props.text}</span>
         <div style={{ opacity: 0.5 }}>
-            <KeyCombo combo={props.hotkey} minimal={true} />
+            <KeyComboTag combo={props.hotkey} minimal={true} />
         </div>
     </div>
 );

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
@@ -9,6 +9,7 @@ export const coreComponentsMigrationMapping = {
     AbstractPureComponent: "AbstractPureComponent2",
     Breadcrumbs: "Breadcrumbs2",
     CollapsibleList: "OverflowList",
+    KeyCombo: "KeyComboTag",
     "MenuItem.popoverProps": "MenuItem2",
     // TODO(@adidahiya): Blueprint v6
     // PanelStack: "PanelStack2",

--- a/packages/eslint-plugin/test/no-deprecated-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-components.test.ts
@@ -106,6 +106,19 @@ ruleTester.run("no-deprecated-components", noDeprecatedComponentsRule, {
                 },
             ],
         },
+        {
+            code: dedent`
+                import { KeyCombo } from "@blueprintjs/core";
+
+                return <KeyCombo />;
+            `,
+            errors: [
+                {
+                    messageId: "migration",
+                    data: { deprecatedComponentName: "KeyCombo", newComponentName: "KeyComboTag" },
+                },
+            ],
+        },
     ],
     valid: [
         {


### PR DESCRIPTION

#### Changes proposed in this pull request:

Deprecate `KeyCombo` in favor of `KeyComboTag`, for forwards-compatibility with v5.0.
