### PR TITLE
[core] fix(Popover): 'lazy' support; add tests for 'shouldReturnFocusOnClose'

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -439,7 +439,16 @@ export class Popover<
     };
 
     private renderPopover = (popperProps: PopperChildrenProps) => {
-        const { interactionKind, shouldReturnFocusOnClose, usePortal } = this.props;
+        const {
+            autoFocus,
+            enforceFocus,
+            backdropProps,
+            canEscapeKeyClose,
+            hasBackdrop,
+            interactionKind,
+            shouldReturnFocusOnClose,
+            usePortal,
+        } = this.props;
         const { isOpen } = this.state;
 
         // compute an appropriate transform origin so the scale animation points towards target
@@ -484,14 +493,15 @@ export class Popover<
 
         return (
             <Overlay
-                autoFocus={this.props.autoFocus ?? defaultAutoFocus}
+                autoFocus={autoFocus ?? defaultAutoFocus}
                 backdropClassName={Classes.POPOVER_BACKDROP}
-                backdropProps={this.props.backdropProps}
-                canEscapeKeyClose={this.props.canEscapeKeyClose}
-                canOutsideClickClose={this.props.interactionKind === PopoverInteractionKind.CLICK}
-                enforceFocus={this.props.enforceFocus}
-                hasBackdrop={this.props.hasBackdrop}
+                backdropProps={backdropProps}
+                canEscapeKeyClose={canEscapeKeyClose}
+                canOutsideClickClose={interactionKind === PopoverInteractionKind.CLICK}
+                enforceFocus={enforceFocus}
+                hasBackdrop={hasBackdrop}
                 isOpen={isOpen}
+                lazy={this.props.lazy}
                 onClose={this.handleOverlayClose}
                 onClosed={this.props.onClosed}
                 onClosing={this.props.onClosing}
@@ -499,7 +509,7 @@ export class Popover<
                 onOpening={this.props.onOpening}
                 transitionDuration={this.props.transitionDuration}
                 transitionName={Classes.POPOVER}
-                usePortal={this.props.usePortal}
+                usePortal={usePortal}
                 portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
                 portalStopPropagationEvents={this.props.portalStopPropagationEvents}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -111,7 +111,7 @@ export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = Def
      * Whether the application should return focus to the last active element in the
      * document after this popover closes.
      *
-     * This is automatically set to `false` if this is a hover interaction popover.
+     * This is automatically set (overridden) to `false` for hover interaction popovers.
      *
      * If you are attaching a popover _and_ a tooltip to the same target, you must take
      * care to either disable this prop for the popover _or_ disable the tooltip's

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -260,7 +260,7 @@ describe("<Popover>", () => {
             }
 
             wrapper = renderPopover({ ...commonProps, onOpened: handleOpened });
-            wrapper.focusTargetButton();
+            wrapper.targetButton.focus();
             wrapper.simulateTarget("click");
         });
 
@@ -275,7 +275,7 @@ describe("<Popover>", () => {
             }
 
             wrapper = renderPopover(commonProps);
-            wrapper.focusTargetButton();
+            wrapper.targetButton.focus();
             assert.strictEqual(
                 document.activeElement,
                 wrapper.targetElement.querySelector("button"),
@@ -345,17 +345,6 @@ describe("<Popover>", () => {
                 assertPopoverOpenStateForInteractionKind("click", false, {
                     autoFocus: false,
                 });
-            });
-
-            it("popover remains open after target focus if autoFocus={true}", () => {
-                wrapper = renderPopover({
-                    autoFocus: true,
-                    interactionKind: "hover",
-                    usePortal: true,
-                });
-                wrapper.focusTargetButton();
-                wrapper.blurTargetButton();
-                wrapper.assertIsOpen();
             });
         });
 
@@ -889,11 +878,10 @@ describe("<Popover>", () => {
     interface PopoverWrapper extends ReactWrapper<PopoverProps, PopoverState> {
         popoverElement: HTMLElement;
         targetElement: HTMLElement;
+        targetButton: HTMLButtonElement;
         assertFindClass(className: string, expected?: boolean, msg?: string): this;
         assertIsOpen(isOpen?: boolean): this;
         assertOnInteractionCalled(called?: boolean): this;
-        blurTargetButton(): this;
-        focusTargetButton(): this;
         simulateContent(eventName: string, ...args: any[]): this;
         /** Careful: simulating "focus" is unsupported by Enzyme, see https://stackoverflow.com/a/56892875/7406866 */
         simulateTarget(eventName: string, ...args: any[]): this;
@@ -919,6 +907,10 @@ describe("<Popover>", () => {
         const instance = wrapper.instance() as Popover<React.HTMLProps<HTMLButtonElement>>;
         wrapper.popoverElement = instance.popoverElement!;
         wrapper.targetElement = instance.targetRef.current!;
+        wrapper.targetButton = wrapper
+            .find("[data-testid='target-button']")
+            .hostNodes()
+            .getDOMNode<HTMLButtonElement>();
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {
             const actual = wrapper!.findClass(className);
             if (expected) {
@@ -944,14 +936,6 @@ describe("<Popover>", () => {
         };
         wrapper.simulateTarget = (eventName: string, ...args) => {
             wrapper!.findClass(Classes.POPOVER_TARGET).simulate(eventName, ...args);
-            return wrapper!;
-        };
-        wrapper.focusTargetButton = () => {
-            wrapper!.find(`[data-testid="target-button"]`).hostNodes().getDOMNode<HTMLElement>().focus();
-            return wrapper!;
-        };
-        wrapper.blurTargetButton = () => {
-            wrapper!.find(`[data-testid="target-button"]`).hostNodes().getDOMNode<HTMLElement>().blur();
             return wrapper!;
         };
         wrapper.sendEscapeKey = () => {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -244,8 +244,6 @@ describe("<Popover>", () => {
         const commonProps: Partial<PopoverProps> = {
             className: targetClassName,
             interactionKind: PopoverInteractionKind.CLICK,
-            openOnTargetFocus: false,
-            popoverClassName: Classes.POPOVER_CONTENT_SIZING,
             shouldReturnFocusOnClose: true,
             transitionDuration: 0,
             usePortal: true,
@@ -355,8 +353,8 @@ describe("<Popover>", () => {
                     interactionKind: "hover",
                     usePortal: true,
                 });
-                wrapper.simulateTarget("focus");
-                wrapper.simulateTarget("blur");
+                wrapper.focusTargetButton();
+                wrapper.blurTargetButton();
                 wrapper.assertIsOpen();
             });
         });
@@ -894,6 +892,7 @@ describe("<Popover>", () => {
         assertFindClass(className: string, expected?: boolean, msg?: string): this;
         assertIsOpen(isOpen?: boolean): this;
         assertOnInteractionCalled(called?: boolean): this;
+        blurTargetButton(): this;
         focusTargetButton(): this;
         simulateContent(eventName: string, ...args: any[]): this;
         /** Careful: simulating "focus" is unsupported by Enzyme, see https://stackoverflow.com/a/56892875/7406866 */
@@ -949,6 +948,10 @@ describe("<Popover>", () => {
         };
         wrapper.focusTargetButton = () => {
             wrapper!.find(`[data-testid="target-button"]`).hostNodes().getDOMNode<HTMLElement>().focus();
+            return wrapper!;
+        };
+        wrapper.blurTargetButton = () => {
+            wrapper!.find(`[data-testid="target-button"]`).hostNodes().getDOMNode<HTMLElement>().blur();
             return wrapper!;
         };
         wrapper.sendEscapeKey = () => {

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -21,6 +21,7 @@ import {
     Button,
     Classes,
     Code,
+    Divider,
     FormGroup,
     H5,
     HTMLSelect,
@@ -71,8 +72,10 @@ export interface PopoverExampleState {
     matchTargetWidth: boolean;
     minimal?: boolean;
     modifiers?: PopperModifierOverrides;
+    openOnTargetFocus: boolean;
     placement?: Placement;
     rangeSliderValue?: NumberRange;
+    shouldReturnFocusOnClose: boolean;
     sliderValue?: number;
     usePortal?: boolean;
 }
@@ -97,8 +100,10 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
             flip: { enabled: true },
             preventOverflow: { enabled: true },
         },
+        openOnTargetFocus: true,
         placement: "auto",
         rangeSliderValue: [0, 10],
+        shouldReturnFocusOnClose: false,
         sliderValue: 5,
         usePortal: true,
     };
@@ -138,6 +143,12 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
     });
 
     private toggleMinimal = handleBooleanChange(minimal => this.setState({ minimal }));
+
+    private toggleOpenOnTargetFocus = handleBooleanChange(openOnTargetFocus => this.setState({ openOnTargetFocus }));
+
+    private toggleShouldReturnFocusOnClose = handleBooleanChange(shouldReturnFocusOnClose =>
+        this.setState({ openOnTargetFocus: shouldReturnFocusOnClose ? false : undefined, shouldReturnFocusOnClose }),
+    );
 
     private toggleUsePortal = handleBooleanChange(usePortal => {
         if (usePortal) {
@@ -194,11 +205,13 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
     }
 
     private renderOptions() {
-        const { matchTargetWidth, modifiers, placement } = this.state;
+        const { interactionKind, matchTargetWidth, modifiers, placement } = this.state;
         const { arrow, flip, preventOverflow } = modifiers;
 
         // popper.js requires this modiifer for "auto" placement
         const forceFlipEnabled = placement.startsWith("auto");
+
+        const isHoverInteractionKind = interactionKind === "hover" || interactionKind === "hover-target";
 
         return (
             <>
@@ -208,11 +221,7 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                     label="Position when opened"
                     labelFor="position"
                 >
-                    <HTMLSelect
-                        value={this.state.placement}
-                        onChange={this.handlePlacementChange}
-                        options={PopperPlacements}
-                    />
+                    <HTMLSelect value={placement} onChange={this.handlePlacementChange} options={PopperPlacements} />
                 </FormGroup>
                 <FormGroup label="Example content">
                     <HTMLSelect value={this.state.exampleIndex} onChange={this.handleExampleIndexChange}>
@@ -241,14 +250,27 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                 <H5>Interactions</H5>
                 <RadioGroup
                     label="Interaction kind"
-                    selectedValue={this.state.interactionKind.toString()}
+                    selectedValue={interactionKind.toString()}
                     options={INTERACTION_KINDS}
                     onChange={this.handleInteractionChange}
                 />
+                <Divider />
                 <Switch
                     checked={this.state.canEscapeKeyClose}
                     label="Can escape key close"
                     onChange={this.toggleEscapeKey}
+                />
+                <Switch
+                    checked={this.state.openOnTargetFocus}
+                    disabled={!isHoverInteractionKind}
+                    label="Open on target focus"
+                    onChange={this.toggleOpenOnTargetFocus}
+                />
+                <Switch
+                    checked={isHoverInteractionKind ? false : this.state.shouldReturnFocusOnClose}
+                    disabled={isHoverInteractionKind}
+                    label="Should return focus on close"
+                    onChange={this.toggleShouldReturnFocusOnClose}
                 />
 
                 <H5>Modifiers</H5>

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -168,8 +168,9 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                 <div className="docs-popover-example-scroll" ref={this.centerScroll}>
                     <Popover
                         popoverClassName={exampleIndex <= 2 ? Classes.POPOVER_CONTENT_SIZING : ""}
-                        portalClassName="foo"
+                        portalClassName="docs-popover-example-portal"
                         {...popoverProps}
+                        content={this.getContents(exampleIndex)}
                         boundary={
                             boundary === "scrollParent"
                                 ? this.scrollParentElement ?? undefined
@@ -179,7 +180,6 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                         }
                         enforceFocus={false}
                         isOpen={this.state.isControlled ? this.state.isOpen : undefined}
-                        content={this.getContents(exampleIndex)}
                     >
                         <Button intent={Intent.PRIMARY} text={buttonText} tabIndex={0} />
                     </Popover>


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Fix `lazy` prop support for `Popover` (the component was never forwarding that prop to `Overlay`)
- Add unit tests for `shouldReturnFocusOnClose` behavior, illustrating that this requires `openOnTargetFocus={false}` and `shouldReturnFocusOnClose={true}` to be set
- Add `shouldReturnFocusOnClose` demo to docs example

#### Reviewers should focus on:

Unit test behavior

#### Screenshot

![2023-11-30 16 49 14](https://github.com/palantir/blueprint/assets/723999/9e597b10-d5c4-429c-a390-78a9563c1c53)

