### PR TITLE
fix(Icon, SVGIconContainer): narrow type of HTML attributes

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -17,16 +17,22 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IconName, IconPaths, Icons, IconSize, SVGIconContainer, SVGIconProps } from "@blueprintjs/icons";
+import {
+    IconName,
+    IconPaths,
+    Icons,
+    IconSize,
+    SVGIconAttributes,
+    SVGIconContainer,
+    SVGIconProps,
+} from "@blueprintjs/icons";
 
 import { Classes, DISPLAYNAME_PREFIX, IntentProps, MaybeElement, Props, removeNonHTMLProps } from "../../common";
 
 // re-export for convenience, since some users won't be importing from or have a direct dependency on the icons package
 export { IconName, IconSize };
 
-export type IconHTMLAttributes = Omit<React.HTMLAttributes<HTMLOrSVGElement>, "children" | "title">;
-
-export interface IconProps extends IntentProps, Props, SVGIconProps, IconHTMLAttributes {
+export interface IconProps extends IntentProps, Props, SVGIconProps, SVGIconAttributes {
     /**
      * Whether the component should automatically load icon contents using an async import.
      *

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -116,6 +116,13 @@ describe("<Icon>", () => {
         assert.isTrue(icon.find(`.${Classes.ICON}`).hostNodes().prop("aria-hidden"));
     });
 
+    it("supports mouse event handlers of type React.MouseEventHandler", () => {
+        const handleClick: React.MouseEventHandler = () => {
+            return;
+        };
+        mount(<Icon icon="add" onClick={handleClick} />);
+    });
+
     /** Asserts that rendered icon has an SVG path. */
     async function assertIconHasPath(icon: React.ReactElement<IconProps>, iconName: IconName) {
         const wrapper = mount(icon);

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -18,7 +18,7 @@
 export { IconSvgPaths16, IconSvgPaths20, getIconPaths } from "./allPaths";
 
 export { Icons, IconLoaderOptions, IconPathsLoader } from "./iconLoader";
-export { SVGIconProps } from "./svgIconProps";
+export { SVGIconAttributes, SVGIconProps } from "./svgIconProps";
 export { SVGIconContainer, SVGIconContainerProps } from "./svgIconContainer";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -16,12 +16,18 @@
 import * as React from "react";
 
 /**
+ * DOM attributes assignable as props to the root element rendered by an SVG icon component
+ * (which may be a `<span>`, `<svg>` or some custom HTML element).
+ */
+export type SVGIconAttributes = React.AriaAttributes &
+    Omit<React.DOMAttributes<Element>, "children" | "dangerouslySetInnerHTML"> &
+    Pick<React.HTMLAttributes<Element>, "id" | "style" | "tabIndex" | "role">;
+
+/**
  * Interface used for generated icon components which already have their name and path defined
  * (through the rendered Handlebars template).
  */
-export interface SVGIconProps
-    extends React.RefAttributes<any>,
-        Omit<React.DOMAttributes<HTMLOrSVGElement>, "children" | "dangerouslySetInnerHTML"> {
+export interface SVGIconProps extends React.RefAttributes<any>, SVGIconAttributes {
     /** A space-delimited list of class names to pass along to the SVG element. */
     className?: string;
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

Further narrow the type of HTML attributes allowed as props to `<Icon>` and generated icon components which use `<SVGIconContainer>`.

This fixes a regression in v5.1.x where event handlers of type `React.MouseEventHandler<T>` with the default type param of `T = Element` were no longer assignable to (for example) `<Icon onClick={...}>`.

