### PR TITLE
[v5] [popover2] fix(Popover2): restore basic support for some legacy class names

### DIFF
--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -34,6 +34,7 @@
     },
     "dependencies": {
         "@blueprintjs/core": "^5.0.0-beta.1",
+        "classnames": "^2.3.1",
         "tslib": "~2.5.0"
     },
     "peerDependencies": {

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -16,7 +16,7 @@
 
 import { Classes as CoreClasses } from "@blueprintjs/core";
 
-/** @deprecated import from @blueprintjs/core instead */
+/** @deprecated use { Classes } from @blueprintjs/core instead */
 export const Classes = {
     CONTEXT_MENU2: CoreClasses.CONTEXT_MENU,
     CONTEXT_MENU2_BACKDROP: CoreClasses.CONTEXT_MENU_BACKDROP,

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -51,8 +51,6 @@ export {
     /** @deprecated import from @blueprintjs/core instead */
     Placement,
     /** @deprecated import from @blueprintjs/core instead */
-    Popover as Popover2,
-    /** @deprecated import from @blueprintjs/core instead */
     PopoverClickTargetHandlers as Popover2ClickTargetHandlers,
     /** @deprecated import from @blueprintjs/core instead */
     PopoverHoverTargetHandlers as Popover2HoverTargetHandlers,
@@ -94,3 +92,4 @@ export {
 } from "@blueprintjs/core";
 
 export { Classes } from "./classes";
+export { Popover2 } from "./popover2";

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+
+import { Classes, DefaultPopoverTargetHTMLProps, Popover, PopoverProps } from "@blueprintjs/core";
+
+// Legacy classes from @blueprintjs/popover2 v1.x. Note that these are distinct from the `Classes` aliases in
+// "./classes.ts" - those strings will continue to work with Popover in Blueprint v5.x, while these values are
+// completely deprecated.
+const NS = Classes.getClassNamespace();
+const POPOVER2 = `${NS}-popover2`;
+const POPOVER2_TARGET = `${NS}-popover2-target`;
+
+/** @deprecated use { Popover } from @blueprintjs/core instead */
+export class Popover2<
+    T extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps,
+> extends React.PureComponent<PopoverProps<T>> {
+    public render() {
+        const { className, popoverClassName, ...props } = this.props;
+        // Inject two classes commonly referenced in CSS selectors in user code which was compatible with
+        // @blueprintjs/popover2 v1.x. Users should ideally migrate to the "-popover-" classes instead, but we want
+        // to allow some of their custom styles to continue working when upgrading from Blueprint v4 -> v5.
+        return (
+            <Popover
+                className={classNames(POPOVER2_TARGET, className)}
+                popoverClassName={classNames(POPOVER2, popoverClassName)}
+                {...props}
+            />
+        );
+    }
+}


### PR DESCRIPTION
#### Changes proposed in this pull request:

Fix a subtle bug in `{ Popover2 } from "@blueprintjs/popover2"`.

Previously, this export was a simple alias for `{ Popover } from "@blueprintjs/core"`. When upgrading code bases to Blueprint v5, I found a some custom styles which reference CSS selectors such as:

```scss
#{bp.$ns}-popover2-target { ... }
#{bp.$ns}-popover2 { ... }
#{bp.$ns}-popover2-content { ... }
#{bp.$ns}-popover2-open { ... }
#{bp.$ns}-popover2-arrow-fill { ... }
```

`<Popover>` no longer renders those class names, which constitutes a break in the CSS API. We expect some breaks, but it's also possible to mitigate them by restoring some of the popover2 classes in `<Popover2>`. We can't reasonably add back all of them, but we can cover the most used one: the target element class.

```ts
<Popover2 />
// will now render:
<Popover className="bp5-popover-target" popoverClassName="bp5-popover" />
```
