### PR TITLE
style: use "as const" instead of "as (literal)"

### DIFF
--- a/packages/core/src/common/alignment.ts
+++ b/packages/core/src/common/alignment.ts
@@ -16,9 +16,9 @@
 
 /** Alignment along the horizontal axis. */
 export const Alignment = {
-    CENTER: "center" as "center",
-    LEFT: "left" as "left",
-    RIGHT: "right" as "right",
+    CENTER: "center" as const,
+    LEFT: "left" as const,
+    RIGHT: "right" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Alignment = (typeof Alignment)[keyof typeof Alignment];

--- a/packages/core/src/common/boundary.ts
+++ b/packages/core/src/common/boundary.ts
@@ -16,9 +16,9 @@
 
 /** Boundary of a one-dimensional interval. */
 export const Boundary = {
-    START: "start" as "start",
+    START: "start" as const,
     // tslint:disable-next-line:object-literal-sort-keys
-    END: "end" as "end",
+    END: "end" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Boundary = (typeof Boundary)[keyof typeof Boundary];

--- a/packages/core/src/common/elevation.ts
+++ b/packages/core/src/common/elevation.ts
@@ -16,11 +16,11 @@
 
 // tslint:disable:object-literal-sort-keys
 export const Elevation = {
-    ZERO: 0 as 0,
-    ONE: 1 as 1,
-    TWO: 2 as 2,
-    THREE: 3 as 3,
-    FOUR: 4 as 4,
+    ZERO: 0 as const,
+    ONE: 1 as const,
+    TWO: 2 as const,
+    THREE: 3 as const,
+    FOUR: 4 as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Elevation = (typeof Elevation)[keyof typeof Elevation];

--- a/packages/core/src/common/intent.ts
+++ b/packages/core/src/common/intent.ts
@@ -20,11 +20,11 @@
  * The four basic intents.
  */
 export const Intent = {
-    NONE: "none" as "none",
-    PRIMARY: "primary" as "primary",
-    SUCCESS: "success" as "success",
-    WARNING: "warning" as "warning",
-    DANGER: "danger" as "danger",
+    NONE: "none" as const,
+    PRIMARY: "primary" as const,
+    SUCCESS: "success" as const,
+    WARNING: "warning" as const,
+    DANGER: "danger" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Intent = (typeof Intent)[keyof typeof Intent];

--- a/packages/core/src/common/keyCodes.ts
+++ b/packages/core/src/common/keyCodes.ts
@@ -18,15 +18,15 @@
 
 /** @deprecated use named keys instead of key codes */
 export const KeyCodes = {
-    BACKSPACE: 8,
-    TAB: 9,
-    ENTER: 13,
-    SHIFT: 16,
-    ESCAPE: 27,
-    SPACE: 32,
-    ARROW_LEFT: 37,
-    ARROW_UP: 38,
-    ARROW_RIGHT: 39,
-    ARROW_DOWN: 40,
-    DELETE: 46,
+    BACKSPACE: 8 as const,
+    TAB: 9 as const,
+    ENTER: 13 as const,
+    SHIFT: 16 as const,
+    ESCAPE: 27 as const,
+    SPACE: 32 as const,
+    ARROW_LEFT: 37 as const,
+    ARROW_UP: 38 as const,
+    ARROW_RIGHT: 39 as const,
+    ARROW_DOWN: 40 as const,
+    DELETE: 46 as const,
 };

--- a/packages/core/src/common/position.ts
+++ b/packages/core/src/common/position.ts
@@ -15,18 +15,18 @@
  */
 
 export const Position = {
-    BOTTOM: "bottom" as "bottom",
-    BOTTOM_LEFT: "bottom-left" as "bottom-left",
-    BOTTOM_RIGHT: "bottom-right" as "bottom-right",
-    LEFT: "left" as "left",
-    LEFT_BOTTOM: "left-bottom" as "left-bottom",
-    LEFT_TOP: "left-top" as "left-top",
-    RIGHT: "right" as "right",
-    RIGHT_BOTTOM: "right-bottom" as "right-bottom",
-    RIGHT_TOP: "right-top" as "right-top",
-    TOP: "top" as "top",
-    TOP_LEFT: "top-left" as "top-left",
-    TOP_RIGHT: "top-right" as "top-right",
+    BOTTOM: "bottom" as const,
+    BOTTOM_LEFT: "bottom-left" as const,
+    BOTTOM_RIGHT: "bottom-right" as const,
+    LEFT: "left" as const,
+    LEFT_BOTTOM: "left-bottom" as const,
+    LEFT_TOP: "left-top" as const,
+    RIGHT: "right" as const,
+    RIGHT_BOTTOM: "right-bottom" as const,
+    RIGHT_TOP: "right-top" as const,
+    TOP: "top" as const,
+    TOP_LEFT: "top-left" as const,
+    TOP_RIGHT: "top-right" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Position = (typeof Position)[keyof typeof Position];

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -53,10 +53,10 @@ import { getBasePlacement, getTransformOrigin } from "./popperUtils";
 import type { PopupKind } from "./popupKind";
 
 export const PopoverInteractionKind = {
-    CLICK: "click" as "click",
-    CLICK_TARGET_ONLY: "click-target" as "click-target",
-    HOVER: "hover" as "hover",
-    HOVER_TARGET_ONLY: "hover-target" as "hover-target",
+    CLICK: "click" as const,
+    CLICK_TARGET_ONLY: "click-target" as const,
+    HOVER: "hover" as const,
+    HOVER_TARGET_ONLY: "hover-target" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PopoverInteractionKind = (typeof PopoverInteractionKind)[keyof typeof PopoverInteractionKind];
@@ -372,7 +372,7 @@ export class Popover<
                 this.props.popupKind ??
                 (this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY
                     ? undefined
-                    : ("true" as "true")),
+                    : ("true" as const)),
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
             // applied to the generated target wrapper element.

--- a/packages/core/src/components/popover/popoverPosition.ts
+++ b/packages/core/src/components/popover/popoverPosition.ts
@@ -18,9 +18,9 @@ import { Position } from "../../common";
 
 export const PopoverPosition = {
     ...Position,
-    AUTO: "auto" as "auto",
-    AUTO_END: "auto-end" as "auto-end",
-    AUTO_START: "auto-start" as "auto-start",
+    AUTO: "auto" as const,
+    AUTO_END: "auto-end" as const,
+    AUTO_START: "auto-start" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PopoverPosition = (typeof PopoverPosition)[keyof typeof PopoverPosition];

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -20,29 +20,29 @@ import type { Intent, Props } from "../../common";
 
 export const HandleType = {
     /** A full handle appears as a small square. */
-    FULL: "full" as "full",
+    FULL: "full" as const,
 
     /** A start handle appears as the left or top half of a square. */
-    START: "start" as "start",
+    START: "start" as const,
 
     /** An end handle appears as the right or bottom half of a square. */
-    END: "end" as "end",
+    END: "end" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HandleType = (typeof HandleType)[keyof typeof HandleType];
 
 export const HandleInteractionKind = {
     /** Locked handles prevent other handles from being dragged past then. */
-    LOCK: "lock" as "lock",
+    LOCK: "lock" as const,
 
     /** Push handles move overlapping handles with them as they are dragged. */
-    PUSH: "push" as "push",
+    PUSH: "push" as const,
 
     /**
      * Handles marked "none" are not interactive and do not appear in the UI.
      * They serve only to break the track into subsections that can be colored separately.
      */
-    NONE: "none" as "none",
+    NONE: "none" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HandleInteractionKind = (typeof HandleInteractionKind)[keyof typeof HandleInteractionKind];

--- a/packages/datetime/src/common/timePrecision.ts
+++ b/packages/datetime/src/common/timePrecision.ts
@@ -15,9 +15,9 @@
  */
 
 export const TimePrecision = {
-    MILLISECOND: "millisecond" as "millisecond",
-    MINUTE: "minute" as "minute",
-    SECOND: "second" as "second",
+    MILLISECOND: "millisecond" as const,
+    MINUTE: "minute" as const,
+    SECOND: "second" as const,
 };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type TimePrecision = (typeof TimePrecision)[keyof typeof TimePrecision];

--- a/packages/datetime/src/common/timezoneDisplayFormat.ts
+++ b/packages/datetime/src/common/timezoneDisplayFormat.ts
@@ -23,28 +23,28 @@ export const TimezoneDisplayFormat = {
      * Short name format: "HST", "EDT", etc.
      * Falls back to "GMT+/-offset" if there is no commonly used abbreviation.
      */
-    ABBREVIATION: "abbreviation" as "abbreviation",
+    ABBREVIATION: "abbreviation" as const,
 
     /**
      * IANA timezone code: "Pacific/Honolulu", "America/New_York", etc.
      */
-    CODE: "code" as "code",
+    CODE: "code" as const,
 
     /**
      * Composite format: "Hawaii Time (HST) -10:00", "New York (EDT) -5:00", etc.
      * Omits abbreviation if there is no short name (it is redundant with offset).
      */
-    COMPOSITE: "composite" as "composite",
+    COMPOSITE: "composite" as const,
 
     /**
      * Long name format: "Hawaii-Aleutian Standard Time", "Eastern Daylight Time", "Coordinated Universal Time", etc.
      */
-    LONG_NAME: "long-name" as "long-name",
+    LONG_NAME: "long-name" as const,
 
     /**
      * Offset format: "-10:00", "-5:00", etc.
      */
-    OFFSET: "offset" as "offset",
+    OFFSET: "offset" as const,
 };
 
 /**


### PR DESCRIPTION
Style only change, no functional change.

Writing it this way accomplishes the same thing without re-declaring the same string literal twice.

![image](https://github.com/palantir/blueprint/assets/87083504/58eb7ad1-b012-45ec-b134-eb1d2219ee01)
