### PR TITLE
[datetime2] various display fixes & docs enhancements

### DIFF
--- a/packages/datetime2/src/classes.ts
+++ b/packages/datetime2/src/classes.ts
@@ -62,6 +62,7 @@ export const DatePicker3Classes = {
     DATEPICKER3_DAY_OUTSIDE: ReactDayPickerClasses.RDP_DAY_OUTSIDE,
     DATEPICKER3_DAY_SELECTED: ReactDayPickerClasses.RDP_DAY_SELECTED,
     DATEPICKER3_HIGHLIGHT_CURRENT_DAY: `${DatetimeClasses.DATEPICKER}-highlight-current-day`,
+    DATEPICKER3_REVERSE_MONTH_AND_YEAR: `${DatetimeClasses.DATEPICKER}-reverse-month-and-year`,
 };
 
 export const DateRangePicker3Classes = {

--- a/packages/datetime2/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime2/src/common/_react-day-picker-overrides.scss
@@ -23,4 +23,5 @@
   --rdp-outline-selected: 2px solid rgba(0, 0, 0, 75%);
 
   margin: 0;
+  min-width: auto;
 }

--- a/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
@@ -11,7 +11,7 @@
 .#{$ns}-datepicker-caption.rdp-caption {
   @include pt-flex-container(row);
   justify-content: space-between;
-  margin: 0 0 $datepicker-padding;
+  margin: 0;
 
   // override HTMLSelect styles for a narrower appearance
   // N.B. these styles are important to achieve accurate measurements to position the dropdown arrows in <DatePickerCaption>

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -21,9 +21,8 @@
   }
 
   .rdp-month {
-    border-collapse: collapse;
-    border-spacing: 0;
-    display: inline-table;
+    display: flex;
+    flex-direction: column;
     margin: 0 $datepicker-padding;
     user-select: none;
 
@@ -34,11 +33,8 @@
   }
 
   .rdp-table {
-    max-width: none;
-  }
-
-  .rdp-weekdays {
-    display: table-header-group;
+    // table is typically slightly narrower than the header, so this ensure that it is horizontally centered
+    align-self: center;
   }
 
   .rdp-head_cell {

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -106,6 +106,10 @@
   &.#{$ns}-datepicker-highlight-current-day .rdp-day.rdp-day_today {
     border: 1px solid $pt-divider-black;
   }
+
+  &.#{$ns}-datepicker-reverse-month-and-year .rdp-caption_dropdowns {
+    flex-direction: row-reverse;
+  }
 }
 
 .#{$ns}-datepicker-content {

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -32,6 +32,11 @@
     }
   }
 
