### PR TITLE
[stylelint-plugin] feat: allow stylelint v15 as peer dependency

### DIFF
--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -18,7 +18,7 @@
         "postcss-value-parser": "^4.2.0"
     },
     "peerDependencies": {
-        "stylelint": "^14.12.1"
+        "stylelint": "^14.12.1 || ^15.10.3"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.2",


### PR DESCRIPTION
No migrations are needed to use these stylelint rules with stylelint v15

#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add stylelint v15 as a peer dependency for @blueprintjs/stylelint-plugin.

#### Reviewers should focus on:

None of the breaking changes affect the code written for the @blueprintjs/stylelint-plugin rules. Consumers can safely continue running the rules when upgrading to stylelint v15

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
