### PR TITLE
[core] fix(Popover): resolve React warning by persisting synthetic event

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -742,7 +742,11 @@ export class Popover<
         // cancel any existing timeout because we have new state
         this.cancelOpenTimeout?.();
         if (timeout !== undefined && timeout > 0) {
-            this.cancelOpenTimeout = this.setTimeout(() => this.setOpenState(isOpen, e), timeout);
+            // Persist the react event since it will be used in a later macrotask.
+            e?.persist();
+            this.cancelOpenTimeout = this.setTimeout(() => {
+                this.setOpenState(isOpen, e)
+            }, timeout);
         } else {
             if (this.props.isOpen == null) {
                 this.setState({ isOpen });

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -494,8 +494,8 @@ export class Popover<
         const shouldReturnFocusOnClose = this.isHoverInteractionKind()
             ? false
             : isClosingViaEscapeKeypress
-            ? true
-            : this.props.shouldReturnFocusOnClose;
+              ? true
+              : this.props.shouldReturnFocusOnClose;
 
         return (
             <Overlay

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -494,8 +494,8 @@ export class Popover<
         const shouldReturnFocusOnClose = this.isHoverInteractionKind()
             ? false
             : isClosingViaEscapeKeypress
-              ? true
-              : this.props.shouldReturnFocusOnClose;
+            ? true
+            : this.props.shouldReturnFocusOnClose;
 
         return (
             <Overlay
@@ -745,7 +745,7 @@ export class Popover<
             // Persist the react event since it will be used in a later macrotask.
             e?.persist();
             this.cancelOpenTimeout = this.setTimeout(() => {
-                this.setOpenState(isOpen, e)
+                this.setOpenState(isOpen, e);
             }, timeout);
         } else {
             if (this.props.isOpen == null) {


### PR DESCRIPTION
#### Fixes #0000
```
Warning: This synthetic event is reused for performance reasons. If you're seeing this, you're accessing the property `nativeEvent` on a released/nullified synthetic event. This is set to null. If you must keep the original synthetic event around, use event.persist(). See https://fb.me/react-event-pooling for more information.
```

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
