### PR TITLE
[datetime2] feat(DateRangeInput3): simpler formatting & parsing API

### DIFF
--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -59,6 +59,7 @@ const defaultProps: DateInput3DefaultProps = {
     closeOnSelection: true,
     disabled: false,
     invalidDateMessage: "Invalid date",
+    locale: "en-US",
     maxDate: DatePickerUtils.getDefaultMaxDate(),
     minDate: DatePickerUtils.getDefaultMinDate(),
     outOfRangeMessage: "Out of range",
@@ -278,6 +279,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
             <DatePicker3
                 {...datePickerProps}
                 dayPickerProps={dayPickerProps}
+                locale={locale}
                 maxDate={maxDate}
                 minDate={minDate}
                 onChange={handleDateChange}

--- a/packages/datetime2/src/components/date-input3/dateInput3Props.ts
+++ b/packages/datetime2/src/components/date-input3/dateInput3Props.ts
@@ -51,6 +51,7 @@ export type DateInput3DefaultProps = Required<
         | "closeOnSelection"
         | "disabled"
         | "invalidDateMessage"
+        | "locale"
         | "maxDate"
         | "minDate"
         | "outOfRangeMessage"

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -19,7 +19,6 @@ import { isSameDay, isValid } from "date-fns";
 import * as React from "react";
 
 import {
-    AbstractPureComponent,
     Boundary,
     Classes as CoreClasses,
     DISPLAYNAME_PREFIX,
@@ -44,8 +43,8 @@ import {
 import { Classes } from "../../classes";
 import { getDateFnsFormatter, getDateFnsParser, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
 import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
-import { loadDateFnsLocale } from "../../common/dateFnsLocaleUtils";
 import { DateRangePicker3 } from "../date-range-picker3/dateRangePicker3";
+import { DateFnsLocalizedComponent } from "../dateFnsLocalizedComponent";
 import type {
     DateRangeInput3DefaultProps,
     DateRangeInput3Props,
@@ -84,7 +83,7 @@ interface StateKeysAndValuesObject {
  *
  * @see https://blueprintjs.com/docs/#datetime2/date-range-input3
  */
-export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props, DateRangeInput3State> {
+export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Props, DateRangeInput3State> {
     public static defaultProps: DateRangeInput3DefaultProps = {
         allowSingleDayRange: false,
         closeOnSelection: true,
@@ -140,11 +139,12 @@ export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props,
     }
 
     public async componentDidMount() {
-        await this.loadLocale(this.props.locale);
+        await super.componentDidMount();
     }
 
-    public async componentDidUpdate(prevProps: DateRangeInput3Props, prevState: DateRangeInput3State) {
-        super.componentDidUpdate(prevProps, prevState);
+    public async componentDidUpdate(prevProps: DateRangeInput3Props) {
+        super.componentDidUpdate(prevProps);
+
         const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
 
         if (prevProps.startInputProps?.inputRef !== this.props.startInputProps?.inputRef) {
@@ -194,11 +194,7 @@ export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props,
             nextState = { ...nextState, formattedMaxDateString };
         }
 
-        if (this.props.locale !== prevProps.locale) {
-            await this.loadLocale(this.props.locale);
-        }
-
-        this.setState(nextState as DateRangeInput3State);
+        this.setState(nextState);
     }
 
     public render() {
@@ -237,47 +233,11 @@ export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props,
         );
     }
 
-    // HACKHACK: type fix for setState which does not accept partial state objects in our outdated version of
-    // @types/react (v16.14.32)
-    public setState<K extends keyof DateRangeInput3State>(
-        nextStateOrAction:
-            | Partial<DateRangeInput3State>
-            | null
-            | ((
-                  prevState: DateRangeInput3State,
-                  prevProps: DateRangeInput3Props,
-              ) => Pick<DateRangeInput3State, K> | null),
-        callback?: () => void,
-    ) {
-        if (typeof nextStateOrAction === "function") {
-            super.setState(nextStateOrAction, callback);
-        } else {
-            super.setState(nextStateOrAction as DateRangeInput3State);
-        }
-    }
-
     protected validateProps(props: DateRangeInput3Props) {
         if (props.value === null) {
             // throw a blocking error here because we don't handle a null value gracefully across this component
             // (it's not allowed by TS under strict null checks anyway)
             throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
-        }
-    }
-
-    private async loadLocale(localeOrCode: string | Locale | undefined) {
-        if (localeOrCode === undefined) {
-            return;
-        } else if (this.state.locale?.code === localeOrCode) {
-            return;
-        }
-
-        if (typeof localeOrCode === "string") {
-            const loader = this.props.dateFnsLocaleLoader ?? loadDateFnsLocale;
-            const locale = await loader(localeOrCode);
-            this.setState({ locale });
-            this.forceUpdate();
-        } else {
-            this.setState({ locale: localeOrCode });
         }
     }
 

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -202,17 +202,18 @@ export class DateRangeInput3 extends AbstractPureComponent<DateRangeInput3Props,
     }
 
     public render() {
-        const { selectedShortcutIndex } = this.state;
+        const { locale, selectedShortcutIndex } = this.state;
         const { popoverProps = {}, popoverRef } = this.props;
 
         const popoverContent = (
             <DateRangePicker3
                 {...this.props}
-                selectedShortcutIndex={selectedShortcutIndex}
                 boundaryToModify={this.state.boundaryToModify}
+                locale={locale}
                 onChange={this.handleDateRangePickerChange}
-                onShortcutChange={this.handleShortcutChange}
                 onHoverChange={this.handleDateRangePickerHoverChange}
+                onShortcutChange={this.handleShortcutChange}
+                selectedShortcutIndex={selectedShortcutIndex}
                 value={this.getSelectedRange()}
             />
         );

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -205,7 +205,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             <DateRangePicker3
                 {...this.props}
                 boundaryToModify={this.state.boundaryToModify}
-                locale={locale}
+                locale={locale ?? this.props.locale}
                 onChange={this.handleDateRangePickerChange}
                 onHoverChange={this.handleDateRangePickerHoverChange}
                 onShortcutChange={this.handleShortcutChange}

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3Props.ts
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3Props.ts
@@ -14,15 +14,36 @@
  * limitations under the License.
  */
 
-import type { DateRangeInputProps } from "@blueprintjs/datetime";
+import type { DateFormatProps, DateRangeInputProps } from "@blueprintjs/datetime";
 
 import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
 import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
 
-/** Props shared between DateRangeInput v1 and v3 */
-type DateRangeInputSharedProps = Omit<DateRangeInputProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
+/**
+ * Props shared between DateRangeInput v1 and v
+ *
+ * Note that we exclude formatDate and parseDate so that we can make those optional in DateInput3 and provide a default
+ * implementation for those functions using date-fns.
+ */
+type DateRangeInputSharedProps = Omit<
+    DateRangeInputProps,
+    "dayPickerProps" | "formatDate" | "locale" | "localeUtils" | "modifiers" | "parseDate"
+>;
 
-export type DateRangeInput3Props = DateRangeInputSharedProps & ReactDayPickerRangeProps & DateFnsLocaleProps;
+export interface DateRangeInput3Props
+    extends DateRangeInputSharedProps,
+        ReactDayPickerRangeProps,
+        DateFnsLocaleProps,
+        Partial<Omit<DateFormatProps, "locale">> {
+    /**
+     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
+     *
+     * Mutually exclusive with the `formatDate` and `parseDate` props.
+     *
+     * @see https://date-fns.org/docs/format
+     */
+    dateFnsFormat?: string;
+}
 
 export type DateRangeInput3DefaultProps = Required<
     Pick<
@@ -34,6 +55,7 @@ export type DateRangeInput3DefaultProps = Required<
         | "disabled"
         | "endInputProps"
         | "invalidDateMessage"
+        | "locale"
         | "maxDate"
         | "minDate"
         | "outOfRangeMessage"

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3State.ts
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3State.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+
+import type { Boundary } from "@blueprintjs/core";
+
+export interface DateRangeInput3State {
+    isOpen?: boolean;
+    boundaryToModify?: Boundary;
+    lastFocusedField?: Boundary;
+    locale?: Locale | undefined;
+
+    formattedMinDateString?: string;
+    formattedMaxDateString?: string;
+
+    isStartInputFocused: boolean;
+    isEndInputFocused: boolean;
+
+    startInputString?: string;
+    endInputString?: string;
+
+    startHoverString?: string | null;
+    endHoverString?: string | null;
+
+    selectedEnd: Date | null;
+    selectedStart: Date | null;
+
+    shouldSelectAfterUpdate?: boolean;
+    wasLastFocusChangeDueToHover?: boolean;
+
+    selectedShortcutIndex?: number;
+}

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -37,7 +37,7 @@ import { loadDateFnsLocale } from "../../common/dateFnsLocaleUtils";
 import { combineModifiers, HOVERED_RANGE_MODIFIER } from "../../common/dayPickerModifiers";
 import { DatePicker3Provider } from "../date-picker3/datePicker3Context";
 import { ContiguousDayRangePicker } from "./contiguousDayRangePicker";
-import type { DateRangePicker3Props } from "./dateRangePicker3Props";
+import type { DateRangePicker3DefaultProps, DateRangePicker3Props } from "./dateRangePicker3Props";
 import type { DateRangePicker3State } from "./dateRangePicker3State";
 import { NonContiguousDayRangePicker } from "./nonContiguousDayRangePicker";
 
@@ -51,7 +51,7 @@ const NULL_RANGE: DateRange = [null, null];
  * @see https://blueprintjs.com/docs/#datetime2/date-range-picker3
  */
 export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Props, DateRangePicker3State> {
-    public static defaultProps: DateRangePicker3Props = {
+    public static defaultProps: DateRangePicker3DefaultProps = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,
         dayPickerProps: {},

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -19,7 +19,7 @@ import { format } from "date-fns";
 import * as React from "react";
 import type { DateFormatter, DayModifiers, DayMouseEventHandler, ModifiersClassNames } from "react-day-picker";
 
-import { AbstractPureComponent, Boundary, DISPLAYNAME_PREFIX, Divider } from "@blueprintjs/core";
+import { Boundary, DISPLAYNAME_PREFIX, Divider } from "@blueprintjs/core";
 import {
     DatePickerShortcutMenu,
     DatePickerUtils,
@@ -33,9 +33,9 @@ import {
 } from "@blueprintjs/datetime";
 
 import { Classes, dayPickerClassNameOverrides } from "../../classes";
-import { loadDateFnsLocale } from "../../common/dateFnsLocaleUtils";
 import { combineModifiers, HOVERED_RANGE_MODIFIER } from "../../common/dayPickerModifiers";
 import { DatePicker3Provider } from "../date-picker3/datePicker3Context";
+import { DateFnsLocalizedComponent } from "../dateFnsLocalizedComponent";
 import { ContiguousDayRangePicker } from "./contiguousDayRangePicker";
 import type { DateRangePicker3DefaultProps, DateRangePicker3Props } from "./dateRangePicker3Props";
 import type { DateRangePicker3State } from "./dateRangePicker3State";
@@ -50,7 +50,7 @@ const NULL_RANGE: DateRange = [null, null];
  *
  * @see https://blueprintjs.com/docs/#datetime2/date-range-picker3
  */
-export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Props, DateRangePicker3State> {
+export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3Props, DateRangePicker3State> {
     public static defaultProps: DateRangePicker3DefaultProps = {
         allowSingleDayRange: false,
         contiguousCalendarMonths: true,
@@ -149,10 +149,12 @@ export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Prop
     }
 
     public async componentDidMount() {
-        await this.loadLocale(this.props.locale);
+        await super.componentDidMount();
     }
 
     public async componentDidUpdate(prevProps: DateRangePicker3Props) {
+        super.componentDidUpdate(prevProps);
+
         const isControlled = prevProps.value !== undefined && this.props.value !== undefined;
 
         if (prevProps.contiguousCalendarMonths !== this.props.contiguousCalendarMonths) {
@@ -169,29 +171,6 @@ export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Prop
 
         if (this.props.selectedShortcutIndex !== prevProps.selectedShortcutIndex) {
             this.setState({ selectedShortcutIndex: this.props.selectedShortcutIndex });
-        }
-
-        if (this.props.locale !== prevProps.locale) {
-            await this.loadLocale(this.props.locale);
-        }
-    }
-
-    // HACKHACK: type fix for setState which does not accept partial state objects in our outdated version of
-    // @types/react (v16.14.32)
-    public setState<K extends keyof DateRangePicker3State>(
-        nextStateOrAction:
-            | Partial<DateRangePicker3State>
-            | null
-            | ((
-                  prevState: DateRangePicker3State,
-                  prevProps: DateRangePicker3Props,
-              ) => Pick<DateRangePicker3State, K> | null),
-        callback?: () => void,
-    ) {
-        if (typeof nextStateOrAction === "function") {
-            super.setState(nextStateOrAction, callback);
-        } else {
-            super.setState(nextStateOrAction as DateRangePicker3State);
         }
     }
 
@@ -217,22 +196,6 @@ export class DateRangePicker3 extends AbstractPureComponent<DateRangePicker3Prop
 
         if (boundaryToModify != null && boundaryToModify !== Boundary.START && boundaryToModify !== Boundary.END) {
             console.error(Errors.DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID);
-        }
-    }
-
-    private async loadLocale(localeOrCode: string | Locale | undefined) {
-        if (localeOrCode === undefined) {
-            return;
-        } else if (this.state.locale?.code === localeOrCode) {
-            return;
-        }
-
-        if (typeof localeOrCode === "string") {
-            const loader = this.props.dateFnsLocaleLoader ?? loadDateFnsLocale;
-            const locale = await loader(localeOrCode);
-            this.setState({ locale });
-        } else {
-            this.setState({ locale: localeOrCode });
         }
     }
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
@@ -23,3 +23,22 @@ import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps"
 type DateRangePickerSharedProps = Omit<DateRangePickerProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
 
 export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;
+
+export type DateRangePicker3DefaultProps = Required<
+    Pick<
+        DateRangePicker3Props,
+        | "allowSingleDayRange"
+        | "contiguousCalendarMonths"
+        | "dayPickerProps"
+        | "locale"
+        | "maxDate"
+        | "minDate"
+        | "reverseMonthAndYearMenus"
+        | "shortcuts"
+        | "singleMonthOnly"
+        | "timePickerProps"
+    >
+>;
+
+export type DateRangePicker3PropsWithDefaults = Omit<DateRangePicker3Props, keyof DateRangePicker3DefaultProps> &
+    DateRangePicker3DefaultProps;

--- a/packages/datetime2/src/components/dateFnsLocalizedComponent.tsx
+++ b/packages/datetime2/src/components/dateFnsLocalizedComponent.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+
+import { AbstractPureComponent } from "@blueprintjs/core";
+
+import type { DateFnsLocaleProps } from "../common/dateFnsLocaleProps";
+import { loadDateFnsLocale } from "../common/dateFnsLocaleUtils";
+
+interface DateFnsLocaleState {
+    locale?: Locale | undefined;
+}
+
+/**
+ * Abstract component which accepts a date-fns locale prop and loads the corresponding `Locale` object as necessary.
+ *
+ * Currently used by DateRangePicker3 and DateRangeInput3, but we would ideally migrate to the `useDateFnsLocale()`
+ * hook once those components are refactored into functional components.
+ */
+export abstract class DateFnsLocalizedComponent<
+    P extends DateFnsLocaleProps,
+    S extends DateFnsLocaleState,
+> extends AbstractPureComponent<P, S> {
+    // HACKHACK: type fix for setState which does not accept partial state objects in our outdated version of
+    // @types/react (v16.14.32)
+    public setState<K extends keyof S>(
+        nextStateOrAction: ((prevState: S, prevProps: P) => Pick<S, K> | null) | Pick<S, K> | Partial<S> | null,
+        callback?: () => void,
+    ) {
+        if (typeof nextStateOrAction === "function") {
+            super.setState(nextStateOrAction, callback);
+        } else {
+            super.setState(nextStateOrAction as S);
+        }
+    }
+
+    public async componentDidMount() {
+        await this.loadLocale(this.props.locale);
+    }
+
+    public async componentDidUpdate(prevProps: DateFnsLocaleProps) {
+        if (this.props.locale !== prevProps.locale) {
+            await this.loadLocale(this.props.locale);
+        }
+    }
+
+    private async loadLocale(localeOrCode: string | Locale | undefined) {
+        if (localeOrCode === undefined) {
+            return;
+        } else if (this.state.locale?.code === localeOrCode) {
+            return;
+        }
+
+        if (typeof localeOrCode === "string") {
+            const loader = this.props.dateFnsLocaleLoader ?? loadDateFnsLocale;
+            const locale = await loader(localeOrCode);
+            this.setState({ locale });
+        } else {
+            this.setState({ locale: localeOrCode });
+        }
+    }
+}

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -17,6 +17,7 @@
 import { expect } from "chai";
 import { format, parse } from "date-fns";
 import * as Locales from "date-fns/locale";
+import esLocale from "date-fns/locale/es";
 import { mount, ReactWrapper } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
@@ -96,10 +97,10 @@ describe("<DateRangeInput3>", () => {
 
     const START_DATE_2 = new Date(2022, Months.JANUARY, 1);
     const START_STR_2 = DATE_FORMAT.formatDate(START_DATE_2);
-    const START_DE_STR_2 = "01.01.2022";
+    const START_STR_2_ES_LOCALE = "1 de enero de 2022";
     const END_DATE_2 = new Date(2022, Months.JANUARY, 31);
     const END_STR_2 = DATE_FORMAT.formatDate(END_DATE_2);
-    const END_DE_STR_2 = "31.01.2022";
+    const END_STR_2_ES_LOCALE = "31 de enero de 2022";
     const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
 
     const INVALID_STR = "<this is an invalid date string>";
@@ -2683,9 +2684,29 @@ describe("<DateRangeInput3>", () => {
             assertInputValuesEqual(root, DEC_2_STR, DEC_8_STR);
         });
 
-        it.skip("Formats locale-specific format strings properly", () => {
-            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} locale="de" value={DATE_RANGE_2} />);
-            assertInputValuesEqual(root, START_DE_STR_2, END_DE_STR_2);
+        describe("localization", () => {
+            describe("with formatDate & parseDate undefined", () => {
+                it("formats date strings with provided Locale object", () => {
+                    const { root } = wrap(
+                        <DateRangeInput3 dateFnsFormat="PPP" locale={esLocale} value={DATE_RANGE_2} />,
+                        true,
+                    );
+                    assertInputValuesEqual(root, START_STR_2_ES_LOCALE, END_STR_2_ES_LOCALE);
+                });
+
+                it("formats date strings with async-loaded locale corresponding to provided locale code", done => {
+                    const { root } = wrap(
+                        <DateRangeInput3 dateFnsFormat="PPP" locale="es" value={DATE_RANGE_2} />,
+                        true,
+                    );
+                    // give the component one animation frame to load the locale upon mount
+                    setTimeout(() => {
+                        root.update();
+                        assertInputValuesEqual(root, START_STR_2_ES_LOCALE, END_STR_2_ES_LOCALE);
+                        done();
+                    });
+                });
+            });
         });
     });
 

--- a/packages/docs-app/src/common/dateFnsLocaleSelect.tsx
+++ b/packages/docs-app/src/common/dateFnsLocaleSelect.tsx
@@ -18,7 +18,7 @@ import * as React from "react";
 
 import { Button, MenuItem } from "@blueprintjs/core";
 import { CaretDown } from "@blueprintjs/icons";
-import { ItemRenderer, Select } from "@blueprintjs/select";
+import { ItemRenderer, Select, SelectPopoverProps } from "@blueprintjs/select";
 
 export type CommonDateFnsLocale = "de" | "en-US" | "es" | "fr" | "hi" | "it" | "zh-CN";
 export const COMMON_DATE_FNS_LOCALES: CommonDateFnsLocale[] = ["de", "en-US", "es", "fr", "hi", "it", "zh-CN"];
@@ -35,6 +35,7 @@ const LOCALE_CODE_TO_NAME: Record<CommonDateFnsLocale, string> = {
 export interface DateFnsLocaleSelectProps {
     value: CommonDateFnsLocale;
     onChange: (newValue: CommonDateFnsLocale) => void;
+    popoverProps?: SelectPopoverProps["popoverProps"];
 }
 
 export const DateFnsLocaleSelect: React.FC<DateFnsLocaleSelectProps> = props => {
@@ -66,7 +67,7 @@ export const DateFnsLocaleSelect: React.FC<DateFnsLocaleSelectProps> = props => 
             items={COMMON_DATE_FNS_LOCALES}
             itemRenderer={renderLocaleItem}
             onItemSelect={props.onChange}
-            popoverProps={{ minimal: true, placement: "bottom-end" }}
+            popoverProps={{ minimal: true, placement: "bottom-end", ...props.popoverProps }}
         >
             <Button alignText="left" fill={true} rightIcon={<CaretDown />} text={props.value} />
         </Select>

--- a/packages/docs-app/src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * Newer datetime2 components support date-fns format strings directly.
+ */
+
+/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+
 import { format, Locale, parse } from "date-fns";
 import * as React from "react";
 
@@ -26,6 +33,7 @@ const locales: { [localeCode: string]: Locale } = require("date-fns/locale");
 
 export type DateFnsFormatSelectorProps = Omit<DateFormatSelectorProps, "formatOptions">;
 
+/** @deprecated use DateFnsFormatSelect */
 export const DateFnsDateFormatPropsSelect: React.FC<DateFnsFormatSelectorProps> = props => (
     <DateFormatSelector
         formatOptions={DATE_FNS_FORMATS}
@@ -38,6 +46,7 @@ export const DateFnsDateFormatPropsSelect: React.FC<DateFnsFormatSelectorProps> 
     />
 );
 
+/** @deprecated use DATE_FNS_FORMAT_OPTIONS */
 export const DATE_FNS_FORMATS: DateFormatProps[] = [
     getDateFnsFormatter("MM/dd/yyyy"),
     getDateFnsFormatter("yyyy-MM-dd"),

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
@@ -17,10 +17,11 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Classes, Code, H5, Icon, Switch } from "@blueprintjs/core";
+import { Classes, Code, FormGroup, H5, Icon, Switch } from "@blueprintjs/core";
 import { DateInput3, TimePrecision } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
+import { type CommonDateFnsLocale, DateFnsLocaleSelect } from "../../common/dateFnsLocaleSelect";
 import { FormattedDateTag } from "../../common/formattedDateTag";
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
@@ -33,6 +34,7 @@ interface DateInput3ExampleState {
     disabled: boolean;
     disableTimezoneSelect: boolean;
     fill: boolean;
+    localeCode: CommonDateFnsLocale;
     reverseMonthAndYearMenus: boolean;
     shortcuts: boolean;
     showActionsBar: boolean;
@@ -51,6 +53,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
         disableTimezoneSelect: false,
         disabled: false,
         fill: false,
+        localeCode: DateInput3.defaultProps.locale as CommonDateFnsLocale,
         reverseMonthAndYearMenus: false,
         shortcuts: false,
         showActionsBar: false,
@@ -91,17 +94,20 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
 
     private handleFormatChange = (dateFnsFormat: string) => this.setState({ dateFnsFormat });
 
+    private handleLocaleCodeChange = (localeCode: CommonDateFnsLocale) => this.setState({ localeCode });
+
     private handleTimePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
         this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
     );
 
     public render() {
-        const { date, showRightElement, showTimePickerArrows, useAmPm, ...spreadProps } = this.state;
+        const { date, localeCode, showRightElement, showTimePickerArrows, useAmPm, ...spreadProps } = this.state;
 
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <DateInput3
                     {...spreadProps}
+                    locale={localeCode}
                     onChange={this.handleDateChange}
                     popoverProps={{ placement: "bottom" }}
                     rightElement={
@@ -165,6 +171,13 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
                 <PropCodeTooltip snippet={`reverseMonthAndYearMenus={${reverse.toString()}}`}>
                     <Switch label="Reverse month and year menus" checked={reverse} onChange={this.toggleReverseMenus} />
                 </PropCodeTooltip>
+                <FormGroup inline={true} label="Locale">
+                    <DateFnsLocaleSelect
+                        value={this.state.localeCode}
+                        onChange={this.handleLocaleCodeChange}
+                        popoverProps={{ placement: "bottom-start" }}
+                    />
+                </FormGroup>
 
                 <H5>Input appearance props</H5>
                 <PropCodeTooltip snippet={`disabled={${disabled.toString()}}`}>

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput3Example.tsx
@@ -17,18 +17,15 @@
 import * as React from "react";
 
 import { Callout, Code, FormGroup, H5, Switch } from "@blueprintjs/core";
-import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";
+import { DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangeInput3 } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { type CommonDateFnsLocale, DateFnsLocaleSelect } from "../../common/dateFnsLocaleSelect";
 import { FormattedDateRange } from "../../common/formattedDateRange";
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
-import {
-    DATE_FNS_FORMATS,
-    DateFnsDateFormatPropsSelect,
-} from "../datetime-examples/common/dateFnsDateFormatPropsSelect";
 import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
+import { DATE_FNS_FORMAT_OPTIONS, DateFnsFormatSelect } from "./common/dateFnsFormatSelect";
 
 const exampleFooterElement = (
     <Callout style={{ maxWidth: 460 }}>
@@ -41,10 +38,10 @@ interface DateRangeInput3ExampleState {
     allowSingleDayRange: boolean;
     closeOnSelection: boolean;
     contiguousCalendarMonths: boolean;
+    dateFnsFormat: string;
     disabled: boolean;
     enableTimePicker: boolean;
     fill: boolean;
-    format: DateFormatProps;
     localeCode: CommonDateFnsLocale;
     range: DateRange;
     reverseMonthAndYearMenus: boolean;
@@ -61,10 +58,10 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
         allowSingleDayRange: false,
         closeOnSelection: false,
         contiguousCalendarMonths: true,
+        dateFnsFormat: DATE_FNS_FORMAT_OPTIONS[0],
         disabled: false,
         enableTimePicker: false,
         fill: false,
-        format: DATE_FNS_FORMATS[0],
         localeCode: DateRangeInput3.defaultProps.locale as CommonDateFnsLocale,
         range: [null, null],
         reverseMonthAndYearMenus: false,
@@ -106,7 +103,11 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
         this.setState({ showTimeArrowButtons }),
     );
 
+    private handleFormatChange = (dateFnsFormat: string) => this.setState({ dateFnsFormat });
+
     private handleLocaleCodeChange = (localeCode: CommonDateFnsLocale) => this.setState({ localeCode });
+
+    private handleRangeChange = (range: DateRange) => this.setState({ range });
 
     private handleTimePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
         this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
@@ -115,7 +116,6 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
     public render() {
         const {
             enableTimePicker,
-            format,
             localeCode,
             range,
             showFooterElement,
@@ -127,7 +127,6 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
             <Example options={this.renderOptions()} showOptionsBelowExample={true} {...this.props}>
                 <DateRangeInput3
                     {...spreadProps}
-                    {...format}
                     locale={localeCode}
                     value={range}
                     onChange={this.handleRangeChange}
@@ -223,7 +222,7 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
                     <PropCodeTooltip snippet={`fill={${fill.toString()}}`}>
                         <Switch label="Fill container width" checked={fill} onChange={this.toggleFill} />
                     </PropCodeTooltip>
-                    <DateFnsDateFormatPropsSelect format={this.state.format} onChange={this.handleFormatChange} />
+                    <DateFnsFormatSelect value={this.state.dateFnsFormat} onChange={this.handleFormatChange} />
                     <br />
 
                     <H5>Time picker props</H5>
@@ -250,8 +249,4 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
             </>
         );
     }
-
-    private handleFormatChange = (format: DateFormatProps) => this.setState({ format });
-
-    private handleRangeChange = (range: DateRange) => this.setState({ range });
 }

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangeInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangeInput3Example.tsx
@@ -16,11 +16,12 @@
 
 import * as React from "react";
 
-import { Callout, Code, H5, Switch } from "@blueprintjs/core";
+import { Callout, Code, FormGroup, H5, Switch } from "@blueprintjs/core";
 import { DateFormatProps, DateRange, TimePrecision } from "@blueprintjs/datetime";
 import { DateRangeInput3 } from "@blueprintjs/datetime2";
 import { Example, ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
+import { type CommonDateFnsLocale, DateFnsLocaleSelect } from "../../common/dateFnsLocaleSelect";
 import { FormattedDateRange } from "../../common/formattedDateRange";
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import {
@@ -44,6 +45,7 @@ interface DateRangeInput3ExampleState {
     enableTimePicker: boolean;
     fill: boolean;
     format: DateFormatProps;
+    localeCode: CommonDateFnsLocale;
     range: DateRange;
     reverseMonthAndYearMenus: boolean;
     selectAllOnFocus: boolean;
@@ -63,6 +65,7 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
         enableTimePicker: false,
         fill: false,
         format: DATE_FNS_FORMATS[0],
+        localeCode: DateRangeInput3.defaultProps.locale as CommonDateFnsLocale,
         range: [null, null],
         reverseMonthAndYearMenus: false,
         selectAllOnFocus: false,
@@ -103,6 +106,8 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
         this.setState({ showTimeArrowButtons }),
     );
 
+    private handleLocaleCodeChange = (localeCode: CommonDateFnsLocale) => this.setState({ localeCode });
+
     private handleTimePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
         this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
     );
@@ -111,6 +116,7 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
         const {
             enableTimePicker,
             format,
+            localeCode,
             range,
             showFooterElement,
             showTimeArrowButtons,
@@ -122,6 +128,7 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
                 <DateRangeInput3
                     {...spreadProps}
                     {...format}
+                    locale={localeCode}
                     value={range}
                     onChange={this.handleRangeChange}
                     footerElement={showFooterElement ? exampleFooterElement : undefined}
@@ -199,6 +206,13 @@ export class DateRangeInput3Example extends React.PureComponent<ExampleProps, Da
                         label="Show custom footer element"
                         onChange={this.toggleShowFooterElement}
                     />
+                    <FormGroup inline={true} label="Locale">
+                        <DateFnsLocaleSelect
+                            value={this.state.localeCode}
+                            onChange={this.handleLocaleCodeChange}
+                            popoverProps={{ placement: "bottom-start" }}
+                        />
+                    </FormGroup>
                 </div>
 
                 <div>

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -670,6 +670,10 @@ $docs-hotkey-piano-height: 510px;
   .docs-example {
     padding: ($pt-grid-size * 4) ($pt-grid-size * 2);
   }
+
+  .#{$ns}-input-group {
+    min-width: 200px;
+  }
 }
 
 //


### PR DESCRIPTION
similar to the same change for DateInput3: https://github.com/palantir/blueprint/pull/6398

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- feat(`DateRangeInput3`): `formatDate` and `parseDate` props are now optional. The component will use a date-fns formatter & parser with a format string inferred from the time precision setting.
- feat(`DateRangeInput3`): new `dateFnsFormat` prop allows users to easily customize the date formatter, parser, and input placeholder without having to write custom formatting & parsing functions
- fix(`DateInput3`): forward `locale` to `DatePicker3` correctly so that month & year dropdown labels are localized
  - N.B. this was done incorrectly in https://github.com/palantir/blueprint/pull/6406

#### Reviewers should focus on:

Test cases, no regressions in example

#### Screenshot

![2023-10-11 12 21 17](https://github.com/palantir/blueprint/assets/723999/5861a803-373a-4b69-ac3c-2b2e9e004c62)

