### PR TITLE
Rename timezone Kiev to Kyiv

### DIFF
--- a/packages/datetime/src/common/timezoneItems.ts
+++ b/packages/datetime/src/common/timezoneItems.ts
@@ -163,7 +163,7 @@ const timezonesWithoutOffset: TimezoneWithoutOffset[] = [
     { label: "Jerusalem", ianaCode: "Asia/Jerusalem" },
     { label: "Johannesburg", ianaCode: "Africa/Johannesburg" },
     { label: "Khartoum", ianaCode: "Africa/Khartoum" },
-    { label: "Kyiv", ianaCode: "Europe/Kyiv" },
+    { label: "Kyiv", ianaCode: "Europe/Kiev" },
     { label: "Maputo", ianaCode: "Africa/Maputo" },
     { label: "Kaliningrad", ianaCode: "Europe/Kaliningrad" },
     { label: "Nicosia", ianaCode: "Asia/Nicosia" },

--- a/packages/datetime/src/common/timezoneItems.ts
+++ b/packages/datetime/src/common/timezoneItems.ts
@@ -163,7 +163,7 @@ const timezonesWithoutOffset: TimezoneWithoutOffset[] = [
     { label: "Jerusalem", ianaCode: "Asia/Jerusalem" },
     { label: "Johannesburg", ianaCode: "Africa/Johannesburg" },
     { label: "Khartoum", ianaCode: "Africa/Khartoum" },
-    { label: "Kiev", ianaCode: "Europe/Kiev" },
+    { label: "Kyiv", ianaCode: "Europe/Kyiv" },
     { label: "Maputo", ianaCode: "Africa/Maputo" },
     { label: "Kaliningrad", ianaCode: "Europe/Kaliningrad" },
     { label: "Nicosia", ianaCode: "Asia/Nicosia" },


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Rename the timezone `Kiev` to `Kyiv`.

https://en.wikipedia.org/wiki/Kyiv

The preferred English spelling of the capital of Ukraine is `Kyiv`. This spelling derives from the Ukranian language, whereas `Kiev` derives from the Russian language.

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

Before 
![image](https://github.com/palantir/blueprint/assets/37716832/a22a0768-23a0-4120-8358-5284716a7557)

After
<img width="369" alt="image" src="https://github.com/palantir/blueprint/assets/37716832/4455f11f-3077-443d-a54b-9ec5e6138ec4">


<!-- Include an image of the most relevant user-facing change, if any. -->
