### PR TITLE
[colors] fix: output legacy ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ generated-icons/
 coverage/
 /docs
 docs-static/**/*.d.ts
+packages/colors/esm/
 
 # exclude site except for site/docs/versions
 site/*

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -3,9 +3,11 @@
     "version": "4.1.23",
     "description": "Blueprint color definitions",
     "main": "lib/index.js",
+    "module": "esm/index.js",
     "scripts": {
         "clean": "rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
+        "compile:cjs": "tsc -p src/ -m commonjs --outDir lib",
         "compile:esm": "tsc -p src/",
         "compile:css": "sass-compile ./src",
         "compile:css-colors": "generate-css-variables --retainDefault true --outputFileName colors _colors.scss",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -7,8 +7,8 @@
     "scripts": {
         "clean": "rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
-        "compile:cjs": "tsc -p src/ -m commonjs --outDir lib",
         "compile:esm": "tsc -p src/",
+        "compile:cjs": "tsc -p src/ -m commonjs --outDir lib",
         "compile:css": "sass-compile ./src",
         "compile:css-colors": "generate-css-variables --retainDefault true --outputFileName colors _colors.scss",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",

--- a/packages/colors/src/tsconfig.json
+++ b/packages/colors/src/tsconfig.json
@@ -2,8 +2,7 @@
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
         "lib": ["es6", "dom"],
-        "module": "commonjs",
-        "outDir": "../lib",
+        "outDir": "../esm",
         "target": "ES2015"
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

This PR adds the `module` field to `package.json` for legacy ESM (instead of `exports` which would potentially be a breaking change). To ensure backwards compatibility (e.g. someone importing from the `lib` directory), the CommonJS build will still go in the `lib` folder, although in the rest of the repo it goes in `lib/cjs`. Similarly, the ESM build will go into `esm` instead of `lib/esm` (because `lib` is already “taken”).

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
