### PR TITLE
[v5] [core] fix(Label): restore support for htmlFor prop

### DIFF
--- a/packages/core/src/components/html/html.tsx
+++ b/packages/core/src/components/html/html.tsx
@@ -22,9 +22,9 @@ import { BLOCKQUOTE, CODE, CODE_BLOCK, HEADING, LABEL, LIST } from "../../common
 function htmlElement<E extends HTMLElement>(
     tagName: keyof JSX.IntrinsicElements,
     tagClassName: string,
-): React.FC<React.HTMLAttributes<E> & React.RefAttributes<E>> {
+): React.FC<React.AllHTMLAttributes<E> & React.RefAttributes<E>> {
     /* eslint-disable-next-line react/display-name */
-    return React.forwardRef<E, React.HTMLAttributes<E>>((props, ref) => {
+    return React.forwardRef<E, React.AllHTMLAttributes<E>>((props, ref) => {
         const { className, children, ...htmlProps } = props;
         return React.createElement(
             tagName,

--- a/packages/core/test/html/htmlTests.tsx
+++ b/packages/core/test/html/htmlTests.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { Label } from "../../src";
+
+describe("HTML components", () => {
+    describe("<Label>", () => {
+        it("supports htmlFor prop", () => {
+            mount(
+                <div>
+                    <Label htmlFor="foo" />
+                    <input id="foo" />
+                </div>,
+            );
+        });
+    });
+});

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -44,6 +44,7 @@ import "./forms/textAreaTests";
 import "./hotkeys/hotkeyTests";
 import "./hotkeys/hotkeysParserTests";
 import "./hotkeys/keyComboTagTests";
+import "./html/htmlTests";
 import "./html-select/htmlSelectTests";
 import "./icon/iconTests";
 import "./menu/menuItemTests";


### PR DESCRIPTION

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- fix(`Label`): restore support for `htmlFor` prop by widening props interface

added a unit test for this regression (caused by an accidental migration of `React.HTMLProps` -> `React.HTMLAttributes`). we don't want `React.HTMLProps` because that includes `React.LegacyRef`, but we can get the rest of the properties through `React.AllHTMLAttributes`.