+  .rdp-caption {
+    border-bottom: solid 1px $pt-divider-black;
+    padding-bottom: $datepicker-padding;
+  }
+
   .rdp-table {
     // table is typically slightly narrower than the header, so this ensure that it is horizontally centered
     align-self: center;

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -87,6 +87,7 @@ export class DatePicker3 extends AbstractPureComponent<DatePicker3Props, DatePic
             <div
                 className={classNames(Classes.DATEPICKER, className, {
                     [Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
+                    [Classes.DATEPICKER3_REVERSE_MONTH_AND_YEAR]: this.props.reverseMonthAndYearMenus,
                 })}
             >
                 {this.maybeRenderShortcuts()}

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -20,15 +20,12 @@
     min-width: $datepicker-min-width;
   }
 
-  &.#{$ns}-daterangepicker .rdp.rdp-multiple_months {
+  .rdp.rdp-multiple_months {
     .rdp-caption {
       // the default "caption" block + "nav" absolute position styles place the nav buttons slightly off,
       // so we use flex instead
       @include pt-flex-container(row);
-      // we can't inject a <Divider /> when only overriding the dropdown & icon components, so we add a CSS divider instead
-      border-bottom: solid 1px $pt-divider-black;
       justify-content: space-between;
-      padding-bottom: $datepicker-padding;
     }
 
     .rdp-caption_start .rdp-caption {

--- a/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
+++ b/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
@@ -19,7 +19,7 @@ import { format } from "date-fns";
 import * as React from "react";
 import { CaptionLabel, CaptionProps, useDayPicker, useNavigation } from "react-day-picker";
 
-import { Button, DISPLAYNAME_PREFIX, Divider, HTMLSelect, OptionProps } from "@blueprintjs/core";
+import { Button, DISPLAYNAME_PREFIX, HTMLSelect, OptionProps } from "@blueprintjs/core";
 import { DateUtils, Months } from "@blueprintjs/datetime";
 import { ChevronLeft, ChevronRight } from "@blueprintjs/icons";
 
@@ -168,18 +168,12 @@ export const DatePicker3Caption: React.FC<CaptionProps> = props => {
     );
 
     return (
-        <>
-            <div
-                className={classNames(CaptionClasses.DATEPICKER3_CAPTION, rdpClassNames.caption)}
-                ref={containerElement}
-            >
-                {hiddenCaptionLabel}
-                {prevButton}
-                {orderedSelects}
-                {nextButton}
-            </div>
-            <Divider />
-        </>
+        <div className={classNames(CaptionClasses.DATEPICKER3_CAPTION, rdpClassNames.caption)} ref={containerElement}>
+            {hiddenCaptionLabel}
+            {prevButton}
+            {orderedSelects}
+            {nextButton}
+        </div>
     );
 };
 DatePicker3Caption.displayName = `${DISPLAYNAME_PREFIX}.DatePicker3Caption`;

--- a/packages/docs-app/src/common/formattedDateRange.tsx
+++ b/packages/docs-app/src/common/formattedDateRange.tsx
@@ -19,14 +19,15 @@ import * as React from "react";
 import { Tag } from "@blueprintjs/core";
 import { DateRange } from "@blueprintjs/datetime";
 import { ArrowRight } from "@blueprintjs/icons";
+
 import { FormattedDateTag } from "./formattedDateTag";
 
-export interface FormattedDateRange {
+export interface FormattedDateRangeProps {
     range: DateRange | null;
     showTime?: boolean;
 }
 
-export const FormattedDateRange: React.FC<FormattedDateRange> = ({ range, showTime = false }) => {
+export const FormattedDateRange: React.FC<FormattedDateRangeProps> = ({ range, showTime = false }) => {
     if (range == null) {
         return <Tag minimal={true}>No range</Tag>;
     }

--- a/packages/docs-app/src/common/formattedDateRange.tsx
+++ b/packages/docs-app/src/common/formattedDateRange.tsx
@@ -14,35 +14,30 @@
  * limitations under the License.
  */
 
-import { format } from "date-fns";
 import * as React from "react";
 
 import { Tag } from "@blueprintjs/core";
 import { DateRange } from "@blueprintjs/datetime";
 import { ArrowRight } from "@blueprintjs/icons";
+import { FormattedDateTag } from "./formattedDateTag";
 
-export interface DateRangeTagProps {
+export interface FormattedDateRange {
     range: DateRange | null;
     showTime?: boolean;
 }
 
-export const DateRangeTag: React.FC<DateRangeTagProps> = ({ range, showTime = false }) => {
-    const className = "docs-date-range";
-
+export const FormattedDateRange: React.FC<FormattedDateRange> = ({ range, showTime = false }) => {
     if (range == null) {
-        return <Tag className={className}>No range</Tag>;
+        return <Tag minimal={true}>No range</Tag>;
     }
 
     const [start, end] = range;
-    const dateFnsFormat = showTime ? "PPPppp" : "PPP";
-    const formattedStart = start == null ? "No date" : format(start, dateFnsFormat);
-    const formattedEnd = end == null ? "No date" : format(end, dateFnsFormat);
 
     return (
         <div className="docs-date-range">
-            <Tag intent={start == null ? "none" : "primary"}>{formattedStart}</Tag>
+            <FormattedDateTag date={start} showTime={showTime} />
             <ArrowRight />
-            <Tag intent={end == null ? "none" : "primary"}>{formattedEnd}</Tag>
+            <FormattedDateTag date={end} showTime={showTime} />
         </div>
     );
 };

--- a/packages/docs-app/src/common/formattedDateTag.tsx
+++ b/packages/docs-app/src/common/formattedDateTag.tsx
@@ -19,10 +19,23 @@ import * as React from "react";
 
 import { Tag } from "@blueprintjs/core";
 
-export interface DateTagProps {
-    date: Date | null;
+export interface FormattedDateTagProps {
+    /** The date or date string to display. */
+    date: Date | string | null;
+
+    /** @default false */
+    showTime?: boolean;
 }
 
-export const DateTag: React.FC<DateTagProps> = ({ date }) => (
-    <Tag intent={date == null ? "none" : "primary"}>{date == null ? "No date" : format(date, "PPPppp")}</Tag>
-);
+export const FormattedDateTag: React.FC<FormattedDateTagProps> = ({ date, showTime }) => {
+    const isEmpty = date == null;
+    const dateFnsFormat = showTime ? "PPPppp" : "PPP";
+    return (
+        <Tag intent={isEmpty ? "none" : "primary"} minimal={isEmpty}>
+            {isEmpty ? "No date" : typeof date === "string" ? date : format(date, dateFnsFormat)}
+        </Tag>
+    );
+};
+FormattedDateTag.defaultProps = {
+    showTime: false,
+};

--- a/packages/docs-app/src/examples/datetime-examples/common/dateFnsDate.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/dateFnsDate.tsx
@@ -24,7 +24,7 @@ import { DateRange } from "@blueprintjs/datetime";
 const FORMAT = "EEEE, MMMM d, yyyy";
 const FORMAT_WITH_TIME = "MMMM d, yyyy 'at' K:mm a";
 
-export const DateFnsDate: React.FC<{ date: Date; formatStr?: string; withTime?: boolean }> = ({
+const DateFnsDate: React.FC<{ date: Date; formatStr?: string; withTime?: boolean }> = ({
     date,
     withTime = false,
     formatStr = withTime ? FORMAT_WITH_TIME : FORMAT,
@@ -36,6 +36,7 @@ export const DateFnsDate: React.FC<{ date: Date; formatStr?: string; withTime?: 
     }
 };
 
+/** @deprecated use `FormattedDateRange` */
 export const DateFnsDateRange: React.FC<{ range: DateRange; formatStr?: string; withTime?: boolean } & Props> = ({
     className,
     range: [start, end],

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -127,6 +127,7 @@ export class DateRangeInputExample extends React.PureComponent<ExampleProps, Dat
                             : undefined
                     }
                 />
+                {/* eslint-disable-next-line deprecation/deprecation */}
                 <DateFnsDateRange range={range} />
             </Example>
         );

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
@@ -17,13 +17,14 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Code, H5, Icon, Switch, Tag } from "@blueprintjs/core";
+import { Classes, Code, H5, Icon, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateInput3, TimePrecision } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "../datetime-examples/common/dateFnsFormatSelector";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
+import { FormattedDateTag } from "../../common/formattedDateTag";
 
 interface DateInput3ExampleState {
     closeOnSelection: boolean;
@@ -110,7 +111,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
                     }
                     value={date}
                 />
-                {date == null ? <Tag minimal={true}>no date</Tag> : <Tag intent="primary">{date}</Tag>}
+                <FormattedDateTag date={date} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
@@ -21,10 +21,10 @@ import { Classes, Code, H5, Icon, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateInput3, TimePrecision } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
+import { FormattedDateTag } from "../../common/formattedDateTag";
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "../datetime-examples/common/dateFnsFormatSelector";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
-import { FormattedDateTag } from "../../common/formattedDateTag";
 
 interface DateInput3ExampleState {
     closeOnSelection: boolean;

--- a/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
@@ -23,6 +23,7 @@ import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@
 import { FormattedDateTag } from "../../common/formattedDateTag";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
+import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
 const exampleFooterElement = <Callout>This additional footer component can be displayed below the date picker</Callout>;
 
@@ -94,18 +95,26 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
         const options = (
             <>
                 <H5>Props</H5>
-                <Switch checked={props.showActionsBar} label="Show actions bar" onChange={this.toggleActionsBar} />
-                <Switch checked={props.shortcuts} label="Show shortcuts" onChange={this.toggleShortcuts} />
-                <Switch
-                    checked={props.highlightCurrentDay}
-                    label="Highlight current day"
-                    onChange={this.toggleHighlight}
-                />
-                <Switch
-                    checked={props.reverseMonthAndYearMenus}
-                    label="Reverse month and year menus"
-                    onChange={this.toggleReverseMenus}
-                />
+                <PropCodeTooltip snippet={`showActionsBar={${props.showActionsBar.toString()}}`}>
+                    <Switch checked={props.showActionsBar} label="Show actions bar" onChange={this.toggleActionsBar} />
+                </PropCodeTooltip>
+                <PropCodeTooltip snippet={`shortcuts={${props.shortcuts.toString()}}`}>
+                    <Switch checked={props.shortcuts} label="Show shortcuts" onChange={this.toggleShortcuts} />
+                </PropCodeTooltip>
+                <PropCodeTooltip snippet={`highlightCurrentDay={${props.highlightCurrentDay.toString()}}`}>
+                    <Switch
+                        checked={props.highlightCurrentDay}
+                        label="Highlight current day"
+                        onChange={this.toggleHighlight}
+                    />
+                </PropCodeTooltip>
+                <PropCodeTooltip snippet={`reverseMonthAndYearMenus={${props.reverseMonthAndYearMenus.toString()}}`}>
+                    <Switch
+                        checked={props.reverseMonthAndYearMenus}
+                        label="Reverse month and year menus"
+                        onChange={this.toggleReverseMenus}
+                    />
+                </PropCodeTooltip>
                 <Switch
                     checked={this.state.showFooterElement}
                     label="Show custom footer element"
@@ -114,16 +123,12 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
                 <MinDateSelect onChange={this.handleMinDateChange} />
                 <MaxDateSelect onChange={this.handleMaxDateChange} />
                 <H5>react-day-picker props</H5>
-                <Switch
-                    checked={this.state.showWeekNumber}
-                    label="Show week numbers"
-                    onChange={this.toggleShowWeekNumber}
-                />
-                <Switch
-                    checked={this.state.showOutsideDays}
-                    label="Show outside days"
-                    onChange={this.toggleShowOutsideDays}
-                />
+                <PropCodeTooltip snippet={`dayPickerProps={{ showWeekNumber: ${showWeekNumber.toString()} }}`}>
+                    <Switch checked={showWeekNumber} label="Show week numbers" onChange={this.toggleShowWeekNumber} />
+                </PropCodeTooltip>
+                <PropCodeTooltip snippet={`dayPickerProps={{ showOutsideDays: ${showOutsideDays.toString()} }}`}>
+                    <Switch checked={showOutsideDays} label="Show outside days" onChange={this.toggleShowOutsideDays} />
+                </PropCodeTooltip>
 
                 <H5>Time picker props</H5>
                 <PrecisionSelect
@@ -132,18 +137,28 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
                     value={props.timePrecision}
                     onChange={this.handlePrecisionChange}
                 />
-                <Switch
+                <PropCodeTooltip
+                    snippet={`timePickerProps={{ showArrowButtons: ${showTimeArrowButtons.toString()} }}`}
                     disabled={!showTimePicker}
-                    checked={showTimeArrowButtons}
-                    label="Show timepicker arrow buttons"
-                    onChange={this.toggleTimepickerArrowButtons}
-                />
-                <Switch
+                >
+                    <Switch
+                        disabled={!showTimePicker}
+                        checked={showTimeArrowButtons}
+                        label="Show timepicker arrow buttons"
+                        onChange={this.toggleTimepickerArrowButtons}
+                    />
+                </PropCodeTooltip>
+                <PropCodeTooltip
+                    snippet={`timePickerProps={{ useAmPm: ${useAmPm.toString()} }}`}
                     disabled={!showTimePicker}
-                    checked={this.state.useAmPm}
-                    label="Use AM/PM"
-                    onChange={this.toggleUseAmPm}
-                />
+                >
+                    <Switch
+                        disabled={!showTimePicker}
+                        checked={useAmPm}
+                        label="Use AM/PM"
+                        onChange={this.toggleUseAmPm}
+                    />
+                </PropCodeTooltip>
             </>
         );
 
@@ -158,13 +173,13 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
             <Example options={options} {...this.props}>
                 <DatePicker3
                     className={Classes.ELEVATION_1}
+                    dayPickerProps={{ showOutsideDays, showWeekNumber }}
+                    footerElement={this.state.showFooterElement ? exampleFooterElement : undefined}
                     onChange={this.handleDateChange}
                     timePickerProps={timePickerProps}
-                    footerElement={this.state.showFooterElement ? exampleFooterElement : undefined}
-                    dayPickerProps={{ showOutsideDays, showWeekNumber }}
                     {...props}
                 />
-                <FormattedDateTag date={date} />
+                <FormattedDateTag date={date} showTime={showTimePicker} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
@@ -20,7 +20,7 @@ import { Callout, Classes, H5, Switch } from "@blueprintjs/core";
 import { DatePicker3, TimePrecision } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
-import { DateTag } from "../../common/dateTag";
+import { FormattedDateTag } from "../../common/formattedDateTag";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
 
@@ -164,7 +164,7 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
                     dayPickerProps={{ showOutsideDays, showWeekNumber }}
                     {...props}
                 />
-                <DateTag date={date} />
+                <FormattedDateTag date={date} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
@@ -21,9 +21,9 @@ import { DatePicker3, TimePrecision } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { FormattedDateTag } from "../../common/formattedDateTag";
+import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
-import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
 const exampleFooterElement = <Callout>This additional footer component can be displayed below the date picker</Callout>;
 

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput3Example.tsx
@@ -21,7 +21,7 @@ import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime
 import { DateRangeInput3 } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
-import { DateRangeTag } from "../../common/dateRangeTag";
+import { FormattedDateRange } from "../../common/formattedDateRange";
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { DATE_FNS_FORMATS, DateFnsFormatSelector } from "../datetime-examples/common/dateFnsFormatSelector";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
@@ -128,7 +128,7 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
                             : undefined
                     }
                 />
-                <DateRangeTag range={range} showTime={enableTimePicker} />
+                <FormattedDateRange range={range} showTime={enableTimePicker} />
             </Example>
         );
     }

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -22,7 +22,7 @@ import { DateRangePicker3 } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { CommonDateFnsLocale, DateFnsLocaleSelect } from "../../common/dateFnsLocaleSelect";
-import { DateRangeTag } from "../../common/dateRangeTag";
+import { FormattedDateRange } from "../../common/formattedDateRange";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
 
@@ -90,7 +90,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     minDate={minDate}
                     onChange={this.handleDateRangeChange}
                 />
-                <DateRangeTag range={dateRange} showTime={props.timePrecision !== undefined} />
+                <FormattedDateRange range={dateRange} showTime={props.timePrecision !== undefined} />
             </Example>
         );
     }


### PR DESCRIPTION

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

More assorted fixes for @blueprintjs/datetime2 components

- Improve docs examples with prop code snippet tooltips
- Fix 1px gap between selected days in range picker
- Fix missing divider below caption element in DatePicker3
- Fix unimplemented `reverseMonthAndYear` prop in DatePicker3

#### Reviewers should focus on:

Fixes actually work

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/0ae1dd75-fc4d-4779-8fd7-7ed171ccf0b6)

![image](https://github.com/palantir/blueprint/assets/723999/85647df2-7cd2-43b9-9344-cd98b0f77f8a)

![image](https://github.com/palantir/blueprint/assets/723999/ab49dc83-5cbc-4f12-af75-471c212c64e3)

