### PR TITLE
[select] fix(MultiSelect): avoid mutating props.tagInputProps

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -256,13 +256,6 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
             } = this.props;
             const { handleKeyDown, handleKeyUp } = listProps;
 
-            if (disabled) {
-                tagInputProps.disabled = true;
-            }
-            if (fill) {
-                tagInputProps.fill = true;
-            }
-
             // add our own inputProps.className so that we can reference it in event handlers
             const inputProps = {
                 ...tagInputProps.inputProps,
@@ -311,6 +304,8 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                     rightElement={maybeClearButton}
                     {...tagInputProps}
                     className={classNames(Classes.MULTISELECT, tagInputProps.className)}
+                    disabled={disabled}
+                    fill={fill}
                     inputRef={this.refHandlers.input}
                     inputProps={inputProps}
                     inputValue={listProps.query}


### PR DESCRIPTION
#### Fixes #6645

#### Changes proposed in this pull request:

Tiny code refactor to avoid mutating `props.tagInputProps`

#### Reviewers should focus on:

No regressions in `fill={true}` or `disabled={true}` behavior for this component.

#### Screenshot


