### PR TITLE
[v5] [core] feat: use CaretRight component in TreeNode

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -24,7 +24,7 @@ import { Classes, DISPLAYNAME_PREFIX, IntentProps, MaybeElement, Props, removeNo
 // re-export for convenience, since some users won't be importing from or have a direct dependency on the icons package
 export { IconName, IconSize };
 
-export type IconHTMLAttributes = Omit<React.HTMLAttributes<HTMLElement>, "children" | "title">;
+export type IconHTMLAttributes = Omit<React.HTMLAttributes<HTMLElement | SVGSVGElement>, "children" | "title">;
 
 export interface IconProps extends IntentProps, Props, SVGIconProps, IconHTMLAttributes {
     /**

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -17,6 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import { ChevronRight } from "@blueprintjs/icons";
+
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Collapse } from "../collapse/collapse";
 import { Icon } from "../icon/icon";
@@ -100,13 +102,11 @@ export class TreeNode<T = {}> extends React.Component<TreeNodeProps<T>> {
                 Classes.TREE_NODE_CARET,
                 isExpanded ? Classes.TREE_NODE_CARET_OPEN : Classes.TREE_NODE_CARET_CLOSED,
             );
-            const onClick = disabled === true ? undefined : this.handleCaretClick;
             return (
-                <Icon
+                <ChevronRight
                     title={isExpanded ? "Collapse group" : "Expand group"}
                     className={caretClasses}
-                    onClick={onClick}
-                    icon={"chevron-right"}
+                    onClick={disabled === true ? undefined : this.handleCaretClick}
                 />
             );
         }

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -19,7 +19,9 @@ import * as React from "react";
  * Interface used for generated icon components which already have their name and path defined
  * (through the rendered Handlebars template).
  */
-export interface SVGIconProps extends React.RefAttributes<any> {
+export interface SVGIconProps
+    extends React.RefAttributes<any>,
+        Omit<React.DOMAttributes<HTMLElement | SVGSVGElement>, "children" | "dangerouslySetInnerHTML"> {
     /** A space-delimited list of class names to pass along to the SVG element. */
     className?: string;
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- feat(`TreeNode`): use `<ChevronRight>` icon component instead of `<Icon>` to remove dependency on icon loader
- feat(`SVGIconProps`): support more DOM attributes in props interface, which allows users to attach arbitrary event handlers to generated icon components
  - for example, `<ChevronRight onClick={...} />`

#### Reviewers should focus on:

No regressions in tree component appearance & behavior

#### Screenshot

![2023-06-22 16 12 17](https://github.com/palantir/blueprint/assets/723999/2d6a6e21-0bf1-47eb-8e0e-d9658bce7967)

