### PR TITLE
[v5] docs(README): link to updated sandbox using v5.0.0-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is optimized for building complex, data-dense web interfaces for _desktop app
 
 [**View the full documentation ▸**](http://blueprintjs.com/docs)
 
-[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4)
+[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/naughty-diffie-wy0ojy)
 
 [**Read frequently asked questions (FAQ) on the wiki ▸**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It is optimized for building complex, data-dense web interfaces for _desktop app
 
 [**View the full documentation ▸**](http://blueprintjs.com/docs)
 
-[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/naughty-diffie-wy0ojy)
+[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/wy0ojy)
 
 [**Read frequently asked questions (FAQ) on the wiki ▸**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 


### PR DESCRIPTION
Attempting to use the new `IconLoader` APIs with Vite dynamic / glob imports here...

- https://blueprintjs.com/docs/versions/5/#icons/loading-icons
- https://vitejs.dev/guide/features.html#glob-import

Ran into this issue (check if fixed):

- [x] https://github.com/palantir/blueprint/issues/6152

Related:

- [x] using this sandbox to attempt to verify fix for https://github.com/palantir/blueprint/issues/5503