### PR TITLE
[core] fix(Callout): remove extra body element, revert DOM break

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -109,7 +109,7 @@ export const BUTTON_SPINNER = `${BUTTON}-spinner`;
 export const BUTTON_TEXT = `${BUTTON}-text`;
 
 export const CALLOUT = `${NS}-callout`;
-export const CALLOUT_HAS_BODY_TEXT = `${CALLOUT}-has-body-text`;
+export const CALLOUT_HAS_BODY_CONTENT = `${CALLOUT}-has-body-content`;
 export const CALLOUT_ICON = `${CALLOUT}-icon`;
 
 export const CARD = `${NS}-card`;

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -109,8 +109,8 @@ export const BUTTON_SPINNER = `${BUTTON}-spinner`;
 export const BUTTON_TEXT = `${BUTTON}-text`;
 
 export const CALLOUT = `${NS}-callout`;
+export const CALLOUT_HAS_BODY_TEXT = `${CALLOUT}-has-body-text`;
 export const CALLOUT_ICON = `${CALLOUT}-icon`;
-export const CALLOUT_BODY = `${CALLOUT}-body`;
 
 export const CARD = `${NS}-card`;
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -67,7 +67,7 @@ $callout-header-margin-top: $pt-grid-size * 0.2;
     margin-top: $callout-header-margin-top;
   }
 
-  &.#{$ns}-callout-has-body-text {
+  &.#{$ns}-callout-has-body-content {
     .#{$ns}-heading {
       margin-bottom: $half-grid-size;
     }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -65,9 +65,11 @@ $callout-header-margin-top: $pt-grid-size * 0.2;
     line-height: $pt-icon-size-standard;
     margin-bottom: 0;
     margin-top: $callout-header-margin-top;
+  }
 
-    + .#{$ns}-callout-body {
-      margin-top: $half-grid-size;
+  &.#{$ns}-callout-has-body-text {
+    .#{$ns}-heading {
+      margin-bottom: $half-grid-size;
     }
   }
 

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -76,7 +76,7 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
         const { className, children, icon, intent, title, ...htmlProps } = this.props;
         const iconElement = this.renderIcon(icon, intent);
         const classes = classNames(Classes.CALLOUT, Classes.intentClass(intent), className, {
-            [Classes.CALLOUT_HAS_BODY_TEXT]: !Utils.isReactNodeEmpty(children),
+            [Classes.CALLOUT_HAS_BODY_CONTENT]: !Utils.isReactNodeEmpty(children),
             [Classes.CALLOUT_ICON]: iconElement != null,
         });
 

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -75,18 +75,16 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
     public render() {
         const { className, children, icon, intent, title, ...htmlProps } = this.props;
         const iconElement = this.renderIcon(icon, intent);
-        const classes = classNames(
-            Classes.CALLOUT,
-            Classes.intentClass(intent),
-            { [Classes.CALLOUT_ICON]: iconElement != null },
-            className,
-        );
+        const classes = classNames(Classes.CALLOUT, Classes.intentClass(intent), className, {
+            [Classes.CALLOUT_HAS_BODY_TEXT]: !Utils.isReactNodeEmpty(children),
+            [Classes.CALLOUT_ICON]: iconElement != null,
+        });
 
         return (
             <div className={classes} {...htmlProps}>
                 {iconElement}
                 {title && <H5>{title}</H5>}
-                {Utils.isReactNodeEmpty(children) ? undefined : <div className={Classes.CALLOUT_BODY}>{children}</div>}
+                {children}
             </div>
         );
     }


### PR DESCRIPTION

#### Changes proposed in this pull request:

Reverts the DOM breaking change in #6276 which introduced an extra wrapper element around `props.children` (this broke downstream `flex` styles on `.bp5-callout` elements) while still keeping the bugfix for #6074

#### Reviewers should focus on:

No regressions, and the `.bp5-callout-body` element is removed

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/8632569d-e919-43be-a3e8-5261ff8bad63)
![image](https://github.com/palantir/blueprint/assets/723999/67dbfb58-0f70-42d5-8898-cc358f967186)
![image](https://github.com/palantir/blueprint/assets/723999/3d8361cc-3924-4321-a079-d8a02ae0f4ab)
![image](https://github.com/palantir/blueprint/assets/723999/4a169fc1-52da-496f-b90e-f9dbe1f5f04c)

