### PR TITLE
style: PopupKind default to "menu"

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -87,11 +87,9 @@ export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     interactionKind?: PopoverInteractionKind;
 
     /**
-     * The kind of popup displayed by the popover. This property is ignored if
-     * `interactionKind` is {@link PopoverInteractionKind.HOVER_TARGET_ONLY}.
-     * This controls the `aria-haspopup` attribute of the target element. The
-     * default is "menu" (technically, `aria-haspopup` will be set to "true",
-     * which is the same as "menu", for backwards compatibility).
+     * The kind of popup displayed by the popover. Gets directly applied to the
+     * `aria-haspopup` attribute of the target element. This property is
+     * ignored if `interactionKind` is {@link PopoverInteractionKind.HOVER_TARGET_ONLY}.
      *
      * @default "menu" or undefined
      */
@@ -388,8 +386,9 @@ export class Popover<
         const childTargetProps = {
             "aria-expanded": isOpen,
             "aria-haspopup":
-                this.props.popupKind ??
-                (this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY ? undefined : true),
+                this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY
+                    ? undefined
+                    : this.props.popupKind ?? "menu",
         } satisfies React.HTMLProps<HTMLElement>;
 
         const targetModifierClasses = {

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -201,7 +201,7 @@ describe("<Popover>", () => {
 
         it("renders with aria-haspopup attr", () => {
             wrapper = renderPopover({ isOpen: true });
-            assert.isTrue(wrapper.find("[aria-haspopup=true]").exists());
+            assert.isTrue(wrapper.find("[aria-haspopup='menu']").exists());
         });
 
         it("sets aria-haspopup attr base on popupKind", () => {


### PR DESCRIPTION
Per aria documentation, value of "true" is same as "menu" - https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup . So, instead of using "true", use "menu" to make it more clear.