### PR TITLE
chore: add @typescript-eslint group for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,12 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
+
+groups:
+  typescript-eslint:
+    patterns:
+      - "@typescript-eslint/*"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -13,8 +19,6 @@ updates:
     ignore:
       # don't try to update internal packages
       - dependency-name: "@blueprintjs/*"
-      # @typescript-eslint/* deps should all be upgraded together
-      - dependency-name: "@typescript-eslint/*"
       # typescript and typedoc are usually upgraded together, and are often require code changes
       - dependency-name: "typescript"
       - dependency-name: "typedoc"


### PR DESCRIPTION
Grouped updates were released for general availability last week. See blog post & documentation: https://github.blog/2023-08-24-a-faster-way-to-manage-version-updates-with-dependabot/