### PR TITLE
fix(Icon, SVGIconContainer): add generic type param to specify root element type

### DIFF
--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -35,13 +35,12 @@ The HTML element rendered by `<Icon>` can be customized with the `tagName` prop
 (defaults to `span`), and additional props are passed to this element.
 
 Data files in the __@blueprintjs/icons__ package provide SVG path information
-for Blueprint's 300+ icons for 16px and 20px grids. The `icon` prop dictates
-which SVG is rendered and `size` determines which pixel grid is used:
-`size >= 20` will use the 20px grid and smaller icons will use the 16px
-grid.
+for Blueprint's 500+ icons for 16px and 20px grids. The `icon` prop specifies
+which SVG is rendered and the `size` prop determines which pixel grid is used:
+`size >= 20` will use the 20px grid and smaller icons will use the 16px grid.
 
-If `title` is not provided to an Icon, `aria-hidden` will be set to true as
-it will be assumed that the icon is decorative if not labeled.
+If `title` is _not_ provided to an `<Icon>`, `aria-hidden` will be set to true as
+it will be assumed that the icon is decorative since it is unlabeled.
 
 ```tsx
 import { Icon, IconSize } from "@blueprintjs/core";
@@ -57,7 +56,7 @@ import { Icon, IconSize } from "@blueprintjs/core";
 <Icon icon="add" onClick={this.handleAdd} onKeyDown={this.handleAddKeys} />
 ```
 
-Custom sizes are supported. The following React component:
+Custom sizes are supported. The following React element:
 
 ```tsx
 <Icon icon="globe" size={30} />
@@ -65,18 +64,19 @@ Custom sizes are supported. The following React component:
 
 ...renders this HTML markup:
 
-```html
-<svg class="@ns-icon" data-icon="globe" width="30" height="30" viewBox="0 0 20 20">
-    <title>globe</title>
-    <path d="..."></path>
-</svg>
+```xml
+<span class="@ns-icon @ns-icon-globe" aria-hidden="true">
+    <svg data-icon="globe" width="30" height="30" viewBox="0 0 20 20" role="img">
+        <path d="..."></path>
+    </svg>
+</span>
 ```
 
 @## Props interface
 
-@interface IconProps
+@interface DefaultIconProps
 
-@## Root element DOM attributes
+@## DOM attributes
 
 The `<Icon>` component forwards extra HTML attributes to its root DOM element. By default,
 the root element is a `<span>` wrapper around the icon `<svg>`. The tag name of this element
@@ -85,10 +85,10 @@ may be customized via the `tagName` prop as either:
 - a custom HTML tag name (for example `<div>` instead of the default `<span>` wrapper), or
 - `null`, which makes the component omit the wrapper element and only render the `<svg>` as its root element
 
-By default, `<Icon>` supports a limited set of HTML attributes which are assignable to all HTML and SVG
-elements. In some cases, you may want to specify more specific attributes which are only available on HTML elements
+By default, `<Icon>` supports a limited set of DOM attributes which are assignable to _all_ HTML and SVG
+elements. In some cases, you may want to use more specific attributes which are only available on HTML elements
 or SVG elements. The `<Icon>` component has a generic type which allows for this more advanced usage. You can
-specify a type parameter on the component opening tag to, for example, set an HTML-only attribute:
+specify a type parameter on the component opening tag to (for example) set an HTML-only attribute:
 
 ```tsx
 import { Icon } from "@blueprintjs/core";
@@ -96,7 +96,22 @@ import * as React from "react";
 
 function Example() {
     const [isDraggable, setIsDraggable] = React.useState();
+    // explicitly declare type of the root element so that we can set the "draggable" DOM attribute
     return <Icon<HTMLSpanElement> icon="drag-handle-horizontal" draggable={isDraggable} />;
+}
+```
+
+Another use case for this type parameter API may be to get the correct type definition for an event handler
+on the root element when _omitting_ the icon wrapper element:
+
+```tsx
+import { Icon } from "@blueprintjs/core";
+import * as React from "react";
+
+function Example() {
+    const handleClick: React.MouseEventHandler<SVGSVGElement> = () => { /* ... */ };
+    // explicitly declare type of the root element so that we can narrow the type of the event handler
+    return <Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />;
 }
 ```
 
