### PR TITLE
[core] fix(Icon): avoid breaking rules against conditional React hooks

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -70,11 +70,6 @@ export interface IconProps extends IntentProps, Props, SVGIconProps, IconHTMLAtt
  */
 export const Icon: React.FC<IconProps> = React.forwardRef<any, IconProps>((props, ref) => {
     const { icon } = props;
-    if (icon == null || typeof icon === "boolean") {
-        return null;
-    } else if (typeof icon !== "string") {
-        return icon;
-    }
 
     const {
         autoLoad,
@@ -126,6 +121,12 @@ export const Icon: React.FC<IconProps> = React.forwardRef<any, IconProps>((props
             shouldCancelIconLoading = true;
         };
     }, [autoLoad, icon, size]);
+
+    if (icon == null || typeof icon === "boolean") {
+        return null;
+    } else if (typeof icon !== "string") {
+        return icon;
+    }
 
     if (iconPaths == null) {
         // fall back to icon font if unloaded or unable to load SVG implementation


### PR DESCRIPTION
#### Fixes #6267

#### Checklist

- [ ] ~~Includes tests~~
- [ ] ~~Update documentation~~

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix conditional hook in Icon component. As the useEffect hook checks for `typeof icon === "string", it won't run anyway in the other cases.

#### Reviewers should focus on:

It would be great to use a linter rule to check for conditional hooks, but I did not succeed to configure it. Maybe other components are affected as well.