### PR TITLE
[popover2] fix(ContextMenu2): allow native ctx menu if content undefined

### DIFF
--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -211,7 +211,7 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
 
             onContextMenu?.(e);
         },
-        [onContextMenu, disabled],
+        [children, content, disabled, onContextMenu, menu],
     );
 
     const containerClassName = classNames(className, Classes.CONTEXT_MENU2);

--- a/packages/popover2/src/contextMenu2.tsx
+++ b/packages/popover2/src/contextMenu2.tsx
@@ -186,15 +186,22 @@ export const ContextMenu2: React.FC<ContextMenu2Props> = React.forwardRef<any, C
                 return;
             }
 
+            const hasMenuContent = menu !== undefined;
+
             // If disabled, we should avoid this extra work.
             // Otherwise: if using the child or content function APIs, we need to make sure contentProps gets updated,
             // so we handle the event regardless of whether the consumer returned an undefined menu.
             const shouldHandleEvent =
-                !disabled &&
-                (CoreUtils.isFunction(children) || CoreUtils.isFunction(content) || maybePopover !== undefined);
+                !disabled && (CoreUtils.isFunction(children) || CoreUtils.isFunction(content) || hasMenuContent);
+
+            // If there is no menu content, we shouldn't automatically swallow the contextmenu event, since the
+            // user probably wants to fall back to default browser behavior. If they still want to disable the
+            // native context menu in that case, they can do so with their own `onContextMenu` handler.
+            if (hasMenuContent) {
+                e.preventDefault();
+            }
 
             if (shouldHandleEvent) {
-                e.preventDefault();
                 e.persist();
                 setMouseEvent(e);
                 setTargetOffset({ left: e.clientX, top: e.clientY });

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -34,8 +34,9 @@ import {
     Tooltip2Props,
 } from "../src";
 
+const MENU_CLASSNAME = "test-menu";
 const MENU = (
-    <Menu>
+    <Menu className={MENU_CLASSNAME}>
         <MenuItem icon="align-left" text="Align Left" />
         <MenuItem icon="align-center" text="Align Center" />
         <MenuItem icon="align-right" text="Align Right" />
@@ -185,6 +186,44 @@ describe("ContextMenu2", () => {
                             </span>
                         </div>
                     )}
+                </ContextMenu2>,
+                { attachTo: containerElement },
+            );
+        }
+    });
+
+    describe("advanced usage (content render function API)", () => {
+        it("renders children and menu content, prevents default context menu handler", done => {
+            const onContextMenu = (e: React.MouseEvent) => {
+                assert.isTrue(e.defaultPrevented);
+                done();
+            };
+            const ctxMenu = mountTestMenu({ onContextMenu });
+            assert.isTrue(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists());
+            openCtxMenu(ctxMenu);
+            assert.isTrue(ctxMenu.find(`.${MENU_CLASSNAME}`).exists());
+        });
+
+        it("triggers native context menu if content function returns undefined", done => {
+            const onContextMenu = (e: React.MouseEvent) => {
+                assert.isFalse(e.defaultPrevented);
+                done();
+            };
+            const ctxMenu = mountTestMenu({
+                content: () => undefined,
+                onContextMenu,
+            });
+            openCtxMenu(ctxMenu);
+        });
+
+        function renderContent() {
+            return MENU;
+        }
+
+        function mountTestMenu(props?: Partial<ContextMenu2Props>) {
+            return mount(
+                <ContextMenu2 content={renderContent} popoverProps={{ transitionDuration: 0 }} {...props}>
+                    <div className={TARGET_CLASSNAME} />
                 </ContextMenu2>,
                 { attachTo: containerElement },
             );


### PR DESCRIPTION

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

If a consumer uses the `content` render function API and returns `undefined`, ContextMenu2 would previously still swallow the event and prevent the native context menu from opening. This was undesirable in most (probably all) cases, so this PR changes behavior so that the default event handler is not prevented. Added a unit test for this behavior.

#### Reviewers should focus on:

No regressions in other usage of ContextMenu2

