### PR TITLE
[core] fix(IconProps): widen type of HTML attributes

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -24,7 +24,7 @@ import { Classes, DISPLAYNAME_PREFIX, IntentProps, MaybeElement, Props, removeNo
 // re-export for convenience, since some users won't be importing from or have a direct dependency on the icons package
 export { IconName, IconSize };
 
-export type IconHTMLAttributes = Omit<React.HTMLAttributes<HTMLElement | SVGSVGElement>, "children" | "title">;
+export type IconHTMLAttributes = Omit<React.HTMLAttributes<HTMLOrSVGElement>, "children" | "title">;
 
 export interface IconProps extends IntentProps, Props, SVGIconProps, IconHTMLAttributes {
     /**

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -21,7 +21,7 @@ import * as React from "react";
  */
 export interface SVGIconProps
     extends React.RefAttributes<any>,
-        Omit<React.DOMAttributes<HTMLElement | SVGSVGElement>, "children" | "dangerouslySetInnerHTML"> {
+        Omit<React.DOMAttributes<HTMLOrSVGElement>, "children" | "dangerouslySetInnerHTML"> {
     /** A space-delimited list of class names to pass along to the SVG element. */
     className?: string;
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

Fix a regression introduced by #6235 where consumers' usage of HTML attribute props on `<Icon>` stopped compiling successfully due to the more specific `React.HTMLAttributes<T>` type. This caused compilation errors such as:

```
  Types of parameters 'evt' and 'event' are incompatible.
    Type 'MouseEvent<HTMLElement | SVGSVGElement, MouseEvent>' is not assignable to type 'SyntheticEvent<HTMLSpanElement, Event>'.
      Types of property 'currentTarget' are incompatible.
        Type 'EventTarget & (HTMLElement | SVGSVGElement)' is not assignable to type 'EventTarget & HTMLSpanElement'.
          Type 'EventTarget & SVGSVGElement' is not assignable to type 'EventTarget & HTMLSpanElement'.
            Type 'EventTarget & SVGSVGElement' is missing the following properties from type 'HTMLSpanElement': accessKey, accessKeyLabel, autocapitalize, dir, and 20 more.

250                     <Icon icon={IconNames.MORE} onClick={this.handleIconClick} />
```

The fix in this case is to widen the type of the element param in `React.HTMLAttributes<T>` which was inadvertently narrowed in #6235. Turns out that `HTMLElement` is really just an alias for `Element` (it adds no extra properties), so we were working with a pretty basic type in the first place.

#### Reviewers should focus on:

Fixes the regression. I verified this in consumer code by editing Blueprint's `.d.ts` files in node_modules.

