### PR TITLE
feat(Popover): spread child props

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -386,7 +386,6 @@ export class Popover<
             ...targetEventHandlers,
         } satisfies React.HTMLProps<HTMLElement>;
         const childTargetProps = {
-            "aria-expanded": isOpen,
             "aria-haspopup":
                 this.props.popupKind ??
                 (this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY ? undefined : true),

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -386,6 +386,7 @@ export class Popover<
             ...targetEventHandlers,
         } satisfies React.HTMLProps<HTMLElement>;
         const childTargetProps = {
+            "aria-expanded": isOpen,
             "aria-haspopup":
                 this.props.popupKind ??
                 (this.props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY ? undefined : true),

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -420,6 +420,7 @@ export class Popover<
 
             const clonedTarget: React.JSX.Element = React.cloneElement(childTarget, {
                 ...childTargetProps,
+                ...childTarget.props,
                 className: classNames(childTarget.props.className, targetModifierClasses),
                 // force disable single Tooltip child when popover is open
                 disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip) ? true : childTarget.props.disabled,


### PR DESCRIPTION
Spread child props to allow overriding of `aria-expanded`