### PR TITLE
[core] fix(Section): Fix `defaultIsOpen` behavior

### DIFF
--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -109,7 +109,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
         title,
         ...htmlProps
     } = props;
-    const [isCollapsed, setIsCollapsed] = React.useState<boolean>(collapseProps?.defaultIsOpen ?? false);
+    const [isCollapsed, setIsCollapsed] = React.useState<boolean>(!collapseProps?.defaultIsOpen ?? false);
     const toggleIsCollapsed = React.useCallback(() => setIsCollapsed(!isCollapsed), [isCollapsed]);
 
     const isHeaderLeftContainerVisible = title != null || icon != null || subtitle != null;


### PR DESCRIPTION
#### Fixes #6322

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

`defaultIsOpen` is currently doing the opposite behavior of what it suggests (if `true` the `Collapse` is default collapsed)

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
