### PR TITLE
chore: bump CI resource class for compile, dist, test jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
 
   compile:
     docker: *docker-node-image
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - restore_cache: *restore-node-modules-cache
@@ -107,7 +107,7 @@ jobs:
 
   dist:
     docker: *docker-node-image
-    resource_class: large
+    resource_class: xlarge
     environment:
       NODE_ENV: test
     steps:
@@ -143,6 +143,7 @@ jobs:
 
   test-react-16: &test-react
     docker: *docker-node-browsers-image
+    resource_class: xlarge
     environment:
       JUNIT_REPORT_PATH: reports
     parallelism: 6


### PR DESCRIPTION
Our CI build times have increased lately:

![image](https://github.com/palantir/blueprint/assets/723999/97897a71-ab76-4cd9-b127-12786d80b290)


Hopefully we can bring them back down by utilizing more compute resources in Circle.

See job insights: https://app.circleci.com/insights/github/palantir/blueprint/workflows/compile_lint_test_dist_deploy/jobs
See resource class docs: https://circleci.com/docs/resource-class-overview/