### PR TITLE
[core] deprecate Portal stopPropagationEvents

### DIFF
--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -315,6 +315,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
                 <Portal
                     className={this.props.portalClassName}
                     container={this.props.portalContainer}
+                    // eslint-disable-next-line deprecation/deprecation
                     stopPropagationEvents={this.props.portalStopPropagationEvents}
                 >
                     {transitionGroup}

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -109,8 +109,10 @@ export interface OverlayableProps extends OverlayLifecycleProps {
      * A list of DOM events which should be stopped from propagating through the Portal.
      * This prop is ignored if `usePortal` is `false`.
      *
+     * @deprecated this prop's implementation no longer works in React v17+
      * @see https://legacy.reactjs.org/docs/portals.html#event-bubbling-through-portals
      * @see https://github.com/palantir/blueprint/issues/6124
+     * @see https://github.com/palantir/blueprint/issues/6580
      */
     portalStopPropagationEvents?: Array<keyof HTMLElementEventMap>;
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -40,7 +40,6 @@ import { Overlay } from "../overlay/overlay";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
 // eslint-disable-next-line import/no-cycle
 import { Tooltip } from "../tooltip/tooltip";
-
 import { matchReferenceWidthModifier } from "./customModifiers";
 import { POPOVER_ARROW_SVG_SIZE, PopoverArrow } from "./popoverArrow";
 import { positionToPlacement } from "./popoverPlacementUtils";
@@ -518,6 +517,7 @@ export class Popover<
                 usePortal={usePortal}
                 portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
+                // eslint-disable-next-line deprecation/deprecation
                 portalStopPropagationEvents={this.props.portalStopPropagationEvents}
                 shouldReturnFocusOnClose={shouldReturnFocusOnClose}
             >

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -40,6 +40,7 @@ import { Overlay } from "../overlay/overlay";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
 // eslint-disable-next-line import/no-cycle
 import { Tooltip } from "../tooltip/tooltip";
+
 import { matchReferenceWidthModifier } from "./customModifiers";
 import { POPOVER_ARROW_SVG_SIZE, PopoverArrow } from "./popoverArrow";
 import { positionToPlacement } from "./popoverPlacementUtils";

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -41,8 +41,10 @@ export interface PortalProps extends Props {
     /**
      * A list of DOM events which should be stopped from propagating through this portal element.
      *
+     * @deprecated this prop's implementation no longer works in React v17+
      * @see https://legacy.reactjs.org/docs/portals.html#event-bubbling-through-portals
      * @see https://github.com/palantir/blueprint/issues/6124
+     * @see https://github.com/palantir/blueprint/issues/6580
      */
     stopPropagationEvents?: Array<keyof HTMLElementEventMap>;
 }
@@ -75,6 +77,7 @@ const PORTAL_LEGACY_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
  * @see https://blueprintjs.com/docs/#core/components/portal
  */
 export function Portal(
+    // eslint-disable-next-line deprecation/deprecation
     { className, stopPropagationEvents, container, onChildrenMount, children }: PortalProps,
     legacyContext: PortalLegacyContext = {},
 ) {


### PR DESCRIPTION
#### addresses #6580, fixes #6428

#### Changes proposed in this pull request:

Deprecate `portalStopPropagationEvents` (added in #6093) since its implementation is not effective in React 17+ and stopping event propagation is discouraged anyway. We should come up with an alternative solution for the problem this was trying to solve.

