### PR TITLE
[core] feat(HTMLSelect): new prop iconName

### DIFF
--- a/packages/core/src/common/utils/index.ts
+++ b/packages/core/src/common/utils/index.ts
@@ -27,6 +27,7 @@ export {
 export * from "./functionUtils";
 export * from "./jsUtils";
 export * from "./reactUtils";
+export { Extends } from "./typeUtils";
 export { isDarkTheme } from "./isDarkTheme";
 
 // ref utils used to live in this folder, but got refactored and moved elsewhere.

--- a/packages/core/src/common/utils/typeUtils.ts
+++ b/packages/core/src/common/utils/typeUtils.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Useful to create a subset of a string union type */
+export type Extends<T, U extends T> = U;

--- a/packages/core/src/components/html-select/html-select.md
+++ b/packages/core/src/components/html-select/html-select.md
@@ -12,11 +12,15 @@ supports custom filtering logic and item rendering.
 
 </div>
 
-@## Props
+@## Usage
 
 Use `HTMLSelect` exactly like you would use a native `<select>` with `value` (or
 `defaultValue`) and `onChange`. Options can be passed as `<option>` children for
 full flexibility or via the `options` prop for simple shorthand.
+
+@reactExample HTMLSelectExample
+
+@## Props interface
 
 @interface IHTMLSelectProps
 

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -20,7 +20,10 @@ import * as React from "react";
 import { AbstractPureComponent2 } from "../../common";
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
 import { IElementRefProps, OptionProps } from "../../common/props";
-import { Icon, IconProps } from "../icon/icon";
+import { Extends } from "../../common/utils";
+import { Icon, IconName, IconProps } from "../icon/icon";
+
+export type HTMLSelectIconName = Extends<IconName, "double-caret-vertical" | "caret-down">;
 
 // eslint-disable-next-line deprecation/deprecation
 export type HTMLSelectProps = IHTMLSelectProps;
@@ -37,7 +40,18 @@ export interface IHTMLSelectProps
     /** Whether this element should fill its container. */
     fill?: boolean;
 
-    /** Props to spread to the `<Icon>` element. */
+    /**
+     * Name of one of the supported icons for this component to display on the right side of the element.
+     *
+     * @default "double-caret-vertical"
+     */
+    iconName?: HTMLSelectIconName;
+
+    /**
+     * Props to spread to the `<Icon>` element.
+     *
+     * Note that `iconProps.icon` is deprecated and will be removed in Blueprint v5; use `iconName` instead.
+     */
     iconProps?: Partial<IconProps>;
 
     /** Whether to use large styles. */
@@ -77,6 +91,7 @@ export class HTMLSelect extends AbstractPureComponent2<HTMLSelectProps> {
             disabled,
             elementRef,
             fill,
+            iconName = "double-caret-vertical",
             iconProps,
             large,
             minimal,
@@ -105,7 +120,7 @@ export class HTMLSelect extends AbstractPureComponent2<HTMLSelectProps> {
                     {optionChildren}
                     {htmlProps.children}
                 </select>
-                <Icon icon="double-caret-vertical" title="Open dropdown" {...iconProps} />
+                <Icon icon={iconName} title="Open dropdown" {...iconProps} />
             </div>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { H5, HTMLSelect, HTMLSelectIconName, Label, Switch } from "@blueprintjs/core";
+import { Example, ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+
+export interface HTMLSelectExampleState {
+    disabled: boolean;
+    fill: boolean;
+    iconName?: "double-caret-vertical" | "caret-down";
+    large: boolean;
+    minimal: boolean;
+}
+
+const SUPPORTED_ICON_NAMES: HTMLSelectIconName[] = ["double-caret-vertical", "caret-down"];
+
+const SELECT_OPTIONS = ["One", "Two", "Three", "Four"];
+
+export class HTMLSelectExample extends React.PureComponent<ExampleProps, HTMLSelectExampleState> {
+    public state: HTMLSelectExampleState = {
+        disabled: false,
+        fill: false,
+        iconName: undefined, // use component default
+        large: false,
+        minimal: false,
+    };
+
+    private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
+
+    private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
+
+    private handleIconChange = handleStringChange(iconName =>
+        this.setState({ iconName: iconName as HTMLSelectIconName }),
+    );
+
+    private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
+
+    private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
+
+    public render() {
+        const options = (
+            <>
+                <H5>Props</H5>
+                <Switch checked={this.state.fill} label="Fill" onChange={this.handleFillChange} />
+                <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
+                <Switch checked={this.state.minimal} label="Minimal" onChange={this.handleMinimalChange} />
+                <Switch checked={this.state.disabled} label="Disabled" onChange={this.handleDisabledChange} />
+                <Label>
+                    Icon
+                    <HTMLSelect
+                        placeholder="Choose an item..."
+                        options={SUPPORTED_ICON_NAMES}
+                        onChange={this.handleIconChange}
+                    />
+                </Label>
+            </>
+        );
+
+        return (
+            <Example options={options} {...this.props}>
+                <HTMLSelect {...this.state} options={SELECT_OPTIONS} />
+            </Example>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -39,6 +39,7 @@ export * from "./formGroupExample";
 export * from "./hotkeyPiano";
 export * from "./hotkeyTesterExample";
 export { HotkeysTarget2Example } from "./hotkeysTarget2Example";
+export { HTMLSelectExample } from "./htmlSelectExample";
 export * from "./iconExample";
 export * from "./menuExample";
 export { MenuItemExample } from "./menuItemExample";


### PR DESCRIPTION
#### Changes proposed in this pull request:

I've observed users customizing the HTMLSelect icon to use "caret-down" instead of the default "double-caret-vertical". We should make this a more first-class option instead of relying on `iconProps`. This is mainly motivated by the fact that `iconProps.icon` is being removed in Blueprint v5, so we need to provide a migration path in v4.x.

Also added a new interactive example for HTMLSelect to the docs

#### Reviewers should focus on:

New example, no regressions

#### Screenshot

![2023-05-26 13 16 50](https://github.com/palantir/blueprint/assets/723999/d34ea820-c9be-4eb7-ab9c-1f7ca878a565)


