### PR TITLE
[core] fix(Icon): use correct font-size for icon font fallback

### DIFF
--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -62,6 +62,14 @@ span.#{$ns}-icon:empty {
   &::before {
     @include pt-icon-font-smoothing();
   }
+
+  &.#{$ns}-icon-standard {
+    font-size: $pt-icon-size-standard;
+  }
+
+  &.#{$ns}-icon-large {
+    font-size: $pt-icon-size-large;
+  }
 }
 
 @each $name, $codepoint in $blueprint-icon-codepoints {


### PR DESCRIPTION
#### Fixes #6409

#### Changes proposed in this pull request:

Add styles to ensure that `span.bp5-icon-standard:empty` and `span.bp5-icon-large:empty` get the correct font-size.

#### Reviewers should focus on:

No regressions

#### Screenshot

coming soon
