### PR TITLE
[v5] [core] fix(ResizeSensor): restore compatibility with React 18

### DIFF
--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -77,7 +77,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     private observer = new ResizeObserver(entries => this.props.onResize?.(entries));
 
-    public render() {
+    public render(): React.ReactNode {
         const onlyChild = React.Children.only(this.props.children);
 
         // if we're provided a ref to the child already, we don't need to attach one ourselves
@@ -98,6 +98,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     public componentWillUnmount() {
         this.observer.disconnect();
+        this.prevElement = undefined;
     }
 
     /**


### PR DESCRIPTION
Port https://github.com/palantir/blueprint/pull/5362 to the `next` branch, which somehow got lost in the ResizeSensor2 promotion.