### PR TITLE
[docs-theme] fix: export DocsExampleProps type alias

### DIFF
--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Callout, Code, H5, Intent, Switch } from "@blueprintjs/core";
-import { Example, handleBooleanChange, IDocsExampleProps } from "@blueprintjs/docs-theme";
+import { DocsExampleProps, Example, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { IconName } from "@blueprintjs/icons";
 
 import { IconSelect } from "./common/iconSelect";
@@ -29,7 +29,7 @@ interface CalloutExampleState {
     showHeader: boolean;
 }
 
-export class CalloutExample extends React.PureComponent<IDocsExampleProps, CalloutExampleState> {
+export class CalloutExample extends React.PureComponent<DocsExampleProps, CalloutExampleState> {
     public state: CalloutExampleState = { showHeader: true };
 
     private handleHeaderChange = handleBooleanChange((showHeader: boolean) => this.setState({ showHeader }));

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -45,11 +45,14 @@ export interface ExampleProps<T = {}> extends Props {
     data?: T;
 }
 
+/** @deprecated use DocsExampleProps */
+export type IDocsExampleProps = DocsExampleProps;
+
 /**
  * Props supported by the `Example` component.
  * Additional props will be spread to the root `<div>` element.
  */
-export interface IDocsExampleProps extends ExampleProps {
+export interface DocsExampleProps extends ExampleProps {
     children?: React.ReactNode;
 
     /**
@@ -107,8 +110,8 @@ export interface IDocsExampleProps extends ExampleProps {
  *     }
  * ```
  */
-export class Example extends React.PureComponent<IDocsExampleProps> {
-    public static defaultProps: Partial<IDocsExampleProps> = {
+export class Example extends React.PureComponent<DocsExampleProps> {
+    public static defaultProps: Partial<DocsExampleProps> = {
         forceUpdate: true,
         showOptionsBelowExample: false,
     };


### PR DESCRIPTION
🤦🏽 Forgot to export this one too, which is a problem now that `IDocsExampleProps` is flagged by the lint rule via https://github.com/palantir/blueprint/pull/6193