### PR TITLE
[core] feat(Button, AnchorButton): ellipsizeText prop

### DIFF
--- a/packages/core/src/components/button/buttonProps.ts
+++ b/packages/core/src/components/button/buttonProps.ts
@@ -41,6 +41,14 @@ export interface ButtonSharedProps extends ActionProps<HTMLElement> {
     /** Button contents. */
     children?: React.ReactNode;
 
+    /**
+     * If set to `true`, the button text element will hide overflow text that does not fit into a
+     * single line and show a trailing ellipsis, similar to the `Text` component.
+     *
+     * @default false
+     */
+    ellipsizeText?: boolean;
+
     /** Whether this button should expand to fill its container. */
     fill?: boolean;
 

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -22,6 +22,7 @@ import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { mergeRefs } from "../../common/refs";
 import { Icon } from "../icon/icon";
 import { Spinner, SpinnerSize } from "../spinner/spinner";
+import { Text } from "../text/text";
 import type { AnchorButtonProps, ButtonProps } from "./buttonProps";
 
 /**
@@ -73,7 +74,20 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
     props: E extends HTMLAnchorElement ? AnchorButtonProps : ButtonProps,
     ref: React.Ref<E>,
 ) {
-    const { active = false, alignText, fill, large, loading = false, outlined, minimal, small, tabIndex } = props;
+    const {
+        active = false,
+        alignText,
+        fill,
+        large,
+        loading = false,
+        minimal,
+        onBlur,
+        onKeyDown,
+        onKeyUp,
+        outlined,
+        small,
+        tabIndex,
+    } = props;
     const disabled = props.disabled || loading;
 
     // the current key being pressed
@@ -88,9 +102,9 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
             if (isActive) {
                 setIsActive(false);
             }
-            props.onBlur?.(e);
+            onBlur?.(e);
         },
-        [isActive, props.onBlur],
+        [isActive, onBlur],
     );
     const handleKeyDown = React.useCallback(
         (e: React.KeyboardEvent<any>) => {
@@ -101,9 +115,9 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
                 }
             }
             setCurrentKeyPressed(e.key);
-            props.onKeyDown?.(e);
+            onKeyDown?.(e);
         },
-        [currentKeyPressed, props.onKeyDown],
+        [currentKeyPressed, onKeyDown],
     );
     const handleKeyUp = React.useCallback(
         (e: React.KeyboardEvent<any>) => {
@@ -112,9 +126,9 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
                 buttonRef.current?.click();
             }
             setCurrentKeyPressed(undefined);
-            props.onKeyUp?.(e);
+            onKeyUp?.(e);
         },
-        [props.onKeyUp],
+        [onKeyUp],
     );
 
     const className = classNames(
@@ -153,17 +167,26 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
 function renderButtonContents<E extends HTMLAnchorElement | HTMLButtonElement>(
     props: E extends HTMLAnchorElement ? AnchorButtonProps : ButtonProps,
 ) {
-    const { children, icon, loading, rightIcon, text, textClassName } = props;
+    const { children, ellipsizeText, icon, loading, rightIcon, text, textClassName } = props;
     const hasTextContent = !Utils.isReactNodeEmpty(text) || !Utils.isReactNodeEmpty(children);
     return (
         <>
             {loading && <Spinner key="loading" className={Classes.BUTTON_SPINNER} size={SpinnerSize.SMALL} />}
             <Icon key="leftIcon" icon={icon} />
             {hasTextContent && (
-                <span key="text" className={classNames(Classes.BUTTON_TEXT, textClassName)}>
+                <Text
+                    key="text"
+                    className={classNames(Classes.BUTTON_TEXT, textClassName)}
+                    ellipsize={ellipsizeText}
+                    tagName="span"
+                >
                     {text}
                     {children}
-                </span>
+                </Text>
+                // <span key="text" className={classNames(Classes.BUTTON_TEXT, textClassName)}>
+                //     {text}
+                //     {children}
+                // </span>
             )}
             <Icon key="rightIcon" icon={rightIcon} />
         </>

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -89,16 +89,16 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
         return this.state.iconOnly
             ? undefined
             : this.state.longText
-            ? "Click to trigger a whimsical wiggling animation"
-            : "Click to wiggle";
+              ? "Click to trigger a whimsical wiggling animation"
+              : "Click to wiggle";
     }
 
     private get duplicateButtonText() {
         return this.state.iconOnly
             ? undefined
             : this.state.longText
-            ? "Duplicate this web page in a new browser tab"
-            : "Duplicate this page";
+              ? "Duplicate this web page in a new browser tab"
+              : "Duplicate this page";
     }
 
     public componentWillUnmount() {

--- a/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonsExample.tsx
@@ -21,6 +21,7 @@ import { type Alignment, AnchorButton, Button, Code, Divider, H5, Intent, Switch
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { Duplicate, Refresh } from "@blueprintjs/icons";
 
+import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { AlignmentSelect } from "./common/alignmentSelect";
 import { IntentSelect } from "./common/intentSelect";
 import { type Size, SizeSelect } from "./common/sizeSelect";
@@ -29,10 +30,12 @@ interface ButtonsExampleState {
     active: boolean;
     alignText: Alignment | undefined;
     disabled: boolean;
+    ellipsizeText: boolean;
     fill: boolean;
     iconOnly: boolean;
     intent: Intent;
     loading: boolean;
+    longText: boolean;
     minimal: boolean;
     outlined: boolean;
     size: Size;
@@ -44,10 +47,12 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
         active: false,
         alignText: undefined,
         disabled: false,
+        ellipsizeText: false,
         fill: false,
         iconOnly: false,
         intent: Intent.NONE,
         loading: false,
+        longText: false,
         minimal: false,
         outlined: false,
         size: "regular",
@@ -60,11 +65,17 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
 
+    private handleEllipsizeTextChange = handleBooleanChange(ellipsizeText => this.setState({ ellipsizeText }));
+
     private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
 
     private handleIconOnlyChange = handleBooleanChange(iconOnly => this.setState({ iconOnly }));
 
+    private handleIntentChange = (intent: Intent) => this.setState({ intent });
+
     private handleLoadingChange = handleBooleanChange(loading => this.setState({ loading }));
+
+    private handleLongTextChange = handleBooleanChange(longText => this.setState({ longText }));
 
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
 
@@ -72,9 +83,23 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
 
     private handleSizeChange = (size: Size) => this.setState({ size });
 
-    private handleIntentChange = (intent: Intent) => this.setState({ intent });
-
     private wiggleTimeoutId: number;
+
+    private get wiggleButtonText() {
+        return this.state.iconOnly
+            ? undefined
+            : this.state.longText
+            ? "Click to trigger a whimsical wiggling animation"
+            : "Click to wiggle";
+    }
+
+    private get duplicateButtonText() {
+        return this.state.iconOnly
+            ? undefined
+            : this.state.longText
+            ? "Duplicate this web page in a new browser tab"
+            : "Duplicate this page";
+    }
 
     public componentWillUnmount() {
         window.clearTimeout(this.wiggleTimeoutId);
@@ -92,12 +117,20 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
                 <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
                 <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
+                <PropCodeTooltip snippet={`ellipsizeText={${this.state.ellipsizeText.toString()}}`}>
+                    <Switch
+                        label="Ellipsize long text"
+                        checked={this.state.ellipsizeText}
+                        onChange={this.handleEllipsizeTextChange}
+                    />
+                </PropCodeTooltip>
                 <Divider />
                 <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignTextChange} />
                 <SizeSelect size={this.state.size} onChange={this.handleSizeChange} />
                 <IntentSelect intent={this.state.intent} onChange={this.handleIntentChange} />
                 <H5>Example</H5>
                 <Switch label="Icons only" checked={this.state.iconOnly} onChange={this.handleIconOnlyChange} />
+                <Switch label="Long text" checked={this.state.longText} onChange={this.handleLongTextChange} />
             </>
         );
 
@@ -113,10 +146,9 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
                         onClick={this.beginWiggling}
                         small={size === "small"}
                         large={size === "large"}
+                        text={this.wiggleButtonText}
                         {...buttonProps}
-                    >
-                        {!iconOnly && "Click to wiggle"}
-                    </Button>
+                    />
                 </div>
                 <div className={classNames({ "docs-flex-column": this.state.fill })}>
                     <p>
@@ -127,7 +159,7 @@ export class ButtonsExample extends React.PureComponent<ExampleProps, ButtonsExa
                         icon={<Duplicate />}
                         rightIcon="share"
                         target="_blank"
-                        text={iconOnly ? undefined : "Duplicate this page"}
+                        text={this.duplicateButtonText}
                         small={size === "small"}
                         large={size === "large"}
                         {...buttonProps}

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -62,6 +62,10 @@
   .docs-wiggle {
     animation: docs-wiggle-rotate $pt-transition-duration $pt-transition-ease infinite;
   }
+
+  .#{$ns}-button:not(.#{$ns}-fill) {
+    max-width: 200px;
+  }
 }
 
 #{example("CardList")} {


### PR DESCRIPTION
#### Fixes #6515

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Use `<Text>` to render button text
- feat(`Button`, `AnchorButton`): add new `ellipsizeText` prop which truncates long text that does not fit into a single line
  - This feature utilizes the `<Text>` component to detect overflow and render a native HTML tooltip to display the full overflowing text upon hover interaction

#### Reviewers should focus on:

- Usage of `<Text>` in such a widely used component (although we already use it in `<MenuItem>`)
- Functionality of the new feature
- Updated docs example options

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/640b30f6-7689-40c6-a968-0bbe4c455318)

![2023-11-13 17 20 39](https://github.com/palantir/blueprint/assets/723999/70458407-5963-48ad-b5f0-337d36c2e2f4)
