### PR TITLE
fix(Slider, AnchorButton, MultiStepDialog, MenuItem): add aria-disabled prop to fix a11y

### DIFF
--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -55,6 +55,7 @@ export const AnchorButton: React.FC<AnchorButtonProps> = React.forwardRef<HTMLAn
                 role="button"
                 {...removeNonHTMLProps(props)}
                 {...commonProps}
+                aria-disabled={commonProps.disabled}
                 href={commonProps.disabled ? undefined : href}
                 tabIndex={commonProps.disabled ? -1 : tabIndex}
             >

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -180,6 +180,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
                     [Classes.DIALOG_STEP_VIEWED]: hasBeenViewed,
                 })}
                 key={index}
+                aria-disabled={!currentlySelected && !hasBeenViewed}
                 aria-selected={currentlySelected}
                 role="tab"
             >

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -133,6 +133,7 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
         const inputProps = {
             type: "text",
             ...removeNonHTMLProps(this.props, NON_HTML_PROPS, true),
+            "aria-disabled": disabled,
             className: classNames(Classes.INPUT, inputClassName),
             onChange: this.handleInputChange,
             style,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -257,9 +257,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             tabIndex: hasSubmenu ? -1 : 0,
             ...removeNonHTMLProps(htmlProps),
             ...(disabled ? DISABLED_PROPS : {}),
-
             className: anchorClasses,
-            disabled,
         },
         isSelected ? <SmallTick className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
         hasIcon ? (

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -257,7 +257,9 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             tabIndex: hasSubmenu ? -1 : 0,
             ...removeNonHTMLProps(htmlProps),
             ...(disabled ? DISABLED_PROPS : {}),
+
             className: anchorClasses,
+            disabled,
         },
         isSelected ? <SmallTick className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
         hasIcon ? (
@@ -323,6 +325,7 @@ const SUBMENU_POPOVER_MODIFIERS: PopoverProps["modifiers"] = {
 
 // props to ignore when disabled
 const DISABLED_PROPS: React.AnchorHTMLAttributes<HTMLAnchorElement> = {
+    "aria-disabled": true,
     href: undefined,
     onClick: undefined,
     onMouseDown: undefined,

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -84,6 +84,7 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
                 aria-valuemin={min}
                 aria-valuemax={max}
                 aria-valuenow={value}
+                aria-disabled={disabled}
                 aria-orientation={vertical ? "vertical" : "horizontal"}
             >
                 {label == null ? null : <span className={Classes.SLIDER_LABEL}>{label}</span>}


### PR DESCRIPTION
#### Fixes #N/A

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `aria-disabled={disabled}` prop to elements that may be disabled, but do no not accept the normal html `disabled` attribute.
