### PR TITLE
fix: improve JSDoc deprecation message formatting

### DIFF
--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -17,27 +17,27 @@
 /* eslint-disable deprecation/deprecation */
 
 export {
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     Classes,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateFormatProps,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateInput as DateInput2,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateInputProps as DateInput2Props,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateRange,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateRangeInput as DateRangeInput2,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateRangeInputProps as DateRangeInput2Props,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     getTimezoneMetadata,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneSelect,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneSelectProps,
-    /** @deprecated import from @blueprintjs/datetime instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneDisplayFormat,
 } from "@blueprintjs/datetime";
 

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -16,7 +16,7 @@
 
 import { Classes as CoreClasses } from "@blueprintjs/core";
 
-/** @deprecated use `{ Classes } from @blueprintjs/core` instead */
+/** @deprecated use `{ Classes } from "@blueprintjs/core"` instead */
 export const Classes = {
     CONTEXT_MENU2: CoreClasses.CONTEXT_MENU,
     CONTEXT_MENU2_BACKDROP: CoreClasses.CONTEXT_MENU_BACKDROP,

--- a/packages/popover2/src/classes.ts
+++ b/packages/popover2/src/classes.ts
@@ -16,7 +16,7 @@
 
 import { Classes as CoreClasses } from "@blueprintjs/core";
 
-/** @deprecated use { Classes } from @blueprintjs/core instead */
+/** @deprecated use `{ Classes } from @blueprintjs/core` instead */
 export const Classes = {
     CONTEXT_MENU2: CoreClasses.CONTEXT_MENU,
     CONTEXT_MENU2_BACKDROP: CoreClasses.CONTEXT_MENU_BACKDROP,

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -17,75 +17,75 @@
 /* eslint-disable deprecation/deprecation */
 
 export {
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     BreadcrumbProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     Breadcrumbs as Breadcrumbs2,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     BreadcrumbsProps as Breadcrumbs2Props,
 
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ContextMenu as ContextMenu2,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ContextMenuChildrenProps as ContextMenu2ChildrenProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ContextMenuContentProps as ContextMenu2ContentProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ContextMenuPopover as ContextMenu2Popover,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ContextMenuPopoverProps as ContextMenu2PopoverProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ContextMenuProps as ContextMenu2Props,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     hideContextMenu,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     showContextMenu,
 
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     MenuItem as MenuItem2,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     MenuItemProps as MenuItem2Props,
 
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     DefaultPopoverTargetHTMLProps as DefaultPopover2TargetHTMLProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     Placement,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopoverClickTargetHandlers as Popover2ClickTargetHandlers,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopoverHoverTargetHandlers as Popover2HoverTargetHandlers,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopoverInteractionKind as Popover2InteractionKind,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopoverSharedProps as Popover2SharedProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopoverTargetProps as Popover2TargetProps,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopperBoundary,
     /**
      * N.B. this misspelling was present in @blueprintjs/popover2 v4, we'll keep it around for now since it will
      * be getting migrated to the correct spelling in @blueprintjs/core v5 anyway.
      *
-     * @deprecated import from @blueprintjs/core instead (with corrected spelling)
+     * @deprecated import from `@blueprintjs/core` instead (with corrected spelling)
      */
     PopperCustomModifier as PopperCustomModifer,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopperModifierOverrides,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopperPlacements as PlacementOptions,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     PopupKind,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     StrictModifierNames,
 
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ResizeSensor as ResizeSensor2,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     ResizeSensorProps as ResizeSensor2Props,
 
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     Tooltip as Tooltip2,
-    /** @deprecated import from @blueprintjs/core instead */
+    /** @deprecated import from `@blueprintjs/core` instead */
     TooltipProps as Tooltip2Props,
 } from "@blueprintjs/core";
 

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";
@@ -28,13 +28,13 @@ const NS = Classes.getClassNamespace();
 const POPOVER2 = `${NS}-popover2`;
 const POPOVER2_TARGET = `${NS}-popover2-target`;
 
-/** @deprecated use { PopoverProps } from @blueprintjs/core instead */
+/** @deprecated use `{ PopoverProps } from "@blueprintjs/core"` instead */
 export interface Popover2Props<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
     extends PopoverProps<TProps> {
     ref?: React.Ref<Popover2<TProps>>;
 }
 
-/** @deprecated use { Popover } from @blueprintjs/core instead */
+/** @deprecated use `{ Popover } from "blueprintjs/core"` instead */
 export class Popover2<
     T extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps,
 > extends React.PureComponent<Popover2Props<T>> {


### PR DESCRIPTION

#### Changes proposed in this pull request:

Fix formatting of JSDoc deprecation messages which include NPM package names.


#### Reviewers should focus on:

N/A

#### Screenshot


Before:

![image](https://github.com/palantir/blueprint/assets/723999/8b3315d8-446a-41ba-b0fb-bf8a11f70c1f)

After:

![image](https://github.com/palantir/blueprint/assets/723999/273df492-8b0c-4f95-9c4f-c1915cdb2125)
