### PR TITLE
[datetime2] feat: export DayPickerProps type

### DIFF
--- a/packages/datetime2/src/common/reactDayPickerProps.ts
+++ b/packages/datetime2/src/common/reactDayPickerProps.ts
@@ -26,7 +26,6 @@ type ReactDayPickerOmittedProps =
     | "mode"
     | "month"
     | "numberOfMonths"
-    | "onSelect"
     | "required"
     | "selected"
     | "toDate"
@@ -54,7 +53,6 @@ export interface ReactDayPickerRangeProps {
      *  - "locale"
      *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
      *  - "numberOfMonths": use "singleMonthOnly" prop instead
-     *  - "onSelect": use "onChange" instead
      *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
      *  - "selected": use "value" instead
      */
@@ -76,7 +74,6 @@ export interface ReactDayPickerSingleProps {
      *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
      *  - "locale"
      *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
-     *  - "onSelect": use "onChange" instead
      *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
      *  - "selected": use "value" instead
      */

--- a/packages/datetime2/src/common/reactDayPickerProps.ts
+++ b/packages/datetime2/src/common/reactDayPickerProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DayPickerRangeProps, DayPickerSingleProps } from "react-day-picker";
+import type { DayPickerBase, DayPickerRangeProps, DayPickerSingleProps } from "react-day-picker";
 
 type ReactDayPickerOmittedProps =
     | "captionLayout"
@@ -26,11 +26,18 @@ type ReactDayPickerOmittedProps =
     | "mode"
     | "month"
     | "numberOfMonths"
+    | "onSelect"
     | "required"
     | "selected"
     | "toDate"
     | "toMonth"
     | "toYear";
+
+/**
+ * react-day-picker v8.x options which may be customized / overriden on
+ * `DatePicker3`, `DateInput3`, `DateRangePicker3`, and `DateRangeInput3` via the `dayPickerProps` prop.
+ */
+export type DayPickerProps = Omit<DayPickerBase, ReactDayPickerOmittedProps>;
 
 export interface ReactDayPickerRangeProps {
     /**
@@ -47,6 +54,7 @@ export interface ReactDayPickerRangeProps {
      *  - "locale"
      *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
      *  - "numberOfMonths": use "singleMonthOnly" prop instead
+     *  - "onSelect": use "onChange" instead
      *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
      *  - "selected": use "value" instead
      */
@@ -68,6 +76,7 @@ export interface ReactDayPickerSingleProps {
      *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
      *  - "locale"
      *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
+     *  - "onSelect": use "onChange" instead
      *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
      *  - "selected": use "value" instead
      */

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export type { DayPickerProps } from "./common/reactDayPickerProps";
 export { DatePicker3, DatePicker3Props } from "./components/date-picker3/datePicker3";
 export { DateInput3, DateInput3Props } from "./components/date-input3/dateInput3";
 export { DateRangeInput3, DateRangeInput3Props } from "./components/date-range-input3/dateRangeInput3";


### PR DESCRIPTION
This type is useful for developers to declare explicit typedefs for `dayPickerProps` objects.