### PR TITLE
Upgrade to TypeScript v5.2

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,16 +1,11 @@
 {
-    "version": "4.5.4",
+    "version": "5.2.2",
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
         "declaration": true,
         "esModuleInterop": true,
         "experimentalDecorators": true,
         "importHelpers": true,
-        "importsNotUsedAsValues": "error",
-        "jsx": "react",
-        "lib": ["dom", "dom.iterable", "es5", "es2015.collection", "es2015.iterable"],
-        "module": "es2020",
-        "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
@@ -21,7 +16,7 @@
         "sourceMap": true,
         "strict": true,
         "stripInternal": true,
-        "target": "es5",
-        "typeRoots": ["../node_modules/@types"]
+        "typeRoots": ["../node_modules/@types"],
+        "verbatimModuleSyntax": true
     }
 }

--- a/config/tsconfig.node.json
+++ b/config/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.base",
+    "compilerOptions": {
+        "forceConsistentCasingInFileNames": true,
+        "lib": ["ES2015"],
+        "module": "node16",
+        "moduleResolution": "node16",
+        "target": "ES2015",
+        "verbatimModuleSyntax": false
+    }
+}

--- a/config/tsconfig.web.json
+++ b/config/tsconfig.web.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.base",
+    "compilerOptions": {
+        "jsx": "react",
+        "lib": ["dom", "dom.iterable", "es5", "es2015.collection", "es2015.iterable"],
+        "module": "es2020",
+        "moduleResolution": "node",
+        "target": "es5"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "sinon": "^16.1.0",
         "stylelint-config-palantir": "^6.0.1",
         "stylelint-scss": "^5.2.1",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "yargs": "^17.7.2",
         "yarn-deduplicate": "^6.0.2"
     },

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -14,7 +14,7 @@
         "clean": "rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "compile:css-colors": "generate-css-variables --retainDefault true --outputFileName colors _colors.scss",
@@ -26,12 +26,12 @@
         "verify": "npm-run-all compile -p dist lint"
     },
     "dependencies": {
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.4",
         "mocha": "^10.2.0",
-        "typescript": "~4.9.5"
+        "typescript": "~5.2.2"
     },
     "repository": {
         "type": "git",

--- a/packages/colors/src/tsconfig.json
+++ b/packages/colors/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -56,7 +56,7 @@
         "normalize.css": "^8.0.1",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -80,7 +80,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -4,7 +4,6 @@
         "declaration": false,
         "downlevelIteration": true,
         "lib": ["dom", "dom.iterable", "es5", "es2015.collection", "es2015.iterable", "es2015.promise"],
-        "module": "commonjs",
         "noEmit": true
     }
 }

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -20,7 +20,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -48,7 +48,7 @@
         "date-fns-tz": "^2.0.0",
         "lodash": "^4.17.21",
         "react-day-picker": "7.4.9",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17",
@@ -73,7 +73,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/datetime/src/tsconfig.json
+++ b/packages/datetime/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm",
         "strictNullChecks": false

--- a/packages/datetime/test/tsconfig.json
+++ b/packages/datetime/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../src/tsconfig",
     "compilerOptions": {
         "declaration": false,
-        "module": "commonjs",
         "noEmit": true
     }
 }

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -18,7 +18,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -42,7 +42,7 @@
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "react-day-picker": "^8.5.1",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -66,7 +66,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/datetime2/src/tsconfig.json
+++ b/packages/datetime2/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "module": "es2020",
         "outDir": "../lib/esm"

--- a/packages/datetime2/test/tsconfig.json
+++ b/packages/datetime2/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../src/tsconfig",
     "compilerOptions": {
         "declaration": false,
-        "module": "commonjs",
         "noEmit": true
     }
 }

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -29,7 +29,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-transition-group": "^4.4.5",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.4",

--- a/packages/demo-app/src/tsconfig.json
+++ b/packages/demo-app/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base.json",
+    "extends": "../../../config/tsconfig.web.json",
     "compilerOptions": {
         "declaration": false,
         "lib": ["dom", "es5", "es6"],

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -27,7 +27,7 @@
         "@blueprintjs/select": "^5.0.16",
         "@blueprintjs/table": "^5.0.16",
         "@blueprintjs/test-commons": "^2.1.2",
-        "@documentalist/client": "^4.0.0",
+        "@documentalist/client": "^5.0.0",
         "chroma-js": "^2.4.2",
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -41,7 +41,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-transition-group": "^4.4.5",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.4",

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { type IHeadingNode, type IPageData, isPageNode, type ITsDocBase } from "@documentalist/client";
+import { type HeadingNode, isPageNode, type PageData, type TsDocBase } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -45,7 +45,7 @@ const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
 const CONTEXT_PATTERN = /\/context(\.[\w-]+)?$/;
 const HOOKS_PATTERN = /\/hooks(\.[\w-]+)?$/;
 const LEGACY_PATTERN = /\/legacy(\.[\w-]+)?$/;
-const isNavSection = ({ route }: IHeadingNode) =>
+const isNavSection = ({ route }: HeadingNode) =>
     COMPONENTS_PATTERN.test(route) ||
     CONTEXT_PATTERN.test(route) ||
     HOOKS_PATTERN.test(route) ||
@@ -94,7 +94,7 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
                 onToggleDark={this.handleToggleDark}
                 useDarkTheme={this.state.themeName === DARK_THEME}
                 useNextVersion={this.props.useNextVersion}
-                packageData={this.getNpmPackage("@blueprintjs/core")}
+                packageInfo={this.getNpmPackage("@blueprintjs/core")}
             />
         );
         return (
@@ -140,7 +140,7 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
         return <NavMenuItem {...props} />;
     };
 
