### PR TITLE
[core] fix(ControlCard): vertically align control indicator to top

### DIFF
--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -22,9 +22,3 @@ $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default
 $card-list-item-padding-vertical-compact: 7px !default;
 $card-list-item-min-height-compact: $pt-button-height + ($card-list-item-padding-vertical-compact * 2) + $card-list-border-width !default;
 $card-list-item-padding-compact: $card-list-item-padding-vertical-compact $card-padding-compact !default;
-
-// CardList ControlCard item min-height is calculated as height of a control indicator + vertical padding
-$card-list-control-item-padding-vertical: $card-padding;
-$card-list-control-item-min-height: $control-indicator-size + ($card-list-control-item-padding-vertical * 2) + $card-list-border-width !default;
-$card-list-control-item-padding-vertical-compact: $card-padding-compact;
-$card-list-control-item-min-height-compact: $control-indicator-size + ($card-list-control-item-padding-vertical-compact * 2) + $card-list-border-width !default;

--- a/packages/core/src/components/control-card/_control-card.scss
+++ b/packages/core/src/components/control-card/_control-card.scss
@@ -18,7 +18,8 @@
   // need a lot of specificity here to override control styles for (switch, checkbox, etc.) and (align-left, align-right)
   // N.B. this is more space-efficient (in terms of generated CSS) than listing multiple compound selectors
   .#{$ns}-control.#{$ns}-control.#{$ns}-control {
-    align-items: center;
+    // control indicators should be top-aligned
+    align-items: flex-start;
     display: flex;
     gap: $pt-grid-size;
     margin: 0;
@@ -36,13 +37,11 @@
     }
 
     .#{$ns}-card-list & {
-      min-height: $card-list-control-item-min-height;
-      padding: $card-list-item-padding;
+      padding: $card-padding;
     }
 
     .#{$ns}-card-list.#{$ns}-compact & {
-      min-height: $card-list-control-item-min-height-compact;
-      padding: $card-list-item-padding-compact;
+      padding: $card-padding-compact;
     }
 
     .#{$ns}-control-indicator {

--- a/packages/docs-app/src/examples/core-examples/checkboxCardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxCardExample.tsx
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
+import classNames from "classnames";
 import * as React from "react";
 
-import { Alignment, CheckboxCard, CheckboxCardProps, FormGroup, H5, Switch } from "@blueprintjs/core";
+import { Alignment, CheckboxCard, CheckboxCardProps, Classes, FormGroup, H5, Switch } from "@blueprintjs/core";
 import { Example, ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { AlignmentSelect } from "./common/alignmentSelect";
 
-type CheckboxCardExampleState = Pick<
-    CheckboxCardProps,
-    "alignIndicator" | "compact" | "disabled" | "showAsSelectedWhenChecked"
->;
+interface CheckboxCardExampleState
+    extends Pick<CheckboxCardProps, "alignIndicator" | "compact" | "disabled" | "showAsSelectedWhenChecked"> {
+    showSubtext: boolean;
+}
 
 export class CheckboxCardExample extends React.PureComponent<ExampleProps, CheckboxCardExampleState> {
     public state: CheckboxCardExampleState = {
@@ -33,22 +34,33 @@ export class CheckboxCardExample extends React.PureComponent<ExampleProps, Check
         compact: false,
         disabled: false,
         showAsSelectedWhenChecked: true,
+        showSubtext: true,
     };
 
     public render() {
+        const { showSubtext, ...checkboxCardProps } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <FormGroup className="docs-control-card-group" label={<H5>Lunch Special</H5>}>
-                    <CheckboxCard {...this.state}>Soup</CheckboxCard>
-                    <CheckboxCard {...this.state}>Salad</CheckboxCard>
-                    <CheckboxCard {...this.state}>Sandwich</CheckboxCard>
+                    <CheckboxCard {...checkboxCardProps}>
+                        Soup
+                        {showSubtext && <Subtext>Tomato Basil or Broccoli Cheddar</Subtext>}
+                    </CheckboxCard>
+                    <CheckboxCard {...checkboxCardProps}>
+                        Salad
+                        {showSubtext && <Subtext>Caesar, Caprese, or Fresh fruit</Subtext>}
+                    </CheckboxCard>
+                    <CheckboxCard {...checkboxCardProps}>
+                        Sandwich
+                        {showSubtext && <Subtext>Chicken, Turkey, or Vegetable</Subtext>}
+                    </CheckboxCard>
                 </FormGroup>
             </Example>
         );
     }
 
     private renderOptions() {
-        const { alignIndicator, compact, disabled, showAsSelectedWhenChecked } = this.state;
+        const { alignIndicator, compact, disabled, showAsSelectedWhenChecked, showSubtext } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -74,6 +86,8 @@ export class CheckboxCardExample extends React.PureComponent<ExampleProps, Check
                         onChange={this.handleAlignChange}
                     />
                 </PropCodeTooltip>
+                <H5>Content</H5>
+                <Switch checked={showSubtext} label="Show sub text" onChange={this.toggleShowSubtext} />
             </>
         );
     }
@@ -86,5 +100,16 @@ export class CheckboxCardExample extends React.PureComponent<ExampleProps, Check
 
     private toggleShowAsSelected = handleBooleanChange(showAsSelectedWhenChecked =>
         this.setState({ showAsSelectedWhenChecked }),
+    );
+
+    private toggleShowSubtext = handleBooleanChange(showSubtext => this.setState({ showSubtext }));
+}
+
+function Subtext(props: { children: React.ReactNode }) {
+    return (
+        <>
+            <br />
+            <span className={classNames(Classes.TEXT_MUTED, Classes.TEXT_SMALL)}>{props.children}</span>
+        </>
     );
 }


### PR DESCRIPTION


#### Checklist

- [x] Update documentation

#### Changes proposed in this pull request:

- docs(`CheckboxCard`): add sub text to labels to show a multi-line text example layout
- fix(`ControlCard`): vertically align control indicator to top of card instead of middle

#### Reviewers should focus on:

no regressions

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/33e9c1ca-0409-4a70-9a0a-f6d17317e372)

