### PR TITLE
Sanitize docs content to prevent XSS

### DIFF
--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -41,7 +41,8 @@
         "@documentalist/client": "^5.0.0",
         "classnames": "^2.3.1",
         "fuzzaldrin-plus": "^0.6.0",
-        "tslib": "~2.6.2"
+        "tslib": "~2.6.2",
+        "dompurify": "^3.0.8"
     },
     "peerDependencies": {
         "@types/react": "^16.14.41 || 17 || 18",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -40,9 +40,9 @@
         "@blueprintjs/select": "workspace:^",
         "@documentalist/client": "^5.0.0",
         "classnames": "^2.3.1",
+        "dompurify": "^3.0.8",
         "fuzzaldrin-plus": "^0.6.0",
-        "tslib": "~2.6.2",
-        "dompurify": "^3.0.8"
+        "tslib": "~2.6.2"
     },
     "peerDependencies": {
         "@types/react": "^16.14.41 || 17 || 18",

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -21,6 +21,7 @@ import * as React from "react";
 import { Classes, Code, H3 } from "@blueprintjs/core";
 
 import type { TagRendererMap } from "../tags";
+import DOMPurify from "dompurify";
 
 export function renderBlock(
     /** the block to render */
@@ -36,7 +37,8 @@ export function renderBlock(
     const textClasses = classNames(Classes.RUNNING_TEXT, textClassName);
     const contents = block.contents.map((node, i) => {
         if (typeof node === "string") {
-            return <div className={textClasses} key={i} dangerouslySetInnerHTML={{ __html: node }} />;
+            const sanitizedNode = DOMPurify.sanitize(node);
+            return <div className={textClasses} key={i} dangerouslySetInnerHTML={{ __html: sanitizedNode }} />;
         }
         try {
             const renderer = tagRenderers[node.tag];

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,6 +647,7 @@ __metadata:
     "@documentalist/client": "npm:^5.0.0"
     "@types/fuzzaldrin-plus": "npm:~0.6.5"
     classnames: "npm:^2.3.1"
+    dompurify: "npm:^3.0.8"
     fuzzaldrin-plus: "npm:^0.6.0"
     npm-run-all: "npm:^4.1.5"
     react: "npm:^16.14.0"
@@ -6433,6 +6434,13 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.3.0"
   checksum: bba1e5932b3e196ad6862286d76adc89a0dbf0c773e5ced1eb01f9af930c50093a084eff14b8de5ea60b895c56a04d5de8bbc4930c5543d029091916770b2d2a
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "dompurify@npm:3.0.8"
+  checksum: e89e03d3dbd99abd64cd90705ce2cdfbc60ee9726ee53f9860e8a2d91b828ef2c173e7031529f9a3aa169ad0fbb76115c6a6683b545bf1ac5d94cc6176fb2a50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Fix for Cross-Site Scripting (XSS) Vulnerability

Hi, I've found a Cross-Site Scripting (XSS) vulnerability in the package @icedesign/richtext-renderer.

**Vulnerability Details:**
- **Severity**: High/Critical
- **Description**: There's a risk of malicious content is passed to docs

#### POC(Proof of Concept)
```
import React, { useEffect } from "react";
import { Documentation } from "@blueprintjs/docs-theme";

const App = () => {
  return (
    <Documentation
      docs={{
        nav: [],
        pages: {
          test: {
            reference: "foo",
            route: "foo",
            sourcePath: "foo",
            title: "foo",
            contents: ["<img src='' onerror=alert(1)>"],
          },
        },
        docs: {
          pages: [],
        },
      }}
      defaultPageId="foo"
    />
  );
};

export default App;

```


<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Sanitize the HTML before rendering it using dangerouslySetInnerHtml

I've already fixed this issue, and have submitted a pull request with the necessary changes. Please review and merge my pull request to resolve this vulnerability. Thanks!

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
