### PR TITLE
[core] fix(AnchorButton): don't show text underline on hover

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -234,6 +234,7 @@ a.#{$ns}-button {
   &:active {
     // override global 'a' styles
     color: $pt-text-color;
+    text-decoration: none;
   }
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -226,7 +226,6 @@ Styleguide button
 
 a.#{$ns}-button {
   text-align: center;
-  text-decoration: none;
   transition: none;
 
   &,


### PR DESCRIPTION
#### Fixes
The `AnchorButton` when hovered will underline the text. This is a regression.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Explicitly list `text-decoration: none` to override the `a:hover` style applied.

#### Reviewers should focus on:
Not sure why this regression happened, but maybe because the generated CSS ordering was changed for some reason? Here's the result of the fix:

<img width="311" alt="Screenshot 2024-01-08 at 2 38 52 PM" src="https://github.com/palantir/blueprint/assets/16532/0aeba155-4a54-48c6-aaa4-a1ff374e4dd9">


#### Screenshot
<!-- Include an image of the most relevant user-facing change, if any. -->
