### PR TITLE
[core] fix(Popover): work around react-popper bug, fix React 18 compat

### DIFF
--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -30,7 +30,7 @@ export function isRefCallback<T>(value: React.Ref<T> | undefined): value is Reac
 export function setRef<T>(refTarget: React.Ref<T> | undefined, ref: T | null): void {
     if (isRefObject<T>(refTarget)) {
         // HACKHACK: .current property is readonly
-        (refTarget.current as any) = ref;
+        (refTarget.current as T | null) = ref;
     } else if (isRefCallback(refTarget)) {
         refTarget(ref);
     }

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -247,6 +247,8 @@ export class Popover<
             return this.renderTarget({ ref: noop });
         }
 
+        // Important: do not use <Reference innerRef> since it has a bug when used in React 18 strict mode
+        // see https://github.com/floating-ui/react-popper/pull/459
         return (
             <Manager>
                 <Reference>{this.renderTarget}</Reference>
@@ -419,8 +421,8 @@ export class Popover<
             target = wrappedTarget;
         }
 
-        // N.B. we must attach the ref ('wrapped' with react-popper functionality) to the DOM element here and
-        // let ResizeSensor know about it
+        // No need to use the merged `ref` here, that only needs to be forwarded to the child node so that React can
+        // notify both popper.js and our components about the mounted DOM element.
         return (
             <ResizeSensor targetRef={this.targetRef} onResize={this.reposition}>
                 {target}

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -74,8 +74,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     private prevElement: HTMLElement | undefined = undefined;
 
-    private observer =
-        globalThis.ResizeObserver != null ? new ResizeObserver(entries => this.props.onResize?.(entries)) : undefined;
+    private observer: ResizeObserver | undefined;
 
     public render(): React.ReactNode {
         const onlyChild = React.Children.only(this.props.children);
@@ -91,6 +90,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     }
 
     public componentDidMount() {
+        this.observer = new ResizeObserver(entries => this.props.onResize?.(entries));
         this.observeElement();
     }
 
@@ -109,7 +109,7 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
      * re-observe.
      */
     private observeElement(force = false) {
-        if (this.observer == null) {
+        if (this.observer === undefined) {
             return;
         }
 

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { AbstractPureComponent, DISPLAYNAME_PREFIX, mergeRefs } from "../../common";
+import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
 // backwards-compatible with @blueprintjs/core v4.x
 export type ResizeEntry = ResizeObserverEntry;
@@ -57,7 +57,7 @@ export interface ResizeSensorProps {
      * If you attach a `ref` to the child yourself when rendering it, you must pass the
      * same value here (otherwise, ResizeSensor won't be able to attach its own).
      */
-    targetRef?: React.Ref<HTMLElement>;
+    targetRef?: React.RefObject<HTMLElement>;
 }
 
 /**
@@ -70,13 +70,7 @@ export interface ResizeSensorProps {
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
-    private ownTargetRef = React.createRef<HTMLElement>();
-
-    private get targetRef() {
-        return this.props.targetRef === undefined
-            ? this.ownTargetRef
-            : mergeRefs(this.props.targetRef, this.ownTargetRef);
-    }
+    private targetRef = this.props.targetRef ?? React.createRef<HTMLElement>();
 
     private prevElement: HTMLElement | undefined = undefined;
 
@@ -85,6 +79,14 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
 
     public render(): React.ReactNode {
         const onlyChild = React.Children.only(this.props.children);
+
+        // If we're provided a mutable ref to the child element already, we must re-use that one. This is necessary
+        // in cases where the child node is not a native DOM element and does not use `React.forwardRef`, since
+        // there's no way for us to know how to attach to the underlying DOM node.
+        if (this.props.targetRef !== undefined) {
+            return onlyChild;
+        }
+
         return React.cloneElement(onlyChild, { ref: this.targetRef });
     }
 
@@ -111,27 +113,27 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
             return;
         }
 
-        if (!(this.ownTargetRef.current instanceof Element)) {
+        if (!(this.targetRef.current instanceof Element)) {
             // stop everything if not defined
             this.observer.disconnect();
             return;
         }
 
-        if (this.ownTargetRef.current === this.prevElement && !force) {
+        if (this.targetRef.current === this.prevElement && !force) {
             // quit if given same element -- nothing to update (unless forced)
             return;
         } else {
             // clear observer list if new element
             this.observer.disconnect();
             // remember element reference for next time
-            this.prevElement = this.ownTargetRef.current;
+            this.prevElement = this.targetRef.current;
         }
 
         // observer callback is invoked immediately when observing new elements
-        this.observer.observe(this.ownTargetRef.current);
+        this.observer.observe(this.targetRef.current);
 
         if (this.props.observeParents) {
-            let parent = this.ownTargetRef.current.parentElement;
+            let parent = this.targetRef.current.parentElement;
             while (parent != null) {
                 this.observer.observe(parent);
                 parent = parent.parentElement;

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -855,7 +855,7 @@ describe("<Popover>", () => {
 
         const instance = wrapper.instance() as Popover<React.HTMLProps<HTMLButtonElement>>;
         wrapper.popoverElement = instance.popoverElement!;
-        wrapper.targetElement = instance.targetRef.current!;
+        wrapper.targetElement = instance.targetElement!;
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {
             const actual = wrapper!.findClass(className);
             if (expected) {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -855,7 +855,7 @@ describe("<Popover>", () => {
 
         const instance = wrapper.instance() as Popover<React.HTMLProps<HTMLButtonElement>>;
         wrapper.popoverElement = instance.popoverElement!;
-        wrapper.targetElement = instance.targetElement!;
+        wrapper.targetElement = instance.targetRef.current!;
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {
             const actual = wrapper!.findClass(className);
             if (expected) {

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -83,7 +83,7 @@ describe("<ResizeSensor>", () => {
         const RESIZE_WIDTH = 200;
         mountResizeSensor({ onResize, targetRef });
         await resize({ width: RESIZE_WIDTH });
-        assert.equal(onResize.callCount, 1);
+        assert.equal(onResize.callCount, 1, "onResize should be called");
         assertResizeArgs(onResize, [`${RESIZE_WIDTH}x0`]);
         assert.isNotNull(targetRef.current, "user-provided targetRef should be set");
         assert.strictEqual(targetRef.current?.clientWidth, RESIZE_WIDTH, "user-provided targetRef.current.clientWidth");
@@ -123,6 +123,6 @@ interface SizeProps {
 type ResizeTesterProps = Omit<ResizeSensorProps, "children"> & SizeProps;
 const ResizeTester: React.FC<ResizeTesterProps> = ({ id, width, height, ...sensorProps }) => (
     <ResizeSensor {...sensorProps}>
-        <div key={id} style={{ width, height }} />
+        <div key={id} style={{ width, height }} ref={sensorProps.targetRef as React.RefObject<HTMLDivElement>} />
     </ResizeSensor>
 );

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -32,11 +32,12 @@ describe("<ResizeSensor>", () => {
         wrapper?.unmount();
         wrapper?.detach();
     });
+
     after(() => testsContainerElement.remove());
 
     it("onResize is called when size changes", async () => {
         const onResize = spy();
-        mountResizeSensor(onResize);
+        mountResizeSensor({ onResize });
         await resize({ width: 200 });
         await resize({ height: 100 });
         await resize({ width: 55 });
@@ -46,7 +47,7 @@ describe("<ResizeSensor>", () => {
 
     it("onResize is NOT called redundantly when size is unchanged", async () => {
         const onResize = spy();
-        mountResizeSensor(onResize);
+        mountResizeSensor({ onResize });
         await resize({ width: 200 });
         await resize({ width: 200 }); // this one should be ignored
         assert.equal(onResize.callCount, 1);
@@ -55,7 +56,7 @@ describe("<ResizeSensor>", () => {
 
     it("onResize is called when element changes", async () => {
         const onResize = spy();
-        mountResizeSensor(onResize);
+        mountResizeSensor({ onResize });
         await resize({ width: 200, id: 1 });
         await resize({ width: 200, id: 2 }); // not ignored bc element recreated
         await resize({ width: 55, id: 3 });
@@ -64,7 +65,7 @@ describe("<ResizeSensor>", () => {
 
     it("onResize can be changed", async () => {
         const onResize1 = spy();
-        mountResizeSensor(onResize1);
+        mountResizeSensor({ onResize: onResize1 });
         await resize({ width: 200, id: 1 });
 
         const onResize2 = spy();
@@ -76,9 +77,21 @@ describe("<ResizeSensor>", () => {
         assert.equal(onResize2.callCount, 2, "second callback should have been called exactly twice");
     });
 
-    function mountResizeSensor(onResize: ResizeSensorProps["onResize"]) {
+    it("still works when user sets their own targetRef", async () => {
+        const onResize = spy();
+        const targetRef = React.createRef<HTMLElement>();
+        const RESIZE_WIDTH = 200;
+        mountResizeSensor({ onResize, targetRef });
+        await resize({ width: RESIZE_WIDTH });
+        assert.equal(onResize.callCount, 1);
+        assertResizeArgs(onResize, [`${RESIZE_WIDTH}x0`]);
+        assert.isNotNull(targetRef.current, "user-provided targetRef should be set");
+        assert.strictEqual(targetRef.current?.clientWidth, RESIZE_WIDTH, "user-provided targetRef.current.clientWidth");
+    });
+
+    function mountResizeSensor(props: Omit<ResizeSensorProps, "children">) {
         return (wrapper = mount<ResizeTesterProps>(
-            <ResizeTester id={0} onResize={onResize} />,
+            <ResizeTester id={0} {...props} />,
             // must be in the DOM for measurement
             { attachTo: testsContainerElement },
         ));
@@ -86,6 +99,7 @@ describe("<ResizeSensor>", () => {
 
     function resize(size: SizeProps) {
         wrapper!.setProps(size);
+        wrapper!.update();
         return new Promise(resolve => setTimeout(resolve, 30));
     }
 

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -63,6 +63,7 @@ describe("Suggest", () => {
                 inputValueRenderer={inputValueRenderer}
                 popoverProps={{ isOpen: true, usePortal: false }}
             />,
+            { attachTo: testsContainerElement },
         ),
     );
 
@@ -337,7 +338,9 @@ describe("Suggest", () => {
     });
 
     function suggest(props: Partial<SuggestProps<Film>> = {}) {
-        return mount<Suggest<Film>>(<Suggest<Film> {...defaultProps} {...handlers} {...props} />);
+        return mount<Suggest<Film>>(<Suggest<Film> {...defaultProps} {...handlers} {...props} />, {
+            attachTo: testsContainerElement,
+        });
     }
 });
 

--- a/packages/table/src/deprecatedAliases.ts
+++ b/packages/table/src/deprecatedAliases.ts
@@ -32,12 +32,12 @@ export {
     /** @deprecated import JSONFormat instead */
     JSONFormat as JSONFormat2,
     /** @deprecated import JSONFormatProps instead */
-    JSONFormatProps as JSONFormat2Props,
+    type JSONFormatProps as JSONFormat2Props,
 } from "./cell/formats/jsonFormat";
 
 export {
     /** @deprecated import TruncatedFormat instead */
     TruncatedFormat as TruncatedFormat2,
     /** @deprecated import TruncatedFormatProps instead */
-    TruncatedFormatProps as TruncatedFormat2Props,
+    type TruncatedFormatProps as TruncatedFormat2Props,
 } from "./cell/formats/truncatedFormat";


### PR DESCRIPTION
#### Fixes #6203

#### Checklist

- [x] Includes tests
- [x] Update (code) documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

fix(`Popover`): adjust target ref behavior to work around react-popper `innerRef` bug, fixing React 18 strict mode compatibility

#### Reviewers should focus on:

No regressions in Popover, table draggable interactions, ResizeSensor

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
