### PR TITLE
fix(icon): allow aria-hidden override

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -169,11 +169,11 @@ export const Icon: IconComponent = React.forwardRef(function <T extends Element>
             size === IconSize.STANDARD
                 ? Classes.ICON_STANDARD
                 : size === IconSize.LARGE
-                  ? Classes.ICON_LARGE
-                  : undefined;
+                ? Classes.ICON_LARGE
+                : undefined;
         return React.createElement(tagName!, {
-            ...removeNonHTMLProps(htmlProps),
             "aria-hidden": title ? undefined : true,
+            ...removeNonHTMLProps(htmlProps),
             className: classNames(
                 Classes.ICON,
                 sizeClass,

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -169,8 +169,8 @@ export const Icon: IconComponent = React.forwardRef(function <T extends Element>
             size === IconSize.STANDARD
                 ? Classes.ICON_STANDARD
                 : size === IconSize.LARGE
-                ? Classes.ICON_LARGE
-                : undefined;
+                  ? Classes.ICON_LARGE
+                  : undefined;
         return React.createElement(tagName!, {
             "aria-hidden": title ? undefined : true,
             ...removeNonHTMLProps(htmlProps),

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -93,8 +93,8 @@ export const SVGIconContainer: SVGIconContainerComponent = React.forwardRef(func
         return React.createElement(
             tagName,
             {
-                ...htmlProps,
                 "aria-hidden": title ? undefined : true,
+                ...htmlProps,
                 className: classNames(Classes.ICON, `${Classes.ICON}-${iconName}`, className),
                 ref,
                 title: htmlTitle,


### PR DESCRIPTION
Allow` aria-hidden` to be overriden in order to correctly follow the existing `title` jsdoc:

```javascript
   /**
     * If this value is nullish, `false`, or an empty string, the component will assume
     * that the icon is decorative and `aria-hidden="true"` will be applied (can be overridden
     * by manually passing `aria-hidden` prop).
     */
    title?: string | false | null;
```