### PR TITLE
[v5] various fixes for regressions in v5.0.0-alpha.x

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -155,6 +155,8 @@ export const EDITABLE_TEXT_PLACEHOLDER = `${EDITABLE_TEXT}-placeholder`;
 export const FLEX_EXPANDER = `${NS}-flex-expander`;
 
 export const HTML_SELECT = `${NS}-html-select`;
+/** @deprecated use `<HTMLSelect>` component or `Classes.HTML_SELECT` instead */
+export const SELECT = `${NS}-select`;
 
 export const HTML_TABLE = `${NS}-html-table`;
 export const HTML_TABLE_BORDERED = `${HTML_TABLE}-bordered`;

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -15,13 +15,14 @@ Markup:
   <input type="text" class="#{$ns}-input" placeholder="Find filters..." />
 </div>
 <div class="#{$ns}-control-group">
-  <div class="#{$ns}-select">
+  <div class="#{$ns}-html-select">
     <select>
       <option selected>Filter...</option>
       <option value="1">Issues</option>
       <option value="2">Requests</option>
       <option value="3">Projects</option>
     </select>
+    <span class="#{$ns}-icon #{$ns}-icon-double-caret-vertical"></span>
   </div>
   <div class="#{$ns}-input-group">
     <span class="#{$ns}-icon #{$ns}-icon-search"></span>
@@ -41,11 +42,12 @@ Markup:
   <button class="#{$ns}-button #{$ns}-intent-primary">Add</button>
 </div>
 <div class="#{$ns}-control-group">
-  <div class="#{$ns}-select">
+  <div class="#{$ns}-html-select">
     <select>
       <option selected value="dollar">$</option>
       <option value="euro">€</option>
     </select>
+    <span class="#{$ns}-icon #{$ns}-icon-double-caret-vertical"></span>
   </div>
   <div class="#{$ns}-control-group #{$ns}-numeric-input">
     <div class="#{$ns}-input-group">
@@ -186,6 +188,7 @@ Styleguide control-group
 
   // select container does not get focus directly (its <select> does), and it
   // sometimes needs to compete with adjacent container elements
+  .#{$ns}-html-select:focus-within,
   .#{$ns}-select:focus-within {
     z-index: index($control-group-stack, "button-focus");
   }

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -22,11 +22,12 @@ Markup:
   </label>
   <label class="#{$ns}-label {{.modifier}}">
     Label C
-    <div class="#{$ns}-select {{.modifier}}">
+    <div class="#{$ns}-html-select {{.modifier}}">
       <select {{:modifier}}>
         <option selected>Choose an item...</option>
         <option value="1">One</option>
       </select>
+      <span class="#{$ns}-icon #{$ns}-icon-double-caret-vertical"></span>
     </div>
   </label>
 </div>

--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -102,7 +102,7 @@ Styleguide select
   }
 }
 
