### PR TITLE
[v5] chore: upgrade typescript + w-d-s, add @types/node

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-    "version": "4.8.4",
+    "version": "4.5.4",
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
         "declaration": true,
@@ -13,6 +13,7 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
+        "noUncheckedIndexedAccess": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "pretty": true,

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -13,7 +13,6 @@
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
-        "noUncheckedIndexedAccess": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "pretty": true,

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@types/enzyme": "~3.10.12",
         "@types/enzyme-adapter-react-16": "~1.0.6",
         "@types/mocha": "~10.0.1",
+        "@types/node": "~18.16.16",
         "@types/react": "~16.14.32",
         "@types/react-dom": "~16.9.10",
         "@types/react-transition-group": "~4.4.5",
@@ -59,7 +60,7 @@
         "sinon": "^15.0.3",
         "stylelint-config-palantir": "^6.0.1",
         "stylelint-scss": "^4.6.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "yargs": "^17.6.0",
         "yarn-deduplicate": "^6.0.1"
     },

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.0-alpha.3",
         "mocha": "^10.2.0",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
     },
     "repository": {
         "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -81,7 +81,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -73,7 +73,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -63,7 +63,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -36,7 +36,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "npm-run-all": "^4.1.5",
         "webpack-cli": "^5.0.1",
-        "webpack-dev-server": "^4.12.0"
+        "webpack-dev-server": "^4.15.0"
     },
     "repository": {
         "type": "git",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -51,7 +51,7 @@
         "monaco-editor-webpack-plugin": "^7.0.1",
         "npm-run-all": "^4.1.5",
         "webpack-cli": "^5.0.1",
-        "webpack-dev-server": "^4.12.0"
+        "webpack-dev-server": "^4.15.0"
     },
     "repository": {
         "type": "git",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -59,7 +59,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -21,7 +21,7 @@
         "dedent": "^0.7.0",
         "mocha": "^10.2.0",
         "ts-node": "^10.9.1",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
     },
     "repository": {
         "type": "git",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -63,7 +63,7 @@
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
         "svg-parser": "^2.0.4",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -28,7 +28,7 @@
         "npm-run-all": "^4.1.5",
         "raw-loader": "^4.0.2",
         "webpack": "^5.76.2",
-        "webpack-dev-server": "^4.12.0"
+        "webpack-dev-server": "^4.15.0"
     },
     "repository": {
         "type": "git",

--- a/packages/monaco-editor-theme/package.json
+++ b/packages/monaco-editor-theme/package.json
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.0-alpha.3",
         "npm-run-all": "^4.1.5",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
     },
     "repository": {
         "type": "git",

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -43,7 +43,7 @@
         "stylelint-junit-formatter": "^0.2.2",
         "svgo": "^1.3.2",
         "ts-node": "^10.9.1",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "yargs": "^17.6.0"
     },
     "devDependencies": {

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -51,7 +51,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
     },
     "repository": {
         "type": "git",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -65,7 +65,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -23,7 +23,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.0-alpha.3",
         "mocha": "^10.2.0",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
     },
     "repository": {
         "type": "git",

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -30,7 +30,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "npm-run-all": "^4.1.5",
         "webpack": "^5.76.2",
-        "webpack-dev-server": "^4.12.0"
+        "webpack-dev-server": "^4.15.0"
     },
     "repository": {
         "type": "git",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -66,7 +66,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.8.4",
+        "typescript": "~4.9.5",
         "webpack": "^5.76.2"
     },
     "repository": {

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -53,6 +53,7 @@ function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: 
     let metaKey = false;
 
     if (modKey) {
+        // eslint-disable-next-line deprecation/deprecation
         if (typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform)) {
             metaKey = true;
         } else {

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -24,7 +24,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.0-alpha.3",
         "react": "^16.13.1",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.5"
     },
     "repository": {
         "type": "git",

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -35,7 +35,7 @@
         "ts-loader": "^9.4.2",
         "webpack": "^5.76.2",
         "webpack-bundle-analyzer": "^4.8.0",
-        "webpack-dev-server": "^4.12.0",
+        "webpack-dev-server": "^4.15.0",
         "webpack-notifier": "^1.15.0"
     },
     "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,10 +1678,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.1.tgz#2f4f65bb08bc368ac39c96da7b2f09140b26851b"
   integrity sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==
 
-"@types/node@*", "@types/node@>=10.0.0":
-  version "16.10.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.4.tgz#592f12b0b5f357533ddc3310b0176d42ea3e45d1"
-  integrity sha512-EITwVTX5B4nDjXjGeQAfXOrm+Jn+qNjDmyDRtWoD+wZsl/RDPRTFRKivs4Mt74iOFlLOrE5+Kf+p5yjyhm3+cA==
+"@types/node@*", "@types/node@>=10.0.0", "@types/node@~18.16.16":
+  version "18.16.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.16.tgz#3b64862856c7874ccf7439e6bab872d245c86d8e"
+  integrity sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -11404,10 +11404,10 @@ typedoc@~0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-"typescript@^3 || ^4", typescript@~4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+"typescript@^3 || ^4", typescript@~4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"
@@ -11721,10 +11721,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.12.0.tgz#e2dcad4d43e486c3bac48ddbf346e77ef03c7428"
-  integrity sha512-XRN9YRnvOj3TQQ5w/0pR1y1xDcVnbWtNkTri46kuEbaWUPTHsWUvOyAAI7PZHLY+hsFki2kRltJjKMw7e+IiqA==
+webpack-dev-server@^4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.15.0.tgz#87ba9006eca53c551607ea0d663f4ae88be7af21"
+  integrity sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"


### PR DESCRIPTION
Upgrade to typescript 4.9
Upgrade webpack-dev-server minor bump
Add explicit `@types/node` dependency to work around https://github.com/microsoft/TypeScript/issues/51567