### PR TITLE
[docs] fix: various documentation improvements

### DIFF
--- a/packages/core/src/components/button/button-group.md
+++ b/packages/core/src/components/button/button-group.md
@@ -56,18 +56,15 @@ all buttons in the group, or set the prop on individual buttons directly.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<ButtonGroup>`](#core/components/button-group)
 </h5>
 
-<div class="@ns-callout-body">
-
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Arrange multiple buttons in a group by wrapping them in `.@ns-button-group`.

--- a/packages/core/src/components/button/buttons.md
+++ b/packages/core/src/components/button/buttons.md
@@ -28,13 +28,11 @@ behaviors according to the HTML spec.
 <button class="@ns-button" type="button"><svg class="@ns-icon">...</svg></button>
 ```
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Disabled __Button__ elements prevent all interaction
 </h5>
-
-<div class="@ns-callout-body">
 
 Use __AnchorButton__ if you need mouse interaction events (such as hovering) on a disabled button.
 
@@ -42,7 +40,6 @@ __Button__ uses the native `disabled` attribute on the `<button>` tag so the bro
 __AnchorButton__ uses the class `.@ns-disabled` because `<a>` tags do not support the `disabled` attribute. As a result,
 the __AnchorButton__ component will prevent *only* the `onClick` handler when disabled but permit other events.
 
-</div>
 </div>
 
 @## Adding icons
