### PR TITLE
[v5] fix: restore various public API exports

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -91,16 +91,17 @@ export {
     StrictModifierNames,
 } from "./popover/popoverSharedProps";
 export { PopupKind } from "./popover/popupKind";
-export { Portal, PortalProps } from "./portal/portal";
+export { Portal, PortalProps, PortalLegacyContext } from "./portal/portal";
 export { ProgressBar, ProgressBarProps } from "./progress-bar/progressBar";
 export { ResizeEntry, ResizeSensor, ResizeSensorProps } from "./resize-sensor/resizeSensor";
 export { HandleHtmlProps, HandleInteractionKind, HandleProps, HandleType } from "./slider/handleProps";
-export { MultiSlider, MultiSliderProps } from "./slider/multiSlider";
+export { MultiSlider, MultiSliderProps, SliderBaseProps } from "./slider/multiSlider";
 export { NumberRange, RangeSlider, RangeSliderProps } from "./slider/rangeSlider";
 export { Slider, SliderProps } from "./slider/slider";
 export { Spinner, SpinnerProps, SpinnerSize } from "./spinner/spinner";
 export { Tab, TabId, TabProps } from "./tabs/tab";
-export { Tabs, TabsProps } from "./tabs/tabs";
+// eslint-disable-next-line deprecation/deprecation
+export { Tabs, TabsProps, TabsExpander, Expander } from "./tabs/tabs";
 export { Tag, TagProps } from "./tag/tag";
 export { TagInput, TagInputProps, TagInputAddMethod } from "./tag-input/tagInput";
 export { OverlayToaster } from "./toast/overlayToaster";

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -21,7 +21,13 @@ import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, Props, Utils } from
 import { Tab, TabId, TabProps } from "./tab";
 import { generateTabPanelId, generateTabTitleId, TabTitle } from "./tabTitle";
 
-export const Expander: React.FC = () => <div className={Classes.FLEX_EXPANDER} />;
+/**
+ * Component that may be inserted between any two children of `<Tabs>` to right-align all subsequent children.
+ */
+export const TabsExpander: React.FC = () => <div className={Classes.FLEX_EXPANDER} />;
+
+/** @deprecated use `TabsExpander` instead */
+export const Expander = TabsExpander;
 
 type TabElement = React.ReactElement<TabProps & { children: React.ReactNode }>;
 
@@ -114,7 +120,7 @@ export interface TabsState {
  */
 export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
     /** Insert a `Tabs.Expander` between any two children to right-align all subsequent children. */
-    public static Expander = Expander;
+    public static Expander = TabsExpander;
 
     public static Tab = Tab;
 

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -26,6 +26,8 @@ export {
     /** @deprecated import from @blueprintjs/datetime instead */
     DateInputProps as DateInput2Props,
     /** @deprecated import from @blueprintjs/datetime instead */
+    DateRange,
+    /** @deprecated import from @blueprintjs/datetime instead */
     DateRangeInput as DateRangeInput2,
     /** @deprecated import from @blueprintjs/datetime instead */
     DateRangeInputProps as DateRangeInput2Props,

--- a/packages/table/src/deprecatedAliases.ts
+++ b/packages/table/src/deprecatedAliases.ts
@@ -18,14 +18,14 @@ export {
     /** @deprecated import ColumnHeaderCell instead */
     ColumnHeaderCell as ColumnHeaderCell2,
     /** @deprecated import ColumnHeaderCellProps instead */
-    type ColumnHeaderCellProps as ColumnHeaderCellProps2,
+    type ColumnHeaderCellProps as ColumnHeaderCell2Props,
 } from "./headers/columnHeaderCell";
 
 export {
     /** @deprecated import RowHeaderCell instead */
     RowHeaderCell as RowHeaderCell2,
     /** @deprecated import RowHeaderCellProps instead */
-    type RowHeaderCellProps as RowHeaderCellProps2,
+    type RowHeaderCellProps as RowHeaderCell2Props,
 } from "./headers/rowHeaderCell";
 
 export {


### PR DESCRIPTION
#### Changes proposed in this pull request:

@blueprintjs/core

- fix: restore exports `PortalLegacyContext`, `Expander`, `SliderBaseProps`
- deprecation: deprecate `Expander` in favor of the more specific name `TabsExpander`

@blueprintjs/datetime

- fix: restore exported alias `DateRange`

@blueprintjs/table

- fix names for deprecated aliases `ColumnHeaderCell2Props`, `RowHeaderCell2Props`