### PR TITLE
Remove unnecessary typography import to remove hover underline in AnchorButton

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -226,6 +226,7 @@ Styleguide button
 
 a.#{$ns}-button {
   text-align: center;
+  text-decoration: none;
   transition: none;
 
   &,
@@ -233,7 +234,6 @@ a.#{$ns}-button {
   &:active {
     // override global 'a' styles
     color: $pt-text-color;
-    text-decoration: none;
   }
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -32,6 +32,7 @@
     flex-direction: row;
     gap: 0.5 * $pt-grid-size;
   }
+
   &-tags-container {
     display: flex;
     gap: 0.2 * $pt-grid-size;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -3,7 +3,6 @@
 
 @import "../../common/variables";
 @import "../../common/variables-extended";
-@import "../../typography";
 
 .#{$ns}-entity-title {
   align-items: center;
@@ -33,7 +32,6 @@
     flex-direction: row;
     gap: 0.5 * $pt-grid-size;
   }
-
   &-tags-container {
     display: flex;
     gap: 0.2 * $pt-grid-size;


### PR DESCRIPTION
#### Fixes #0000
Unnecessary underline in `AnchorButton` was removed in #6636 by overriding the hover. Turns out, the actual issue was caused by unnecessary import of `typography.scss` in `EntityTitle`.

This PR reverts #6636 and removes the unnecessary import.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
