### PR TITLE
[select] fix(Select, MultiSelect): load icons statically

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -33,6 +33,7 @@ import {
     TagInputProps,
     Utils,
 } from "@blueprintjs/core";
+import { Cross } from "@blueprintjs/icons";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { QueryList, QueryListRendererProps } from "../query-list/queryList";
@@ -275,7 +276,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                     <Button
                         aria-label="Clear selected items"
                         disabled={disabled}
-                        icon="cross"
+                        icon={<Cross />}
                         minimal={true}
                         onClick={this.handleClearButtonClick}
                         title="Clear selected items"

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -32,6 +32,7 @@ import {
     setRef,
     Utils,
 } from "@blueprintjs/core";
+import { Cross, Search } from "@blueprintjs/icons";
 
 import { Classes, ListItemsProps, SelectPopoverProps } from "../../common";
 import { QueryList, QueryListRendererProps } from "../query-list/queryList";
@@ -166,7 +167,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         const input = (
             <InputGroup
                 aria-autocomplete="list"
-                leftIcon="search"
+                leftIcon={<Search />}
                 placeholder="Filter..."
                 rightElement={this.maybeRenderClearButton(listProps.query)}
                 {...inputProps}
@@ -249,7 +250,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         return query.length > 0 ? (
             <Button
                 aria-label="Clear filter query"
-                icon="cross"
+                icon={<Cross />}
                 minimal={true}
                 onClick={this.resetQuery}
                 title="Clear filter query"


### PR DESCRIPTION
related to #6249 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

`Select` and `MultiSelect` components were dynamically loading icons, modified to load them statically.

#### Reviewers should focus on:

- Whether the appropriate icons are being loaded.
- Whether there are any other locations that are dynamically loading icons.

Best regards.

<!-- Fill this out. -->

