### PR TITLE
Pass `portalStopPropagationEvents` prop given to `Popover` to underlying `Overlay`

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -477,6 +477,7 @@ export class Popover<
                 usePortal={this.props.usePortal}
                 portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
+                portalStopPropagationEvents={this.props.portalStopPropagationEvents}
                 // if hover interaction, it doesn't make sense to take over focus control
                 shouldReturnFocusOnClose={this.isHoverInteractionKind() ? false : shouldReturnFocusOnClose}
             >


### PR DESCRIPTION
## Changes

In https://github.com/palantir/blueprint/pull/6093, the `portalStopPropagationEvents` prop was added to the `<Overlay />` component. Since the `PopoverProps` extends `OverlayableProps`, popovers now also accept this new prop. However, the `<Popover />` component wasn't using this new prop and simply discard it.

Let's propagate it to the underlying `<Overlay />`. I think this was the original intention in https://github.com/palantir/blueprint/pull/6093.