### PR TITLE
Feature: Add Prop to NonIdealState to Disable Muted Icon Style

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -359,6 +359,7 @@ export const TREE_ROOT = `${NS}-tree-root`;
 export const ICON = `${NS}-icon`;
 export const ICON_STANDARD = `${ICON}-standard`;
 export const ICON_LARGE = `${ICON}-large`;
+export const ICON_MUTED = `${ICON}-muted`;
 
 /**
  * Returns the namespace prefix for all Blueprint CSS classes.

--- a/packages/core/src/components/forms/controlProps.ts
+++ b/packages/core/src/components/forms/controlProps.ts
@@ -68,7 +68,7 @@ export interface ControlProps
     label?: string;
 
     /**
-     * JSX Element label for the control.
+     * JSX element label for the control.
      *
      * This prop is a workaround for TypeScript consumers as the type definition for `label` only
      * accepts strings. JavaScript consumers can provide a JSX element directly to `label`.

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -33,6 +33,25 @@
       fill: currentcolor;
     }
   }
+
+  // muted icon style used by NonIdealState
+  &.#{$ns}-icon-muted svg {
+    fill-opacity: 15%;
+    // need to show overflow for some strokes on paths that reach the edge of the icon bounding box
+    overflow: visible;
+
+    path {
+      stroke: $gray3;
+      stroke-opacity: 50%;
+      stroke-width: 0.5px;
+    }
+  }
+
+  .#{$ns}-dark & {
+    .#{$ns}-icon-muted svg {
+      fill-opacity: 20%;
+    }
+  }
 }
 
 // intent colors for both SVG and font icons are set in _typography-colors.scss

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -10,7 +10,7 @@ Non-ideal state
 Markup:
 <div class="#{$ns}-non-ideal-state">
   <div class="#{$ns}-non-ideal-state-visual" style="font-size: 48px; line-height: 48px;">
-    <span class="#{$ns}-icon #{$ns}-icon-folder-open"></span>
+    <span class="#{$ns}-icon #{$ns}-icon-muted #{$ns}-icon-folder-open"></span>
   </div>
   <div class="#{$ns}-non-ideal-state-text">
     <h4 class="#{$ns}-heading">This folder is empty</h4>
@@ -68,22 +68,4 @@ Styleguide non-ideal-state
 
 .#{$ns}-non-ideal-state-visual {
   color: $gray3;
-
-  .#{$ns}-icon svg {
-    fill-opacity: 15%;
-    // need to show overflow for some strokes on paths that reach the edge of the icon bounding box
-    overflow: visible;
-
-    path {
-      stroke: $gray3;
-      stroke-opacity: 50%;
-      stroke-width: 0.5px;
-    }
-  }
-
-  .#{$ns}-dark & {
-    .#{$ns}-icon svg {
-      fill-opacity: 20%;
-    }
-  }
 }

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -7,18 +7,18 @@ parent: components
 Non-ideal UI states inform the user that some content is unavailable. There are several types of non-ideal states,
 including:
 
--   **Empty state:** a container has just been created and has no data in it yet, or a container's contents have been
+*   **Empty state:** a container has just been created and has no data in it yet, or a container's contents have been
     intentionally removed.
--   **Loading state:** a container is awaiting data. A good practice is to show a spinner for this state with optional
+*   **Loading state:** a container is awaiting data. A good practice is to show a spinner for this state with optional
     explanatory text below the spinner.
--   **Error state:** something went wrong (for instance, 404 and 500 HTTP errors). In this case, a good practice is to
+*   **Error state:** something went wrong (for instance, 404 and 500 HTTP errors). In this case, a good practice is to
     add a call to action directing the user what to do next.
 
 @reactExample NonIdealStateExample
 
 @## Usage
 
-**NonIdealState** component props are rendered in this order in the DOM, with comfortable spacing between each child:
+__NonIdealState__ component props are rendered in this order in the DOM, with comfortable spacing between each child:
 
 1. `icon`
 1. text (`title` + optional `description`)

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -47,7 +47,7 @@ often fall out of sync as the design system is updated. You should use the React
 Note that you are required to set the `font-size` and `line-height` styles for the icon element to render it properly.
 
 Also, since the CSS API uses the icon font, Blueprint styles cannot adjust the icon visual design to have a muted
-appearance like it does with the React component API. This means **NonIdealState** elements rendered with this API will
+appearance like it does with the React component API. This means __NonIdealState__ elements rendered with this API will
 stand out visually (in a bad way) within the design system.
 
 </div>

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -28,7 +28,7 @@ __NonIdealState__ component props are rendered in this order in the DOM, with co
 By default, a vertical layout is used, but you can make it horizontal with `layout="horizontal"`.
 
 Icons take on a muted appearance inside this component, but their shape contrast is preserved by adding a small stroke
-to the SVG paths.
+to the SVG paths. This behavior may be disabled by setting `mutedIcon={false}`.
 
 @## Props interface
 

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -53,7 +53,7 @@ stand out visually (in a bad way) within the design system.
 </div>
 
 Apply the `.@ns-non-ideal-state` class to the root container element and wrap the icon element with a
-`.@ns-non-ideal-state-visual` container. To use the muted icon style, apply `.@ns-icon-muted` to the icon element.
+`.@ns-non-ideal-state-visual` container.
 
 The root container should only have direct element children, no grandchildren (except for text, which is enclosed in a
 `.@ns-non-ideal-state-text` wrapper element). This constraint ensures proper spacing between each child.

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -7,18 +7,18 @@ parent: components
 Non-ideal UI states inform the user that some content is unavailable. There are several types of non-ideal states,
 including:
 
-* **Empty state:** a container has just been created and has no data in it yet, or a container's contents have been
-  intentionally removed.
-* **Loading state:** a container is awaiting data. A good practice is to show a spinner for this state with optional
-  explanatory text below the spinner.
-* **Error state:** something went wrong (for instance, 404 and 500 HTTP errors). In this case, a good practice is to
-  add a call to action directing the user what to do next.
+-   **Empty state:** a container has just been created and has no data in it yet, or a container's contents have been
+    intentionally removed.
+-   **Loading state:** a container is awaiting data. A good practice is to show a spinner for this state with optional
+    explanatory text below the spinner.
+-   **Error state:** something went wrong (for instance, 404 and 500 HTTP errors). In this case, a good practice is to
+    add a call to action directing the user what to do next.
 
 @reactExample NonIdealStateExample
 
 @## Usage
 
-__NonIdealState__ component props are rendered in this order in the DOM, with comfortable spacing between each child:
+**NonIdealState** component props are rendered in this order in the DOM, with comfortable spacing between each child:
 
 1. `icon`
 1. text (`title` + optional `description`)
@@ -26,9 +26,7 @@ __NonIdealState__ component props are rendered in this order in the DOM, with co
 1. `children`
 
 By default, a vertical layout is used, but you can make it horizontal with `layout="horizontal"`.
-
-Icons take on a muted appearance inside this component, but their shape contrast is preserved by adding a small stroke
-to the SVG paths. This behavior may be disabled by setting `mutedIcon={false}`.
+Icons will also take on a muted appearance inside this component, with their shape contrast preserved by adding a small stroke to the SVG paths. This behavior can be disabled by setting `iconMuted={false}`.
 
 @## Props interface
 
@@ -49,13 +47,13 @@ often fall out of sync as the design system is updated. You should use the React
 Note that you are required to set the `font-size` and `line-height` styles for the icon element to render it properly.
 
 Also, since the CSS API uses the icon font, Blueprint styles cannot adjust the icon visual design to have a muted
-appearance like it does with the React component API. This means __NonIdealState__ elements rendered with this API will
+appearance like it does with the React component API. This means **NonIdealState** elements rendered with this API will
 stand out visually (in a bad way) within the design system.
 
 </div>
 
 Apply the `.@ns-non-ideal-state` class to the root container element and wrap the icon element with a
-`.@ns-non-ideal-state-visual` container.
+`.@ns-non-ideal-state-visual` container. To use the muted icon style, apply `.@ns-icon-muted` to the icon element.
 
 The root container should only have direct element children, no grandchildren (except for text, which is enclosed in a
 `.@ns-non-ideal-state-text` wrapper element). This constraint ensures proper spacing between each child.

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -26,6 +26,7 @@ __NonIdealState__ component props are rendered in this order in the DOM, with co
 1. `children`
 
 By default, a vertical layout is used, but you can make it horizontal with `layout="horizontal"`.
+
 Icons will also take on a muted appearance inside this component, with their shape contrast preserved by adding a small stroke to the SVG paths. This behavior can be disabled by setting `iconMuted={false}`.
 
 @## Props interface

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -46,7 +46,7 @@ export interface NonIdealStateProps extends Props {
      */
     description?: React.ReactChild;
 
