### PR TITLE
[docs] fix hotkeys piano example usage of WebAudio API

### DIFF
--- a/packages/docs-app/src/examples/core-examples/audio/envelope.ts
+++ b/packages/docs-app/src/examples/core-examples/audio/envelope.ts
@@ -47,9 +47,9 @@ export class Envelope {
         const now = this.context.currentTime;
         // The below code helps remove waveform popping artifacts, but there is
         // a bug in Firefox that breaks the whole example if we use it.
-        // this.amplitude.cancelScheduledValues(now);
-        // this.amplitude.setValueAtTime(this.amplitude.value, now);
-        this.amplitude.exponentialRampToValueAtTime(0.01, now + this.releaseTime);
+        this.amplitude.cancelScheduledValues(now);
+        this.amplitude.setValueAtTime(this.sustainLevel, now);
+        this.amplitude.exponentialRampToValueAtTime(0.1, now + this.releaseTime);
         this.amplitude.linearRampToValueAtTime(0, now + this.releaseTime + 0.01);
     }
 }

--- a/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
@@ -16,17 +16,15 @@
 
 import * as React from "react";
 
-import { Hotkey, Hotkeys, HotkeysTarget } from "@blueprintjs/core";
+import { Hotkey, Hotkeys, HotkeysTarget, NonIdealState } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PianoKey } from "./audio";
 
 export interface HotkeyPianoState {
+    audioContext?: AudioContext;
     keys: boolean[];
 }
-
-// eslint-disable-next-line @typescript-eslint/dot-notation
-const AUDIO_CONTEXT = (window as any)["AudioContext"] != null ? new AudioContext() : null;
 
 // eslint-disable-next-line deprecation/deprecation
 @HotkeysTarget
@@ -36,52 +34,22 @@ export class HotkeyPiano extends React.PureComponent<ExampleProps, HotkeyPianoSt
         keys: Array.apply(null, Array(24)).map(() => false),
     };
 
