### PR TITLE
Update `editor.codeActionsOnSave` values for VS Code November 2023

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,7 @@
     "editor.insertSpaces": true,
     "editor.tabSize": 4,
     "editor.codeActionsOnSave": {
-        "source.fixAll": true
+        "source.fixAll": "explicit"
     },
     "[scss]": {
         "editor.tabSize": 2


### PR DESCRIPTION
I'm seeing VS Code make this change as soon as I open the Blueprint repo.

- It looks like VS Code `1.83.0` (September 2023) added new string values for this setting. https://code.visualstudio.com/updates/v1_83#_code-actions-on-save-and-auto-save
- VS Code `1.85.0` (November 2023) then deprecated the older boolean values. https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto

From the release notes (linked above):

> `explicit` - Triggers Code Actions when explicitly saved. Same as `true.`