### PR TITLE
[core] fix(HotkeysProvider): avoid unnecessary children re-renders

### DIFF
--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -42,6 +42,7 @@ type HotkeysAction =
 export type HotkeysContextInstance = [HotkeysContextState, React.Dispatch<HotkeysAction>];
 
 const initialHotkeysState: HotkeysContextState = { hasProvider: false, hotkeys: [], isDialogOpen: false };
+// const initialHotkeysState: HotkeysContextState = { hasProvider: false };
 const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
 
 /**
@@ -122,9 +123,14 @@ export const HotkeysProvider = ({ children, dialogProps, renderDialog, value }: 
         />
     );
 
+    const reducedState = React.useMemo<HotkeysContextState>(
+        () => ({ hasProvider: state.hasProvider }),
+        [state.hasProvider],
+    );
+
     // if we are working with an existing context, we don't need to generate our own dialog
     return (
-        <HotkeysContext.Provider value={[state, dispatch]}>
+        <HotkeysContext.Provider value={[reducedState, dispatch]}>
             {children}
             {hasExistingContext ? undefined : dialog}
         </HotkeysContext.Provider>


### PR DESCRIPTION
#### Fixes #5178

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

WIP - attempts to apply https://gist.github.com/stephen/873773683fc15d1fb290b338a6c59d38

#### Reviewers should focus on:

No regressions in hotkey APIs
No regressions in advanced usage APIs with nested providers: https://github.com/palantir/blueprint/pull/4767

#### Screenshot

N/A
