### PR TITLE
[core] fix(ResizeSensor): ResizeObserver feature detection

### DIFF
--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -90,7 +90,12 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     }
 
     public componentDidMount() {
-        this.observer = new ResizeObserver(entries => this.props.onResize?.(entries));
+        // ResizeObserver is available in all modern browsers supported by Blueprint but not in server-side rendering
+        // and some test environments like jsdom, so we to do a feature check here.
+        this.observer =
+            globalThis.ResizeObserver != null
+                ? new ResizeObserver(entries => this.props.onResize?.(entries))
+                : undefined;
         this.observeElement();
     }
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/pull/6458/files#r1360920703

#### Changes proposed in this pull request:

Fixes a regression caused by #6458 where we stopped feature checking for the existence of `ResizeObserver`. It turns out that this broke usage in jsdom testing environments, so we need to add back the check.

#### Reviewers should focus on:

No regressions in Popover resize behavior & ResizeSensor tests

#### Screenshot

N/A