-    /** The name of a Blueprint icon or a JSX Element (such as `<Spinner/>`) to render above the title. */
+    /** The name of a Blueprint icon or a JSX element (such as `<Spinner/>`) to render above the title. */
     icon?: IconName | MaybeElement;
 
     /**
@@ -55,6 +55,13 @@ export interface NonIdealStateProps extends Props {
      * @default NonIdealStateIconSize.STANDARD
      */
     iconSize?: NonIdealStateIconSize;
+
+    /**
+     * Whether the `icon` should attempt to use a muted appearence.
+     *
+     * @default true
+     */
+    mutedIcon?: boolean;
 
     /**
      * Component layout, either vertical or horizontal.
@@ -78,6 +85,7 @@ export class NonIdealState extends AbstractPureComponent<NonIdealStateProps> {
     public static defaultProps: Partial<NonIdealStateProps> = {
         iconSize: NonIdealStateIconSize.STANDARD,
         layout: "vertical",
+        mutedIcon: true,
     };
 
     public render() {
@@ -94,13 +102,13 @@ export class NonIdealState extends AbstractPureComponent<NonIdealStateProps> {
     }
 
     private maybeRenderVisual() {
-        const { icon, iconSize } = this.props;
+        const { icon, iconSize, mutedIcon } = this.props;
         if (icon == null) {
             return undefined;
         } else {
             return (
                 <div
-                    className={Classes.NON_IDEAL_STATE_VISUAL}
+                    className={classNames(mutedIcon && Classes.NON_IDEAL_STATE_VISUAL)}
                     style={{ fontSize: `${iconSize}px`, lineHeight: `${iconSize}px` }}
                 >
                     <Icon icon={icon} size={iconSize} aria-hidden={true} tabIndex={-1} />

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -111,7 +111,13 @@ export class NonIdealState extends AbstractPureComponent<NonIdealStateProps> {
                     className={Classes.NON_IDEAL_STATE_VISUAL}
                     style={{ fontSize: `${iconSize}px`, lineHeight: `${iconSize}px` }}
                 >
-                    <Icon className={classNames({ [Classes.ICON_MUTED]: iconMuted })} icon={icon} size={iconSize} aria-hidden={true} tabIndex={-1} />
+                    <Icon
+                        className={classNames({ [Classes.ICON_MUTED]: iconMuted })}
+                        icon={icon}
+                        size={iconSize}
+                        aria-hidden={true}
+                        tabIndex={-1}
+                    />
                 </div>
             );
         }

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -61,7 +61,7 @@ export interface NonIdealStateProps extends Props {
      *
      * @default true
      */
