### PR TITLE
dialog: remove invalid aria role "dialogbody"

### DIFF
--- a/packages/core/src/components/dialog/dialogBody.tsx
+++ b/packages/core/src/components/dialog/dialogBody.tsx
@@ -45,7 +45,6 @@ export class DialogBody extends AbstractPureComponent2<DialogBodyProps> {
     public render() {
         return (
             <div
-                role="dialogbody"
                 className={classNames(Classes.DIALOG_BODY, this.props.className, {
                     [Classes.DIALOG_BODY_SCROLL_CONTAINER]: this.props.useOverflowScrollContainer,
                 })}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Remove `role="dialogbody"` from `dialogBody`, is not  a real / valid aria role.
