### PR TITLE
[core] fix(Button): omit 'ellipsizeText' prop from HTML attrs

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -134,6 +134,7 @@ const INVALID_PROPS = [
     "containerRef",
     "current",
     "elementRef", // not used anymore in Blueprint v5.x, but kept for backcompat if consumers use this naming pattern
+    "ellipsizeText", // ButtonProps
     "fill",
     "icon",
     "iconSize",


### PR DESCRIPTION

#### Changes proposed in this pull request:

Omit the new `ellipsizeText` prop from being forwarded to the DOM as an HTML attribute

This fixes React console errors like this one:

![image](https://github.com/palantir/blueprint/assets/723999/2ee2e5d7-e287-4415-bf3f-f7335ad8c9c9)
