### PR TITLE
[core] fix(Section): apply collapsed style when empty children

### DIFF
--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -28,6 +28,7 @@ import {
     IntentProps,
     MaybeElement,
     Props,
+    Utils,
 } from "../../common";
 import { H5 } from "../html/html";
 import { Icon } from "../icon/icon";
@@ -85,7 +86,7 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
             <div className={classes} {...htmlProps}>
                 {iconElement}
                 {title && <H5>{title}</H5>}
-                {this.hasEmptyContent() ? undefined : <div className={Classes.CALLOUT_BODY}>{children}</div>}
+                {Utils.isReactNodeEmpty(children) ? undefined : <div className={Classes.CALLOUT_BODY}>{children}</div>}
             </div>
         );
     }
@@ -116,10 +117,5 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
             default:
                 return undefined;
         }
-    }
-
-    private hasEmptyContent() {
-        const { children } = this.props;
-        return children == null || (typeof children === "string" && children.trim().length === 0);
     }
 }

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -104,7 +104,8 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
             elevation={Elevation.ZERO}
             className={classNames(className, Classes.SECTION, {
                 [Classes.COMPACT]: compact,
-                [Classes.SECTION_COLLAPSED]: collapsible && isCollapsed,
+                [Classes.SECTION_COLLAPSED]:
+                    (collapsible && isCollapsed) || React.Children.toArray(children).length === 0,
             })}
             ref={ref}
             {...cardProps}

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { ChevronDown, ChevronUp, IconName } from "@blueprintjs/icons";
 
-import { Classes, Elevation } from "../../common";
+import { Classes, Elevation, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX, HTMLDivProps, MaybeElement, Props } from "../../common/props";
 import { Card } from "../card/card";
 import { Collapse, CollapseProps } from "../collapse/collapse";
@@ -119,8 +119,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
         <Card
             className={classNames(className, Classes.SECTION, {
                 [Classes.COMPACT]: compact,
-                [Classes.SECTION_COLLAPSED]:
-                    (collapsible && isCollapsed) || React.Children.toArray(children).length === 0,
+                [Classes.SECTION_COLLAPSED]: (collapsible && isCollapsed) || Utils.isReactNodeEmpty(children),
             })}
             elevation={elevation}
             ref={ref}


### PR DESCRIPTION
#### Checklist
 - [ ] Includes tests
 - [ ] Update documentation
 
#### Changes proposed in this pull request:

Apply `Classes.SECTION_COLLAPSED` on `<Section />` when children is empty. This will remove the border bottom of the section header which is unnecessary in this case.

#### Reviewers should focus on:

Section header do not have a double border anymore when children is empty. Should not have other effects.

#### Screenshot

|Before|After|
|--|--|
|![Screenshot 2023-07-17 at 16 18 50](https://github.com/palantir/blueprint/assets/6755553/29e1d20d-0b6e-48d3-a982-f8dd6b3ae0d1)|![Screenshot 2023-07-17 at 16 18 56](https://github.com/palantir/blueprint/assets/6755553/04295d79-73cf-4a34-9fa4-94147f0dd0ad)|
