### PR TITLE
[datetime2] fix: allow react 18 peer dep

### DIFF
--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -45,9 +45,9 @@
         "tslib": "~2.5.0"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.32 || 17",
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "@types/react": "^16.14.32 || 17 || 18",
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {


### PR DESCRIPTION

#### Changes proposed in this pull request:

Allow React 18 as a peer dependency of @blueprintjs/datetime2 now that we have support for react-day-picker v8.x
