### PR TITLE
[datetime] fix: increase caption select CSS specificity

### DIFF
--- a/packages/datetime/src/components/date-picker/_datepicker.scss
+++ b/packages/datetime/src/components/date-picker/_datepicker.scss
@@ -168,8 +168,9 @@ $header-margin: ($header-height - $pt-input-height) * 0.5 !default;
   justify-content: space-between;
   margin: 0 ($pt-button-height - $datepicker-padding) $datepicker-padding;
 
-  // HTMLSelect overrides for a narrower appearance
-  select {
+  // override HTMLSelect styles for a narrower appearance
+  // N.B. these styles are important to achieve accurate measurements to position the dropdown arrows in <DatePickerCaption>
+  .#{$ns}-html-select select {
     font-weight: 600;
     padding-left: $datepicker-padding;
     padding-right: $pt-icon-size-standard;


### PR DESCRIPTION
Fixes #6294

#### Changes proposed in this pull request:

Increase specificity of DatePickerCaption > HTMLSelect CSS overrides to be resilient to situations where `blueprint.css` is loaded onto the page _after_ `blueprint-datetime.css` (even though this is not recommended).

#### Reviewers should focus on:

No regressions in datepicker caption layout.
