### PR TITLE
[core] feat(typography): muted text modifier for headings

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -13,13 +13,15 @@ Headings
 
 Markup:
 <div>
-  <h1 class="@ns-heading">H1 heading</h1>
-  <h2 class="@ns-heading">H2 heading</h2>
-  <h3 class="@ns-heading">H3 heading</h3>
-  <h4 class="@ns-heading">H4 heading</h4>
-  <h5 class="@ns-heading">H5 heading</h5>
-  <h6 class="@ns-heading">H6 heading</h6>
+  <h1 class="@ns-heading {{.modifier}}">H1 heading</h1>
+  <h2 class="@ns-heading {{.modifier}}">H2 heading</h2>
+  <h3 class="@ns-heading {{.modifier}}">H3 heading</h3>
+  <h4 class="@ns-heading {{.modifier}}">H4 heading</h4>
+  <h5 class="@ns-heading {{.modifier}}">H5 heading</h5>
+  <h6 class="@ns-heading {{.modifier}}">H6 heading</h6>
 </div>
+
+.#{$ns}-text-muted - Change text color to a gentler gray.
 
 Styleguide headings
 */

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -65,6 +65,14 @@ $pt-dark-intent-text-colors: (
   .#{$ns}-dark & {
     color: $pt-dark-heading-color;
   }
+
+  &.#{$ns}-text-muted {
+    color: $pt-text-color-muted;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-text-color-muted;
+    }
+  }
 }
 
 @mixin monospace-typography() {


### PR DESCRIPTION
#### Checklist

- ~Includes tests~
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add support for `Classes.TEXT_MUTED` modifier class to `Classes.HEADING` elements.

Before this change, this modifier class had no effect on the color of the heading text.

#### Reviewers should focus on:

N/A

#### Screenshot

<img width="727" alt="image" src="https://github.com/palantir/blueprint/assets/723999/2f6761c9-f84c-400c-b7a9-30568ae6a9dc">

