### PR TITLE
[core] fix(Icon): restore predecence of iconSize prop

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -89,8 +89,10 @@ export const Icon: React.FC<IconProps> = React.forwardRef<any, IconProps>((props
         ...htmlProps
     } = props;
     const [iconPaths, setIconPaths] = React.useState<IconPaths>();
+
+    // Preserve Blueprint v4.x behavior: iconSize prop takes predecence, then size prop, then fall back to default value
     // eslint-disable-next-line deprecation/deprecation
-    const size = (props.size ?? props.iconSize)!;
+    const size = props.iconSize ?? props.size ?? IconSize.STANDARD;
 
     React.useEffect(() => {
         let shouldCancelIconLoading = false;
@@ -170,7 +172,6 @@ export const Icon: React.FC<IconProps> = React.forwardRef<any, IconProps>((props
 });
 Icon.defaultProps = {
     autoLoad: true,
-    size: IconSize.STANDARD,
     tagName: "span",
 };
 Icon.displayName = `${DISPLAYNAME_PREFIX}.Icon`;


### PR DESCRIPTION

#### Changes proposed in this pull request:

Fix a regression in v5.0.0 where the `iconSize` prop stopped taking precedence over the `size` prop.

You can see it was implemented this way in v4.x: https://github.com/palantir/blueprint/blob/42fd01177f9feac4d6dd69cab056cf793f695de2/packages/core/src/components/icon/icon.tsx#L131-L133

#### Reviewers should focus on:

Implementation matches v4.x

