### PR TITLE
chore: pin Chrome version used in CI test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,10 @@ jobs:
       - checkout
       - restore_cache: *restore-node-modules-cache
       - attach_workspace: { at: "." }
+      # HACKHACK: pin Chrome version to work around bug in v115
+      # see https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chrome:
+          chrome-version: "114.0.5735.90"
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ jobs:
       - attach_workspace: { at: "." }
       # HACKHACK: pin Chrome version to work around bug in v115
       # see https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - run: sudo apt-get update
       - browser-tools/install-chrome:
           chrome-version: "114.0.5735.90"
       - browser-tools/install-chrome


### PR DESCRIPTION
Workaround for https://github.com/CircleCI-Public/browser-tools-orb/issues/75