### PR TITLE
[v5] [icons] feat: reduce bundle size, load paths instead of components

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -27,9 +27,6 @@
   > svg {
     // prevent extra vertical whitespace
     display: block;
-    // paths parsed by generate-icon-paths.js are mirrored vertically, so we need
-    // to flip them upright here
-    transform: scaleY(-1);
 
     // inherit text color unless explicit fill is set
     &:not([fill]) {

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -19,7 +19,9 @@ import { mount } from "enzyme";
 import * as React from "react";
 import Sinon, { stub } from "sinon";
 
-import { Add, Airplane, Calendar, Graph, IconName, Icons, IconSize } from "@blueprintjs/icons";
+import { IconName, Icons, IconSize } from "@blueprintjs/icons";
+// eslint-disable-next-line @typescript-eslint/tslint/config
+import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 
 import { Classes, Icon, IconProps, Intent } from "../../src";
 
@@ -29,12 +31,12 @@ describe("<Icon>", () => {
     before(() => {
         stub(Icons, "load").resolves(undefined);
         // stub the dynamic icon loader with a synchronous, static one
-        iconLoader = stub(Icons, "getComponent");
+        iconLoader = stub(Icons, "getPaths");
         iconLoader.returns(undefined);
-        iconLoader.withArgs("graph").returns(Graph);
         iconLoader.withArgs("add").returns(Add);
-        iconLoader.withArgs("calendar").returns(Calendar);
         iconLoader.withArgs("airplane").returns(Airplane);
+        iconLoader.withArgs("calendar").returns(Calendar);
+        iconLoader.withArgs("graph").returns(Graph);
     });
 
     afterEach(() => {

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -35,12 +35,12 @@ const tagRenderers = {
 
 // this compiles all the icon modules into this chunk, so async Icon.load() calls don't block later
 Icons.loadAll({
-    loader: async name => {
+    loader: async (name, size) => {
         return (
             await import(
                 /* webpackInclude: /\.js$/ */
                 /* webpackMode: "eager" */
-                `@blueprintjs/icons/lib/esm/generated/components/${name}`
+                `@blueprintjs/icons/lib/esm/generated/${size}px/paths/${name}`
             )
         ).default;
     },

--- a/packages/icons/scripts/iconComponent.tsx.hbs
+++ b/packages/icons/scripts/iconComponent.tsx.hbs
@@ -13,73 +13,23 @@
  * limitations under the License.
  */
 
-import classNames from "classnames";
 import * as React from "react";
 import type { SVGIconProps } from "../../svgIconProps";
 import { IconSize } from "../../iconSize";
-import * as Classes from "../../classes";
-import { uniqueId } from "../../jsUtils";
+import { SVGIconContainer } from "../../svgIconContainer";
 
-export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>(({
-    className,
-    color,
-    size = IconSize.STANDARD,
-    title,
-    htmlTitle,
-    svgProps,
-    tagName = "span",
-    ...htmlProps
-}, ref) => {
-    const isLarge = size >= IconSize.LARGE;
-    const pixelGridSize =  isLarge ? IconSize.LARGE : IconSize.STANDARD;
-    const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
-    const titleId = uniqueId("iconTitle");
-    const path = (
+export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>((props, ref) => (
+    <SVGIconContainer iconName="{{iconName}}" ref={ref} {...props}>
         <path
             d={
-                isLarge
-                    ? "{{icon20pxPath}}"
-                    : "{{icon16pxPath}}"
+                props.size === undefined || props.size < IconSize.LARGE
+                    ? "{{icon16pxPath}}"
+                    : "{{icon20pxPath}}"
             }
             fillRule="evenodd"
             transform="scale({{pathScaleFactor}} {{pathScaleFactor}})"
         />
-    );
-
-    if (tagName === null) {
-        return (
-            <svg
-                aria-labelledby={title ? titleId : undefined}
-                data-icon="{{iconName}}"
-                fill={color}
-                height={size}
-                ref={ref}
-                role="img"
-                viewBox={viewBox}
-                width={size}
-                {...svgProps}
-                {...htmlProps}
-            >
-                {title && <title id={titleId}>{title}</title>}
-                {path}
-            </svg>
-        );
-    } else {
-        return React.createElement(
-            tagName,
-            {
-                ...htmlProps,
-                "aria-hidden": title ? undefined : true,
-                className: classNames(Classes.ICON, `${Classes.ICON}-{{iconName}}`, className),
-                ref,
-                title: htmlTitle,
-            },
-            <svg fill={color} data-icon="{{iconName}}" width={size} height={size} role="img" viewBox={viewBox} {...svgProps}>
-                {title && <title>{title}</title>}
-                {path}
-            </svg>
-        );
-    }
-});
+    </SVGIconContainer>
+));
 {{pascalCase iconName}}.displayName = `Blueprint5.Icon.{{pascalCase iconName}}`;
 export default {{pascalCase iconName}};

--- a/packages/icons/scripts/iconComponent.tsx.hbs
+++ b/packages/icons/scripts/iconComponent.tsx.hbs
@@ -18,18 +18,25 @@ import type { SVGIconProps } from "../../svgIconProps";
 import { IconSize } from "../../iconSize";
 import { SVGIconContainer } from "../../svgIconContainer";
 
-export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>((props, ref) => (
-    <SVGIconContainer iconName="{{iconName}}" ref={ref} {...props}>
-        <path
-            d={
-                props.size === undefined || props.size < IconSize.LARGE
-                    ? "{{icon16pxPath}}"
-                    : "{{icon20pxPath}}"
-            }
-            fillRule="evenodd"
-            transform="scale({{pathScaleFactor}} {{pathScaleFactor}})"
-        />
-    </SVGIconContainer>
-));
+export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>((props, ref) => {
+    const translation = `${-1 * props.size! / {{pathScaleFactor}} / 2}`;
+    return (
+        <SVGIconContainer iconName="{{iconName}}" ref={ref}  {...props}>
+            <path
+                d={
+                    props.size! < IconSize.LARGE
+                        ? "{{icon16pxPath}}"
+                        : "{{icon20pxPath}}"
+                }
+                fillRule="evenodd"
+                transform-origin="center"
+                transform={`scale({{pathScaleFactor}}, -{{pathScaleFactor}}) translate(${translation}, ${translation})`}
+            />
+        </SVGIconContainer>
+   )
+});
+{{pascalCase iconName}}.defaultProps = {
+    size: IconSize.STANDARD,
+};
 {{pascalCase iconName}}.displayName = `Blueprint5.Icon.{{pascalCase iconName}}`;
 export default {{pascalCase iconName}};

--- a/packages/icons/src/iconSvgPaths.ts
+++ b/packages/icons/src/iconSvgPaths.ts
@@ -19,9 +19,12 @@ import { pascalCase } from "change-case";
 import * as IconSvgPaths16 from "./generated/16px/paths";
 import * as IconSvgPaths20 from "./generated/20px/paths";
 import type { IconName } from "./iconNames";
+import { IconSize } from "./iconSize";
 import type { PascalCase } from "./type-utils";
 
 export { IconSvgPaths16, IconSvgPaths20 };
+
+export type IconPaths = string[];
 
 /**
  * Type safe string literal conversion of snake-case icon names to PascalCase icon names.
@@ -29,4 +32,18 @@ export { IconSvgPaths16, IconSvgPaths20 };
  */
 export function iconNameToPathsRecordKey(name: IconName): PascalCase<IconName> {
     return pascalCase(name) as PascalCase<IconName>;
+}
+
+/**
+ * Get the list of vector paths that define a given icon. These path strings are used to render `<path>`
+ * elements inside an `<svg>` icon element. For full implementation details and nuances, see the icon component
+ * handlebars template and `generate-icon-components` script in the __@blueprintjs/icons__ package.
+ *
+ * Note: this function loads all icon definitions __statically__, which means every icon is included in your
+ * JS bundle. If you are looking for a dynamic icon loader which loads icon definitions on-demand, use
+ * `{ Icons } from "@blueprintjs/icons"`.
+ */
+export function getIconPaths(name: IconName, size: IconSize): IconPaths {
+    const key = iconNameToPathsRecordKey(name);
+    return size === IconSize.STANDARD ? IconSvgPaths16[key] : IconSvgPaths20[key];
 }

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-export { Icons, IconComponent, IconLoaderOptions, IconComponentLoader } from "./iconLoader";
+export { Icons, IconLoaderOptions, IconPathsLoader as IconComponentLoader } from "./iconLoader";
 export { SVGIconProps } from "./svgIconProps";
+export { SVGIconContainer, SVGIconContainerProps } from "./svgIconContainer";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";
 export { IconSize } from "./iconSize";
-export { IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "./iconSvgPaths";
+export { getIconPaths, IconPaths, IconSvgPaths16, IconSvgPaths20, iconNameToPathsRecordKey } from "./iconSvgPaths";

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { Icons, IconLoaderOptions, IconPathsLoader as IconComponentLoader } from "./iconLoader";
+export { Icons, IconLoaderOptions, IconPathsLoader } from "./iconLoader";
 export { SVGIconProps } from "./svgIconProps";
 export { SVGIconContainer, SVGIconContainerProps } from "./svgIconContainer";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";

--- a/packages/icons/src/loading-icons.md
+++ b/packages/icons/src/loading-icons.md
@@ -64,7 +64,7 @@ The following strategies assume you are bundling with Webpack; if you are using 
 to its available APIs.
 </div>
 
-1. Load all icons statically, similar to behavior in Blueprint versions prior to v5.x. This results in the largest bundle size for your main chunk.
+1. Load all icon paths statically, similar to behavior in Blueprint versions prior to v5.x. This results in the largest bundle size for your main chunk.
 
     In the entry point for your bundle, use `Icons.loadAll()` with its default annotated icon loader function _or_ specify
     a custom one. This will to ensure that webpack will bundle all the icon modules in your main chunk
@@ -76,19 +76,19 @@ to its available APIs.
 
     // or, optionally specify a custom loader function optimized for loading all icons statically
     Icons.loadAll({
-        loader: async name => {
+        loader: async (name, size) => {
             return (
                 await import(
                     /* webpackInclude: /\.js$/ */
                     /* webpackMode: "eager" */
-                    `@blueprintjs/icons/lib/esm/generated/components/${name}`
+                    `@blueprintjs/icons/lib/esm/generated/${size}px/paths/${name}`
                 )
             ).default;
         },
     });
     ```
 
-2. Load some icons up front (but still dynamically) with network requests, and the rest lazily/on-demand.
+2. Load some icon paths up front (but still dynamically) with network requests, and the rest lazily/on-demand.
 
     In the entry point for your bundle:
 

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -22,27 +22,30 @@ import { IconSize } from "./iconSize";
 import { uniqueId } from "./jsUtils";
 import type { SVGIconProps } from "./svgIconProps";
 
-/**
- * Interface for an SVG icon container component.
- * Contents should be loaded via `IconLoader` and specified as `<path>` JSX elements in `props.children`.
- */
 export interface SVGIconContainerProps extends Omit<SVGIconProps, "children"> {
+    /**
+     * Icon name.
+     */
     iconName: IconName;
+
+    /**
+     * Icon contents, loaded via `IconLoader` and specified as `<path>` elements.
+     */
     children: JSX.Element | JSX.Element[];
 }
 
 export const SVGIconContainer: React.FC<SVGIconContainerProps> = React.forwardRef<any, SVGIconContainerProps>(
     (props, ref) => {
         const {
+            children,
             className,
             color,
-            children,
-            size = IconSize.STANDARD,
-            title,
             htmlTitle,
             iconName,
+            size = IconSize.STANDARD,
             svgProps,
             tagName = "span",
+            title,
             ...htmlProps
         } = props;
 
@@ -50,21 +53,19 @@ export const SVGIconContainer: React.FC<SVGIconContainerProps> = React.forwardRe
         const pixelGridSize = isLarge ? IconSize.LARGE : IconSize.STANDARD;
         const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
         const titleId = uniqueId("iconTitle");
+        const sharedSvgProps = {
+            "data-icon": iconName,
+            fill: color,
+            height: size,
+            role: "img",
+            viewBox,
+            width: size,
+            ...svgProps,
+        };
 
         if (tagName === null) {
             return (
-                <svg
-                    aria-labelledby={title ? titleId : undefined}
-                    data-icon="{{iconName}}"
-                    fill={color}
-                    height={size}
-                    ref={ref}
-                    role="img"
-                    viewBox={viewBox}
-                    width={size}
-                    {...svgProps}
-                    {...htmlProps}
-                >
+                <svg aria-labelledby={title ? titleId : undefined} ref={ref} {...sharedSvgProps} {...htmlProps}>
                     {title && <title id={titleId}>{title}</title>}
                     {children}
                 </svg>
@@ -75,19 +76,11 @@ export const SVGIconContainer: React.FC<SVGIconContainerProps> = React.forwardRe
                 {
                     ...htmlProps,
                     "aria-hidden": title ? undefined : true,
-                    className: classNames(Classes.ICON, `${Classes.ICON}-{{iconName}}`, className),
+                    className: classNames(Classes.ICON, `${Classes.ICON}-${iconName}`, className),
                     ref,
                     title: htmlTitle,
                 },
-                <svg
-                    fill={color}
-                    data-icon="{{iconName}}"
-                    width={size}
-                    height={size}
-                    role="img"
-                    viewBox={viewBox}
-                    {...svgProps}
-                >
+                <svg {...sharedSvgProps}>
                     {title && <title>{title}</title>}
                     {children}
                 </svg>,

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+
+import * as Classes from "./classes";
+import type { IconName } from "./iconNames";
+import { IconSize } from "./iconSize";
+import { uniqueId } from "./jsUtils";
+import type { SVGIconProps } from "./svgIconProps";
+
+/**
+ * Interface for an SVG icon container component.
+ * Contents should be loaded via `IconLoader` and specified as `<path>` JSX elements in `props.children`.
+ */
+export interface SVGIconContainerProps extends Omit<SVGIconProps, "children"> {
+    iconName: IconName;
+    children: JSX.Element | JSX.Element[];
+}
+
+export const SVGIconContainer: React.FC<SVGIconContainerProps> = React.forwardRef<any, SVGIconContainerProps>(
+    (props, ref) => {
+        const {
+            className,
+            color,
+            children,
+            size = IconSize.STANDARD,
+            title,
+            htmlTitle,
+            iconName,
+            svgProps,
+            tagName = "span",
+            ...htmlProps
+        } = props;
+
+        const isLarge = size >= IconSize.LARGE;
+        const pixelGridSize = isLarge ? IconSize.LARGE : IconSize.STANDARD;
+        const viewBox = `0 0 ${pixelGridSize} ${pixelGridSize}`;
+        const titleId = uniqueId("iconTitle");
+
+        if (tagName === null) {
+            return (
+                <svg
+                    aria-labelledby={title ? titleId : undefined}
+                    data-icon="{{iconName}}"
+                    fill={color}
+                    height={size}
+                    ref={ref}
+                    role="img"
+                    viewBox={viewBox}
+                    width={size}
+                    {...svgProps}
+                    {...htmlProps}
+                >
+                    {title && <title id={titleId}>{title}</title>}
+                    {children}
+                </svg>
+            );
+        } else {
+            return React.createElement(
+                tagName,
+                {
+                    ...htmlProps,
+                    "aria-hidden": title ? undefined : true,
+                    className: classNames(Classes.ICON, `${Classes.ICON}-{{iconName}}`, className),
+                    ref,
+                    title: htmlTitle,
+                },
+                <svg
+                    fill={color}
+                    data-icon="{{iconName}}"
+                    width={size}
+                    height={size}
+                    role="img"
+                    viewBox={viewBox}
+                    {...svgProps}
+                >
+                    {title && <title>{title}</title>}
+                    {children}
+                </svg>,
+            );
+        }
+    },
+);
+SVGIconContainer.displayName = "Blueprint5.SVGIconContainer";

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -15,6 +15,10 @@
 
 import * as React from "react";
 
+/**
+ * Interface used for generated icon components which already have their name and path defined
+ * (through the rendered Handlebars template).
+ */
 export interface SVGIconProps extends React.RefAttributes<any> {
     /** A space-delimited list of class names to pass along to the SVG element. */
     className?: string;


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/2193#issuecomment-1576973611, fixes #6159

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- ⚠️ BREAK: refactor `IconLoader` to load icon path modules instead of generated React components
  - This changes the type and semantics of the icon loader function, which now has the signature `Icons.load(name: IconName, size: IconSize)`
  - If you were previously specifying a custom icon loading function, it will have to be adjusted to account for the new paths of the expected modules:
  ```diff
  loader: async (name, size) => {
    await import(
      /* webpackInclude: /\.js$/ */
      /* webpackMode: "eager" */
  -     `@blueprintjs/icons/lib/esm/generated/components/${name}`
  +     `@blueprintjs/icons/lib/esm/generated/${size}px/paths/${name}`
    ),
  }
  ```
- feat: reduce size of generated icon component modules by deduplicating code with a new shared component `<SVGIconContainer>`
- feat: new `getIconPaths()` function in `@blueprintjs/icons` which provides a less verbose API to _statically_ load icon paths

#### Reviewers should focus on:

No regressions

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