-    mutedIcon?: boolean;
+    iconMuted?: boolean;
 
     /**
      * Component layout, either vertical or horizontal.
@@ -108,10 +108,10 @@ export class NonIdealState extends AbstractPureComponent<NonIdealStateProps> {
         } else {
             return (
                 <div
-                    className={classNames(mutedIcon && Classes.NON_IDEAL_STATE_VISUAL)}
+                    className={Classes.NON_IDEAL_STATE_VISUAL}
                     style={{ fontSize: `${iconSize}px`, lineHeight: `${iconSize}px` }}
                 >
-                    <Icon icon={icon} size={iconSize} aria-hidden={true} tabIndex={-1} />
+                    <Icon className={classNames({ [Classes.ICON_MUTED]: iconMuted })} icon={icon} size={iconSize} aria-hidden={true} tabIndex={-1} />
                 </div>
             );
         }

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -57,7 +57,7 @@ export interface NonIdealStateProps extends Props {
     iconSize?: NonIdealStateIconSize;
 
     /**
-     * Whether the `icon` should attempt to use a muted style.
+     * Whether the icon should use a muted style.
      *
      * @default true
      */
@@ -83,9 +83,9 @@ export class NonIdealState extends AbstractPureComponent<NonIdealStateProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NonIdealState`;
 
     public static defaultProps: Partial<NonIdealStateProps> = {
+        iconMuted: true,
         iconSize: NonIdealStateIconSize.STANDARD,
         layout: "vertical",
-        mutedIcon: true,
     };
 
     public render() {
@@ -102,7 +102,7 @@ export class NonIdealState extends AbstractPureComponent<NonIdealStateProps> {
     }
 
     private maybeRenderVisual() {
-        const { icon, iconSize, mutedIcon } = this.props;
+        const { icon, iconMuted, iconSize } = this.props;
         if (icon == null) {
             return undefined;
         } else {

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -57,7 +57,7 @@ export interface NonIdealStateProps extends Props {
     iconSize?: NonIdealStateIconSize;
 
     /**
-     * Whether the `icon` should attempt to use a muted appearence.
+     * Whether the `icon` should attempt to use a muted style.
      *
      * @default true
      */

--- a/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
+++ b/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
@@ -36,6 +36,14 @@ describe("<NonIdealState>", () => {
         });
     });
 
+    it("doesn't render muted icon style", () => {
+        const wrapper = shallow(<NonIdealState title="ERROR" icon="folder-close" mutedIcon={false} />);
+        assert.isFalse(
+            wrapper.find(`.${Classes.NON_IDEAL_STATE_VISUAL}`).exists(),
+            `unexpected ${Classes.NON_IDEAL_STATE_VISUAL}`,
+        );
+    });
+
     it("ensures description is wrapped in an element", () => {
         const wrapper = shallow(<NonIdealState action={<strong />} description="foo" />);
         const div = wrapper.find(`.${Classes.NON_IDEAL_STATE_TEXT}`).children().find("div");

--- a/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
+++ b/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
@@ -25,23 +25,20 @@ describe("<NonIdealState>", () => {
         const wrapper = shallow(
             <NonIdealState
                 action={<p>More text!</p>}
-                description="An error occured."
+                description="An error occurred."
                 title="ERROR"
                 icon="folder-close"
             />,
         );
         assert.exists(wrapper.find(H4), "missing H4");
-        [Classes.NON_IDEAL_STATE_VISUAL, Classes.NON_IDEAL_STATE].forEach(className => {
-            assert.isTrue(wrapper.find(`.${className}`).exists(), `missing ${className}`);
+        [Classes.NON_IDEAL_STATE_VISUAL, Classes.ICON_MUTED, Classes.NON_IDEAL_STATE].forEach(className => {
+            assert.exists(wrapper.find(`.${className}`), `missing ${className}`);
         });
     });
 
-    it("doesn't render muted icon style", () => {
-        const wrapper = shallow(<NonIdealState title="ERROR" icon="folder-close" mutedIcon={false} />);
-        assert.isFalse(
-            wrapper.find(`.${Classes.NON_IDEAL_STATE_VISUAL}`).exists(),
-            `unexpected ${Classes.NON_IDEAL_STATE_VISUAL}`,
-        );
+    it("does not apply icon muted style", () => {
+        const wrapper = shallow(<NonIdealState title="ERROR" icon="folder-close" iconMuted={false} />);
+        assert.isFalse(wrapper.find(`.${Classes.ICON_MUTED}`).exists(), `unexpected ${Classes.ICON_MUTED}`);
     });
 
     it("ensures description is wrapped in an element", () => {


### PR DESCRIPTION
#### Introduction

This PR adds a prop `mutedIcon` to `NonIdealState` which can be used to explicitly opt-out of the muted style for the `icon`. This makes it possible to, for example, use an `<Icon>` component with an `intent` specified alongside `NonIdealState`, which is currently impossible since `Classes.NON_IDEAL_STATE_VISUAL` always overrides the `intent` (even when passing an explicit `<Icon>` JSX element). 

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

This PR adds a `mutedIcon` prop to `NonIdealState`. `mutedIcon` defaults to `true` to preserve backwards-comparability. When set to `false`, `Classes.NON_IDEAL_STATE_VISUAL` is no longer applied to the `icon` prop, which can prevent issues with certain props getting overridden in an undesirable (and unexpected) way. 

#### Screenshot
Example of a `NonIdealState` with a custom `<Icon>` and `intent`:
![fix](https://github.com/palantir/blueprint/assets/89172296/078109e7-b62d-4038-b721-470976f84f23)

#### First Time Contributor Notes

As a first time contributor on this repo, I'll briefly discuss my experience getting the code to run and build. I first tried on my Windows 10 machine, which I ultimately gave up on. The primary issues I encountered there were:

- `windows-build-tools` refused to install for me. The primary suggestion I saw while troubleshooting was that it is now natively available with Node as an option during install. I'm not sure if that worked for me or not.
- Issues with `C:` paths being disallowed. The suggestion I saw while troubleshooting was to use a later version of Node (the post said they saw it resolved going from Node 12 to Node 16), but it was nevertheless occurring with the project's Node 18.

Since I couldn't find any fixes for the above issues, I eventually gave up and switched to Ubuntu in WSL, which worked much better. My main feedback there is that ChromeHeadless is needed to run `yarn test`, which isn't mentioned in the documentation (as far as I can tell). These commands resolved it for me:
```
wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
sudo apt install ./google-chrome-stable_current_amd64.deb
```