### PR TITLE
[popover2] fix(ContextMenu2): disable native menu correctly with content function API

### DIFF
--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -216,7 +216,10 @@ describe("ContextMenu2", () => {
             openCtxMenu(ctxMenu);
         });
 
-        function renderContent() {
+        function renderContent({ mouseEvent, targetOffset }: ContextMenu2ContentProps) {
+            if (mouseEvent === undefined || targetOffset === undefined) {
+                return undefined;
+            }
             return MENU;
         }
 

--- a/packages/popover2/test/contextMenu2Tests.tsx
+++ b/packages/popover2/test/contextMenu2Tests.tsx
@@ -193,6 +193,8 @@ describe("ContextMenu2", () => {
     });
 
     describe("advanced usage (content render function API)", () => {
+        const ALT_CONTENT_WRAPPER = "alternative-content-wrapper";
+
         it("renders children and menu content, prevents default context menu handler", done => {
             const onContextMenu = (e: React.MouseEvent) => {
                 assert.isTrue(e.defaultPrevented);
@@ -216,11 +218,35 @@ describe("ContextMenu2", () => {
             openCtxMenu(ctxMenu);
         });
 
+        it("updates menu if content prop value changes", () => {
+            const ctxMenu = mountTestMenu();
+            openCtxMenu(ctxMenu);
+            assert.isTrue(ctxMenu.find(`.${MENU_CLASSNAME}`).exists());
+            assert.isFalse(ctxMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+            ctxMenu.setProps({ content: renderAlternativeContent });
+            assert.isTrue(ctxMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+        });
+
+        it("updates menu if content render function return value changes", () => {
+            const testMenu = mount(<TestMenuWithChangingContent useAltContent={false} />, {
+                attachTo: containerElement,
+            });
+            openCtxMenu(testMenu);
+            assert.isTrue(testMenu.find(`.${MENU_CLASSNAME}`).exists());
+            assert.isFalse(testMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+            testMenu.setProps({ useAltContent: true });
+            assert.isTrue(testMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+        });
+
         function renderContent({ mouseEvent, targetOffset }: ContextMenu2ContentProps) {
             if (mouseEvent === undefined || targetOffset === undefined) {
                 return undefined;
             }
             return MENU;
+        }
+
+        function renderAlternativeContent() {
+            return <div className={ALT_CONTENT_WRAPPER}>{MENU}</div>;
         }
 
         function mountTestMenu(props?: Partial<ContextMenu2Props>) {
@@ -229,6 +255,19 @@ describe("ContextMenu2", () => {
                     <div className={TARGET_CLASSNAME} />
                 </ContextMenu2>,
                 { attachTo: containerElement },
+            );
+        }
+
+        function TestMenuWithChangingContent({ useAltContent } = { useAltContent: false }) {
+            const content = React.useCallback(
+                (contentProps: ContextMenu2ContentProps) =>
+                    useAltContent ? renderAlternativeContent() : renderContent(contentProps),
+                [useAltContent],
+            );
+            return (
+                <ContextMenu2 content={content} popoverProps={{ transitionDuration: 0 }}>
+                    <div className={TARGET_CLASSNAME} />
+                </ContextMenu2>
             );
         }
     });


### PR DESCRIPTION

#### Fixes #6225

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix implementation of ContextMenu2's "contextmenu" event handler to behave correctly when `content` is specified as a render prop.

Previously, the event handler was referencing outdated state for the menu content and incorrectly assuming that the user returned an `undefined` menu (a typical usage pattern in user code when `contentProps.mouseEvent === undefined`).

Now, we make sure to run the `props.content()` render function again in the event handler to make sure we have the latest rendered menu content.

#### Reviewers should focus on:

No regressions in ContextMenu2; completeness of unit tests.

#### Screenshot

![2023-06-20 11 44 21](https://github.com/palantir/blueprint/assets/723999/45c66f5c-dc6c-44ea-bee5-123adb551319)

