### PR TITLE
docs: use latest code sandbox link everywhere

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -13,7 +13,7 @@ about: Something not working as expected?
 
 #### Code Sandbox
 
-Link to a minimal repro (fork [this code sandbox](https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4)): <!-- here -->
+Link to a minimal repro (fork [this code sandbox](https://codesandbox.io/p/sandbox/blueprint-v5-x-sandbox-react-16-wy0ojy)): <!-- here -->
 
 #### Steps to reproduce
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is not a mobile-first UI toolkit.
 
 [**View the full documentation ▸**](http://blueprintjs.com/docs)
 
-[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/blueprint-sandbox-2023-fjo3z4)
+[**Try it out on CodeSandbox ▸**](https://codesandbox.io/p/sandbox/blueprint-v5-x-sandbox-react-16-wy0ojy)
 
 [**Read frequently asked questions (FAQ) on the wiki ▸**](https://github.com/palantir/blueprint/wiki/Frequently-Asked-Questions)
 

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -24,7 +24,11 @@ export class Welcome extends React.PureComponent {
             <div className="blueprint-welcome">
                 <WelcomeCard href="#blueprint/getting-started" icon="star" title="Getting started" sameTab={true} />
                 <WelcomeCard href="https://github.com/palantir/blueprint" icon="git-repo" title="Git repository" />
-                <WelcomeCard href="https://codesandbox.io/p/sandbox/wy0ojy" icon="code-block" title="Code Sandbox" />
+                <WelcomeCard
+                    href="https://codesandbox.io/p/sandbox/blueprint-v5-x-sandbox-react-16-wy0ojy"
+                    icon="code-block"
+                    title="Code Sandbox"
+                />
                 <WelcomeCard
                     href="https://github.com/palantir/blueprint#contributing"
                     icon="git-merge"


### PR DESCRIPTION
Fixes an outdated link which was recently changed in abcd19ecf8ee2078fcd28d00cf0c35927eecd5a7

Updates all instances of the sandbox link to use the latest one with v5.x packages and React 16: https://codesandbox.io/p/sandbox/blueprint-v5-x-sandbox-react-16-wy0ojy