### PR TITLE
Add `OverlayToaster.createAsync` method to support React 18

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -93,6 +93,10 @@ export const TOASTER_CREATE_NULL =
     ns +
     ` OverlayToaster.create() is not supported inside React lifecycle methods in React 16.` +
     ` See usage example on the docs site.`;
+export const TOASTER_CREATE_ASYNC_NULL =
+    ns +
+    ` OverlayToaster.createAsync() received a null component ref. This can happen if called inside React lifecycle ` +
+    `methods in React 16. See usage example on the docs site.`;
 export const TOASTER_MAX_TOASTS_INVALID =
     ns + ` <OverlayToaster> maxToasts is set to an invalid number, must be greater than 0`;
 export const TOASTER_WARN_INLINE =

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -92,11 +92,12 @@ export const SPINNER_WARN_CLASSES_SIZE = ns + ` <Spinner> Classes.SMALL/LARGE ar
 export const TOASTER_CREATE_NULL =
     ns +
     ` OverlayToaster.create() is not supported inside React lifecycle methods in React 16.` +
-    ` See usage example on the docs site.`;
+    ` See usage example on the docs site. https://blueprintjs.com/docs/#core/components/toast.example`;
 export const TOASTER_CREATE_ASYNC_NULL =
     ns +
     ` OverlayToaster.createAsync() received a null component ref. This can happen if called inside React lifecycle ` +
-    `methods in React 16. See usage example on the docs site.`;
+    `methods in React 16. See usage example on the docs site. ` +
+    `https://blueprintjs.com/docs/#core/components/toast.example`;
 export const TOASTER_MAX_TOASTS_INVALID =
     ns + ` <OverlayToaster> maxToasts is set to an invalid number, must be greater than 0`;
 export const TOASTER_WARN_INLINE =

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -117,7 +117,7 @@ export { Tab, type TabId, type TabProps } from "./tabs/tab";
 export { Tabs, type TabsProps, TabsExpander, Expander } from "./tabs/tabs";
 export { Tag, type TagProps } from "./tag/tag";
 export { TagInput, type TagInputProps, type TagInputAddMethod } from "./tag-input/tagInput";
-export { OverlayToaster } from "./toast/overlayToaster";
+export { OverlayToaster, type OverlayToasterCreateOptions } from "./toast/overlayToaster";
 export type { OverlayToasterProps, ToasterPosition } from "./toast/overlayToasterProps";
 export { Toast, type ToastProps } from "./toast/toast";
 export { Toaster, type ToastOptions } from "./toast/toaster";

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -36,6 +36,8 @@ There are three ways to use __OverlayToaster__:
     myToaster.show({ ...toastOptions });
     ```
 
+    We recommend calling `OverlayToaster.createAsync` once in your application and [sharing the created instance](#core/components/toast.example) throughout your application.
+
     A synchronous `OverlayToaster.create()` static method is also available, but will be phased out since React 18+ no longer synchronously renders components to the DOM.
 
     ```ts