-// N.B. this icon implementation is deprecated and will be removed in Blueprint 5.0
+// N.B. this icon implementation is deprecated and will be removed in Blueprint 6.0
 .#{$ns}-select {
   &::after {
     @extend %pt-select-arrow;

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -105,8 +105,7 @@ export { Tag, TagProps } from "./tag/tag";
 export { TagInput, TagInputProps, TagInputAddMethod } from "./tag-input/tagInput";
 export { OverlayToaster, OverlayToasterProps } from "./toast/overlayToaster";
 export { Toast, ToastProps } from "./toast/toast";
-// eslint-disable-next-line deprecation/deprecation
-export { Toaster, ToasterInstance, ToastOptions, ToasterPosition } from "./toast/toaster";
+export { Toaster, ToastOptions, ToasterPosition } from "./toast/toaster";
 export { TooltipProps, Tooltip } from "./tooltip/tooltip";
 export { Tree, TreeProps } from "./tree/tree";
 export { TreeNodeInfo, TreeEventHandler } from "./tree/treeTypes";

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -93,7 +93,7 @@ export {
 export { PopupKind } from "./popover/popupKind";
 export { Portal, PortalProps } from "./portal/portal";
 export { ProgressBar, ProgressBarProps } from "./progress-bar/progressBar";
-export { ResizeSensor, ResizeSensorProps } from "./resize-sensor/resizeSensor";
+export { ResizeEntry, ResizeSensor, ResizeSensorProps } from "./resize-sensor/resizeSensor";
 export { HandleHtmlProps, HandleInteractionKind, HandleProps, HandleType } from "./slider/handleProps";
 export { MultiSlider, MultiSliderProps } from "./slider/multiSlider";
 export { NumberRange, RangeSlider, RangeSliderProps } from "./slider/rangeSlider";

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -19,6 +19,9 @@ import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
+// backwards-compatible with @blueprintjs/core v4.x
+export { ResizeObserverEntry as ResizeEntry };
+
 /** `ResizeSensor` requires a single DOM element child and will error otherwise. */
 export interface ResizeSensorProps {
     /**

--- a/packages/core/src/deprecatedTypeAliases.ts
+++ b/packages/core/src/deprecatedTypeAliases.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @fileoverview type aliases for backwards-compatibility with @blueprintjs/core v4.x */
+
+export {
+    /** @deprecated use AbstractComponent */
+    AbstractComponent as AbstractComponent2,
+} from "./common/abstractComponent";
+
+export {
+    /** @deprecated use AbstractPureComponent */
+    AbstractPureComponent as AbstractPureComponent2,
+} from "./common/abstractPureComponent";
+
+export type {
+    /** @deprecated use InputGroupProps */
+    InputGroupProps as InputGroupProps2,
+} from "./components/forms/inputGroup";
+
+export type {
+    /** @deprecated use Toaster */
+    Toaster as ToasterInstance,
+} from "./components/toast/toaster";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,8 @@ export * from "./context";
 export * from "./hooks";
 
 /* eslint-disable deprecation/deprecation */
+export * from "./deprecatedTypeAliases";
+
 export {
     HotkeysTargetLegacy as HotkeysTarget,
     type HotkeysTargetLegacyComponent as IHotkeysTargetComponent,

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -33,6 +33,8 @@ export {
     TimezoneSelect,
     /** @deprecated import from @blueprintjs/datetime instead */
     TimezoneSelectProps,
+    /** @deprecated import from @blueprintjs/datetime instead */
+    TimezoneDisplayFormat,
 } from "@blueprintjs/datetime";
 
 export * as DateInput2MigrationUtils from "./dateInput2MigrationUtils";

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -46,7 +46,7 @@ const WelcomeCard: React.FC<{
     href: string;
     sameTab?: boolean;
 }> = props => (
-    <a href={props.href} target={props.sameTab ? "" : "_blank"}>
+    <a className="blueprint-welcome-card" href={props.href} target={props.sameTab ? "" : "_blank"}>
         <Card interactive={true}>
             <Icon icon={props.icon} size={40} />
             <H4>{props.title}</H4>

--- a/packages/docs-app/src/styles/_welcome.scss
+++ b/packages/docs-app/src/styles/_welcome.scss
@@ -6,6 +6,10 @@
   margin: ($content-padding * 2) 0;
   text-align: center;
 
+  .blueprint-welcome-card {
+    flex-grow: 1;
+  }
+
   .#{$ns}-heading {
     color: inherit;
     margin: $content-padding 0 0;

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -241,13 +241,9 @@ export class Documentation extends React.PureComponent<DocumentationProps, Docum
         );
     }
 
-    public componentWillMount() {
+    public componentDidMount() {
         addScrollbarStyle();
         this.updateHash();
-    }
-
-    public componentDidMount() {
-        // hooray! so you don't have to!
         FocusStyleManager.onlyShowFocusOnTabs();
         this.scrollToActiveSection();
         this.props.onComponentUpdate?.(this.state.activePageId);
@@ -301,7 +297,7 @@ export class Documentation extends React.PureComponent<DocumentationProps, Docum
                 page: location.pathname + location.search + location.hash,
             });
         }
-        // Don't call componentWillMount since the HotkeysTarget decorator will be invoked on every hashchange.
+        // Don't call componentDidMount since the HotkeysTarget decorator will be invoked on every hashchange.
         this.updateHash();
     };
 

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -11,7 +11,8 @@
     "files": [
         "dist",
         "lib",
-        "src"
+        "src",
+        "icons.json"
     ],
     "sideEffects": [
         "**/*.css"

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -343,6 +343,7 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
         super(props);
         this.stateStore = new LocalStore<MutableTableState>("BP_TABLE_MUTABLE_TABLE_DEV_PREVIEW", true);
         this.state = this.stateStore.getWithDefaults(DEFAULT_STATE);
+        this.resetCellContent();
     }
 
     // React Lifecycle
@@ -372,10 +373,6 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
                 </div>
             </HotkeysProvider>
         );
-    }
-
-    public componentWillMount() {
-        this.resetCellContent();
     }
 
     public componentDidMount() {

--- a/packages/table/src/deprecatedAliases.ts
+++ b/packages/table/src/deprecatedAliases.ts
@@ -27,3 +27,17 @@ export {
     /** @deprecated import RowHeaderCellProps instead */
     type RowHeaderCellProps as RowHeaderCellProps2,
 } from "./headers/rowHeaderCell";
+
+export {
+    /** @deprecated import JSONFormat instead */
+    JSONFormat as JSONFormat2,
+    /** @deprecated import JSONFormatProps instead */
+    JSONFormatProps as JSONFormat2Props,
+} from "./cell/formats/jsonFormat";
+
+export {
+    /** @deprecated import TruncatedFormat instead */
+    TruncatedFormat as TruncatedFormat2,
+    /** @deprecated import TruncatedFormatProps instead */
+    TruncatedFormatProps as TruncatedFormat2Props,
+} from "./cell/formats/truncatedFormat";


### PR DESCRIPTION

#### Changes proposed in this pull request:

- [icons] fix: restore `icons.json` file in NPM distributable package
- [datetime2] fix: restore `TimezoneDisplayFormat` export
- [table] fix: restore `JSONFormat2`, `TruncatedFormat2` aliases
- [core] fix: restore `ResizeEntry` type export
- [core] fix: restore various types as deprecated aliases:
  - `AbstractComponent2`
  - `AbstractPureComponent2`
  - `InputGroupProps2`
- [core] fix: restore `Classes.SELECT`, punt removal to v6.0
- [docs-theme, table-dev-app] fix: remove usage of deprecated `componentWillMount` lifecycle method

