### PR TITLE
[datetime2] feat: support Locale object in props

### DIFF
--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -41,6 +41,7 @@ import {
 } from "@blueprintjs/core";
 
 import { Classes, DateFormatProps, DatePickerBaseProps } from "../../common";
+import { getFormattedDateString } from "../../common/dateFormatProps";
 import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import { hasMonthChanged, hasTimeChanged, isDateValid, isDayInRange } from "../../common/dateUtils";
 import * as Errors from "../../common/errors";
@@ -266,7 +267,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function _DateInpu
 
     // rendered as the text input's value
     const formattedDateString = React.useMemo(() => {
-        return valueAsDate === null ? undefined : DatePickerUtils.getFormattedDateString(valueAsDate, props);
+        return valueAsDate === null ? undefined : getFormattedDateString(valueAsDate, props);
     }, [
         valueAsDate,
         minDate,
@@ -354,7 +355,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function _DateInpu
                 setIsInputFocused(newIsInputFocused);
                 setIsOpen(newIsOpen);
             } else {
-                const newFormattedDateString = DatePickerUtils.getFormattedDateString(newDate, props);
+                const newFormattedDateString = getFormattedDateString(newDate, props);
                 setIsInputFocused(newIsInputFocused);
                 setIsOpen(newIsOpen);
                 setValue(newDate);

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -44,6 +44,7 @@ import {
 } from "@blueprintjs/core";
 
 import { Classes, DateFormatProps, DatePickerBaseProps, DateRange, NonNullDateRange } from "../../common";
+import { getFormattedDateString } from "../../common/dateFormatProps";
 import { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import { isDayInRange, isSameTime } from "../../common/dateUtils";
 import * as Errors from "../../common/errors";
@@ -695,7 +696,7 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
         // We may be reacting to a programmatic focus triggered by componentDidUpdate() at a point when
         // values.selectedValue may not have been updated yet in controlled mode, so we must use values.controlledValue
         // in that case.
-        const inputString = DatePickerUtils.getFormattedDateString(
+        const inputString = getFormattedDateString(
             isValueControlled ? values.controlledValue : values.selectedValue,
             this.props,
             true,
@@ -732,7 +733,7 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
             if (isValueControlled) {
                 nextState = {
                     ...nextState,
-                    [keys.inputString]: DatePickerUtils.getFormattedDateString(values.controlledValue, this.props),
+                    [keys.inputString]: getFormattedDateString(values.controlledValue, this.props),
                 };
             } else {
                 nextState = {
@@ -885,7 +886,7 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
         } else if (this.doesEndBoundaryOverlapStartBoundary(selectedValue, boundary)) {
             return this.props.overlappingDatesMessage;
         } else {
-            return DatePickerUtils.getFormattedDateString(selectedValue, this.props);
+            return getFormattedDateString(selectedValue, this.props);
         }
     };
 
@@ -1026,7 +1027,7 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
         const defaultDate = DateRangeInput.defaultProps[propName];
         // default values are applied only if a prop is strictly `undefined`
         // See: https://facebook.github.io/react/docs/react-component.html#defaultprops
-        return DatePickerUtils.getFormattedDateString(date === undefined ? defaultDate : date, this.props);
+        return getFormattedDateString(date === undefined ? defaultDate : date, this.props);
     }
 
     private parseDate(dateString: string | undefined): Date | null {

--- a/packages/datetime2/src/common/dateFnsLocaleProps.ts
+++ b/packages/datetime2/src/common/dateFnsLocaleProps.ts
@@ -14,15 +14,22 @@
  * limitations under the License.
  */
 
+import type { Locale } from "date-fns";
+
 export interface DateFnsLocaleProps {
     /**
-     * date-fns locale code ((ISO 639-1 + optional country code) used to localize the date picker.
+     * date-fns `Locale` object or locale code string ((ISO 639-1 + optional country code) which will be used
+     * to localize the date picker.
      *
-     * If you are unable to load a specific locale, make sure it is included in the list of date-fns'
-     * [supported locales](https://github.com/date-fns/date-fns/tree/main/src/locale).
+     * If you provide a locale code string and receive a loading error, please make sure it is included in the list of
+     * date-fns' [supported locales](https://github.com/date-fns/date-fns/tree/main/src/locale).
      *
      * @default "en-US"
      * @see https://date-fns.org/docs/Locale
      */
-    locale?: string;
+    locale?: Locale | string;
+}
+
+export function getLocaleCodeFromProps(props: DateFnsLocaleProps): string | undefined {
+    return typeof props.locale === "string" ? props.locale : props.locale?.code;
 }

--- a/packages/datetime2/src/common/dateFnsLocaleProps.ts
+++ b/packages/datetime2/src/common/dateFnsLocaleProps.ts
@@ -30,6 +30,6 @@ export interface DateFnsLocaleProps {
     locale?: Locale | string;
 }
 
-export function getLocaleCodeFromProps(props: DateFnsLocaleProps): string | undefined {
-    return typeof props.locale === "string" ? props.locale : props.locale?.code;
+export function getLocaleCodeFromProps(localeOrCode: DateFnsLocaleProps["locale"]): string | undefined {
+    return typeof localeOrCode === "string" ? localeOrCode : localeOrCode?.code;
 }

--- a/packages/datetime2/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime2/src/common/dateFnsLocaleUtils.ts
@@ -27,7 +27,7 @@ export async function loadDateFnsLocale(localeOrCode: string | Locale | undefine
         return;
     } else if (typeof localeOrCode === "string") {
         try {
-            const localeModule = await import(`date-fns/locale/${localeOrCode}`);
+            const localeModule = await import(`date-fns/locale/${localeOrCode}/index.js`);
             return localeModule.default;
         } catch {
             if (!Utils.isNodeEnv("production")) {

--- a/packages/datetime2/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime2/src/common/dateFnsLocaleUtils.ts
@@ -22,7 +22,7 @@ import { Utils } from "@blueprintjs/core";
 /**
  * Lazy-loads a date-fns locale for use in a datetime class component.
  */
-export async function loadDateFnsLocale(localeOrCode: string | Locale | undefined): Promise<Locale | undefined> {
+export async function loadDateFnsLocale(localeOrCode: Locale | string | undefined): Promise<Locale | undefined> {
     if (localeOrCode === undefined) {
         return;
     } else if (typeof localeOrCode === "string") {
@@ -45,7 +45,7 @@ export async function loadDateFnsLocale(localeOrCode: string | Locale | undefine
 /**
  * Lazy-loads a date-fns locale for use in a datetime function component.
  */
-export function useDateFnsLocale(localeOrCode: string | Locale | undefined) {
+export function useDateFnsLocale(localeOrCode: Locale | string | undefined) {
     const [locale, setLocale] = React.useState<Locale | undefined>(undefined);
     React.useEffect(() => {
         if (localeOrCode === undefined) {

--- a/packages/datetime2/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime2/src/common/dateFnsLocaleUtils.ts
@@ -46,17 +46,21 @@ export async function loadDateFnsLocale(localeOrCode: Locale | string | undefine
  * Lazy-loads a date-fns locale for use in a datetime function component.
  */
 export function useDateFnsLocale(localeOrCode: Locale | string | undefined) {
-    const [locale, setLocale] = React.useState<Locale | undefined>(undefined);
+    // make sure to set the locale correctly on first render if it is available
+    const [locale, setLocale] = React.useState<Locale | undefined>(
+        typeof localeOrCode === "object" ? localeOrCode : undefined,
+    );
+
     React.useEffect(() => {
-        if (localeOrCode === undefined) {
-            return;
-        } else if (typeof localeOrCode === "string") {
-            if (localeOrCode !== locale?.code) {
+        setLocale(prevLocale => {
+            if (typeof localeOrCode === "string") {
                 loadDateFnsLocale(localeOrCode).then(setLocale);
+                // keep the current locale for now, it will be updated async
+                return prevLocale;
+            } else {
+                return localeOrCode;
             }
-        } else {
-            setLocale(localeOrCode);
-        }
-    }, [locale?.code, localeOrCode]);
+        });
+    }, [localeOrCode]);
     return locale;
 }

--- a/packages/datetime2/src/common/reactDayPickerProps.ts
+++ b/packages/datetime2/src/common/reactDayPickerProps.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DayPickerRangeProps, DayPickerSingleProps } from "react-day-picker";
+
+type ReactDayPickerOmittedProps =
+    | "fromDate"
+    | "fromMonth"
+    | "fromYear"
+    | "locale"
+    | "mode"
+    | "month"
+    | "required"
+    | "selected"
+    | "toDate"
+    | "toMonth"
+    | "toYear";
+
+export interface ReactDayPickerRangeProps {
+    /**
+     * Props to pass to react-day-picker's day range picker. See API documentation
+     * [here](https://react-day-picker.js.org/api/interfaces/DayPickerRangeProps).
+     *
+     * Some properties are unavailable or have alternative names as top-level props:
+     *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
+     *  - "locale"
+     *  - "mode": fixed to "range"
+     *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
+     *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
+     *  - "selected": use "value" instead
+     */
+    dayPickerProps?: Omit<DayPickerRangeProps, ReactDayPickerOmittedProps>;
+}
+
+export interface ReactDayPickerSingleProps {
+    /**
+     * Props to pass to react-day-picker's single day picker. See API documentation
+     * [here](https://react-day-picker.js.org/api/interfaces/DayPickerSingleProps).
+     *
+     * Some properties are unavailable or have alternative names as top-level props:
+     *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
+     *  - "locale"
+     *  - "mode": fixed to "single"
+     *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
+     *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
+     *  - "selected": use "value" instead
+     */
+    dayPickerProps?: Omit<DayPickerSingleProps, ReactDayPickerOmittedProps>;
+}

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -80,7 +80,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
         fill,
         inputProps = {},
         invalidDateMessage,
-        locale: localeCode,
+        locale: localeOrCode,
         maxDate,
         minDate,
         onChange,
@@ -97,7 +97,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
         ...datePickerProps
     } = props as DateInput3PropsWithDefaults;
 
-    const locale = useDateFnsLocale(localeCode);
+    const locale = useDateFnsLocale(localeOrCode);
     const placeholder = getPlaceholder(props);
     const formatDateString = useDateFormatter(props, locale);
     const parseDateString = useDateParser(props, locale);

--- a/packages/datetime2/src/components/date-input3/dateInput3Props.ts
+++ b/packages/datetime2/src/components/date-input3/dateInput3Props.ts
@@ -32,7 +32,7 @@ type DateInputSharedProps = Omit<
 export interface DateInput3Props
     extends DateInputSharedProps,
         Pick<DatePicker3Props, "dayPickerProps" | "locale">,
-        Partial<DateFormatProps> {
+        Partial<Omit<DateFormatProps, "locale">> {
     /**
      * [date-fns] format string used to format & parse date strings.
      *

--- a/packages/datetime2/src/components/date-input3/useDateFormatter.ts
+++ b/packages/datetime2/src/components/date-input3/useDateFormatter.ts
@@ -32,6 +32,7 @@ import { DateInput3Props, DateInput3PropsWithDefaults } from "./dateInput3Props"
 export function useDateFormatter(props: DateInput3Props, locale: Locale | undefined) {
     const {
         dateFnsFormat,
+        locale: localeFromProps,
         formatDate,
         invalidDateMessage,
         maxDate,
@@ -51,7 +52,7 @@ export function useDateFormatter(props: DateInput3Props, locale: Locale | undefi
             } else if (DateUtils.isDayInRange(date, [minDate, maxDate])) {
                 if (formatDate !== undefined) {
                     // user-provided date formatter
-                    return formatDate(date, locale?.code ?? getLocaleCodeFromProps(props));
+                    return formatDate(date, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
                 } else {
                     // use user-provided date-fns format or one of the default formats inferred from time picker props
                     const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
@@ -66,10 +67,10 @@ export function useDateFormatter(props: DateInput3Props, locale: Locale | undefi
             formatDate,
             invalidDateMessage,
             locale,
+            localeFromProps,
             maxDate,
             minDate,
             outOfRangeMessage,
-            props.locale,
             timePickerProps,
             timePrecision,
         ],

--- a/packages/datetime2/src/components/date-input3/useDateFormatter.ts
+++ b/packages/datetime2/src/components/date-input3/useDateFormatter.ts
@@ -20,6 +20,7 @@ import * as React from "react";
 import { DateUtils } from "@blueprintjs/datetime";
 
 import { getDateFnsFormatter, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
+import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
 import { DateInput3Props, DateInput3PropsWithDefaults } from "./dateInput3Props";
 
 /**
@@ -50,7 +51,7 @@ export function useDateFormatter(props: DateInput3Props, locale: Locale | undefi
             } else if (DateUtils.isDayInRange(date, [minDate, maxDate])) {
                 if (formatDate !== undefined) {
                     // user-provided date formatter
-                    return formatDate(date, locale?.code ?? props.locale);
+                    return formatDate(date, locale?.code ?? getLocaleCodeFromProps(props));
                 } else {
                     // use user-provided date-fns format or one of the default formats inferred from time picker props
                     const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });

--- a/packages/datetime2/src/components/date-input3/useDateParser.ts
+++ b/packages/datetime2/src/components/date-input3/useDateParser.ts
@@ -30,8 +30,15 @@ const INVALID_DATE = new Date(undefined!);
  * default formats inferred from time picker props.
  */
 export function useDateParser(props: DateInput3Props, locale: Locale | undefined) {
-    const { dateFnsFormat, invalidDateMessage, outOfRangeMessage, parseDate, timePickerProps, timePrecision } =
-        props as DateInput3PropsWithDefaults;
+    const {
+        dateFnsFormat,
+        invalidDateMessage,
+        locale: localeFromProps,
+        outOfRangeMessage,
+        parseDate,
+        timePickerProps,
+        timePrecision,
+    } = props as DateInput3PropsWithDefaults;
 
     return React.useCallback(
         (dateString: string): Date | null => {
@@ -42,7 +49,7 @@ export function useDateParser(props: DateInput3Props, locale: Locale | undefined
 
             if (parseDate !== undefined) {
                 // user-provided date parser
-                newDate = parseDate(dateString, locale?.code ?? getLocaleCodeFromProps(props));
+                newDate = parseDate(dateString, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
             } else {
                 // use user-provided date-fns format or one of the default formats inferred from time picker props
                 const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
@@ -55,9 +62,9 @@ export function useDateParser(props: DateInput3Props, locale: Locale | undefined
             dateFnsFormat,
             invalidDateMessage,
             locale,
+            localeFromProps,
             outOfRangeMessage,
             parseDate,
-            props.locale,
             timePickerProps,
             timePrecision,
         ],

--- a/packages/datetime2/src/components/date-input3/useDateParser.ts
+++ b/packages/datetime2/src/components/date-input3/useDateParser.ts
@@ -18,6 +18,7 @@ import { Locale } from "date-fns";
 import * as React from "react";
 
 import { getDateFnsParser, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
+import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
 import { DateInput3Props, DateInput3PropsWithDefaults } from "./dateInput3Props";
 
 const INVALID_DATE = new Date(undefined!);
@@ -41,7 +42,7 @@ export function useDateParser(props: DateInput3Props, locale: Locale | undefined
 
             if (parseDate !== undefined) {
                 // user-provided date parser
-                newDate = parseDate(dateString, locale?.code ?? props.locale);
+                newDate = parseDate(dateString, locale?.code ?? getLocaleCodeFromProps(props));
             } else {
                 // use user-provided date-fns format or one of the default formats inferred from time picker props
                 const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });

--- a/packages/datetime2/src/components/date-picker3/date-picker3.md
+++ b/packages/datetime2/src/components/date-picker3/date-picker3.md
@@ -77,9 +77,37 @@ for more info.
 
 @## Localization
 
-**DatePicker3** supports calendar localization using date-fns [Locale](https://date-fns.org/docs/Locale).
-Use the `locale` prop to specify a locale code (ISO 639-1 + optional country code) and the component will
-load the corresponding date-fns locale. For example, `locale="fr"` is used below by default.
+**DatePicker3**, **DateInput3**, **DateRangePicker3**, and **DateRangeInput3** support calendar
+localization using date-fns [Locale](https://date-fns.org/docs/Locale).
+
+The `locale` prop on each of these components accepts two types of values, either a `Locale` object or
+a locale code `string`.
+
+### Using a `Locale` object
+
+Use the `locale: Locale` type if you wish to statically load date-fns locale modules:
+
+```ts
+import { DatePicker3 } from "@blueprintjs/datetime2";
+import enUS from "date-fns/locale/en-US";
+
+function Example() {
+    return <DatePicker3 locale={enUS} />;
+}
+```
+
+### Using a locale code
+
+Use the `locale: string` type to interpret the prop as a locale code (ISO 639-1 + optional country code).
+The component will attempt to dynamically intepret the corresponding date-fns locale module.
+
+```ts
+import { DatePicker3 } from "@blueprintjs/datetime2";
+
+function Example() {
+    return <DatePicker3 locale="en-US" />;
+}
+```
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">

--- a/packages/datetime2/src/components/date-picker3/date-picker3.md
+++ b/packages/datetime2/src/components/date-picker3/date-picker3.md
@@ -78,10 +78,8 @@ for more info.
 @## Localization
 
 **DatePicker3**, **DateInput3**, **DateRangePicker3**, and **DateRangeInput3** support calendar
-localization using date-fns [Locale](https://date-fns.org/docs/Locale).
-
-The `locale` prop on each of these components accepts two types of values, either a `Locale` object or
-a locale code `string`.
+localization using date-fns's [Locale](https://date-fns.org/docs/Locale) features. The `locale` prop on each
+of these components accepts two types of values, either a `Locale` object or a locale code `string`.
 
 ### Using a `Locale` object
 
@@ -99,7 +97,7 @@ function Example() {
 ### Using a locale code
 
 Use the `locale: string` type to interpret the prop as a locale code (ISO 639-1 + optional country code).
-The component will attempt to dynamically intepret the corresponding date-fns locale module.
+The component will attempt to dynamically import the corresponding date-fns locale module.
 
 ```ts
 import { DatePicker3 } from "@blueprintjs/datetime2";

--- a/packages/datetime2/src/components/date-picker3/date-picker3.md
+++ b/packages/datetime2/src/components/date-picker3/date-picker3.md
@@ -81,19 +81,6 @@ for more info.
 localization using date-fns's [Locale](https://date-fns.org/docs/Locale) features. The `locale` prop on each
 of these components accepts two types of values, either a `Locale` object or a locale code `string`.
 
-### Using a `Locale` object
-
-Use the `locale: Locale` type if you wish to statically load date-fns locale modules:
-
-```ts
-import { DatePicker3 } from "@blueprintjs/datetime2";
-import enUS from "date-fns/locale/en-US";
-
-function Example() {
-    return <DatePicker3 locale={enUS} />;
-}
-```
-
 ### Using a locale code
 
 Use the `locale: string` type to interpret the prop as a locale code (ISO 639-1 + optional country code).
@@ -104,6 +91,25 @@ import { DatePicker3 } from "@blueprintjs/datetime2";
 
 function Example() {
     return <DatePicker3 locale="en-US" />;
+}
+```
+
+At runtime, this will trigger a dynamic import like the following statement:
+
+```ts
+await import("date-fns/locale/en-US");
+```
+
+### Using a `Locale` object
+
+Use the `locale: Locale` type if you wish to statically load date-fns locale modules:
+
+```ts
+import { DatePicker3 } from "@blueprintjs/datetime2";
+import enUS from "date-fns/locale/en-US";
+
+function Example() {
+    return <DatePicker3 locale={enUS} />;
 }
 ```
 

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -177,14 +177,14 @@ export class DatePicker3 extends AbstractPureComponent<DatePicker3Props, DatePic
         }
     }
 
-    private async loadLocale(localeCode: string | undefined) {
-        if (localeCode === undefined) {
+    private async loadLocale(localeOrCode: string | Locale | undefined) {
+        if (localeOrCode === undefined) {
             return;
-        } else if (this.state.locale?.code === localeCode) {
+        } else if (this.state.locale?.code === localeOrCode) {
             return;
         }
 
-        const locale = await loadDateFnsLocale(localeCode);
+        const locale = await loadDateFnsLocale(localeOrCode);
         this.setState({ locale });
     }
 

--- a/packages/datetime2/src/components/date-picker3/datePicker3Props.ts
+++ b/packages/datetime2/src/components/date-picker3/datePicker3Props.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import type { DayPickerSingleProps } from "react-day-picker";
-
-import type { Props } from "@blueprintjs/core";
 import type { DatePickerProps } from "@blueprintjs/datetime";
 
 import { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
 
 /** Props shared between DatePicker v1 and v3 */
 type DatePickerSharedProps = Omit<
@@ -27,20 +25,7 @@ type DatePickerSharedProps = Omit<
     "dayPickerProps" | "defaultValue" | "locale" | "localeUtils" | "modifiers" | "onChange" | "value"
 >;
 
-export interface DatePicker3Props extends DatePickerSharedProps, DateFnsLocaleProps, Props {
-    /**
-     * Props to pass to react-day-picker's single day picker. See API documentation
-     * [here](https://react-day-picker.js.org/api/interfaces/DayPickerSingleProps).
-     *
-     * Some properties are unavailable or have alternative names as top-level props:
-     *  - "mode": fixed to "single"
-     *  - "fromDate", "toDate": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
-     *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
-     *  - "selected": use "value" instead
-     *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
-     */
-    dayPickerProps?: Omit<DayPickerSingleProps, "fromDate" | "mode" | "month" | "required" | "selected" | "toDate">;
-
+export interface DatePicker3Props extends DatePickerSharedProps, DateFnsLocaleProps, ReactDayPickerSingleProps {
     /**
      * Initial day the calendar will display as selected.
      * This should not be set if `value` is set.

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -932,7 +932,7 @@ export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props,
         ) {
             return null;
         }
-        const newDate = this.props.parseDate(dateString, getLocaleCodeFromProps(this.props));
+        const newDate = this.props.parseDate(dateString, getLocaleCodeFromProps(this.props.locale));
         return newDate === false ? new Date() : newDate;
     }
 
@@ -940,7 +940,7 @@ export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props,
         if (!this.isDateValidAndInRange(date)) {
             return "";
         }
-        return this.props.formatDate(date, getLocaleCodeFromProps(this.props));
+        return this.props.formatDate(date, getLocaleCodeFromProps(this.props.locale));
     }
 }
 
@@ -953,7 +953,7 @@ function formatDateString(date: Date | false | null | undefined, props: DateRang
     } else if (!DateUtils.isDateValid(date)) {
         return invalidDateMessage;
     } else if (ignoreRange || DateUtils.isDayInRange(date, [minDate, maxDate])) {
-        return formatDate(date, getLocaleCodeFromProps(props));
+        return formatDate(date, getLocaleCodeFromProps(props.locale));
     } else {
         return outOfRangeMessage;
     }

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3Props.ts
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3Props.ts
@@ -22,3 +22,28 @@ import { DateRangePicker3Props } from "../date-range-picker3/dateRangePicker3Pro
 type DateRangeInputSharedProps = Omit<DateRangeInputProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
 
 export type DateRangeInput3Props = DateRangeInputSharedProps & Pick<DateRangePicker3Props, "dayPickerProps" | "locale">;
+
+export type DateRangeInput3DefaultProps = Required<
+    Pick<
+        DateRangeInput3Props,
+        | "allowSingleDayRange"
+        | "closeOnSelection"
+        | "contiguousCalendarMonths"
+        | "dayPickerProps"
+        | "disabled"
+        | "endInputProps"
+        | "invalidDateMessage"
+        | "maxDate"
+        | "minDate"
+        | "outOfRangeMessage"
+        | "overlappingDatesMessage"
+        | "popoverProps"
+        | "selectAllOnFocus"
+        | "shortcuts"
+        | "singleMonthOnly"
+        | "startInputProps"
+    >
+>;
+
+export type DateRangeInput3PropsWithDefaults = Omit<DateRangeInput3Props, keyof DateRangeInput3DefaultProps> &
+    DateRangeInput3DefaultProps;

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -220,14 +220,14 @@ export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Prop
         }
     }
 
-    private async loadLocale(localeCode: string | undefined) {
-        if (localeCode === undefined) {
+    private async loadLocale(localeOrCode: string | Locale | undefined) {
+        if (localeOrCode === undefined) {
             return;
-        } else if (this.state.locale?.code === localeCode) {
+        } else if (this.state.locale?.code === localeOrCode) {
             return;
         }
 
-        const locale = await loadDateFnsLocale(localeCode);
+        const locale = await loadDateFnsLocale(localeOrCode);
         this.setState({ locale });
     }
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
@@ -14,38 +14,12 @@
  * limitations under the License.
  */
 
-import type { DayPickerRangeProps } from "react-day-picker";
-
 import type { DateRangePickerProps } from "@blueprintjs/datetime";
 
-import { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
 
 /** Props shared between DateRangePicker v1 and v3 */
 type DateRangePickerSharedProps = Omit<DateRangePickerProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
 
-export interface DateRangePicker3Props extends DateRangePickerSharedProps, DateFnsLocaleProps {
-    /**
-     * Props to pass to react-day-picker's day range picker. See API documentation
-     * [here](https://react-day-picker.js.org/api/interfaces/DayPickerRangeProps).
-     *
-     * Some properties are unavailable or have alternative names as top-level props:
-     *  - "mode": fixed to "range"
-     *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
-     *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
-     *  - "selected": use "value" instead
-     *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
-     */
-    dayPickerProps?: Omit<
-        DayPickerRangeProps,
-        | "fromDate"
-        | "fromMonth"
-        | "fromYear"
-        | "mode"
-        | "month"
-        | "required"
-        | "selected"
-        | "toDate"
-        | "toMonth"
-        | "toYear"
-    >;
-}
+export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;

--- a/packages/datetime2/test/common/loadDateFnsLocaleFake.ts
+++ b/packages/datetime2/test/common/loadDateFnsLocaleFake.ts
@@ -16,12 +16,26 @@
 
 import * as Locales from "date-fns/locale";
 
-export function loadDateFnsLocaleFake(localeCode: string) {
+export async function loadDateFnsLocaleFake(localeOrCode: Locale | string | undefined) {
+    if (localeOrCode === undefined) {
+        return undefined;
+    } else if (typeof localeOrCode === "string") {
+        const localeKey = localeCodeToKey(localeOrCode);
+        return Locales[localeKey];
+    } else {
+        return localeOrCode;
+    }
+}
+
+/**
+ * Converts "en-US" to "enUS" which can be used to index into locales export object
+ */
+function localeCodeToKey(localeCode: string): keyof typeof Locales {
     let localeKey = localeCode as keyof typeof Locales;
     // convert "en-US" to "enUS" which can be used to index into locales export object
     if (localeKey.includes("-")) {
         const splits = localeKey.split("-");
         localeKey = `${splits[0]}${splits[1].toUpperCase()}` as keyof typeof Locales;
     }
-    return Promise.resolve(Locales[localeKey]);
+    return localeKey;
 }


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- feat(`DatePicker3`, `DateInput3`, `DateRangePicker3`, `DateRangeInput3`): widen type of `locale` prop to allow statically-imported date-fns `Locale` objects

#### Reviewers should focus on:

No regressions, test suite coverage

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/0858ee0c-6eee-4132-9db5-3a86e1b36d41)

