### PR TITLE
[datetime2] Do not use `export * as ns` for webpack 4 compatibility

### DIFF
--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -18,8 +18,9 @@ export { DatePicker3, DatePicker3Props } from "./components/date-picker3/datePic
 export { DateInput3, DateInput3Props } from "./components/date-input3/dateInput3";
 export { DateRangeInput3, DateRangeInput3Props } from "./components/date-range-input3/dateRangeInput3";
 export { DateRangePicker3, DateRangePicker3Props } from "./components/date-range-picker3/dateRangePicker3";
-export * as DateInput2MigrationUtils from "./dateInput2MigrationUtils";
+import * as DateInput2MigrationUtils from "./dateInput2MigrationUtils";
 
+export { DateInput2MigrationUtils };
 export { Classes as Datetime2Classes, ReactDayPickerClasses } from "./classes";
 
 /* eslint-disable deprecation/deprecation */


### PR DESCRIPTION
#### Fixes #6420 