### PR TITLE
[eslint-plugin] feat: no-deprecated-popover2-components rule

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -106,7 +106,7 @@ Note that this rule only supports hardcoded values in the `icon` prop; it does n
 
 A fixer is available for this rule that will convert between string literals and named `Icon` components. Note that the implementation is naive and may require intervention, such as to import a component or fix an invalid name.
 
-Named icon components (`TickIcon`, `GraphIcon`, etc) can be imported from the `@blueprintjs/icons` package.
+Named icon components (`Tick`, `Graph`, etc) can be imported from the `@blueprintjs/icons` package.
 
 This rule is disabled in the `blueprint-rules` config as it is most useful to ensure that the `@blueprintjs/icons` package can be tree-shaken (an opt-in process which requires using components and _never_ `IconName` literals).
 
@@ -137,32 +137,41 @@ This rule is disabled in the `blueprint-rules` config as it is most useful to en
 
 ### `@blueprintjs/no-deprecated-components`
 
-Ban usage of deprecated Blueprint components, including:
+Ban usage of deprecated components in the current major version of all Blueprint packages, including:
 
--   AbstractComponent
--   AbstractPureComponent
 -   Breadcrumbs
--   CollapsibleList
+-   ContextMenu2
 -   DateInput
+-   DateInput2
+-   DatePicker
 -   DateRangeInput
--   DateTimePicker
--   MenuItem
--   MultiSelect
--   PanelStack
--   Popover
--   Select
--   Suggest
--   TimezonePicker
--   Tooltip
+-   DateRangeInput2
+-   DateRangePicker
+-   MenuItem2
+-   Popover2
+-   ResizeSensor2
+-   Tooltip2
 
-**Rationale**: Many Blueprint components have "V2" variants as a part of their natural API evolution.
-Blueprint consumers are recommended to migrate from the deprecated V1 components to their newer V2 counterparts
-in order to future-proof their code for the next major version of Blueprint, where the V2 components will become the
-only available API and the V1 variants will be removed. Flagging usage of deprecated APIs can be done with other
-ESLint rules like `deprecation/deprecation`, but that rule is often too broad to enable as an "error" globally across
-a large code base. `@blueprintjs/no-deprecated-components` provides a simpler, more scoped rule which only flags
-usage of deprecated Blueprint components in JSX. The idea here is that you can enable this rule as an "error" in ESLint
-to prevent any backwards progress in your Blueprint migration as you move from V1 -> V2 APIs in preparation for v5.0.
+**Rationale**: There are two reasons why a particular component may be deprecated:
+
+1.  Many Blueprint components have next-generation variants as a part of their natural API evolution. Blueprint
+    consumers are recommended to migrate from the deprecated "V1" components to their newer V2 counterparts
+    in order to future-proof their code for the next major version of Blueprint, where the V2 components will become
+    the only available API and the "V1" variants will be removed. Flagging usage of deprecated APIs can be done with
+    other ESLint rules like `deprecation/deprecation`, but that rule is often too broad to enable as an "error"
+    globally across a large code base. `@blueprintjs/no-deprecated-components` provides a simpler, more scoped rule
+    which only flags usage of deprecated Blueprint components in JSX syntax. The idea here is that you can enable this
+    rule as an "error" in ESLint to prevent any backwards progress in your Blueprint migration as you migrate to newer
+    APIs in preparation for the next major version.
+
+2.  When a next-generation component API (designated as "V2" or "V3") is "promoted" to the standard "V1" API in a
+    major version of Blueprint, we keep around aliases for the "V2" names which referred to that same API in the
+    _previous_ major version. These names are immediately marked as `/** @deprecated */` and you are encouraged to
+    migrate to their corresponding "V1" symbols after a major upgrade. For example,
+    `{ Popover2 } from "@blueprintjs/popover2"` is the recommended popover API in Blueprint v4.x, but it is deprecated
+    in Blueprint v5.x. If you continue to use `Popover2` in v5.x, you will get a lint error suggesting a rename
+    migration to `{ Popover } from "@blueprintjs/core"`. Since these symbols are aliases for each other in v5.x, there
+    should be no runtime impact from this kind of migration.
 
 ### `@blueprintjs/no-deprecated-core-components`
 
