### PR TITLE
[core] feat: add SliderBaseProps replacement for I-prefixed interface

### DIFF
--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -32,6 +32,10 @@ import { argMin, fillValues, formatPercentage } from "./sliderUtils";
 const MultiSliderHandle: React.FC<HandleProps> = () => null;
 MultiSliderHandle.displayName = `${DISPLAYNAME_PREFIX}.MultiSliderHandle`;
 
+// eslint-disable-next-line deprecation/deprecation
+export type SliderBaseProps = ISliderBaseProps;
+
+/** @deprecated use SliderBaseProps */
 export interface ISliderBaseProps extends Props, IntentProps {
     children?: React.ReactNode;
 
@@ -116,7 +120,7 @@ export interface ISliderBaseProps extends Props, IntentProps {
 // eslint-disable-next-line deprecation/deprecation
 export type MultiSliderProps = IMultiSliderProps;
 /** @deprecated use MultiSliderProps */
-export interface IMultiSliderProps extends ISliderBaseProps {
+export interface IMultiSliderProps extends SliderBaseProps {
     /** Default intent of a track segment, used only if no handle specifies `intentBefore/After`. */
     defaultTrackIntent?: Intent;
 
@@ -141,7 +145,7 @@ export interface ISliderState {
  * @see https://blueprintjs.com/docs/#core/components/sliders.multi-slider
  */
 export class MultiSlider extends AbstractPureComponent2<MultiSliderProps, ISliderState> {
-    public static defaultSliderProps: ISliderBaseProps = {
+    public static defaultSliderProps: SliderBaseProps = {
         disabled: false,
         max: 10,
         min: 0,

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -20,7 +20,7 @@ import { AbstractPureComponent2, Intent } from "../../common";
 import * as Errors from "../../common/errors";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { HandleHtmlProps } from "./handleProps";
-import { ISliderBaseProps, MultiSlider } from "./multiSlider";
+import { MultiSlider, SliderBaseProps } from "./multiSlider";
 
 export type NumberRange = [number, number];
 
@@ -32,7 +32,7 @@ enum RangeIndex {
 // eslint-disable-next-line deprecation/deprecation
 export type RangeSliderProps = IRangeSliderProps;
 /** @deprecated use RangeSliderProps */
-export interface IRangeSliderProps extends ISliderBaseProps {
+export interface IRangeSliderProps extends SliderBaseProps {
     /**
      * Range value of slider. Handles will be rendered at each position in the range.
      *

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -19,12 +19,12 @@ import * as React from "react";
 import { AbstractPureComponent2, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { HandleHtmlProps } from "./handleProps";
-import { ISliderBaseProps, MultiSlider } from "./multiSlider";
+import { MultiSlider, SliderBaseProps } from "./multiSlider";
 
 // eslint-disable-next-line deprecation/deprecation
 export type SliderProps = ISliderProps;
 /** @deprecated use SliderProps */
-export interface ISliderProps extends ISliderBaseProps {
+export interface ISliderProps extends SliderBaseProps {
     /**
      * Initial value of the slider. This determines the other end of the
      * track fill: from `initialValue` to `value`.


### PR DESCRIPTION

#### Changes proposed in this pull request:

@blueprintjs/core

- feat: add `SliderBaseProps` alias for deprecated interface name with `I` prefix
- deprecation: `ISliderBaseProps`