@@ -115,6 +117,19 @@ function synchronousFn() {
 
 Note that `OverlayToaster.createAsync()` will throw an error if invoked inside a component lifecycle method, as
 `ReactDOM.render()` will return `null` resulting in an inaccessible toaster instance.
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">Beware of memory leaks</h5>
+
+The static `createAsync` and `create` methods create a new `OverlayToaster` instance for the full lifetime of your
+application. Since there's no React parent component, these methods create a new DOM node as a container for the
+rendered `<OverlayToaster>` component. Every `createAsync` call will add a new DOM node. We do not recommend creating a
+new `Toaster` every time a toast needs to be shown. To minimize leaking:
+
+1. Call `OverlayToaster.createAsync` once in an application and [share the instance](#core/components/toast.example).
+2. Consider one of the alternative APIs that mount the `<OverlayToaster>` somewhere in the application's React component tree. This provides component lifecycle management out of the box. See [_React component usage_](#core/components/toast.react-component-usage) for an example.
+
+</div>
 
 @interface Toaster
 

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -175,6 +175,26 @@ The example below uses the `OverlayToaster.createAsync()` static method. Clickin
 
 @reactExample ToastCreateAsyncExample
 
+#### React 18
+
+To maintain backwards compatibility with React 16 and 17, `OverlayToaster.createAsync` uses `ReactDOM.render` out of the box. This triggers a [console warning on React 18](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis). A future major version of Blueprint will drop support for React versions before 18 and switch the default rendering function from `ReactDOM.render` to `createRoot`.
+
+If you're using React 18, we recommend passing in a custom `domRenderer` function.
+
+```tsx
+import { OverlayToaster } from "@blueprintjs/core";
+import { createRoot } from "react-dom/client";
+
+const toaster = await OverlayToaster.createAsync(toasterProps, {
+    // Use createRoot() instead of ReactDOM.render(). This can be deleted after
+    // a future Blueprint version uses createRoot() for Toasters by default.
+    domRenderer: (toaster, containerElement) => createRoot(containerElement).render(toaster),
+});
+
+toaster.show({ message: "Hello React 18!" })
+```
+
+
 @## React component usage
 
 Render the `<OverlayToaster>` component like any other element and supply `<Toast>` elements as `children`. You can

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -30,7 +30,14 @@ horizontally aligned along the left edge, center, or right edge of its container
 
 There are three ways to use __OverlayToaster__:
 
-1. __Recommended__: use the `OverlayToaster.create()` static method to create a new `Toaster` instance:
+1. __Recommended__: use the `OverlayToaster.createAsync()` static method to create a new `Toaster` instance:
+    ```ts
+    const myToaster: Toaster = await OverlayToaster.createAsync({ position: "bottom" });
+    myToaster.show({ ...toastOptions });
+    ```
+
+    A synchronous `OverlayToaster.create()` static method is also available, but will be phased out since React 18+ no longer synchronously renders components to the DOM.
+
     ```ts
     const myToaster: Toaster = OverlayToaster.create({ position: "bottom" });
     myToaster.show({ ...toastOptions });

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -143,6 +143,10 @@ export class App extends React.PureComponent {
 }
 ```
 
+The example below uses the `OverlayToaster.createAsync()` static method. Clicking the button will create a new toaster mounted to `<body>`, show a message, and unmount the toaster from the DOM once the message is dismissed.
+
+@reactExample ToastCreateAsyncExample
+
 @## React component usage
 
 Render the `<OverlayToaster>` component like any other element and supply `<Toast>` elements as `children`. You can

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -86,21 +86,34 @@ enable `autoFocus` for an individual `OverlayToaster` via a prop, if desired.
 
 @## Static usage
 
-__OverlayToaster__ provides the static `create` method that returns a new `Toaster`, rendered into an
+__OverlayToaster__ provides the static `createAsync` method that returns a new `Toaster`, rendered into an
 element attached to `<body>`. A toaster instance has a collection of methods to show and hide toasts in its given container.
 
 ```ts
-OverlayToaster.create(props?: ToasterProps, container = document.body): Toaster
+OverlayToaster.createAsync(props?: OverlayToasterProps, options?: OverlayToasterCreateOptions): Promise<Toaster>;
 ```
+
+@interface OverlayToasterCreateOptions
 
 The toaster will be rendered into a new element appended to the given `container`.
 The `container` determines which element toasts are positioned relative to; the default value of `<body>` allows them to use the entire viewport.
 
-Note that the return type is `Toaster`, which is a minimal interface that exposes only the instance
-methods detailed below. It can be thought of as `OverlayToaster` minus the `React.Component` methods,
-because the `OverlayToaster` should not be treated as a normal React component.
+The return type is `Promise<Toaster>`, which is a minimal interface that exposes only the instance methods detailed
+below. It can be thought of as `OverlayToaster` minus the `React.Component` methods, because the `OverlayToaster` should
+not be treated as a normal React component.
 
-Note that `OverlayToaster.create()` will throw an error if invoked inside a component lifecycle method, as
+A promise is returned as React components cannot be rendered synchronously after React version 18. If this makes
+`Toaster` usage difficult outside of a function that's not `async`, it's still possible to attach `.then()` handlers to
+the returned toaster.
+
+```ts
+function synchronousFn() {
+    const toasterPromise = OverlayToaster.createAsync({});
+    toasterPromise.then(toaster => toaster.show({ message: "Toast!" }));
+}
+```
+
+Note that `OverlayToaster.createAsync()` will throw an error if invoked inside a component lifecycle method, as
 `ReactDOM.render()` will return `null` resulting in an inaccessible toaster instance.
 
 @interface Toaster
@@ -117,7 +130,7 @@ The following code samples demonstrate our preferred pattern for intergrating a 
 import { OverlayToaster, Position } from "@blueprintjs/core";
 
 /** Singleton toaster instance. Create separate instances for different options. */
-export const AppToaster = OverlayToaster.create({
+export const AppToaster = OverlayToaster.createAsync({
     className: "recipe-toaster",
     position: Position.TOP,
 });
@@ -135,10 +148,10 @@ export class App extends React.PureComponent {
         return <Button onClick={this.showToast} text="Toast please" />;
     }
 
-    showToast = () => {
+    showToast = async () => {
         // create toasts in response to interactions.
         // in most cases, it's enough to simply create and forget (thanks to timeout).
-        AppToaster.show({ message: "Toasted." });
+        (await AppToaster).show({ message: "Toasted." });
     }
 }
 ```

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -32,6 +32,12 @@ const SPECS = [
             OverlayToaster.create(props, containerElement),
         name: "create",
     },
+    {
+        cleanup: unmountReact16Toaster,
+        create: (props: OverlayToasterProps | undefined, containerElement: HTMLElement) =>
+            OverlayToaster.createAsync(props, { container: containerElement }),
+        name: "createAsync",
+    },
 ];
 
 /**
@@ -63,10 +69,10 @@ describe("OverlayToaster", () => {
 
     describeEach(SPECS, spec => {
         describe("with default props", () => {
-            before(() => {
+            before(async () => {
                 testsContainerElement = document.createElement("div");
                 document.documentElement.appendChild(testsContainerElement);
-                toaster = spec.create({}, testsContainerElement);
+                toaster = await spec.create({}, testsContainerElement);
             });
 
             afterEach(() => {
@@ -189,10 +195,10 @@ describe("OverlayToaster", () => {
         });
 
         describe("with maxToasts set to finite value", () => {
-            before(() => {
+            before(async () => {
                 testsContainerElement = document.createElement("div");
                 document.documentElement.appendChild(testsContainerElement);
-                toaster = spec.create({ maxToasts: 3 }, testsContainerElement);
+                toaster = await spec.create({ maxToasts: 3 }, testsContainerElement);
             });
 
             after(() => {
@@ -210,10 +216,10 @@ describe("OverlayToaster", () => {
         });
 
         describe("with autoFocus set to true", () => {
-            before(() => {
+            before(async () => {
                 testsContainerElement = document.createElement("div");
                 document.documentElement.appendChild(testsContainerElement);
-                toaster = spec.create({ autoFocus: true }, testsContainerElement);
+                toaster = await spec.create({ autoFocus: true }, testsContainerElement);
             });
 
             after(() => {

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -22,8 +22,29 @@ import sinon, { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
-import { Classes, OverlayToaster, type Toaster } from "../../src";
+import { Classes, OverlayToaster, type OverlayToasterProps, type Toaster } from "../../src";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
+
+const SPECS = [
+    {
+        cleanup: unmountReact16Toaster,
+        create: (props: OverlayToasterProps | undefined, containerElement: HTMLElement) =>
+            OverlayToaster.create(props, containerElement),
+        name: "create",
+    },
+];
+
+/**
+ * Dynamically run describe blocks. The helper function here reduces indentation
+ * width compared to inlining a for loop.
+ *
+ * https://mochajs.org/#dynamically-generating-tests
+ */
+function describeEach<T extends { name: string }>(specs: readonly T[], runner: (spec: T) => void) {
+    for (const spec of specs) {
+        describe(spec.name, () => runner(spec));
+    }
+}
 
 /**
  * @param containerElement The container argument passed to OverlayToaster.create/OverlayToaster.createAsync
@@ -40,191 +61,197 @@ describe("OverlayToaster", () => {
     let testsContainerElement: HTMLElement;
     let toaster: Toaster;
 
-    describe("with default props", () => {
-        before(() => {
-            testsContainerElement = document.createElement("div");
-            document.documentElement.appendChild(testsContainerElement);
-            toaster = OverlayToaster.create({}, testsContainerElement);
-        });
-
-        afterEach(() => {
-            toaster.clear();
-        });
-
-        after(() => {
-            unmountReact16Toaster(testsContainerElement);
-            document.documentElement.removeChild(testsContainerElement);
-        });
-
-        it("does not attach toast container to body on script load", () => {
-            assert.lengthOf(document.getElementsByClassName(Classes.TOAST_CONTAINER), 0, "unexpected toast container");
-        });
-
-        it("show() renders toast immediately", () => {
-            toaster.show({
-                message: "Hello world",
+    describeEach(SPECS, spec => {
+        describe("with default props", () => {
+            before(() => {
+                testsContainerElement = document.createElement("div");
+                document.documentElement.appendChild(testsContainerElement);
+                toaster = spec.create({}, testsContainerElement);
             });
-            assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-            assert.isNotNull(document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`));
-        });
 
