### PR TITLE
[eslint-plugin] feat(no-deprecated-select-components): lint V2 APIs

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -148,8 +148,11 @@ Ban usage of deprecated components in the current major version of all Blueprint
 -   DateRangeInput2
 -   DateRangePicker
 -   MenuItem2
+-   MultiSelect2
 -   Popover2
 -   ResizeSensor2
+-   Select2
+-   Suggest2
 -   Tooltip2
 
 **Rationale**: There are two reasons why a particular component may be deprecated:

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-select-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-select-components.ts
@@ -4,10 +4,13 @@
 
 import type { TSESLint } from "@typescript-eslint/utils";
 
-import { createNoDeprecatedComponentsRule } from "./createNoDeprecatedComponentsRule";
+import { createNoDeprecatedComponentsRule, type DeprecatedComponentsConfig } from "./createNoDeprecatedComponentsRule";
 
-export const selectComponentsMigrationMapping = {
-    // nothing, for now
+export const selectComponentsMigrationMapping: DeprecatedComponentsConfig = {
+    // listed in packages/select/src/components/deprecatedAliases.ts
+    MultiSelect2: "MultiSelect",
+    Select2: "Select",
+    Suggest2: "Suggest",
 };
 
 /**

--- a/packages/eslint-plugin/test/no-deprecated-select-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-select-components.test.ts
@@ -35,8 +35,32 @@ const ruleTester = new RuleTester({
 ruleTester.run("no-deprecated-select-components", noDeprecatedSelectComponentsRule, {
     // N.B. most other deprecated components are tested by no-deprecated-components.test.ts, this suite just tests
     // for more specific violations which involve certain syntax
-    invalid: [],
+    invalid: [
+        {
+            code: dedent`
+                import { Select2 } from "@blueprintjs/select";
+
+                return <Select2<string> />;
+            `,
+            errors: [
+                {
+                    messageId: "migration",
+                    data: {
+                        deprecatedComponentName: "Select2",
+                        newComponentName: "Select",
+                    },
+                },
+            ],
+        },
+    ],
     valid: [
+        {
+            code: dedent`
+                import { Select } from "@blueprintjs/select";
+
+                return <Select<string> />;
+            `,
+        },
         {
             code: dedent`
                 import { MultiSelect } from "@blueprintjs/select";


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Following up on #6474:

feat(`no-deprecated-select-components`): check usage of `MultiSelect2`, `Select2`, and `Suggest2` components

⚠️ break(`no-deprecated-components`): check usage of deprecated components from `@blueprintjs/select@5.x`

#### Reviewers should focus on:

- Test cases
- No regressions

#### Screenshot

N/A
