### PR TITLE
[demo-app] fix: load blueprint-datetime2.css

### DIFF
--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -19,6 +19,7 @@
     "dependencies": {
         "@blueprintjs/core": "^5.3.3",
         "@blueprintjs/datetime": "^5.2.1",
+        "@blueprintjs/datetime2": "^2.0.2",
         "@blueprintjs/icons": "^5.1.8",
         "@blueprintjs/select": "^5.0.13",
         "@blueprintjs/table": "^5.0.13",

--- a/packages/demo-app/src/index.scss
+++ b/packages/demo-app/src/index.scss
@@ -1,5 +1,6 @@
 @import "@blueprintjs/core/lib/css/blueprint.css";
 @import "@blueprintjs/datetime/lib/css/blueprint-datetime.css";
+@import "@blueprintjs/datetime2/lib/css/blueprint-datetime2.css";
 @import "@blueprintjs/table/lib/css/table.css";
 
 @import "./styles/examples";


### PR DESCRIPTION
Fixes this display bug in demo-app:

![image](https://github.com/palantir/blueprint/assets/723999/17d9aaad-fb80-476c-8dc7-40d93171cd4f)