@@ -110,7 +125,7 @@ Note that some `<Icon>` props are not yet supported for these components, such a
 
 @reactExample IconGeneratedComponentExample
 
-@interface SVGIconProps
+@interface DefaultSVGIconProps
 
 @## CSS API
 

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -72,7 +72,33 @@ Custom sizes are supported. The following React component:
 </svg>
 ```
 
+@## Props interface
+
 @interface IconProps
+
+@## Root element DOM attributes
+
+The `<Icon>` component forwards extra HTML attributes to its root DOM element. By default,
+the root element is a `<span>` wrapper around the icon `<svg>`. The tag name of this element
+may be customized via the `tagName` prop as either:
+
+- a custom HTML tag name (for example `<div>` instead of the default `<span>` wrapper), or
+- `null`, which makes the component omit the wrapper element and only render the `<svg>` as its root element
+
+By default, `<Icon>` supports a limited set of HTML attributes which are assignable to all HTML and SVG
+elements. In some cases, you may want to specify more specific attributes which are only available on HTML elements
+or SVG elements. The `<Icon>` component has a generic type which allows for this more advanced usage. You can
+specify a type parameter on the component opening tag to, for example, set an HTML-only attribute:
+
+```tsx
+import { Icon } from "@blueprintjs/core";
+import * as React from "react";
+
+function Example() {
+    const [isDraggable, setIsDraggable] = React.useState();
+    return <Icon<HTMLSpanElement> icon="drag-handle-horizontal" draggable={isDraggable} />;
+}
+```
 
 @## Static components
 

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -75,7 +75,6 @@ interface GenericIcon extends React.FC<IconProps<Element>> {
  *
  * @see https://blueprintjs.com/docs/#core/components/icon
  */
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export const Icon: GenericIcon = React.forwardRef(function <T extends Element>(props: IconProps<T>, ref: React.Ref<T>) {
     const { autoLoad, className, color, icon, intent, tagName, svgProps, title, htmlTitle, ...htmlProps } = props;
 

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -17,54 +17,77 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { IconName, IconPaths, Icons, IconSize, SVGIconContainer, SVGIconProps } from "@blueprintjs/icons";
+import {
+    DefaultSVGIconProps,
+    IconName,
+    IconPaths,
+    Icons,
+    IconSize,
+    SVGIconContainer,
+    SVGIconProps,
+} from "@blueprintjs/icons";
 
 import { Classes, DISPLAYNAME_PREFIX, IntentProps, MaybeElement, Props, removeNonHTMLProps } from "../../common";
 
 // re-export for convenience, since some users won't be importing from or have a direct dependency on the icons package
 export { IconName, IconSize };
 
-export type IconProps<T extends Element = Element> = IntentProps &
-    Props &
-    SVGIconProps<T> & {
-        /**
-         * Whether the component should automatically load icon contents using an async import.
-         *
-         * @default true
-         */
-        autoLoad?: boolean;
+export interface IconOwnProps {
+    /**
+     * Whether the component should automatically load icon contents using an async import.
+     *
+     * @default true
+     */
+    autoLoad?: boolean;
 
-        /**
-         * Name of a Blueprint UI icon, or an icon element, to render. This prop is
-         * required because it determines the content of the component, but it can
-         * be explicitly set to falsy values to render nothing.
-         *
-         * - If `null` or `undefined` or `false`, this component will render nothing.
-         * - If given an `IconName` (a string literal union of all icon names), that
-         *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
-         *   will render a blank icon to occupy space.
-         * - If given a `JSX.Element`, that element will be rendered and _all other
-         *   props on this component are ignored._ This type is supported to
-         *   simplify icon support in other Blueprint components. As a consumer, you
-         *   should avoid using `<Icon icon={<Element />}` directly; simply render
-         *   `<Element />` instead.
-         */
-        icon: IconName | MaybeElement;
+    /**
+     * Name of a Blueprint UI icon, or an icon element, to render. This prop is
+     * required because it determines the content of the component, but it can
+     * be explicitly set to falsy values to render nothing.
+     *
+     * - If `null` or `undefined` or `false`, this component will render nothing.
+     * - If given an `IconName` (a string literal union of all icon names), that
+     *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
+     *   will render a blank icon to occupy space.
+     * - If given a `JSX.Element`, that element will be rendered and _all other
+     *   props on this component are ignored._ This type is supported to
+     *   simplify icon support in other Blueprint components. As a consumer, you
+     *   should avoid using `<Icon icon={<Element />}` directly; simply render
+     *   `<Element />` instead.
+     */
+    icon: IconName | MaybeElement;
 
-        /**
-         * Alias for `size` prop. Kept around for backwards-compatibility with Blueprint v4.x,
-         * will be removed in v6.0.
-         *
-         * @deprecated use `size` prop instead
-         */
-        iconSize?: number;
+    /**
+     * Alias for `size` prop. Kept around for backwards-compatibility with Blueprint v4.x,
+     * will be removed in v6.0.
+     *
+     * @deprecated use `size` prop instead
+     */
+    iconSize?: number;
 
-        /** Props to apply to the `SVG` element */
-        svgProps?: React.HTMLAttributes<SVGElement>;
-    };
+    /** Props to apply to the `SVG` element */
+    svgProps?: React.HTMLAttributes<SVGElement>;
+}
+
+// N.B. the following inteface is defined as a type alias instead of an interface due to a TypeScript limitation
+// where interfaces cannot extend conditionally-defined union types.
+/**
+ * Generic interface for the `<Icon>` component which may be parameterized by its root element type.
+ *
+ * @see https://blueprintjs.com/docs/#core/components/icon.dom-attributes
+ */
+export type IconProps<T extends Element = Element> = IntentProps & Props & SVGIconProps<T> & IconOwnProps;
+
+/**
+ * The default `<Icon>` props interface, equivalent to `IconProps` with its default type parameter.
+ * This is primarly exported for documentation purposes; users should reference `IconProps<T>` instead.
+ */
+export interface DefaultIconProps extends IntentProps, Props, DefaultSVGIconProps, IconOwnProps {
+    // empty interface for documentation purposes (documentalist handles this better than the IconProps<T> type alias)
+}
 
 // Type hack required to make forwardRef work with generic components. Note that this slows down TypeScript
-// compilation quite a bit, but it better than the alternative of globally augmenting "@types/react".
+// compilation, but it better than the alternative of globally augmenting "@types/react".
 // see https://stackoverflow.com/a/73795494/7406866
 interface GenericIcon extends React.FC<IconProps<Element>> {
     <T extends Element = Element>(props: IconProps<T>): React.ReactElement | null;

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -75,6 +75,7 @@ interface GenericIcon extends React.FC<IconProps<Element>> {
  *
  * @see https://blueprintjs.com/docs/#core/components/icon
  */
+// eslint-disable-next-line prefer-arrow-callback
 export const Icon: GenericIcon = React.forwardRef(function <T extends Element>(props: IconProps<T>, ref: React.Ref<T>) {
     const { autoLoad, className, color, icon, intent, tagName, svgProps, title, htmlTitle, ...htmlProps } = props;
 

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -57,7 +57,7 @@ export { Blockquote, Code, H1, H2, H3, H4, H5, H6, Label, OL, Pre, UL } from "./
 export { HTMLSelect, HTMLSelectIconName, HTMLSelectProps } from "./html-select/htmlSelect";
 export { HTMLTable, HTMLTableProps } from "./html-table/htmlTable";
 export * from "./hotkeys";
-export { Icon, IconName, IconProps, IconSize } from "./icon/icon";
+export { DefaultIconProps, Icon, IconName, IconProps, IconSize } from "./icon/icon";
 export { Menu, MenuProps } from "./menu/menu";
 export { MenuDivider, MenuDividerProps } from "./menu/menuDivider";
 export { MenuItem, MenuItemProps } from "./menu/menuItem";

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -117,10 +117,22 @@ describe("<Icon>", () => {
     });
 
     it("supports mouse event handlers of type React.MouseEventHandler", () => {
-        const handleClick: React.MouseEventHandler = () => {
-            return;
-        };
+        const handleClick: React.MouseEventHandler = () => undefined;
         mount(<Icon icon="add" onClick={handleClick} />);
+    });
+
+    it("accepts HTML attributes", () => {
+        mount(<Icon<HTMLSpanElement> icon="drag-handle-vertical" draggable={false} />);
+    });
+
+    it("accepts generic type param specifying the type of the root element", () => {
+        const handleClick: React.MouseEventHandler<HTMLSpanElement> = () => undefined;
+        mount(<Icon<HTMLSpanElement> icon="add" onClick={handleClick} />);
+    });
+
+    it("allows specifying the root element as <svg> when tagName={null}", () => {
+        const handleClick: React.MouseEventHandler<SVGSVGElement> = () => undefined;
+        mount(<Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />);
     });
 
     /** Asserts that rendered icon has an SVG path. */

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -18,7 +18,7 @@
 export { IconSvgPaths16, IconSvgPaths20, getIconPaths } from "./allPaths";
 
 export { Icons, IconLoaderOptions, IconPathsLoader } from "./iconLoader";
-export { DefaultSVGIconAttributes, SVGIconAttributes, SVGIconProps } from "./svgIconProps";
+export { DefaultSVGIconAttributes, DefaultSVGIconProps, SVGIconAttributes, SVGIconProps } from "./svgIconProps";
 export { SVGIconContainer, SVGIconContainerProps } from "./svgIconContainer";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -18,7 +18,7 @@
 export { IconSvgPaths16, IconSvgPaths20, getIconPaths } from "./allPaths";
 
 export { Icons, IconLoaderOptions, IconPathsLoader } from "./iconLoader";
-export { SVGIconAttributes, SVGIconProps } from "./svgIconProps";
+export { DefaultSVGIconAttributes, SVGIconAttributes, SVGIconProps } from "./svgIconProps";
 export { SVGIconContainer, SVGIconContainerProps } from "./svgIconContainer";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -35,7 +35,7 @@ export type SVGIconContainerProps<T extends Element> = Omit<SVGIconProps<T>, "ch
 };
 
 // Type hack required to make forwardRef work with generic components. Note that this slows down TypeScript
-// compilation quite a bit, but it better than the alternative of globally augmenting "@types/react".
+// compilation, but it better than the alternative of globally augmenting "@types/react".
 // see https://stackoverflow.com/a/73795494/7406866
 interface GenericSVGIconContainer extends React.FC<SVGIconContainerProps<Element>> {
     <T extends Element = Element>(props: SVGIconContainerProps<T>): React.ReactElement | null;

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -41,6 +41,7 @@ interface GenericSVGIconContainer extends React.FC<SVGIconContainerProps<Element
     <T extends Element = Element>(props: SVGIconContainerProps<T>): React.ReactElement | null;
 }
 
+// eslint-disable-next-line prefer-arrow-callback
 export const SVGIconContainer: GenericSVGIconContainer = React.forwardRef(function <T extends Element>(
     props: SVGIconContainerProps<T>,
     ref: React.Ref<T>,

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -15,71 +15,103 @@
 
 import * as React from "react";
 
+type OmittedDOMAttributes = "children" | "dangerouslySetInnerHTML";
+
 /**
- * DOM attributes assignable as props to the root element rendered by an SVG icon component
- * (which may be a `<span>`, `<svg>` or some custom HTML element).
+ * Default set of DOM attributes which are assignable as props to the root element rendered by an
+ * SVG icon component. This limited set of attributes is assignable to any `<Icon>` component regardless
+ * of its `tagName` prop (it works for both HTML and SVG elements).
  */
-export type SVGIconAttributes = React.AriaAttributes &
-    Omit<React.DOMAttributes<Element>, "children" | "dangerouslySetInnerHTML"> &
+export type DefaultSVGIconAttributes = React.AriaAttributes &
+    Omit<React.DOMAttributes<Element>, OmittedDOMAttributes> &
     Pick<React.HTMLAttributes<Element>, "id" | "style" | "tabIndex" | "role">;
 
 /**
- * Interface used for generated icon components which already have their name and path defined
- * (through the rendered Handlebars template).
+ * DOM attributes which are assignable as props to the root element rendered by an SVG icon component.
+ * Specify a type parameter to narrow this type and allow more attributes to be passed to the root element.
+ *
+ * @see https://blueprintjs.com/docs/#core/components/icon.root-element-dom-attributes
+ *
+ * When `tagName` is specified, either:
+ *  - as a custom HTML element tag name,
+ *  - as `null` to signfiy that there should be no wrapper around the `<svg>` element,
+ *  - or its default value of "span" is used,
+ * then it may be useful to narrow this type to pass along additional attributes which not supported by
+ * the more general `DefaultSVGIconAttributes` interface. You can do this by specifying a generic type param
+ * on `<Icon>` components, for example:
+ *
+ * ```
+ * <Icon<HTMLSpanElement> icon="drag-handle-horizontal" draggable="false" />
+ * ```
  */
-export interface SVGIconProps extends React.RefAttributes<any>, SVGIconAttributes {
-    /** A space-delimited list of class names to pass along to the SVG element. */
-    className?: string;
+export type SVGIconAttributes<T extends Element = Element> = T extends SVGElement
+    ? Omit<React.SVGAttributes<T>, OmittedDOMAttributes>
+    : T extends HTMLElement
+    ? Omit<React.HTMLAttributes<T>, OmittedDOMAttributes>
+    : DefaultSVGIconAttributes;
 
-    /** This component does not support custom children. */
-    children?: never;
+// N.B. the following inteface is defined as a type alias instead of an interface due to a TypeScript limitation
+// where interfaces cannot extend conditionally-defined union types.
+/**
+ * Interface for generated icon components which have their name and icon paths statically defined
+ * inside their JS implementation.
+ *
+ * @see https://blueprintjs.com/docs/#core/components/icon.static-components
+ */
+export type SVGIconProps<T extends Element = Element> = React.RefAttributes<T> &
+    SVGIconAttributes<T> & {
+        /** A space-delimited list of class names to pass along to the SVG element. */
+        className?: string;
 
-    /**
-     * Color of icon. This is used as the `fill` attribute on the `<svg>` image
-     * so it will override any CSS `color` property, including that set by
-     * `intent`. If this prop is omitted, icon color is inherited from
-     * surrounding text.
-     */
-    color?: string;
+        /** This component does not support child nodes. */
+        children?: never;
 
-    /**
-     * String for the `title` attribute on the rendered element, which will appear
-     * on hover as a native browser tooltip.
-     */
-    htmlTitle?: string;
+        /**
+         * Color of icon. This is used as the `fill` attribute on the `<svg>` image
+         * so it will override any CSS `color` property, including that set by
+         * `intent`. If this prop is omitted, icon color is inherited from
+         * surrounding text.
+         */
+        color?: string;
 
-    /**
-     * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
-     * images, and chooses the appropriate resolution based on this prop.
-     *
-     * @default 16
-     */
-    size?: number;
+        /**
+         * String for the `title` attribute on the rendered element, which will appear
+         * on hover as a native browser tooltip.
+         */
+        htmlTitle?: string;
 
-    /** CSS style properties. */
-    style?: React.CSSProperties;
+        /**
+         * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
+         * images, and chooses the appropriate resolution based on this prop.
+         *
+         * @default 16
+         */
+        size?: number;
 
-    /**
-     * HTML tag to use for the rendered element. Commonly "span" or "div".
-     * If `null`, no wrapper will be rendered, just the `<svg>` element.
-     *
-     * @default "span"
-     */
-    tagName?: keyof JSX.IntrinsicElements | null;
+        /** CSS style properties. */
+        style?: React.CSSProperties;
 
-    /**
-     * Description string. This string does not appear in normal browsers, but
-     * it increases accessibility. For instance, screen readers will use it for
-     * aural feedback.
-     *
-     * If this value is nullish, `false`, or an empty string, the component will assume
-     * that the icon is decorative and `aria-hidden="true"` will be applied (can be overridden
-     * by manually passing `aria-hidden` prop).
-     *
-     * @see https://www.w3.org/WAI/tutorials/images/decorative/
-     */
-    title?: string | false | null;
+        /**
+         * HTML tag to use for the rendered element. Commonly "span" or "div".
+         * If `null`, no wrapper will be rendered, just the `<svg>` element.
+         *
+         * @default "span"
+         */
+        tagName?: keyof JSX.IntrinsicElements | null;
 
-    /** Props to apply to the `SVG` element */
-    svgProps?: React.HTMLAttributes<SVGElement>;
-}
+        /**
+         * Description string. This string does not appear in normal browsers, but
+         * it increases accessibility. For instance, screen readers will use it for
+         * aural feedback.
+         *
+         * If this value is nullish, `false`, or an empty string, the component will assume
+         * that the icon is decorative and `aria-hidden="true"` will be applied (can be overridden
+         * by manually passing `aria-hidden` prop).
+         *
+         * @see https://www.w3.org/WAI/tutorials/images/decorative/
+         */
+        title?: string | false | null;
+
+        /** Props to apply to the `SVG` element */
+        svgProps?: React.HTMLAttributes<SVGElement>;
+    };

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -30,7 +30,7 @@ export type DefaultSVGIconAttributes = React.AriaAttributes &
  * DOM attributes which are assignable as props to the root element rendered by an SVG icon component.
  * Specify a type parameter to narrow this type and allow more attributes to be passed to the root element.
  *
- * @see https://blueprintjs.com/docs/#core/components/icon.root-element-dom-attributes
+ * @see https://blueprintjs.com/docs/#core/components/icon.dom-attributes
  *
  * When `tagName` is specified, either:
  *  - as a custom HTML element tag name,
@@ -50,6 +50,63 @@ export type SVGIconAttributes<T extends Element = Element> = T extends SVGElemen
     ? Omit<React.HTMLAttributes<T>, OmittedDOMAttributes>
     : DefaultSVGIconAttributes;
 
+export interface SVGIconOwnProps {
+    /** A space-delimited list of class names to pass along to the SVG element. */
+    className?: string;
+
+    /** This component does not support child nodes. */
+    children?: never;
+
+    /**
+     * Color of icon. This is used as the `fill` attribute on the `<svg>` image
+     * so it will override any CSS `color` property, including that set by
+     * `intent`. If this prop is omitted, icon color is inherited from
+     * surrounding text.
+     */
+    color?: string;
+
+    /**
+     * String for the `title` attribute on the rendered element, which will appear
+     * on hover as a native browser tooltip.
+     */
+    htmlTitle?: string;
+
+    /**
+     * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
+     * images, and chooses the appropriate resolution based on this prop.
+     *
+     * @default 16
+     */
+    size?: number;
+
+    /** CSS style properties. */
+    style?: React.CSSProperties;
+
+    /**
+     * HTML tag to use for the rendered element. Commonly "span" or "div".
+     * If `null`, no wrapper will be rendered, just the `<svg>` element.
+     *
+     * @default "span"
+     */
+    tagName?: keyof JSX.IntrinsicElements | null;
+
+    /**
+     * Description string. This string does not appear in normal browsers, but
+     * it increases accessibility. For instance, screen readers will use it for
+     * aural feedback.
+     *
+     * If this value is nullish, `false`, or an empty string, the component will assume
+     * that the icon is decorative and `aria-hidden="true"` will be applied (can be overridden
+     * by manually passing `aria-hidden` prop).
+     *
+     * @see https://www.w3.org/WAI/tutorials/images/decorative/
+     */
+    title?: string | false | null;
+
+    /** Props to apply to the `SVG` element */
+    svgProps?: React.HTMLAttributes<SVGElement>;
+}
+
 // N.B. the following inteface is defined as a type alias instead of an interface due to a TypeScript limitation
 // where interfaces cannot extend conditionally-defined union types.
 /**
@@ -58,60 +115,12 @@ export type SVGIconAttributes<T extends Element = Element> = T extends SVGElemen
  *
  * @see https://blueprintjs.com/docs/#core/components/icon.static-components
  */
-export type SVGIconProps<T extends Element = Element> = React.RefAttributes<T> &
-    SVGIconAttributes<T> & {
-        /** A space-delimited list of class names to pass along to the SVG element. */
-        className?: string;
+export type SVGIconProps<T extends Element = Element> = React.RefAttributes<T> & SVGIconAttributes<T> & SVGIconOwnProps;
 
-        /** This component does not support child nodes. */
-        children?: never;
-
-        /**
-         * Color of icon. This is used as the `fill` attribute on the `<svg>` image
-         * so it will override any CSS `color` property, including that set by
-         * `intent`. If this prop is omitted, icon color is inherited from
-         * surrounding text.
-         */
-        color?: string;
-
-        /**
-         * String for the `title` attribute on the rendered element, which will appear
-         * on hover as a native browser tooltip.
-         */
-        htmlTitle?: string;
-
-        /**
-         * Size of the icon, in pixels. Blueprint contains 16px and 20px SVG icon
-         * images, and chooses the appropriate resolution based on this prop.
-         *
-         * @default 16
-         */
-        size?: number;
-
-        /** CSS style properties. */
-        style?: React.CSSProperties;
-
-        /**
-         * HTML tag to use for the rendered element. Commonly "span" or "div".
-         * If `null`, no wrapper will be rendered, just the `<svg>` element.
-         *
-         * @default "span"
-         */
-        tagName?: keyof JSX.IntrinsicElements | null;
-
-        /**
-         * Description string. This string does not appear in normal browsers, but
-         * it increases accessibility. For instance, screen readers will use it for
-         * aural feedback.
-         *
-         * If this value is nullish, `false`, or an empty string, the component will assume
-         * that the icon is decorative and `aria-hidden="true"` will be applied (can be overridden
-         * by manually passing `aria-hidden` prop).
-         *
-         * @see https://www.w3.org/WAI/tutorials/images/decorative/
-         */
-        title?: string | false | null;
-
-        /** Props to apply to the `SVG` element */
-        svgProps?: React.HTMLAttributes<SVGElement>;
-    };
+/**
+ * The default SVG icon props interface, equivalent to `SVGIconProps` with its default type parameter.
+ * This is primarly exported for documentation purposes; users should reference `SVGIconProps<T>` instead.
+ */
+export interface DefaultSVGIconProps extends React.RefAttributes<Element>, SVGIconAttributes<Element>, SVGIconOwnProps {
+    // empty interface for documentation purposes (documentalist handles this better than the SVGIconProps<T> type alias)
+}

--- a/packages/icons/test/generatedIconsTests.tsx
+++ b/packages/icons/test/generatedIconsTests.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ */
+
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { Add } from "../src/generated/components";
+
+describe("<Add> icon component", () => {
+    it("allows attaching an event handler", () => {
+        const handleClick: React.MouseEventHandler<HTMLSpanElement> = () => undefined;
+        mount(<Add onClick={handleClick} />);
+    });
+
+    it("disallows child elements", () => {
+        const handleClick: React.MouseEventHandler<HTMLSpanElement> = () => undefined;
+        mount(
+            <Add onClick={handleClick}>
+                {/* @ts-expect-error */}
+                <path />
+            </Add>,
+        );
+    });
+});

--- a/packages/icons/test/index.ts
+++ b/packages/icons/test/index.ts
@@ -4,4 +4,6 @@
 
 import "@blueprintjs/test-commons/bootstrap";
 
-import "iconLoaderTests";
+import "./generatedIconsTests";
+import "./iconLoaderTests";
+import "./svgIconContainerTests";

--- a/packages/icons/test/svgIconContainerTests.tsx
+++ b/packages/icons/test/svgIconContainerTests.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ */
+
+import { mount } from "enzyme";
+import * as React from "react";
+
+import { SVGIconContainer } from "../src/svgIconContainer";
+
+describe("SVGIconContainer", () => {
+    it("accepts generic type param specifying the type of the root element", () => {
+        const handleClick: React.MouseEventHandler<HTMLSpanElement> = () => undefined;
+        mount(
+            <SVGIconContainer<HTMLSpanElement> iconName="add" onClick={handleClick}>
+                <path />
+            </SVGIconContainer>,
+        );
+    });
+});


### PR DESCRIPTION
#### Changes proposed in this pull request:

This fixes a regression in @blueprintjs/core v5.1.x where `<Icon>` elements no longer accepted HTML attributes like `draggable={true}`. Previously, these attributes were unsafely allowed to be forwarded to the root element of any `<Icon>` component, even when `tagName={null}` and those the root element was an `<svg>` element which should not accept them.

After much iteration, I figured out a way to make `<Icon>` and `<SVGIconContainer>` each have a generic type parameter (similar to `<Select>`). This turned out to be a lot harder to do for function components which use `React.forwardRef()` than for class components. See my code comments for more info.

I added documentation and test cases to demonstrate the new behavior. This may be a bit of overkill (we could be a little unsafe and just allow `React.HTMLAttributes` to go through to `<Icon>` root elements), but it turned out to be an interesting exercise in exploring TypeScript generics & conditional types. I think it makes the public API a little more expressive.

#### Reviewers should focus on:

No regressions in `<Icon>` component props (these should be mostly covered by test cases).

#### Screenshot

N/A
