### PR TITLE
fix(DateInput, DateInput3): use flex layout to display rightElement

### DIFF
--- a/packages/datetime/src/components/date-input/_dateinput.scss
+++ b/packages/datetime/src/components/date-input/_dateinput.scss
@@ -3,6 +3,9 @@
 
 @import "../../common";
 
-.#{$ns}-dateinput-popover {
-  padding: 0;
+.#{$ns}-date-input {
+  .#{$ns}-input-action {
+    display: flex;
+    flex-direction: row;
+  }
 }

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -583,8 +583,8 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function _DateInpu
                     placeholder={placeholder}
                     rightElement={
                         <>
-                            {maybeTimezonePicker}
                             {props.rightElement}
+                            {maybeTimezonePicker}
                         </>
                     }
                     tagName={popoverProps.targetTagName}

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -467,8 +467,8 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
                     placeholder={placeholder}
                     rightElement={
                         <>
-                            {maybeTimezonePicker}
                             {props.rightElement}
+                            {maybeTimezonePicker}
                         </>
                     }
                     tagName={popoverProps.targetTagName}

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -101,9 +101,7 @@ export class DateInputExample extends React.PureComponent<ExampleProps, DateInpu
                     onChange={this.handleDateChange}
                     popoverProps={{ placement: "bottom" }}
                     rightElement={
-                        showRightElement && (
-                            <Icon icon="globe" intent="primary" style={{ padding: 7, marginLeft: -5 }} />
-                        )
+                        showRightElement && <Icon icon="globe" intent="primary" style={{ padding: "7px 5px" }} />
                     }
                     timePickerProps={
                         this.state.timePrecision === undefined

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
@@ -101,9 +101,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
                     onChange={this.handleDateChange}
                     popoverProps={{ placement: "bottom" }}
                     rightElement={
-                        showRightElement && (
-                            <Icon icon="globe" intent="primary" style={{ padding: 7, marginLeft: -5 }} />
-                        )
+                        showRightElement && <Icon icon="globe" intent="primary" style={{ padding: "7px 5px" }} />
                     }
                     timePickerProps={
                         this.state.timePrecision === undefined


### PR DESCRIPTION
#### Fixes #6371

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add flex styles around DateInput's rightElement to fix the linked styling bug. Also update order of DOM elements so that the timezone picker displays after the user-specified `props.rightElement`.

Same fix has also been applied to DateInput3.

#### Reviewers should focus on:

No regressions.

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/4b975382-49dc-42c8-95a9-a7ce59da0fec)

