### PR TITLE
[v5] [core] feat(Card): refactor into function component, support ref

### DIFF
--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -17,10 +17,10 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes, Elevation } from "../../common";
+import { Classes, Elevation } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, Props } from "../../common/props";
 
-export interface CardProps extends Props, HTMLDivProps {
+export interface CardProps extends Props, HTMLDivProps, React.RefAttributes<HTMLDivElement> {
     /**
      * Controls the intensity of the drop shadow beneath the card: the higher
      * the elevation, the higher the drop shadow. At elevation `0`, no drop
@@ -53,22 +53,18 @@ export interface CardProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/card
  */
-export class Card extends AbstractPureComponent<CardProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.Card`;
-
-    public static defaultProps: CardProps = {
-        elevation: Elevation.ZERO,
-        interactive: false,
-    };
-
-    public render() {
-        const { className, elevation, interactive, ...htmlProps } = this.props;
-        const classes = classNames(
-            Classes.CARD,
-            { [Classes.INTERACTIVE]: interactive },
-            Classes.elevationClass(elevation!),
-            className,
-        );
-        return <div className={classes} {...htmlProps} />;
-    }
-}
+export const Card: React.FC<CardProps> = React.forwardRef((props, ref) => {
+    const { className, elevation, interactive, ...htmlProps } = props;
+    const classes = classNames(
+        Classes.CARD,
+        { [Classes.INTERACTIVE]: interactive },
+        Classes.elevationClass(elevation!),
+        className,
+    );
+    return <div className={classes} ref={ref} {...htmlProps} />;
+});
+Card.defaultProps = {
+    elevation: Elevation.ZERO,
+    interactive: false,
+};
+Card.displayName = `${DISPLAYNAME_PREFIX}.Card`;

--- a/packages/core/test/card/cardTests.tsx
+++ b/packages/core/test/card/cardTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 import * as React from "react";
 import sinon from "sinon";
 
@@ -51,5 +51,11 @@ describe("<Card>", () => {
         const card = shallow(<Card onChange={onChange} title="foo" tabIndex={4000} />).find("div");
         assert.strictEqual(card.prop("onChange"), onChange);
         assert.strictEqual(card.prop("title"), "foo");
+    });
+
+    it("supports ref prop", () => {
+        const elementRef = React.createRef<HTMLDivElement>();
+        mount(<Card ref={elementRef} />);
+        assert.isDefined(elementRef.current);
     });
 });

--- a/packages/demo-app/src/examples/ExampleCard.tsx
+++ b/packages/demo-app/src/examples/ExampleCard.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Card, Classes, H4, H5 } from "@blueprintjs/core";
+import { Card, H5 } from "@blueprintjs/core";
 
 export interface ExampleCardProps {
     children: React.ReactNode;
@@ -31,13 +31,13 @@ const DEFAULT_WIDTH = 500;
 
 export class ExampleCard extends React.PureComponent<ExampleCardProps> {
     public render() {
-        const width = this.props.width ?? DEFAULT_WIDTH;
+        const { width = DEFAULT_WIDTH } = this.props;
         return (
             <div className="example-card-container">
-                <H4 className={Classes.HEADING}>{this.props.label}</H4>
-                {this.props.subLabel ?? <H5 className={Classes.HEADING}>{this.props.subLabel}</H5>}
+                <H5>{this.props.label}</H5>
+                {this.props.subLabel ?? <H5>{this.props.subLabel}</H5>}
                 <Card
-                    className={classNames("example-card", { ["horizontal"]: this.props.horizontal })}
+                    className={classNames("example-card", { horizontal: this.props.horizontal })}
                     elevation={0}
                     style={{ width: `${width}px` }}
                 >

--- a/packages/docs-app/src/examples/core-examples/cardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardExample.tsx
@@ -51,9 +51,7 @@ export class CardExample extends React.PureComponent<ExampleProps, CardExampleSt
         return (
             <Example options={options} {...this.props}>
                 <Card {...this.state}>
-                    <H5>
-                        <a href="#">Analytical applications</a>
-                    </H5>
+                    <H5>Analytical applications</H5>
                     <p>
                         User interfaces that enable people to interact smoothly with data, ask better questions, and
                         make better decisions.


### PR DESCRIPTION

#### Changes proposed in this pull request:

Refactor `<Card>` into an FC, use `React.forwardRef` to support the `ref` prop

