### PR TITLE
Custom fonts use font-display: swap

### DIFF
--- a/packages/docs-app/src/index.html
+++ b/packages/docs-app/src/index.html
@@ -6,6 +6,7 @@
 <!--[if (gte IE 9)|(gt IEMobile 7)]><!--> <html class="no-js" lang="en"> <!--<![endif]-->
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width" />
   <title>Blueprint – Documentation</title>
 
   <meta name="description" content="">

--- a/packages/icons/scripts/icons.css.hbs
+++ b/packages/icons/scripts/icons.css.hbs
@@ -1,4 +1,5 @@
 @font-face {
+    font-display: swap;
     font-family: "{{ name }}";
     src: {{{ fontSrc }}};
 }


### PR DESCRIPTION
#### Fixes

Running Chrome Lighthouse against https://blueprintjs.com/docs/ and applications using Blueprint identifies some places where we are using custom fonts that may not be visible until font is downloaded.

See https://developer.chrome.com/docs/lighthouse/performance/font-display/

> ### Ensure text remains visible during webfont load
> Leverage the font-display CSS feature to ensure text is user-visible
> while webfonts are loading. Learn more about > font-display

![image](https://github.com/palantir/blueprint/assets/54594/c8dfb081-9670-4273-8f5f-6c2438284bf0)

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Set `font-display: swap` on `@font-face` custom fonts.


#### Reviewers should focus on:

correctness

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
