### PR TITLE
[core] feat(Portal): Add `portalContainer` context option

### DIFF
--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -7,8 +7,11 @@ need to use a Portal directly; this documentation is provided simply for referen
 
 @## DOM Behavior
 
-__Portal__ component functions like a declarative `appendChild()`, or jQuery's
-`$.fn.appendTo()`. The children of a __Portal__ are inserted into a new child of the document `<body>`.
+__Portal__ component functions like a declarative `appendChild()`. The children of a __Portal__ are inserted into a *new child* of the target element. This target element is determined in the following order:
+1. The `container` prop, if specified
+2. The `portalContainer` from the closest [PortalProvider](#core/context/portal-provider), if specified
+3. Otherwise `document.body`
+
 
 __Portal__ is used inside [Overlay](#core/components/overlay) to actually overlay the content on the
 application.
@@ -28,10 +31,10 @@ apply `position: absolute` to the `<body>` tag.
 
 @## React context options
 
-__Portal__ supports some customization through [React context](https://reactjs.org/docs/context.html).
+__Portal__ supports some customization through [React context](https://react.dev/learn/passing-data-deeply-with-context).
 Using this API can be helpful if you need to apply some custom styling or logic to _all_ Blueprint
 components which use portals (popovers, tooltips, dialogs, etc.). You can do so by rendering a
-[PortalProvider](#core/context/portal/portal-provider) in your React tree
+[PortalProvider](#core/context/portal-provider) in your React tree
 (usually, this should be done near the root of your application).
 
 ```tsx

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -80,8 +80,8 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
 
     const container =  props.container ?? context.portalContainer ?? document?.body
 
-    const [hasMounted, setHasMounted] = React.useState(false);
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
+    const hasMounted = portalElement != null
 
     const createContainerElement = React.useCallback(() => {
         const newContainer = document.createElement("div");
@@ -108,12 +108,10 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
         const newPortalElement = createContainerElement();
         container.appendChild(newPortalElement);
         setPortalElement(newPortalElement);
-        setHasMounted(true);
 
         return () => {
             removeStopPropagationListeners(newPortalElement, props.stopPropagationEvents);
             newPortalElement.remove();
-            setHasMounted(false);
             setPortalElement(undefined);
         };
     }, [container, createContainerElement]);

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -35,7 +35,7 @@ export interface PortalProps extends Props {
     /**
      * The HTML element that children will be mounted to.
      *
-     * @default document.body
+     * @default PortalContext.portalContainer ?? document.body
      */
     container?: HTMLElement;
 
@@ -78,7 +78,7 @@ const PORTAL_LEGACY_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
 export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = {}) {
     const context = React.useContext(PortalContext);
 
-    const container =  props.container ?? context.portalContainer ?? document?.body
+    const portalContainer =  props.container ?? context.portalContainer ?? document?.body
 
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
 
@@ -101,11 +101,11 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
 
     // create the container element & attach it to the DOM
     React.useEffect(() => {
-        if (container == null) {
+        if (portalContainer == null) {
             return;
         }
         const newPortalElement = createPortalElement();
-        container.appendChild(newPortalElement);
+        portalContainer.appendChild(newPortalElement);
         setPortalElement(newPortalElement);
 
         return () => {
@@ -113,7 +113,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             newPortalElement.remove();
             setPortalElement(undefined);
         };
-    }, [container, createPortalElement]);
+    }, [portalContainer, createPortalElement]);
 
     // wait until next successful render to invoke onChildrenMount callback
     React.useEffect(() => {

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -77,7 +77,7 @@ const PORTAL_LEGACY_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
 export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = {}) {
     const context = React.useContext(PortalContext);
 
-    const portalContainer =  props.container ?? context.portalContainer ?? document?.body
+    const portalContainer = props.container ?? context.portalContainer ?? document?.body;
 
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
 
@@ -126,7 +126,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             maybeAddClass(portalElement.classList, props.className);
             return () => maybeRemoveClass(portalElement.classList, props.className);
         }
-        return undefined
+        return undefined;
     }, [props.className]);
 
     React.useEffect(() => {
@@ -134,7 +134,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             addStopPropagationListeners(portalElement, props.stopPropagationEvents);
             return () => removeStopPropagationListeners(portalElement, props.stopPropagationEvents);
         }
-        return undefined
+        return undefined;
     }, [props.stopPropagationEvents]);
 
     // Only render `children` once this component has mounted in a browser environment, so they are

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -82,21 +82,21 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
 
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
 
-    const createContainerElement = React.useCallback(() => {
-        const newContainer = document.createElement("div");
-        newContainer.classList.add(Classes.PORTAL);
-        maybeAddClass(newContainer.classList, props.className); // directly added to this portal element
-        maybeAddClass(newContainer.classList, context.portalClassName); // added via PortalProvider context
-        addStopPropagationListeners(newContainer, props.stopPropagationEvents);
+    const createPortalElement = React.useCallback(() => {
+        const portalElement = document.createElement("div");
+        portalElement.classList.add(Classes.PORTAL);
+        maybeAddClass(portalElement.classList, props.className); // directly added to this portal element
+        maybeAddClass(portalElement.classList, context.portalClassName); // added via PortalProvider context
+        addStopPropagationListeners(portalElement, props.stopPropagationEvents);
 
         // TODO: remove legacy context support in Blueprint v6.0
         const { blueprintPortalClassName } = legacyContext;
         if (blueprintPortalClassName != null && blueprintPortalClassName !== "") {
             console.error(Errors.PORTAL_LEGACY_CONTEXT_API);
-            maybeAddClass(newContainer.classList, blueprintPortalClassName); // added via legacy context
+            maybeAddClass(portalElement.classList, blueprintPortalClassName); // added via legacy context
         }
 
-        return newContainer;
+        return portalElement;
     }, [props.className, context.portalClassName]);
 
     // create the container element & attach it to the DOM
@@ -104,7 +104,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
         if (container == null) {
             return;
         }
-        const newPortalElement = createContainerElement();
+        const newPortalElement = createPortalElement();
         container.appendChild(newPortalElement);
         setPortalElement(newPortalElement);
 
@@ -113,7 +113,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             newPortalElement.remove();
             setPortalElement(undefined);
         };
-    }, [container, createContainerElement]);
+    }, [container, createPortalElement]);
 
     // wait until next successful render to invoke onChildrenMount callback
     React.useEffect(() => {

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -92,14 +92,14 @@ export function Portal(
         addStopPropagationListeners(newPortalElement, stopPropagationEvents);
 
         // TODO: remove legacy context support in Blueprint v6.0
-        const { blueprintPortalClassName } = legacyContext;
+        const blueprintPortalClassName = legacyContext.blueprintPortalClassName;
         if (blueprintPortalClassName != null && blueprintPortalClassName !== "") {
             console.error(Errors.PORTAL_LEGACY_CONTEXT_API);
             maybeAddClass(newPortalElement.classList, blueprintPortalClassName); // added via legacy context
         }
 
         return newPortalElement;
-    }, [className, context.portalClassName, stopPropagationEvents, legacyContext]);
+    }, [className, context.portalClassName, legacyContext.blueprintPortalClassName, stopPropagationEvents]);
 
     // create the container element & attach it to the DOM
     React.useEffect(() => {

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -82,21 +82,21 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
 
     const createPortalElement = React.useCallback(() => {
-        const portalElement = document.createElement("div");
-        portalElement.classList.add(Classes.PORTAL);
-        maybeAddClass(portalElement.classList, props.className); // directly added to this portal element
-        maybeAddClass(portalElement.classList, context.portalClassName); // added via PortalProvider context
-        addStopPropagationListeners(portalElement, props.stopPropagationEvents);
+        const newPortalElement = document.createElement("div");
+        newPortalElement.classList.add(Classes.PORTAL);
+        maybeAddClass(newPortalElement.classList, props.className); // directly added to this portal element
+        maybeAddClass(newPortalElement.classList, context.portalClassName); // added via PortalProvider context
+        addStopPropagationListeners(newPortalElement, props.stopPropagationEvents);
 
         // TODO: remove legacy context support in Blueprint v6.0
         const { blueprintPortalClassName } = legacyContext;
         if (blueprintPortalClassName != null && blueprintPortalClassName !== "") {
             console.error(Errors.PORTAL_LEGACY_CONTEXT_API);
-            maybeAddClass(portalElement.classList, blueprintPortalClassName); // added via legacy context
+            maybeAddClass(newPortalElement.classList, blueprintPortalClassName); // added via legacy context
         }
 
-        return portalElement;
-    }, [props.className, context.portalClassName]);
+        return newPortalElement;
+    }, [props.className, props.stopPropagationEvents, context.portalClassName, legacyContext]);
 
     // create the container element & attach it to the DOM
     React.useEffect(() => {
@@ -112,14 +112,14 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             newPortalElement.remove();
             setPortalElement(undefined);
         };
-    }, [portalContainer, createPortalElement]);
+    }, [portalContainer, createPortalElement, props.stopPropagationEvents]);
 
     // wait until next successful render to invoke onChildrenMount callback
     React.useEffect(() => {
         if (portalElement != null) {
             props.onChildrenMount?.();
         }
-    }, [props.onChildrenMount]);
+    }, [portalElement, props, props.onChildrenMount]);
 
     React.useEffect(() => {
         if (portalElement != null) {
@@ -127,7 +127,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             return () => maybeRemoveClass(portalElement.classList, props.className);
         }
         return undefined;
-    }, [props.className]);
+    }, [portalElement, props.className]);
 
     React.useEffect(() => {
         if (portalElement != null) {
@@ -135,7 +135,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             return () => removeStopPropagationListeners(portalElement, props.stopPropagationEvents);
         }
         return undefined;
-    }, [props.stopPropagationEvents]);
+    }, [portalElement, props.stopPropagationEvents]);
 
     // Only render `children` once this component has mounted in a browser environment, so they are
     // immediately attached to the DOM tree and can do DOM things like measuring or `autoFocus`.

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -81,7 +81,6 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
     const container =  props.container ?? context.portalContainer ?? document?.body
 
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
-    const hasMounted = portalElement != null
 
     const createContainerElement = React.useCallback(() => {
         const newContainer = document.createElement("div");
@@ -118,10 +117,10 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
 
     // wait until next successful render to invoke onChildrenMount callback
     React.useEffect(() => {
-        if (hasMounted) {
+        if (portalElement != null) {
             props.onChildrenMount?.();
         }
-    }, [hasMounted, props.onChildrenMount]);
+    }, [props.onChildrenMount]);
 
     React.useEffect(() => {
         if (portalElement != null) {
@@ -140,7 +139,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
     // Only render `children` once this component has mounted in a browser environment, so they are
     // immediately attached to the DOM tree and can do DOM things like measuring or `autoFocus`.
     // See long comment on componentDidMount in https://reactjs.org/docs/portals.html#event-bubbling-through-portals
-    if (typeof document === "undefined" || !hasMounted || portalElement == null) {
+    if (typeof document === "undefined" || portalElement == null) {
         return null;
     } else {
         return ReactDOM.createPortal(props.children, portalElement);

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -34,7 +34,7 @@ export interface PortalProps extends Props {
     /**
      * The HTML element that children will be mounted to.
      *
-     * @default PortalContext.portalContainer ?? document.body
+     * @default PortalProvider#portalContainer ?? document.body
      */
     container?: HTMLElement;
 

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -21,7 +21,6 @@ import { Classes, DISPLAYNAME_PREFIX, Props } from "../../common";
 import { ValidationMap } from "../../common/context";
 import * as Errors from "../../common/errors";
 import { PortalContext } from "../../context/portal/portalProvider";
-import { usePrevious } from "../../hooks/usePrevious";
 
 export interface PortalProps extends Props {
     /** Contents to send through the portal. */
@@ -127,6 +126,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             maybeAddClass(portalElement.classList, props.className);
             return () => maybeRemoveClass(portalElement.classList, props.className);
         }
+        return undefined
     }, [props.className]);
 
     React.useEffect(() => {
@@ -134,6 +134,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
             addStopPropagationListeners(portalElement, props.stopPropagationEvents);
             return () => removeStopPropagationListeners(portalElement, props.stopPropagationEvents);
         }
+        return undefined
     }, [props.stopPropagationEvents]);
 
     // Only render `children` once this component has mounted in a browser environment, so they are

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -74,19 +74,22 @@ const PORTAL_LEGACY_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
  *
  * @see https://blueprintjs.com/docs/#core/components/portal
  */
-export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = {}) {
+export function Portal(
+    { className, stopPropagationEvents, container, onChildrenMount, children }: PortalProps,
+    legacyContext: PortalLegacyContext = {},
+) {
     const context = React.useContext(PortalContext);
 
-    const portalContainer = props.container ?? context.portalContainer ?? document?.body;
+    const portalContainer = container ?? context.portalContainer ?? document?.body;
 
     const [portalElement, setPortalElement] = React.useState<HTMLElement>();
 
     const createPortalElement = React.useCallback(() => {
         const newPortalElement = document.createElement("div");
         newPortalElement.classList.add(Classes.PORTAL);
-        maybeAddClass(newPortalElement.classList, props.className); // directly added to this portal element
+        maybeAddClass(newPortalElement.classList, className); // directly added to this portal element
         maybeAddClass(newPortalElement.classList, context.portalClassName); // added via PortalProvider context
-        addStopPropagationListeners(newPortalElement, props.stopPropagationEvents);
+        addStopPropagationListeners(newPortalElement, stopPropagationEvents);
 
         // TODO: remove legacy context support in Blueprint v6.0
         const { blueprintPortalClassName } = legacyContext;
@@ -96,7 +99,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
         }
 
         return newPortalElement;
-    }, [props.className, props.stopPropagationEvents, context.portalClassName, legacyContext]);
+    }, [className, context.portalClassName, stopPropagationEvents, legacyContext]);
 
     // create the container element & attach it to the DOM
     React.useEffect(() => {
@@ -108,34 +111,34 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
         setPortalElement(newPortalElement);
 
         return () => {
-            removeStopPropagationListeners(newPortalElement, props.stopPropagationEvents);
+            removeStopPropagationListeners(newPortalElement, stopPropagationEvents);
             newPortalElement.remove();
             setPortalElement(undefined);
         };
-    }, [portalContainer, createPortalElement, props.stopPropagationEvents]);
+    }, [portalContainer, createPortalElement, stopPropagationEvents]);
 
     // wait until next successful render to invoke onChildrenMount callback
     React.useEffect(() => {
         if (portalElement != null) {
-            props.onChildrenMount?.();
+            onChildrenMount?.();
         }
-    }, [portalElement, props, props.onChildrenMount]);
+    }, [portalElement, onChildrenMount]);
 
     React.useEffect(() => {
         if (portalElement != null) {
-            maybeAddClass(portalElement.classList, props.className);
-            return () => maybeRemoveClass(portalElement.classList, props.className);
+            maybeAddClass(portalElement.classList, className);
+            return () => maybeRemoveClass(portalElement.classList, className);
         }
         return undefined;
-    }, [portalElement, props.className]);
+    }, [className, portalElement]);
 
     React.useEffect(() => {
         if (portalElement != null) {
-            addStopPropagationListeners(portalElement, props.stopPropagationEvents);
-            return () => removeStopPropagationListeners(portalElement, props.stopPropagationEvents);
+            addStopPropagationListeners(portalElement, stopPropagationEvents);
+            return () => removeStopPropagationListeners(portalElement, stopPropagationEvents);
         }
         return undefined;
-    }, [portalElement, props.stopPropagationEvents]);
+    }, [portalElement, stopPropagationEvents]);
 
     // Only render `children` once this component has mounted in a browser environment, so they are
     // immediately attached to the DOM tree and can do DOM things like measuring or `autoFocus`.
@@ -143,7 +146,7 @@ export function Portal(props: PortalProps, legacyContext: PortalLegacyContext = 
     if (typeof document === "undefined" || portalElement == null) {
         return null;
     } else {
-        return ReactDOM.createPortal(props.children, portalElement);
+        return ReactDOM.createPortal(children, portalElement);
     }
 }
 

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -19,6 +19,8 @@ import * as React from "react";
 export interface PortalContextOptions {
     /** Additional CSS classes to add to all `Portal` elements in this React context. */
     portalClassName?: string;
+    /** Portal container element which the default parent for all `Portal` elements in this React context */
+    portalContainer?: HTMLElement;
 }
 
 /**
@@ -32,6 +34,10 @@ export const PortalContext = React.createContext<PortalContextOptions>({});
  *
  * @see https://blueprintjs.com/docs/#core/context/portal-provider
  */
-export const PortalProvider = ({ children, ...options }: React.PropsWithChildren<PortalContextOptions>) => {
-    return <PortalContext.Provider value={options}>{children}</PortalContext.Provider>;
+export const PortalProvider = ({ children, portalClassName, portalContainer }: React.PropsWithChildren<PortalContextOptions>) => {
+    const contextOptions = React.useMemo<PortalContextOptions>(() => ({
+        portalClassName,
+        portalContainer
+    }), [portalClassName, portalContainer])
+    return <PortalContext.Provider value={contextOptions}>{children}</PortalContext.Provider>;
 };

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 export interface PortalContextOptions {
     /** Additional CSS classes to add to all `Portal` elements in this React context. */
     portalClassName?: string;
-    /** The HTML element that all `Portal` elements in this React context will be mounted to.  */
+    /** The HTML element that all `Portal` elements in this React context will be added as children to  */
     portalContainer?: HTMLElement;
 }
 

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 export interface PortalContextOptions {
     /** Additional CSS classes to add to all `Portal` elements in this React context. */
     portalClassName?: string;
-    /** Portal container element which the default parent for all `Portal` elements in this React context */
+    /** The HTML element that all `Portal` elements in this React context will be mounted to.  */
     portalContainer?: HTMLElement;
 }
 

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -34,10 +34,17 @@ export const PortalContext = React.createContext<PortalContextOptions>({});
  *
  * @see https://blueprintjs.com/docs/#core/context/portal-provider
  */
-export const PortalProvider = ({ children, portalClassName, portalContainer }: React.PropsWithChildren<PortalContextOptions>) => {
-    const contextOptions = React.useMemo<PortalContextOptions>(() => ({
-        portalClassName,
-        portalContainer
-    }), [portalClassName, portalContainer])
+export const PortalProvider = ({
+    children,
+    portalClassName,
+    portalContainer,
+}: React.PropsWithChildren<PortalContextOptions>) => {
+    const contextOptions = React.useMemo<PortalContextOptions>(
+        () => ({
+            portalClassName,
+            portalContainer,
+        }),
+        [portalClassName, portalContainer],
+    );
     return <PortalContext.Provider value={contextOptions}>{children}</PortalContext.Provider>;
 };


### PR DESCRIPTION
#### Fixes #6210

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This changes forces all (blueprint) children that who render below a given `PortalProvider` (like `<Dialog/>`, `<Popover2/>`) to have a common element where `React.createPortal` usages become direct children of. 

To be more precise here, `portalContainer` acts ONLY as a parent element of a new `div` and that new `div` becomes the target container in the `React.createPortal` syntax -- so `children` are rendered into that element. 

We also memoize the `PortalProvider` value to avoid thrashing on every re-render.

#### Reviewers should focus on:

- I changed the way that `addStopPropagationListeners`,  `removeStopPropagationListeners` (and `maybeAddClass`) work -- using `React.useEffect`'s cleanup function to avoid leaving, what I believe would have been, dangling listeners when the portal unmounted. 
- I removed the `hasMounted` state, since it was purely duplicative with `portalElement != null`
- I removed `Portal.defaultProps` and replaces it with an internal `?? document?.body` fallback.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