-    private pianoRef: HTMLElement | null = null;
+    private pianoRef = React.createRef<HTMLDivElement>();
 
     public render() {
-        const { keys } = this.state;
-
-        if (AUDIO_CONTEXT == null) {
-            return (
-                <Example options={false} {...this.props}>
-                    <div tabIndex={0}>
-                        Oops! This browser does not support the WebAudio API needed for this example.
-                    </div>
-                </Example>
-            );
-        }
+        const { audioContext } = this.state;
 
         return (
             <Example options={false} {...this.props}>
-                <div tabIndex={0} className="docs-hotkey-piano-example" ref={ref => (this.pianoRef = ref)}>
-                    <div>
-                        <PianoKey note="C5" hotkey="Q" pressed={keys[0]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="C#5" hotkey="2" pressed={keys[1]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="D5" hotkey="W" pressed={keys[2]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="D#5" hotkey="3" pressed={keys[3]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="E5" hotkey="E" pressed={keys[4]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="F5" hotkey="R" pressed={keys[5]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="F#5" hotkey="5" pressed={keys[6]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="G5" hotkey="T" pressed={keys[7]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="G#5" hotkey="6" pressed={keys[8]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="A5" hotkey="Y" pressed={keys[9]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="A#5" hotkey="7" pressed={keys[10]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="B5" hotkey="U" pressed={keys[11]} context={AUDIO_CONTEXT} />
-                    </div>
-                    <div>
-                        <PianoKey note="C4" hotkey="Z" pressed={keys[12]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="C#4" hotkey="S" pressed={keys[13]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="D4" hotkey="X" pressed={keys[14]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="D#4" hotkey="D" pressed={keys[15]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="E4" hotkey="C" pressed={keys[16]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="F4" hotkey="V" pressed={keys[17]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="F#4" hotkey="G" pressed={keys[18]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="G4" hotkey="B" pressed={keys[19]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="G#4" hotkey="H" pressed={keys[20]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="A4" hotkey="N" pressed={keys[21]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="A#4" hotkey="J" pressed={keys[22]} context={AUDIO_CONTEXT} />
-                        <PianoKey note="B4" hotkey="M" pressed={keys[23]} context={AUDIO_CONTEXT} />
-                    </div>
+                <div tabIndex={0} className="docs-hotkey-piano-example" ref={this.pianoRef} onClick={this.focusPiano}>
+                    {audioContext == null ? (
+                        <NonIdealState
+                            icon="select"
+                            title="Click here to start this WebAudio-based interactive example"
+                        />
+                    ) : (
+                        this.renderPianoWithAudioContext(audioContext)
+                    )}
                 </div>
             </Example>
         );
@@ -265,9 +233,47 @@ export class HotkeyPiano extends React.PureComponent<ExampleProps, HotkeyPianoSt
         );
     }
 
+    private renderPianoWithAudioContext(audioContext: AudioContext) {
+        const { keys } = this.state;
+
+        return (
+            <>
+                <div>
+                    <PianoKey note="C5" hotkey="Q" pressed={keys[0]} context={audioContext} />
+                    <PianoKey note="C#5" hotkey="2" pressed={keys[1]} context={audioContext} />
+                    <PianoKey note="D5" hotkey="W" pressed={keys[2]} context={audioContext} />
+                    <PianoKey note="D#5" hotkey="3" pressed={keys[3]} context={audioContext} />
+                    <PianoKey note="E5" hotkey="E" pressed={keys[4]} context={audioContext} />
+                    <PianoKey note="F5" hotkey="R" pressed={keys[5]} context={audioContext} />
+                    <PianoKey note="F#5" hotkey="5" pressed={keys[6]} context={audioContext} />
+                    <PianoKey note="G5" hotkey="T" pressed={keys[7]} context={audioContext} />
+                    <PianoKey note="G#5" hotkey="6" pressed={keys[8]} context={audioContext} />
+                    <PianoKey note="A5" hotkey="Y" pressed={keys[9]} context={audioContext} />
+                    <PianoKey note="A#5" hotkey="7" pressed={keys[10]} context={audioContext} />
+                    <PianoKey note="B5" hotkey="U" pressed={keys[11]} context={audioContext} />
+                </div>
+                <div>
+                    <PianoKey note="C4" hotkey="Z" pressed={keys[12]} context={audioContext} />
+                    <PianoKey note="C#4" hotkey="S" pressed={keys[13]} context={audioContext} />
+                    <PianoKey note="D4" hotkey="X" pressed={keys[14]} context={audioContext} />
+                    <PianoKey note="D#4" hotkey="D" pressed={keys[15]} context={audioContext} />
+                    <PianoKey note="E4" hotkey="C" pressed={keys[16]} context={audioContext} />
+                    <PianoKey note="F4" hotkey="V" pressed={keys[17]} context={audioContext} />
+                    <PianoKey note="F#4" hotkey="G" pressed={keys[18]} context={audioContext} />
+                    <PianoKey note="G4" hotkey="B" pressed={keys[19]} context={audioContext} />
+                    <PianoKey note="G#4" hotkey="H" pressed={keys[20]} context={audioContext} />
+                    <PianoKey note="A4" hotkey="N" pressed={keys[21]} context={audioContext} />
+                    <PianoKey note="A#4" hotkey="J" pressed={keys[22]} context={audioContext} />
+                    <PianoKey note="B4" hotkey="M" pressed={keys[23]} context={audioContext} />
+                </div>
+            </>
+        );
+    }
+
     private focusPiano = () => {
-        if (this.pianoRef != null) {
-            this.pianoRef.focus();
+        this.pianoRef.current?.focus();
+        if (typeof window.AudioContext !== "undefined" && this.state.audioContext === undefined) {
+            this.setState({ audioContext: new AudioContext() });
         }
     };
 

--- a/packages/docs-app/src/examples/core-examples/hotkeysTarget2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeysTarget2Example.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { HotkeyProps, HotkeysTarget2 } from "@blueprintjs/core";
+import { HotkeyProps, HotkeysTarget2, NonIdealState } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PianoKey } from "./audio";
@@ -36,16 +36,12 @@ export class HotkeysTarget2Example extends React.PureComponent<ExampleProps, Hot
         keys: Array.apply(null, Array(24)).map(() => false),
     };
 
-    private pianoRef: HTMLDivElement | null = null;
-
-    private handlePianoRef = (ref: HTMLDivElement | null) => (this.pianoRef = ref);
+    private pianoRef = React.createRef<HTMLDivElement>();
 
     private focusPiano = () => {
-        if (this.pianoRef !== null) {
-            this.pianoRef.focus();
-            if (typeof window.AudioContext !== "undefined" && this.state.audioContext === undefined) {
-                this.setState({ audioContext: new AudioContext() });
-            }
+        this.pianoRef.current.focus();
+        if (typeof window.AudioContext !== "undefined" && this.state.audioContext === undefined) {
+            this.setState({ audioContext: new AudioContext() });
         }
     };
 
@@ -235,7 +231,7 @@ export class HotkeysTarget2Example extends React.PureComponent<ExampleProps, Hot
     ];
 
     public render() {
-        const { audioContext, keys } = this.state;
+        const { audioContext } = this.state;
 
         return (
             <Example className="docs-hotkeys-target-2-example" options={false} {...this.props}>
@@ -244,43 +240,60 @@ export class HotkeysTarget2Example extends React.PureComponent<ExampleProps, Hot
                         <div
                             tabIndex={0}
                             className="docs-hotkey-piano-example"
-                            ref={this.handlePianoRef}
+                            ref={this.pianoRef}
                             onClick={this.focusPiano}
                             onKeyDown={handleKeyDown}
                             onKeyUp={handleKeyUp}
                         >
-                            <div>
-                                <PianoKey note="C5" hotkey="Q" pressed={keys[0]} context={audioContext} />
-                                <PianoKey note="C#5" hotkey="2" pressed={keys[1]} context={audioContext} />
-                                <PianoKey note="D5" hotkey="W" pressed={keys[2]} context={audioContext} />
-                                <PianoKey note="D#5" hotkey="3" pressed={keys[3]} context={audioContext} />
-                                <PianoKey note="E5" hotkey="E" pressed={keys[4]} context={audioContext} />
-                                <PianoKey note="F5" hotkey="R" pressed={keys[5]} context={audioContext} />
-                                <PianoKey note="F#5" hotkey="5" pressed={keys[6]} context={audioContext} />
-                                <PianoKey note="G5" hotkey="T" pressed={keys[7]} context={audioContext} />
-                                <PianoKey note="G#5" hotkey="6" pressed={keys[8]} context={audioContext} />
-                                <PianoKey note="A5" hotkey="Y" pressed={keys[9]} context={audioContext} />
-                                <PianoKey note="A#5" hotkey="7" pressed={keys[10]} context={audioContext} />
-                                <PianoKey note="B5" hotkey="U" pressed={keys[11]} context={audioContext} />
-                            </div>
-                            <div>
-                                <PianoKey note="C4" hotkey="Z" pressed={keys[12]} context={audioContext} />
-                                <PianoKey note="C#4" hotkey="S" pressed={keys[13]} context={audioContext} />
-                                <PianoKey note="D4" hotkey="X" pressed={keys[14]} context={audioContext} />
-                                <PianoKey note="D#4" hotkey="D" pressed={keys[15]} context={audioContext} />
-                                <PianoKey note="E4" hotkey="C" pressed={keys[16]} context={audioContext} />
-                                <PianoKey note="F4" hotkey="V" pressed={keys[17]} context={audioContext} />
-                                <PianoKey note="F#4" hotkey="G" pressed={keys[18]} context={audioContext} />
-                                <PianoKey note="G4" hotkey="B" pressed={keys[19]} context={audioContext} />
-                                <PianoKey note="G#4" hotkey="H" pressed={keys[20]} context={audioContext} />
-                                <PianoKey note="A4" hotkey="N" pressed={keys[21]} context={audioContext} />
-                                <PianoKey note="A#4" hotkey="J" pressed={keys[22]} context={audioContext} />
-                                <PianoKey note="B4" hotkey="M" pressed={keys[23]} context={audioContext} />
-                            </div>
+                            {audioContext == null ? (
+                                <NonIdealState
+                                    icon="select"
+                                    title="Click here to start this WebAudio-based interactive example"
+                                />
+                            ) : (
+                                this.renderPianoWithAudioContext(audioContext)
+                            )}
                         </div>
                     )}
                 </HotkeysTarget2>
             </Example>
+        );
+    }
+
+    private renderPianoWithAudioContext(audioContext: AudioContext) {
+        const { keys } = this.state;
+
+        return (
+            <>
+                <div>
+                    <PianoKey note="C5" hotkey="Q" pressed={keys[0]} context={audioContext} />
+                    <PianoKey note="C#5" hotkey="2" pressed={keys[1]} context={audioContext} />
+                    <PianoKey note="D5" hotkey="W" pressed={keys[2]} context={audioContext} />
+                    <PianoKey note="D#5" hotkey="3" pressed={keys[3]} context={audioContext} />
+                    <PianoKey note="E5" hotkey="E" pressed={keys[4]} context={audioContext} />
+                    <PianoKey note="F5" hotkey="R" pressed={keys[5]} context={audioContext} />
+                    <PianoKey note="F#5" hotkey="5" pressed={keys[6]} context={audioContext} />
+                    <PianoKey note="G5" hotkey="T" pressed={keys[7]} context={audioContext} />
+                    <PianoKey note="G#5" hotkey="6" pressed={keys[8]} context={audioContext} />
+                    <PianoKey note="A5" hotkey="Y" pressed={keys[9]} context={audioContext} />
+                    <PianoKey note="A#5" hotkey="7" pressed={keys[10]} context={audioContext} />
+                    <PianoKey note="B5" hotkey="U" pressed={keys[11]} context={audioContext} />
+                </div>
+                <div>
+                    <PianoKey note="C4" hotkey="Z" pressed={keys[12]} context={audioContext} />
+                    <PianoKey note="C#4" hotkey="S" pressed={keys[13]} context={audioContext} />
+                    <PianoKey note="D4" hotkey="X" pressed={keys[14]} context={audioContext} />
+                    <PianoKey note="D#4" hotkey="D" pressed={keys[15]} context={audioContext} />
+                    <PianoKey note="E4" hotkey="C" pressed={keys[16]} context={audioContext} />
+                    <PianoKey note="F4" hotkey="V" pressed={keys[17]} context={audioContext} />
+                    <PianoKey note="F#4" hotkey="G" pressed={keys[18]} context={audioContext} />
+                    <PianoKey note="G4" hotkey="B" pressed={keys[19]} context={audioContext} />
+                    <PianoKey note="G#4" hotkey="H" pressed={keys[20]} context={audioContext} />
+                    <PianoKey note="A4" hotkey="N" pressed={keys[21]} context={audioContext} />
+                    <PianoKey note="A#4" hotkey="J" pressed={keys[22]} context={audioContext} />
+                    <PianoKey note="B4" hotkey="M" pressed={keys[23]} context={audioContext} />
+                </div>
+            </>
         );
     }
 }

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { useHotkeys } from "@blueprintjs/core";
+import { NonIdealState, useHotkeys } from "@blueprintjs/core";
 import { Example, ExampleProps } from "@blueprintjs/docs-theme";
 
 import { PianoKey } from "./audio";
@@ -30,7 +30,7 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
         if (typeof window.AudioContext !== "undefined" && audioContext === undefined) {
             setAudioContext(new AudioContext());
         }
-    }, [pianoRef]);
+    }, [audioContext, pianoRef]);
 
     const [keyPressed, setKeyPressed] = React.useState<readonly boolean[]>(new Array(25).fill(false));
 
@@ -217,20 +217,13 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
                 onKeyUp: () => setKeyState(23, false),
             },
         ],
-        [],
+        [focusPiano, setKeyState],
     );
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys);
 
-    return (
-        <Example className="docs-use-hotkeys-example" options={false} {...props}>
-            <div
-                tabIndex={0}
-                className="docs-hotkey-piano-example"
-                ref={pianoRef}
-                onClick={focusPiano}
-                onKeyDown={handleKeyDown}
-                onKeyUp={handleKeyUp}
-            >
+    const pianoWithAudioContext = React.useMemo(
+        () => (
+            <>
                 <div>
                     <PianoKey note="C5" hotkey="Q" pressed={keyPressed[0]} context={audioContext} />
                     <PianoKey note="C#5" hotkey="2" pressed={keyPressed[1]} context={audioContext} />
@@ -259,6 +252,26 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
                     <PianoKey note="A#4" hotkey="J" pressed={keyPressed[22]} context={audioContext} />
                     <PianoKey note="B4" hotkey="M" pressed={keyPressed[23]} context={audioContext} />
                 </div>
+            </>
+        ),
+        [audioContext, keyPressed],
+    );
+
+    return (
+        <Example className="docs-use-hotkeys-example" options={false} {...props}>
+            <div
+                tabIndex={0}
+                className="docs-hotkey-piano-example"
+                ref={pianoRef}
+                onClick={focusPiano}
+                onKeyDown={handleKeyDown}
+                onKeyUp={handleKeyUp}
+            >
+                {audioContext == null ? (
+                    <NonIdealState icon="select" title="Click here to start this WebAudio-based interactive example" />
+                ) : (
+                    pianoWithAudioContext
+                )}
             </div>
         </Example>
     );

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -158,18 +158,27 @@
   }
 }
 
+$docs-hotkey-piano-height: 510px;
+
 .docs-hotkey-piano-example {
-  opacity: 0.4;
+  min-height: $docs-hotkey-piano-height;
+  opacity: 0.5;
   transition: opacity ($pt-transition-duration * 2) $pt-transition-ease;
 
   &:hover {
     cursor: pointer;
-    opacity: 0.6;
+    opacity: 0.75;
   }
 
   &:focus {
     cursor: default;
     opacity: 1;
+  }
+
+  .#{$ns}-non-ideal-state {
+    margin: 0;
+    min-height: $docs-hotkey-piano-height - ($pt-grid-size * 2);
+    padding: $pt-grid-size * 2;
   }
 
   > :first-child {


### PR DESCRIPTION
#### Fixes #6155

#### Checklist

- (N/A) Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Refactor hotkeys piano examples in docs-app to render a `<NonIdealState>` until a user clicks on the example container (we need to wait until a user interaction before starting the WebAudio API with `new AudioContext()`).
- Fix some react hook usage lint warnings
- Fix a bug where piano keys would play their note upon first mount (they are now disconnected from audio output until the first key press)

#### Reviewers should focus on:

Correct behavior of all 3 examples ("Hotkeys (legacy)", "HotkeysTarget2", "useHotkeys") in Chrome & Firefox.

#### Screenshot

Chrome:

![2023-07-27 13 55 13](https://github.com/palantir/blueprint/assets/723999/fd51ed74-7ef7-49c2-afe4-1d46205faa92)

Firefox:

![2023-07-27 13 56 01](https://github.com/palantir/blueprint/assets/723999/a1ec9e85-65ab-4982-b6f9-04208b356be7)
