### PR TITLE
chore: exclude minimatch from clean lockfile check

### DIFF
--- a/scripts/verifyCleanLockfile.sh
+++ b/scripts/verifyCleanLockfile.sh
@@ -6,8 +6,13 @@ set -e
 set -o pipefail
 
 scripts_dir="$( dirname "$(readlink -f "$0")" )"
+
 bin="$scripts_dir/../node_modules/.bin"
-duplicates="$("$bin/yarn-deduplicate" "$scripts_dir/../yarn.lock" --strategy fewer --exclude react-day-picker --list)"
+
+# Exclude certain packages from deduplication, including:
+#     - react-day-picker (we have two major versions while we upgrade from v7 to v8, see https://github.com/palantir/blueprint/pull/5935)
+#     - minimatch (this node.js library is widely used by build tools and its lockfile entries often "dirty" the lockfile in a low-signal manner)
+duplicates="$("$bin/yarn-deduplicate" "$scripts_dir/../yarn.lock" --strategy fewer --exclude minimatch react-day-picker --list)"
 
 if [[ $duplicates ]]; then
     echo "Found duplicate blocks in yarn.lock which can be cleaned up. Please run 'yarn-deduplicate yarn.lock --strategy fewer'"


### PR DESCRIPTION

#### Changes proposed in this pull request:

Adjust the `clean-lockfile` build job to exclude `minimatch` from `yarn-deduplicate` since its duplicate entries are generally harmless. Without this change, we often get low-signal build failures about a "dirty" lockfile such as https://app.circleci.com/jobs/github/palantir/blueprint/77653