@@ -192,6 +201,16 @@ Similar to `@blueprintjs/no-deprecated-components`, but only flags usage of depr
 **Rationale**: In migrations of large code bases, it may be useful to apply more granular rule configuration of
 "no-deprecated-components" to make incremental progress towards the newer APIs. This allows you, for example, to flag
 deprecated `@blueprintjs/datetime2` component usage as errors while allowing deprecated components from other packages
+to pass as lint warnings.
+
+### `@blueprintjs/no-deprecated-popover2-components`
+
+Similar to `@blueprintjs/no-deprecated-components`, but only flags usage of deprecated components from the
+`@blueprintjs/popover2` package instead of all `@blueprintjs/` packages.
+
+**Rationale**: In migrations of large code bases, it may be useful to apply more granular rule configuration of
+"no-deprecated-components" to make incremental progress towards the newer APIs. This allows you, for example, to flag
+deprecated `@blueprintjs/popover2` component usage as errors while allowing deprecated components from other packages
 to pass as lint warnings.
 
 ### `@blueprintjs/no-deprecated-select-components`

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -139,7 +139,7 @@ This rule is disabled in the `blueprint-rules` config as it is most useful to en
 
 Ban usage of deprecated components in the current major version of all Blueprint packages, including:
 
--   Breadcrumbs
+-   Breadcrumbs2
 -   ContextMenu2
 -   DateInput
 -   DateInput2

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/index.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/index.ts
@@ -6,5 +6,6 @@ export * from "./no-deprecated-components";
 export * from "./no-deprecated-core-components";
 export * from "./no-deprecated-datetime-components";
 export * from "./no-deprecated-datetime2-components";
+export * from "./no-deprecated-popover2-components";
 export * from "./no-deprecated-select-components";
 export * from "./no-deprecated-table-components";

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-components.ts
@@ -8,14 +8,17 @@ import { createNoDeprecatedComponentsRule } from "./createNoDeprecatedComponents
 import { coreComponentsMigrationMapping } from "./no-deprecated-core-components";
 import { datetimeComponentsMigrationMapping } from "./no-deprecated-datetime-components";
 import { datetime2ComponentsMigrationMapping } from "./no-deprecated-datetime2-components";
+import { popover2ComponentsMigrationMapping } from "./no-deprecated-popover2-components";
 import { selectComponentsMigrationMapping } from "./no-deprecated-select-components";
 import { tableComponentsMigrationMapping } from "./no-deprecated-table-components";
 
 /**
- * This rule checks a hardcoded list of components that Blueprint is actively migrating to a newer version (e.g. v1 -> v2)
- * If deprecated versions (v1) are detected, it will recommend using the replacement component (e.g. the v2) instead.
- * Note that this does not rely on the \@deprecated JSDoc annotation, and is thus distinct/very different from the
- * deprecated/deprecated ESLint rule
+ * This rule checks target source code against a static list of deprecated React components.
+ * If deprecated versions are detected, it will recommend using the replacement component instead
+ * (for example, "v1" API -> "v2" API).
+ *
+ * Note that this implementation does not rely on the \@deprecated JSDoc annotation, and is thus distinct
+ * from the 'deprecated/deprecated' ESLint rule.
  */
 export const noDeprecatedComponentsRule: TSESLint.RuleModule<string, unknown[]> = createNoDeprecatedComponentsRule(
     "no-deprecated-components",
@@ -23,6 +26,7 @@ export const noDeprecatedComponentsRule: TSESLint.RuleModule<string, unknown[]> 
         "@blueprintjs/core",
         "@blueprintjs/datetime",
         "@blueprintjs/datetime2",
+        "@blueprintjs/popover2",
         "@blueprintjs/select",
         "@blueprintjs/table",
     ],
