### PR TITLE
[docs-app] feat: add intent options for InputGroup, TextArea

### DIFF
--- a/packages/core/src/components/forms/input-group.md
+++ b/packages/core/src/components/forms/input-group.md
@@ -1,6 +1,6 @@
 @# Input group
 
-__InputGroup__ is basic building block used to render text inputs across many Blueprint components.
+**InputGroup** is basic building block used to render text inputs across many Blueprint components.
 This component allows you to optionally add icons and buttons _within_ a text input to expand its appearance and
 functionality. For example, you might use an input group to build a visibility toggle for a password field.
 
@@ -8,19 +8,21 @@ functionality. For example, you might use an input group to build a visibility t
 
 @## Usage
 
-__InputGroup__ supports one non-interactive icon on the left side and one arbitrary element on the right side.
+**InputGroup** supports one non-interactive icon on the left side and one arbitrary element on the right side.
 It measures the width of its child elements to create the appropriate right padding inside the input to accommodate
 content of any length.
 
-__InputGroup__ should be used like a standard React `<input>` element, either in a controlled or uncontrolled fashion.
+**InputGroup** should be used like a standard React `<input>` element, either in a controlled or uncontrolled fashion.
 In addition to its own props, it supports all valid `<input>` HTML attributes and forwards them to the DOM
 (the most common ones are detailed below).
 
-If controlled with the `value` prop, __InputGroup__ has support for _asynchronous updates_, which may occur with some
+If controlled with the `value` prop, **InputGroup** has support for _asynchronous updates_, which may occur with some
 form handling libraries like `redux-form`. This is not broadly encouraged (a value returned from `onChange` should be
 sent back to the component as a controlled `value` synchronously), but there is basic support for it using the
 `asyncControl` prop. Note that the input cursor may jump to the end of the input if the speed of text entry
 (time between change events) is faster than the speed of the async update.
+
+For _multiline text_: use [**TextArea**](#core/components/text-area) instead.
 
 @## Props interface
 
@@ -28,11 +30,11 @@ sent back to the component as a controlled `value` synchronously), but there is 
 
 @## Search input
 
-Apply the attribute `<InputGroup type="search">` to style a text input as a search field. This styling is equivalent
+Apply the attribute `type="search"` to style a text input as a search field. This styling is equivalent
 to what is applied using the `Classes.ROUND` modifier class&mdash;it is automatically applied for `[type="search"]`
 inputs.
 
-Note that some browsers also implement a handler for the `esc` key to clear the text in a search field.
+Note that some browsers also implement a handler for the <kbd>esc</kbd> key to clear the text in a search field.
 
 @reactExample SearchInputExample
 

--- a/packages/core/src/components/forms/text-area.md
+++ b/packages/core/src/components/forms/text-area.md
@@ -1,6 +1,7 @@
 @# Text area
 
