### PR TITLE
chore: fix dependabot configuration syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,6 @@
 
 version: 2
 
-groups:
-  typescript-eslint:
-    patterns:
-      - "@typescript-eslint/*"
-
 updates:
   - package-ecosystem: "npm"
     directory: "/"
@@ -16,6 +11,10 @@ updates:
     reviewers:
       - "adidahiya"
     versioning-strategy: increase
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
     ignore:
       # don't try to update internal packages
       - dependency-name: "@blueprintjs/*"


### PR DESCRIPTION
Attempting to fix this syntax error: https://github.com/palantir/blueprint/runs/16283669815

```
The property '#/' contains additional properties ["groups"] outside of the schema when none are allowed
```

Unfortunately the docs aren't very clear about where the `groups` key is allowed and the full schema is not yet available: https://github.com/dependabot/dependabot-core/issues/1927