@@ -30,6 +34,7 @@ export const noDeprecatedComponentsRule: TSESLint.RuleModule<string, unknown[]> 
         ...coreComponentsMigrationMapping,
         ...datetimeComponentsMigrationMapping,
         ...datetime2ComponentsMigrationMapping,
+        ...popover2ComponentsMigrationMapping,
         ...selectComponentsMigrationMapping,
         ...tableComponentsMigrationMapping,
     },

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-popover2-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-popover2-components.ts
@@ -1,0 +1,28 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { TSESLint } from "@typescript-eslint/utils";
+
+import { createNoDeprecatedComponentsRule, type DeprecatedComponentsConfig } from "./createNoDeprecatedComponentsRule";
+
+export const popover2ComponentsMigrationMapping: DeprecatedComponentsConfig = {
+    Breadcrumbs2: ["Breadcrumbs", "@blueprintjs/core"],
+    ContextMenu2: ["ContextMenu", "@blueprintjs/core"],
+    MenuItem2: ["MenuItem", "@blueprintjs/core"],
+    Popover2: ["Popover", "@blueprintjs/core"],
+    ResizeSensor2: ["ResizeSensor", "@blueprintjs/core"],
+    Tooltip2: ["Tooltip", "@blueprintjs/core"],
+};
+
+/**
+ * This rule is similar to "@blueprintjs/no-deprecated-components", but it only checks for usage
+ * of deprecated components from @blueprintjs/popover2. This is useful for incremental migration to
+ * newer Blueprint APIs.
+ */
+export const noDeprecatedPopover2ComponentsRule: TSESLint.RuleModule<string, unknown[]> =
+    createNoDeprecatedComponentsRule(
+        "no-deprecated-popover2-components",
+        ["@blueprintjs/popover2"],
+        popover2ComponentsMigrationMapping,
+    );

--- a/packages/eslint-plugin/test/no-deprecated-popover2-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-popover2-components.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tslint:disable object-literal-sort-keys
+/* eslint-disable no-template-curly-in-string */
+
+import { RuleTester } from "@typescript-eslint/rule-tester";
+import dedent from "dedent";
+
+import { noDeprecatedPopover2ComponentsRule } from "../src/rules/no-deprecated-components";
+
+const ruleTester = new RuleTester({
+    parser: require.resolve("@typescript-eslint/parser"),
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true,
+        },
+        sourceType: "module",
+    },
+});
+
+ruleTester.run("no-deprecated-popover2-components", noDeprecatedPopover2ComponentsRule, {
+    invalid: [
+        {
+            code: dedent`
+                import { Popover2 } from "@blueprintjs/popover2";
+
+                return <Popover2 />;
+            `,
+            errors: [
+                {
+                    messageId: "migrationToNewPackage",
+                    data: {
+                        deprecatedComponentName: "Popover2",
+                        newComponentName: "Popover",
+                        newPackageName: "@blueprintjs/core",
+                    },
+                },
+            ],
+        },
+    ],
+    valid: [
+        {
+            code: dedent`
+                import { Popover } from "@blueprintjs/core";
+
+                return <Popover />;
+            `,
+        },
+    ],
+});


### PR DESCRIPTION

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- (internal) feat: implement additional configuration syntax for "no-deprecated-*-components" rule implementations so that we can include target package names in deprecation messages, for example: `"Usage of Popover2 is deprecated, migrate to Popover from '@blueprintjs/core' instead"`
- [eslint-plugin] feat: new lint rule `no-deprecated-popover2-components`
- [eslint-plugin] break(`no-deprecated-components`): check usage of deprecated components from `@blueprintjs/popover2@2.x`

#### Reviewers should focus on:

- New config syntax
- Test cases
- No regressions

#### Screenshot

N/A
