### PR TITLE
[table] fix regression in stricter type for context menu

### DIFF
--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -21,14 +21,13 @@ import { MenuItem, MenuItemProps } from "@blueprintjs/core";
 import { Clipboard } from "../../common/clipboard";
 import { TABLE_COPY_FAILED } from "../../common/errors";
 import { Regions } from "../../regions";
-import { IMenuContext } from "./menuContext";
+import { MenuContext } from "./menuContext";
 
 export interface ICopyCellsMenuItemProps extends MenuItemProps {
     /**
-     * The `MenuContext` that launched the menu.
+     * The menu context that launched the menu.
      */
-    // eslint-disable-next-line deprecation/deprecation
-    context: IMenuContext;
+    context: MenuContext;
 
     /**
      * A callback that returns the data for a specific cell. This need not

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -21,13 +21,14 @@ import { MenuItem, MenuItemProps } from "@blueprintjs/core";
 import { Clipboard } from "../../common/clipboard";
 import { TABLE_COPY_FAILED } from "../../common/errors";
 import { Regions } from "../../regions";
-import { MenuContext } from "./menuContext";
+import { IMenuContext } from "./menuContext";
 
 export interface ICopyCellsMenuItemProps extends MenuItemProps {
     /**
      * The `MenuContext` that launched the menu.
      */
-    context: MenuContext;
+    // eslint-disable-next-line deprecation/deprecation
+    context: IMenuContext;
 
     /**
      * A callback that returns the data for a specific cell. This need not

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -17,7 +17,8 @@
 import { CellCoordinate, Region, Regions } from "../../regions";
 
 /** @deprecated use `ContextMenuRenderer` */
-export type IContextMenuRenderer = (context: MenuContext) => JSX.Element;
+// eslint-disable-next-line deprecation/deprecation
+export type IContextMenuRenderer = (context: IMenuContext) => JSX.Element;
 // eslint-disable-next-line deprecation/deprecation
 export type ContextMenuRenderer = IContextMenuRenderer;
 

--- a/packages/table/src/interactions/menus/menuContext.ts
+++ b/packages/table/src/interactions/menus/menuContext.ts
@@ -17,12 +17,11 @@
 import { CellCoordinate, Region, Regions } from "../../regions";
 
 /** @deprecated use `ContextMenuRenderer` */
-// eslint-disable-next-line deprecation/deprecation
-export type IContextMenuRenderer = (context: IMenuContext) => JSX.Element;
+export type IContextMenuRenderer = (context: MenuContext) => JSX.Element;
 // eslint-disable-next-line deprecation/deprecation
 export type ContextMenuRenderer = IContextMenuRenderer;
 
-/** @deprecated use `MenuContext`, which is forwards-compatible with Blueprint v5.0 */
+/** @deprecated use `MenuContext` */
 export interface IMenuContext {
     /**
      * Returns an array of `Region`s that represent the user-intended context
@@ -52,9 +51,11 @@ export interface IMenuContext {
      */
     getUniqueCells: () => CellCoordinate[];
 }
+// eslint-disable-next-line deprecation/deprecation
+export type MenuContext = IMenuContext;
 
 // eslint-disable-next-line deprecation/deprecation
-export class MenuContext implements IMenuContext {
+export class MenuContextImpl implements MenuContext {
     private regions: Region[];
 
     constructor(

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -31,7 +31,7 @@ import * as Classes from "./common/classes";
 import { ContextMenuTargetWrapper } from "./common/contextMenuTargetWrapper";
 import { RenderMode } from "./common/renderMode";
 import { ICoordinateData } from "./interactions/dragTypes";
-import { ContextMenuRenderer, MenuContext } from "./interactions/menus";
+import { ContextMenuRenderer, MenuContextImpl } from "./interactions/menus";
 import { DragSelectable, ISelectableProps } from "./interactions/selectable";
 import { ILocator } from "./locator";
 import { Region, Regions } from "./regions";
@@ -159,7 +159,7 @@ export class TableBody extends AbstractComponent2<TableBodyProps> {
             onFocusedCell(nextFocusedCell);
         }
 
-        const menuContext = new MenuContext(targetRegion, nextSelectedRegions, numRows, numCols);
+        const menuContext = new MenuContextImpl(targetRegion, nextSelectedRegions, numRows, numCols);
         const contextMenu = bodyContextMenuRenderer(menuContext);
 
         return contextMenu == null ? undefined : contextMenu;

--- a/packages/table/src/tableBody2.tsx
+++ b/packages/table/src/tableBody2.tsx
@@ -24,7 +24,7 @@ import type { CellCoordinates } from "./common/cellTypes";
 import * as Classes from "./common/classes";
 import { RenderMode } from "./common/renderMode";
 import type { CoordinateData } from "./interactions/dragTypes";
-import { MenuContext } from "./interactions/menus";
+import { MenuContextImpl } from "./interactions/menus";
 import { DragSelectable } from "./interactions/selectable";
 import { Region, Regions } from "./regions";
 import type { TableBodyProps } from "./tableBody";
@@ -118,7 +118,7 @@ export class TableBody2 extends AbstractComponent2<TableBodyProps> {
             nextSelectedRegions = [targetRegion];
         }
 
-        const menuContext = new MenuContext(targetRegion, nextSelectedRegions, numRows, numCols);
+        const menuContext = new MenuContextImpl(targetRegion, nextSelectedRegions, numRows, numCols);
         const contextMenu = bodyContextMenuRenderer(menuContext);
 
         return contextMenu == null ? undefined : contextMenu;

--- a/packages/table/test/menusTests.tsx
+++ b/packages/table/test/menusTests.tsx
@@ -21,14 +21,14 @@ import * as sinon from "sinon";
 import { Classes, Menu } from "@blueprintjs/core";
 
 import { Clipboard } from "../src/common/clipboard";
-import { CopyCellsMenuItem, MenuContext } from "../src/interactions/menus";
+import { CopyCellsMenuItem, MenuContextImpl } from "../src/interactions/menus";
 import { Regions } from "../src/regions";
 import { ReactHarness } from "./harness";
 
 describe("Menus", () => {
-    describe("MenuContext", () => {
+    describe("MenuContextImpl", () => {
         it("uses selected regions if clicked inside selection", () => {
-            const context = new MenuContext(Regions.cell(1, 1), [Regions.column(1)], 3, 3);
+            const context = new MenuContextImpl(Regions.cell(1, 1), [Regions.column(1)], 3, 3);
             expect(context.getRegions()).to.deep.equal([Regions.column(1)]);
             expect(context.getUniqueCells()).to.deep.equal([
                 [0, 1],
@@ -38,7 +38,7 @@ describe("Menus", () => {
         });
 
         it("uses target cell if clicked outside selection", () => {
-            const context = new MenuContext(Regions.cell(1, 2), [Regions.column(1)], 3, 3);
+            const context = new MenuContextImpl(Regions.cell(1, 2), [Regions.column(1)], 3, 3);
             expect(context.getTarget()).to.deep.equal(Regions.cell(1, 2));
             expect(context.getSelectedRegions()).to.deep.equal([Regions.column(1)]);
             expect(context.getRegions()).to.deep.equal([Regions.cell(1, 2)]);
@@ -60,7 +60,7 @@ describe("Menus", () => {
         });
 
         it("copies cells", done => {
-            const context = new MenuContext(Regions.cell(1, 1), [Regions.column(1)], 3, 3);
+            const context = new MenuContextImpl(Regions.cell(1, 1), [Regions.column(1)], 3, 3);
             const getCellData = () => "X";
             const onCopySpy = sinon.spy();
             const menu = harness.mount(


### PR DESCRIPTION
Fix a regression in https://github.com/palantir/blueprint/pull/6196, we can't require the more specific `MenuContext` type yet, we need to continue being compatible with the deprecated `IMenuContext` type in `<CopyCellsMenuItem>` and `<TableBody>` props.

It turns out that `MenuContext` was not exported until #6196, so it's safe to rename the class to `MenuContextImpl` (which will be its name in v5.0) and use `MenuContext` to simply be an alias for `IMenuContext` now. This will fix any assignability issues caused by the latest @blueprintjs/table release.