-    private renderPageActions = (page: IPageData) => {
+    private renderPageActions = (page: PageData) => {
         return (
             <AnchorButton
                 href={`${GITHUB_SOURCE_URL}/${page.sourcePath}`}
@@ -178,7 +178,7 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
         );
     }
 
-    private renderViewSourceLinkText = (entry: ITsDocBase) => {
+    private renderViewSourceLinkText = (entry: TsDocBase) => {
         return `@blueprintjs/${entry.fileName.split("/", 2)[1]}`;
     };
 

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { INpmPackage } from "@documentalist/client";
+import type { NpmPackageInfo } from "@documentalist/client";
 import * as React from "react";
 
 import { Classes, HotkeysTarget2, type Intent, Menu, MenuItem, NavbarHeading, Popover, Tag } from "@blueprintjs/core";
@@ -26,7 +26,7 @@ export interface NavHeaderProps {
     onToggleDark: (useDark: boolean) => void;
     useDarkTheme: boolean;
     useNextVersion: boolean;
-    packageData: INpmPackage;
+    packageInfo: NpmPackageInfo;
 }
 
 export class NavHeader extends React.PureComponent<NavHeaderProps> {
@@ -75,7 +75,7 @@ export class NavHeader extends React.PureComponent<NavHeaderProps> {
 
     private renderVersionsMenu() {
         const { useNextVersion } = this.props;
-        const { version, nextVersion, versions } = this.props.packageData;
+        const { version, nextVersion, versions } = this.props.packageInfo;
         if (versions.length === 1) {
             return <div className={Classes.TEXT_MUTED}>v{versions[0]}</div>;
         }

--- a/packages/docs-app/src/tsconfig.json
+++ b/packages/docs-app/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base.json",
+    "extends": "../../../config/tsconfig.web.json",
     "compilerOptions": {
         "declaration": false,
         "lib": ["dom", "es5", "es6"],

--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -16,6 +16,17 @@ import { Classes } from "@blueprintjs/core";
 
 import { markedRenderer } from "./markdownRenderer.mjs";
 
+/** Run Documentalist on Sass, TypeScript, and package.json files in these packages */
+const LIBRARY_PACKAGES = ["core", "datetime", "datetime2", "icons", "select", "table"];
+
+/** This package is expected to have the markdown "navPage" */
+const DOCS_PACKAGE = "docs-app";
+
+/** Run Documentalist on Markdown files in these packages */
+const LIBRARY_AND_DOCS_PACKAGES = [...LIBRARY_PACKAGES, DOCS_PACKAGE];
+
+console.info(`[docs-data] compiling documentation for library packages: ${LIBRARY_PACKAGES.join(", ")}`);
+
 // assume we are running from packages/docs-app
 const monorepoRootDir = resolve(cwd(), "../../");
 const generatedSrcDir = resolve(cwd(), "./src/generated");
@@ -58,7 +69,6 @@ async function generateDocumentalistData() {
             new TypescriptPlugin({
                 excludeNames: [/.+State$/],
                 excludePaths: ["node_modules/", "-app/", "test-commons/", "-build-scripts/", "test/"],
-                // tsconfigPath: resolve(monorepoRootDir, "./config/tsconfig.node.json"),
                 verbose: true,
             }),
         )
@@ -66,9 +76,10 @@ async function generateDocumentalistData() {
         .use("package.json", new NpmPlugin());
 
     const docs = await documentalist.documentGlobs(
-        "../*/src/**/*.{scss,md}",
-        "../*/src/index.{ts,tsx}",
-        "../*/package.json",
+        `../{${LIBRARY_AND_DOCS_PACKAGES.join(",")}}/src/**/*.md`,
+        `../{${LIBRARY_PACKAGES.join(",")}}/src/**/*.scss`,
+        `../{${LIBRARY_PACKAGES.join(",")}}/src/index.ts`,
+        `../{${LIBRARY_PACKAGES}}/package.json`,
     );
 
     const content = JSON.stringify(docs, transformDocumentalistData, 2);

--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -12,8 +12,6 @@ import { join, resolve } from "node:path";
 import { cwd } from "node:process";
 import semver from "semver";
 
-import { Classes } from "@blueprintjs/core";
-
 import { hooks, markedRenderer } from "./markdownRenderer.mjs";
 
 /** Run Documentalist on Sass, TypeScript, and package.json files in these packages */
@@ -107,18 +105,5 @@ function transformDocumentalistData(key, value) {
         // reverse the list so highest version is first (easier indexing)
         return Array.from(majors.values()).reverse();
     }
-    if (value != null) {
-        return interpolateClassNamespace(value);
-    }
     return undefined;
-}
-
-/**
- * If value is a string, replaces `#{$ns}` in that string with the actual Blueprint class namespace.
- * Otherwise, simply returns the value.
- *
- * @param {any} value
- */
-function interpolateClassNamespace(value) {
-    return typeof value === "string" ? value.replace(/#{\$ns}|@ns/g, Classes.getClassNamespace()) : value;
 }

--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -105,5 +105,5 @@ function transformDocumentalistData(key, value) {
         // reverse the list so highest version is first (easier indexing)
         return Array.from(majors.values()).reverse();
     }
-    return undefined;
+    return value;
 }

--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -56,9 +56,10 @@ async function generateDocumentalistData() {
         .use(
             /\.tsx?$/,
             new TypescriptPlugin({
-                excludeNames: [/I.+State$/],
-                excludePaths: ["node_modules/", "-app/", "test-commons/", "-build-scripts/"],
-                tsconfigPath: resolve(monorepoRootDir, "./config/tsconfig.node.json"),
+                excludeNames: [/.+State$/],
+                excludePaths: ["node_modules/", "-app/", "test-commons/", "-build-scripts/", "test/"],
+                // tsconfigPath: resolve(monorepoRootDir, "./config/tsconfig.node.json"),
+                verbose: true,
             }),
         )
         .use(".scss", new KssPlugin())

--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -58,7 +58,7 @@ async function generateDocumentalistData() {
             new TypescriptPlugin({
                 excludeNames: [/I.+State$/],
                 excludePaths: ["node_modules/", "-app/", "test-commons/", "-build-scripts/"],
-                tsconfigPath: resolve(monorepoRootDir, "./config/tsconfig.base.json"),
+                tsconfigPath: resolve(monorepoRootDir, "./config/tsconfig.node.json"),
             }),
         )
         .use(".scss", new KssPlugin())

--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -14,7 +14,7 @@ import semver from "semver";
 
 import { Classes } from "@blueprintjs/core";
 
-import { markedRenderer } from "./markdownRenderer.mjs";
+import { hooks, markedRenderer } from "./markdownRenderer.mjs";
 
 /** Run Documentalist on Sass, TypeScript, and package.json files in these packages */
 const LIBRARY_PACKAGES = ["core", "datetime", "datetime2", "icons", "select", "table"];
@@ -52,7 +52,10 @@ console.info(`[docs-data] successfully generated docs.json`);
  */
 async function generateDocumentalistData() {
     const documentalist = new Documentalist({
-        markdown: { renderer: markedRenderer },
+        markdown: {
+            renderer: markedRenderer,
+            hooks,
+        },
         sourceBaseDir: monorepoRootDir,
         // must mark our @Decorator APIs as reserved so we can use them in code samples
         reservedTags: ["import", "ContextMenuTarget", "HotkeysTarget", "param", "returns"],

--- a/packages/docs-data/markdownRenderer.mjs
+++ b/packages/docs-data/markdownRenderer.mjs
@@ -47,4 +47,13 @@ function renderMarkdown(textContent) {
     return marked(textContent, { renderer });
 }
 
-export { renderMarkdown, renderer as markedRenderer };
+const hooks = {
+    // HACKHACK: workaround for https://github.com/palantir/documentalist/issues/248
+    // We are getting inline code snippets wrapped by newlines, which breaks the markdown rendering of multiline JSDoc
+    // comments. We can work around this by removing the newlines. This should work for all practical cases since we
+    // don't expect any JSDoc comment line to simply have a `code` token as its only contents.
+    preprocess: md => md.replace(/\n(\`.*\`)\n/g, "$1"),
+    postprocess: html => html,
+};
+
+export { hooks, renderMarkdown, renderer as markedRenderer };

--- a/packages/docs-data/markdownRenderer.mjs
+++ b/packages/docs-data/markdownRenderer.mjs
@@ -49,10 +49,14 @@ function renderMarkdown(textContent) {
 
 const hooks = {
     // HACKHACK: workaround for https://github.com/palantir/documentalist/issues/248
-    // We are getting inline code snippets wrapped by newlines, which breaks the markdown rendering of multiline JSDoc
-    // comments. We can work around this by removing the newlines. This should work for all practical cases since we
-    // don't expect any JSDoc comment line to simply have a `code` token as its only contents.
-    preprocess: md => md.replace(/\n(\`.*\`)\n/g, "$1"),
+    // As of Documentalist v5.0.0 & TypeDoc v0.25, we are getting inline code snippets wrapped by newlines, which
+    // breaks the markdown rendering of multiline JSDoc comments. We can work around this by removing the newlines.
+    // This should work for all practical cases since we don't expect any JSDoc comment line to simply have a `code`
+    // token as its only contents. N.B. we must take care to avoid matching triple-backtick fenced code blocks (hence
+    // the negative look-ahead).
+    preprocess: md => {
+        return md.replace(/\n(\`(?!\`).*\`)\n/g, "$1");
+    },
     postprocess: html => html,
 };
 

--- a/packages/docs-data/markdownRenderer.mjs
+++ b/packages/docs-data/markdownRenderer.mjs
@@ -7,9 +7,8 @@
 import escapeHTML from "escape-html";
 import { marked } from "marked";
 
-// HACKHACK: class names copied from @blueprintjs/core and @blueprintjs/docs-theme to avoid taking a dependency
-// on those packages, which prevents us from parallelizing compilation of this package with the other libraries.
-const NS = "bp5";
+import { Classes } from "@blueprintjs/core";
+import { Classes as DocsClasses } from "@blueprintjs/docs-theme";
 
 /**
  * Markdown renderer with some custom logic to handle `<code>` tags.
@@ -37,7 +36,7 @@ renderer.code = (textContent, language, isEscaped) => {
             break;
     }
 
-    return `<pre class="${NS}-code-block ${NS}-docs-code-block" data-lang="${language}">${textContent}</pre>`;
+    return `<pre class="${Classes.CODE_BLOCK} ${DocsClasses.DOCS_CODE_BLOCK}" data-lang="${language}">${textContent}</pre>`;
 };
 
 /**
@@ -46,6 +45,8 @@ renderer.code = (textContent, language, isEscaped) => {
 function renderMarkdown(textContent) {
     return marked(textContent, { renderer });
 }
+
+const NS = Classes.getClassNamespace();
 
 const hooks = {
     /**

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -10,8 +10,6 @@
         "test": "exit 0"
     },
     "dependencies": {
-        "@blueprintjs/core": "^5.5.1",
-        "@blueprintjs/docs-theme": "^5.1.1",
         "@documentalist/compiler": "^5.0.0",
         "escape-html": "^1.0.3",
         "marked": "^9.1.2",

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -12,7 +12,7 @@
     "dependencies": {
         "@blueprintjs/core": "^5.5.1",
         "@blueprintjs/docs-theme": "^5.1.1",
-        "@documentalist/compiler": "^4.0.0",
+        "@documentalist/compiler": "^5.0.0",
         "escape-html": "^1.0.3",
         "marked": "^9.1.0",
         "semver": "^7.5.2"

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -14,11 +14,8 @@
         "@blueprintjs/docs-theme": "^5.1.1",
         "@documentalist/compiler": "^5.0.0",
         "escape-html": "^1.0.3",
-        "marked": "^9.1.0",
-        "semver": "^7.5.2"
-    },
-    "devDependencies": {
-        "@types/marked": "^4.0.8"
+        "marked": "^9.1.2",
+        "semver": "^7.5.4"
     },
     "repository": {
         "type": "git",

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -10,6 +10,8 @@
         "test": "exit 0"
     },
     "dependencies": {
+        "@blueprintjs/core": "^5.5.1",
+        "@blueprintjs/docs-theme": "^5.1.1",
         "@documentalist/compiler": "^5.0.0",
         "escape-html": "^1.0.3",
         "marked": "^9.1.2",

--- a/packages/docs-data/src/index.d.ts
+++ b/packages/docs-data/src/index.d.ts
@@ -2,14 +2,8 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-import {
-    INpmPluginData,
-    IMarkdownPluginData,
-    IKssExample,
-    IKssPluginData,
-    ITypescriptPluginData,
-} from "@documentalist/client";
+import { NpmPluginData, MarkdownPluginData, KssPluginData, TypescriptPluginData } from "@documentalist/client";
 
-export type DocsCompleteData = IMarkdownPluginData & INpmPluginData & IKssPluginData & ITypescriptPluginData;
+export type DocsCompleteData = MarkdownPluginData & NpmPluginData & KssPluginData & TypescriptPluginData;
 
 export const docsData: DocsCompleteData;

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -38,7 +38,7 @@
         "@blueprintjs/colors": "^5.0.4",
         "@blueprintjs/core": "^5.5.1",
         "@blueprintjs/select": "^5.0.16",
-        "@documentalist/client": "^4.0.0",
+        "@documentalist/client": "^5.0.0",
         "classnames": "^2.3.1",
         "fuzzaldrin-plus": "^0.6.0",
         "tslib": "~2.6.2"

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -20,7 +20,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -41,7 +41,7 @@
         "@documentalist/client": "^4.0.0",
         "classnames": "^2.3.1",
         "fuzzaldrin-plus": "^0.6.0",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -59,7 +59,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -15,33 +15,30 @@
  */
 
 import type {
-    IBlock,
-    IKssPluginData,
-    IMarkdownPluginData,
-    INpmPluginData,
-    ITsDocBase,
-    ITypescriptPluginData,
+    Block,
+    KssPluginData,
+    MarkdownPluginData,
+    NpmPluginData,
+    TsDocBase,
+    TypescriptPluginData,
 } from "@documentalist/client";
 import * as React from "react";
 
 /* eslint-disable @typescript-eslint/ban-types */
 /** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
-export type DocsData = IMarkdownPluginData &
-    (ITypescriptPluginData | {}) &
-    (IKssPluginData | {}) &
-    (INpmPluginData | {});
+export type DocsData = MarkdownPluginData & (TypescriptPluginData | {}) & (KssPluginData | {}) & (NpmPluginData | {});
 /* eslint-enable @typescript-eslint/ban-types */
 
-export function hasTypescriptData(docs: DocsData): docs is IMarkdownPluginData & ITypescriptPluginData {
-    return docs != null && (docs as ITypescriptPluginData).typescript != null;
+export function hasTypescriptData(docs: DocsData): docs is MarkdownPluginData & TypescriptPluginData {
+    return docs != null && (docs as TypescriptPluginData).typescript != null;
 }
 
-export function hasNpmData(docs: DocsData): docs is IMarkdownPluginData & INpmPluginData {
-    return docs != null && (docs as INpmPluginData).npm != null;
+export function hasNpmData(docs: DocsData): docs is MarkdownPluginData & NpmPluginData {
+    return docs != null && (docs as NpmPluginData).npm != null;
 }
 
-export function hasKssData(docs: DocsData): docs is IMarkdownPluginData & IKssPluginData {
-    return docs != null && (docs as IKssPluginData).css != null;
+export function hasKssData(docs: DocsData): docs is MarkdownPluginData & KssPluginData {
+    return docs != null && (docs as KssPluginData).css != null;
 }
 
 /**
@@ -56,13 +53,13 @@ export interface DocumentationContextApi {
     getDocsData: () => DocsData;
 
     /** Render a block of Documentalist documentation to a React node. */
-    renderBlock: (block: IBlock) => React.ReactNode;
+    renderBlock: (block: Block) => React.ReactNode;
 
     /** Render a Documentalist Typescript type string to a React node. */
     renderType: (type: string) => React.ReactNode;
 
     /** Render the text of a "View source" link. */
-    renderViewSourceLinkText: (entry: ITsDocBase) => React.ReactNode;
+    renderViewSourceLinkText: (entry: TsDocBase) => React.ReactNode;
 
     /** Open the API browser to the given member name. */
     showApiDocs: (name: string) => void;
@@ -70,8 +67,8 @@ export interface DocumentationContextApi {
 
 export const DocumentationContext = React.createContext<DocumentationContextApi>({
     getDocsData: () => ({}) as DocsData,
-    renderBlock: (_block: IBlock) => undefined,
+    renderBlock: (_block: Block) => undefined,
     renderType: (type: string) => type,
-    renderViewSourceLinkText: (entry: ITsDocBase) => entry.sourceUrl,
+    renderViewSourceLinkText: (entry: TsDocBase) => entry.sourceUrl,
     showApiDocs: () => void 0,
 });

--- a/packages/docs-theme/src/common/documentalistUtils.ts
+++ b/packages/docs-theme/src/common/documentalistUtils.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { type IHeadingNode, type IPageNode, isPageNode } from "@documentalist/client";
+import { type HeadingNode, isPageNode, type PageNode } from "@documentalist/client";
 
 /**
  * Performs an in-order traversal of the layout tree, invoking the callback for each node.
  * Callback receives an array of ancestors with direct parent first in the list.
  */
 export function eachLayoutNode(
-    layout: Array<IHeadingNode | IPageNode>,
-    callback: (node: IHeadingNode | IPageNode, parents: IPageNode[]) => void,
-    parents: IPageNode[] = [],
+    layout: Array<HeadingNode | PageNode>,
+    callback: (node: HeadingNode | PageNode, parents: PageNode[]) => void,
+    parents: PageNode[] = [],
 ) {
     layout.forEach(node => {
         callback(node, parents);

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IBlock } from "@documentalist/client";
+import type { Block } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -24,7 +24,7 @@ import type { TagRendererMap } from "../tags";
 
 export function renderBlock(
     /** the block to render */
-    block: IBlock | undefined,
+    block: Block | undefined,
     /** known tag renderers */
     tagRenderers: TagRendererMap,
     /** class names to apply to element wrapping string content. */

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -15,12 +15,12 @@
  */
 
 import {
-    type IHeadingNode,
-    type IPageData,
-    type IPageNode,
+    type HeadingNode,
     isPageNode,
-    type ITsDocBase,
     linkify,
+    type PageData,
+    type PageNode,
+    type TsDocBase,
 } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
@@ -81,7 +81,7 @@ export interface DocumentationProps extends Props {
      * searchable in the navigator. Returning `true` will exclude the item from
      * the navigator search results.
      */
-    navigatorExclude?: (node: IPageNode | IHeadingNode) => boolean;
+    navigatorExclude?: (node: PageNode | HeadingNode) => boolean;
 
     /**
      * Callback invoked whenever the component props or state change (specifically,
@@ -96,7 +96,7 @@ export interface DocumentationProps extends Props {
      *
      * @default "View source"
      */
-    renderViewSourceLinkText?: (entry: ITsDocBase) => React.ReactNode;
+    renderViewSourceLinkText?: (entry: TsDocBase) => React.ReactNode;
 
     /**
      * Callback invoked to render the clickable nav menu items. (Nested menu structure is handled by the library.)
@@ -108,7 +108,7 @@ export interface DocumentationProps extends Props {
      * Callback invoked to render actions for a documentation page.
      * Actions appear in an element in the upper-right corner of the page.
      */
-    renderPageActions?: (page: IPageData) => React.ReactNode;
+    renderPageActions?: (page: PageData) => React.ReactNode;
 
     /**
      * HTML element to use as the scroll parent. By default `document.documentElement` is assumed to be the scroll container.

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -288,9 +288,10 @@ export class Documentation extends React.PureComponent<DocumentationProps, Docum
             getDocsData: () => docs,
             renderBlock: block => renderBlock(block, this.props.tagRenderers),
             renderType: hasTypescriptData(docs)
-                ? type =>
-                      linkify(type, docs.typescript, (name, _d, idx) => <ApiLink key={`${name}-${idx}`} name={name} />)
-                : type => type,
+                ? omitEmptyTypeParamsList(type =>
+                      linkify(type, docs.typescript, (name, _d, idx) => <ApiLink key={`${name}-${idx}`} name={name} />),
+                  )
+                : omitEmptyTypeParamsList(type => type),
             renderViewSourceLinkText: renderViewSourceLinkText ?? (() => "View source"),
             showApiDocs: this.handleApiBrowserOpen,
         };
@@ -414,4 +415,13 @@ function scrollToReference(reference: string, scrollContainer: HTMLElement = doc
             scrollContainer.scrollTop = scrollOffset;
         }
     });
+}
+
+type TypeRenderer = (type: string) => React.ReactNode;
+
+/**
+ * HACKHACK: workaround for https://github.com/palantir/documentalist/issues/246
+ */
+function omitEmptyTypeParamsList(typeRenderer: TypeRenderer): TypeRenderer {
+    return (type: string) => typeRenderer(type.replace("<>", ""));
 }

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { type IHeadingNode, type IPageNode, isPageNode } from "@documentalist/client";
+import { type HeadingNode, isPageNode, type PageNode } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -28,7 +28,7 @@ export interface NavMenuProps extends Props {
     activeSectionId: string;
     level: number;
     onItemClick: (reference: string) => void;
-    items: Array<IPageNode | IHeadingNode>;
+    items: Array<PageNode | HeadingNode>;
     renderNavMenuItem?: (props: NavMenuItemProps) => JSX.Element;
 }
 

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IHeadingNode, IPageNode } from "@documentalist/client";
+import type { HeadingNode, PageNode } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -41,7 +41,7 @@ export interface NavMenuItemProps {
     onClick: () => void;
 
     /** The section for this menu item, either a page or a heading node. */
-    section: IPageNode | IHeadingNode;
+    section: PageNode | HeadingNode;
 }
 
 export const NavMenuItem: React.FunctionComponent<NavMenuItemProps> = props => {

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IHeadingNode, IPageNode } from "@documentalist/client";
+import type { HeadingNode, PageNode } from "@documentalist/client";
 import { filter } from "fuzzaldrin-plus";
 import * as React from "react";
 
@@ -29,10 +29,10 @@ export interface NavigatorProps {
     isOpen: boolean;
 
     /** All potentially navigable items. */
-    items: Array<IPageNode | IHeadingNode>;
+    items: Array<PageNode | HeadingNode>;
 
     /** Callback to determine if a given item should be excluded. */
-    itemExclude?: (node: IPageNode | IHeadingNode) => boolean;
+    itemExclude?: (node: PageNode | HeadingNode) => boolean;
 
     /**
      * Callback invoked when the navigator is closed. Navigation is performed by

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IPageData } from "@documentalist/client";
+import type { PageData } from "@documentalist/client";
 import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
@@ -23,8 +23,8 @@ import type { TagRendererMap } from "../tags";
 import { renderBlock } from "./block";
 
 export interface PageProps {
-    page: IPageData;
-    renderActions?: (page: IPageData) => React.ReactNode;
+    page: PageData;
+    renderActions?: (page: PageData) => React.ReactNode;
     tagRenderers: TagRendererMap;
 }
 

--- a/packages/docs-theme/src/components/typescript/apiHeader.tsx
+++ b/packages/docs-theme/src/components/typescript/apiHeader.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { isTsClass, isTsInterface, type ITsDocBase } from "@documentalist/client";
+import { isTsClass, isTsInterface, type TsDocBase } from "@documentalist/client";
 import * as React from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
 import { DocumentationContext } from "../../common/context";
 
-interface ApiHeaderProps extends ITsDocBase {
+interface ApiHeaderProps extends TsDocBase {
     children?: React.ReactNode;
 }
 

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ITsEnum, ITsEnumMember } from "@documentalist/client";
+import type { TsEnum, TsEnumMember } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -29,14 +29,14 @@ import { DeprecatedTag } from "./deprecatedTag";
 export type Renderer<T> = (props: T) => React.ReactNode;
 
 export interface EnumTableProps extends Props {
-    data: ITsEnum;
+    data: TsEnum;
 }
 
 export const EnumTable: React.FC<EnumTableProps> = props => {
     const { renderBlock } = React.useContext(DocumentationContext);
 
     const renderPropRow = React.useCallback(
-        (entry: ITsEnumMember) => {
+        (entry: TsEnumMember) => {
             const { flags, name } = entry;
 
             const classes = classNames("docs-prop-name", {

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -26,8 +26,6 @@ import { ModifierTable } from "../modifierTable";
 import { ApiHeader } from "./apiHeader";
 import { DeprecatedTag } from "./deprecatedTag";
 
-export type Renderer<T> = (props: T) => React.ReactNode;
-
 export interface EnumTableProps extends Props {
     data: TsEnum;
 }

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -17,11 +17,11 @@
 import {
     isTag,
     isTsProperty,
-    type ITsClass,
-    type ITsInterface,
-    type ITsMethod,
-    type ITsProperty,
-    type ITsSignature,
+    type TsClass,
+    type TsInterface,
+    type TsMethod,
+    type TsProperty,
+    type TsSignature,
 } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
@@ -37,7 +37,7 @@ import { DeprecatedTag } from "./deprecatedTag";
 export type Renderer<T> = (props: T) => React.ReactNode;
 
 export interface InterfaceTableProps extends Props {
-    data: ITsClass | ITsInterface;
+    data: TsClass | TsInterface;
     title: string;
 }
 
@@ -47,7 +47,7 @@ export interface InterfaceTableProps extends Props {
 export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data, title }) => {
     const { renderBlock, renderType } = React.useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback((entry: ITsProperty | ITsMethod) => {
+    const renderPropRow = React.useCallback((entry: TsProperty | TsMethod) => {
         const { flags, name, inheritedFrom } = entry;
         const { documentation } = isTsProperty(entry) ? entry : entry.signatures[0]!;
 
@@ -99,7 +99,7 @@ export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data,
         );
     }, []);
 
-    const renderIndexSignature = React.useCallback((entry?: ITsSignature) => {
+    const renderIndexSignature = React.useCallback((entry?: TsSignature) => {
         if (entry == null) {
             return null;
         }

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -34,8 +34,6 @@ import { ModifierTable } from "../modifierTable";
 import { ApiHeader } from "./apiHeader";
 import { DeprecatedTag } from "./deprecatedTag";
 
-export type Renderer<T> = (props: T) => React.ReactNode;
-
 export interface InterfaceTableProps extends Props {
     data: TsClass | TsInterface;
     title: string;
@@ -47,77 +45,83 @@ export interface InterfaceTableProps extends Props {
 export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data, title }) => {
     const { renderBlock, renderType } = React.useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback((entry: TsProperty | TsMethod) => {
-        const { flags, name, inheritedFrom } = entry;
-        const { documentation } = isTsProperty(entry) ? entry : entry.signatures[0]!;
+    const renderPropRow = React.useCallback(
+        (entry: TsProperty | TsMethod) => {
+            const { flags, name, inheritedFrom } = entry;
+            const { documentation } = isTsProperty(entry) ? entry : entry.signatures[0]!;
 
-        // ignore props marked with `@internal` tag (this tag is in contents instead of in flags)
-        if (
-            documentation != null &&
-            documentation.contents != null &&
-            documentation.contents.some(val => isTag(val) && val.tag === "internal")
-        ) {
-            return null;
-        }
+            // ignore props marked with `@internal` tag (this tag is in contents instead of in flags)
+            if (
+                documentation != null &&
+                documentation.contents != null &&
+                documentation.contents.some(val => isTag(val) && val.tag === "internal")
+            ) {
+                return null;
+            }
 
-        const classes = classNames("docs-prop-name", {
-            "docs-prop-is-deprecated": flags?.isDeprecated === true || typeof flags?.isDeprecated === "string",
-            "docs-prop-is-internal": !flags?.isExternal,
-            "docs-prop-is-required": !flags?.isOptional,
-        });
+            const classes = classNames("docs-prop-name", {
+                "docs-prop-is-deprecated": flags?.isDeprecated === true || typeof flags?.isDeprecated === "string",
+                "docs-prop-is-internal": !flags?.isExternal,
+                "docs-prop-is-required": !flags?.isOptional,
+            });
 
-        const typeInfo = isTsProperty(entry) ? (
-            <>
-                <strong>{renderType(entry.type)}</strong>
-                <em className={classNames("docs-prop-default", Classes.TEXT_MUTED)}>{entry.defaultValue}</em>
-            </>
-        ) : (
-            <>
-                <strong>{renderType(entry.signatures[0]!.type)}</strong>
-            </>
-        );
+            const typeInfo = isTsProperty(entry) ? (
+                <>
+                    <strong>{renderType(entry.type)}</strong>
+                    <em className={classNames("docs-prop-default", Classes.TEXT_MUTED)}>{entry.defaultValue}</em>
+                </>
+            ) : (
+                <>
+                    <strong>{renderType(entry.signatures[0]!.type)}</strong>
+                </>
+            );
 
-        return (
-            <tr key={name}>
-                <td className={classes}>
-                    <code>{name}</code>
-                </td>
-                <td className="docs-prop-details">
-                    <code className="docs-prop-type">{typeInfo}</code>
-                    <div className="docs-prop-description">{documentation && renderBlock(documentation)}</div>
-                    <div className="docs-prop-tags">
-                        {!flags?.isOptional && <Tag children="Required" intent={Intent.SUCCESS} minimal={true} />}
-                        <DeprecatedTag isDeprecated={flags?.isDeprecated} />
-                        {inheritedFrom && (
-                            <Tag minimal={true}>
-                                Inherited from <code>{renderType(inheritedFrom)}</code>
-                            </Tag>
-                        )}
-                    </div>
-                </td>
-            </tr>
-        );
-    }, []);
+            return (
+                <tr key={name}>
+                    <td className={classes}>
+                        <code>{name}</code>
+                    </td>
+                    <td className="docs-prop-details">
+                        <code className="docs-prop-type">{typeInfo}</code>
+                        <div className="docs-prop-description">{documentation && renderBlock(documentation)}</div>
+                        <div className="docs-prop-tags">
+                            {!flags?.isOptional && <Tag children="Required" intent={Intent.SUCCESS} minimal={true} />}
+                            <DeprecatedTag isDeprecated={flags?.isDeprecated} />
+                            {inheritedFrom && (
+                                <Tag minimal={true}>
+                                    Inherited from <code>{renderType(inheritedFrom)}</code>
+                                </Tag>
+                            )}
+                        </div>
+                    </td>
+                </tr>
+            );
+        },
+        [renderBlock, renderType],
+    );
 
-    const renderIndexSignature = React.useCallback((entry?: TsSignature) => {
-        if (entry == null) {
-            return null;
-        }
-        // HACKHACK: Documentalist's indexSignature support isn't _great_, but it's certainly _good enough_
-        // entry.type looks like "{ [name: string]: (date: Date) => boolean }"
-        const [signature, returnType] = entry.type.slice(2, -2).split("]: ");
-        return (
-            <tr key={entry.name}>
-                <td className="docs-prop-name">
-                    <code>{renderType(signature!)}]</code>
-                </td>
-                <td className="docs-prop-details">
-                    <code className="docs-prop-type">{renderType(returnType!)}</code>
-                    <div className="docs-prop-description">{renderBlock(entry.documentation!)}</div>
-                </td>
-            </tr>
-        );
-    }, []);
+    const renderIndexSignature = React.useCallback(
+        (entry?: TsSignature) => {
+            if (entry == null) {
+                return null;
+            }
+            // HACKHACK: Documentalist's indexSignature support isn't _great_, but it's certainly _good enough_
+            // entry.type looks like "{ [name: string]: (date: Date) => boolean }"
+            const [signature, returnType] = entry.type.slice(2, -2).split("]: ");
+            return (
+                <tr key={entry.name}>
+                    <td className="docs-prop-name">
+                        <code>{renderType(signature!)}]</code>
+                    </td>
+                    <td className="docs-prop-details">
+                        <code className="docs-prop-type">{renderType(returnType!)}</code>
+                        <div className="docs-prop-description">{renderBlock(entry.documentation!)}</div>
+                    </td>
+                </tr>
+            );
+        },
+        [renderBlock, renderType],
+    );
 
     const propRows = [...data.properties, ...data.methods]
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -68,7 +68,7 @@ export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data,
             const typeInfo = isTsProperty(entry) ? (
                 <>
                     <strong>{renderType(entry.type)}</strong>
-                    <em className={classNames("docs-prop-default", Classes.TEXT_MUTED)}>{entry.defaultValue}</em>
+                    <TsPropertyDefaultValue entry={entry} />
                 </>
             ) : (
                 <>
@@ -139,3 +139,21 @@ export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data,
     );
 };
 InterfaceTable.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.InterfaceTable`;
+
+function TsPropertyDefaultValue({ entry }: { entry: TsProperty }) {
+    let { defaultValue } = entry;
+
+    if (defaultValue == null) {
+        return null;
+    }
+
+    // HACKHACK: workaround for https://github.com/palantir/documentalist/issues/245
+    // extract code snippet if it is wrapped in some extra markup
+    const codeSnippetMatches = defaultValue.match(/```ts\s(.*)\s```/);
+
+    if (codeSnippetMatches != null) {
+        defaultValue = codeSnippetMatches[1].trim();
+    }
+
+    return <em className={classNames("docs-prop-default", Classes.TEXT_MUTED)}>{defaultValue}</em>;
+}

--- a/packages/docs-theme/src/components/typescript/methodTable.tsx
+++ b/packages/docs-theme/src/components/typescript/methodTable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isTag, type ITsMethod, type ITsParameter, type ITsSignature } from "@documentalist/client";
+import { isTag, type TsMethod, type TsParameter, type TsSignature } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -29,13 +29,13 @@ import { DeprecatedTag } from "./deprecatedTag";
 export type Renderer<T> = (props: T) => React.ReactNode;
 
 export interface MethodTableProps extends Props {
-    data: ITsMethod;
+    data: TsMethod;
 }
 
 export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => {
     const { renderBlock, renderType } = React.useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback((parameter: ITsParameter) => {
+    const renderPropRow = React.useCallback((parameter: TsParameter) => {
         const { flags, name } = parameter;
         const { documentation } = parameter;
 
@@ -77,7 +77,7 @@ export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => 
         );
     }, []);
 
-    const renderReturnSignature = React.useCallback((entry?: ITsSignature) => {
+    const renderReturnSignature = React.useCallback((entry?: TsSignature) => {
         if (entry == null) {
             return null;
         }
@@ -96,7 +96,7 @@ export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => 
 
     const propRows = [...data.signatures]
         .sort((a, b) => a.name.localeCompare(b.name))
-        .map((entry: ITsSignature) => entry.parameters.map(renderPropRow));
+        .map((entry: TsSignature) => entry.parameters.map(renderPropRow));
     return (
         <div className={classNames("docs-modifiers", className)}>
             <ApiHeader {...data} />

--- a/packages/docs-theme/src/components/typescript/methodTable.tsx
+++ b/packages/docs-theme/src/components/typescript/methodTable.tsx
@@ -26,8 +26,6 @@ import { ModifierTable } from "../modifierTable";
 import { ApiHeader } from "./apiHeader";
 import { DeprecatedTag } from "./deprecatedTag";
 
-export type Renderer<T> = (props: T) => React.ReactNode;
-
 export interface MethodTableProps extends Props {
     data: TsMethod;
 }
@@ -35,64 +33,70 @@ export interface MethodTableProps extends Props {
 export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => {
     const { renderBlock, renderType } = React.useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback((parameter: TsParameter) => {
-        const { flags, name } = parameter;
-        const { documentation } = parameter;
+    const renderPropRow = React.useCallback(
+        (parameter: TsParameter) => {
+            const { flags, name } = parameter;
+            const { documentation } = parameter;
 
-        // ignore props marked with `@internal` tag (this tag is in contents instead of in flags)
-        if (
-            documentation != null &&
-            documentation.contents != null &&
-            documentation.contents.some(val => isTag(val) && val.tag === "internal")
-        ) {
-            return null;
-        }
+            // ignore props marked with `@internal` tag (this tag is in contents instead of in flags)
+            if (
+                documentation != null &&
+                documentation.contents != null &&
+                documentation.contents.some(val => isTag(val) && val.tag === "internal")
+            ) {
+                return null;
+            }
 
-        const classes = classNames("docs-prop-name", {
-            "docs-prop-is-deprecated": flags?.isDeprecated === true || typeof flags?.isDeprecated === "string",
-            "docs-prop-is-internal": !flags?.isExternal,
-            "docs-prop-is-required": !flags?.isOptional,
-        });
+            const classes = classNames("docs-prop-name", {
+                "docs-prop-is-deprecated": flags?.isDeprecated === true || typeof flags?.isDeprecated === "string",
+                "docs-prop-is-internal": !flags?.isExternal,
+                "docs-prop-is-required": !flags?.isOptional,
+            });
 
-        const typeInfo = (
-            <>
-                <strong>{renderType(parameter.type)}</strong>
-            </>
-        );
+            const typeInfo = (
+                <>
+                    <strong>{renderType(parameter.type)}</strong>
+                </>
+            );
 
-        return (
-            <tr key={name}>
-                <td className={classes}>
-                    <Code>{name}</Code>
-                </td>
-                <td className="docs-prop-details">
-                    <Code className="docs-prop-type">{typeInfo}</Code>
-                    <div className="docs-prop-description">{renderBlock(documentation!)}</div>
-                    <div className="docs-prop-tags">
-                        {!flags?.isOptional && <Tag children="Required" intent={Intent.SUCCESS} minimal={true} />}
-                        <DeprecatedTag isDeprecated={flags?.isDeprecated} />
-                    </div>
-                </td>
-            </tr>
-        );
-    }, []);
+            return (
+                <tr key={name}>
+                    <td className={classes}>
+                        <Code>{name}</Code>
+                    </td>
+                    <td className="docs-prop-details">
+                        <Code className="docs-prop-type">{typeInfo}</Code>
+                        <div className="docs-prop-description">{renderBlock(documentation!)}</div>
+                        <div className="docs-prop-tags">
+                            {!flags?.isOptional && <Tag children="Required" intent={Intent.SUCCESS} minimal={true} />}
+                            <DeprecatedTag isDeprecated={flags?.isDeprecated} />
+                        </div>
+                    </td>
+                </tr>
+            );
+        },
+        [renderBlock, renderType],
+    );
 
-    const renderReturnSignature = React.useCallback((entry?: TsSignature) => {
-        if (entry == null) {
-            return null;
-        }
+    const renderReturnSignature = React.useCallback(
+        (entry?: TsSignature) => {
+            if (entry == null) {
+                return null;
+            }
 
-        return (
-            <tr key={entry.name}>
-                <td className="docs-prop-name">
-                    <Code className="docs-prop-type">{renderType(entry.returnType)}</Code>
-                </td>
-                <td className="docs-prop-details">
-                    <div className="docs-prop-description">{renderBlock(entry.documentation!)}</div>
-                </td>
-            </tr>
-        );
-    }, []);
+            return (
+                <tr key={entry.name}>
+                    <td className="docs-prop-name">
+                        <Code className="docs-prop-type">{renderType(entry.returnType)}</Code>
+                    </td>
+                    <td className="docs-prop-details">
+                        <div className="docs-prop-description">{renderBlock(entry.documentation!)}</div>
+                    </td>
+                </tr>
+            );
+        },
+        [renderBlock, renderType],
+    );
 
     const propRows = [...data.signatures]
         .sort((a, b) => a.name.localeCompare(b.name))

--- a/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
+++ b/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ITsTypeAlias } from "@documentalist/client";
+import type { TsTypeAlias } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -25,7 +25,7 @@ import { DocumentationContext } from "../../common/context";
 import { ApiHeader } from "./apiHeader";
 
 export interface TypeAliasTableProps extends Props {
-    data: ITsTypeAlias;
+    data: TsTypeAlias;
 }
 
 export const TypeAliasTable: React.FC<TypeAliasTableProps> = ({ className, data }) => {

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IKssPluginData, ITag } from "@documentalist/client";
+import type { KssPluginData, Tag } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -27,7 +27,7 @@ import { Example } from "../components/example";
 const MODIFIER_ATTR_REGEXP = /\{\{:modifier}}/g;
 const MODIFIER_CLASS_REGEXP = /\{\{\.modifier}}/g;
 
-export const CssExample: React.FC<ITag> = ({ value }) => {
+export const CssExample: React.FC<Tag> = ({ value }) => {
     const { getDocsData } = React.useContext(DocumentationContext);
     const [activeModifiers, setActiveModifiers] = React.useState<Set<string>>(new Set());
 
@@ -53,7 +53,7 @@ export const CssExample: React.FC<ITag> = ({ value }) => {
         };
     };
 
-    const { css } = getDocsData() as IKssPluginData;
+    const { css } = getDocsData() as KssPluginData;
     if (css == null || css[value] == null) {
         return null;
     }

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -26,8 +26,7 @@ import { TypescriptExample } from "./typescript";
 export function createDefaultRenderers(): Record<string, React.ComponentType<Tag>> {
     return {
         css: CssExample,
-        // HACKHACK https://github.com/palantir/blueprint/issues/4342
-        heading: Heading as React.ComponentType<Tag>,
+        heading: Heading,
         interface: TypescriptExample,
         method: Method,
         page: () => null,

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ITag } from "@documentalist/client";
+import type { Tag } from "@documentalist/client";
 import type * as React from "react";
 
 import { CssExample } from "./css";
@@ -23,11 +23,11 @@ import { Method } from "./method";
 import { SeeTag } from "./see";
 import { TypescriptExample } from "./typescript";
 
-export function createDefaultRenderers(): Record<string, React.ComponentType<ITag>> {
+export function createDefaultRenderers(): Record<string, React.ComponentType<Tag>> {
     return {
         css: CssExample,
         // HACKHACK https://github.com/palantir/blueprint/issues/4342
-        heading: Heading as React.ComponentType<ITag>,
+        heading: Heading as React.ComponentType<Tag>,
         interface: TypescriptExample,
         method: Method,
         page: () => null,

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IHeadingTag } from "@documentalist/client";
+import type { HeadingTag } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -23,7 +23,7 @@ import { Link } from "@blueprintjs/icons";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 
-export const Heading: React.FC<IHeadingTag> = ({ level, route, value }) =>
+export const Heading: React.FC<HeadingTag> = ({ level, route, value }) =>
     // use createElement so we can dynamically choose tag based on depth
     React.createElement(
         `h${level}`,

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { HeadingTag } from "@documentalist/client";
+import { isHeadingTag, type Tag } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -23,15 +23,22 @@ import { Link } from "@blueprintjs/icons";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 
-export const Heading: React.FC<HeadingTag> = ({ level, route, value }) =>
-    // use createElement so we can dynamically choose tag based on depth
-    React.createElement(
-        `h${level}`,
-        { className: classNames(Classes.HEADING, "docs-title") },
+export const Heading: React.FC<Tag> = props => {
+    if (!isHeadingTag(props)) {
+        return null;
+    }
+
+    const { level, route, value } = props;
+    const className = classNames(Classes.HEADING, "docs-title");
+    const children = [
         <a className="docs-anchor" data-route={route} key="anchor" />,
         <a className="docs-anchor-link" href={"#" + route} key="link">
             <Link />
         </a>,
         value,
-    );
+    ];
+
+    // use createElement so we can dynamically choose tag based on depth
+    return React.createElement(`h${level}`, { className }, children);
+};
 Heading.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.Heading`;

--- a/packages/docs-theme/src/tags/index.ts
+++ b/packages/docs-theme/src/tags/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import type { ITag } from "@documentalist/client";
+import type { Tag } from "@documentalist/client";
 
 export interface TagRendererMap {
-    [tagName: string]: React.ComponentType<ITag> | undefined;
+    [tagName: string]: React.ComponentType<Tag> | undefined;
 }
 
 export * from "./css";

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isTsClass, isTsMethod, type ITag, type ITsClass, type ITypescriptPluginData } from "@documentalist/client";
+import { isTsClass, isTsMethod, type Tag, type TsClass, type TypescriptPluginData } from "@documentalist/client";
 import * as React from "react";
 
 import type { Props } from "@blueprintjs/core";
@@ -23,15 +23,15 @@ import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 import { DocumentationContext } from "../common/context";
 import { MethodTable } from "../components/typescript/methodTable";
 
-export const Method: React.FC<ITag & Props> = ({ className, value }) => {
+export const Method: React.FC<Tag & Props> = ({ className, value }) => {
     const { getDocsData } = React.useContext(DocumentationContext);
-    const { typescript } = getDocsData() as ITypescriptPluginData;
+    const { typescript } = getDocsData() as TypescriptPluginData;
     const member = typescript[value];
 
     if (member === undefined) {
         const possibleClass = value.split(".")[0];
         const possibleClassMethod = value.split(".")[1];
-        const classMember = typescript[possibleClass] as ITsClass;
+        const classMember = typescript[possibleClass] as TsClass;
         if (isTsClass(classMember) && possibleClassMethod) {
             const classMethod = classMember.methods.find(method => method.name === possibleClassMethod);
             if (isTsMethod(classMethod)) {

--- a/packages/docs-theme/src/tags/reactDocs.tsx
+++ b/packages/docs-theme/src/tags/reactDocs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ITag } from "@documentalist/client";
+import type { Tag } from "@documentalist/client";
 import * as React from "react";
 
 export interface DocsMap {
@@ -29,7 +29,7 @@ export class ReactDocsTagRenderer {
      * it to an actual component class in the given map, or in the default map which contains
      * valid docs components from this package. Provide a custom map to inject your own components.
      */
-    public render: React.FC<ITag> = ({ value: componentName }) => {
+    public render: React.FC<Tag> = ({ value: componentName }) => {
         if (componentName == null) {
             return null;
         }

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ITag } from "@documentalist/client";
+import type { Tag } from "@documentalist/client";
 import * as React from "react";
 
 import { AnchorButton, Intent } from "@blueprintjs/core";
@@ -41,7 +41,7 @@ export class ReactExampleTagRenderer {
      * it to an actual example component exported by one of the packages. Also returns
      * the URL of the source code on GitHub.
      */
-    public render: React.FC<ITag> = ({ value: exampleName }) => {
+    public render: React.FC<Tag> = ({ value: exampleName }) => {
         if (exampleName == null) {
             return null;
         }

--- a/packages/docs-theme/src/tags/see.tsx
+++ b/packages/docs-theme/src/tags/see.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import type { ITag } from "@documentalist/client";
+import type { Tag } from "@documentalist/client";
 import * as React from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 import { DocumentationContext } from "../common/context";
 
-export const SeeTag: React.FC<ITag> = ({ value }) => {
+export const SeeTag: React.FC<Tag> = ({ value }) => {
     const { renderType } = React.useContext(DocumentationContext);
     return <p>See: {renderType(value)}</p>;
 };

--- a/packages/docs-theme/src/tags/typescript.tsx
+++ b/packages/docs-theme/src/tags/typescript.tsx
@@ -19,8 +19,8 @@ import {
     isTsEnum,
     isTsInterface,
     isTsTypeAlias,
-    type ITag,
-    type ITypescriptPluginData,
+    type Tag,
+    type TypescriptPluginData,
 } from "@documentalist/client";
 import * as React from "react";
 
@@ -32,9 +32,9 @@ import { EnumTable } from "../components/typescript/enumTable";
 import { InterfaceTable } from "../components/typescript/interfaceTable";
 import { TypeAliasTable } from "../components/typescript/typeAliasTable";
 
-export const TypescriptExample: React.FC<ITag & Props> = ({ className, value }) => {
+export const TypescriptExample: React.FC<Tag & Props> = ({ className, value }) => {
     const { getDocsData } = React.useContext(DocumentationContext);
-    const { typescript } = getDocsData() as ITypescriptPluginData;
+    const { typescript } = getDocsData() as TypescriptPluginData;
     if (typescript == null || typescript[value] == null) {
         return null;
     }

--- a/packages/docs-theme/src/tsconfig.json
+++ b/packages/docs-theme/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -23,7 +23,7 @@
         "@typescript-eslint/rule-tester": "^6.7.4",
         "dedent": "^1.5.1",
         "mocha": "^10.2.0",
-        "typescript": "~4.9.5"
+        "typescript": "~5.2.2"
     },
     "repository": {
         "type": "git",

--- a/packages/eslint-plugin/src/tsconfig.json
+++ b/packages/eslint-plugin/src/tsconfig.json
@@ -1,10 +1,7 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.node",
     "compilerOptions": {
-        "lib": ["es6", "dom"],
-        "module": "commonjs",
-        "moduleResolution": "node16",
-        "outDir": "../lib",
-        "target": "ES2015"
+        "lib": ["ES2015", "dom"],
+        "outDir": "../lib"
     }
 }

--- a/packages/eslint-plugin/test/tsconfig.json
+++ b/packages/eslint-plugin/test/tsconfig.json
@@ -1,19 +1,10 @@
 {
+    "extends": "../../../config/tsconfig.node",
     "compilerOptions": {
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "moduleResolution": "nodenext",
         "lib": ["es2021"],
         "module": "commonjs",
         "noEmit": true,
-        "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "pretty": true,
         "skipLibCheck": true,
-        "strict": true,
         "target": "es2021"
     }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,7 +21,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/**/* && rm -rf src/generated/*",
         "compile": "npm-run-all -s \"generate-icon-src\" -p \"compile:*\" -p \"copy:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "copy:scss": "scripts/copy-scss.sh",
@@ -44,7 +44,7 @@
     "dependencies": {
         "change-case": "^4.1.2",
         "classnames": "^2.3.1",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -69,7 +69,7 @@
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
         "svg-parser": "^2.0.4",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/icons/src/tsconfig.json
+++ b/packages/icons/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/icons/test/tsconfig.json
+++ b/packages/icons/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../src/tsconfig",
     "compilerOptions": {
         "declaration": false,
-        "module": "commonjs",
         "noEmit": true
     }
 }

--- a/packages/landing-app/src/tsconfig.json
+++ b/packages/landing-app/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base.json",
+    "extends": "../../../config/tsconfig.web.json",
     "compilerOptions": {
         "declaration": false,
         "lib": ["dom", "es5", "es6"],

--- a/packages/monaco-editor-theme/package.json
+++ b/packages/monaco-editor-theme/package.json
@@ -15,7 +15,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "dev": "run-p \"compile:esm -- --watch\"",
         "dist": "run-s \"dist:*\"",
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.4",
         "npm-run-all": "^4.1.5",
-        "typescript": "~4.9.5"
+        "typescript": "~5.2.2"
     },
     "repository": {
         "type": "git",

--- a/packages/monaco-editor-theme/src/tsconfig.json
+++ b/packages/monaco-editor-theme/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -42,7 +42,7 @@
         "stylelint": "~14.16.1",
         "stylelint-junit-formatter": "^0.2.2",
         "svgo": "^1.3.2",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "yargs": "^17.7.2"
     },
     "devDependencies": {

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -18,7 +18,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -35,7 +35,7 @@
     "dependencies": {
         "@blueprintjs/core": "^5.5.1",
         "classnames": "^2.3.1",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -52,7 +52,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "typescript": "~4.9.5"
+        "typescript": "~5.2.2"
     },
     "repository": {
         "type": "git",

--- a/packages/popover2/src/tsconfig.json
+++ b/packages/popover2/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -20,7 +20,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -43,7 +43,7 @@
         "@blueprintjs/core": "^5.5.1",
         "@blueprintjs/icons": "^5.2.1",
         "classnames": "^2.3.1",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -65,7 +65,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack-cli": "^5.0.1"
     },
     "repository": {

--- a/packages/select/src/tsconfig.json
+++ b/packages/select/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
     }

--- a/packages/select/test/tsconfig.json
+++ b/packages/select/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../src/tsconfig",
     "compilerOptions": {
         "declaration": false,
-        "module": "commonjs",
         "noEmit": true
     }
 }

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -23,7 +23,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.4",
         "mocha": "^10.2.0",
-        "typescript": "~4.9.5"
+        "typescript": "~5.2.2"
     },
     "repository": {
         "type": "git",

--- a/packages/stylelint-plugin/src/tsconfig.json
+++ b/packages/stylelint-plugin/src/tsconfig.json
@@ -1,9 +1,7 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.node",
     "compilerOptions": {
-        "lib": ["es6", "dom"],
-        "module": "commonjs",
-        "outDir": "../lib",
-        "target": "ES2015"
+        "lib": ["ES2015", "dom"],
+        "outDir": "../lib"
     }
 }

--- a/packages/table-dev-app/src/tsconfig.json
+++ b/packages/table-dev-app/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base.json",
+    "extends": "../../../config/tsconfig.web.json",
     "compilerOptions": {
         "lib": ["dom", "es5", "es6"],
         "outDir": "../dist",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -20,7 +20,7 @@
         "clean": "rm -rf dist/* && rm -rf lib/*",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
-        "compile:cjs": "tsc -p ./src -m commonjs --outDir lib/cjs",
+        "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
         "compile:css": "sass-compile ./src",
         "dev": "run-p \"compile:esm -- --watch\" \"compile:css -- --watch\"",
@@ -43,7 +43,7 @@
         "@blueprintjs/core": "^5.5.1",
         "classnames": "^2.3.1",
         "react-innertext": "^1.1.5",
-        "tslib": "~2.5.0"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.32 || 17 || 18",
@@ -66,7 +66,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
-        "typescript": "~4.9.5",
+        "typescript": "~5.2.2",
         "webpack": "^5.76.2"
     },
     "repository": {

--- a/packages/table/src/tsconfig.json
+++ b/packages/table/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "lib": ["dom", "es5", "es6"],
         "outDir": "../lib/esm"

--- a/packages/table/test/tsconfig.json
+++ b/packages/table/test/tsconfig.json
@@ -2,7 +2,6 @@
     "extends": "../src/tsconfig",
     "compilerOptions": {
         "declaration": false,
-        "module": "commonjs",
         "noEmit": true
     }
 }

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -24,7 +24,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "^8.0.4",
         "react": "^16.13.1",
-        "typescript": "~4.9.5"
+        "typescript": "~5.2.2"
     },
     "repository": {
         "type": "git",

--- a/packages/test-commons/src/tsconfig.json
+++ b/packages/test-commons/src/tsconfig.json
@@ -2,8 +2,6 @@
     "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "lib": ["dom", "es5", "es6", "es2016.array.include"],
-        "module": "commonjs",
-        "outDir": "../lib/cjs",
-        "verbatimModuleSyntax": false
+        "outDir": "../lib/cjs"
     }
 }

--- a/packages/test-commons/src/tsconfig.json
+++ b/packages/test-commons/src/tsconfig.json
@@ -2,6 +2,8 @@
     "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "lib": ["dom", "es5", "es6", "es2016.array.include"],
-        "outDir": "../lib/cjs"
+        "module": "commonjs",
+        "outDir": "../lib/cjs",
+        "verbatimModuleSyntax": false
     }
 }

--- a/packages/test-commons/src/tsconfig.json
+++ b/packages/test-commons/src/tsconfig.json
@@ -1,8 +1,9 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "lib": ["dom", "es5", "es6", "es2016.array.include"],
         "module": "commonjs",
-        "outDir": "../lib/cjs"
+        "outDir": "../lib/cjs",
+        "verbatimModuleSyntax": false
     }
 }

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -7,9 +7,10 @@
         "test": "tslint --rules-dir ./lib/rules --test test/rules/**/tslint.json"
     },
     "dependencies": {
-        "tslib": "~2.5.0",
+        "tslib": "~2.6.2",
         "tslint-react": "^5.0.0",
-        "tsutils": "^3.21.0"
+        "tsutils": "^3.21.0",
+        "typescript": "~5.2.2"
     },
     "peerDependencies": {
         "tslint": "^6.0.0"

--- a/packages/tslint-config/src/tsconfig.json
+++ b/packages/tslint-config/src/tsconfig.json
@@ -1,8 +1,7 @@
 {
-    "extends": "../../../config/tsconfig.base",
+    "extends": "../../../config/tsconfig.node",
     "compilerOptions": {
-        "lib": ["es6", "dom"],
-        "module": "commonjs",
+        "lib": ["ES2015", "dom"],
         "outDir": "../lib/rules"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,15 +11821,10 @@ tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0, tslib@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
-
-tslib@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslint-react@^5.0.0:
   version "5.0.0"
@@ -12057,10 +12052,10 @@ typedoc@~0.19.2:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.11.4"
 
-"typescript@>=3 < 6", typescript@~4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+"typescript@>=3 < 6", typescript@~5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,11 +1875,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.199.tgz#c3edb5650149d847a277a8961a7ad360c474e9bf"
   integrity sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg==
 
-"@types/marked@^4.0.8":
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.8.tgz#b316887ab3499d0a8f4c70b7bd8508f92d477955"
-  integrity sha512-HVNzMT5QlWCOdeuBsgXP8EZzKUf0+AXzN+sLmjvaB3ZlLqO+e4u0uXrdw9ub69wBKFs+c6/pA4r9sy6cCDvImw==
-
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
@@ -8184,10 +8179,10 @@ marked@^4.0.12, marked@^4.3.0:
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
-marked@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-9.1.0.tgz#7a085c7d46730dee2b801f1c1b35c5745479e270"
-  integrity sha512-VZjm0PM5DMv7WodqOUps3g6Q7dmxs9YGiFUZ7a2majzQTTCgX+6S6NAJHPvOhgFBzYz8s4QZKWWMfZKFmsfOgA==
+marked@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-9.1.2.tgz#a54ca772d2b5a43de7d8ed40111354b4b7985527"
+  integrity sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==
 
 mathml-tag-names@^2.1.3:
   version "2.1.3"
@@ -10720,7 +10715,7 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
+semver@^7.0.0, semver@^7.1.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -334,23 +334,24 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@documentalist/client@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@documentalist/client/-/client-4.0.0.tgz#0ded0827d5d2fc88f31ce1c65ba38d9e996bd33c"
-  integrity sha512-6CwkNCMUkrT5dqpXuu/x5pBCwRUYaSafa/8AbA7mznx2bWRnGEjUAQl0UWewwpK/w/zW9/kRagbguCJzVuUpKA==
+"@documentalist/client@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@documentalist/client/-/client-5.0.0.tgz#fbe47084abb855eba436b0306caf3b016fe63087"
+  integrity sha512-I4yh9qcP4jO2LeBU9y9K+ms0uhDHzmIEnhUpcPnjXKAoK2O4wrOKRM6JhzDEZ1WL5X2eW6h/zX5q+/PqIimfFw==
 
-"@documentalist/compiler@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@documentalist/compiler/-/compiler-4.0.0.tgz#1b1911db8a51dfb22b36a7845dc28448eb191773"
-  integrity sha512-2o1nhNKuC1duk1WkmfXoBvCnUPedygANG+dcP0Ur3DnqTXl+mcc/QLEuxoD3523A7jx0dwt/1HBrTUm4iK4XLw==
+"@documentalist/compiler@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@documentalist/compiler/-/compiler-5.0.0.tgz#b9e5ac12dcaa9ea3f21e707fea69379da71be139"
+  integrity sha512-XMLQMgzWPOSV10p56koLMFifmRU7C5oaZJVcniVsjWMy4RtgbSNi4FozKaicBveIXOZCmSM50aazZEtJiWwJ1Q==
   dependencies:
-    "@documentalist/client" "^4.0.0"
+    "@documentalist/client" "^5.0.0"
     "@types/kss" "^3.0.2"
-    glob "^7.2.0"
+    glob "^10.3.10"
     js-yaml "^4.1.0"
     kss "^3.0.1"
     marked "^4.0.12"
-    typedoc "~0.19.2"
+    tsconfig-resolver "^3.0.1"
+    typedoc "~0.25.2"
     yargs "^17.4.0"
 
 "@es-joy/jsdoccomment@~0.40.1":
@@ -1845,6 +1846,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/json5@^0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.30.tgz#44cb52f32a809734ca562e685c6473b5754a7818"
+  integrity sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA==
+
 "@types/jsonfile@*":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.1.tgz#ac84e9aefa74a2425a0fb3012bdea44f58970f1b"
@@ -1958,6 +1964,11 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/resolve@^1.17.0":
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.4.tgz#d2df996a35695c843dbf180e26bc2c7a0f1a3e12"
+  integrity sha512-BKGK0T1VgB1zD+PwQR4RRf0ais3NyvH1qjLUrHI5SEiccYaJrhLstLuoXFWJ+2Op9whGizSPUMGPJY/Qtb/A2w==
 
 "@types/retry@0.12.0":
   version "0.12.0"
@@ -2517,6 +2528,11 @@ ansi-regex@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -5625,7 +5641,7 @@ fs-extra@^11.0.0, fs-extra@^11.1.0, fs-extra@^11.1.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -5867,7 +5883,7 @@ glob@7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.2.0, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
+glob@7.2.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -6127,11 +6143,6 @@ header-case@^2.0.4:
   dependencies:
     capital-case "^1.0.4"
     tslib "^2.0.3"
-
-highlight.js@^10.2.0:
-  version "10.4.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.4.1.tgz#d48fbcf4a9971c4361b3f95f302747afe19dbad0"
-  integrity sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==
 
 highlight.js@^9.18.1:
   version "9.18.5"
@@ -6483,11 +6494,6 @@ internal-slot@^1.0.3, internal-slot@^1.0.5:
     get-intrinsic "^1.2.0"
     has "^1.0.3"
     side-channel "^1.0.4"
-
-interpret@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
-  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 interpret@^3.1.1:
   version "3.1.1"
@@ -7465,7 +7471,7 @@ json5@^1.0.1, json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2, json5@^2.2.2:
+json5@^2.1.2, json5@^2.1.3, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -7994,7 +8000,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8173,15 +8179,10 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^1.1.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.5.tgz#a44b31f2a0b8b5bfd610f00d55d1952d1ac1dfdb"
-  integrity sha512-2AlqgYnVPOc9WDyWu7S5DJaEZsfk6dNh/neatQ3IHUW4QLutM/VPSH9lG7bif+XjFWc9K9XR3QvR+fXuECmfdA==
-
-marked@^4.0.12:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.2.5.tgz#979813dfc1252cc123a79b71b095759a32f42a5d"
-  integrity sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==
+marked@^4.0.12, marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 marked@^9.1.0:
   version "9.1.0"
@@ -8366,14 +8367,7 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@3.0.5, minimatch@3.0.x:
+"minimatch@2 || 3", minimatch@3.0.5, minimatch@3.0.x, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.5.tgz#4da8f1290ee0f0f8e83d60ca69f8f134068604a3"
   integrity sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==
@@ -8387,6 +8381,13 @@ minimatch@5.0.1, minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^8.0.2:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-8.0.4.tgz#847c1b25c014d4e9a7f68aaf63dedd668a626229"
@@ -8394,7 +8395,7 @@ minimatch@^8.0.2:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.0, minimatch@^9.0.1:
+minimatch@^9.0.0, minimatch@^9.0.1, minimatch@^9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
@@ -10029,11 +10030,6 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
-progress@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
-  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
-
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -10385,13 +10381,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  dependencies:
-    resolve "^1.1.6"
-
 rechoir@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.8.0.tgz#49f866e0d32146142da3ad8f0eff352b3215ff22"
@@ -10509,10 +10498,10 @@ resolve@1.1.x:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.16.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.4, resolve@^1.3.2:
-  version "1.22.4"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.4.tgz#1dc40df46554cdaf8948a486a10f6ba1e2026c34"
-  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
+resolve@^1.10.0, resolve@^1.16.0, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.4, resolve@^1.3.2:
+  version "1.22.8"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
   dependencies:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
@@ -10854,19 +10843,20 @@ shell-quote@^1.6.1, shell-quote@^1.7.3:
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.0.tgz#20d078d0eaf71d54f43bd2ba14a1b5b9bfa5c8ba"
   integrity sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==
 
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shiki@^0.14.1:
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.5.tgz#375dd214e57eccb04f0daf35a32aa615861deb93"
+  integrity sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==
+  dependencies:
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -11829,6 +11819,18 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tsconfig-resolver@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/tsconfig-resolver/-/tsconfig-resolver-3.0.1.tgz#c9e62e328ecfbeaae4a4f1131a92cdbed12350c4"
+  integrity sha512-ZHqlstlQF449v8glscGRXzL6l2dZvASPCdXJRWG4gHEZlUVx2Jtmr+a2zeVG4LCsKhDXKRj5R3h0C/98UcVAQg==
+  dependencies:
+    "@types/json5" "^0.0.30"
+    "@types/resolve" "^1.17.0"
+    json5 "^2.1.3"
+    resolve "^1.17.0"
+    strip-bom "^4.0.0"
+    type-fest "^0.13.1"
+
 tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
@@ -11951,6 +11953,11 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
+type-fest@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
+  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+
 type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
@@ -12043,27 +12050,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
-  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
-
-typedoc@~0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
-  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
+typedoc@~0.25.2:
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.2.tgz#39f525c28b6eb61da54dda4ec6b1500df620bed8"
+  integrity sha512-286F7BeATBiWe/qC4PCOCKlSTwfnsLbC/4cZ68oGBbvAqb9vV33quEOXx7q176OXotD+JdEerdQ1OZGJ818lnA==
   dependencies:
-    fs-extra "^9.0.1"
-    handlebars "^4.7.6"
-    highlight.js "^10.2.0"
-    lodash "^4.17.20"
     lunr "^2.3.9"
-    marked "^1.1.1"
-    minimatch "^3.0.0"
-    progress "^2.0.3"
-    semver "^7.3.2"
-    shelljs "^0.8.4"
-    typedoc-default-themes "^0.11.4"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
+    shiki "^0.14.1"
 
 "typescript@>=3 < 6", typescript@~5.2.2:
   version "5.2.2"
@@ -12296,6 +12291,16 @@ void-elements@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
+
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 walk@2.3.x:
   version "2.3.14"


### PR DESCRIPTION
Fixes #4342

✅ Prerequisites:

- [x] https://github.com/palantir/blueprint/pull/6478
- [x] https://github.com/palantir/documentalist/pull/156

#### Changes proposed in this pull request:

- Upgrade from TypeScript v4.8 to v5.2
- Refactor tsconfig files to extend from two possible base configs, `tsconfig.web.json` and `tsconfig.node.json`
- Remove deprecated `importsNotUsedAsValues` config option, enable [`verbatimModuleSyntax`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#--verbatimmodulesyntax) instead
- Upgrade to `@documentalist/compiler` and `@documentalist/client` v5.0.0 to use the latest TypeDoc library
- Implement workarounds for various Documentalist regressions:
  - https://github.com/palantir/documentalist/issues/246
  - https://github.com/palantir/documentalist/issues/245
  - https://github.com/palantir/documentalist/issues/248

#### Reviewers should focus on:

- TypeScript config changes
- Documentation changes resulting from a major TypeDoc upgrade
- Not sure if this will require Documentalist to also bump to marked v9.0, as that was missed in v5.0: https://github.com/palantir/documentalist/pull/247

#### Notes

See TypeScript release notes:

- [TypeScript 4.9](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html)
- [TypeScript 5.0](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html)
- [TypeScript 5.1](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-1.html)
- [TypeScript 5.2](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html)

