### PR TITLE
[node-build-scripts] chore: use non-deprecated syntax to import 'sass'

### DIFF
--- a/packages/core/src/docs/classes.md
+++ b/packages/core/src/docs/classes.md
@@ -93,7 +93,7 @@ for a custom Sass compiler that can import Blueprint `.scss` sources:
 
 ```js
 import { sassNodeModulesLoadPaths, sassSvgInlinerFactory } from "@blueprintjs/node-build-scripts";
-import sass from "sass";
+import * as sass from "sass";
 
 const result = await sass.compileAsync("path/to/input.scss", {
     loadPaths: sassNodeModulesLoadPaths,
@@ -118,7 +118,7 @@ In addition to the JS API, you can specify this configuration with Webpack's sas
 // webpack.config.mjs
 
 import { sassNodeModulesLoadPaths, sassSvgInlinerFactory } from "@blueprintjs/node-build-scripts";
-import sass from "sass";
+import * as sass from "sass";
 
 const functions = {
     /**

--- a/packages/node-build-scripts/sass-compile.mjs
+++ b/packages/node-build-scripts/sass-compile.mjs
@@ -8,7 +8,7 @@ import { watch } from "chokidar";
 import fsExtra from "fs-extra";
 import { basename, extname, join, resolve } from "node:path";
 import { argv } from "node:process";
-import sass from "sass";
+import * as sass from "sass";
 import yargs from "yargs";
 
 import { sassCompileFile } from "./src/sass/sassCompileFile.mjs";

--- a/packages/node-build-scripts/src/sass/sassCompileFile.mjs
+++ b/packages/node-build-scripts/src/sass/sassCompileFile.mjs
@@ -6,7 +6,7 @@
 
 import fsExtra from "fs-extra";
 import { dirname, join, parse as parsePath, relative } from "node:path";
-import sass from "sass";
+import * as sass from "sass";
 import { SourceMapGenerator } from "source-map-js";
 
 import defaultCustomFunctions from "./sassCustomFunctions.mjs";

--- a/packages/node-build-scripts/src/sass/sassCustomFunctions.mjs
+++ b/packages/node-build-scripts/src/sass/sassCustomFunctions.mjs
@@ -4,7 +4,7 @@
 
 // @ts-check
 
-import sass from "sass";
+import * as sass from "sass";
 
 import { sassSvgInlinerFactory } from "./sassSvgInliner.mjs";
 

--- a/packages/node-build-scripts/src/sass/sassSvgInliner.mjs
+++ b/packages/node-build-scripts/src/sass/sassSvgInliner.mjs
@@ -15,7 +15,7 @@ import { parseDocument } from "htmlparser2";
 import svgToDataUri from "mini-svg-data-uri";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import sass from "sass";
+import * as sass from "sass";
 
 import { svgOptimizer } from "../svg/svgOptimizer.mjs";
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

Migrate `import sass from "sass"` imports to use the `import * as sass` syntax to avoid some deprecation warnings that are now being produced by the latest version of dart-sass.

#### Reviewers should focus on:

N/A - if it builds successfully, it's good to go :shipit: 

