### PR TITLE
[docs-app] feat: use SegmentedControl across examples

### DIFF
--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { type Alignment, AnchorButton, Button, Code, H5, Intent, Switch } from "@blueprintjs/core";
+import { type Alignment, AnchorButton, Button, Code, Divider, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Duplicate, Refresh } from "@blueprintjs/icons";
 
@@ -92,6 +92,7 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
                 <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
+                <Divider />
                 <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignTextChange} />
                 <SizeSelect size={this.state.size} onChange={this.handleSizeChange} />
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />

--- a/packages/docs-app/src/examples/core-examples/cardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Card, Classes, type Elevation, H5, Label, Slider, Switch } from "@blueprintjs/core";
+import { Button, Card, Classes, type Elevation, FormGroup, H5, Slider, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface CardExampleState {
@@ -57,8 +57,7 @@ export class CardExample extends React.PureComponent<ExampleProps, CardExampleSt
                 <Switch checked={this.state.selected} label="Selected" onChange={this.handleSelectedChange} />
             )}
             <Switch checked={this.state.compact} label="Compact" onChange={this.handleCompactChange} />
-            <Label>
-                Elevation
+            <FormGroup label="Elevation">
                 <Slider
                     max={4}
                     showTrackFill={false}
@@ -66,7 +65,7 @@ export class CardExample extends React.PureComponent<ExampleProps, CardExampleSt
                     onChange={this.handleElevationChange}
                     handleHtmlProps={{ "aria-label": "card elevation" }}
                 />
-            </Label>
+            </FormGroup>
         </>
     );
 

--- a/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Alignment, Button, ButtonGroup } from "@blueprintjs/core";
+import { Alignment, FormGroup, SegmentedControl } from "@blueprintjs/core";
 
 interface AlignmentSelectProps {
     align: Alignment | undefined;
@@ -25,30 +25,26 @@ interface AlignmentSelectProps {
     onChange: (align: Alignment) => void;
 }
 
-export class AlignmentSelect extends React.PureComponent<AlignmentSelectProps> {
-    public render() {
-        const { align, allowCenter = true, label = "Align text" } = this.props;
-        return (
-            <div>
-                {label}
-                <ButtonGroup fill={true} style={{ marginTop: 5 }}>
-                    <Button active={align === Alignment.LEFT} text="Left" onClick={this.handleAlignLeft} />
-                    {allowCenter && (
-                        <Button
-                            active={align == null || align === Alignment.CENTER}
-                            text="Center"
-                            onClick={this.handleAlignCenter}
-                        />
-                    )}
-                    <Button active={align === Alignment.RIGHT} text="Right" onClick={this.handleAlignRight} />
-                </ButtonGroup>
-            </div>
-        );
-    }
+export const AlignmentSelect: React.FC<AlignmentSelectProps> = ({
+    align,
+    allowCenter = true,
+    label = "Align text",
+    onChange,
+}) => {
+    const options = [
+        { label: "Left", value: Alignment.LEFT },
+        allowCenter && { label: "Center", value: Alignment.CENTER },
+        { label: "Right", value: Alignment.RIGHT },
+    ].filter(Boolean);
 
-    private handleAlignLeft = () => this.props.onChange(Alignment.LEFT);
+    const handleChange = React.useCallback((value: string) => onChange(value as Alignment), [onChange]);
 
-    private handleAlignCenter = () => this.props.onChange(Alignment.CENTER);
-
-    private handleAlignRight = () => this.props.onChange(Alignment.RIGHT);
-}
+    return (
+        <FormGroup label={label}>
+            <SegmentedControl small={true} fill={true} options={options} onValueChange={handleChange} value={align} />
+        </FormGroup>
+    );
+};
+AlignmentSelect.defaultProps = {
+    align: "center",
+};

--- a/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, ButtonGroup, Code, Label } from "@blueprintjs/core";
+import { FormGroup, SegmentedControl } from "@blueprintjs/core";
 
 export type BooleanOrUndefined = undefined | false | true;
 
