### PR TITLE
fix(menuDivider): no tabIndex on role="separator"

### DIFF
--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -45,10 +45,14 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
 
     public render() {
         const { className, title, titleId } = this.props;
+        const hasTitle = title !== null;
 
         return (
-            <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
-                {title !== null && <H6 id={titleId}>{title}</H6>}
+            <li
+                className={classNames(hasTitle ? Classes.MENU_HEADER : Classes.MENU_DIVIDER, className)}
+                role="separator"
+            >
+                {hasTitle && <H6 id={titleId}>{title}</H6>}
             </li>
         );
     }

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -45,14 +45,10 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
 
     public render() {
         const { className, title, titleId } = this.props;
-        const hasTitle = title !== null;
 
         return (
-            <li
-                className={classNames(hasTitle ? Classes.MENU_HEADER : Classes.MENU_DIVIDER, className)}
-                role="separator"
-            >
-                {hasTitle && <H6 id={titleId}>{title}</H6>}
+            <li className={classNames(title ? Classes.MENU_HEADER : Classes.MENU_DIVIDER, className)} role="separator">
+                {title && <H6 id={titleId}>{title}</H6>}
             </li>
         );
     }

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -45,16 +45,11 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
 
     public render() {
         const { className, title, titleId } = this.props;
-        if (title == null) {
-            // simple divider
-            return <li className={classNames(Classes.MENU_DIVIDER, className)} role="separator" />;
-        } else {
-            // section header with title
-            return (
-                <li className={classNames(Classes.MENU_HEADER, className)} role="separator" tabIndex={-1}>
-                    <H6 id={titleId}>{title}</H6>
-                </li>
-            );
-        }
+
+        return (
+            <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
+                {title !== null && <H6 id={titleId}>{title}</H6>}
+            </li>
+        );
     }
 }


### PR DESCRIPTION
#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

#### Changes proposed in this pull request:

We must remove `tabIndex={-1}`, is causing aXe a11y testing failure. Read discussion here:
https://github.com/dequelabs/axe-core/issues/4062
