### PR TITLE
[core] fix(Drawer): allow clicking on overlaid contents when hasBackdrop=false

### DIFF
--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -111,8 +111,10 @@ export class Drawer extends AbstractPureComponent<DrawerProps> {
     };
 
     public render() {
-        const { size, style, position } = this.props;
+        const { hasBackdrop, size, style, position } = this.props;
         const realPosition = getPositionIgnoreAngles(position!);
+
+        const overlayClasses = hasBackdrop ? { className: Classes.OVERLAY_CONTAINER } : {};
 
         const classes = classNames(
             Classes.DRAWER,
@@ -130,7 +132,7 @@ export class Drawer extends AbstractPureComponent<DrawerProps> {
                       [isPositionHorizontal(realPosition) ? "height" : "width"]: size,
                   };
         return (
-            <Overlay {...this.props} className={Classes.OVERLAY_CONTAINER}>
+            <Overlay {...this.props} {...overlayClasses}>
                 <div className={classes} style={styleProp}>
                     {this.maybeRenderHeader()}
                     {this.props.children}

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -112,16 +112,15 @@ export class Drawer extends AbstractPureComponent<DrawerProps> {
 
     public render() {
         const { hasBackdrop, size, style, position } = this.props;
+        const { className, children, ...overlayProps } = this.props;
         const realPosition = getPositionIgnoreAngles(position!);
-
-        const overlayClasses = hasBackdrop ? { className: Classes.OVERLAY_CONTAINER } : {};
 
         const classes = classNames(
             Classes.DRAWER,
             {
                 [Classes.positionClass(realPosition) ?? ""]: true,
             },
-            this.props.className,
+            className,
         );
 
         const styleProp =
@@ -132,10 +131,10 @@ export class Drawer extends AbstractPureComponent<DrawerProps> {
                       [isPositionHorizontal(realPosition) ? "height" : "width"]: size,
                   };
         return (
-            <Overlay {...this.props} {...overlayClasses}>
+            <Overlay {...overlayProps} className={classNames({ [Classes.OVERLAY_CONTAINER]: hasBackdrop })}>
                 <div className={classes} style={styleProp}>
                     {this.maybeRenderHeader()}
-                    {this.props.children}
+                    {children}
                 </div>
             </Overlay>
         );

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -587,7 +587,8 @@ $docs-hotkey-piano-height: 510px;
 }
 
 #{example("ButtonGroup")},
-#{example("ButtonGroupPopover")} {
+#{example("ButtonGroupPopover")},
+#{example("Drawer")} {
   .docs-example > * {
     margin: 0;
   }


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/3515

#### Checklist

- [X] Includes tests (n/a)
- [X] Update documentation (n/a)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Remove the modal trait of Drawer when `hasBackdrop` is set to `false` 
by making overlay container styles conditional to `hasBackdrop`.

#### Reviewers should focus on:

* Verify the behavior with and without portal
* Verify the scrolling of Drawer content on smaller screen size
* Note that `canOutsideClickClose` becomes ignore when `hasBackdrop` is false

#### Screenshot
New: clicking outside the drawer discards it **and** changes the position selection
![drawer-backdrop](https://github.com/palantir/blueprint/assets/4532785/5218a43a-29fc-4620-8461-e4251bb42467)

Old: clicking outside the drawer discards it. An additional click is required to change the position selection
![drawer-backdrop-old](https://github.com/palantir/blueprint/assets/4532785/7272f2cf-9c6a-4764-a61b-bb0be9f60669)



<!-- Include an image of the most relevant user-facing change, if any. -->
