### PR TITLE
[table] fix: hide frozen quadrant scrollbar when zoomed out

### DIFF
--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -174,7 +174,8 @@ $scroll-container-overflow-high-dpi: 10px; // for device pixel-ratio >2.5
 
 // N.B. we could do something fancier by detecting the exact width of the scroll bar and setting that value
 // as the overflow dimension, but this is good enough for most use cases.
-@media (max-device-pixel-ratio: 1.5) {
+/* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
+@media (-webkit-max-device-pixel-ratio: 1.5) {
   // low dpi screen has larger scrollbars relative to quadrant dimensions
   .#{$ns}-table-quadrant-top .#{$ns}-table-quadrant-scroll-container {
     bottom: -$scroll-container-overflow-low-dpi;
@@ -190,7 +191,8 @@ $scroll-container-overflow-high-dpi: 10px; // for device pixel-ratio >2.5
   }
 }
 
-@media (min-device-pixel-ratio: 2.5) {
+/* stylelint-disable-next-line media-feature-name-no-vendor-prefix */
+@media (-webkit-min-device-pixel-ratio: 2.5) {
   // high dpi screen has smaller scrollbars relative to quadrant dimensions
   .#{$ns}-table-quadrant-top .#{$ns}-table-quadrant-scroll-container {
     bottom: -$scroll-container-overflow-high-dpi;

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -6,10 +6,16 @@ $table-quadrant-z-index-top: $table-quadrant-z-index-main + 1;
 $table-quadrant-z-index-left: $table-quadrant-z-index-top + 1;
 $table-quadrant-z-index-top-left: $table-quadrant-z-index-left + 1;
 
-// we mask the scrollable container with a smaller parent div to hide the scrollbars in the TOP,
+// We mask the scrollable container with a smaller parent div to hide the scrollbars in the TOP,
 // LEFT, and TOP_LEFT quadrants. this value specifies the distance the scroll containers should
 // overflow within their parents; it should be large enough to hide a scrollbar of typical width.
-$table-quadrant-scroll-container-overflow: 20px;
+// Note that we require multiple values for different screen zoom levels (detectable via -webkit-device-pixel-ratio).
+// See:
+//  - https://developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-device-pixel-ratio
+//  - https://github.com/palantir/blueprint/issues/6172
+$scroll-container-overflow-default: 20px; // for standard device pixel ratio
+$scroll-container-overflow-low-dpi: 50px; // for device-pixel-ratio <1.5
+$scroll-container-overflow-high-dpi: 10px; // for device pixel-ratio >2.5
 
 .#{$ns}-table-quadrant-stack {
   display: flex;
@@ -118,7 +124,7 @@ $table-quadrant-scroll-container-overflow: 20px;
   z-index: $table-quadrant-z-index-top;
 
   .#{$ns}-table-quadrant-scroll-container {
-    bottom: -$table-quadrant-scroll-container-overflow;
+    bottom: -$scroll-container-overflow-default;
     overflow-y: hidden;
   }
 }
@@ -135,7 +141,7 @@ $table-quadrant-scroll-container-overflow: 20px;
     height: auto;
     overflow-x: hidden;
     position: absolute;
-    right: -$table-quadrant-scroll-container-overflow;
+    right: -$scroll-container-overflow-default;
     top: 0;
   }
 
@@ -154,14 +160,48 @@ $table-quadrant-scroll-container-overflow: 20px;
   z-index: $table-quadrant-z-index-top-left;
 
   .#{$ns}-table-quadrant-scroll-container {
-    bottom: -$table-quadrant-scroll-container-overflow;
+    bottom: -$scroll-container-overflow-default;
     overflow-x: hidden;
     overflow-y: hidden;
-    right: -$table-quadrant-scroll-container-overflow;
+    right: -$scroll-container-overflow-default;
   }
 
   // correct missing bottom-right corner in the menu-element (addresses #1444).
   .#{$ns}-table-body-virtual-client {
     min-width: 1px;
