### PR TITLE
docs: add 'deprecated' tag to nav menu items

### DIFF
--- a/packages/core/src/components/panel-stack/panel-stack.md
+++ b/packages/core/src/components/panel-stack/panel-stack.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Panel stack
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
@@ -8,7 +12,7 @@ Deprecated: use [PanelStack2](#core/components/panel-stack2)
 </h5>
 
 This API is **deprecated since @blueprintjs/core v3.40.0** in favor of the new
-__PanelStack2__ component. You should migrate to the new API which will become the
+**PanelStack2** component. You should migrate to the new API which will become the
 standard in a future major version of Blueprint.
 
 </div>
@@ -46,7 +50,7 @@ import { Button, IPanelProps, PanelStack } from "@blueprintjs/core";
 
 class MyPanel extends React.Component<IPanelProps> {
     public render() {
-        return <Button onClick={this.openSettingsPanel} text="Settings" />
+        return <Button onClick={this.openSettingsPanel} text="Settings" />;
     }
 
     private openSettingsPanel() {
@@ -54,7 +58,7 @@ class MyPanel extends React.Component<IPanelProps> {
         this.props.openPanel({
             component: SettingsPanel, // <- class or stateless function type
             props: { enabled: true }, // <- SettingsPanel props without IPanelProps
-            title: "Settings",        // <- appears in header and back button
+            title: "Settings", // <- appears in header and back button
         });
     }
 }
@@ -63,7 +67,7 @@ class SettingsPanel extends React.Component<IPanelProps & { enabled: boolean }> 
     // ...
 }
 
-<PanelStack initialPanel={{ component: MyPanel, title: "Home" }} />
+<PanelStack initialPanel={{ component: MyPanel, title: "Home" }} />;
 ```
 
 @interface IPanel

--- a/packages/core/src/legacy/hotkeys-legacy.md
+++ b/packages/core/src/legacy/hotkeys-legacy.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Hotkeys (legacy)
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
@@ -9,7 +13,7 @@ Deprecated: use [useHotkeys](#core/hooks/use-hotkeys)
 
 This API is **deprecated since @blueprintjs/core v3.39.0** in favor of the new
 [`useHotkeys` hook](#core/hooks/use-hotkeys) and
-[__HotkeysTarget2__ component](#core/components/hotkeys-target2). You should migrate to one of
+[**HotkeysTarget2** component](#core/components/hotkeys-target2). You should migrate to one of
 these new APIs, as they will become the standard in future major version of Blueprint.
 
 </div>

--- a/packages/datetime/src/components/date-input/date-input.md
+++ b/packages/datetime/src/components/date-input/date-input.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Date input
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">

--- a/packages/datetime/src/components/date-picker/datepicker.md
+++ b/packages/datetime/src/components/date-picker/datepicker.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Date picker
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">

--- a/packages/datetime/src/components/date-range-input/date-range-input.md
+++ b/packages/datetime/src/components/date-range-input/date-range-input.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Date range input
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">

--- a/packages/datetime/src/components/date-range-picker/daterangepicker.md
+++ b/packages/datetime/src/components/date-range-picker/daterangepicker.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Date range picker
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -18,7 +18,7 @@ import { IHeadingNode, IPageData, isPageNode, ITsDocBase } from "@documentalist/
 import classNames from "classnames";
 import * as React from "react";
 
-import { AnchorButton, Classes, HotkeysProvider, Tag } from "@blueprintjs/core";
+import { AnchorButton, Classes, HotkeysProvider, Intent, Tag } from "@blueprintjs/core";
 import type { DocsCompleteData } from "@blueprintjs/docs-data";
 import { Banner, Documentation, DocumentationProps, NavMenuItem, NavMenuItemProps } from "@blueprintjs/docs-theme";
 
@@ -148,11 +148,25 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
 
     private maybeRenderPageTag(reference: string) {
         const tag = this.props.docs.pages[reference].metadata.tag;
+
         if (tag == null) {
             return null;
         }
+
+        let intent: Intent = "none";
+        switch (tag) {
+            case "new":
+                intent = "success";
+                break;
+            case "deprecated":
+                intent = "danger";
+                break;
+            default:
+                break;
+        }
+
         return (
-            <Tag className="docs-nav-tag" minimal={true} intent={tag === "new" ? "success" : "none"}>
+            <Tag className="docs-nav-tag" minimal={true} intent={intent}>
                 {tag}
             </Tag>
         );


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Add a new frontmatter metadata tag to documentation markdown pages
- Detect the new tag in blueprint-docs-app navigation sidebar menu items and mark those items as "deprecated"

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/0e8bc295-aac0-440f-aa95-fbf7da786baf)