-__TextArea__ is a multiline text input component which can be controlled similar to an `<InputGroup>` or `<input>`.
+**TextArea** is a multiline text input component which can be controlled similar to an
+[**InputGroup**](#core/components/input-group) component or `<input>` element.
 
 @reactExample TextAreaExample
 

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -18,6 +18,7 @@ import * as React from "react";
 
 import {
     Button,
+    Divider,
     H5,
     Icon,
     InputGroup,
@@ -33,13 +34,16 @@ import {
 import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
 import { IconSize } from "@blueprintjs/icons";
 
+import { IntentSelect } from "./common/intentSelect";
+
 export interface InputGroupExampleState {
     disabled: boolean;
-    readOnly: boolean;
     filterValue: string;
+    intent: Intent;
     large: boolean;
-    small: boolean;
+    readOnly: boolean;
     showPassword: boolean;
+    small: boolean;
     tagValue: string;
 }
 
@@ -47,6 +51,7 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, InputGr
     public state: InputGroupExampleState = {
         disabled: false,
         filterValue: "",
+        intent: Intent.NONE,
         large: false,
         readOnly: false,
         showPassword: false,
@@ -55,6 +60,8 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, InputGr
     };
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
+
+    private handleIntentChange = (intent: Intent) => this.setState({ intent });
 
     private handleReadOnlyChange = handleBooleanChange(readOnly => this.setState({ readOnly }));
 
@@ -69,7 +76,7 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, InputGr
     private handleTagChange = handleStringChange(tagValue => this.setState({ tagValue }));
 
     public render() {
-        const { disabled, filterValue, large, readOnly, small, showPassword, tagValue } = this.state;
+        const { disabled, filterValue, intent, large, readOnly, small, showPassword, tagValue } = this.state;
 
         const maybeSpinner = filterValue ? <Spinner size={IconSize.STANDARD} /> : undefined;
 
@@ -104,56 +111,42 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, InputGr
 
         const resultsTag = <Tag minimal={true}>{Math.floor(10000 / Math.max(1, Math.pow(tagValue.length, 2)))}</Tag>;
 
+        const sharedProps = { disabled, large, small, readOnly, intent };
+
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <Tooltip content="My input value state is updated asynchronously with a 10ms delay">
                     <InputGroup
+                        {...sharedProps}
                         asyncControl={true}
-                        disabled={disabled}
-                        large={large}
                         leftIcon="filter"
                         onChange={this.handleFilterChange}
                         placeholder="Filter histogram..."
-                        readOnly={readOnly}
                         rightElement={maybeSpinner}
-                        small={small}
                         value={filterValue}
                     />
                 </Tooltip>
                 <InputGroup
-                    disabled={disabled}
-                    large={large}
+                    {...sharedProps}
                     placeholder="Enter your password..."
-                    readOnly={readOnly}
                     rightElement={lockButton}
-                    small={small}
                     type={showPassword ? "text" : "password"}
                 />
                 <InputGroup
-                    disabled={disabled}
-                    large={large}
+                    {...sharedProps}
                     leftElement={<Icon icon="tag" />}
                     onChange={this.handleTagChange}
                     placeholder="Find tags"
-                    readOnly={readOnly}
                     rightElement={resultsTag}
-                    small={small}
                     value={tagValue}
                 />
-                <InputGroup
-                    disabled={disabled}
-                    large={large}
-                    placeholder="Add people or groups..."
-                    readOnly={readOnly}
-                    rightElement={permissionsMenu}
-                    small={small}
-                />
+                <InputGroup {...sharedProps} placeholder="Add people or groups..." rightElement={permissionsMenu} />
             </Example>
         );
     }
 
     private renderOptions() {
-        const { disabled, readOnly, large, small } = this.state;
+        const { disabled, intent, readOnly, large, small } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -161,6 +154,8 @@ export class InputGroupExample extends React.PureComponent<ExampleProps, InputGr
                 <Switch label="Read-only" onChange={this.handleReadOnlyChange} checked={readOnly} />
                 <Switch label="Large" onChange={this.handleLargeChange} checked={large} />
                 <Switch label="Small" onChange={this.handleSmallChange} checked={small} />
+                <Divider />
+                <IntentSelect intent={intent} onChange={this.handleIntentChange} />
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -16,10 +16,11 @@
 
 import * as React from "react";
 
-import { AnchorButton, Code, ControlGroup, H5, Switch, TextArea, Tooltip } from "@blueprintjs/core";
+import { AnchorButton, Code, ControlGroup, H5, Intent, Switch, TextArea, Tooltip } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
+import { IntentSelect } from "./common/intentSelect";
 
 const INTITIAL_CONTROLLED_TEXT = "In a galaxy far, far away...";
 const CONTROLLED_TEXT_TO_APPEND =
@@ -29,6 +30,7 @@ interface TextAreaExampleState {
     autoResize: boolean;
     controlled: boolean;
     disabled: boolean;
+    intent: Intent;
     growVertically: boolean;
     large: boolean;
     readOnly: boolean;
@@ -42,6 +44,7 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
         controlled: false,
         disabled: false,
         growVertically: false,
+        intent: Intent.NONE,
         large: false,
         readOnly: false,
         small: false,
@@ -51,6 +54,8 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     private handleControlledChange = handleBooleanChange(controlled => this.setState({ controlled }));
 
     private handleDisabledChange = handleBooleanChange(disabled => this.setState({ disabled }));
+
+    private handleIntentChange = (intent: Intent) => this.setState({ intent });
 
     private handleAutoResizeChange = handleBooleanChange(autoResize => this.setState({ autoResize }));
 
@@ -83,12 +88,13 @@ export class TextAreaExample extends React.PureComponent<ExampleProps, TextAreaE
     }
 
     private renderOptions() {
-        const { controlled, disabled, growVertically, large, readOnly, small, autoResize } = this.state;
+        const { controlled, disabled, growVertically, intent, large, readOnly, small, autoResize } = this.state;
         return (
             <>
                 <H5>Appearance props</H5>
                 <Switch label="Large" disabled={small} onChange={this.handleLargeChange} checked={large} />
                 <Switch label="Small" disabled={large} onChange={this.handleSmallChange} checked={small} />
+                <IntentSelect intent={intent} onChange={this.handleIntentChange} />
                 <H5>Behavior props</H5>
                 <Switch label="Disabled" onChange={this.handleDisabledChange} checked={disabled} />
                 <Switch label="Read-only" onChange={this.handleReadOnlyChange} checked={readOnly} />


### PR DESCRIPTION

#### Checklist

- ~Includes tests~
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add an intent select dropdown to the InputGroup example to demonstrate what different visual intents look like on this component.

I mostly wanted to verify that `readOnly={true}` had no effect on the border of an input with an intent applied (it does not).

#### Reviewers should focus on:

N/A

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/b2adc15d-afc2-4e4c-b79b-2f00a12bb27f)
![image](https://github.com/palantir/blueprint/assets/723999/190ce67a-2201-4ff0-8e77-49fb113be97a)
