### PR TITLE
[core] fix(SegmentedControl): remove border style override

### DIFF
--- a/packages/core/src/components/segmented-control/_segmented-control.scss
+++ b/packages/core/src/components/segmented-control/_segmented-control.scss
@@ -21,8 +21,6 @@
   }
 
   > .#{$ns}-button:not(.#{$ns}-minimal) {
-    box-shadow: 0 0 0 1px $pt-divider-black-muted;
-
     &:not(.#{$ns}-intent-primary) {
       background-color: $white;
 


### PR DESCRIPTION

#### Changes proposed in this pull request:

Fix the appearance of the selected option in a SegmentedControl to use the default button styles rather than a `box-shadow` override which we have decided is an unnecessary departure from the design system.

#### Reviewers should focus on:

No regressions other than the intended visual change

#### Screenshot

| Before | After |
| - | - |
| ![image](https://github.com/palantir/blueprint/assets/723999/744dd2bd-2dc1-407f-9a28-312d8e3f590f) | ![image](https://github.com/palantir/blueprint/assets/723999/22df5f05-8624-44fc-95e0-5eeed1758fee) |

