### PR TITLE
Change Entity Title docs icon to Shop

### DIFF
--- a/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
@@ -75,7 +75,7 @@ export const EntityTitleExample: React.FC<ExampleProps> = props => {
                 <EntityTitle
                     ellipsize={ellipsize}
                     heading={getHeading(heading)}
-                    icon={icon ? IconNames.Circle : undefined}
+                    icon={icon ? IconNames.Shop : undefined}
                     loading={loading}
                     title="Buy groceries on my way home"
                     subtitle={withSubtitle ? "Reminder set for today at 6:00 PM" : undefined}


### PR DESCRIPTION
#### Fixes [this PR comment](https://github.com/palantir/blueprint/pull/6590#pullrequestreview-1806882877)

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This PR changes the icon in the Entity Title demo to `Shop` instead of `Circle`. This is because `Circle` looked like it was clickable despite not being interactive.

#### Screenshot

##### Before
<img width="826" alt="image" src="https://github.com/palantir/blueprint/assets/12519846/7421fb6d-40af-4088-8283-d2743ffacab4"> 

##### After
<img width="813" alt="image" src="https://github.com/palantir/blueprint/assets/12519846/5ef2b5fc-161f-41e0-8193-1739ab4a7353">