### PR TITLE
[v5] fix: restore access to some datetime2 and icons APIs

### DIFF
--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -30,6 +30,8 @@ export {
     /** @deprecated import from @blueprintjs/datetime instead */
     DateRangeInputProps as DateRangeInput2Props,
     /** @deprecated import from @blueprintjs/datetime instead */
+    getTimezoneMetadata,
+    /** @deprecated import from @blueprintjs/datetime instead */
     TimezoneSelect,
     /** @deprecated import from @blueprintjs/datetime instead */
     TimezoneSelectProps,

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -19,3 +19,4 @@ export { SVGIconProps } from "./svgIconProps";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";
 export { IconSize } from "./iconSize";
+export { IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "./iconSvgPaths";


### PR DESCRIPTION

#### Changes proposed in this pull request:

Restore some missing exports that were present in v4.x
