### PR TITLE
Fix DateRangePicker3 bug when initialMonth is equal to the maxDate's month

### DIFF
--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -451,12 +451,18 @@ function getInitialMonth(props: DateRangePicker3Props, value: DateRange): Date {
             month.setMonth(month.getMonth() - 1);
         }
         return month;
-    } else if (
-        DateUtils.isDayInRange(today, [props.minDate!, props.maxDate!]) &&
-        !DateUtils.isSameMonth(today, props.maxDate!)
-    ) {
+    } else if (DateUtils.isDayInRange(today, [props.minDate!, props.maxDate!])) {
+        if (!isSingleMonthOnly && DateUtils.isSameMonth(today, props.maxDate!)) {
+            // special case: if today is in the maxDate month, display it on the right calendar
+            today.setMonth(today.getMonth() - 1);
+        }
         return today;
     } else {
-        return props.minDate!;
+        const betweenDate = DateUtils.getDateBetween([props.minDate!, props.maxDate!]);
+        if (!isSingleMonthOnly && DateUtils.isSameMonth(betweenDate, props.maxDate!)) {
+            // special case: if betweenDate is in the maxDate month, display it on the right calendar
+            betweenDate.setMonth(betweenDate.getMonth() - 1);
+        }
+        return betweenDate;
     }
 }

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -451,9 +451,12 @@ function getInitialMonth(props: DateRangePicker3Props, value: DateRange): Date {
             month.setMonth(month.getMonth() - 1);
         }
         return month;
-    } else if (DateUtils.isDayInRange(today, [props.minDate!, props.maxDate!])) {
+    } else if (
+        DateUtils.isDayInRange(today, [props.minDate!, props.maxDate!]) &&
+        !DateUtils.isSameMonth(today, props.maxDate!)
+    ) {
         return today;
     } else {
-        return DateUtils.getDateBetween([props.minDate!, props.maxDate!]);
+        return props.minDate!;
     }
 }


### PR DESCRIPTION


#### Fixes https://github.com/palantir/blueprint/issues/6546

The bug occurs when `initialMonthAndYear` is equal to the `maxDate`'s month and year resulting in a buggy selection state.

We already handle this special case when using `props.initialMonth` or `value[0]` as the initial month, this PR just expands the special case check to also include the `today` and `dateBetween` cases.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Additionally checks that `today` or `dateBetween` (if being used as initialMonth) is not the same month as `maxDate`s month and if it is use the previous month

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

Testing locally on the docs app setting the minDate as and `new Date(2023, 9, 23)` and maxDate as `new Date(2023, 10, 15)`

before:
<img width="644" alt="Screenshot 2023-11-14 at 8 40 46 PM" src="https://github.com/palantir/blueprint/assets/13280642/217726da-abfe-4196-99e3-128030157bc8">
<img width="822" alt="Screenshot 2023-11-14 at 8 40 41 PM" src="https://github.com/palantir/blueprint/assets/13280642/5fb33c37-6caa-4682-b63b-ca86124e3fdd">


after:
<img width="837" alt="Screenshot 2023-11-14 at 8 39 54 PM" src="https://github.com/palantir/blueprint/assets/13280642/469c2d74-8244-4ea3-b2a3-e480b36a6402">
<img width="667" alt="Screenshot 2023-11-14 at 8 39 02 PM" src="https://github.com/palantir/blueprint/assets/13280642/4036153b-9ceb-42f8-b1d1-303456dab4b1">


