### PR TITLE
chore: fix npm auth setting for Yarn

### DIFF
--- a/scripts/publish-npm-semver-tagged
+++ b/scripts/publish-npm-semver-tagged
@@ -19,10 +19,8 @@ if [ -z "${NPM_AUTH_TOKEN}" ]; then
     exit 1
 fi
 
-# set the auth token for this user, not just the repo
-# N.B. `npm set` doesn't work here, it complains that it doesn't work for NPM workspaces
-echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
-chmod 0600 ~/.npmrc
+# see https://yarnpkg.com/cli/config/set, https://yarnpkg.com/configuration/yarnrc#npmAuthToken
+yarn config set npmAuthToken "${NPM_AUTH_TOKEN}"
 
 for path in $publishable_paths; do
     pushd "$path"


### PR DESCRIPTION
the latest [publish CI job](https://app.circleci.com/pipelines/github/palantir/blueprint/5400/workflows/737b8fcf-fc92-40f4-91c1-9e80aef59c96/jobs/81835) failed; I had to SSH in and publish it manually.

This fixes the publish script to set the auth token for `yarn npm publish` correctly.