### PR TITLE
fix(a11y): popover target aria-expanded

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -368,6 +368,7 @@ export class Popover<
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const ownTargetProps = {
+            "aria-expanded": isOpen,
             "aria-haspopup":
                 this.props.popupKind ??
                 (this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY


### PR DESCRIPTION
Add `aria-expanded` prop to popover target. Improve a11y.