### PR TITLE
[docs-data] fix: interpolate class namespace correctly in KSS markup

### DIFF
--- a/packages/docs-data/compile-docs-data.mjs
+++ b/packages/docs-data/compile-docs-data.mjs
@@ -12,6 +12,8 @@ import { join, resolve } from "node:path";
 import { cwd } from "node:process";
 import semver from "semver";
 
+import { Classes } from "@blueprintjs/core";
+
 import { hooks, markedRenderer } from "./markdownRenderer.mjs";
 
 /** Run Documentalist on Sass, TypeScript, and package.json files in these packages */
@@ -105,5 +107,19 @@ function transformDocumentalistData(key, value) {
         // reverse the list so highest version is first (easier indexing)
         return Array.from(majors.values()).reverse();
     }
+
+    if (typeof value === "string") {
+        return interpolateClassNamespace(value);
+    }
+
     return value;
+}
+
+/**
+ * Replaces `#{$ns}` placeholder in string values  with the actual Blueprint class namespace.
+ *
+ * @param {string} value
+ */
+function interpolateClassNamespace(value) {
+    return value.replace(/#{\$ns}|@ns/g, Classes.getClassNamespace());
 }

--- a/packages/docs-data/markdownRenderer.mjs
+++ b/packages/docs-data/markdownRenderer.mjs
@@ -46,17 +46,12 @@ function renderMarkdown(textContent) {
     return marked(textContent, { renderer });
 }
 
-const NS = Classes.getClassNamespace();
-
 const hooks = {
     /**
      * @param md {string}
      * @returns {string}
      */
     preprocess: md => {
-        // interpolate class namespace in TS and Sass syntax
-        md = md.replace(/#{\$ns}|@ns/g, NS);
-
         // HACKHACK: workaround for https://github.com/palantir/documentalist/issues/248
         // As of Documentalist v5.0.0 & TypeDoc v0.25, we are getting inline code snippets wrapped by newlines, which
         // breaks the markdown rendering of multiline JSDoc comments. We can work around this by removing the newlines.


### PR DESCRIPTION

#### Fixes #6517

#### Checklist

- ~Includes tests~
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Restore the previous approach of transforming all Documentalist data to interpolate the class namespace, instead of only doing it in the Markdown plugin.

#### Reviewers should focus on:

Fixes the linked regression

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
