### PR TITLE
fix(html-select): icon position

### DIFF
--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -99,6 +99,7 @@ Styleguide select
 .#{$ns}-html-select {
   .#{$ns}-icon {
     @extend %pt-select-arrow;
+    margin-right: 2px;
   }
 }
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6184

#### Checklist

- N/A Includes tests
- N/A Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adds a margin in html-select icon to match the icon spacing of the button. I also noticed a shadow in the button icon, should we match it as well?

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot
![blueprint 1](https://github.com/palantir/blueprint/assets/27746333/6b9ae962-f279-4677-a649-5b8a60a911fe)

