### PR TITLE
Use `React.FC` for PanelStack2 `renderPanel` typing to fix compilation on newer `@types/react` versions

### DIFF
--- a/packages/core/src/components/panel-stack2/panelTypes.ts
+++ b/packages/core/src/components/panel-stack2/panelTypes.ts
@@ -21,7 +21,7 @@ export interface Panel<P> {
     /**
      * The renderer for this panel.
      */
-    renderPanel: (props: PanelProps<P>) => JSX.Element | null;
+    renderPanel: React.FC<PanelProps<P>>;
 
     /**
      * HTML title to be passed to the <Text> component


### PR DESCRIPTION
## Context

A [semi-recent change in `@types/react`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/65135) switched `React.FunctionComponent`'s return type from `ReactElement` to `ReactNode`.

```diff
 interface FunctionComponent<P = {}> {
-    (props: P, context?: any): ReactElement<any, any> | null;
+    (props: P, context?: any): ReactNode;
     propTypes?: WeakValidationMap<P> | undefined;
     contextTypes?: ValidationMap<any> | undefined;
     defaultProps?: Partial<P> | undefined;
     displayName?: string | undefined;
 }
```

## Break

Under `@types/react@16.14.32` and `@types/react@18.0.25`, the [following minimal example](https://codesandbox.io/s/wild-fog-5qdk3p?file=/src/App.tsx) from the docs passes TypeScript compilation.

```ts
import { Panel, PanelProps } from "@blueprintjs/core";
import {} from "@blueprintjs/core";

type AccountSettingsPanelInfo = {
  /* ...  */
};

const AccountSettingsPanel: React.FC<PanelProps<AccountSettingsPanelInfo>> = (
  props
) => {
  return null;
};

const _panel: Panel<unknown> = {
  renderPanel: AccountSettingsPanel,
  title: "Account settings"
};
```

However, on `@types/react@18.2.34`, it fails with:

```ts
Type 'FC<PanelActions>' is not assignable to type '(props: PanelActions) => Element | null'.
  Type 'ReactNode' is not assignable to type 'Element | null'.
    Type 'undefined' is not assignable to type 'Element | null'.ts(2322)
```

## Changes

This PR fixes compilation of panel stack components under newer versions of `@types/react` by following `React.FC`'s typings.

## Notes for Reviews

My initial attempt to fix this was to add `React.ReactNode` as another possible `renderPanel` return type. While this works on newer versions of `@types/react`, it breaks on older versions.

<img width="1340" alt="Screenshot 2023-11-06 at 7 26 51 PM" src="https://github.com/palantir/blueprint/assets/906558/8a272d46-1031-4774-8db8-976dbd69f824">

