### PR TITLE
fix(MenuItem): a11y fix - disabled has aria-disabled

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -257,9 +257,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             tabIndex: hasSubmenu ? -1 : 0,
             ...removeNonHTMLProps(htmlProps),
             ...(disabled ? DISABLED_PROPS : {}),
-
             className: anchorClasses,
-            disabled,
         },
         isSelected ? <SmallTick className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
         hasIcon ? (

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -257,7 +257,9 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             tabIndex: hasSubmenu ? -1 : 0,
             ...removeNonHTMLProps(htmlProps),
             ...(disabled ? DISABLED_PROPS : {}),
+
             className: anchorClasses,
+            disabled,
         },
         isSelected ? <SmallTick className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
         hasIcon ? (
@@ -323,6 +325,7 @@ const SUBMENU_POPOVER_MODIFIERS: PopoverProps["modifiers"] = {
 
 // props to ignore when disabled
 const DISABLED_PROPS: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+    "aria-disabled": true,
     href: undefined,
     onClick: undefined,
     onMouseDown: undefined,


### PR DESCRIPTION
Add `aria-disabled` prop to disabled `MenuItem`. Improves a11y and fixes a11y aXe failure.