### PR TITLE
[colors] fix: output lib/cjs and lib/esm modules

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -2,11 +2,20 @@
     "name": "@blueprintjs/colors",
     "version": "4.1.24",
     "description": "Blueprint color definitions",
-    "main": "lib/index.js",
+    "main": "lib/cjs/index.js",
+    "module": "lib/esm/index.js",
+    "esnext": "lib/esnext/index.js",
+    "typings": "lib/esm/index.d.ts",
+    "files": [
+        "lib",
+        "src"
+    ],
     "scripts": {
         "clean": "rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
-        "compile:esm": "tsc -p src/",
+        "compile:esm": "tsc -p ./src",
+        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "compile:css-colors": "generate-css-variables --retainDefault true --outputFileName colors _colors.scss",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",

--- a/packages/colors/src/tsconfig.json
+++ b/packages/colors/src/tsconfig.json
@@ -1,9 +1,6 @@
 {
     "extends": "../../../config/tsconfig.base",
     "compilerOptions": {
-        "lib": ["es6", "dom"],
-        "module": "commonjs",
-        "outDir": "../lib",
-        "target": "ES2015"
+        "outDir": "../lib/esm"
     }
 }


### PR DESCRIPTION

#### Changes proposed in this pull request:

@blueprintjs/colors was set up with a nonstandard `/lib` folder from the beginning. This PR updates the build outputs to match the other @blueprintjs packages.

Submodule paths are not part of our public API (users shouldn't be reaching into `/lib/` manually), so it's not a breaking change.
