### PR TITLE
fix(Tree): Export TreeNodeProps

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -114,4 +114,4 @@ export { Toaster, ToastOptions } from "./toast/toaster";
 export { TooltipProps, Tooltip } from "./tooltip/tooltip";
 export { Tree, TreeProps } from "./tree/tree";
 export { TreeNodeInfo, TreeEventHandler } from "./tree/treeTypes";
-export { TreeNode } from "./tree/treeNode";
+export { TreeNode, TreeNodeProps } from "./tree/treeNode";


### PR DESCRIPTION
#### Changes proposed in this pull request:

Exports TreeNodeProps so custom implementations of the tree can import the type. This used to be present in `@blueprintjs/core@4`

#### Reviewers should focus on:

N/A

#### Screenshot

N/A
