### PR TITLE
[core] fix(Popover): return focus to target on ESC keypress

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -446,7 +446,7 @@ export class Popover<
     private renderPopover = (popperProps: PopperChildrenProps) => {
         const { autoFocus, enforceFocus, backdropProps, canEscapeKeyClose, hasBackdrop, interactionKind, usePortal } =
             this.props;
-        const { isClosingViaEscapeKeypress: isClosingViaKeyboardInteraction, isOpen } = this.state;
+        const { isClosingViaEscapeKeypress, isOpen } = this.state;
 
         // compute an appropriate transform origin so the scale animation points towards target
         const transformOrigin = getTransformOrigin(
@@ -490,7 +490,7 @@ export class Popover<
         // if hover interaction, it doesn't make sense to take over focus control
         const shouldReturnFocusOnClose = this.isHoverInteractionKind()
             ? false
-            : isClosingViaKeyboardInteraction
+            : isClosingViaEscapeKeypress
               ? true
               : this.props.shouldReturnFocusOnClose;
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -719,7 +719,11 @@ export class Popover<
         if (!shouldIgnoreClick) {
             // ensure click did not originate from within inline popover before closing
             if (!this.props.disabled && !this.isElementInPopover(e.target as HTMLElement)) {
-                this.setOpenState(!this.props.isOpen, e);
+                if (this.props.isOpen == null) {
+                    this.setState(prevState => ({ isOpen: !prevState.isOpen }));
+                } else {
+                    this.setOpenState(!this.props.isOpen, e);
+                }
             }
         }
     };


### PR DESCRIPTION

#### Changes proposed in this pull request:

- fix(`Popover`): improve keyboard a11y: always return focus to target element when an <kbd>ESC</kbd> keypress closes the popover

#### Reviewers should focus on:

Updated behavior in docs example.

Note that we need to be conservative here and not enable this behavior for _all_ keyboard interactions because there may be some interactions where a confirmation action (e.g. "Enter" key) on a "popover dismiss element" (like a MenuItem) pulls the user's focus away from the popover, and we don't want to break that kind of functionality.

#### Screenshot

Returns focus on ESC key:

![2023-12-06 18 18 26](https://github.com/palantir/blueprint/assets/723999/77d2eb1a-6ded-4882-83a3-599eea8e5354)

Does not return focus (previous behavior) on Enter key:

![2023-12-06 18 18 56](https://github.com/palantir/blueprint/assets/723999/22896377-00eb-4992-b64a-68731441788d)