@@ -62,18 +59,16 @@ The two button components each support arbitrary HTML attributes for their under
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use `<Button>` or `<AnchorButton>`
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Use the `@ns-button` class to access button styles. You should implement buttons using the

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -11,18 +11,16 @@ a title, an icon and content. Each intent has a default icon associated with it.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Callout>`](#core/components/callout)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Callouts use the same visual intent modifier classes as buttons. If you need a heading, use the `<h5>`

--- a/packages/core/src/components/card/card.md
+++ b/packages/core/src/components/card/card.md
@@ -29,17 +29,15 @@ Note that the `Classes.ELEVATION_*` classes can be used on any element (not just
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Card>`](#core/components/card)
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Start with `.@ns-card` and add an elevation class `.@ns-elevation-*` to apply a drop shadow that simulates height in

--- a/packages/core/src/components/components.md
+++ b/packages/core/src/components/components.md
@@ -43,9 +43,10 @@
 
 @## Form inputs
 
+@page input-group
+@page text-area
 @page file-input
 @page numeric-input
-@page text-inputs
 @page tag-input
 
 @## Overlays

--- a/packages/core/src/components/context-menu/context-menu-popover.md
+++ b/packages/core/src/components/context-menu/context-menu-popover.md
@@ -1,17 +1,15 @@
 @# ContextMenuPopover
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Consider [ContextMenu](#core/components/context-menu) first
 
 </h5>
-<div class="@ns-callout-body">
 
 The APIs described on this page are lower-level and have some limitations compared to
 [ContextMenu](#core/components/context-menu), so you should try that API _first_ to see if it addresses your use case.
 
-</div>
 </div>
 
 __ContextMenuPopover__ is a lower-level API for [ContextMenu](#core/components/context-menu) which does not hook up any

--- a/packages/core/src/components/dialog/dialog.md
+++ b/packages/core/src/components/dialog/dialog.md
@@ -2,17 +2,14 @@
 
 __Dialog__ presents content overlaid over other parts of the UI.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Terminology note</h5>
-
-<div class="@ns-callout-body">
 
 The term "modal" is sometimes used to mean "dialog," but this is a misnomer.
 _Modal_ is an adjective that describes parts of a UI. An element is considered to be "modal" if it
 [blocks interaction with the rest of the application](https://en.wikipedia.org/wiki/Modal_window).
 We use the term "dialog" in Blueprint to avoid confusion with the adjective.
 
-</div>
 </div>
 
 Blueprint provides two types of dialogs:
@@ -62,18 +59,16 @@ towards the right side of the footer container element.
 
 @### CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use `<Dialog>`
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 @css dialog

--- a/packages/core/src/components/editable-text/editable-text.md
+++ b/packages/core/src/components/editable-text/editable-text.md
@@ -9,7 +9,7 @@ editing text.
 You might use this component for inline renaming, or for an
 [editable multiline description](#core/components/editable-text.multiline-mode).
 You should not use __EditableText__ when a more static, always-editable
-[__InputGroup__](#core/components/text-inputs.input-group) or [__TextArea__](#core/components/text-inputs.text-area)
+[__InputGroup__](#core/components/input-group) or [__TextArea__](#core/components/text-area)
 component would suffice.
 
 @reactExample EditableTextExample

--- a/packages/core/src/components/editable-text/editable-text.md
+++ b/packages/core/src/components/editable-text/editable-text.md
@@ -14,15 +14,13 @@ component would suffice.
 
 @reactExample EditableTextExample
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">Centering EditableText</h5>
-<div class="@ns-callout-body">
 
 **Do not center this component** using `text-align: center`, as it will cause an infinite loop
 in the browser ([more details](https://github.com/JedWatson/react-select/issues/540)). Instead,
 you should center the component via flexbox or with `position` and `transform: translateX(-50%)`.
 
-</div>
 </div>
 
 

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -76,22 +76,6 @@ Styleguide input
 
 
 /*
-Search inputs
-
-Markup:
-<div class="#{$ns}-input-group {{.modifier}}">
-  <span class="#{$ns}-icon #{$ns}-icon-search"></span>
-  <input class="#{$ns}-input" {{:modifier}} type="search" placeholder="Search input" dir="auto" />
-</div>
-
-:disabled - Disabled. Also add <code>.#{$ns}-disabled</code> to <code>.#{$ns}-input-group</code> for icon coloring (not shown below).
-.#{$ns}-large - Large
-.#{$ns}-small - Small
-
-Styleguide input-search
-*/
-
-/*
 Textareas
 
 Markup:

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -3,9 +3,8 @@
 A __ControlGroup__ renders multiple distinct form controls as one unit, with a small margin between elements. It
 supports any number of buttons, text inputs, input groups, numeric inputs, and HTML selects as direct children.
 
-<div class="@ns-callout @ns-intent-success @ns-icon-comparison">
+<div class="@ns-callout @ns-intent-success @ns-icon-comparison @ns-callout-has-body-content">
     <h5 class="@ns-heading">Control group vs. input group</h5>
-<div class="@ns-callout-body">
 
 Both components group multiple elements into a single unit, but their usage patterns are quite different.
 
@@ -15,7 +14,6 @@ Conversely, an [__InputGroup__](#core/components/input-group) is a single contro
 so. A button inside of an input group should only affect that input; if its reach is further, then it should be
 promoted to live in a control group.
 
-</div>
 </div>
 
 @reactExample ControlGroupExample
@@ -52,18 +50,16 @@ those listed in the props interface below.
 
 @## CSS
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<ControlGroup>`](#core/components/control-group)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Note that `.@ns-control-group` does not cascade any modifiers to its children. For example, each

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -11,7 +11,7 @@ Both components group multiple elements into a single unit, but their usage patt
 
 Think of __ControlGroup__ as a parent with multiple children, with each one a separate control.
 
-Conversely, an [__InputGroup__](#core/components/text-inputs.input-group) is a single control, and should behave like
+Conversely, an [__InputGroup__](#core/components/input-group) is a single control, and should behave like
 so. A button inside of an input group should only affect that input; if its reach is further, then it should be
 promoted to live in a control group.
 

--- a/packages/core/src/components/forms/file-input.md
+++ b/packages/core/src/components/forms/file-input.md
@@ -10,14 +10,12 @@ __FileInput__ is a lightweight wrapper around a `<label>` container element whic
 <FileInput disabled={true} text="Choose file..." onInputChange={...} />
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Static file name</h5>
-<div class="@ns-callout-body">
 
 File name does not automatically update after a user selects a file.
 To get this behavior, you must update the `text` prop.
 
-</div>
 </div>
 
 @## Props interface
@@ -29,18 +27,16 @@ Use `inputProps` to forward props to the `<input>` element.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<FileInput>`](#core/components/forms/file-input)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Use the standard `input type="file"` along with a `span` with class `@ns-file-upload-input`.

--- a/packages/core/src/components/forms/file-input.md
+++ b/packages/core/src/components/forms/file-input.md
@@ -1,28 +1,29 @@
 @# File input
 
+__FileInput__ is a lightweight wrapper around a `<label>` container element which contains an `<input type="file">`.
+
 @reactExample FileInputExample
 
 @## Usage
-
-__FileInput__ is a lightweight wrapper around a `<label>` container element which contains an `<input type="file">`.
-It supports the full range of HTML `<label>` DOM attributes.
-
-Use `inputProps` to forward props to the `<input>` element.
-
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h5 class="@ns-heading">Static file name</h5>
-<div class="@ns-callout-body">
-
-File name does not update on file selection. To get this behavior, you must implement it separately in JS.
-
-</div>
-</div>
 
 ```tsx
 <FileInput disabled={true} text="Choose file..." onInputChange={...} />
 ```
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h5 class="@ns-heading">Static file name</h5>
+<div class="@ns-callout-body">
+
+File name does not automatically update after a user selects a file.
+To get this behavior, you must update the `text` prop.
+
+</div>
+</div>
+
 @## Props interface
+
+__FileInput__ supports the full range of HTML `<label>` DOM attributes.
+Use `inputProps` to forward props to the `<input>` element.
 
 @interface FileInputProps
 

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -56,11 +56,10 @@ export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelEleme
     /**
      * Callback invoked on `<input>` `change` events.
      *
-     * This callback is offered as a convenience; it is equivalent to passing
-     * `onChange` to `inputProps`.
+     * This callback is offered as a convenience; it is equivalent to `inputProps.onChange`.
      *
-     * __Note:__ The top-level `onChange` prop is passed to the wrapping
-     * `<label>` rather than the `<input>`, which may not be what you expect.
+     * __Note:__ The top-level `onChange` prop is passed to the `<label>` element rather than the `<input>`,
+     * which may not be what you expect.
      */
     onInputChange?: React.FormEventHandler<HTMLInputElement>;
 
@@ -70,19 +69,21 @@ export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelEleme
     small?: boolean;
 
     /**
-     * The text to display.
+     * The text to display inside the input.
      *
      * @default "Choose file..."
      */
     text?: React.ReactNode;
 
     /**
-     * The button text.
+     * The button text to display on the right side of the input.
      *
      * @default "Browse"
      */
     buttonText?: string;
 }
+
+const NS = Classes.getClassNamespace();
 
 // this is a simple component, unit tests would be mostly tautological
 /* istanbul ignore next */
@@ -115,19 +116,13 @@ export class FileInput extends AbstractPureComponent<FileInputProps> {
             ...htmlProps
         } = this.props;
 
-        const rootClasses = classNames(
-            Classes.FILE_INPUT,
-            {
-                [Classes.FILE_INPUT_HAS_SELECTION]: hasSelection,
-                [Classes.DISABLED]: disabled,
-                [Classes.FILL]: fill,
-                [Classes.LARGE]: large,
-                [Classes.SMALL]: small,
-            },
-            className,
-        );
-
-        const NS = Classes.getClassNamespace();
+        const rootClasses = classNames(className, Classes.FILE_INPUT, {
+            [Classes.FILE_INPUT_HAS_SELECTION]: hasSelection,
+            [Classes.DISABLED]: disabled,
+            [Classes.FILL]: fill,
+            [Classes.LARGE]: large,
+            [Classes.SMALL]: small,
+        });
 
         const uploadProps = {
             [`${NS}-button-text`]: buttonText,

--- a/packages/core/src/components/forms/input-group.md
+++ b/packages/core/src/components/forms/input-group.md
@@ -38,13 +38,12 @@ Note that some browsers also implement a handler for the `esc` key to clear the 
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<InputGroup>`](#core/components/input-group)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
@@ -52,7 +51,6 @@ often fall out of sync as the design system is updated. You should use the React
 Note that you cannot use buttons with text in the CSS API for input groups. The padding for text inputs
 in CSS cannot accommodate buttons whose width varies due to text content.
 
-</div>
 </div>
 
 #### `.@ns-input-group`

--- a/packages/core/src/components/forms/input-group.md
+++ b/packages/core/src/components/forms/input-group.md
@@ -1,19 +1,12 @@
-@# Text inputs
+@# Input group
 
-Blueprint provides two kinds of text input components
-
-1. [__InputGroup__](#core/components/text-inputs.input-group) for single-line inputs
-1. [__TextArea__](#core/components/text-inputs.text-area) for multiline inputs
-
-@## Input group
-
-Input groups are a basic building block used to render text inputs across many Blueprint components.
-They allow you to add icons and buttons _within_ a text input to expand its appearance and functionality.
-For example, you might use an input group to build a visibility toggle for a password field.
+__InputGroup__ is basic building block used to render text inputs across many Blueprint components.
+This component allows you to optionally add icons and buttons _within_ a text input to expand its appearance and
+functionality. For example, you might use an input group to build a visibility toggle for a password field.
 
 @reactExample InputGroupExample
 
-@### Usage
+@## Usage
 
 __InputGroup__ supports one non-interactive icon on the left side and one arbitrary element on the right side.
 It measures the width of its child elements to create the appropriate right padding inside the input to accommodate
@@ -29,16 +22,26 @@ sent back to the component as a controlled `value` synchronously), but there is 
 `asyncControl` prop. Note that the input cursor may jump to the end of the input if the speed of text entry
 (time between change events) is faster than the speed of the async update.
 
-@### Props interface
+@## Props interface
 
 @interface InputGroupProps
 
-@### CSS API
+@## Search input
+
+Apply the attribute `<InputGroup type="search">` to style a text input as a search field. This styling is equivalent
+to what is applied using the `Classes.ROUND` modifier class&mdash;it is automatically applied for `[type="search"]`
+inputs.
+
+Note that some browsers also implement a handler for the `esc` key to clear the text in a search field.
+
+@reactExample SearchInputExample
+
+@## CSS API
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h5 class="@ns-heading">
 
-Deprecated API: use [`<InputGroup>`](#core/components/text-inputs.input-group)
+Deprecated API: use [`<InputGroup>`](#core/components/input-group)
 
 </h5>
 <div class="@ns-callout-body">
@@ -68,43 +71,3 @@ Apply `Classes.INPUT` on an `input[type="text"]`. You should also specify `dir="
 (in all browsers except Internet Explorer).
 
 @css input
-
-@## Text area
-
-__TextArea__ is a multiline text input component which can be controlled similar to an `<InputGroup>` or `<input>`.
-
-@reactExample TextAreaExample
-
-@### Props interface
-
-@interface TextAreaProps
-
-@### CSS API
-
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h5 class="@ns-heading">
-
-Deprecated API: use [`<TextArea>`](#core/components/text-inputs.text-area)
-
-</h5>
-<div class="@ns-callout-body">
-
-CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
-often fall out of sync as the design system is updated. You should use the React component APIs instead.
-
-</div>
-</div>
-
-Apply `Classes.INPUT` to a `<textarea>` element.
-
-@css textarea
-
-@## Search field
-
-Changing the `<input>` element's `type` attribute to `"search"` styles it to look like a search
-field, giving it a rounded appearance. This style is equivalent to the `.@ns-round` modifier, but it
-is applied automatically for `[type="search"]` inputs.
-
-Note that some browsers also implement a handler for the `esc` key to clear the text in a search field.
-
-@css input-search

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -69,7 +69,7 @@ export interface InputGroupState {
 /**
  * Input group component.
  *
- * @see https://blueprintjs.com/docs/#core/components/text-inputs.input-group
+ * @see https://blueprintjs.com/docs/#core/components/input-group
  */
 export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGroupState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.InputGroup`;

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -5,15 +5,13 @@ __Labels__ enhance the usability of your forms.
 Wrapping a `<label>` element around a form input effectively increases the area where the user can click to activate
 the control. Notice how in the examples below, clicking a label focuses its `<input>`.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Prefer form groups over labels</h5>
-<div class="@ns-callout-body">
 
 The [__FormGroup__ component](#core/components/form-group) provides additional functionality such as helper text and
 modifier props as well as full label support. __FormGroup__ supports both simple and complex use cases, therefore we
 recommend using it exclusively when constructing forms.
 
-</div>
 </div>
 
 @## Usage
@@ -36,18 +34,16 @@ This component supports the full range of `<label>` DOM attributes.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Label>`](#core/components/forms/label)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Simple labels are useful for basic forms for a single `<input>`.

--- a/packages/core/src/components/forms/switch.md
+++ b/packages/core/src/components/forms/switch.md
@@ -13,18 +13,16 @@ Its whole label is interactive and it supports a few visual modifiers for differ
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Switch>`](#core/components/switch)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 @css switch

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -1,0 +1,29 @@
+@# Text area
+
+__TextArea__ is a multiline text input component which can be controlled similar to an `<InputGroup>` or `<input>`.
+
+@reactExample TextAreaExample
+
+@## Props interface
+
+@interface TextAreaProps
+
+@## CSS API
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+    <h5 class="@ns-heading">
+
+Deprecated API: use [`<TextArea>`](#core/components/text-area)
+
+</h5>
+<div class="@ns-callout-body">
+
+CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
+often fall out of sync as the design system is updated. You should use the React component APIs instead.
+
+</div>
+</div>
+
+Apply `Classes.INPUT` to a `<textarea>` element.
+
+@css textarea

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -10,18 +10,16 @@ __TextArea__ is a multiline text input component which can be controlled similar
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<TextArea>`](#core/components/text-area)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Apply `Classes.INPUT` to a `<textarea>` element.

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -56,7 +56,7 @@ export interface TextAreaState {
 /**
  * Text area component.
  *
- * @see https://blueprintjs.com/docs/#core/components/text-inputs.text-area
+ * @see https://blueprintjs.com/docs/#core/components/text-area
  */
 export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TextArea`;

--- a/packages/core/src/components/hotkeys/hotkeys-target2.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target2.md
@@ -1,19 +1,17 @@
 @# HotkeysTarget2
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Migrating from [HotkeysTarget](#core/legacy/hotkeys-legacy)?
 
 </h5>
-<div class="@ns-callout-body">
 
 __HotkeysTarget2__ is a replacement for HotkeysTarget. You are encouraged to use this new API, or
 the `useHotkeys` hook directly in your function components, as they will become the standard
 APIs in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration) on the wiki.
 
-</div>
 </div>
 
 

--- a/packages/core/src/components/html-select/html-select.md
+++ b/packages/core/src/components/html-select/html-select.md
@@ -3,7 +3,7 @@
 Styling HTML `<select>` tags requires a wrapper element to customize the dropdown caret, so Blueprint provides
 a __HTMLSelect__ component to streamline this process.
 
-<div class="@ns-callout @ns-intent-success @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-success @ns-icon-info-sign @ns-callout-has-body-content">
 
 The [__Select__](#select/select-component) component in the [**@blueprintjs/select**](#select)
 package provides a more full-features alternative to the native HTML `<select>` tag. Notably, it
@@ -24,18 +24,16 @@ Options can be passed as `<option>` children for full flexibility or via the `op
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<HTMLSelect>`](#core/components/html-select)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Put class modifiers on the wrapper and attribute modifiers and event handlers directly on the `<select>`.

--- a/packages/core/src/components/html-table/html-table.md
+++ b/packages/core/src/components/html-table/html-table.md
@@ -2,15 +2,13 @@
 
 __HTMLTable__ provides Blueprint styling to native HTML tables.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">This is not @blueprintjs/table</h5>
-<div class="@ns-callout-body">
 
 This component is a simple CSS-only skin for HTML `<table>` elements.
 It is ideal for basic static tables. If you're looking for more complex
 spreadsheet-like features, check out [**@blueprintjs/table**](#table).
 
-</div>
 </div>
 
 @## Props interface
@@ -22,18 +20,16 @@ responsible for rendering `<thead>` and `<tbody>` elements as children.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<HTMLTable>`](#core/components/html-table)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Apply the `@ns-html-table` class to a `<table>` element. You can apply modifiers as additional classes.

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -147,13 +147,11 @@ Icon classes also support the four `.@ns-intent-*` modifiers to color the image.
 <span class="@ns-icon-large @ns-icon-geosearch @ns-intent-success"></span>
 ```
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Non-standard sizes</h5>
-<div class="@ns-callout-body">
 
 Generally, font icons should only be used at either 16px or 20px. However, if a non-standard size is
 necessary, set a `font-size` that is whole multiple of 16 or 20 with the relevant size class.
 You can instead use the class `@ns-icon` to make the icon inherit its size from surrounding text.
 
-</div>
 </div>

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -92,18 +92,16 @@ room to the right.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Menu>` and `<MenuItem>`](#core/components/menu)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Menus can be constructed manually using the following HTML markup and `@ns-menu-*` classes
@@ -134,7 +132,7 @@ Menus can be constructed manually using the following HTML markup and `@ns-menu-
 <small>\* You do not need to add a `@ns-icon-<sizing>` class to menu items—icon sizing is
 defined as part of `.@ns-menu-item`.</small>
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
 
 Note that the following examples are `display: inline-block`; you may need to adjust
 menu width in your own usage.

--- a/packages/core/src/components/navbar/navbar.md
+++ b/packages/core/src/components/navbar/navbar.md
@@ -34,14 +34,12 @@ so-called "sticky" behavior: the navbar stays at the top of the screen as the us
 
 This modifier is not illustrated here because it breaks the document flow.
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">Body padding required</h5>
-<div class="@ns-callout-body">
 
 The fixed navbar will lie on top of your other content unless you add padding to the top of the `<body>` element equal
 to the height of the navbar. Use the `$pt-navbar-height` Sass variable.
 
-</div>
 </div>
 
 @### Fixed width
@@ -64,18 +62,16 @@ center it.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use `<Navbar>`
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Use the following classes to construct a navbar:

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -36,13 +36,12 @@ to the SVG paths.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<NonIdealState>`](#core/components/non-ideal-state)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
@@ -53,7 +52,6 @@ Also, since the CSS API uses the icon font, Blueprint styles cannot adjust the i
 appearance like it does with the React component API. This means __NonIdealState__ elements rendered with this API will
 stand out visually (in a bad way) within the design system.
 
-</div>
 </div>
 
 Apply the `.@ns-non-ideal-state` class to the root container element and wrap the icon element with a

--- a/packages/core/src/components/overlay/overlay.md
+++ b/packages/core/src/components/overlay/overlay.md
@@ -23,14 +23,12 @@ will be inserted before the children if `hasBackdrop={true}`.
 The `onClose` callback prop is invoked when user interaction causes the overlay to close, but your application is
 responsible for updating the state that actually closes the overlay.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">A note about overlay content positioning</h5>
-<div class="@ns-callout-body">
 
 When rendered inline, content will automatically be set to `position: absolute` to respect
 document flow. Otherwise, content will be set to `position: fixed` to cover the entire viewport.
 
-</div>
 </div>
 
 ```tsx

--- a/packages/core/src/components/panel-stack/panel-stack.md
+++ b/packages/core/src/components/panel-stack/panel-stack.md
@@ -1,18 +1,16 @@
 @# Panel stack
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated: use [PanelStack2](#core/components/panel-stack2)
 
 </h5>
-<div class="@ns-callout-body">
 
 This API is **deprecated since @blueprintjs/core v3.40.0** in favor of the new
 __PanelStack2__ component. You should migrate to the new API which will become the
 standard in a future major version of Blueprint.
 
-</div>
 </div>
 
 `PanelStack` manages a stack of panels and displays only the topmost panel.

--- a/packages/core/src/components/panel-stack2/panel-stack2.md
+++ b/packages/core/src/components/panel-stack2/panel-stack2.md
@@ -1,18 +1,16 @@
 @# Panel stack (v2)
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Migrating from [PanelStack](#core/components/panel-stack)?
 
 </h5>
-<div class="@ns-callout-body">
 
 __PanelStack2__ is a replacement for __PanelStack__. It will become the standard API in a future major version of
 Blueprint. You are encouraged to use this new API now for forwards-compatibility. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/PanelStack2-migration) on the wiki.
 
-</div>
 </div>
 
 __PanelStack2__ manages a stack of panels and displays only the topmost panel.

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -55,16 +55,14 @@ The **content** will be shown inside the popover itself. When opened, the popove
 positioned on the page next to the target; the `placement` prop determines its relative placement (on
 which side of the target).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Button targets</h5>
-<div class="@ns-callout-body">
 
 Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
 events, which interferes with the popover functioning. If you need to disable a button which
 triggers a popover, you should use [`AnchorButton`](#core/components/button.anchor-button) instead.
 See the [callout here](#core/components/button.props) for more details.
 
-</div>
 </div>
 
 ```tsx
@@ -151,14 +149,12 @@ You may override the default modifiers with the `modifiers` prop, which is an ob
 the modifier name and its options object, respectively. See the
 [Popper.js modifiers docs page](https://popper.js.org/docs/v2/modifiers/) for more info.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Auto placement requires flip modifier</h5>
-<div class="@ns-callout-body">
 
 Be careful when disabling the "flip" modifier, since the default "auto" placement relies on it. If you _do_ decide
 to disable this modifier, be sure to also specify a placement which is not "auto".
 
-</div>
 </div>
 
 You may also add custom modifiers using the `modifiersCustom` prop. See the
@@ -179,14 +175,12 @@ It is important to pay attention to the value of the `nextOpenState` parameter a
 in your application logic whether you should care about a particular invocation (for instance,
 if the `nextOpenState` is not the same as the __Popover__'s current state).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Disabling controlled popovers</h5>
-<div class="@ns-callout-body">
 
 If `disabled={true}`, a controlled popover will remain closed even if `isOpen={true}`.
 The popover will re-open when `disabled` is set to `false`.
 
-</div>
 </div>
 
 #### Example controlled usage
@@ -246,14 +240,12 @@ The following example demonstrates the various interaction kinds (note: these Po
 
 @reactExample PopoverInteractionKindExample
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Conditionally styling popover targets</h5>
-<div class="@ns-callout-body">
 
 When a popover is open, `Classes.POPOVER_OPEN` is applied to the target.
 You can use this to style the target differently when the popover is open.
 
-</div>
 </div>
 
 @### Closing on click
@@ -320,15 +312,13 @@ a translucent background color, like the backdrop for the [`Dialog`](#core/compo
 
 The backdrop element has the same opacity-fade transition as the `Dialog` backdrop.
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">Dangerous edge case</h5>
-<div class="@ns-callout-body">
 
 Rendering a `<Popover isOpen={true} hasBackdrop={true}>` outside the viewport bounds can easily break your application
 by covering the UI with an invisible non-interactive backdrop. This edge case must be handled by your application code
 or (if possible) avoided entirely.
 
-</div>
 </div>
 
 @### Portal rendering

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -16,15 +16,13 @@ __Portal__ component functions like a declarative `appendChild()`. The children 
 __Portal__ is used inside [Overlay](#core/components/overlay) to actually overlay the content on the
 application.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-move">
+<div class="@ns-callout @ns-intent-warning @ns-icon-move @ns-callout-has-body-content">
     <h5 class="@ns-heading">A note about responsive layouts</h5>
-<div class="@ns-callout-body">
 
 For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal`
 may take up extra whitespace and cause the window to undesirably scroll. To fix this, instead
 apply `position: absolute` to the `<body>` tag.
 
-</div>
 </div>
 
 @## Props interface
@@ -58,13 +56,11 @@ ReactDOM.render(
 
 @## Legacy context options
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">Legacy React API</h5>
-<div class="@ns-callout-body">
 
 This feature uses React's legacy context API. Support for this API will be removed in Blueprint v6.0.
 
-</div>
 </div>
 
 __Portal__ supports the following options via the [React legacy context API](https://reactjs.org/docs/legacy-context.html).

--- a/packages/core/src/components/progress-bar/progress-bar.md
+++ b/packages/core/src/components/progress-bar/progress-bar.md
@@ -14,18 +14,16 @@ progress meter that fills the entire bar.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<ProgressBar>`](#core/components/progress-bar)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Set the current progress of the bar via a `width` style rule on the inner `.@ns-progress-meter` element. This is a very

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -5,16 +5,14 @@ It is a thin wrapper around [`ResizeObserver`][resizeobserver] to provide React 
 
 [resizeobserver]: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">DOM ref required</h5>
-<div class="@ns-callout-body">
 
 ResizeSensor's implementation relies on a React ref being attached to a DOM element,
 so the child of this component _must be a native DOM element_ or utilize
 [`React.forwardRef()`](https://reactjs.org/docs/forwarding-refs.html) to forward any
 injected ref to the underlying DOM element.
 
-</div>
 </div>
 
 @## Usage
@@ -42,16 +40,14 @@ const myRef = React.createRef();
 </ResizeSensor>
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Asynchronous behavior</h5>
-<div class="@ns-callout-body">
 
 The `onResize` callback is invoked asynchronously after a resize is detected
 and typically happens at the end of a frame (after layout, before paint).
 Therefore, testing behavior that relies on this component involves setting a
 timeout for the next frame.
 
-</div>
 </div>
 
 @## Props interface

--- a/packages/core/src/components/section/section.md
+++ b/packages/core/src/components/section/section.md
@@ -1,3 +1,7 @@
+---
+tag: new
+---
+
 @# Section
 
 The __Section__ component can be used to contain, structure, and create hierarchy for information in your UI. It makes use of some concepts from other more atomic Blueprint components:

--- a/packages/core/src/components/skeleton/skeleton.md
+++ b/packages/core/src/components/skeleton/skeleton.md
@@ -14,13 +14,11 @@ to, so you should supply a placeholder while awaiting real content.
 Apply the class `.@ns-skeleton` to elements that you would like to cover up with
 a loading animation.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Manually disable focusable elements</h5>
-<div class="@ns-callout-body">
 
 When using the `.@ns-skeleton` class on focusable elements such as inputs and buttons, be sure to disable the element,
 via either the `disabled` or `tabindex="-1"` attributes. Failing to do so will allow these skeleton elements to be
 focused when they shouldn't be.
 
-</div>
 </div>

--- a/packages/core/src/components/tabs/tabs.md
+++ b/packages/core/src/components/tabs/tabs.md
@@ -54,18 +54,16 @@ be useful when you want the associated panel to appear elsewhere in the DOM (by 
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Tabs>`](#core/components/tabs)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Blueprint offers tab styles with the class `@ns-tabs`. You should add the proper accessibility attributes

--- a/packages/core/src/components/tag-input/tag-input.md
+++ b/packages/core/src/components/tag-input/tag-input.md
@@ -6,14 +6,12 @@ Clicking anywhere on the container will focus the text input.
 
 @reactExample TagInputExample
 
-<div class="@ns-callout @ns-intent-success @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-success @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Looking for a dropdown menu?</h5>
-<div class="@ns-callout-body">
 
 [The __MultiSelect__ component in the **@blueprintjs/select** package](#select/multi-select)
 composes this component with a dropdown menu.
 
-</div>
 </div>
 
 @## Usage
@@ -39,26 +37,22 @@ updated `values` array, with new items appended to the end and removed items fil
 The `<input>` element can be controlled directly via the `inputValue` and `onInputChange` props. Additional properties
 (such as custom event handlers) can be forwarded to the input via `inputProps`.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Handling long words</h5>
-<div class="@ns-callout-body">
 
 Set an explicit `width` on the container element to cause long tags to wrap onto multiple lines.
 Either supply a specific pixel value, or use `<TagInput className={Classes.FILL}>`
 to fill its container's width (try this in the example above).
 
 </div>
-</div>
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Disabling a tag input</h5>
-<div class="@ns-callout-body">
 
 Disabling this component requires setting the `disabled` prop to `true`
 and separately disabling the component's `rightElement` as appropriate
 (because `TagInput` accepts any `JSX.Element` as its `rightElement`).
 
-</div>
 </div>
 
 @## Props interface

--- a/packages/core/src/components/tag/tag.md
+++ b/packages/core/src/components/tag/tag.md
@@ -15,18 +15,16 @@ It supports all valid `<span>` DOM attributes.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Tag>`](#core/components/tag)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 Create a tag with a `span.@ns-tag`. An optional "remove" button can be added with a `button.@ns-tag-remove` as the last

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -56,26 +56,22 @@ There are three ways to use __OverlayToaster__:
     myToaster.current?.show({ ...toastOptions });
     ```
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Working with multiple toasters</h5>
-<div class="@ns-callout-body">
 
 You can have multiple toasters in a single application, but you must ensure that each has a unique `position` to
 prevent overlap.
 
 </div>
-</div>
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Toaster focus</h5>
-<div class="@ns-callout-body">
 
 __OverlayToaster__ always disables Overlay's `enforceFocus` behavior (meaning that you're not blocked
 from accessing other parts of the application while a toast is active), and by default also
 disables `autoFocus` (meaning that focus will not switch to a toast when it appears). You can
 enable `autoFocus` for an individual `OverlayToaster` via a prop, if desired.
 
-</div>
 </div>
 
 

--- a/packages/core/src/components/tooltip/tooltip.md
+++ b/packages/core/src/components/tooltip/tooltip.md
@@ -17,16 +17,14 @@ The **content** will be shown inside the tooltip itself. When opened, the toolti
 positioned on the page next to the target; the `placement` prop determines its relative placement (on
 which side of the target).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Button targets</h5>
-<div class="@ns-callout-body">
 
 Buttons make great tooltip targets, but the `disabled` attribute will prevent all
 events so the enclosing __Tooltip__ will not know when to respond.
 Use [__AnchorButton__](#core/components/button.anchor-button) instead;
 see the [callout here](#core/components/button.props) for more details.
 
-</div>
 </div>
 
 @## Props interface

--- a/packages/core/src/components/tree/tree.md
+++ b/packages/core/src/components/tree/tree.md
@@ -34,18 +34,16 @@ are shown.
 
 @## CSS API
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated API: use [`<Tree>`](#core/components/tree)
 
 </h5>
-<div class="@ns-callout-body">
 
 CSS APIs for Blueprint components are considered deprecated, as they are verbose, error-prone, and they
 often fall out of sync as the design system is updated. You should use the React component APIs instead.
 
-</div>
 </div>
 
 @css tree

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -1,19 +1,17 @@
 @# HotkeysProvider
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Migrating from [HotkeysTarget](#core/legacy/hotkeys-legacy)?
 
 </h5>
-<div class="@ns-callout-body">
 
 __HotkeysProvider__ and `useHotkeys`, used together, are a replacement for __HotkeysTarget__.
 You are encouraged to use this new API, as it will become the standard APIs in a future major version of Blueprint.
 See the full [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration)
 on the wiki.
 
-</div>
 </div>
 
 HotkeysProvider generates a React context necessary for the [`useHotkeys` hook](#core/hooks/use-hotkeys)

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -1,19 +1,17 @@
 @# useHotkeys
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Migrating from [__HotkeysTarget__](#core/legacy/hotkeys-legacy)?
 
 </h5>
-<div class="@ns-callout-body">
 
 `useHotkeys` is a replacement for __HotkeysTarget__. You are encouraged to use this new API in your function
 components, or the [__HotkeysTarget2__ component](#core/components/hotkeys-target2) in your component classes,
 as they will become the standard APIs in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration) on the wiki.
 
-</div>
 </div>
 
 The `useHotkeys` hook adds hotkey / keyboard shortcut interactions to your application using a custom React hook.

--- a/packages/core/src/legacy/hotkeys-legacy.md
+++ b/packages/core/src/legacy/hotkeys-legacy.md
@@ -1,19 +1,17 @@
 @# Hotkeys (legacy)
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error">
+<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
 Deprecated: use [useHotkeys](#core/hooks/use-hotkeys)
 
 </h5>
-<div class="@ns-callout-body">
 
 This API is **deprecated since @blueprintjs/core v3.39.0** in favor of the new
 [`useHotkeys` hook](#core/hooks/use-hotkeys) and
 [__HotkeysTarget2__ component](#core/components/hotkeys-target2). You should migrate to one of
 these new APIs, as they will become the standard in future major version of Blueprint.
 
-</div>
 </div>
 
 Hotkeys enable you to create interactions based on user keyboard events.

--- a/packages/datetime/src/components/date-input/date-input.md
+++ b/packages/datetime/src/components/date-input/date-input.md
@@ -1,6 +1,6 @@
 @# Date input
 
-The __DateInput__ component is an [__InputGroup__](#core/components/text-inputs.input-group)
+The __DateInput__ component is an [__InputGroup__](#core/components/input-group)
 that shows a [__DatePicker__](#datetime/datepicker) inside a [__Popover__](#core/components/popover)
 on focus. It optionally shows a [__TimezoneSelect__](#datetime/timezone-select) on the right side of
 the InputGroup, allowing the user to change the timezone of the selected date.

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -101,7 +101,7 @@ export interface DateInputProps extends DatePickerBaseProps, DateFormatProps, Da
     fill?: boolean;
 
     /**
-     * Props to pass to the [InputGroup component](#core/components/text-inputs.input-group).
+     * Props to pass to the [InputGroup component](#core/components/input-group).
      *
      * Some properties are unavailable:
      * - `inputProps.value`: use `value` instead

--- a/packages/datetime/src/components/date-range-input/date-range-input.md
+++ b/packages/datetime/src/components/date-range-input/date-range-input.md
@@ -1,7 +1,7 @@
 @# Date range input
 
 The __DateRangeInput__ component is [__ControlGroup__](#core/components/control-group) composed
-of two [__InputGroups__](#core/components/text-inputs.input-group). It shows a
+of two [__InputGroups__](#core/components/input-group). It shows a
 [__DateRangePicker__](#datetime/daterangepicker) in a [__Popover__](#core/components/popover)
 on focus.
 

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -95,7 +95,7 @@ export interface DateRangeInputProps extends DatePickerBaseProps, DateFormatProp
     fill?: boolean;
 
     /**
-     * Props to pass to the end-date [input group](#core/components/text-inputs.input-group).
+     * Props to pass to the end-date [input group](#core/components/input-group).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `ref` is not supported; use `inputRef` instead.
      */
@@ -151,7 +151,7 @@ export interface DateRangeInputProps extends DatePickerBaseProps, DateFormatProp
     singleMonthOnly?: boolean;
 
     /**
-     * Props to pass to the start-date [input group](#core/components/text-inputs.input-group).
+     * Props to pass to the start-date [input group](#core/components/input-group).
      * `disabled` and `value` will be ignored in favor of the top-level props on this component.
      * `ref` is not supported; use `inputRef` instead.
      */

--- a/packages/datetime/src/components/timezone-select/timezone-select.md
+++ b/packages/datetime/src/components/timezone-select/timezone-select.md
@@ -41,15 +41,13 @@ in this case, all button-specific props will be ignored:
 </TimezonePicker>
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Local timezone detection</h5>
-<div class="@ns-callout-body">
 
 __TimezoneSelect__ detects the local timezone using the
 [i18n API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions)
 when the `showLocalTimezone` prop is enabled and cannot guarantee correctness in all browsers.
 
-</div>
 </div>
 
 @## Props interface

--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -6,13 +6,11 @@ It is optimized for building complex data-dense interfaces for desktop applicati
 
 @reactDocs Welcome
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-star">
+<div class="@ns-callout @ns-intent-primary @ns-icon-star @ns-callout-has-body-content">
     <h5 class="@ns-heading">Blueprint v5.0 is now available</h5>
-<div class="@ns-callout-body">
 
 Check out the [migration guides to upgrade from v4.x &rarr;](https://github.com/palantir/blueprint/wiki/Blueprint-5.0)
 
-</div>
 </div>
 
 @## Quick start

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -72,6 +72,7 @@ export * from "./textExample";
 export * from "./spinnerExample";
 export * from "./tabsExample";
 export * from "./inputGroupExample";
+export { SearchInputExample } from "./searchInputExample";
 export * from "./tagExample";
 export * from "./toastExample";
 export * from "./tooltipExample";

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -92,7 +92,9 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
         this.setState({ buttonPosition }),
     );
 
-    private handleLocaleChange = handleStringChange(locale => this.setState({ locale }));
+    private handleLocaleChange = handleStringChange(locale =>
+        this.setState({ locale: locale === "default" ? undefined : locale }),
+    );
 
     private toggleDisabled = handleBooleanChange(disabled => this.setState({ disabled }));
 
@@ -185,7 +187,7 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
                 {this.renderSelectMenu(
                     "Locale",
                     locale,
-                    [{ label: "Default", value: undefined }, ...LOCALES],
+                    [{ label: "Default", value: "default" }, ...LOCALES],
                     this.handleLocaleChange,
                 )}
             </>

--- a/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { H5, InputGroup, Switch } from "@blueprintjs/core";
+import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+
+interface SearchInputExampleProps {
+    disabled: boolean;
+    readOnly: boolean;
+    large: boolean;
+    small: boolean;
+}
+
+export class SearchInputExample extends React.PureComponent<ExampleProps, SearchInputExampleProps> {
+    public state: SearchInputExampleProps = {
+        disabled: false,
+        large: false,
+        readOnly: false,
+        small: false,
+    };
+
+    private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
+
+    private handleReadOnlyChange = handleBooleanChange(readOnly => this.setState({ readOnly }));
+
+    private handleLargeChange = handleBooleanChange(large => this.setState({ large, ...(large && { small: false }) }));
+
+    private handleSmallChange = handleBooleanChange(small => this.setState({ small, ...(small && { large: false }) }));
+
+    public render() {
+        const { disabled, large, readOnly, small } = this.state;
+
+        return (
+            <Example options={this.renderOptions()} {...this.props}>
+                <InputGroup
+                    disabled={disabled}
+                    large={large}
+                    placeholder="Search..."
+                    readOnly={readOnly}
+                    small={small}
+                />
+            </Example>
+        );
+    }
+
+    private renderOptions() {
+        const { disabled, readOnly, large, small } = this.state;
+        return (
+            <>
+                <H5>Props</H5>
+                <Switch label="Disabled" onChange={this.handleDisabledChange} checked={disabled} />
+                <Switch label="Read-only" onChange={this.handleReadOnlyChange} checked={readOnly} />
+                <Switch label="Large" onChange={this.handleLargeChange} checked={large} />
+                <Switch label="Small" onChange={this.handleSmallChange} checked={small} />
+            </>
+        );
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
@@ -53,6 +53,7 @@ export class SearchInputExample extends React.PureComponent<ExampleProps, Search
                     placeholder="Search..."
                     readOnly={readOnly}
                     small={small}
+                    type="search"
                 />
             </Example>
         );

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -49,14 +49,12 @@ The JavaScript components are stable and their APIs adhere to [semantic versioni
     </head>
     ```
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">CDN-only usage</h5>
-<div class="@ns-callout-body">
 
 Blueprint can be added to a page using the Unpkg CDN.
 [See below for instructions](#blueprint/getting-started.cdn-consumption).
 
-</div>
 </div>
 
 @## JS environment

--- a/packages/select/src/components/multi-select/multi-select.md
+++ b/packages/select/src/components/multi-select/multi-select.md
@@ -9,14 +9,12 @@ You may react to user interactions with the `onItemSelect` and `onRemove` callba
 
 @reactExample MultiSelectExample
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Generic components and custom filtering</h5>
-<div class="@ns-callout-body">
 
 For more information on controlled usage, generic components, creating new items, and custom filtering,
 please visit the documentation for [__Select__](#select/select).
 
-</div>
 </div>
 
 @## Props interface

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -2,7 +2,7 @@
 
 The __Select__ component renders a UI to choose one item from a list. Its children are wrapped in a
 [__Popover__](#core/components/popover) that contains the list and an optional
-[__InputGroup__](#core/components/text-inputs.input-group) to filter it.
+[__InputGroup__](#core/components/input-group) to filter it.
 You may provide a predicate to customize the filtering algorithm. The value of a __Select__
 (the currently chosen item) is uncontrolled: listen to changes with the `onItemSelect` callback prop.
 

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -67,7 +67,7 @@ export interface SelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
     filterable?: boolean;
 
     /**
-     * Props to pass to the query [InputGroup component](#core/components/text-inputs.input-group).
+     * Props to pass to the query [InputGroup component](#core/components/input-group).
      *
      * Some properties are unavailable:
      * - `inputProps.value`: use `query` instead

--- a/packages/select/src/components/suggest/suggest.md
+++ b/packages/select/src/components/suggest/suggest.md
@@ -1,7 +1,7 @@
 @# Suggest
 
 __Suggest__ behaves similarly to [__Select__](#select/select-component), except it renders a text input group as the
-__Popover__ target instead of arbitrary children. This [__InputGroup__](#core/components/text-inputs.input-group) can
+__Popover__ target instead of arbitrary children. This [__InputGroup__](#core/components/input-group) can
 be customized using `inputProps`.
 
 @reactExample SuggestExample

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -52,7 +52,7 @@ export interface SuggestProps<T> extends ListItemsProps<T>, Omit<SelectPopoverPr
     fill?: boolean;
 
     /**
-     * Props to pass to the query [InputGroup component](#core/components/text-inputs.input-group).
+     * Props to pass to the query [InputGroup component](#core/components/input-group).
      *
      * Some properties are unavailable:
      * - `inputProps.value`: use `query` instead


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Fix callout HTML markup in Markdown docs to match `<Collapse>` rendered markup (`.bp5-collapse-body` was added in https://github.com/palantir/blueprint/pull/6291, but we reverted this DOM break in https://github.com/palantir/blueprint/pull/6297)
- Fix "missing React key" warning in NumericInput docs example
- Split "Text inputs" docs page into two pages for the two relevant components, InputGroup and TextArea
  - This fixes a documentalist error - there were duplicate section headings for the "CSS API" sections for each of these components on the same docs page
- Add "Search input" React example to InputGroup docs (this replaces the demo of "Search field" styling with the deprecated CSS API) 
- Add "new" tag to the "Section" docs page in the sidebar 

#### Screenshots

<img width="1128" alt="image" src="https://github.com/palantir/blueprint/assets/723999/de8eb575-c49a-4fc7-a514-f4807e9fd1b9">

<img width="806" alt="image" src="https://github.com/palantir/blueprint/assets/723999/5726fe25-cb43-4d70-a98e-21f5ed77c6d7">

<img width="817" alt="image" src="https://github.com/palantir/blueprint/assets/723999/87112366-9ee1-4685-a6cf-ae61b6615326">


<img width="259" alt="image" src="https://github.com/palantir/blueprint/assets/723999/61436f19-41db-449f-abba-229d50d71462">

