### PR TITLE
[core] fix(HotkeyParser): restore 'del' and 'esc' aliases

### DIFF
--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -46,6 +46,8 @@ export const MODIFIER_BIT_MASKS: KeyCodeReverseTable = {
 export const CONFIG_ALIASES: KeyMap = {
     cmd: "meta",
     command: "meta",
+    del: "delete",
+    esc: "escape",
     escape: "escape",
     minus: "-",
     mod: isMac() ? "meta" : "ctrl",

--- a/packages/core/test/hotkeys/hotkeysParserTests.ts
+++ b/packages/core/test/hotkeys/hotkeysParserTests.ts
@@ -148,6 +148,8 @@ describe("HotkeysParser", () => {
         it("applies aliases", () => {
             expect(comboMatches(parseKeyCombo("return"), parseKeyCombo("enter"))).to.be.true;
             expect(comboMatches(parseKeyCombo("win + F"), parseKeyCombo("meta + f"))).to.be.true;
+            // regression test for https://github.com/palantir/blueprint/issues/6471
+            expect(comboMatches(parseKeyCombo("esc"), parseKeyCombo("escape"))).to.be.true;
         });
     });
 


### PR DESCRIPTION
#### Fixes #6471

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Restore two important aliases for hotkey configuration: "del" -> <kbd>delete</kbd> and "esc" -> <kbd>escape</kbd>

#### Reviewers should focus on:

Fixes the linked regression, also the unit test

#### Screenshot

N/A
