### PR TITLE
[core] fix(OverlayToaster): declare children prop explicitly

### DIFF
--- a/packages/core/src/components/toast/overlayToasterProps.ts
+++ b/packages/core/src/components/toast/overlayToasterProps.ts
@@ -45,6 +45,9 @@ export interface OverlayToasterProps extends Props {
      */
     canEscapeKeyClear?: boolean;
 
+    /** Toasts to display inside the Overlay. */
+    children?: React.ReactNode;
+
     /**
      * Whether the toaster should be rendered into a new element attached to `document.body`.
      * If `false`, then positioning will be relative to the parent element.


### PR DESCRIPTION
#### Fixes #6363

#### Changes proposed in this pull request:

Add `children` as an explicit prop in `OverlayToasterProps` to fix compatibility of the children API with @types/react v18.x

This is similar to the change we made for other components in https://github.com/palantir/blueprint/pull/5266

