### PR TITLE
[core] fix(HotkeysProvider): memoize context value

### DIFF
--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -39,7 +39,7 @@ type HotkeysAction =
     | { type: "ADD_HOTKEYS" | "REMOVE_HOTKEYS"; payload: HotkeyConfig[] }
     | { type: "CLOSE_DIALOG" | "OPEN_DIALOG" };
 
-export type HotkeysContextInstance = [HotkeysContextState, React.Dispatch<HotkeysAction>];
+export type HotkeysContextInstance = readonly [HotkeysContextState, React.Dispatch<HotkeysAction>];
 
 const initialHotkeysState: HotkeysContextState = { hasProvider: false, hotkeys: [], isDialogOpen: false };
 const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
@@ -111,6 +111,8 @@ export const HotkeysProvider = ({ children, dialogProps, renderDialog, value }: 
     const hasExistingContext = value != null;
     const fallbackReducer = React.useReducer(hotkeysReducer, { ...initialHotkeysState, hasProvider: true });
     const [state, dispatch] = value ?? fallbackReducer;
+    // The `useState` array isn't stable between renders -- so memo it outselves
+    const contextValue = React.useMemo(() => [state, dispatch] as const, [state, dispatch]);
     const handleDialogClose = React.useCallback(() => dispatch({ type: "CLOSE_DIALOG" }), [dispatch]);
 
     const dialog = renderDialog?.(state, { handleDialogClose }) ?? (
@@ -124,7 +126,7 @@ export const HotkeysProvider = ({ children, dialogProps, renderDialog, value }: 
 
     // if we are working with an existing context, we don't need to generate our own dialog
     return (
-        <HotkeysContext.Provider value={[state, dispatch]}>
+        <HotkeysContext.Provider value={contextValue}>
             {children}
             {hasExistingContext ? undefined : dialog}
         </HotkeysContext.Provider>


### PR DESCRIPTION
#### Related to https://github.com/palantir/blueprint/issues/5178

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Split out the memoization work from https://github.com/palantir/blueprint/pull/6643 since it should be very-safe to land.

- Prevent unnecessary renders when the state doesn't change
- The `useReducer`/`useState` _array_ isn't stable between renders, otherwise we could just use that directly. 

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
