### PR TITLE
chore: speed up artifact upload in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,10 +202,27 @@ jobs:
       - checkout
       - restore_cache: *restore-node-modules-cache
       - attach_workspace: { at: "." }
-      - store_artifacts: { path: packages/docs-app/dist }
-      - store_artifacts: { path: packages/landing-app/dist }
-      - store_artifacts: { path: packages/table-dev-app/dist }
-      - store_artifacts: { path: packages/demo-app/dist }
+      # We have lots of files, so we need to use compression to speed up the upload
+      # see https://support.circleci.com/hc/en-us/articles/360024275534-Uploading-artifacts-is-slow
+      - run:
+          name: Compress artifacts
+          command: |
+            tar -cvzf demo-app.tar packages/demo-app/dist
+            tar -cvzf docs-app.tar packages/docs-app/dist
+            tar -cvzf landing-app.tar packages/landing-app/dist
+            tar -cvzf table-dev-app.tar packages/table-dev-app/dist
+      - store_artifacts:
+          path: demo-app.tar
+          destination: packages/demo-app/dist
+      - store_artifacts:
+          path: docs-app.tar
+          destination: packages/docs-app/dist
+      - store_artifacts:
+          path: landing-app.tar
+          destination: packages/landing-app/dist
+      - store_artifacts:
+          path: table-dev-app.tar
+          destination: packages/table-dev-app/dist
       - run: ./scripts/submit-preview-comment.sh
 
   deploy-npm:

--- a/scripts/submit-comment-with-artifact-links.mjs
+++ b/scripts/submit-comment-with-artifact-links.mjs
@@ -14,10 +14,12 @@ import { execSync } from "node:child_process";
 import { basename } from "node:path";
 import { Octokit } from "octokit";
 
+const artifactsManifest = await import("./artifacts.json", { assert: { type: "json" }});
+
 /**
- * @type {Array<{path: string; url: string;}>}
+ * @type {{ items: Array<{path: string; url: string;}> }}
  */
-const { default: artifacts } = await import("./artifacts.json", { assert: { type: "json" }});
+const artifacts = artifactsManifest.default;
 
 if (artifacts.items === undefined) {
     throw new Error(


### PR DESCRIPTION
fixes #6494

using strategy from https://support.circleci.com/hc/en-us/articles/360024275534-Uploading-artifacts-is-slow