### PR TITLE
style: props objects satisfies React.HtmlProps

### DIFF
--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Error, type IconName, InfoSign, Tick, WarningSign } from "@blueprintjs/icons";
+import { Error, type IconName, InfoSign, type SVGIconProps, Tick, WarningSign } from "@blueprintjs/icons";
 
 import {
     AbstractPureComponent,
@@ -95,7 +95,7 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
             return undefined;
         }
 
-        const iconProps = { "aria-hidden": true, tabIndex: -1 };
+        const iconProps = { "aria-hidden": true, tabIndex: -1 } satisfies SVGIconProps;
 
         // 2. icon specified by name or as a custom SVG element
         if (icon !== undefined) {

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -129,7 +129,7 @@ export class FileInput extends AbstractPureComponent<FileInputProps> {
             className: classNames(Classes.FILE_UPLOAD_INPUT, {
                 [Classes.FILE_UPLOAD_INPUT_CUSTOM_TEXT]: !!buttonText,
             }),
-        };
+        } satisfies React.HTMLProps<HTMLElement>;
 
         return (
             <label {...htmlProps} className={rootClasses}>

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -134,7 +134,7 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
             className: classNames(Classes.INPUT, inputClassName),
             onChange: this.handleInputChange,
             style,
-        };
+        } satisfies React.HTMLProps<HTMLInputElement>;
         const inputElement = asyncControl ? (
             <AsyncControllableInput {...inputProps} inputRef={inputRef} />
         ) : (

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -389,7 +389,7 @@ export class Popover<
             }),
             ref,
             ...targetEventHandlers,
-        };
+        } satisfies React.HTMLProps<HTMLElement>;
 
         const targetModifierClasses = {
             // this class is mainly useful for Blueprint <Button> targets; we should only apply it for

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -43,7 +43,7 @@ export interface HandleState {
 }
 
 // props that require number values, for validation
-const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"];
+const NUMBER_PROPS = ["max", "min", "stepSize", "tickSize", "value"] satisfies Array<keyof InternalHandleProps>;
 
 /** Internal component for a Handle with click/drag/keyboard logic to determine a new value. */
 export class Handle extends AbstractPureComponent<InternalHandleProps, HandleState> {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -288,7 +288,7 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
             onPaste: this.handleInputPaste,
             placeholder: resolvedPlaceholder,
             ref: this.handleRef,
-        };
+        } satisfies React.HTMLProps<HTMLElement>;
 
         return (
             <div className={classes} onBlur={this.handleContainerBlur} onClick={this.handleContainerClick}>

--- a/packages/core/src/legacy/hotkeysDialogLegacy.tsx
+++ b/packages/core/src/legacy/hotkeysDialogLegacy.tsx
@@ -46,7 +46,7 @@ const DELAY_IN_MS = 10;
 class HotkeysDialogLegacy {
     public componentProps = {
         globalHotkeysGroup: "Global hotkeys",
-    } as any as HotkeysDialogProps;
+    } as HotkeysDialogProps;
 
     private container: HTMLElement | null = null;
 


### PR DESCRIPTION
Just a style change, adds `satisfies` for objects that are html props, that previously were un-typed.