### PR TITLE
[core] feat(TextArea): new `autoResize` prop allows input to shrink vertically

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -175,6 +175,9 @@ export const INPUT_ACTION = `${INPUT}-action`;
 
 export const RESIZABLE_INPUT_SPAN = `${NS}-resizable-input-span`;
 
+export const TEXT_AREA = `${NS}-text-area`;
+export const TEXT_AREA_AUTO_RESIZE = `${TEXT_AREA}-auto-resize`;
+
 export const CONTROL = `${NS}-control`;
 export const CONTROL_INDICATOR = `${CONTROL}-indicator`;
 export const CONTROL_INDICATOR_CHILD = `${CONTROL_INDICATOR}-child`;

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -110,3 +110,10 @@ textarea.#{$ns}-input {
     padding: $input-small-padding;
   }
 }
+
+.#{$ns}-text-area {
+  &.#{$ns}-text-area-auto-resize {
+    // we are controlling vertical resizing automatically, so restrict user resizing to horizontal dimension only
+    resize: horizontal;
+  }
+}

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -22,27 +22,19 @@ import { DISPLAYNAME_PREFIX, IntentProps, Props } from "../../common/props";
 
 export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAttributes<HTMLTextAreaElement> {
     /**
-     * Whether the text area should take up the full width of its container.
-     */
-    fill?: boolean;
-
-    /**
-     * Whether the text area should appear with large styling.
-     */
-    large?: boolean;
-
-    /**
-     * Whether the text area should appear with small styling.
-     */
-    small?: boolean;
-
-    /**
-     * Whether the component should automatically resize as a user types in the text input.
-     * Please note that this will disable manual resizing.
+     * Whether the component should automatically resize vertically as a user types in the text input.
+     * This will disable manual resizing in the vertical dimension.
      *
      * @default false
      */
     autoResize?: boolean;
+
+    /**
+     * Whether the text area should take up the full width of its container.
+     *
+     * @default false
+     */
+    fill?: boolean;
 
     /**
      * Whether the text area should automatically grow vertically to accomodate content.
@@ -55,6 +47,20 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
      * Ref handler that receives HTML `<textarea>` element backing this component.
      */
     inputRef?: React.Ref<HTMLTextAreaElement>;
+
+    /**
+     * Whether the text area should appear with large styling.
+     *
+     * @default false
+     */
+    large?: boolean;
+
+    /**
+     * Whether the text area should appear with small styling.
+     *
+     * @default false
+     */
+    small?: boolean;
 }
 
 export interface TextAreaState {
@@ -69,6 +75,13 @@ export interface TextAreaState {
  * @see https://blueprintjs.com/docs/#core/components/text-area
  */
 export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState> {
+    public static defaultProps: TextAreaProps = {
+        autoResize: false,
+        fill: false,
+        large: false,
+        small: false,
+    };
+
     public static displayName = `${DISPLAYNAME_PREFIX}.TextArea`;
 
     public state: TextAreaState = {};
@@ -83,6 +96,24 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     );
 
     private maybeSyncHeightToScrollHeight = () => {
+        // eslint-disable-next-line deprecation/deprecation
+        const { autoResize, growVertically } = this.props;
+
+        if (this.textareaElement != null) {
+            const { scrollHeight } = this.textareaElement;
+
+            if (autoResize) {
+                // set height to 0 to force scrollHeight to be the minimum height to fit
+                // the content of the textarea
+                this.textareaElement.style.height = "0px";
+                this.textareaElement.style.height = scrollHeight.toString() + "px";
+                this.setState({ height: scrollHeight });
+            } else if (growVertically && scrollHeight > 0) {
+                // N.B. this code path will be deleted in Blueprint v6.0 when `growVertically` is removed
+                this.setState({ height: scrollHeight });
+            }
+        }
+
         if (this.props.autoResize && this.textareaElement != null) {
             // set height to 0 to force scrollHeight to be the minimum height to fit
             // the content of the textarea
@@ -111,28 +142,31 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     }
 
     public render() {
-        const { className, fill, inputRef, intent, large, small, autoResize, ...htmlProps } = this.props;
+        // eslint-disable-next-line deprecation/deprecation
+        const { autoResize, className, fill, growVertically, inputRef, intent, large, small, ...htmlProps } =
+            this.props;
 
         const rootClasses = classNames(
             Classes.INPUT,
+            Classes.TEXT_AREA,
             Classes.intentClass(intent),
             {
                 [Classes.FILL]: fill,
                 [Classes.LARGE]: large,
                 [Classes.SMALL]: small,
+                [Classes.TEXT_AREA_AUTO_RESIZE]: autoResize,
             },
             className,
         );
 
         // add explicit height style while preserving user-supplied styles if they exist
         let { style = {} } = htmlProps;
-        if (autoResize && this.state.height != null) {
+        if ((autoResize || growVertically) && this.state.height != null) {
             // this style object becomes non-extensible when mounted (at least in the enzyme renderer),
             // so we make a new one to add a property
             style = {
                 ...style,
                 height: `${this.state.height}px`,
-                resize: "none",
             };
         }
 

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -37,6 +37,12 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
     small?: boolean;
 
     /**
+     * Whether the text area should automatically fit vertically to it's content. Only works if
+     * growVertically is enabled.
+     */
+    fitToContent?: boolean;
+
+    /**
      * Whether the text area should automatically grow vertically to accomodate content.
      */
     growVertically?: boolean;
@@ -74,10 +80,14 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
 
     private maybeSyncHeightToScrollHeight = () => {
         if (this.props.growVertically && this.textareaElement != null) {
-            const { scrollHeight } = this.textareaElement;
-            if (scrollHeight > 0) {
-                this.setState({ height: scrollHeight });
+            if (this.props.fitToContent){
+                // set height to 0 to force scrollHeight to be the minimum height to fit
+                // the content of the textarea
+                this.textareaElement.style.height = "0px"
             }
+            const { scrollHeight } = this.textareaElement;
+            this.textareaElement.style.height = scrollHeight.toString() + "px"
+            this.setState({ height: scrollHeight });
         }
     };
 
@@ -98,7 +108,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     }
 
     public render() {
-        const { className, fill, inputRef, intent, large, small, growVertically, ...htmlProps } = this.props;
+        const { className, fill, inputRef, intent, large, small, growVertically, fitToContent, ...htmlProps } = this.props;
 
         const rootClasses = classNames(
             Classes.INPUT,
@@ -113,7 +123,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
 
         // add explicit height style while preserving user-supplied styles if they exist
         let { style = {} } = htmlProps;
-        if (growVertically && this.state.height != null) {
+        if (growVertically && fitToContent && this.state.height != null) {
             // this style object becomes non-extensible when mounted (at least in the enzyme renderer),
             // so we make a new one to add a property
             style = {

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -37,13 +37,17 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
     small?: boolean;
 
     /**
-     * Whether the text area should automatically fit vertically to it's content. Only works if
-     * growVertically is enabled.
+     * Whether the component should automatically resize as a user types in the text input.
+     * Please note that this will disable manual resizing.
+     *
+     * @default false
      */
-    fitToContent?: boolean;
+    autoResize?: boolean;
 
     /**
      * Whether the text area should automatically grow vertically to accomodate content.
+     *
+     * @deprecated use the `autoResize` prop instead.
      */
     growVertically?: boolean;
 
@@ -79,12 +83,11 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     );
 
     private maybeSyncHeightToScrollHeight = () => {
-        if (this.props.growVertically && this.textareaElement != null) {
-            if (this.props.fitToContent) {
-                // set height to 0 to force scrollHeight to be the minimum height to fit
-                // the content of the textarea
-                this.textareaElement.style.height = "0px";
-            }
+        if (this.props.autoResize && this.textareaElement != null) {
+            // set height to 0 to force scrollHeight to be the minimum height to fit
+            // the content of the textarea
+            this.textareaElement.style.height = "0px";
+
             const { scrollHeight } = this.textareaElement;
             this.textareaElement.style.height = scrollHeight.toString() + "px";
             this.setState({ height: scrollHeight });
@@ -108,8 +111,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     }
 
     public render() {
-        const { className, fill, inputRef, intent, large, small, growVertically, fitToContent, ...htmlProps } =
-            this.props;
+        const { className, fill, inputRef, intent, large, small, autoResize, ...htmlProps } = this.props;
 
         const rootClasses = classNames(
             Classes.INPUT,
@@ -124,12 +126,13 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
 
         // add explicit height style while preserving user-supplied styles if they exist
         let { style = {} } = htmlProps;
-        if (growVertically && fitToContent && this.state.height != null) {
+        if (autoResize && this.state.height != null) {
             // this style object becomes non-extensible when mounted (at least in the enzyme renderer),
             // so we make a new one to add a property
             style = {
                 ...style,
                 height: `${this.state.height}px`,
+                resize: "none",
             };
         }
 

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -80,13 +80,13 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
 
     private maybeSyncHeightToScrollHeight = () => {
         if (this.props.growVertically && this.textareaElement != null) {
-            if (this.props.fitToContent){
+            if (this.props.fitToContent) {
                 // set height to 0 to force scrollHeight to be the minimum height to fit
                 // the content of the textarea
-                this.textareaElement.style.height = "0px"
+                this.textareaElement.style.height = "0px";
             }
             const { scrollHeight } = this.textareaElement;
-            this.textareaElement.style.height = scrollHeight.toString() + "px"
+            this.textareaElement.style.height = scrollHeight.toString() + "px";
             this.setState({ height: scrollHeight });
         }
     };
@@ -108,7 +108,8 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     }
 
     public render() {
-        const { className, fill, inputRef, intent, large, small, growVertically, fitToContent, ...htmlProps } = this.props;
+        const { className, fill, inputRef, intent, large, small, growVertically, fitToContent, ...htmlProps } =
+            this.props;
 
         const rootClasses = classNames(
             Classes.INPUT,

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -81,8 +81,8 @@ describe("<TextArea>", () => {
         assert.notEqual(scrollHeightInPixelsBefore, scrollHeightInPixelsAfter);
     });
 
-    // coleary: growVertically deprecated as of 28/07/2023
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
+    // Note that growVertically is deprecated as of 28/07/2023
     it.skip("can resize automatically", () => {
         const wrapper = mount(<TextArea growVertically={true} />, { attachTo: containerElement });
         const textarea = wrapper.find("textarea");
@@ -116,8 +116,8 @@ describe("<TextArea>", () => {
         assert.equal(textarea.getDOMNode<HTMLElement>().style.marginTop, "10px");
     });
 
-    // coleary: growVertically deprecated as of 28/07/2023
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
+    // Note that growVertically is deprecated as of 28/07/2023
     it.skip("can fit large initial content", () => {
         const initialValue = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
         Aenean finibus eget enim non accumsan.
@@ -173,8 +173,8 @@ describe("<TextArea>", () => {
         assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
     });
 
-    // coleary: growVertically deprecated as of 28/07/2023
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
+    // Note that growVertically is deprecated as of 28/07/2023
     it.skip("resizes when props change if growVertically is true", () => {
         const initialText = "A";
         const longText = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -35,6 +35,53 @@ describe("<TextArea>", () => {
         containerElement!.remove();
     });
 
+    it("No manual resizes when autoResize enabled", () => {
+        const wrapper = mount(<TextArea autoResize={true} />, { attachTo: containerElement });
+        const textarea = wrapper.find("textarea");
+
+        textarea.simulate("change", { target: { scrollHeight: 500 } });
+
+        assert.notEqual(textarea.getDOMNode<HTMLElement>().style.height, "500px");
+    });
+
+    it("resizes with large initial input when autoResize enabled", () => {
+        const initialValue = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Aenean finibus eget enim non accumsan.
+        Nunc lobortis luctus magna eleifend consectetur.
+        Suspendisse ut semper sem, quis efficitur felis.
+        Praesent suscipit nunc non semper tempor.
+        Sed eros sapien, semper sed imperdiet sed,
+        dictum eget purus. Donec porta accumsan pretium.
+        Fusce at felis mattis, tincidunt erat non, varius erat.`;
+        const wrapper = mount(<TextArea value={initialValue} autoResize={true} />, { attachTo: containerElement });
+        const textarea = wrapper.find("textarea");
+
+        const scrollHeightInPixels = `${textarea.getDOMNode<HTMLElement>().scrollHeight}px`;
+
+        assert.equal(textarea.getDOMNode<HTMLElement>().style.height, scrollHeightInPixels);
+    });
+
+    it("resizes with long text input when autoResize enabled", () => {
+        const initialValue = "A";
+        const nextValue = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        Aenean finibus eget enim non accumsan.
+        Nunc lobortis luctus magna eleifend consectetur.
+        Suspendisse ut semper sem, quis efficitur felis.
+        Praesent suscipit nunc non semper tempor.
+        Sed eros sapien, semper sed imperdiet sed,
+        dictum eget purus. Donec porta accumsan pretium.
+        Fusce at felis mattis, tincidunt erat non, varius erat.`;
+        const wrapper = mount(<TextArea value={initialValue} autoResize={true} />, { attachTo: containerElement });
+        const textarea = wrapper.find("textarea");
+
+        const scrollHeightInPixelsBefore = `${textarea.getDOMNode<HTMLElement>().scrollHeight}px`;
+        wrapper.setProps({ value: nextValue }).update();
+        const scrollHeightInPixelsAfter = `${textarea.getDOMNode<HTMLElement>().scrollHeight}px`;
+
+        assert.notEqual(scrollHeightInPixelsBefore, scrollHeightInPixelsAfter);
+    });
+
+    // coleary: growVertically deprecated as of 28/07/2023
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
     it.skip("can resize automatically", () => {
         const wrapper = mount(<TextArea growVertically={true} />, { attachTo: containerElement });
@@ -59,7 +106,7 @@ describe("<TextArea>", () => {
     });
 
     it("doesn't clobber user-supplied styles", () => {
-        const wrapper = mount(<TextArea growVertically={true} style={{ marginTop: 10 }} />, {
+        const wrapper = mount(<TextArea autoResize={true} style={{ marginTop: 10 }} />, {
             attachTo: containerElement,
         });
         const textarea = wrapper.find("textarea");
@@ -69,6 +116,7 @@ describe("<TextArea>", () => {
         assert.equal(textarea.getDOMNode<HTMLElement>().style.marginTop, "10px");
     });
 
+    // coleary: growVertically deprecated as of 28/07/2023
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
     it.skip("can fit large initial content", () => {
         const initialValue = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -125,6 +173,7 @@ describe("<TextArea>", () => {
         assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
     });
 
+    // coleary: growVertically deprecated as of 28/07/2023
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
     it.skip("resizes when props change if growVertically is true", () => {
         const initialText = "A";

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -26,6 +26,7 @@ const CONTROLLED_TEXT_TO_APPEND =
 interface TextAreaExampleState {
     controlled: boolean;
     disabled: boolean;
+    fitToContent: boolean;
     growVertically: boolean;
     large: boolean;
     readOnly: boolean;
@@ -37,6 +38,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     public state: TextAreaExampleState = {
         controlled: false,
         disabled: false,
+        fitToContent: false,
         growVertically: true,
         large: false,
         readOnly: false,
@@ -47,6 +49,8 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     private handleControlledChange = handleBooleanChange(controlled => this.setState({ controlled }));
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
+
+    private handleFitToContentChange = handleBooleanChange(fitToContent => this.setState({ fitToContent }));
 
     private handleGrowVerticallyChange = handleBooleanChange(growVertically => this.setState({ growVertically }));
 
@@ -77,7 +81,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     }
 
     private renderOptions() {
-        const { controlled, disabled, growVertically, large, readOnly, small } = this.state;
+        const { controlled, disabled, growVertically, large, readOnly, small, fitToContent } = this.state;
         return (
             <>
                 <H5>Appearance props</H5>
@@ -86,6 +90,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
                 <H5>Behavior props</H5>
                 <Switch label="Disabled" onChange={this.handleDisabledChange} checked={disabled} />
                 <Switch label="Read-only" onChange={this.handleReadOnlyChange} checked={readOnly} />
+                <Switch label="Fit content" onChange={this.handleFitToContentChange} checked={fitToContent} />
                 <Switch label="Grow vertically" onChange={this.handleGrowVerticallyChange} checked={growVertically} />
                 <Switch label="Controlled usage" onChange={this.handleControlledChange} checked={controlled} />
                 <ControlGroup>

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -16,8 +16,10 @@
 
 import * as React from "react";
 
-import { AnchorButton, ControlGroup, H5, Switch, TextArea, Tooltip } from "@blueprintjs/core";
+import { AnchorButton, Code, ControlGroup, H5, Switch, TextArea, Tooltip } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+
+import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
 const INTITIAL_CONTROLLED_TEXT = "In a galaxy far, far away...";
 const CONTROLLED_TEXT_TO_APPEND =
@@ -27,6 +29,7 @@ interface TextAreaExampleState {
     autoResize: boolean;
     controlled: boolean;
     disabled: boolean;
+    growVertically: boolean;
     large: boolean;
     readOnly: boolean;
     small: boolean;
@@ -38,6 +41,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
         autoResize: false,
         controlled: false,
         disabled: false,
+        growVertically: false,
         large: false,
         readOnly: false,
         small: false,
@@ -49,6 +53,8 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
 
     private handleAutoResizeChange = handleBooleanChange(autoResize => this.setState({ autoResize }));
+
+    private handleGrowVerticallyChange = handleBooleanChange(growVertically => this.setState({ growVertically }));
 
     private handleLargeChange = handleBooleanChange(large => this.setState({ large, ...(large && { small: false }) }));
 
@@ -77,7 +83,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     }
 
     private renderOptions() {
-        const { controlled, disabled, large, readOnly, small, autoResize } = this.state;
+        const { controlled, disabled, growVertically, large, readOnly, small, autoResize } = this.state;
         return (
             <>
                 <H5>Appearance props</H5>
@@ -86,7 +92,9 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
                 <H5>Behavior props</H5>
                 <Switch label="Disabled" onChange={this.handleDisabledChange} checked={disabled} />
                 <Switch label="Read-only" onChange={this.handleReadOnlyChange} checked={readOnly} />
-                <Switch label="Auto resize" onChange={this.handleAutoResizeChange} checked={autoResize} />
+                <PropCodeTooltip snippet={`autoResize={${autoResize}}`}>
+                    <Switch label="Auto resize" onChange={this.handleAutoResizeChange} checked={autoResize} />
+                </PropCodeTooltip>
                 <Switch label="Controlled usage" onChange={this.handleControlledChange} checked={controlled} />
                 <ControlGroup>
                     <AnchorButton
@@ -99,6 +107,22 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
                         <AnchorButton disabled={!controlled} icon="reset" onClick={this.resetControlledText} />
                     </Tooltip>
                 </ControlGroup>
+                <H5>Deprecated props</H5>
+                <PropCodeTooltip
+                    content={
+                        <span>
+                            This behavior is enabled by the new <Code>autoResize</Code> prop
+                        </span>
+                    }
+                    disabled={!autoResize}
+                >
+                    <Switch
+                        disabled={autoResize}
+                        label="Grow vertically"
+                        onChange={this.handleGrowVerticallyChange}
+                        checked={autoResize || growVertically}
+                    />
+                </PropCodeTooltip>
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -24,10 +24,9 @@ const CONTROLLED_TEXT_TO_APPEND =
     "The approach will not be easy. You are required to maneuver straight down this trench and skim the surface to this point. The target area is only two meters wide. It's a small thermal exhaust port, right below the main port. The shaft leads directly to the reactor system.";
 
 interface TextAreaExampleState {
+    autoResize: boolean;
     controlled: boolean;
     disabled: boolean;
-    fitToContent: boolean;
-    growVertically: boolean;
     large: boolean;
     readOnly: boolean;
     small: boolean;
@@ -36,10 +35,9 @@ interface TextAreaExampleState {
 
 export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaExampleState> {
     public state: TextAreaExampleState = {
+        autoResize: false,
         controlled: false,
         disabled: false,
-        fitToContent: false,
-        growVertically: true,
         large: false,
         readOnly: false,
         small: false,
@@ -50,9 +48,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
 
-    private handleFitToContentChange = handleBooleanChange(fitToContent => this.setState({ fitToContent }));
-
-    private handleGrowVerticallyChange = handleBooleanChange(growVertically => this.setState({ growVertically }));
+    private handleAutoResizeChange = handleBooleanChange(autoResize => this.setState({ autoResize }));
 
     private handleLargeChange = handleBooleanChange(large => this.setState({ large, ...(large && { small: false }) }));
 
@@ -81,7 +77,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     }
 
     private renderOptions() {
-        const { controlled, disabled, growVertically, large, readOnly, small, fitToContent } = this.state;
+        const { controlled, disabled, large, readOnly, small, autoResize } = this.state;
         return (
             <>
                 <H5>Appearance props</H5>
@@ -90,8 +86,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
                 <H5>Behavior props</H5>
                 <Switch label="Disabled" onChange={this.handleDisabledChange} checked={disabled} />
                 <Switch label="Read-only" onChange={this.handleReadOnlyChange} checked={readOnly} />
-                <Switch label="Fit content" onChange={this.handleFitToContentChange} checked={fitToContent} />
-                <Switch label="Grow vertically" onChange={this.handleGrowVerticallyChange} checked={growVertically} />
+                <Switch label="Auto resize" onChange={this.handleAutoResizeChange} checked={autoResize} />
                 <Switch label="Controlled usage" onChange={this.handleControlledChange} checked={controlled} />
                 <ControlGroup>
                     <AnchorButton


### PR DESCRIPTION
#### Checklist

- [x] Test completed (no tests for TextArea component)
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add a `fitToContent: boolean` prop to TextArea component to allow for more granularity control over vertical resizing when `growVertically` is enabled.

**Before**:
<img width="790" alt="image" src="https://github.com/palantir/blueprint/assets/52145084/0ca40ee4-4e7b-48f3-bb27-5e44b60f9fae">
**After**:
<img width="782" alt="image" src="https://github.com/palantir/blueprint/assets/52145084/a791e35f-3235-4c64-aa0a-e6aac0ca8982">



