### PR TITLE
fix: export private component types which are part of public API

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -86,10 +86,14 @@ export interface DefaultIconProps extends IntentProps, Props, DefaultSVGIconProp
     // empty interface for documentation purposes (documentalist handles this better than the IconProps<T> type alias)
 }
 
-// Type hack required to make forwardRef work with generic components. Note that this slows down TypeScript
-// compilation, but it better than the alternative of globally augmenting "@types/react".
-// see https://stackoverflow.com/a/73795494/7406866
-interface GenericIcon extends React.FC<IconProps<Element>> {
+/**
+ * Generic icon component type. This is essentially a type hack required to make forwardRef work with generic
+ * components. Note that this slows down TypeScript compilation, but it better than the alternative of globally
+ * augmenting "@types/react".
+ *
+ * @see https://stackoverflow.com/a/73795494/7406866
+ */
+export interface IconComponent extends React.FC<IconProps<Element>> {
     <T extends Element = Element>(props: IconProps<T>): React.ReactElement | null;
 }
 
@@ -99,7 +103,10 @@ interface GenericIcon extends React.FC<IconProps<Element>> {
  * @see https://blueprintjs.com/docs/#core/components/icon
  */
 // eslint-disable-next-line prefer-arrow-callback
-export const Icon: GenericIcon = React.forwardRef(function <T extends Element>(props: IconProps<T>, ref: React.Ref<T>) {
+export const Icon: IconComponent = React.forwardRef(function <T extends Element>(
+    props: IconProps<T>,
+    ref: React.Ref<T>,
+) {
     const { autoLoad, className, color, icon, intent, tagName, svgProps, title, htmlTitle, ...htmlProps } = props;
 
     // Preserve Blueprint v4.x behavior: iconSize prop takes predecence, then size prop, then fall back to default value

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -57,7 +57,7 @@ export { Blockquote, Code, H1, H2, H3, H4, H5, H6, Label, OL, Pre, UL } from "./
 export { HTMLSelect, HTMLSelectIconName, HTMLSelectProps } from "./html-select/htmlSelect";
 export { HTMLTable, HTMLTableProps } from "./html-table/htmlTable";
 export * from "./hotkeys";
-export { DefaultIconProps, Icon, IconName, IconProps, IconSize } from "./icon/icon";
+export { DefaultIconProps, Icon, IconComponent, IconName, IconProps, IconSize } from "./icon/icon";
 export { Menu, MenuProps } from "./menu/menu";
 export { MenuDivider, MenuDividerProps } from "./menu/menuDivider";
 export { MenuItem, MenuItemProps } from "./menu/menuItem";

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -19,7 +19,7 @@ export { IconSvgPaths16, IconSvgPaths20, getIconPaths } from "./allPaths";
 
 export { Icons, IconLoaderOptions, IconPathsLoader } from "./iconLoader";
 export { DefaultSVGIconAttributes, DefaultSVGIconProps, SVGIconAttributes, SVGIconProps } from "./svgIconProps";
-export { SVGIconContainer, SVGIconContainerProps } from "./svgIconContainer";
+export { SVGIconContainer, SVGIconContainerComponent, SVGIconContainerProps } from "./svgIconContainer";
 export { getIconContentString, IconCodepoints } from "./iconCodepoints";
 export { IconName, IconNames } from "./iconNames";
 export { IconSize, IconPaths } from "./iconTypes";

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -34,15 +34,19 @@ export type SVGIconContainerProps<T extends Element> = Omit<SVGIconProps<T>, "ch
     children: JSX.Element | JSX.Element[];
 };
 
-// Type hack required to make forwardRef work with generic components. Note that this slows down TypeScript
-// compilation, but it better than the alternative of globally augmenting "@types/react".
-// see https://stackoverflow.com/a/73795494/7406866
-interface GenericSVGIconContainer extends React.FC<SVGIconContainerProps<Element>> {
+/**
+ * Generic icon container component type. This is essentially a type hack required to make forwardRef work with generic
+ * components. Note that this slows down TypeScript compilation, but it better than the alternative of globally
+ * augmenting "@types/react".
+ *
+ * @see https://stackoverflow.com/a/73795494/7406866
+ */
+export interface SVGIconContainerComponent extends React.FC<SVGIconContainerProps<Element>> {
     <T extends Element = Element>(props: SVGIconContainerProps<T>): React.ReactElement | null;
 }
 
 // eslint-disable-next-line prefer-arrow-callback
-export const SVGIconContainer: GenericSVGIconContainer = React.forwardRef(function <T extends Element>(
+export const SVGIconContainer: SVGIconContainerComponent = React.forwardRef(function <T extends Element>(
     props: SVGIconContainerProps<T>,
     ref: React.Ref<T>,
 ) {


### PR DESCRIPTION
#### Changes proposed in this pull request:

- [core] fix: export `IconComponent` type (previously named `GenericIcon`) in public API
- [icons] fix: export `SVGIconContainerComponent` type (previously named `GenericSVGIconContainer`) in public API

Before this change, users may have received a TS compilation error when trying to re-export `Icon` or `SVGIconContainer` as TS would attempt to reference a private type symbol:

```
error TS4023: Exported variable '[redacted]' has or is using name 'GenericIcon' from external module "/home/circleci/project/node_modules/.pnpm/@blueprintjs+core@5.1.4_ugrpyuvudjf6jbttetu7vnqf5m/node_modules/@blueprintjs/core/lib/esm/components/icon/icon" but cannot be named.
```
