### PR TITLE
[table] deprecate IMenuContext in favor of MenuContext

### DIFF
--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -25,7 +25,7 @@ import {
     Column,
     ColumnHeaderCell2,
     CopyCellsMenuItem,
-    IMenuContext,
+    MenuContext,
     SelectionModes,
     Table2,
     Utils,
@@ -230,7 +230,7 @@ export class TableSortableExample extends React.PureComponent<ExampleProps> {
         return this.state.data[rowIndex][columnIndex];
     };
 
-    private renderBodyContextMenu = (context: IMenuContext) => {
+    private renderBodyContextMenu = (context: MenuContext) => {
         return (
             <Menu>
                 <CopyCellsMenuItem context={context} getCellData={this.getCellData} text="Copy" />

--- a/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
@@ -142,6 +142,7 @@ const DEPRECATED_TYPE_REFERENCES_BY_PACKAGE = {
         "IColumnHeaderCellRenderer",
         "IColumnHeaderRenderer",
         "IColumnProps",
+        "IContextMenuRenderer",
         "ICoordinateData",
         "IFocusedCellCoordinates",
         "IJSONFormatProps",

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -29,8 +29,8 @@ import {
     CopyCellsMenuItem,
     EditableCell2,
     EditableName,
-    IMenuContext,
     JSONFormat2,
+    MenuContext,
     Region,
     RegionCardinality,
     Regions,
@@ -449,7 +449,7 @@ ReactDOM.render(
     document.getElementById("table-1"),
 );
 
-const bodyContextMenuRenderer = (context: IMenuContext) => {
+const bodyContextMenuRenderer = (context: MenuContext) => {
     const getCellData = (row: number, col: number) => {
         return Utils.toBase26Alpha(col) + (row + 1);
     };

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -44,6 +44,7 @@ import {
     EditableName,
     FocusedCellCoordinates,
     JSONFormat2,
+    MenuContext,
     Region,
     RegionCardinality,
     Regions,
@@ -56,7 +57,6 @@ import {
     TruncatedPopoverMode,
     Utils,
 } from "@blueprintjs/table";
-import { IMenuContext } from "@blueprintjs/table/src";
 import type { ColumnIndices, RowIndices } from "@blueprintjs/table/src/common/grid";
 
 import { DenseGridMutableStore } from "./denseGridMutableStore";
@@ -1111,7 +1111,7 @@ export class MutableTable extends React.Component<{}, IMutableTableState> {
         return handleStringChange(value => this.setState({ [stateKey]: value }));
     };
 
-    private renderBodyContextMenu = (context: IMenuContext) => {
+    private renderBodyContextMenu = (context: MenuContext) => {
         const menu = (
             <Menu>
                 <CopyCellsMenuItem context={context} icon="clipboard" getCellData={this.getCellValue} text="Copy" />

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -61,6 +61,7 @@ export type {
 
 export {
     CopyCellsMenuItem,
+    MenuContext,
     type IContextMenuRenderer,
     type ContextMenuRenderer,
     type IMenuContext,

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -21,13 +21,13 @@ import { MenuItem, MenuItemProps } from "@blueprintjs/core";
 import { Clipboard } from "../../common/clipboard";
 import { TABLE_COPY_FAILED } from "../../common/errors";
 import { Regions } from "../../regions";
-import { IMenuContext } from "./menuContext";
+import { MenuContext } from "./menuContext";
 
 export interface ICopyCellsMenuItemProps extends MenuItemProps {
     /**
-     * The `IMenuContext` that launched the menu.
+     * The `MenuContext` that launched the menu.
      */
-    context: IMenuContext;
+    context: MenuContext;
 
     /**
      * A callback that returns the data for a specific cell. This need not

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -52,6 +52,7 @@ export interface IMenuContext {
     getUniqueCells: () => CellCoordinate[];
 }
 
+// eslint-disable-next-line deprecation/deprecation
 export class MenuContext implements IMenuContext {
     private regions: Region[];
 

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -16,9 +16,12 @@
 
 import { CellCoordinate, Region, Regions } from "../../regions";
 
-export type IContextMenuRenderer = (context: IMenuContext) => JSX.Element;
+/** @deprecated use `ContextMenuRenderer` */
+export type IContextMenuRenderer = (context: MenuContext) => JSX.Element;
+// eslint-disable-next-line deprecation/deprecation
 export type ContextMenuRenderer = IContextMenuRenderer;
 
+/** @deprecated use `MenuContext`, which is forwards-compatible with Blueprint v5.0 */
 export interface IMenuContext {
     /**
      * Returns an array of `Region`s that represent the user-intended context

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -31,7 +31,7 @@ import * as Classes from "./common/classes";
 import { ContextMenuTargetWrapper } from "./common/contextMenuTargetWrapper";
 import { RenderMode } from "./common/renderMode";
 import { ICoordinateData } from "./interactions/dragTypes";
-import { IContextMenuRenderer, MenuContext } from "./interactions/menus";
+import { ContextMenuRenderer, MenuContext } from "./interactions/menus";
 import { DragSelectable, ISelectableProps } from "./interactions/selectable";
 import { ILocator } from "./locator";
 import { Region, Regions } from "./regions";
@@ -42,10 +42,10 @@ export type TableBodyProps = ITableBodyProps;
 export interface ITableBodyProps extends ISelectableProps, ITableBodyCellsProps {
     /**
      * An optional callback for displaying a context menu when right-clicking
-     * on the table body. The callback is supplied with an `IMenuContext`
+     * on the table body. The callback is supplied with an `MenuContext`
      * containing the `Region`s of interest.
      */
-    bodyContextMenuRenderer?: IContextMenuRenderer;
+    bodyContextMenuRenderer?: ContextMenuRenderer;
 
     /**
      * Locates the row/column/cell given a mouse event.

--- a/packages/table/src/tableProps.ts
+++ b/packages/table/src/tableProps.ts
@@ -23,7 +23,7 @@ import type { ColumnIndices, RowIndices } from "./common/grid";
 import type { RenderMode } from "./common/renderMode";
 import type { IColumnWidths } from "./headers/columnHeader";
 import type { IRowHeights, RowHeaderRenderer } from "./headers/rowHeader";
-import type { IContextMenuRenderer } from "./interactions/menus";
+import type { ContextMenuRenderer } from "./interactions/menus";
 import type { IIndexedResizeCallback } from "./interactions/resizable";
 import type { ISelectedRegionTransform } from "./interactions/selectable";
 import type { Region, RegionCardinality, StyledRegionGroup, TableLoadingOption } from "./regions";
@@ -53,7 +53,7 @@ export interface ITableProps extends Props, Partial<IRowHeights>, Partial<IColum
      * contain all selected regions. Otherwise it will have one `Region` that
      * represents the clicked cell.
      */
-    bodyContextMenuRenderer?: IContextMenuRenderer;
+    bodyContextMenuRenderer?: ContextMenuRenderer;
 
     /**
      * If `true`, adds an interaction bar on top of all column header cells, and


### PR DESCRIPTION

#### Changes proposed in this pull request:

I realized after updating the no-deprecated-type-references rule to flag `IMenuContext` as invalid that we never actually exported `MenuContext` from the table package API.

This PR changes that, we now export `MenuContext`. The `I`-prefixed interface is now deprecated (it will be removed in v5.0).

