### PR TITLE
[eslint-plugin] autofix IDatePickerShortcut type

### DIFF
--- a/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
@@ -101,6 +101,7 @@ const DEPRECATED_TYPE_REFERENCES_BY_PACKAGE = {
         "IDateInputProps",
         "IDatePickerProps",
         "IDatePickerModifiers",
+        "IDatePickerShortcut",
         "IDateRangeInputProps",
         "IDateRangeShortcut",
         "ITimePickerProps",


### PR DESCRIPTION
feat(`no-deprecated-type-references`): flag `IDatePickerShortcut`, apply auto-fix to use non-prefixed symbol name