### PR TITLE
chore: further dependabot update refinements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
           - "eslint-plugin-import"
       postcss:
         patterns:
+          - "autoprefixer"
           - "postcss"
           - "postcss-*"
       stylelint:
@@ -29,29 +30,51 @@ updates:
           - "stylelint-*"
       test-infra:
         patterns:
+          - "chai"
+          - "@types/chai"
+          - "enzyme"
+          - "enzyme-*"
+          - "@types/enzyme"
+          - "@types/enzyme-*"
           - "jest"
           - "@jest/*"
           - "ts-jest"
           - "karma"
           - "karma-*"
           - "mocha"
+          - "@types/mocha"
+          - "sinon"
+          - "@sinonjs/*"
+          - "@types/sinon"
+      sass:
+        patterns:
+          - "sass"
       webpack:
         patterns:
           - "webpack"
           - "webpack-*"
           - "*-webpack-*"
           - "*-loader"
-      runtime-dependencies:
-        dependency-type: "production"
-      dev-dependencies:
-        dependency-type: "development"
+      date-fns:
+        patterns:
+          - "date-fns"
+          - "date-fns-tz"
     ignore:
       # don't try to update internal packages
       - dependency-name: "@blueprintjs/*"
       # typescript and typedoc are usually upgraded together, and are often require code changes
       - dependency-name: "typescript"
       - dependency-name: "typedoc"
-      # deprecated dependencies
+      # we are stuck on react v16 for now
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-test-renderer"
+      - dependency-name: "react-testing-library"
+      - dependency-name: "react-transition-group"
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/react-dom"
+      - dependency-name: "@types/react-transition-group"
+      # moment is deprecated, we only use it in limited places in the docs
       - dependency-name: "moment"
       - dependency-name: "moment-*"
       # we are stuck on svgo v1 for now
@@ -60,5 +83,13 @@ updates:
       - dependency-name: "@types/svgo"
       # lodash hasn't released for >2 years
       - dependency-name: "lodash"
+      # we are stuck on fantasticon v1 for now
       # see https://github.com/tancredi/fantasticon/issues/470
       - dependency-name: "fantasticon"
+        update-types:
+        - "version-update:semver-major"
+      # we rarely bump Node.js versions, and it requires additional code changes to do so
+      - dependency-name: "@types/node"
+        update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"


### PR DESCRIPTION
- Create more groups
- Add more libs to existing groups
- Remove the catch-all "runtime" and "dev-deps" groups, as these are meaningless. This is evident in recent automated PRs for these groups:
  - https://github.com/palantir/blueprint/pull/6351
  - https://github.com/palantir/blueprint/pull/6352)
- Exclude more packages from being updated