### PR TITLE
[v5] [core] fix(Icon): don't use default loader if icon is already loaded

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -104,12 +104,20 @@ export const Icon: React.FC<IconProps> = React.forwardRef<any, IconProps>((props
             if (loadedIconComponent !== undefined) {
                 setIconComponent(loadedIconComponent);
             } else if (autoLoad) {
-                Icons.load(icon).then(() => {
-                    // if this effect expired by the time icon loaded, then don't set state
-                    if (!shouldCancelIconLoading) {
-                        setIconComponent(Icons.getComponent(icon));
-                    }
-                });
+                Icons.load(icon)
+                    .then(() => {
+                        // if this effect expired by the time icon loaded, then don't set state
+                        if (!shouldCancelIconLoading) {
+                            setIconComponent(Icons.getComponent(icon));
+                        }
+                    })
+                    .catch(reason => {
+                        console.error(`[Blueprint] Icon '${icon}' could not be loaded.`, reason);
+                    });
+            } else {
+                console.error(
+                    `[Blueprint] Icon '${icon}' is not loaded yet and autoLoad={false}, did you call Icons.load('${icon}')?`,
+                );
             }
         }
         return () => {

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -95,16 +95,21 @@ export const Icon: React.FC<IconProps> = React.forwardRef<any, IconProps>((props
     React.useEffect(() => {
         let shouldCancelIconLoading = false;
         if (typeof icon === "string") {
-            if (autoLoad) {
-                // load the module to get the component (it will be cached if it's the same icon)
+            // The icon may have been loaded already, in which case we can simply grab it.
+            // N.B. when `autoLoad={true}`, we can't rely on simply calling Icons.load() here to re-load an icon module
+            // which has already been loaded & cached, since it may have been loaded with special loading options which
+            // this component knows nothing about.
+            const loadedIconComponent = Icons.getComponent(icon);
+
+            if (loadedIconComponent !== undefined) {
+                setIconComponent(loadedIconComponent);
+            } else if (autoLoad) {
                 Icons.load(icon).then(() => {
                     // if this effect expired by the time icon loaded, then don't set state
                     if (!shouldCancelIconLoading) {
                         setIconComponent(Icons.getComponent(icon));
                     }
                 });
-            } else {
-                setIconComponent(Icons.getComponent(icon));
             }
         }
         return () => {

--- a/packages/core/test/hotkeys/hotkeyTests.tsx
+++ b/packages/core/test/hotkeys/hotkeyTests.tsx
@@ -36,7 +36,7 @@ describe("Hotkey", () => {
 
         it("logs an error for non-global hotkey without a group", () => {
             render(<Hotkey combo="cmd+C" label="test copy me" />);
-            expect(consoleError.calledOnce).to.be.true;
+            expect(consoleError.callCount).to.equal(1);
         });
     });
 });

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -60,21 +60,18 @@ describe("<TagInput>", () => {
     });
 
     it("leftIcon renders an icon as first child", () => {
-        const wrapper = mount(<TagInput leftIcon="add" values={VALUES} />);
+        const leftIcon = "add";
+        const wrapper = mount(<TagInput leftIcon={leftIcon} values={VALUES} />);
 
-        // use a helper since Enzyme 3 (1) includes React wrappers in .childAt()
-        // calls, making them convoluted, and (2) does not preserve referential
-        // identity, meaning we have to re-query elements to detect changes.
-        const assertLeftIconHasClass = (className: string, errorMessage: string) => {
-            const hasClass = wrapper
+        assert.isTrue(
+            wrapper
                 .childAt(0) // TagInput's root <div> element
                 .childAt(0) // left-icon React wrapper
                 .childAt(0) // left-icon <div> element
-                .hasClass(className);
-            assert.isTrue(hasClass, errorMessage);
-        };
-
-        assertLeftIconHasClass(Classes.ICON, "icon");
+                .find(`.${Classes.ICON}`)
+                .hasClass(Classes.iconClass(leftIcon)),
+            `Expected .${Classes.ICON} element to have .${Classes.iconClass(leftIcon)} class`,
+        );
     });
 
     it("rightElement appears as last child", () => {

--- a/packages/icons/src/iconLoader.ts
+++ b/packages/icons/src/iconLoader.ts
@@ -83,14 +83,11 @@ export class Icons {
     }
 
     /**
-     * Get the icon SVG component.
+     * Get the icon SVG component. Returns `undefined` if the icon has not been loaded yet.
      */
     public static getComponent(icon: IconName): IconComponent | undefined {
         if (!this.isValidIconName(icon)) {
             // don't warn, since this.load() will have warned already
-            return undefined;
-        } else if (!singleton.loadedIcons.has(icon)) {
-            console.error(`[Blueprint] Icon '${icon}' not loaded yet, did you call Icons.load('${icon}')?`);
             return undefined;
         }
 


### PR DESCRIPTION

#### Fixes #6152

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update icon loading logic in `<Icon>` to avoid loading icon components with the default loader (which will be invalid in non-webpack bundlers) in cases when the icon has already been loaded (through `Icons.loadAll()` or `Icons.load()`).

It's a bit difficult to test this change in the current build system. I'll test this out after the next `.alpha` release. I will consider adding a Vite build package to this monorepo to test this kind of thing out in the future (perhaps packages/demo-app is a good candidate).

