### PR TITLE
Rework heading line heights

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -34,12 +34,12 @@ Styleguide headings
 
 // tag: (font-size, line-height)
 $headings: (
-  "h1": (36px, 40px),
-  "h2": (28px, 32px),
-  "h3": (22px, 25px),
-  "h4": (18px, 21px),
-  "h5": (16px, 19px),
-  "h6": (14px, 16px)
+  "h1": (36px, 44px),
+  "h2": (28px, 34px),
+  "h3": (22px, 26px),
+  "h4": (18px, 22px),
+  "h5": (16px, 20px),
+  "h6": (14px, 18px)
 ) !default;
 
 @each $tag, $props in $headings {


### PR DESCRIPTION
- Align H6 to base text (18px)
- Multiply font-size by 1.2 and took the closest even number

Not a large change but will make it easier to align icons and default text with headings.

Before
![Screenshot 2023-12-01 at 10 34 01](https://github.com/palantir/blueprint/assets/6755553/970ae267-95ef-4202-83cd-9b9da2a2f748)



After
![Screenshot 2023-12-01 at 10 32 56](https://github.com/palantir/blueprint/assets/6755553/14d90b22-d8f4-4f9b-937b-8e92adfc0b08)