+  }
+}
+
+// N.B. we could do something fancier by detecting the exact width of the scroll bar and setting that value
+// as the overflow dimension, but this is good enough for most use cases.
+@media (-webkit-max-device-pixel-ratio: 1.5) {
+  // low dpi screen has larger scrollbars relative to quadrant dimensions
+  .#{$ns}-table-quadrant-top .#{$ns}-table-quadrant-scroll-container {
+    bottom: -$scroll-container-overflow-low-dpi;
+  }
+
+  .#{$ns}-table-quadrant-left .#{$ns}-table-quadrant-scroll-container {
+    right: -$scroll-container-overflow-low-dpi;
+  }
+
+  .#{$ns}-table-quadrant-top-left .#{$ns}-table-quadrant-scroll-container {
+    bottom: -$scroll-container-overflow-low-dpi;
+    right: -$scroll-container-overflow-low-dpi;
+  }
+}
+
+@media (-webkit-min-device-pixel-ratio: 2.5) {
+  // high dpi screen has smaller scrollbars relative to quadrant dimensions
+  .#{$ns}-table-quadrant-top .#{$ns}-table-quadrant-scroll-container {
+    bottom: -$scroll-container-overflow-high-dpi;
+  }
+
+  .#{$ns}-table-quadrant-left .#{$ns}-table-quadrant-scroll-container {
+    right: -$scroll-container-overflow-high-dpi;
+  }
+
+  .#{$ns}-table-quadrant-top-left .#{$ns}-table-quadrant-scroll-container {
+    bottom: -$scroll-container-overflow-high-dpi;
+    right: -$scroll-container-overflow-high-dpi;
   }
 }

--- a/packages/table/src/quadrants/_quadrants.scss
+++ b/packages/table/src/quadrants/_quadrants.scss
@@ -174,7 +174,7 @@ $scroll-container-overflow-high-dpi: 10px; // for device pixel-ratio >2.5
 
 // N.B. we could do something fancier by detecting the exact width of the scroll bar and setting that value
 // as the overflow dimension, but this is good enough for most use cases.
-@media (-webkit-max-device-pixel-ratio: 1.5) {
+@media (max-device-pixel-ratio: 1.5) {
   // low dpi screen has larger scrollbars relative to quadrant dimensions
   .#{$ns}-table-quadrant-top .#{$ns}-table-quadrant-scroll-container {
     bottom: -$scroll-container-overflow-low-dpi;
@@ -190,7 +190,7 @@ $scroll-container-overflow-high-dpi: 10px; // for device pixel-ratio >2.5
   }
 }
 
-@media (-webkit-min-device-pixel-ratio: 2.5) {
+@media (min-device-pixel-ratio: 2.5) {
   // high dpi screen has smaller scrollbars relative to quadrant dimensions
   .#{$ns}-table-quadrant-top .#{$ns}-table-quadrant-scroll-container {
     bottom: -$scroll-container-overflow-high-dpi;

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -146,11 +146,3 @@ $menu-z-index: $row-z-index + 1 !default;
   display: inline-block;
   position: absolute;
 }
-
-.#{$ns}-table-scrollbar-measure {
-  height: $pt-grid-size * 10;
-  overflow: scroll;
-  position: absolute;
-  top: -9999px;
-  width: $pt-grid-size * 10;
-}


### PR DESCRIPTION
#### Fixes #6172

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update existing CSS which attempts to hide frozen table quadrant scrollbars. We now use media queries to apply different scrollbar width offsets so that this "feature" works on different display pixel densities (this is the easiest way to detect zoom level in CSS).

#### Reviewers should focus on:

Whether this fixes the bug and causes no regressions in table scrolling in Chrome, Edge, and Firefox.

#### Screenshot

![2023-05-23 11 52 02](https://github.com/palantir/blueprint/assets/723999/87f54ca7-2d9f-468a-8a69-e9e1a5fd64b3)

