### PR TITLE
[core] fix(KeyComboTag): use static icon imports

### DIFF
--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -17,23 +17,36 @@
 import classNames from "classnames";
 import * as React from "react";
 
+import {
+    ArrowDown,
+    ArrowLeft,
+    ArrowRight,
+    ArrowUp,
+    KeyCommand,
+    KeyControl,
+    KeyDelete,
+    KeyEnter,
+    KeyOption,
+    KeyShift,
+} from "@blueprintjs/icons";
+
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
-import { Icon, type IconName } from "../icon/icon";
+import { Icon } from "../icon/icon";
 
 import { normalizeKeyCombo } from "./hotkeyParser";
 
-const KEY_ICONS: Record<string, { icon: IconName; iconTitle: string }> = {
-    ArrowDown: { icon: "arrow-down", iconTitle: "Down key" },
-    ArrowLeft: { icon: "arrow-left", iconTitle: "Left key" },
-    ArrowRight: { icon: "arrow-right", iconTitle: "Right key" },
-    ArrowUp: { icon: "arrow-up", iconTitle: "Up key" },
-    alt: { icon: "key-option", iconTitle: "Alt/Option key" },
-    cmd: { icon: "key-command", iconTitle: "Command key" },
-    ctrl: { icon: "key-control", iconTitle: "Control key" },
-    delete: { icon: "key-delete", iconTitle: "Delete key" },
-    enter: { icon: "key-enter", iconTitle: "Enter key" },
-    meta: { icon: "key-command", iconTitle: "Command key" },
-    shift: { icon: "key-shift", iconTitle: "Shift key" },
+const KEY_ICONS: Record<string, { icon: JSX.Element; iconTitle: string }> = {
+    ArrowDown: { icon: <ArrowDown />, iconTitle: "Down key" },
+    ArrowLeft: { icon: <ArrowLeft />, iconTitle: "Left key" },
+    ArrowRight: { icon: <ArrowRight />, iconTitle: "Right key" },
+    ArrowUp: { icon: <ArrowUp />, iconTitle: "Up key" },
+    alt: { icon: <KeyOption />, iconTitle: "Alt/Option key" },
+    cmd: { icon: <KeyCommand />, iconTitle: "Command key" },
+    ctrl: { icon: <KeyControl />, iconTitle: "Control key" },
+    delete: { icon: <KeyDelete />, iconTitle: "Delete key" },
+    enter: { icon: <KeyEnter />, iconTitle: "Enter key" },
+    meta: { icon: <KeyCommand />, iconTitle: "Command key" },
+    shift: { icon: <KeyShift />, iconTitle: "Shift key" },
 };
 
 /** Reverse table of some CONFIG_ALIASES fields, for display by KeyComboTag */


### PR DESCRIPTION
#### Related to #6249

#### Checklist

- [x] Includes tests (n/a)
- [x] Update documentation (n/a)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This component previously passed icon string names to a child Icon
component, preventing tree shaking of unused icons. Passing statically
imported icons from @blueprintjs/icons fixes this problem.

Related to #6249.

#### Reviewers should focus on:

- Verify combo tag icons are rendered at the correct size. (Statically imported icons have a default size of 16, which I think is the correct default?)
- I noticed that the arrow up/down/left/right icons don't render in either version of the combo tester. I didn't try to address that here.
- Perhaps there is a slight regression due to this open issue (https://github.com/palantir/blueprint/issues/6329#issuecomment-1693399125) but since none of these icons are round, it's not very noticeable at all

#### Screenshot

New:
![2024-01-06 14 08 19](https://github.com/palantir/blueprint/assets/3681045/d0cbcacd-c55d-47d9-88b5-fc5f3efa3edc)


Old:
![2024-01-06 14 08 19](https://github.com/palantir/blueprint/assets/3681045/d95ceca8-d614-4343-b699-31c0cb5dcc63)

