### PR TITLE
fix(Spinner)(a11y): add default aria-label prop

### DIFF
--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -110,6 +110,7 @@ export class Spinner extends AbstractPureComponent2<SpinnerProps> {
         return React.createElement(
             tagName,
             {
+                "aria-label": "loading",
                 "aria-valuemax": 100,
                 "aria-valuemin": 0,
                 "aria-valuenow": value === undefined ? undefined : value * 100,


### PR DESCRIPTION
#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation


#### Changes proposed in this pull request:

Add default `aria-label` prop to the `Spinner` component to solve `aria-progressbar-name` failure. Can still be overridden with custom value if desired.
