### PR TITLE
[colors] fix Sass variable values for cerulean

### DIFF
--- a/packages/colors/src/_colors.scss
+++ b/packages/colors/src/_colors.scss
@@ -84,7 +84,7 @@ $indigo5: #bdadff !default;
 $cerulean1: #0c5174 !default;
 $cerulean2: #0f6894 !default;
 $cerulean3: #147eb3 !default;
-$cerulean4: #3fa6dA !default;
+$cerulean4: #3fa6da !default;
 $cerulean5: #68c1ee !default;
 
 $turquoise1: #004d46 !default;

--- a/packages/colors/src/_colors.scss
+++ b/packages/colors/src/_colors.scss
@@ -81,11 +81,11 @@ $indigo3: #7961db !default;
 $indigo4: #9881f3 !default;
 $indigo5: #bdadff !default;
 
-$cerulean1: #1f4b99 !default;
-$cerulean2: #2458b3 !default;
-$cerulean3: #2965cc !default;
-$cerulean4: #4580e6 !default;
-$cerulean5: #669eff !default;
+$cerulean1: #0c5174 !default;
+$cerulean2: #0f6894 !default;
+$cerulean3: #147eb3 !default;
+$cerulean4: #3fa6dA !default;
+$cerulean5: #68c1ee !default;
 
 $turquoise1: #004d46 !default;
 $turquoise2: #007067 !default;


### PR DESCRIPTION
#### Fixes #6657

#### Changes proposed in this pull request:

Fix values for "cerulean" colors in @blueprintjs/colors Sass variables 

#### Reviewers should focus on:

I believe these values were mistakenly copied from the old "cobalt" colors in https://github.com/palantir/blueprint/pull/4932. The colors [docs page](https://blueprintjs.com/docs/#core/colors) uses the JS values, which are correct (I also checked this against the Figma kit).

#### Screenshot

v4 and v5 colors:

![image](https://github.com/palantir/blueprint/assets/723999/c7a45bc5-7046-47cc-98f3-118e41a62883)

v3 colors (outdated):

![image](https://github.com/palantir/blueprint/assets/723999/8b42b799-9e26-41fe-b5df-a2b30b16ac6d)

