### PR TITLE
[core] Fix Section tests broken by semantic merge conflict

### DIFF
--- a/packages/core/test/section/sectionTests.tsx
+++ b/packages/core/test/section/sectionTests.tsx
@@ -64,7 +64,7 @@ describe("<Section>", () => {
 
     it("collapsible is open when defaultIsOpen={undefined}", () => {
         const wrapper = mount(
-            <Section collapsible={true} collapseProps={{ defaultIsOpen: undefined }}>
+            <Section collapsible={true} collapseProps={{ defaultIsOpen: undefined }} title="">
                 <SectionCard>is open</SectionCard>
             </Section>,
             {
@@ -76,7 +76,7 @@ describe("<Section>", () => {
 
     it("collapsible is open when defaultIsOpen={true}", () => {
         const wrapper = mount(
-            <Section collapsible={true} collapseProps={{ defaultIsOpen: true }}>
+            <Section collapsible={true} collapseProps={{ defaultIsOpen: true }} title="">
                 <SectionCard>is open</SectionCard>
             </Section>,
             {
@@ -88,7 +88,7 @@ describe("<Section>", () => {
 
     it("collapsible is closed when defaultIsOpen={false}", () => {
         const wrapper = mount(
-            <Section collapsible={true} collapseProps={{ defaultIsOpen: false }}>
+            <Section collapsible={true} collapseProps={{ defaultIsOpen: false }} title="">
                 <SectionCard>is closed</SectionCard>
             </Section>,
             {

--- a/packages/core/test/section/sectionTests.tsx
+++ b/packages/core/test/section/sectionTests.tsx
@@ -64,7 +64,7 @@ describe("<Section>", () => {
 
     it("collapsible is open when defaultIsOpen={undefined}", () => {
         const wrapper = mount(
-            <Section collapsible={true} collapseProps={{ defaultIsOpen: undefined }} title="">
+            <Section collapsible={true} collapseProps={{ defaultIsOpen: undefined }} title="Test">
                 <SectionCard>is open</SectionCard>
             </Section>,
             {
@@ -76,7 +76,7 @@ describe("<Section>", () => {
 
     it("collapsible is open when defaultIsOpen={true}", () => {
         const wrapper = mount(
-            <Section collapsible={true} collapseProps={{ defaultIsOpen: true }} title="">
+            <Section collapsible={true} collapseProps={{ defaultIsOpen: true }} title="Test">
                 <SectionCard>is open</SectionCard>
             </Section>,
             {
@@ -88,7 +88,7 @@ describe("<Section>", () => {
 
     it("collapsible is closed when defaultIsOpen={false}", () => {
         const wrapper = mount(
-            <Section collapsible={true} collapseProps={{ defaultIsOpen: false }} title="">
+            <Section collapsible={true} collapseProps={{ defaultIsOpen: false }} title="Test">
                 <SectionCard>is closed</SectionCard>
             </Section>,
             {


### PR DESCRIPTION
Fixing section tests, failing due to a semantic merge conflict between https://github.com/palantir/blueprint/pull/6321 and https://github.com/palantir/blueprint/pull/6326

If `title` isn't provided, the header isn't rendered