### PR TITLE
feat(DateInput, DateInput3): controlled timezone support

### DIFF
--- a/packages/datetime/src/common/errors.ts
+++ b/packages/datetime/src/common/errors.ts
@@ -42,3 +42,4 @@ export const DATERANGEINPUT_NULL_VALUE =
     " uncontrolled mode, or pass [null, null] to clear the value and continue operating in controlled mode.";
 
 export const DATEINPUT_INVALID_DEFAULT_TIMEZONE = `${ns} <DateInput> was provided an invalid defaultTimezone, defaulting to Etc/UTC instead`;
+export const DATEINPUT_INVALID_TIMEZONE = `${ns} <DateInput> was provided an invalid timezone, defaulting to Etc/UTC instead`;

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -480,7 +480,7 @@ describe("<DateInput>", () => {
             assert.isTrue(isEqual(parseISO(onChange.firstCall.args[0]), DATE));
         });
 
-        describe("allows changing timezone", () => {
+        describe("allows changing timezone via user interaction (uncontrolled timezone value)", () => {
             it("before selecting a date", () => {
                 const wrapper = mount(<DateInput {...DEFAULT_PROPS} />, { attachTo: containerElement });
                 focusInput(wrapper);
@@ -499,10 +499,30 @@ describe("<DateInput>", () => {
             });
         });
 
-        describe("allows changing defaultTimezone", () => {
+        describe("allows changing timezone programmatically (controlled timezone value)", () => {
+            it("before selecting a date", () => {
+                const wrapper = mount(<DateInput {...DEFAULT_PROPS} timezone={UTC_TIME.ianaCode} />, {
+                    attachTo: containerElement,
+                });
+                wrapper.setProps({ timezone: TOKYO_TIMEZONE.ianaCode }).update();
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+
+            it("after selecting a date", () => {
+                const wrapper = mount(<DateInput {...DEFAULT_PROPS} timezone={UTC_TIME.ianaCode} />, {
+                    attachTo: containerElement,
+                });
+                focusInput(wrapper);
+                clickCalendarDay(wrapper, 1);
+                wrapper.setProps({ timezone: TOKYO_TIMEZONE.ianaCode }).update();
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+        });
+
+        it("allows changing defaultTimezone", () => {
             const wrapper = mount(<DateInput {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
             assert.strictEqual(wrapper.find(TimezoneSelect).text(), getTimezoneShortName(UTC_TIME.ianaCode, undefined));
-            wrapper.setProps({ defaultTimezone: TOKYO_TIMEZONE.ianaCode });
+            wrapper.setProps({ defaultTimezone: TOKYO_TIMEZONE.ianaCode }).update();
             assert.strictEqual(
                 wrapper.find(TimezoneSelect).text(),
                 getTimezoneShortName(TOKYO_TIMEZONE.ianaCode, undefined),

--- a/packages/datetime2/test/components/dateInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateInput3Tests.tsx
@@ -492,7 +492,7 @@ describe("<DateInput3>", () => {
             assert.isTrue(isEqual(parseISO(onChange.firstCall.args[0]), DATE));
         });
 
-        describe("allows changing timezone", () => {
+        describe("allows changing timezone via user interaction (uncontrolled timezone value)", () => {
             it("before selecting a date", () => {
                 const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} />, { attachTo: testsContainerElement });
                 focusInput(wrapper);
@@ -511,13 +511,33 @@ describe("<DateInput3>", () => {
             });
         });
 
-        describe("allows changing defaultTimezone", () => {
+        describe("allows changing timezone programmatically (controlled timezone value)", () => {
+            it("before selecting a date", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} timezone={TimezoneUtils.UTC_TIME.ianaCode} />, {
+                    attachTo: testsContainerElement,
+                });
+                wrapper.setProps({ timezone: TOKYO_TIMEZONE.ianaCode }).update();
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+
+            it("after selecting a date", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} timezone={TimezoneUtils.UTC_TIME.ianaCode} />, {
+                    attachTo: testsContainerElement,
+                });
+                focusInput(wrapper);
+                clickCalendarDay(wrapper, 1);
+                wrapper.setProps({ timezone: TOKYO_TIMEZONE.ianaCode }).update();
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+        });
+
+        it("allows changing defaultTimezone", () => {
             const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
             assert.strictEqual(
                 wrapper.find(TimezoneSelect).text(),
                 TimezoneNameUtils.getTimezoneShortName(TimezoneUtils.UTC_TIME.ianaCode, undefined),
             );
-            wrapper.setProps({ defaultTimezone: TOKYO_TIMEZONE.ianaCode });
+            wrapper.setProps({ defaultTimezone: TOKYO_TIMEZONE.ianaCode }).update();
             assert.strictEqual(
                 wrapper.find(TimezoneSelect).text(),
                 TimezoneNameUtils.getTimezoneShortName(TOKYO_TIMEZONE.ianaCode, undefined),


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- feat(`DateInput`): add controlled TimezoneSelect support via new props `timezone` and `onTimezoneChange`
- feat(`DateInput3`): add controlled TimezoneSelect support via new props `timezone` and `onTimezoneChange`

#### Reviewers should focus on:

New test cases, no regressions

#### Screenshot

N/A
