### PR TITLE
[core] fix(MenuDivider): remove tabIndex attr to resolve a11y failure

### DIFF
--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -47,7 +47,7 @@ export class MenuDivider extends React.Component<MenuDividerProps> {
         } else {
             // section header with title
             return (
-                <li className={classNames(Classes.MENU_HEADER, className)} role="separator" tabIndex={-1}>
+                <li className={classNames(Classes.MENU_HEADER, className)} role="separator">
                     <H6 id={titleId}>{title}</H6>
                 </li>
             );


### PR DESCRIPTION
Does not need `tabIndex={-1}`, `role="separator"` already makes it non-focusable. Having any `tabIndex` (even -1) causes this to fail aXe a11y tests, so we must remove it.
