### PR TITLE
[datetime2] various fixes to V3 components

### DIFF
--- a/packages/datetime2/src/blueprint-datetime2.scss
+++ b/packages/datetime2/src/blueprint-datetime2.scss
@@ -2,6 +2,6 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "common/react-day-picker-overrides";
-@import "components/date-picker3/date-picker3-caption";
 @import "components/date-picker3/date-picker3";
+@import "components/date-picker3/date-picker3-caption";
 @import "components/date-range-picker3/date-range-picker3";

--- a/packages/datetime2/src/classes.ts
+++ b/packages/datetime2/src/classes.ts
@@ -22,7 +22,7 @@ import { Classes as DatetimeClasses } from "@blueprintjs/datetime";
 
 const RDP = "rdp";
 const RDP_DAY = `${RDP}-day`;
-const DATEPICKER_NAV_BUTTON = `${DatetimeClasses.DATEPICKER}-nav-button`;
+const DATEPICKER3_NAV_BUTTON = `${DatetimeClasses.DATEPICKER}-nav-button`;
 
 export const ReactDayPickerClasses = {
     RDP,
@@ -37,21 +37,15 @@ export const ReactDayPickerClasses = {
 };
 
 const DatePicker3Classes = {
-    // these classes need the "3" suffix because they overlap with DatePicker v1 / react-day-picker v7 classes
     DATEPICKER3_DAY: RDP_DAY,
     DATEPICKER3_DAY_DISABLED: `${RDP_DAY}_disabled`,
     DATEPICKER3_DAY_IS_TODAY: `${RDP_DAY}_today`,
     DATEPICKER3_DAY_OUTSIDE: `${RDP_DAY}_outside`,
     DATEPICKER3_DAY_SELECTED: `${RDP_DAY}_selected`,
-    // these classes intentionally left without "3" suffix because they do not overlap with DatePicker v1, and this way we don't need to migrate them later, which reduces code churn
-    DATEPICKER_DROPDOWN_CONTAINER: `${DatetimeClasses.DATEPICKER}-dropdown-container`,
-    DATEPICKER_DROPDOWN_MONTH: `${RDP}-dropdown_month`,
-    DATEPICKER_DROPDOWN_YEAR: `${RDP}-dropdown_year`,
-    DATEPICKER_HIGHLIGHT_CURRENT_DAY: `${DatetimeClasses.DATEPICKER}-highlight-current-day`,
-    DATEPICKER_NAV_BUTTON,
-    DATEPICKER_NAV_BUTTON_HIDDEN: `${DATEPICKER_NAV_BUTTON}-hidden`,
-    DATEPICKER_NAV_BUTTON_NEXT: `${DATEPICKER_NAV_BUTTON}-next`,
-    DATEPICKER_NAV_BUTTON_PREVIOUS: `${DATEPICKER_NAV_BUTTON}-previous`,
+    DATEPICKER3_HIGHLIGHT_CURRENT_DAY: `${DatetimeClasses.DATEPICKER}-highlight-current-day`,
+    DATEPICKER3_NAV_BUTTON,
+    DATEPICKER3_NAV_BUTTON_NEXT: `${DATEPICKER3_NAV_BUTTON}-next`,
+    DATEPICKER3_NAV_BUTTON_PREVIOUS: `${DATEPICKER3_NAV_BUTTON}-previous`,
 };
 
 const DateRangePicker3Classes = {
@@ -61,7 +55,7 @@ const DateRangePicker3Classes = {
     DATERANGEPICKER3_DAY_RANGE_END: `${RDP_DAY}_range_end`,
     DATERANGEPICKER3_DAY_RANGE_MIDDLE: `${RDP_DAY}_range_middle`,
     DATERANGEPICKER3_DAY_RANGE_START: `${RDP_DAY}_range_start`,
-    DATERANGEPICKER_REVERSE_MONTH_AND_YEAR: `${DatetimeClasses.DATERANGEPICKER}-reverse-month-and-year`,
+    DATERANGEPICKER3_REVERSE_MONTH_AND_YEAR: `${DatetimeClasses.DATERANGEPICKER}-reverse-month-and-year`,
 };
 
 export const Classes = {
@@ -80,8 +74,8 @@ export const dayPickerClassNameOverrides: Partial<StyledElement<string>> = {
     button_reset: undefined,
     dropdown_month: DatetimeClasses.DATEPICKER_MONTH_SELECT,
     dropdown_year: DatetimeClasses.DATEPICKER_YEAR_SELECT,
-    nav_button: Classes.DATEPICKER_NAV_BUTTON,
-    nav_button_next: Classes.DATEPICKER_NAV_BUTTON_NEXT,
-    nav_button_previous: Classes.DATEPICKER_NAV_BUTTON_PREVIOUS,
+    nav_button: Classes.DATEPICKER3_NAV_BUTTON,
+    nav_button_next: Classes.DATEPICKER3_NAV_BUTTON_NEXT,
+    nav_button_previous: Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS,
     /* eslint-enable camelcase */
 };

--- a/packages/datetime2/src/classes.ts
+++ b/packages/datetime2/src/classes.ts
@@ -74,6 +74,8 @@ export const dayPickerClassNameOverrides: Partial<StyledElement<string>> = {
     /* eslint-disable camelcase */
     button: classNames(CoreClasses.BUTTON, CoreClasses.MINIMAL),
     button_reset: undefined,
+    dropdown_month: DatetimeClasses.DATEPICKER_MONTH_SELECT,
+    dropdown_year: DatetimeClasses.DATEPICKER_YEAR_SELECT,
     nav_button: Classes.DATEPICKER_NAV_BUTTON,
     nav_button_next: Classes.DATEPICKER_NAV_BUTTON_NEXT,
     nav_button_previous: Classes.DATEPICKER_NAV_BUTTON_PREVIOUS,

--- a/packages/datetime2/src/classes.ts
+++ b/packages/datetime2/src/classes.ts
@@ -24,10 +24,15 @@ const RDP = "rdp";
 const RDP_DAY = `${RDP}-day`;
 const DATEPICKER_NAV_BUTTON = `${DatetimeClasses.DATEPICKER}-nav-button`;
 
-const ReactDayPickerClasses = {
+export const ReactDayPickerClasses = {
     RDP,
+    RDP_CAPTION: `${RDP}-caption`,
+    RDP_CAPTION_DROPDOWNS: `${RDP}-caption_dropdowns`,
     RDP_CAPTION_LABEL: `${RDP}-caption_label`,
     RDP_DAY,
+    RDP_MONTH: `${RDP}-month`,
+    RDP_NAV: `${RDP}-nav`,
+    RDP_TABLE: `${RDP}-table`,
     RDP_VHIDDEN: `${RDP}-vhidden`,
 };
 
@@ -63,7 +68,6 @@ export const Classes = {
     ...DatetimeClasses,
     ...DatePicker3Classes,
     ...DateRangePicker3Classes,
-    ...ReactDayPickerClasses,
 };
 
 /**

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -120,6 +120,18 @@
   }
 }
 
+.#{$ns}-datepicker-month-select, .#{$ns}-datepicker-year-select {
+  select {
+    font-weight: 600;
+    padding-left: $datepicker-padding;
+    padding-right: $pt-icon-size-standard;
+
+    + .#{$ns}-icon {
+      right: 2px;
+    }
+  }
+}
+
 .#{$ns}-datepicker-footer {
   display: flex;
   justify-content: space-between;

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -33,6 +33,10 @@
     }
   }
 
+  .rdp-table {
+    max-width: none;
+  }
+
   .rdp-weekdays {
     display: table-header-group;
   }

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -45,21 +45,12 @@
     text-transform: none;
   }
 
-  .rdp-tbody {
-    display: table-row-group;
-  }
-
-  .rdp-row {
-    display: table-row;
-  }
-
   .rdp-weeknumber {
-    color: $pt-text-color-disabled;
+    color: $pt-text-color-muted;
   }
 
   .rdp-day {
     border-radius: $pt-border-radius;
-    cursor: pointer;
 
     // spelling out full name so these are equal specificity to pseudo-classes (.DayPicker-Day:hover)
     &.rdp-day_outside {
@@ -135,7 +126,7 @@
   background: $dark-datepicker-background-color;
 
   .rdp-week-number {
-    color: $pt-dark-text-color-disabled;
+    color: $pt-dark-text-color-muted;
   }
 
   .rdp-day {

--- a/packages/datetime2/src/components/date-picker3/date-picker3.md
+++ b/packages/datetime2/src/components/date-picker3/date-picker3.md
@@ -11,14 +11,14 @@ Migrating from [DatePicker](#datetime/datepicker)?
 
 </h5>
 
-__DatePicker3__ is a replacement for DatePicker and will replace it in Blueprint v6.
+**DatePicker3** is a replacement for DatePicker and will replace it in Blueprint v6.
 You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
 See the [react-day-picker v8 migration guide](https://github.com/palantir/blueprint/wiki/react-day-picker-8-migration)
 on the wiki.
 
 </div>
 
-__DatePicker3__ has the same functionality as [DatePicker](#datetime/datepicker) but uses
+**DatePicker3** has the same functionality as [DatePicker](#datetime/datepicker) but uses
 [react-day-picker v8](https://react-day-picker.js.org/) instead of [v7](https://react-day-picker-v7.netlify.app/)
 to render its calendar. It renders a UI to choose a single date and (optionally) a time of day. Time selection
 is enabled by the [TimePicker](#datetime/timepicker) component.
@@ -27,13 +27,13 @@ is enabled by the [TimePicker](#datetime/timepicker) component.
 
 @## Usage
 
-__DatePicker3__ supports both controlled and uncontrolled usage. You can control the selected day by setting the `value`
+**DatePicker3** supports both controlled and uncontrolled usage. You can control the selected day by setting the `value`
 prop, or use the component in uncontrolled mode and specify an initial day by setting `defaultValue`. Use the `onChange`
 prop to listen for changes to the selected day.
 
 @## Props interface
 
-In addition to top-level __DatePicker3__ props, you may forward some props to `<DayPicker mode="single">` to customize
+In addition to top-level **DatePicker3** props, you may forward some props to `<DayPicker mode="single">` to customize
 react-day-picker's behavior via `dayPickerProps` (the full list is
 [documented here](https://react-day-picker.js.org/api/interfaces/DayPickerSingleProps)).
 
@@ -41,15 +41,14 @@ react-day-picker's behavior via `dayPickerProps` (the full list is
 
 @## Shortcuts
 
-The menu on the left of the calendars provides "shortcuts" which allow users to
-quickly select common dates. The items in this menu are controlled through
-the `shortcuts` prop:
+The menu on the left of the calendars provides "shortcuts" which allow users to quickly select common dates.
+The items in this menu are controlled through the `shortcuts` prop:
 
 -   `false` (default) will hide the shortcuts menu,
 -   `true` will show the built-in shortcuts, and
 -   custom shortcuts can be shown by defining an array of `DatePickerShortcut` objects.
 
-The **preset shortcuts** can be seen in the example above. They are as follows:
+The built-in **preset shortcuts** can be seen in the example above. They are as follows:
 
 -   Today
 -   Yesterday
@@ -64,7 +63,7 @@ The **preset shortcuts** can be seen in the example above. They are as follows:
 
 @## Modifiers
 
-__DatePicker3__ utilizes react-day-picker's built-in [modifiers](https://react-day-picker.js.org/basics/modifiers) for
+**DatePicker3** utilizes react-day-picker's built-in [modifiers](https://react-day-picker.js.org/basics/modifiers) for
 various functionality (highlighting the current day, showing selected days, etc.).
 
 You may extend and customize the default modifiers by specifying various properties in the `dayPickerProps` prop object.
@@ -78,8 +77,21 @@ for more info.
 
 @## Localization
 
-__DatePicker3__ supports calendar localization using date-fns [Locale](https://date-fns.org/docs/Locale).
+**DatePicker3** supports calendar localization using date-fns [Locale](https://date-fns.org/docs/Locale).
 Use the `locale` prop to specify a locale code (ISO 639-1 + optional country code) and the component will
 load the corresponding date-fns locale. For example, `locale="fr"` is used below by default.
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Localizing shortcuts
+
+</h5>
+
+Built-in preset shortcut labels are not automatically localized by setting the `locale` prop. If you need these
+strings to appear in different languages, you will need to specify custom shortcuts and update their `label`
+properties accordingly.
+
+</div>
 
 @reactExample DatePicker3LocalizedExample

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -30,7 +30,7 @@ import {
     TimePicker,
 } from "@blueprintjs/datetime";
 
-import { Classes } from "../../classes";
+import { Classes, dayPickerClassNameOverrides } from "../../classes";
 import { loadDateFnsLocale } from "../../common/dateFnsLocaleUtils";
 import { DatePicker3Caption } from "../react-day-picker/datePicker3Caption";
 import { DatePicker3Provider } from "./datePicker3Context";
@@ -95,6 +95,10 @@ export class DatePicker3 extends AbstractPureComponent<DatePicker3Props, DatePic
                             locale={locale}
                             showOutsideDays={true}
                             {...dayPickerProps}
+                            classNames={{
+                                ...dayPickerClassNameOverrides,
+                                ...dayPickerProps?.classNames,
+                            }}
                             components={{
                                 Caption: DatePicker3Caption,
                                 ...dayPickerProps?.components,

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -32,7 +32,8 @@ import {
 
 import { Classes, dayPickerClassNameOverrides } from "../../classes";
 import { loadDateFnsLocale } from "../../common/dateFnsLocaleUtils";
-import { DatePicker3Caption } from "../react-day-picker/datePicker3Caption";
+import { IconLeft, IconRight } from "../react-day-picker/datePickerNavIcons";
+import { DatePicker3Dropdown } from "../react-day-picker/datePicker3Dropdown";
 import { DatePicker3Provider } from "./datePicker3Context";
 import { DatePicker3Props } from "./datePicker3Props";
 import { DatePicker3State } from "./datePicker3State";
@@ -95,12 +96,15 @@ export class DatePicker3 extends AbstractPureComponent<DatePicker3Props, DatePic
                             locale={locale}
                             showOutsideDays={true}
                             {...dayPickerProps}
+                            captionLayout="dropdown-buttons"
                             classNames={{
                                 ...dayPickerClassNameOverrides,
                                 ...dayPickerProps?.classNames,
                             }}
                             components={{
-                                Caption: DatePicker3Caption,
+                                Dropdown: DatePicker3Dropdown,
+                                IconLeft,
+                                IconRight,
                                 ...dayPickerProps?.components,
                             }}
                             formatters={{

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -85,7 +85,7 @@ export class DatePicker3 extends AbstractPureComponent<DatePicker3Props, DatePic
         return (
             <div
                 className={classNames(Classes.DATEPICKER, className, {
-                    [Classes.DATEPICKER_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
+                    [Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
                 })}
             >
                 {this.maybeRenderShortcuts()}

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -32,8 +32,8 @@ import {
 
 import { Classes, dayPickerClassNameOverrides } from "../../classes";
 import { loadDateFnsLocale } from "../../common/dateFnsLocaleUtils";
-import { IconLeft, IconRight } from "../react-day-picker/datePickerNavIcons";
 import { DatePicker3Dropdown } from "../react-day-picker/datePicker3Dropdown";
+import { IconLeft, IconRight } from "../react-day-picker/datePickerNavIcons";
 import { DatePicker3Provider } from "./datePicker3Context";
 import { DatePicker3Props } from "./datePicker3Props";
 import { DatePicker3State } from "./datePicker3State";

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -11,18 +11,6 @@
 /* stylelint-disable selector-class-pattern */
 
 .#{$ns}-daterangepicker {
-  .rdp {
-    .#{$ns}-html-select select {
-      font-weight: 600;
-      padding-left: $datepicker-padding;
-      padding-right: $pt-icon-size-standard;
-
-      + .#{$ns}-icon {
-        right: 2px;
-      }
-    }
-  }
-
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
     min-width: $datepicker-min-width + $pt-grid-size;
@@ -72,13 +60,6 @@
       top: initial;
       transform: none;
     }
-  }
-
-  // need some extra specificity to override react-day-picker styles
-  .rdp-button.rdp-nav_button {
-    @include pt-button-minimal();
-    border: none;
-    border-radius: $pt-border-radius;
   }
 
   // need some extra specificity to override DatePicker styles

--- a/packages/datetime2/src/components/date-range-picker3/contiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/contiguousDayRangePicker.tsx
@@ -64,7 +64,7 @@ export const ContiguousDayRangePicker: React.FC<DayRangePickerProps> = ({
             );
             onRangeSelect(nextValue, selectedDay, boundary);
         },
-        [allowSingleDayRange, boundaryToModify, dayPickerProps?.onSelect, onRangeSelect, value],
+        [allowSingleDayRange, boundaryToModify, dayPickerProps, onRangeSelect, value],
     );
 
     return (
@@ -129,20 +129,20 @@ function useContiguousCalendarViews(
             return;
         }
 
-        if (selectedRange[0] == null || selectedRange[1] == null) {
-            // special case: if only one boundary of the range is selected and it is already displayed in one of the
-            // months, don't update the display month. this prevents the picker from shifting around when a user is in
-            // the middle of a selection.
-            if (
-                isDateDisplayed(selectedRange[0], displayMonth, singleMonthOnly) ||
-                isDateDisplayed(selectedRange[1], displayMonth, singleMonthOnly)
-            ) {
-                return;
-            }
-        }
-
         setDisplayMonth(prevDisplayMonth => {
             let newDisplayMonth = prevDisplayMonth.clone();
+
+            if (selectedRange[0] == null || selectedRange[1] == null) {
+                // special case: if only one boundary of the range is selected and it is already displayed in one of the
+                // months, don't update the display month. this prevents the picker from shifting around when a user is in
+                // the middle of a selection.
+                if (
+                    isDateDisplayed(selectedRange[0], prevDisplayMonth, singleMonthOnly) ||
+                    isDateDisplayed(selectedRange[1], prevDisplayMonth, singleMonthOnly)
+                ) {
+                    return newDisplayMonth;
+                }
+            }
 
             const nextRangeStart = MonthAndYear.fromDate(selectedRange[0]);
             const nextRangeEnd = MonthAndYear.fromDate(selectedRange[1]);

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -125,10 +125,10 @@ export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Prop
         const isSingleMonthOnly = getIsSingleMonthOnly(this.props);
 
         const classes = classNames(Classes.DATEPICKER, Classes.DATERANGEPICKER, className, {
-            [Classes.DATEPICKER_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
+            [Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
             [Classes.DATERANGEPICKER_CONTIGUOUS]: contiguousCalendarMonths,
             [Classes.DATERANGEPICKER_SINGLE_MONTH]: isSingleMonthOnly,
-            [Classes.DATERANGEPICKER_REVERSE_MONTH_AND_YEAR]: this.props.reverseMonthAndYearMenus,
+            [Classes.DATERANGEPICKER3_REVERSE_MONTH_AND_YEAR]: this.props.reverseMonthAndYearMenus,
         });
 
         // use the left DayPicker when we only need one

--- a/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
+++ b/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
@@ -23,7 +23,7 @@ import { Button, DISPLAYNAME_PREFIX, Divider, HTMLSelect, OptionProps } from "@b
 import { DateUtils, Months } from "@blueprintjs/datetime";
 import { ChevronLeft, ChevronRight } from "@blueprintjs/icons";
 
-import { Classes } from "../../classes";
+import { Classes, ReactDayPickerClasses } from "../../classes";
 import { useMonthSelectRightOffset } from "../../common/useMonthSelectRightOffset";
 import { DatePicker3Context } from "../date-picker3/datePicker3Context";
 
@@ -159,7 +159,7 @@ export const DatePicker3Caption: React.FC<CaptionProps> = props => {
     const orderedSelects = reverseMonthAndYearMenus ? [yearSelect, monthSelect] : [monthSelect, yearSelect];
 
     const hiddenCaptionLabel = (
-        <div className={Classes.RDP_VHIDDEN}>
+        <div className={ReactDayPickerClasses.RDP_VHIDDEN}>
             <CaptionLabel displayMonth={props.displayMonth} id={props.id} />
         </div>
     );

--- a/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
+++ b/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
@@ -59,7 +59,7 @@ export const DatePicker3Caption: React.FC<CaptionProps> = props => {
     const prevButton = (
         <Button
             aria-label={labels.labelPrevious(previousMonth, { locale })}
-            className={classNames(Classes.DATEPICKER_NAV_BUTTON, Classes.DATEPICKER_NAV_BUTTON_PREVIOUS)}
+            className={classNames(Classes.DATEPICKER3_NAV_BUTTON, Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS)}
             disabled={!previousMonth}
             icon={<ChevronLeft />}
             minimal={true}
@@ -69,7 +69,7 @@ export const DatePicker3Caption: React.FC<CaptionProps> = props => {
     const nextButton = (
         <Button
             aria-label={labels.labelNext(nextMonth, { locale })}
-            className={classNames(Classes.DATEPICKER_NAV_BUTTON, Classes.DATEPICKER_NAV_BUTTON_NEXT)}
+            className={classNames(Classes.DATEPICKER3_NAV_BUTTON, Classes.DATEPICKER3_NAV_BUTTON_NEXT)}
             disabled={!nextMonth}
             icon={<ChevronRight />}
             minimal={true}

--- a/packages/datetime2/src/components/react-day-picker/datePicker3Dropdown.tsx
+++ b/packages/datetime2/src/components/react-day-picker/datePicker3Dropdown.tsx
@@ -19,7 +19,6 @@ import { DropdownProps } from "react-day-picker";
 
 import { HTMLSelect } from "@blueprintjs/core";
 
-import { Classes } from "../../classes";
 import { useMonthSelectRightOffset } from "../../common/useMonthSelectRightOffset";
 
 /**
@@ -39,7 +38,7 @@ export function DatePicker3Dropdown({ caption, children, ...props }: DropdownPro
     const iconProps = props.name === "months" ? { style: { right: monthSelectRightOffset } } : {};
 
     return (
-        <div className={Classes.DATEPICKER_DROPDOWN_CONTAINER} ref={containerElement}>
+        <div ref={containerElement}>
             <HTMLSelect iconProps={iconProps} minimal={true} ref={selectElement} {...props}>
                 {children}
             </HTMLSelect>

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -19,7 +19,7 @@ export { DateInput3, DateInput3Props } from "./components/date-input3/dateInput3
 export { DateRangePicker3, DateRangePicker3Props } from "./components/date-range-picker3/dateRangePicker3";
 export * as DateInput2MigrationUtils from "./dateInput2MigrationUtils";
 
-export { Classes as Datetime2Classes } from "./classes";
+export { Classes as Datetime2Classes, ReactDayPickerClasses } from "./classes";
 
 /* eslint-disable deprecation/deprecation */
 

--- a/packages/datetime2/test/components/datePicker3Tests.tsx
+++ b/packages/datetime2/test/components/datePicker3Tests.tsx
@@ -775,8 +775,9 @@ describe("<DatePicker3>", () => {
                         .map(d => +d.text()),
                     days,
                 ),
-            clickNextMonth: () => wrapper.find(Button).last().simulate("click"),
-            clickPreviousMonth: () => wrapper.find(Button).first().simulate("click"),
+            clickNextMonth: () => wrapper.find(`.${Classes.DATEPICKER3_NAV_BUTTON_NEXT}`).hostNodes().simulate("click"),
+            clickPreviousMonth: () =>
+                wrapper.find(`.${Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS}`).hostNodes().simulate("click"),
             clickShortcut: (index = 0) => {
                 wrapper.find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`).hostNodes().find("a").at(index).simulate("click");
             },

--- a/packages/datetime2/test/components/datePicker3Tests.tsx
+++ b/packages/datetime2/test/components/datePicker3Tests.tsx
@@ -75,12 +75,12 @@ describe("<DatePicker3>", () => {
 
     it("current day is not highlighted by default", () => {
         const { root } = wrap(<DatePicker3 />);
-        assert.lengthOf(root.find(`.${Classes.DATEPICKER_HIGHLIGHT_CURRENT_DAY}`), 0);
+        assert.lengthOf(root.find(`.${Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY}`), 0);
     });
 
     it("current day should be highlighted when highlightCurrentDay={true}", () => {
         const { root } = wrap(<DatePicker3 highlightCurrentDay={true} />);
-        assert.lengthOf(root.find(`.${Classes.DATEPICKER_HIGHLIGHT_CURRENT_DAY}`), 1);
+        assert.lengthOf(root.find(`.${Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY}`), 1);
     });
 
     describe("reconciliates dayPickerProps", () => {
@@ -149,14 +149,14 @@ describe("<DatePicker3>", () => {
             it("calls onMonthChange on button next click", () => {
                 const onMonthChange = sinon.spy();
                 const { root } = wrap(<DatePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />);
-                root.find(`.${Classes.DATEPICKER_NAV_BUTTON_NEXT}`).first().simulate("click");
+                root.find(`.${Classes.DATEPICKER3_NAV_BUTTON_NEXT}`).first().simulate("click");
                 assert.isTrue(onMonthChange.called);
             });
 
             it("calls onMonthChange on button prev click", () => {
                 const onMonthChange = sinon.spy();
                 const { root } = wrap(<DatePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />);
-                root.find(`.${Classes.DATEPICKER_NAV_BUTTON_PREVIOUS}`).first().simulate("click");
+                root.find(`.${Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS}`).first().simulate("click");
                 assert.isTrue(onMonthChange.called);
             });
 

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -95,10 +95,10 @@ describe("<DatePicker3>", () => {
             const defaultValue: DateRange = [new Date(2017, Months.SEPTEMBER, 1), null];
             const { wrapper } = wrap(<DateRangePicker3 defaultValue={defaultValue} />);
             assert.isFalse(
-                wrapper.find(".rdp-month").at(0).find(`.${Datetime2Classes.DATEPICKER_NAV_BUTTON_NEXT}`).exists(),
+                wrapper.find(".rdp-month").at(0).find(`.${Datetime2Classes.DATEPICKER3_NAV_BUTTON_NEXT}`).exists(),
             );
             assert.isFalse(
-                wrapper.find(".rdp-month").at(1).find(`.${Datetime2Classes.DATEPICKER_NAV_BUTTON_PREVIOUS}`).exists(),
+                wrapper.find(".rdp-month").at(1).find(`.${Datetime2Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS}`).exists(),
             );
         });
 
@@ -1367,7 +1367,7 @@ describe("<DatePicker3>", () => {
                 findTimeInput(precision, which).simulate("change", { target: { value } }),
             clickNavButton: (which: "next" | "previous", navIndex = 0) => {
                 const month = wrapper.find(`.rdp-month`).at(navIndex);
-                const navButton = month.find(`.${Datetime2Classes.DATEPICKER_NAV_BUTTON}-${which}`);
+                const navButton = month.find(`.${Datetime2Classes.DATEPICKER3_NAV_BUTTON}-${which}`);
                 navButton.hostNodes().simulate("click");
                 return harness;
             },

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -36,7 +36,7 @@ import {
     TimePrecision,
 } from "@blueprintjs/datetime";
 
-import { DateRangePicker3, DateRangePicker3Props, Datetime2Classes } from "../../src";
+import { DateRangePicker3, DateRangePicker3Props, Datetime2Classes, ReactDayPickerClasses } from "../../src";
 import * as DateFnsLocaleUtils from "../../src/common/dateFnsLocaleUtils";
 import { DateRangePicker3State } from "../../src/components/date-range-picker3/dateRangePicker3State";
 import { assertDayDisabled } from "../common/dayPickerTestUtils";
@@ -1399,7 +1399,7 @@ describe("<DatePicker3>", () => {
                     .at(whichCalendar === "left" ? 0 : 1);
             },
             get displayMonthAndYear(): MonthAndYear {
-                const captionLabel = harness.wrapper.find(`.${Datetime2Classes.RDP_CAPTION_LABEL}`);
+                const captionLabel = harness.wrapper.find(`.${ReactDayPickerClasses.RDP_CAPTION_LABEL}`);
                 assert.exists(captionLabel, "Expected caption label which labels the current display month to exist");
                 const [monthText, yearText] = captionLabel.text().split(" ");
                 const month = getMonthIndex(monthText);
@@ -1407,10 +1407,10 @@ describe("<DatePicker3>", () => {
                 return new MonthAndYear(month, year);
             },
             get monthSelect() {
-                return harness.wrapper.find(`.${Datetime2Classes.DATEPICKER_DROPDOWN_MONTH}`).find("select");
+                return harness.wrapper.find(`.${Datetime2Classes.DATEPICKER_MONTH_SELECT}`).find("select");
             },
             get yearSelect() {
-                return harness.wrapper.find(`.${Datetime2Classes.DATEPICKER_DROPDOWN_YEAR}`).find("select");
+                return harness.wrapper.find(`.${Datetime2Classes.DATEPICKER_YEAR_SELECT}`).find("select");
             },
 
             assertDisplayMonth: (expectedMonth: number, expectedYear?: number) => {

--- a/packages/datetime2/test/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/dateInput2MigrationUtilsTests.tsx
@@ -96,13 +96,15 @@ describe("DateInput2MigrationUtils", () => {
 
     it("Adapters work in common usage pattern with React.useCallback + React.useMemo", () => {
         function TestComponent() {
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             const handleChange = React.useCallback(
                 DateInput2MigrationUtils.onChangeAdapter(controlledDateInputProps.onChange),
-                [controlledDateInputProps.onChange],
+                [],
             );
+            // eslint-disable-next-line react-hooks/exhaustive-deps
             const value = React.useMemo(
                 () => DateInput2MigrationUtils.valueAdapter(controlledDateInputProps.value),
-                [controlledDateInputProps.value],
+                [],
             );
 
             return <DateInput2 {...dateFormattingProps} onChange={handleChange} value={value} />;

--- a/packages/docs-app/src/examples/datetime2-examples/common/minMaxDateSelect.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/common/minMaxDateSelect.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { add } from "date-fns";
+import * as React from "react";
+
+import { HTMLSelect, Label } from "@blueprintjs/core";
+import { handleNumberChange } from "@blueprintjs/docs-theme";
+
+interface DateOption {
+    label: string;
+    value: Date | undefined;
+}
+
+const today = new Date();
+
+export interface DateSelectProps {
+    label: string;
+    onChange: (newDate: Date) => void;
+    options: DateOption[];
+}
+
+const DateSelect: React.FC<DateSelectProps> = ({ label, onChange, options }) => {
+    const [selectedOptionIndex, setSelectedOptionIndex] = React.useState(0);
+
+    const handleSelectChange = React.useCallback(
+        handleNumberChange(optionIndex => {
+            setSelectedOptionIndex(optionIndex);
+            onChange(options[optionIndex].value);
+        }),
+        [onChange, options],
+    );
+
+    return (
+        <Label>
+            {label}
+            <HTMLSelect value={selectedOptionIndex} onChange={handleSelectChange}>
+                {options.map((opt, i) => (
+                    <option key={i} value={i} label={opt.label} />
+                ))}
+            </HTMLSelect>
+        </Label>
+    );
+};
+
+const MIN_DATE_OPTIONS: DateOption[] = [
+    { label: "Default (20 years ago)", value: undefined },
+    {
+        label: "1 week ago",
+        value: add(today, { weeks: -1 }),
+    },
+    {
+        label: "4 months ago",
+        value: add(today, { months: -4 }),
+    },
+    {
+        label: "1 year ago",
+        value: add(today, { years: -1 }),
+    },
+];
+
+export type MinDateSelectProps = Pick<DateSelectProps, "onChange">;
+
+export const MinDateSelect: React.FC<MinDateSelectProps> = props => (
+    <DateSelect label="Minimum date" onChange={props.onChange} options={MIN_DATE_OPTIONS} />
+);
+
+const MAX_DATE_OPTIONS: DateOption[] = [
+    { label: "Default (6 months from now)", value: undefined },
+    {
+        label: "Today",
+        value: today,
+    },
+    {
+        label: "1 week from now",
+        value: add(today, { weeks: 1 }),
+    },
+    {
+        label: "4 months from now",
+        value: add(today, { months: 4 }),
+    },
+    {
+        label: "1 year from now",
+        value: add(today, { years: 1 }),
+    },
+];
+
+export const MaxDateSelect: React.FC<MinDateSelectProps> = props => (
+    <DateSelect label="Maximum date" onChange={props.onChange} options={MAX_DATE_OPTIONS} />
+);

--- a/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
@@ -22,12 +22,15 @@ import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@
 
 import { DateTag } from "../../common/dateTag";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
+import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
 
 const exampleFooterElement = <Callout>This additional footer component can be displayed below the date picker</Callout>;
 
 export interface DatePicker3ExampleState {
     date: Date | null;
     highlightCurrentDay: boolean;
+    maxDate: Date | undefined;
+    minDate: Date | undefined;
     reverseMonthAndYearMenus: boolean;
     shortcuts: boolean;
     showActionsBar: boolean;
@@ -43,6 +46,8 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
     public state: DatePicker3ExampleState = {
         date: null,
         highlightCurrentDay: false,
+        maxDate: undefined,
+        minDate: undefined,
         reverseMonthAndYearMenus: false,
         shortcuts: false,
         showActionsBar: true,
@@ -67,6 +72,10 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
     private toggleShortcuts = handleBooleanChange(shortcuts => this.setState({ shortcuts }));
 
     private toggleReverseMenus = handleBooleanChange(reverse => this.setState({ reverseMonthAndYearMenus: reverse }));
+
+    private handleMaxDateChange = (maxDate: Date) => this.setState({ maxDate });
+
+    private handleMinDateChange = (minDate: Date) => this.setState({ minDate });
 
     private handlePrecisionChange = handleValueChange((p: TimePrecision | "none") =>
         this.setState({ timePrecision: p === "none" ? undefined : p }),
@@ -102,6 +111,8 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
                     label="Show custom footer element"
                     onChange={this.toggleShowFooterElement}
                 />
+                <MinDateSelect onChange={this.handleMinDateChange} />
+                <MaxDateSelect onChange={this.handleMaxDateChange} />
                 <H5>react-day-picker props</H5>
                 <Switch
                     checked={this.state.showWeekNumber}

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -14,23 +14,17 @@
  * limitations under the License.
  */
 
-import { add } from "date-fns";
 import * as React from "react";
 
-import { Classes, FormGroup, H5, HTMLSelect, Label, Switch } from "@blueprintjs/core";
+import { Classes, FormGroup, H5, Switch } from "@blueprintjs/core";
 import { DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangePicker3 } from "@blueprintjs/datetime2";
-import {
-    Example,
-    ExampleProps,
-    handleBooleanChange,
-    handleNumberChange,
-    handleValueChange,
-} from "@blueprintjs/docs-theme";
+import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { CommonDateFnsLocale, DateFnsLocaleSelect } from "../../common/dateFnsLocaleSelect";
 import { DateRangeTag } from "../../common/dateRangeTag";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
+import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
 
 interface DateRangePicker3ExampleState {
     allowSingleDayRange?: boolean;
@@ -38,55 +32,12 @@ interface DateRangePicker3ExampleState {
     contiguousCalendarMonths?: boolean;
     dateRange?: DateRange;
     localeCode: CommonDateFnsLocale;
-    maxDateIndex?: number;
-    minDateIndex?: number;
+    maxDate: Date | undefined;
+    minDate: Date | undefined;
     reverseMonthAndYearMenus?: boolean;
     shortcuts?: boolean;
     timePrecision?: TimePrecision;
 }
-
-interface DateOption {
-    label: string;
-    value?: Date;
-}
-
-const today = new Date();
-
-const MIN_DATE_OPTIONS: DateOption[] = [
-    { label: "None", value: undefined },
-    {
-        label: "1 week ago",
-        value: add(today, { weeks: -1 }),
-    },
-    {
-        label: "4 months ago",
-        value: add(today, { months: -4 }),
-    },
-    {
-        label: "1 year ago",
-        value: add(today, { years: -1 }),
-    },
-];
-
-const MAX_DATE_OPTIONS: DateOption[] = [
-    { label: "None", value: undefined },
-    {
-        label: "Today",
-        value: today,
-    },
-    {
-        label: "1 week from now",
-        value: add(today, { weeks: 1 }),
-    },
-    {
-        label: "4 months from now",
-        value: add(today, { months: 4 }),
-    },
-    {
-        label: "1 year from now",
-        value: add(today, { years: 1 }),
-    },
-];
 
 export class DateRangePicker3Example extends React.PureComponent<ExampleProps, DateRangePicker3ExampleState> {
     public state: DateRangePicker3ExampleState = {
@@ -94,8 +45,8 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
         contiguousCalendarMonths: true,
         dateRange: [null, null],
         localeCode: DateRangePicker3.defaultProps.locale as CommonDateFnsLocale,
-        maxDateIndex: 0,
-        minDateIndex: 0,
+        maxDate: undefined,
+        minDate: undefined,
         reverseMonthAndYearMenus: false,
         shortcuts: true,
         singleMonthOnly: false,
@@ -105,9 +56,9 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
 
     private handleLocaleCodeChange = (localeCode: CommonDateFnsLocale) => this.setState({ localeCode });
 
-    private handleMaxDateIndexChange = handleNumberChange(maxDateIndex => this.setState({ maxDateIndex }));
+    private handleMaxDateChange = (maxDate: Date) => this.setState({ maxDate });
 
-    private handleMinDateIndexChange = handleNumberChange(minDateIndex => this.setState({ minDateIndex }));
+    private handleMinDateChange = (minDate: Date) => this.setState({ minDate });
 
     private handlePrecisionChange = handleValueChange((timePrecision: TimePrecision | undefined) =>
         this.setState({ timePrecision }),
@@ -128,9 +79,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
     });
 
     public render() {
-        const { dateRange, localeCode, minDateIndex, maxDateIndex, ...props } = this.state;
-        const minDate = MIN_DATE_OPTIONS[minDateIndex].value;
-        const maxDate = MAX_DATE_OPTIONS[maxDateIndex].value;
+        const { dateRange, localeCode, maxDate, minDate, ...props } = this.state;
         return (
             <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
                 <DateRangePicker3
@@ -175,18 +124,8 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     />
                 </div>
                 <div>
-                    {this.renderSelectMenu(
-                        "Minimum date",
-                        this.state.minDateIndex,
-                        MIN_DATE_OPTIONS,
-                        this.handleMinDateIndexChange,
-                    )}
-                    {this.renderSelectMenu(
-                        "Maximum date",
-                        this.state.maxDateIndex,
-                        MAX_DATE_OPTIONS,
-                        this.handleMaxDateIndexChange,
-                    )}
+                    <MinDateSelect onChange={this.handleMinDateChange} />
+                    <MaxDateSelect onChange={this.handleMaxDateChange} />
                 </div>
                 <div>
                     <PrecisionSelect
@@ -200,24 +139,6 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     </FormGroup>
                 </div>
             </>
-        );
-    }
-
-    private renderSelectMenu(
-        label: string,
-        selectedValue: number | string,
-        options: DateOption[],
-        onChange: React.FormEventHandler<HTMLElement>,
-    ) {
-        return (
-            <Label>
-                {label}
-                <HTMLSelect value={selectedValue} onChange={onChange}>
-                    {options.map((opt, i) => (
-                        <option key={i} value={i} label={opt.label} />
-                    ))}
-                </HTMLSelect>
-            </Label>
         );
     }
 }


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Various fixes to the new v3 components which were recently added to @blueprintjs/datetime2

- fix: some dead/unused Sass styles
- docs: mention localization / i18n support for shortcut item labels
- docs: use correct label for default min/max date in example options
- docs: add min/max date options to DatePicker3 example
- feat(DatePicker3): use rdp native caption component instead of our custom DatePicker3Caption, similar to DateRangePicker3 with contiguous months. we now only customize the dropdown & icon components, so we use the new "dropdown-buttons" layout which is more efficient for quickly navigating months one at a time
- fix(API): export `ReactDayPicker` class names as a separate object


#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/4d004b76-8e6c-4a4e-9a98-93f4e6880878)

![image](https://github.com/palantir/blueprint/assets/723999/9733736c-0a04-426a-a948-ca246df81242)