@@ -33,23 +33,24 @@ export const BooleanOrUndefinedSelect: React.FC<BooleanOrUndefinedSelectProps> =
     value,
     onChange,
 }) => {
-    const handleUndefined = React.useCallback(() => onChange(undefined), []);
-    const handleTrue = React.useCallback(() => onChange(true), []);
-    const handleFalse = React.useCallback(() => onChange(false), []);
+    const handleChange = React.useCallback(
+        (newValue: string) => onChange(newValue === "undefined" ? undefined : newValue === "true" ? true : false),
+        [onChange],
+    );
 
     return (
-        <Label>
-            {label}
-            <ButtonGroup fill={true} style={{ marginTop: 5 }}>
-                <Button
-                    disabled={disabled}
-                    active={value === undefined}
-                    text={<Code>undefined</Code>}
-                    onClick={handleUndefined}
-                />
-                <Button disabled={disabled} active={value === true} text={<Code>true</Code>} onClick={handleTrue} />
-                <Button disabled={disabled} active={value === false} text={<Code>false</Code>} onClick={handleFalse} />
-            </ButtonGroup>
-        </Label>
+        <FormGroup label={label}>
+            <SegmentedControl
+                fill={true}
+                options={[
+                    { disabled, label: "undefined", value: "undefined" },
+                    { disabled, label: "true", value: "true" },
+                    { disabled, label: "false", value: "false" },
+                ]}
+                onValueChange={handleChange}
+                small={true}
+                value={value === undefined ? "undefined" : value === true ? "true" : "false"}
+            />
+        </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, ControlGroup, HTMLSelect, Intent, Label } from "@blueprintjs/core";
+import { Button, ControlGroup, FormGroup, HTMLSelect, Intent } from "@blueprintjs/core";
 import { handleValueChange } from "@blueprintjs/docs-theme";
 
 const INTENTS = [
@@ -39,15 +39,14 @@ export const IntentSelect: React.FC<IntentSelectProps> = props => {
     const handleChange = handleValueChange(props.onChange);
     const handleClear = React.useCallback(() => props.onChange("none"), []);
     return (
-        <Label>
-            {props.label}
+        <FormGroup label={props.label}>
             <ControlGroup>
                 <HTMLSelect value={props.intent} onChange={handleChange} options={INTENTS} fill={true} />
                 {props.showClearButton && (
                     <Button aria-label="Clear" disabled={props.intent === "none"} icon="cross" onClick={handleClear} />
                 )}
             </ControlGroup>
-        </Label>
+        </FormGroup>
     );
 };
 IntentSelect.defaultProps = {

--- a/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, ButtonGroup, Label } from "@blueprintjs/core";
+import { FormGroup, SegmentedControl } from "@blueprintjs/core";
 
 export type Layout = "horizontal" | "vertical";
 
@@ -27,16 +27,20 @@ export interface LayoutSelectProps {
 
 /** Button radio group to switch between horizontal and vertical layouts. */
 export const LayoutSelect: React.FC<LayoutSelectProps> = ({ layout, onChange }) => {
-    const handleVertical = React.useCallback(() => onChange("vertical"), []);
-    const handleHorizontal = React.useCallback(() => onChange("horizontal"), []);
+    const handleChange = React.useCallback((value: string) => onChange(value as Layout), [onChange]);
 
     return (
-        <Label>
-            Layout
-            <ButtonGroup fill={true} style={{ marginTop: 5 }}>
-                <Button active={layout === "vertical"} text="Vertical" onClick={handleVertical} />
-                <Button active={layout === "horizontal"} text="Horizontal" onClick={handleHorizontal} />
-            </ButtonGroup>
-        </Label>
+        <FormGroup label="Layout">
+            <SegmentedControl
+                fill={true}
+                onValueChange={handleChange}
+                options={[
+                    { label: "Horizontal", value: "horizontal" },
+                    { label: "Vertical", value: "vertical" },
+                ]}
+                small={true}
+                value={layout}
+            />
+        </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, ButtonGroup, Label } from "@blueprintjs/core";
+import { FormGroup, SegmentedControl } from "@blueprintjs/core";
 
 export type Size = "small" | "regular" | "large";
 
@@ -28,19 +28,22 @@ export interface SizeSelectProps {
 }
 
 export const SizeSelect: React.FC<SizeSelectProps> = ({ label, size, optionLabels, onChange }) => {
-    const handleSmall = React.useCallback(() => onChange("small"), []);
-    const handleRegular = React.useCallback(() => onChange("regular"), []);
-    const handleLarge = React.useCallback(() => onChange("large"), []);
+    const handleChange = React.useCallback((value: string) => onChange(value as Size), [onChange]);
 
     return (
-        <Label>
-            {label}
-            <ButtonGroup fill={true} style={{ marginTop: 5 }}>
-                <Button active={size === "small"} text={optionLabels[0]} onClick={handleSmall} />
-                <Button active={size === "regular"} text={optionLabels[1]} onClick={handleRegular} />
-                <Button active={size === "large"} text={optionLabels[2]} onClick={handleLarge} />
-            </ButtonGroup>
-        </Label>
+        <FormGroup label={label}>
+            <SegmentedControl
+                fill={true}
+                small={true}
+                options={[
+                    { label: optionLabels[0], value: "small" },
+                    { label: optionLabels[1], value: "regular" },
+                    { label: optionLabels[2], value: "large" },
+                ]}
+                onValueChange={handleChange}
+                value={size}
+            />
+        </FormGroup>
     );
 };
 SizeSelect.defaultProps = {

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -24,22 +24,17 @@ import {
     Divider,
     Drawer,
     DrawerSize,
+    FormGroup,
     H5,
     HTMLSelect,
-    Label,
     Menu,
     MenuItem,
     type OptionProps,
     Position,
+    SegmentedControl,
     Switch,
 } from "@blueprintjs/core";
-import {
-    Example,
-    type ExampleProps,
-    handleBooleanChange,
-    handleStringChange,
-    handleValueChange,
-} from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
 
 import type { BlueprintExampleData } from "../../tags/types";
 
@@ -77,7 +72,7 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
 
     private handleUsePortalChange = handleBooleanChange(usePortal => this.setState({ usePortal }));
 
-    private handlePositionChange = handleValueChange((position: Position) => this.setState({ position }));
+    private handlePositionChange = (position: string) => this.setState({ position: position as Position });
 
     private handleOutsideClickChange = handleBooleanChange(val => this.setState({ canOutsideClickClose: val }));
 
@@ -143,22 +138,28 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
     }
 
     private renderOptions() {
-        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, hasBackdrop, usePortal } = this.state;
+        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, hasBackdrop, position, usePortal } =
+            this.state;
         return (
             <>
                 <H5>Props</H5>
-                <Label>
-                    Position
-                    <HTMLSelect
-                        value={this.state.position}
-                        onChange={this.handlePositionChange}
-                        options={VALID_POSITIONS}
+                <FormGroup label="Position">
+                    <SegmentedControl
+                        fill={true}
+                        options={[
+                            { label: Position.TOP, value: Position.TOP },
+                            { label: Position.RIGHT, value: Position.RIGHT },
+                            { label: Position.BOTTOM, value: Position.BOTTOM },
+                            { label: Position.LEFT, value: Position.LEFT },
+                        ]}
+                        onValueChange={this.handlePositionChange}
+                        small={true}
+                        value={position}
                     />
-                </Label>
-                <Label>
-                    Size
+                </FormGroup>
+                <FormGroup label="Size">
                     <HTMLSelect options={SIZES} onChange={this.handleSizeChange} />
-                </Label>
+                </FormGroup>
                 <Divider />
                 <Switch checked={autoFocus} label="Auto focus" onChange={this.handleAutoFocusChange} />
                 <Switch checked={enforceFocus} label="Enforce focus" onChange={this.handleEnforceFocusChange} />
@@ -189,5 +190,3 @@ const SIZES: Array<string | OptionProps> = [
     "72%",
     "560px",
 ];
-
-const VALID_POSITIONS: Position[] = [Position.TOP, Position.RIGHT, Position.BOTTOM, Position.LEFT];

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Classes, Code, FormGroup, H5, Icon, InputGroup, Intent, Switch, Tooltip } from "@blueprintjs/core";
+import { Classes, Code, Divider, FormGroup, H5, Icon, InputGroup, Intent, Switch, Tooltip } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -62,6 +62,7 @@ export const FormGroupExample: React.FC<ExampleProps> = props => {
             <Switch label="Show label" checked={label} onChange={handleBooleanChange(setLabel)} />
             <Switch label="Show label info" checked={requiredLabel} onChange={handleBooleanChange(setRequiredLabel)} />
             <Switch label="Show sub label" checked={subLabel} onChange={handleBooleanChange(setSubLabel)} />
+            <Divider />
             <IntentSelect intent={intent} label={intentLabelInfo} onChange={setIntent} showClearButton={true} />
         </>
     );

--- a/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { H5, HTMLSelect, type HTMLSelectIconName, Label, Switch } from "@blueprintjs/core";
+import { Divider, FormGroup, H5, HTMLSelect, type HTMLSelectIconName, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
 
 export interface HTMLSelectExampleState {
@@ -60,14 +60,14 @@ export class HTMLSelectExample extends React.PureComponent<ExampleProps, HTMLSel
                 <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
                 <Switch checked={this.state.minimal} label="Minimal" onChange={this.handleMinimalChange} />
                 <Switch checked={this.state.disabled} label="Disabled" onChange={this.handleDisabledChange} />
-                <Label>
-                    Icon
+                <Divider />
+                <FormGroup label="Icon">
                     <HTMLSelect
                         placeholder="Choose an item..."
                         options={SUPPORTED_ICON_NAMES}
                         onChange={this.handleIconChange}
                     />
-                </Label>
+                </FormGroup>
             </>
         );
 

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -82,8 +82,9 @@ export function MenuItemExample(props: ExampleProps) {
                         { label: "menuitem", value: "menuitem" },
                         { label: "listoption", value: "listoption" },
                     ]}
-                    value={roleStructure}
                     onValueChange={handleRoleStructureChange}
+                    small={true}
+                    value={roleStructure}
                 />
             </FormGroup>
         </>

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -19,16 +19,16 @@ import * as React from "react";
 import {
     Classes,
     Code,
+    FormGroup,
     H5,
-    HTMLSelect,
     type Intent,
-    Label,
     Menu,
     MenuItem,
     type MenuItemProps,
+    SegmentedControl,
     Switch,
 } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { BooleanOrUndefinedSelect } from "./common/booleanOrUndefinedSelect";
@@ -42,6 +42,11 @@ export function MenuItemExample(props: ExampleProps) {
     const [iconEnabled, setIconEnabled] = React.useState(true);
     const [submenuEnabled, setSubmenuEnabled] = React.useState(true);
     const [roleStructure, setRoleStructure] = React.useState<MenuItemProps["roleStructure"]>("menuitem");
+
+    const handleRoleStructureChange = React.useCallback(
+        (newValue: string) => setRoleStructure(newValue as MenuItemProps["roleStructure"]),
+        [],
+    );
 
     const isSelectable = roleStructure === "listoption";
 
@@ -71,14 +76,16 @@ export function MenuItemExample(props: ExampleProps) {
             <Switch label="Enable icon" checked={iconEnabled} onChange={handleBooleanChange(setIconEnabled)} />
             <Switch label="Enable submenu" checked={submenuEnabled} onChange={handleBooleanChange(setSubmenuEnabled)} />
             <IntentSelect intent={intent} onChange={setIntent} showClearButton={true} />
-            <Label>
-                Role structure
-                <HTMLSelect
-                    options={["menuitem", "listoption"]}
+            <FormGroup label="Role structure">
+                <SegmentedControl
+                    options={[
+                        { label: "menuitem", value: "menuitem" },
+                        { label: "listoption", value: "listoption" },
+                    ]}
                     value={roleStructure}
-                    onChange={handleValueChange(setRoleStructure)}
+                    onValueChange={handleRoleStructureChange}
                 />
-            </Label>
+            </FormGroup>
         </>
     );
 

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -22,23 +22,18 @@ import {
     Code,
     DialogBody,
     DialogStep,
+    Divider,
+    FormGroup,
     H5,
-    HTMLSelect,
-    Label,
     MultistepDialog,
     type MultistepDialogNavPosition,
     NumericInput,
     Radio,
     RadioGroup,
+    SegmentedControl,
     Switch,
 } from "@blueprintjs/core";
-import {
-    Example,
-    type ExampleProps,
-    handleBooleanChange,
-    handleStringChange,
-    handleValueChange,
-} from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
 
 import type { BlueprintExampleData } from "../../tags/types";
 
@@ -95,9 +90,8 @@ export class MultistepDialogExample extends React.PureComponent<
 
     private handleHasTitleChange = handleBooleanChange(hasTitle => this.setState({ hasTitle }));
 
-    private handleNavPositionChange = handleValueChange((navPosition: MultistepDialogNavPosition) =>
-        this.setState({ navPosition }),
-    );
+    private handleNavPositionChange = (newValue: string) =>
+        this.setState({ navPosition: newValue as MultistepDialogNavPosition });
 
     public render() {
         const finalButtonProps: Partial<ButtonProps> = {
@@ -147,7 +141,7 @@ export class MultistepDialogExample extends React.PureComponent<
             hasTitle,
             initialStepIndex,
             isCloseButtonShown,
-            navPosition: position,
+            navPosition,
             showCloseButtonInFooter,
         } = this.state;
         return (
@@ -175,17 +169,24 @@ export class MultistepDialogExample extends React.PureComponent<
                     onChange={this.handleFooterCloseButtonChange}
                 />
                 <Switch checked={canEscapeKeyClose} label="Escape key to close" onChange={this.handleEscapeKeyChange} />
-                <Label>
-                    Navigation Position
-                    <HTMLSelect value={position} onChange={this.handleNavPositionChange} options={NAV_POSITIONS} />
-                </Label>
-                <Label>Initial step index (0-indexed)</Label>
-                <NumericInput
-                    value={initialStepIndex}
-                    onValueChange={this.handleInitialStepIndexChange}
-                    max={2}
-                    min={-1}
-                />
+                <Divider />
+                <FormGroup label="Navigation Position">
+                    <SegmentedControl
+                        fill={true}
+                        onValueChange={this.handleNavPositionChange}
+                        options={NAV_POSITIONS.map(p => ({ label: p, value: p }))}
+                        small={true}
+                        value={navPosition}
+                    />
+                </FormGroup>
+                <FormGroup label="Initial step index (0-indexed)">
+                    <NumericInput
+                        value={initialStepIndex}
+                        onValueChange={this.handleInitialStepIndexChange}
+                        max={2}
+                        min={-1}
+                    />
+                </FormGroup>
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -18,11 +18,11 @@ import * as React from "react";
 
 import {
     Button,
-    ButtonGroup,
+    FormGroup,
     H5,
-    Label,
     NonIdealState,
     NonIdealStateIconSize,
+    SegmentedControl,
     Spinner,
     Switch,
 } from "@blueprintjs/core";
@@ -52,7 +52,7 @@ export interface NonIdealStateExampleState {
     showAction: boolean;
     showDescription: boolean;
     showTitle: boolean;
-    visual: VisualKind;
+    visual: NonIdealStateVisualKind;
 }
 
 export class NonIdealStateExample extends React.PureComponent<ExampleProps, NonIdealStateExampleState> {
@@ -78,14 +78,14 @@ export class NonIdealStateExample extends React.PureComponent<ExampleProps, NonI
 
     private handleSizeChange = (size: Size) => this.setState({ iconSize: sizeToNonIdealStateIconSize[size] });
 
-    private handleVisualKindChange = (visual: VisualKind) => this.setState({ visual });
+    private handleVisualKindChange = (visual: NonIdealStateVisualKind) => this.setState({ visual });
 
     public render() {
         const options = (
             <>
                 <H5>Props</H5>
                 <LayoutSelect layout={this.state.layout} onChange={this.handleLayoutChange} />
-                <VisualSelect visual={this.state.visual} onChange={this.handleVisualKindChange} />
+                <NonIdealStateVisualSelect visual={this.state.visual} onChange={this.handleVisualKindChange} />
                 <IconSelect
                     disabled={this.state.visual !== "icon"}
                     iconName={this.state.icon}
@@ -132,23 +132,27 @@ export class NonIdealStateExample extends React.PureComponent<ExampleProps, NonI
     }
 }
 
-type VisualKind = "icon" | "spinner";
+type NonIdealStateVisualKind = "icon" | "spinner";
 
 /** Button radio group to switch between icon and spinner visuals. */
-const VisualSelect: React.FC<{ visual: VisualKind; onChange: (option: VisualKind) => void }> = ({
-    visual,
-    onChange,
-}) => {
-    const handleIcon = React.useCallback(() => onChange("icon"), []);
-    const handleSpinner = React.useCallback(() => onChange("spinner"), []);
+const NonIdealStateVisualSelect: React.FC<{
+    visual: NonIdealStateVisualKind;
+    onChange: (option: NonIdealStateVisualKind) => void;
+}> = ({ visual, onChange }) => {
+    const handleChange = React.useCallback((value: string) => onChange(value as NonIdealStateVisualKind), [onChange]);
 
     return (
-        <Label>
-            Visual
-            <ButtonGroup fill={true} style={{ marginTop: 5 }}>
-                <Button active={visual === "icon"} text="Icon" onClick={handleIcon} />
-                <Button active={visual === "spinner"} text="Spinner" onClick={handleSpinner} />
-            </ButtonGroup>
-        </Label>
+        <FormGroup label="Visual">
+            <SegmentedControl
+                fill={true}
+                onValueChange={handleChange}
+                options={[
+                    { label: "Icon", value: "icon" },
+                    { label: "Spinner", value: "spinner" },
+                ]}
+                small={true}
+                value={visual}
+            />
+        </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -17,10 +17,11 @@ import * as React from "react";
 
 import {
     Button,
+    Divider,
+    FormGroup,
     H5,
     HTMLSelect,
     Intent,
-    Label,
     Menu,
     MenuItem,
     NumericInput,
@@ -175,6 +176,7 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
                 {this.renderSwitch("Numeric characters only", allowNumericCharactersOnly, this.toggleNumericCharsOnly)}
                 {this.renderSwitch("Select all on focus", selectAllOnFocus, this.toggleSelectAllOnFocus)}
                 {this.renderSwitch("Select all on increment", selectAllOnIncrement, this.toggleSelectAllOnIncrement)}
+                <Divider />
                 {this.renderSelectMenu("Minimum value", min, MIN_VALUES, this.handleMinChange)}
                 {this.renderSelectMenu("Maximum value", max, MAX_VALUES, this.handleMaxChange)}
                 {this.renderSelectMenu(
@@ -205,10 +207,9 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
         onChange: React.FormEventHandler,
     ) {
         return (
-            <Label>
-                {label}
+            <FormGroup label={label}>
                 <HTMLSelect {...{ value, onChange, options }} />
-            </Label>
+            </FormGroup>
         );
     }
 

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -25,7 +25,6 @@ import {
     H5,
     HTMLSelect,
     Intent,
-    Label,
     Menu,
     MenuDivider,
     MenuItem,
@@ -215,8 +214,7 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                         options={PopperPlacements}
                     />
                 </FormGroup>
-                <Label>
-                    Example content
+                <FormGroup label="Example content">
                     <HTMLSelect value={this.state.exampleIndex} onChange={this.handleExampleIndexChange}>
                         <option value="0">Text</option>
                         <option value="1">Input</option>
@@ -225,7 +223,7 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                         <option value="4">Select</option>
                         <option value="5">Empty</option>
                     </HTMLSelect>
-                </Label>
+                </FormGroup>
                 <Switch checked={this.state.usePortal} onChange={this.toggleUsePortal}>
                     Use <Code>Portal</Code>
                 </Switch>
@@ -279,7 +277,7 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                 </Switch>
                 <Switch checked={matchTargetWidth} label="Match target width" onChange={this.toggleMatchTargetWidth} />
 
-                <Label>
+                <FormGroup>
                     <AnchorButton
                         href={POPPER_DOCS_URL}
                         fill={true}
@@ -291,7 +289,7 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                     >
                         Visit Popper.js docs
                     </AnchorButton>
-                </Label>
+                </FormGroup>
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -22,8 +22,8 @@ import {
     Classes,
     EditableText,
     Elevation,
+    FormGroup,
     H5,
-    Label,
     Section,
     SectionCard,
     type SectionElevation,
@@ -92,7 +92,7 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
                 <Switch checked={hasDescription} label="Sub-title" onChange={this.toggleHasDescription} />
                 <Switch checked={hasRightElement} label="Right element" onChange={this.toggleHasRightElement} />
                 <Switch checked={collapsible} label="Collapsible" onChange={this.toggleCollapsible} />
-                <Label>
+                <FormGroup label="Elevation">
                     Elevation
                     <Slider
                         max={1}
@@ -101,7 +101,7 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
                         onChange={this.handleElevationChange}
                         handleHtmlProps={{ "aria-label": "Section elevation" }}
                     />
-                </Label>
+                </FormGroup>
 
                 <H5>Collapse Props</H5>
                 <Switch

--- a/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
@@ -33,6 +33,7 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
             <H5>Props</H5>
             <FormGroup label="Intent">
                 <SegmentedControl
+                    defaultValue="none"
                     inline={true}
                     options={[
                         {
@@ -44,8 +45,8 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
                             value: "primary",
                         },
                     ]}
-                    defaultValue="none"
                     onValueChange={handleIntentChange}
+                    small={true}
                 />
             </FormGroup>
             <SizeSelect size={size} onChange={setSize} />

--- a/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { FormGroup, H5, SegmentedControl, type SegmentedControlIntent, Switch } from "@blueprintjs/core";
+import { Divider, FormGroup, H5, SegmentedControl, type SegmentedControlIntent, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { type Size, SizeSelect } from "./common/sizeSelect";
@@ -26,11 +26,15 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
     const handleIntentChange = React.useCallback(newIntent => setIntent(newIntent as SegmentedControlIntent), []);
 
     const [fill, setFill] = React.useState<boolean>(false);
+    const [inline, setInline] = React.useState<boolean>(false);
     const [size, setSize] = React.useState<Size>("small");
 
     const options = (
         <>
             <H5>Props</H5>
+            <Switch checked={inline} label="Inline" onChange={handleBooleanChange(setInline)} />
+            <Switch checked={fill} label="Fill" onChange={handleBooleanChange(setFill)} />
+            <Divider />
             <FormGroup label="Intent">
                 <SegmentedControl
                     defaultValue="none"
@@ -50,7 +54,6 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
                 />
             </FormGroup>
             <SizeSelect size={size} onChange={setSize} />
-            <Switch checked={fill} label="Fill" onChange={handleBooleanChange(setFill)} />
         </>
     );
 
@@ -59,6 +62,7 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
             <SegmentedControl
                 defaultValue="list"
                 fill={fill}
+                inline={inline}
                 intent={intent}
                 options={[
                     {

--- a/packages/docs-app/src/examples/core-examples/switchCardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchCardExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { type Alignment, FormGroup, H5, Switch, SwitchCard, type SwitchCardProps } from "@blueprintjs/core";
+import { type Alignment, Divider, FormGroup, H5, Switch, SwitchCard, type SwitchCardProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
@@ -66,6 +66,7 @@ export class SwitchCardExample extends React.PureComponent<ExampleProps, SwitchC
                         onChange={this.toggleShowAsSelected}
                     />
                 </PropCodeTooltip>
+                <Divider />
                 <PropCodeTooltip snippet={`alignIndicator={${alignIndicator}}`}>
                     <AlignmentSelect
                         align={alignIndicator}

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Code, Label, Switch } from "@blueprintjs/core";
+import { Code, FormGroup, Switch } from "@blueprintjs/core";
 
 import { CheckboxExample } from "./checkboxExample";
 
@@ -25,13 +25,12 @@ export class SwitchExample extends CheckboxExample {
     protected renderExample() {
         return (
             <>
-                <div>
-                    <Label>Privacy setting</Label>
+                <FormGroup label="Privacy setting">
                     <Switch {...this.state} labelElement={<strong>Enabled</strong>} />
                     <Switch {...this.state} labelElement={<em>Public</em>} />
                     <Switch {...this.state} labelElement={<u>Cooperative</u>} defaultChecked={true} />
                     <Switch {...this.state} labelElement={"Containing Text"} innerLabelChecked="on" innerLabel="off" />
-                </div>
+                </FormGroup>
                 <small style={{ width: "100%", textAlign: "center" }}>
                     This example uses <Code>labelElement</Code> to demonstrate JSX labels.
                 </small>

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, H5, Intent, Switch, TagInput, type TagProps } from "@blueprintjs/core";
+import { Button, Divider, H5, Intent, Switch, TagInput, type TagProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -127,6 +127,7 @@ export class TagInputExample extends React.PureComponent<ExampleProps, TagInputE
                 <Switch label="Disabled" checked={this.state.disabled} onChange={this.handleDisabledChange} />
                 <Switch label="Left icon" checked={this.state.leftIcon} onChange={this.handleLeftIconChange} />
                 <Switch label="Fill container width" checked={this.state.fill} onChange={this.handleFillChange} />
+                <Divider />
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <H5>Behavior props</H5>
                 <Switch label="Add on blur" checked={this.state.addOnBlur} onChange={this.handleAddOnBlurChange} />

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -20,10 +20,10 @@ import * as React from "react";
 import {
     Button,
     Classes,
+    FormGroup,
     H5,
     HTMLSelect,
     Intent,
-    Label,
     NumericInput,
     OverlayToaster,
     type OverlayToasterProps,
@@ -158,12 +158,10 @@ export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExam
         return (
             <>
                 <H5>Props</H5>
-                <Label>
-                    Position
+                <FormGroup label="Position">
                     <HTMLSelect value={position} onChange={this.handlePositionChange} options={POSITIONS} />
-                </Label>
-                <Label>
-                    Maximum active toasts
+                </FormGroup>
+                <FormGroup label="Maximum active toasts">
                     <NumericInput
                         allowNumericCharactersOnly={true}
                         placeholder="No maximum!"
@@ -171,7 +169,7 @@ export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExam
                         value={maxToasts}
                         onValueChange={this.handleValueChange}
                     />
-                </Label>
+                </FormGroup>
                 <Switch label="Auto focus" checked={autoFocus} onChange={this.toggleAutoFocus} />
                 <Switch label="Can escape key clear" checked={canEscapeKeyClear} onChange={this.toggleEscapeKey} />
                 <Switch label="Use portal" checked={usePortal} onChange={this.toggleUsePortal} />

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -24,7 +24,7 @@
 import moment from "moment";
 import * as React from "react";
 
-import { Classes, H5, HTMLSelect, Label, Switch } from "@blueprintjs/core";
+import { Classes, FormGroup, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { type DateRange, DateRangePicker, type TimePrecision } from "@blueprintjs/datetime";
 import {
     Example,
@@ -204,14 +204,13 @@ export class DateRangePickerExample extends React.PureComponent<ExampleProps, Da
         onChange: React.FormEventHandler<HTMLElement>,
     ) {
         return (
-            <Label>
-                {label}
+            <FormGroup label={label}>
                 <HTMLSelect value={selectedValue} onChange={onChange}>
                     {options.map((opt, i) => (
                         <option key={i} value={i} label={opt.label} />
                     ))}
                 </HTMLSelect>
-            </Label>
+            </FormGroup>
         );
     }
 }

--- a/packages/docs-app/src/examples/datetime2-examples/common/minMaxDateSelect.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/common/minMaxDateSelect.tsx
@@ -17,7 +17,7 @@
 import { add } from "date-fns";
 import * as React from "react";
 
-import { HTMLSelect, Label } from "@blueprintjs/core";
+import { FormGroup, HTMLSelect } from "@blueprintjs/core";
 import { handleNumberChange } from "@blueprintjs/docs-theme";
 
 interface DateOption {
@@ -36,6 +36,7 @@ export interface DateSelectProps {
 const DateSelect: React.FC<DateSelectProps> = ({ label, onChange, options }) => {
     const [selectedOptionIndex, setSelectedOptionIndex] = React.useState(0);
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const handleSelectChange = React.useCallback(
         handleNumberChange(optionIndex => {
             setSelectedOptionIndex(optionIndex);
@@ -45,14 +46,13 @@ const DateSelect: React.FC<DateSelectProps> = ({ label, onChange, options }) => 
     );
 
     return (
-        <Label>
-            {label}
+        <FormGroup label={label}>
             <HTMLSelect value={selectedOptionIndex} onChange={handleSelectChange}>
                 {options.map((opt, i) => (
                     <option key={i} value={i} label={opt.label} />
                 ))}
             </HTMLSelect>
-        </Label>
+        </FormGroup>
     );
 };
 

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { HTMLSelect, Label } from "@blueprintjs/core";
+import { FormGroup, HTMLSelect } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleNumberChange } from "@blueprintjs/docs-theme";
 import { Cell, Column, ColumnLoadingOption, Table2 } from "@blueprintjs/table";
 
@@ -55,12 +55,11 @@ export class ColumnLoadingExample extends React.PureComponent<ExampleProps, Colu
             options.push(<option key={i} value={i} label={label} />);
         }
         return (
-            <Label>
-                Loading column
+            <FormGroup label="Loading column">
                 <HTMLSelect value={this.state.loadingColumn} onChange={this.handleLoadingColumnChange}>
                     {options}
                 </HTMLSelect>
-            </Label>
+            </FormGroup>
         );
     }
 


### PR DESCRIPTION


#### Checklist

- ~Includes tests~
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update various docs-app examples to:

- Replace ButtonGroup selectors with the new SegmentedControl component
- Replace usage of `<Label>` with `<FormGroup>` (we should deprecate the former, as suggested in the docs...)

#### Reviewers should focus on:

N/A

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![image](https://github.com/palantir/blueprint/assets/723999/fed2c0a5-d114-46ea-a97b-86be439a5fa3)
![image](https://github.com/palantir/blueprint/assets/723999/e27ce7b8-fbec-4645-8f45-5efc8af47c60)
![image](https://github.com/palantir/blueprint/assets/723999/d0a86815-5182-4015-83e9-2fa818fdd476)
![image](https://github.com/palantir/blueprint/assets/723999/d1745596-79ce-40b0-be06-18b8874bc91d)

