### PR TITLE
[docs-app] fix: show 'latest' versions in sidebar

### DIFF
--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -37,6 +37,6 @@ const tagRenderers = {
 };
 
 ReactDOM.render(
-    <BlueprintDocs defaultPageId="blueprint" docs={docsData} tagRenderers={tagRenderers} useNextVersion={true} />,
+    <BlueprintDocs defaultPageId="blueprint" docs={docsData} tagRenderers={tagRenderers} useNextVersion={false} />,
     document.querySelector("#blueprint-documentation"),
 );


### PR DESCRIPTION
Now that v5 is stable, we should stop showing the `next` tag version numbers in the docs sidebar. We should use `latest` instead.