-        it("multiple show()s renders them all", () => {
-            toaster.show({ message: "one" });
-            toaster.show({ message: "two" });
-            toaster.show({ message: "six" });
-            assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
-        });
-
-        it("show() updates existing toast", () => {
-            const key = toaster.show({ message: "one" });
-            assert.deepEqual(toaster.getToasts()[0].message, "one");
-            toaster.show({ message: "two" }, key);
-            assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-            assert.deepEqual(toaster.getToasts()[0].message, "two");
-        });
-
-        it("dismiss() removes just the toast in question", () => {
-            toaster.show({ message: "one" });
-            const key = toaster.show({ message: "two" });
-            toaster.show({ message: "six" });
-            toaster.dismiss(key);
-            assert.deepEqual(
-                toaster.getToasts().map(t => t.message),
-                ["six", "one"],
-            );
-        });
-
-        it("clear() removes all toasts", () => {
-            toaster.show({ message: "one" });
-            toaster.show({ message: "two" });
-            toaster.show({ message: "six" });
-            assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
-            toaster.clear();
-            assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
-        });
-
-        it("action onClick callback invoked when action clicked", () => {
-            const onClick = spy();
-            toaster.show({
-                action: { onClick, text: "action" },
-                message: "message",
-                timeout: 0,
+            afterEach(() => {
+                toaster.clear();
             });
-            // action is first descendant button
-            const action = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
-            action?.click();
-            assert.isTrue(onClick.calledOnce, "expected onClick to be called once");
-        });
 
-        it("onDismiss callback invoked when close button clicked", () => {
-            const handleDismiss = spy();
-            toaster.show({
-                message: "dismiss",
-                onDismiss: handleDismiss,
-                timeout: 0,
+            after(() => {
+                spec.cleanup(testsContainerElement);
+                document.documentElement.removeChild(testsContainerElement);
             });
-            // without action, dismiss is first descendant button
-            const dismiss = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
-            dismiss?.click();
-            assert.isTrue(handleDismiss.calledOnce);
-        });
 
-        it("onDismiss callback invoked on toaster.dismiss()", () => {
-            const onDismiss = spy();
-            const key = toaster.show({ message: "dismiss me", onDismiss });
-            toaster.dismiss(key);
-            assert.isTrue(onDismiss.calledOnce, "onDismiss not called");
-        });
+            it("does not attach toast container to body on script load", () => {
+                assert.lengthOf(
+                    document.getElementsByClassName(Classes.TOAST_CONTAINER),
+                    0,
+                    "unexpected toast container",
+                );
+            });
 
-        it("onDismiss callback invoked on toaster.clear()", () => {
-            const onDismiss = spy();
-            toaster.show({ message: "dismiss me", onDismiss });
-            toaster.clear();
-            assert.isTrue(onDismiss.calledOnce, "onDismiss not called");
-        });
+            it("show() renders toast immediately", () => {
+                toaster.show({
+                    message: "Hello world",
+                });
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                assert.isNotNull(document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`));
+            });
 
-        it("reusing props object does not produce React errors", () => {
-            const errorSpy = spy(console, "error");
-            try {
-                // if Toaster doesn't clone the props object before injecting key then there will be a
-                // React error that both toasts have the same key, because both instances refer to the
-                // same object.
-                const toast = { message: "repeat" };
-                toaster.show(toast);
-                toaster.show(toast);
-                assert.isFalse(errorSpy.calledWithMatch("two children with the same key"), "mutation side effect!");
-            } finally {
-                // Restore console.error. Otherwise other tests will fail
-                // with "TypeError: Attempted to wrap error which is already
-                // wrapped" when attempting to spy on console.error again.
-                sinon.restore();
-            }
-        });
-    });
+            it("multiple show()s renders them all", () => {
+                toaster.show({ message: "one" });
+                toaster.show({ message: "two" });
+                toaster.show({ message: "six" });
+                assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+            });
 
-    describe("with maxToasts set to finite value", () => {
-        before(() => {
-            testsContainerElement = document.createElement("div");
-            document.documentElement.appendChild(testsContainerElement);
-            toaster = OverlayToaster.create({ maxToasts: 3 }, testsContainerElement);
-        });
+            it("show() updates existing toast", () => {
+                const key = toaster.show({ message: "one" });
+                assert.deepEqual(toaster.getToasts()[0].message, "one");
+                toaster.show({ message: "two" }, key);
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                assert.deepEqual(toaster.getToasts()[0].message, "two");
+            });
 
-        after(() => {
-            unmountReact16Toaster(testsContainerElement);
-            document.documentElement.removeChild(testsContainerElement);
-        });
+            it("dismiss() removes just the toast in question", () => {
+                toaster.show({ message: "one" });
+                const key = toaster.show({ message: "two" });
+                toaster.show({ message: "six" });
+                toaster.dismiss(key);
+                assert.deepEqual(
+                    toaster.getToasts().map(t => t.message),
+                    ["six", "one"],
+                );
+            });
 
-        it("does not exceed the maximum toast limit set", () => {
-            toaster.show({ message: "one" });
-            toaster.show({ message: "two" });
-            toaster.show({ message: "three" });
-            toaster.show({ message: "oh no" });
-            assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
-        });
-    });
+            it("clear() removes all toasts", () => {
+                toaster.show({ message: "one" });
+                toaster.show({ message: "two" });
+                toaster.show({ message: "six" });
+                assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+                toaster.clear();
+                assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
+            });
 
-    describe("with autoFocus set to true", () => {
-        before(() => {
-            testsContainerElement = document.createElement("div");
-            document.documentElement.appendChild(testsContainerElement);
-            toaster = OverlayToaster.create({ autoFocus: true }, testsContainerElement);
-        });
+            it("action onClick callback invoked when action clicked", () => {
+                const onClick = spy();
+                toaster.show({
+                    action: { onClick, text: "action" },
+                    message: "message",
+                    timeout: 0,
+                });
+                // action is first descendant button
+                const action = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
+                action?.click();
+                assert.isTrue(onClick.calledOnce, "expected onClick to be called once");
+            });
 
-        after(() => {
-            unmountReact16Toaster(testsContainerElement);
-            document.documentElement.removeChild(testsContainerElement);
-        });
+            it("onDismiss callback invoked when close button clicked", () => {
+                const handleDismiss = spy();
+                toaster.show({
+                    message: "dismiss",
+                    onDismiss: handleDismiss,
+                    timeout: 0,
+                });
+                // without action, dismiss is first descendant button
+                const dismiss = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
+                dismiss?.click();
+                assert.isTrue(handleDismiss.calledOnce);
+            });
 
-        it("focuses inside toast container", done => {
-            toaster.show({ message: "focus near me" });
-            // small explicit timeout reduces flakiness of these tests
-            setTimeout(() => {
-                const toastElement = testsContainerElement.querySelector(`.${Classes.TOAST_CONTAINER}`);
-                assert.isTrue(toastElement?.contains(document.activeElement));
-                done();
-            }, 100);
-        });
-    });
+            it("onDismiss callback invoked on toaster.dismiss()", () => {
+                const onDismiss = spy();
+                const key = toaster.show({ message: "dismiss me", onDismiss });
+                toaster.dismiss(key);
+                assert.isTrue(onDismiss.calledOnce, "onDismiss not called");
+            });
 
-    it("throws an error if used within a React lifecycle method", () => {
-        testsContainerElement = document.createElement("div");
+            it("onDismiss callback invoked on toaster.clear()", () => {
+                const onDismiss = spy();
+                toaster.show({ message: "dismiss me", onDismiss });
+                toaster.clear();
+                assert.isTrue(onDismiss.calledOnce, "onDismiss not called");
+            });
 
-        class LifecycleToaster extends React.Component {
-            public render() {
-                return React.createElement("div");
-            }
-
-            public componentDidMount() {
+            it("reusing props object does not produce React errors", () => {
+                const errorSpy = spy(console, "error");
                 try {
-                    OverlayToaster.create({}, testsContainerElement);
-                } catch (err: any) {
-                    assert.equal(err.message, TOASTER_CREATE_NULL);
+                    // if Toaster doesn't clone the props object before injecting key then there will be a
+                    // React error that both toasts have the same key, because both instances refer to the
+                    // same object.
+                    const toast = { message: "repeat" };
+                    toaster.show(toast);
+                    toaster.show(toast);
+                    assert.isFalse(errorSpy.calledWithMatch("two children with the same key"), "mutation side effect!");
                 } finally {
-                    unmountReact16Toaster(testsContainerElement);
+                    // Restore console.error. Otherwise other tests will fail
+                    // with "TypeError: Attempted to wrap error which is already
+                    // wrapped" when attempting to spy on console.error again.
+                    sinon.restore();
+                }
+            });
+        });
+
+        describe("with maxToasts set to finite value", () => {
+            before(() => {
+                testsContainerElement = document.createElement("div");
+                document.documentElement.appendChild(testsContainerElement);
+                toaster = spec.create({ maxToasts: 3 }, testsContainerElement);
+            });
+
+            after(() => {
+                unmountReact16Toaster(testsContainerElement);
+                document.documentElement.removeChild(testsContainerElement);
+            });
+
+            it("does not exceed the maximum toast limit set", () => {
+                toaster.show({ message: "one" });
+                toaster.show({ message: "two" });
+                toaster.show({ message: "three" });
+                toaster.show({ message: "oh no" });
+                assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+            });
+        });
+
+        describe("with autoFocus set to true", () => {
+            before(() => {
+                testsContainerElement = document.createElement("div");
+                document.documentElement.appendChild(testsContainerElement);
+                toaster = spec.create({ autoFocus: true }, testsContainerElement);
+            });
+
+            after(() => {
+                spec.cleanup(testsContainerElement);
+                document.documentElement.removeChild(testsContainerElement);
+            });
+
+            it("focuses inside toast container", done => {
+                toaster.show({ message: "focus near me" });
+                // small explicit timeout reduces flakiness of these tests
+                setTimeout(() => {
+                    const toastElement = testsContainerElement.querySelector(`.${Classes.TOAST_CONTAINER}`);
+                    assert.isTrue(toastElement?.contains(document.activeElement));
+                    done();
+                }, 100);
+            });
+        });
+
+        it("throws an error if used within a React lifecycle method", () => {
+            testsContainerElement = document.createElement("div");
+
+            class LifecycleToaster extends React.Component {
+                public render() {
+                    return React.createElement("div");
+                }
+
+                public componentDidMount() {
+                    try {
+                        spec.create({}, testsContainerElement);
+                    } catch (err: any) {
+                        assert.equal(err.message, TOASTER_CREATE_NULL);
+                    } finally {
+                        spec.cleanup(testsContainerElement);
+                    }
                 }
             }
-        }
-        mount(React.createElement(LifecycleToaster));
+            mount(React.createElement(LifecycleToaster));
+        });
     });
 
     describe("validation", () => {

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -80,6 +80,7 @@ export * from "./tabsExample";
 export * from "./inputGroupExample";
 export { SearchInputExample } from "./searchInputExample";
 export * from "./tagExample";
+export * from "./toastCreateAsyncExample";
 export * from "./toastExample";
 export * from "./tooltipExample";
 export * from "./treeExample";

--- a/packages/docs-app/src/examples/core-examples/toastCreateAsyncExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastCreateAsyncExample.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import ReactDOM from "react-dom";
+
+import { Button, Intent, OverlayToaster } from "@blueprintjs/core";
+import { Example } from "@blueprintjs/docs-theme";
+
+// This example adapts the docs example slightly:
+// https://blueprintjs.com/docs/#core/components/toast.example
+//
+// Instead of a singleton toaster, the Toaster is only created when the user
+// clicks the button. This avoids creating a singleton Toaster for the entire
+// Blueprint docs app.
+export function ToastCreateAsyncExample() {
+    const [isToastShown, setIsToastShown] = React.useState(false);
+
+    const handleClick = React.useCallback(async () => {
+        setIsToastShown(true);
+        try {
+            await showMessageFromNewToaster();
+        } finally {
+            setIsToastShown(false);
+        }
+    }, []);
+
+    return (
+        <Example>
+            <Button
+                intent={Intent.PRIMARY}
+                onClick={handleClick}
+                // Disable the button while the toaster is shown. Since this
+                // button creates a new OverlayToaster each time, the toasts
+                // will overlap.
+                disabled={isToastShown}
+            >
+                Toast please
+            </Button>
+        </Example>
+    );
+}
+
+/**
+ * Create a new OverlayToaster and show a message. The return promise will
+ * resolve when the message has been dismissed.
+ */
+async function showMessageFromNewToaster() {
+    const container = document.createElement("div");
+    // Since this toaster isn't created in a portal, a fixed position container
+    // is required for it to show at the top of the viewport. Otherwise the
+    // toaster won't be visible until the user scrolls upward.
+    container.style.position = "fixed";
+    container.style.top = "0";
+    container.style.width = "100%";
+
+    document.body.appendChild(container);
+
+    return new Promise<void>(async resolve => {
+        async function onDismiss() {
+            resolve();
+
+            // Wait for the message to fade out before completely unmounting the OverlayToaster.
+            await sleep(1_000);
+
+            unmountReact16Toaster(container);
+            document.body.removeChild(container);
+        }
+
+        const toaster = await OverlayToaster.createAsync({}, { container });
+        toaster.show({ message: "Toasted", intent: Intent.PRIMARY, onDismiss });
+    });
+}
+
+/**
+ * @param containerElement The container argument passed to OverlayToaster.create/OverlayToaster.createAsync
+ */
+function unmountReact16Toaster(containerElement: HTMLElement) {
+    const toasterRenderRoot = containerElement.firstElementChild;
+    if (toasterRenderRoot == null) {
+        throw new Error("No elements were found under Toaster container.");
+    }
+    ReactDOM.unmountComponentAtNode(toasterRenderRoot);
+}
+
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## PR Stack

- https://github.com/palantir/blueprint/pull/6601
- https://github.com/palantir/blueprint/pull/6599

## Checklist

- [x] Includes tests
- [x] Update documentation

## Changes

Fixes #6239. A new `OverlayToaster.createAsync()` utility is added alongside `OverlayToaster.create()`.

This asynchronous function allows a custom `domRenderer` utility to be passed to better support codebases on React 18.

```tsx
import { OverlayToaster } from "@blueprintjs/core";
import { createRoot } from "react-dom/client";

const toaster = await OverlayToaster.createAsync(/* props */ {}, {
  domRenderer: (toaster, containerElement) => createRoot(containerElement).render(toaster),
});

toaster.show({ message: "Hello React 18!" })
```

The existing `OverlayToaster.create()` method uses `ReactDOM.render` without any ability to customize this call, which [results in a console warning when upgrading to React 18](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis).

<img width="914" alt="Screenshot 2023-12-11 at 5 38 23 PM" src="https://github.com/palantir/blueprint/assets/906558/3e59bd47-a248-4d2b-bc01-a25267d980d7">


#### Why is the new API asynchronous?

The change to Blueprint's API reflects a change in React's API. The new `createRoot` function from `react-dom/client` no longer renders components synchronously.

```ts
import * as React from "react";
import { createRoot } from "react-dom/client";

const toaster = React.createRef<OverlayToaster>();

createRoot(containerElement)
  .render(<OverlayToaster {...props} ref={toaster} usePortal={false} />)
  
// OverlayToaster render function is not yet executed.

// ‼️ This is null ‼️
ref.current

setTimeout(() => {
  // Okay, now the OverlayToaster render() function has ran.
  ref.current // now available
}, 0)
```

This is different than `ReactDOM.render`, which does synchronously populate the `ref`.

```tsx
import * as React from "react";
import * as ReactDOM from "react-dom";

const toaster = React.createRef<OverlayToaster>();

ReactDOM.render(
  <OverlayToaster {...props} ref={toaster} usePortal={false} />,
  containerElement
);

// OverlayToaster render function has ran by this point.

ref.current // instance of <OverlayToaster />
```

This seems to be an intentional change in React 18. See the “_What about the render callback?_” section under [Replacing render with createRoot](https://github.com/reactwg/react-18/discussions/5#top).

#### Why do I need to pass in a custom `domRenderer` value for React 18?

The `createRoot` function is an import on `react-dom/client`. Blueprint is an NPM library that needs to support multiple bundlers (e.g. Webpack, Vite). Most bundlers will fail if it encounters a non-existent submodule import. Since the current major version of Blueprint needs to support React 16 to 18, imports into 18-specific code paths can't be made directly in Blueprint.

As a workaround, consumers of Blueprint can provide the `createRoot` function to Blueprint. This is an application of [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).

When Blueprint drops support for React 16 in a future major version, the `domRenderer` option will change its current default from `ReactDOM.render` to a function using the new `createRoot` API. This breaking change will make `OverlayToaster.createAsync` easier to use in the future.

#### How do I migrate?

The most one-to-one conversion would be from:

```tsx
OverlayToaster.create().show({ message: "Hello!" });
```

to:

```tsx
OverlayToaster.createAsync().then(toaster => toaster.show({ message: "Hello!" }));
```

You may notice:

1. We're swallowing errors that happen when rendering the component. There's no rejection handler on the promise object.
2. The `OverlayToaster` component is never unmounted or removed from the DOM after the message is dismissed.

Both of these are true of the original synchronous `OverlayToaster.create()` API. The new API makes these existing problems more apparent. We recommend [mounting the toaster directly to your React application tree](https://blueprintjs.com/docs/#core/components/toast.react-component-usage) if the first problem is a concern, and [sharing the Toaster to avoid the second problem](https://blueprintjs.com/docs/#core/components/toast.example).

#### Reviewers should focus on:

- Whether the new API makes sense.
- Reviewing each commit individually should be easier than reviewing all changes at once. Hiding whitespace only changes should also make the diff easier to look at since a few tests were nested.
- Several refactors had to be made to the `OverlayToaster` tests to make them reusable for both `OverlayToaster.create` and `OverlayToaster.createAsync`.
- I briefly spent some time attempting to add a React 18 dependency for testing, but hit issues with NPM aliases discovering `@types/react-dom@18`. I can take another stab if we think a React 18 test is valuable to commit, but it's a bit hard to have multiple version of React in the same codebase, even for testing.
