### PR TITLE
[core] fix(Section): Section header should only render if title is provided

### DIFF
--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -74,6 +74,7 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
 
     /**
      * Element to render on the right side of the section header.
+     * Note that the header will only be rendered if `title` is provided.
      */
     rightElement?: JSX.Element;
 
@@ -125,7 +126,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
             ref={ref}
             {...htmlProps}
         >
-            <div
+            {title && <div
                 role={collapsible ? "button" : undefined}
                 aria-pressed={collapsible ? isCollapsed : undefined}
                 className={classNames(Classes.SECTION_HEADER, {
@@ -163,7 +164,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
                             ))}
                     </div>
                 )}
-            </div>
+            </div>}
 
             {collapsible ? (
                 <Collapse {...collapseProps} isOpen={!isCollapsed}>

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -126,45 +126,49 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
             ref={ref}
             {...htmlProps}
         >
-            {title && <div
-                role={collapsible ? "button" : undefined}
-                aria-pressed={collapsible ? isCollapsed : undefined}
-                className={classNames(Classes.SECTION_HEADER, {
-                    [Classes.INTERACTIVE]: collapsible,
-                })}
-                onClick={collapsible != null ? toggleIsCollapsed : undefined}
-            >
-                {isHeaderLeftContainerVisible && (
-                    <>
-                        <div className={Classes.SECTION_HEADER_LEFT}>
-                            {icon && (
-                                <Icon icon={icon} aria-hidden={true} tabIndex={-1} className={Classes.TEXT_MUTED} />
-                            )}
-
-                            <div>
-                                <H6 className={Classes.SECTION_HEADER_TITLE}>{title}</H6>
-                                {subtitle && (
-                                    <div className={classNames(Classes.TEXT_MUTED, Classes.SECTION_HEADER_SUB_TITLE)}>
-                                        {subtitle}
-                                    </div>
+            {title && (
+                <div
+                    role={collapsible ? "button" : undefined}
+                    aria-pressed={collapsible ? isCollapsed : undefined}
+                    className={classNames(Classes.SECTION_HEADER, {
+                        [Classes.INTERACTIVE]: collapsible,
+                    })}
+                    onClick={collapsible != null ? toggleIsCollapsed : undefined}
+                >
+                    {isHeaderLeftContainerVisible && (
+                        <>
+                            <div className={Classes.SECTION_HEADER_LEFT}>
+                                {icon && (
+                                    <Icon icon={icon} aria-hidden={true} tabIndex={-1} className={Classes.TEXT_MUTED} />
                                 )}
-                            </div>
-                        </div>
-                    </>
-                )}
 
-                {isHeaderRightContainerVisible && (
-                    <div className={Classes.SECTION_HEADER_RIGHT}>
-                        {rightElement}
-                        {collapsible &&
-                            (isCollapsed ? (
-                                <ChevronDown className={Classes.TEXT_MUTED} />
-                            ) : (
-                                <ChevronUp className={Classes.TEXT_MUTED} />
-                            ))}
-                    </div>
-                )}
-            </div>}
+                                <div>
+                                    <H6 className={Classes.SECTION_HEADER_TITLE}>{title}</H6>
+                                    {subtitle && (
+                                        <div
+                                            className={classNames(Classes.TEXT_MUTED, Classes.SECTION_HEADER_SUB_TITLE)}
+                                        >
+                                            {subtitle}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </>
+                    )}
+
+                    {isHeaderRightContainerVisible && (
+                        <div className={Classes.SECTION_HEADER_RIGHT}>
+                            {rightElement}
+                            {collapsible &&
+                                (isCollapsed ? (
+                                    <ChevronDown className={Classes.TEXT_MUTED} />
+                                ) : (
+                                    <ChevronUp className={Classes.TEXT_MUTED} />
+                                ))}
+                        </div>
+                    )}
+                </div>
+            )}
 
             {collapsible ? (
                 <Collapse {...collapseProps} isOpen={!isCollapsed}>

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -137,13 +137,13 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
                 {isHeaderLeftContainerVisible && (
                     <>
                         <div className={Classes.SECTION_HEADER_LEFT}>
-                            {title && icon && (
+                            {icon && (
                                 <Icon icon={icon} aria-hidden={true} tabIndex={-1} className={Classes.TEXT_MUTED} />
                             )}
 
                             <div>
-                                {title && <H6 className={Classes.SECTION_HEADER_TITLE}>{title}</H6>}
-                                {title && subtitle && (
+                                <H6 className={Classes.SECTION_HEADER_TITLE}>{title}</H6>
+                                {subtitle && (
                                     <div className={classNames(Classes.TEXT_MUTED, Classes.SECTION_HEADER_SUB_TITLE)}>
                                         {subtitle}
                                     </div>


### PR DESCRIPTION
#### Fixes #6324

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Hide the header if there's no passed in `title` prop

#### Reviewers should focus on:

Maybe we should have a separate prop for this? It seems a bit strange that we'd just ignore `subtitle` and `rightElement` if there's no `title`...

#### Screenshot

<img width="359" alt="image" src="https://github.com/palantir/blueprint/assets/21962852/0514245e-88e0-4a3e-9731-85b9c49cfb06">

