### PR TITLE
[colors] fix: declare explicit dependency on `tslib`

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -25,6 +25,9 @@
         "lint-fix": "es-lint --fix && sass-lint --fix",
         "verify": "npm-run-all compile -p dist lint"
     },
+    "dependencies": {
+        "tslib": "~2.5.0"
+    },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^7.1.3",
         "mocha": "^10.2.0",


### PR DESCRIPTION
Fixes a regression in @blueprintjs/colors where it started using an implicit dependency on "tslib"

See https://github.com/palantir/blueprint/pull/6179#issuecomment-1563264322