### PR TITLE
[core] feat: OverlaysProvider

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
         "normalize.css": "^8.0.1",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5",
+        "react-uid": "^2.3.3",
         "tslib": "~2.6.2"
     },
     "peerDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,8 @@
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5",
         "react-uid": "^2.3.3",
-        "tslib": "~2.6.2"
+        "tslib": "~2.6.2",
+        "use-sync-external-store": "^1.2.0"
     },
     "peerDependencies": {
         "@types/react": "^16.14.41 || 17 || 18",
@@ -74,6 +75,7 @@
         "@blueprintjs/node-build-scripts": "workspace:^",
         "@blueprintjs/test-commons": "workspace:^",
         "@testing-library/react": "^12.1.5",
+        "@types/use-sync-external-store": "0.0.6",
         "enzyme": "^3.11.0",
         "karma": "^6.4.2",
         "mocha": "^10.2.0",

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -110,6 +110,10 @@ export const DIALOG_WARN_NO_HEADER_CLOSE_BUTTON =
 export const DRAWER_ANGLE_POSITIONS_ARE_CASTED =
     ns + ` <Drawer> all angle positions are casted into pure position (TOP, BOTTOM, LEFT or RIGHT)`;
 
+export const OVERLAY2_REQUIRES_OVERLAY_PROVDER =
+    ns +
+    ` <Overlay2> was used outside of a <OverlaysProvider> context. This will no longer be supported in ` +
+    `Blueprint v6. See https://github.com/palantir/blueprint/wiki/Overlay2-migration`;
 export const OVERLAY_CHILD_REF_AND_REFS_MUTEX =
     ns + ` <Overlay2> cannot use childRef and childRefs props simultaneously`;
 export const OVERLAY_WITH_MULTIPLE_CHILDREN_REQUIRES_CHILD_REFS =

--- a/packages/core/src/components/dialog/dialog.md
+++ b/packages/core/src/components/dialog/dialog.md
@@ -1,6 +1,6 @@
 @# Dialogs
 
-__Dialog__ presents content overlaid over other parts of the UI.
+**Dialog** presents content overlaid over other parts of the UI.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Terminology note</h5>
@@ -21,15 +21,29 @@ Blueprint provides two types of dialogs:
 
 @reactExample DialogExample
 
-A standard __Dialog__ renders its contents in an [__Overlay__](#core/components/overlay) with a
+@## Usage
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+[OverlaysProvider](#core/context/overlays-provider) recommended
+
+</h5>
+
+This component renders an **Overlay2** which works best inside a React tree which includes an
+**OverlaysProvider**. Blueprint v5.x includes a backwards-compatibile shim which allows this context
+to be optional, but it will be required in a future major version. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+
+</div>
+
+A standard **Dialog** renders its contents in an [**Overlay2**](#core/components/overlay2) with a
 `Classes.DIALOG` element. You can use some simple dialog markup sub-components or CSS classes
 to structure its contents:
 
 ```tsx
 <Dialog title="Informational dialog" icon="info-sign">
-    <DialogBody>
-        {/* body contents here */}
-    </DialogBody>
+    <DialogBody>{/* body contents here */}</DialogBody>
     <DialogFooter actions={<Button intent="primary" text="Close" onClick={/* ... */} />} />
 </Dialog>
 ```
@@ -79,7 +93,7 @@ often fall out of sync as the design system is updated. You should use the React
 
 @### Multistep dialog props
 
-__MultistepDialog__ is a wrapper around __Dialog__ that displays a dialog with multiple steps. Each step has a
+**MultistepDialog** is a wrapper around **Dialog** that displays a dialog with multiple steps. Each step has a
 corresponding panel.
 
 This component expects `<DialogStep>` child elements: each "step" is rendered in order and its panel is shown as the
@@ -89,8 +103,8 @@ dialog body content when the corresponding step is selected in the navigation pa
 
 @### DialogStep
 
-__DialogStep__ is a minimal wrapper with no functionality of its own&mdash;it is managed entirely by its parent
-__MultistepDialog__ container. Typically, you should render a `<DialogBody>` element as the `panel` element. A step's
+**DialogStep** is a minimal wrapper with no functionality of its own&mdash;it is managed entirely by its parent
+**MultistepDialog** container. Typically, you should render a `<DialogBody>` element as the `panel` element. A step's
 title text can be set via the `title` prop.
 
 @interface DialogStepProps

--- a/packages/core/src/components/drawer/drawer.md
+++ b/packages/core/src/components/drawer/drawer.md
@@ -7,6 +7,20 @@ the lower-level [**Overlay**](#core/components/overlay) component.
 
 @## Usage
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+[OverlaysProvider](#core/context/overlays-provider) recommended
+
+</h5>
+
+This component renders an **Overlay2** which works best inside a React tree which includes an
+**OverlaysProvider**. Blueprint v5.x includes a backwards-compatibile shim which allows this context
+to be optional, but it will be required in a future major version. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+
+</div>
+
 `<Drawer>` is a stateless React component controlled by its `isOpen` prop.
 
 Use the `size` prop to set the size of a **Drawer**. This prop sets CSS `width` if `vertical={false}` (default)

--- a/packages/core/src/components/overlay/overlay.md
+++ b/packages/core/src/components/overlay/overlay.md
@@ -1,3 +1,7 @@
+---
+tag: deprecated
+---
+
 @# Overlay
 
 <div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">

--- a/packages/core/src/components/overlay2/overlay2.md
+++ b/packages/core/src/components/overlay2/overlay2.md
@@ -11,8 +11,9 @@ Migrating from [Overlay](#core/components/overlay)?
 
 </h5>
 
-**Overlay2** is a replacement for **Overlay**. It will become the standard API in a future major version of
-Blueprint. You are encouraged to use this new API now for forwards-compatibility. See the full
+[**OverlaysProvider**](#core/context/overlays-provider) and **Overlay2**, when used
+together, are a replacement for **Overlay**. You are encouraged to use these new APIs, as they will
+become the standard in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
 
 </div>
@@ -42,7 +43,7 @@ The optional backdrop element will be inserted before the children if `hasBackdr
 The `onClose` callback prop is invoked when user interaction causes the overlay to close, but your
 application is responsible for updating the state that actually closes the overlay.
 
-**Overlay2** _strongly recommends_ usage only within a React subtree which has a
+**Overlay2** _strongly recommends_ usage only within a React subtree which has an
 [**OverlaysProvider**](#core/context/overlays-provider). In Blueprint v5.x, the component
 implements backwards-compatibilty (via the [`useOverlayStack()` hook](#core/hooks/use-overlay-stack))
 such that it will work without one, but this functionality will be removed in a future major version.

--- a/packages/core/src/components/overlay2/overlay2.md
+++ b/packages/core/src/components/overlay2/overlay2.md
@@ -42,7 +42,13 @@ The optional backdrop element will be inserted before the children if `hasBackdr
 The `onClose` callback prop is invoked when user interaction causes the overlay to close, but your
 application is responsible for updating the state that actually closes the overlay.
 
+**Overlay2** _strongly recommends_ usage only within a React subtree which has a
+[**OverlaysProvider**](#core/context/overlays-provider). In Blueprint v5.x, the component
+implements backwards-compatibilty (via the [`useOverlayStack()` hook](#core/hooks/use-overlay-stack))
+such that it will work without one, but this functionality will be removed in a future major version.
+
 ```tsx
+import { Button, Overlay2, OverlaysProvider } from "@blueprintjs/core";
 import { useCallback, useState } from "react";
 
 function Example() {
@@ -50,12 +56,14 @@ function Example() {
     const toggleOverlay = useCallback(() => setIsOpen(open => !open), [setIsOpen]);
 
     return (
-        <div>
-            <Button text="Show overlay" onClick={toggleOverlay} />
-            <Overlay2 isOpen={isOpen} onClose={toggleOverlay}>
-                Overlaid contents...
-            </Overlay2>
-        </div>
+        <OverlaysProvider>
+            <div>
+                <Button text="Show overlay" onClick={toggleOverlay} />
+                <Overlay2 isOpen={isOpen} onClose={toggleOverlay}>
+                    Overlaid contents...
+                </Overlay2>
+            </div>
+        </OverlaysProvider>
     );
 }
 ```

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -46,7 +46,7 @@ import { Portal } from "../portal/portal";
  * Public instance properties & methods for an overlay in the current overlay stack.
  */
 export interface OverlayInstance {
-    /** Bring document focus inside this eoverlay element. */
+    /** Bring document focus inside this overlay element. */
     bringFocusInsideOverlay: () => void;
 
     /** Reference to the overlay container element which may or may not be in a Portal. */

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -62,7 +62,9 @@ export interface OverlayInstance {
     props: Pick<OverlayProps, "autoFocus" | "enforceFocus" | "usePortal" | "hasBackdrop">;
 }
 
-export interface Overlay2Props extends OverlayProps, React.RefAttributes<OverlayInstance> {
+export interface Overlay2Props
+    extends Omit<OverlayProps, "portalStopPropagationEvents">,
+        React.RefAttributes<OverlayInstance> {
     /**
      * If you provide a single child element to Overlay2 and attach your own `ref` to the node, you must pass the
      * same value here (otherwise, Overlay2 won't be able to render CSSTransition correctly).

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -267,11 +267,6 @@ export const Overlay2: React.FC<Overlay2Props> = React.forwardRef<OverlayInstanc
             document.addEventListener("mousedown", handleDocumentClick);
         }
 
-        if (hasBackdrop && usePortal) {
-            // add a class to the body to prevent scrolling of content below the overlay
-            document.body.classList.add(Classes.OVERLAY_OPEN);
-        }
-
         setRef(lastActiveElementBeforeOpened, getActiveElement(getRef(containerElement)));
     }, [
         autoFocus,
@@ -284,7 +279,6 @@ export const Overlay2: React.FC<Overlay2Props> = React.forwardRef<OverlayInstanc
         hasBackdrop,
         instance,
         openOverlay,
-        usePortal,
     ]);
 
     const overlayWillClose = React.useCallback(() => {

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -62,9 +62,7 @@ export interface OverlayInstance {
     props: Pick<OverlayProps, "autoFocus" | "enforceFocus" | "usePortal" | "hasBackdrop">;
 }
 
-export interface Overlay2Props
-    extends Omit<OverlayProps, "portalStopPropagationEvents">,
-        React.RefAttributes<OverlayInstance> {
+export interface Overlay2Props extends OverlayProps, React.RefAttributes<OverlayInstance> {
     /**
      * If you provide a single child element to Overlay2 and attach your own `ref` to the node, you must pass the
      * same value here (otherwise, Overlay2 won't be able to render CSSTransition correctly).

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -9,6 +9,20 @@ Popper.js is a small library that offers a powerful, customizable, and performan
 
 @## Usage
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+[OverlaysProvider](#core/context/overlays-provider) recommended
+
+</h5>
+
+This component renders an **Overlay2** which works best inside a React tree which includes an
+**OverlaysProvider**. Blueprint v5.x includes a backwards-compatibile shim which allows this context
+to be optional, but it will be required in a future major version. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+
+</div>
+
 **Popover** supports controlled and uncontrolled usage through `isOpen` and `defaultIsOpen`, respectively.
 Use `onInteraction` in controlled mode to respond to changes in the `isOpen` state.
 

--- a/packages/core/src/context/context.md
+++ b/packages/core/src/context/context.md
@@ -3,4 +3,5 @@
 <!-- Exact ordering of items in the navbar: -->
 
 @page hotkeys-provider
+@page overlays-provider
 @page portal-provider

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -7,14 +7,14 @@ Migrating from [HotkeysTarget](#core/legacy/hotkeys-legacy)?
 
 </h5>
 
-__HotkeysProvider__ and `useHotkeys`, used together, are a replacement for __HotkeysTarget__.
+**HotkeysProvider** and `useHotkeys`, used together, are a replacement for **HotkeysTarget**.
 You are encouraged to use this new API, as it will become the standard APIs in a future major version of Blueprint.
 See the full [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration)
 on the wiki.
 
 </div>
 
-HotkeysProvider generates a React context necessary for the [`useHotkeys` hook](#core/hooks/use-hotkeys)
+**HotkeysProvider** generates a React context necessary for the [`useHotkeys` hook](#core/hooks/use-hotkeys)
 to maintain state for the globally-accessible hotkeys dialog. As your application runs and components
 are mounted/unmounted, global and local hotkeys are registered/unregistered with this context and
 the dialog displays/hides the relevant information. You can try it out in the Blueprint docs app
@@ -44,12 +44,7 @@ it with the root context instance. This ensures that there will only be one "glo
 which has multiple HotkeysProviders.
 
 ```tsx
-import {
-    HotkeyConfig,
-    HotkeysContext,
-    HotkeysProvider,
-    HotkeysTarget2
-} from "@blueprintjs/core";
+import { HotkeyConfig, HotkeysContext, HotkeysProvider, HotkeysTarget2 } from "@blueprintjs/core";
 import React, { useContext, useEffect, useRef } from "react";
 import * as ReactDOM from "react-dom";
 
@@ -84,7 +79,7 @@ function Plugin() {
             global: true,
             label: "Search",
             onKeyDown: () => console.info("search"),
-        }
+        },
     ];
 
     return (
@@ -100,12 +95,7 @@ function PluginSlot(props) {
 
     useEffect(() => {
         if (ref.current != null) {
-            ReactDOM.render(
-                <HotkeysProvider value={hotkeysContext}>
-                    {props.children}
-                </HotkeysProvider>,
-                ref.current,
-            );
+            ReactDOM.render(<HotkeysProvider value={hotkeysContext}>{props.children}</HotkeysProvider>, ref.current);
         }
     }, [ref, hotkeysContext, props.children]);
 

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -20,4 +20,10 @@ export {
     HotkeysProvider,
     type HotkeysProviderProps,
 } from "./hotkeys/hotkeysProvider";
+export {
+    OverlaysContext,
+    OverlaysProvider,
+    type OverlaysContextInstance,
+    type OverlaysProviderProps,
+} from "./overlays/overlaysProvider";
 export { PortalContext, type PortalContextOptions, PortalProvider } from "./portal/portalProvider";

--- a/packages/core/src/context/overlays/overlays-provider.md
+++ b/packages/core/src/context/overlays/overlays-provider.md
@@ -1,3 +1,7 @@
+---
+tag: new
+---
+
 @# OverlaysProvider
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
@@ -7,17 +11,17 @@ Migrating from [Overlay](#core/components/overlay)?
 
 </h5>
 
-**OverlaysProvider** and [`useOverlayStack()`](#core/hooks/overlays/use-overlay-stack), when used
+**OverlaysProvider** and [**Overlay2**](#core/components/overlay2), when used
 together, are a replacement for **Overlay**. You are encouraged to use these new APIs, as they will
 become the standard in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
 
 </div>
 
-**OverlaysProvider** is responsible for managing global overlay state in the application,
-specifically the stack of all overlays which are currently open. It provides a
-[React context](https://react.dev/learn/passing-data-deeply-with-context) which is used primarily by
-the [**Overlay2** component](#core/components/overlay2).
+**OverlaysProvider** is responsible for managing global overlay state in an application,
+specifically the stack of all overlays which are currently open. It provides the necessary
+[React context](https://react.dev/learn/passing-data-deeply-with-context) for the
+[**Overlay2** component](#core/components/overlay2).
 
 ## Usage
 
@@ -35,7 +39,3 @@ ReactDOM.render(
     document.querySelector("#app"),
 );
 ```
-
-@## Props interface
-
-@interface OverlaysProviderProps

--- a/packages/core/src/context/overlays/overlays-provider.md
+++ b/packages/core/src/context/overlays/overlays-provider.md
@@ -1,0 +1,41 @@
+@# OverlaysProvider
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Migrating from [Overlay](#core/components/overlay)?
+
+</h5>
+
+**OverlaysProvider** and [`useOverlayStack()`](#core/hooks/overlays/use-overlay-stack), when used
+together, are a replacement for **Overlay**. You are encouraged to use these new APIs, as they will
+become the standard in a future major version of Blueprint. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+
+</div>
+
+**OverlaysProvider** is responsible for managing global overlay state in the application,
+specifically the stack of all overlays which are currently open. It provides a
+[React context](https://react.dev/learn/passing-data-deeply-with-context) which is used primarily by
+the [**Overlay2** component](#core/components/overlay2).
+
+## Usage
+
+To use **OverlaysProvider**, wrap your application with it at the root level:
+
+```tsx
+import { OverlaysProvider } from "@blueprintjs/core";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+ReactDOM.render(
+    <OverlaysProvider>
+        <div>My app has overlays 😎</div>
+    </OverlaysProvider>,
+    document.querySelector("#app"),
+);
+```
+
+@## Props interface
+
+@interface OverlaysProviderProps

--- a/packages/core/src/context/overlays/overlaysProvider.tsx
+++ b/packages/core/src/context/overlays/overlaysProvider.tsx
@@ -84,6 +84,11 @@ export interface OverlaysProviderProps {
     children: React.ReactNode;
 }
 
+/**
+ * Overlays context provider, necessary for the `useOverlayStack` hook.
+ *
+ * @see https://blueprintjs.com/docs/#core/context/overlays-provider
+ */
 export const OverlaysProvider = ({ children }: OverlaysProviderProps) => {
     const contextValue = React.useReducer(overlaysReducer, { ...initialOverlaysState, hasProvider: true });
     return <OverlaysContext.Provider value={contextValue}>{children}</OverlaysContext.Provider>;

--- a/packages/core/src/context/overlays/overlaysProvider.tsx
+++ b/packages/core/src/context/overlays/overlaysProvider.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import type { OverlayInstance } from "../../components/overlay2/overlay2";
+
+interface OverlaysContextState {
+    stack: OverlayInstance[];
+}
+
+type OverlayStackAction =
+    | { type: "OPEN_OVERLAY" | "CLOSE_OVERLAY"; payload: OverlayInstance }
+    | { type: "RESET_STACK" };
+
+export type OverlaysContextInstance = readonly [OverlaysContextState, React.Dispatch<OverlayStackAction>];
+
+const initialOverlaysState: OverlaysContextState = { stack: [] };
+const noOpDispatch: React.Dispatch<OverlayStackAction> = () => null;
+
+/**
+ * A React context used to interact with the overlay stack in an application.
+ * Users should take care to make sure that only _one_ of these is instantiated and used within an
+ * application.
+ *
+ * You will likely not be using this OverlaysContext directly, it's mostly used internally by the
+ * Overlay2 component.
+ *
+ * For more information, see the [OverlaysProvider documentation](https://blueprintjs.com/docs/#core/context/overlays-provider).
+ */
+export const OverlaysContext = React.createContext<OverlaysContextInstance>([initialOverlaysState, noOpDispatch]);
+
+const overlaysReducer = (state: OverlaysContextState, action: OverlayStackAction) => {
+    switch (action.type) {
+        case "OPEN_OVERLAY":
+            return { stack: [...state.stack, action.payload] };
+        case "CLOSE_OVERLAY":
+            const index = state.stack.findIndex(o => o.id === action.payload.id);
+            if (index === -1) {
+                return state;
+            }
+            const newStack = state.stack.slice();
+            newStack.splice(index, 1);
+            return { stack: newStack };
+        case "RESET_STACK":
+            return initialOverlaysState;
+        default:
+            return state;
+    }
+};
+
+export interface OverlaysProviderProps {
+    /** The component subtree which will have access to this overlay stack context. */
+    children: React.ReactNode;
+}
+
+export const OverlaysProvider = ({ children }: OverlaysProviderProps) => {
+    const contextValue = React.useReducer(overlaysReducer, initialOverlaysState);
+    return <OverlaysContext.Provider value={contextValue}>{children}</OverlaysContext.Provider>;
+};

--- a/packages/core/src/hooks/hooks.md
+++ b/packages/core/src/hooks/hooks.md
@@ -3,3 +3,4 @@
 <!-- Exact ordering of items in the navbar: -->
 
 @page use-hotkeys
+@page use-overlay-stack

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -3,18 +3,18 @@
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
-Migrating from [__HotkeysTarget__](#core/legacy/hotkeys-legacy)?
+Migrating from [**HotkeysTarget**](#core/legacy/hotkeys-legacy)?
 
 </h5>
 
-`useHotkeys` is a replacement for __HotkeysTarget__. You are encouraged to use this new API in your function
-components, or the [__HotkeysTarget2__ component](#core/components/hotkeys-target2) in your component classes,
+`useHotkeys()` is a replacement for **HotkeysTarget**. You are encouraged to use this new API in your function
+components, or the [**HotkeysTarget2** component](#core/components/hotkeys-target2) in your component classes,
 as they will become the standard APIs in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration) on the wiki.
 
 </div>
 
-The `useHotkeys` hook adds hotkey / keyboard shortcut interactions to your application using a custom React hook.
+The `useHotkeys()` hook adds hotkey / keyboard shortcut interactions to your application using a custom React hook.
 Compared to the deprecated [Hotkeys API](#core/legacy/hotkeys-legacy), it works with function components and its
 corresponding [context provider](#core/context/hotkeys-provider) allows more customization of the hotkeys dialog.
 
@@ -24,7 +24,7 @@ Focus on the piano below to try its hotkeys. The global hotkeys dialog can be sh
 
 @## Usage
 
-First, make sure [__HotkeysProvider__](#core/context/hotkeys-provider) is configured correctly at the root of your
+First, make sure [**HotkeysProvider**](#core/context/hotkeys-provider) is configured correctly at the root of your
 React application.
 
 Then, to register hotkeys and generate the relevant event handlers, use the hook like so:
@@ -33,26 +33,29 @@ Then, to register hotkeys and generate the relevant event handlers, use the hook
 import { InputGroup, KeyComboTag, useHotkeys } from "@blueprintjs/core";
 import React, { createRef, useCallback, useMemo } from "react";
 
-export default function() {
+export default function () {
     const inputRef = createRef<HTMLInputElement>();
     const handleRefresh = useCallback(() => console.info("Refreshing data..."), []);
     const handleFocus = useCallback(() => inputRef.current?.focus(), [inputRef]);
 
     // important: hotkeys array must be memoized to avoid infinitely re-binding hotkeys
-    const hotkeys = useMemo(() => [
-        {
-            combo: "R",
-            global: true,
-            label: "Refresh data",
-            onKeyDown: handleRefresh,
-        },
-        {
-            combo: "F",
-            group: "Input",
-            label: "Focus text input",
-            onKeyDown: handleFocus,
-        },
-    ], [handleRefresh, handleFocus]);
+    const hotkeys = useMemo(
+        () => [
+            {
+                combo: "R",
+                global: true,
+                label: "Refresh data",
+                onKeyDown: handleRefresh,
+            },
+            {
+                combo: "F",
+                group: "Input",
+                label: "Focus text input",
+                onKeyDown: handleFocus,
+            },
+        ],
+        [handleRefresh, handleFocus],
+    );
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys);
 
     return (
@@ -64,7 +67,7 @@ export default function() {
 }
 ```
 
-__Important__: the `hotkeys` array must be memoized, as shown above, to prevent the hook from re-binding
+**Important**: the `hotkeys` array must be memoized, as shown above, to prevent the hook from re-binding
 hotkeys on every render.
 
 Hotkeys must define a group, or be marked as global. The hook will automatically bind global event handlers

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -16,4 +16,7 @@
 
 export type { HotkeyConfig } from "./hotkeys/hotkeyConfig";
 export { useHotkeys, type UseHotkeysOptions, type UseHotkeysReturnValue } from "./hotkeys/useHotkeys";
+export { useOverlayStack } from "./overlays/useOverlayStack";
 export { useAsyncControllableValue } from "./useAsyncControllableValue";
+export { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+export { usePrevious } from "./usePrevious";

--- a/packages/core/src/hooks/overlays/use-overlay-stack.md
+++ b/packages/core/src/hooks/overlays/use-overlay-stack.md
@@ -1,34 +1,20 @@
 @# useOverlayStack
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">Internal API</h5>
 
-Migrating from [Overlay](#core/components/overlay)?
-
-</h5>
-
-[**OverlaysProvider**](#core/context/overlays-provider) and `useOverlayStack()`, when used together,
-are a replacement for **Overlay**. You are encouraged to use these new APIs, as they will become the
-standard in a future major version of Blueprint. See the full
-[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+This hook is mainly intended to be an internal Blueprint API used by the **Overlay2** component.
+Its usage outside of `@blueprintjs/` packages is not fully supported.
 
 </div>
 
 The `useOverlayStack()` hook allows Blueprint components to interact with the global overlay stack
 in an application. Compared to the deprecated [**Overlay**](#core/components/overlay) component,
-it avoids storing global state at the JS module level.
+this hook avoids storing global state at the JS module level.
 
 @## Usage
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Internal API</h5>
-
-This hook is mainly intended to be an internal Blueprint API used by the **Overlay2** component.
-Its usage outside of `@blueprintjs/` packages is not fully supported or guaranteed.
-
-</div>
-
-First, make sure [**OverlaysProvider**](#core/context/overlays-provider) is configured corectly at
+First, make sure [**OverlaysProvider**](#core/context/overlays-provider) is configured correctly at
 the root of your React application.
 
 Then, use the hook to interact with the global overlay stack:
@@ -38,7 +24,8 @@ import { OverlayInstance, OverlayProps, Portal, useOverlayStack, usePrevious } f
 import * as React from "react";
 import { useUID } from "react-uid";
 
-export default function ({ autoFocus, children, enforceFocus, hasBackdrop, isOpen, usePortal }: OverlayProps) {
+export function Example(props: OverlayProps) {
+    const { autoFocus, children, enforceFocus, hasBackdrop, isOpen, usePortal } = props;
     const { openOverlay, closeOverlay } = useOverlayStack();
 
     const containerElement = React.useRef<HTMLDivElement>(null);

--- a/packages/core/src/hooks/overlays/use-overlay-stack.md
+++ b/packages/core/src/hooks/overlays/use-overlay-stack.md
@@ -1,0 +1,96 @@
+@# useOverlayStack
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Migrating from [Overlay](#core/components/overlay)?
+
+</h5>
+
+[**OverlaysProvider**](#core/context/overlays-provider) and `useOverlayStack()`, when used together,
+are a replacement for **Overlay**. You are encouraged to use these new APIs, as they will become the
+standard in a future major version of Blueprint. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+
+</div>
+
+The `useOverlayStack()` hook allows Blueprint components to interact with the global overlay stack
+in an application. Compared to the deprecated [**Overlay**](#core/components/overlay) component,
+it avoids storing global state at the JS module level.
+
+@## Usage
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">Internal API</h5>
+
+This hook is mainly intended to be an internal Blueprint API used by the **Overlay2** component.
+Its usage outside of `@blueprintjs/` packages is not fully supported or guaranteed.
+
+</div>
+
+First, make sure [**OverlaysProvider**](#core/context/overlays-provider) is configured corectly at
+the root of your React application.
+
+Then, use the hook to interact with the global overlay stack:
+
+```tsx
+import { OverlayInstance, OverlayProps, Portal, useOverlayStack, usePrevious } from "@blueprintjs/core";
+import * as React from "react";
+import { useUID } from "react-uid";
+
+export default function ({ autoFocus, children, enforceFocus, hasBackdrop, isOpen, usePortal }: OverlayProps) {
+    const { openOverlay, closeOverlay } = useOverlayStack();
+
+    const containerElement = React.useRef<HTMLDivElement>(null);
+
+    const bringFocusInsideOverlay = React.useCallback(() => {
+        // TODO: implement
+    }, []);
+
+    const handleDocumentFocus = React.useCallback((e: FocusEvent) => {
+        // TODO: implement
+    }, []);
+
+    const id = useUID();
+    const instance = React.useMemo<OverlayInstance>(
+        () => ({
+            bringFocusInsideOverlay,
+            containerElement,
+            handleDocumentFocus,
+            id,
+            props: {
+                autoFocus,
+                enforceFocus,
+                hasBackdrop,
+                usePortal,
+            },
+        }),
+        [autoFocus, bringFocusInsideOverlay, enforceFocus, handleDocumentFocus, hasBackdrop, id, usePortal],
+    );
+
+    const prevIsOpen = usePrevious(isOpen) ?? false;
+    React.useEffect(() => {
+        if (!prevIsOpen && isOpen) {
+            // just opened
+            openOverlay(instance);
+        }
+
+        if (prevIsOpen && !isOpen) {
+            // just closed
+            closeOverlay(instance);
+        }
+    }, [isOpen, openOverlay, closeOverlay, prevIsOpen, instance]);
+
+    // run once on unmount
+    React.useEffect(() => {
+        return () => {
+            if (isOpen) {
+                closeOverlay(instance);
+            }
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return usePortal ? <Portal>{children}</Portal> : children;
+}
+```

--- a/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
@@ -60,13 +60,6 @@ export function useLegacyOverlayStack(): UseOverlayStackReturnValue {
         legacyGlobalOverlayStackStore.getSnapshot,
     );
 
-    // const prevStack = usePrevious(stack);
-    // React.useEffect(() => {
-    //     if (prevStack !== stack) {
-    //         legacyGlobalOverlayStoreListeners.forEach(listener => listener());
-    //     }
-    // }, [stack, prevStack]);
-
     const getLastOpened = React.useCallback(() => stack.at(-1), [stack]);
 
     const getThisOverlayAndDescendants = React.useCallback(

--- a/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+// tslint:disable-next-line no-submodule-imports
+import { useSyncExternalStore } from "use-sync-external-store/shim";
+
+import { Classes } from "../../common";
+import type { OverlayInstance } from "../../components";
+import { overlaysReducer, type OverlayStackAction } from "../../context/overlays/overlaysProvider";
+
+import type { UseOverlayStackReturnValue } from "./useOverlayStack";
+
+let legacyGlobalOverlayStack: OverlayInstance[] = [];
+let legacyGlobalOverlayStoreListeners: Array<() => void> = [];
+
+const legacyGlobalOverlayStackStore = {
+    getSnapshot: () => legacyGlobalOverlayStack,
+    subscribe: (listener: () => void) => {
+        legacyGlobalOverlayStoreListeners = [...legacyGlobalOverlayStoreListeners, listener];
+        return () => {
+            legacyGlobalOverlayStoreListeners = legacyGlobalOverlayStoreListeners.filter(l => l !== listener);
+        };
+    },
+};
+
+const dispatch: React.Dispatch<OverlayStackAction> = action => {
+    const state = { stack: legacyGlobalOverlayStack, hasProvider: false };
+    const newStack = overlaysReducer(state, action).stack;
+    legacyGlobalOverlayStack = newStack;
+    // IMPORTANT: notify all listeners that the global stack has changed
+    legacyGlobalOverlayStoreListeners.forEach(listener => listener());
+};
+
+/**
+ * Legacy implementation of a global overlay stack which maintains state in a global variable.
+ * This is used for backwards-compatibility with overlay-based components in Blueprint v5.
+ * It will be removed in Blueprint v6 once `<OverlaysProvider>` is required.
+ *
+ * @see https://github.com/palantir/blueprint/wiki/Overlay2-migration
+ */
+export function useLegacyOverlayStack(): UseOverlayStackReturnValue {
+    const stack = useSyncExternalStore(
+        legacyGlobalOverlayStackStore.subscribe,
+        legacyGlobalOverlayStackStore.getSnapshot,
+        // server snapshot is the same as client snapshot
+        legacyGlobalOverlayStackStore.getSnapshot,
+    );
+
+    // const prevStack = usePrevious(stack);
+    // React.useEffect(() => {
+    //     if (prevStack !== stack) {
+    //         legacyGlobalOverlayStoreListeners.forEach(listener => listener());
+    //     }
+    // }, [stack, prevStack]);
+
+    const getLastOpened = React.useCallback(() => stack.at(-1), [stack]);
+
+    const getThisOverlayAndDescendants = React.useCallback(
+        (overlay: OverlayInstance) => {
+            const stackIndex = stack.findIndex(o => o.id === overlay.id);
+            return stack.slice(stackIndex);
+        },
+        [stack],
+    );
+
+    const resetStack = React.useCallback(() => dispatch({ type: "RESET_STACK" }), []);
+
+    const openOverlay = React.useCallback((overlay: OverlayInstance) => {
+        dispatch({ type: "OPEN_OVERLAY", payload: overlay });
+        if (overlay.props.usePortal && overlay.props.hasBackdrop) {
+            // add a class to the body to prevent scrolling of content below the overlay
+            document.body.classList.add(Classes.OVERLAY_OPEN);
+        }
+    }, []);
+
+    const closeOverlay = React.useCallback(
+        (overlay: OverlayInstance) => {
+            const otherOverlaysWithBackdrop = stack.filter(
+                o => o.props.usePortal && o.props.hasBackdrop && o.id !== overlay.id,
+            );
+
+            dispatch({ type: "CLOSE_OVERLAY", payload: overlay });
+
+            if (otherOverlaysWithBackdrop.length === 0) {
+                // remove body class which prevents scrolling of content below overlay
+                document.body.classList.remove(Classes.OVERLAY_OPEN);
+            }
+        },
+        [stack],
+    );
+
+    return {
+        closeOverlay,
+        getLastOpened,
+        getThisOverlayAndDescendants,
+        openOverlay,
+        resetStack,
+    };
+}

--- a/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
@@ -37,7 +37,10 @@ const legacyGlobalOverlayStackStore = {
     },
 };
 
-const dispatch: React.Dispatch<OverlayStackAction> = action => {
+/**
+ * Public only for testing.
+ */
+export const dispatch: React.Dispatch<OverlayStackAction> = action => {
     const state = { stack: legacyGlobalOverlayStack, hasProvider: false };
     const newStack = overlaysReducer(state, action).stack;
     legacyGlobalOverlayStack = newStack;

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -104,7 +104,7 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
     );
 
     if (!state.hasProvider) {
-        if (!isNodeEnv("production")) {
+        if (isNodeEnv("development")) {
             console.error(OVERLAY2_REQUIRES_OVERLAY_PROVDER);
         }
         return legacyOverlayStack;

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -67,10 +67,13 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
 
     const getLastOpened = React.useCallback(() => stack.at(-1), [stack]);
 
+    console.log("stack", stack);
+    console.log("prevStack", prevStack);
     React.useEffect(() => {
         // if no overlays remain on the stack which have a backdrop over the document body, remove
         // the class which disables body scrolling
         if (didClose && stack.filter(o => o.props.usePortal && o.props.hasBackdrop).length === 0) {
+            console.log("******** all overlays with backdrop closed, removing body scrolling class");
             document.body.classList.remove(Classes.OVERLAY_OPEN);
         }
     }, [didClose, stack]);
@@ -87,8 +90,12 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
 
     const openOverlay = React.useCallback(
         (overlay: OverlayInstance) => {
-            // console.log("******* openOverlay *******", overlay);
             dispatch({ type: "OPEN_OVERLAY", payload: overlay });
+            if (overlay.props.usePortal && overlay.props.hasBackdrop) {
+                console.log("******** adding body scrolling class");
+                // add a class to the body to prevent scrolling of content below the overlay
+                document.body.classList.add(Classes.OVERLAY_OPEN);
+            }
         },
         [dispatch],
     );

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -17,8 +17,12 @@
 import React from "react";
 
 import { Classes } from "../../common";
+import { OVERLAY2_REQUIRES_OVERLAY_PROVDER } from "../../common/errors";
+import { isNodeEnv } from "../../common/utils";
 import type { OverlayInstance } from "../../components";
 import { OverlaysContext } from "../../context/overlays/overlaysProvider";
+
+import { useLegacyOverlayStack } from "./useLegacyOverlayStack";
 
 export interface UseOverlayStackReturnValue {
     /**
@@ -55,7 +59,9 @@ export interface UseOverlayStackReturnValue {
  * @see https://blueprintjs.com/docs/#core/hooks/use-overlay-stack
  */
 export function useOverlayStack(): UseOverlayStackReturnValue {
+    // get the overlay stack from application-wide React context
     const [state, dispatch] = React.useContext(OverlaysContext);
+    const legacyOverlayStack = useLegacyOverlayStack();
     const { stack } = state;
 
     const getLastOpened = React.useCallback(() => stack.at(-1), [stack]);
@@ -96,6 +102,13 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
         },
         [dispatch, stack],
     );
+
+    if (!state.hasProvider) {
+        if (!isNodeEnv("production")) {
+            console.error(OVERLAY2_REQUIRES_OVERLAY_PROVDER);
+        }
+        return legacyOverlayStack;
+    }
 
     return {
         closeOverlay,

--- a/packages/core/src/hooks/useAsyncControllableValue.ts
+++ b/packages/core/src/hooks/useAsyncControllableValue.ts
@@ -17,7 +17,7 @@ interface UseAsyncControllableValueProps<E extends HTMLInputElement | HTMLTextAr
  */
 export const ASYNC_CONTROLLABLE_VALUE_COMPOSITION_END_DELAY = 10;
 
-/*
+/**
  * A hook to workaround the following [React bug](https://github.com/facebook/react/issues/3926).
  * This bug is reproduced when an input receives CompositionEvents
  * (for example, through IME composition) and has its value prop updated asychronously.

--- a/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
@@ -18,4 +18,7 @@ import * as React from "react";
 
 import { hasDOMEnvironment } from "../common/utils/domUtils";
 
+/**
+ * @returns the appropriate React layout effect hook for the current environment (server or client).
+ */
 export const useIsomorphicLayoutEffect = hasDOMEnvironment() ? React.useLayoutEffect : React.useEffect;

--- a/packages/core/src/hooks/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious.ts
@@ -17,9 +17,14 @@
 import * as React from "react";
 
 export function usePrevious<T>(value: T) {
+    // create a new reference
     const ref = React.useRef<T>();
+
+    // store current value in ref
     React.useEffect(() => {
-        ref.current = value; // assign the value of ref to the argument
-    }, [value]); // this code will run when the value of 'value' changes
-    return ref.current; // in the end, return the current ref value.
+        ref.current = value;
+    }, [value]);
+
+    // return previous value (happens before update in useEffect above)
+    return ref.current;
 }

--- a/packages/core/src/hooks/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious.ts
@@ -16,6 +16,7 @@
 
 import * as React from "react";
 
+/** React hook which tracks the previous state of a given value. */
 export function usePrevious<T>(value: T) {
     // create a new reference
     const ref = React.useRef<T>();

--- a/packages/core/test/hooks/useOverlayStackTests.tsx
+++ b/packages/core/test/hooks/useOverlayStackTests.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import { useUID } from "react-uid";
+import { spy } from "sinon";
+
+import type { OverlayProps } from "../../src/components/overlay/overlayProps";
+import type { OverlayInstance } from "../../src/components/overlay2/overlay2";
+import { OverlaysProvider } from "../../src/context";
+import { useOverlayStack, usePrevious } from "../../src/hooks";
+
+interface TestComponentProps extends OverlayProps {
+    handleLastOpenedChange?: (lastOpened: OverlayInstance | undefined) => void;
+    containerRef: React.RefObject<HTMLDivElement>;
+}
+
+const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
+    autoFocus,
+    children,
+    enforceFocus,
+    containerRef: containerElement,
+    handleLastOpenedChange,
+    hasBackdrop,
+    isOpen,
+    usePortal,
+}) => {
+    const { openOverlay, getLastOpened, closeOverlay } = useOverlayStack();
+
+    const bringFocusInsideOverlay = React.useCallback(() => {
+        // TODO: implement
+    }, []);
+
+    const handleDocumentFocus = React.useCallback((_e: FocusEvent) => {
+        // TODO: implement
+    }, []);
+
+    const id = useUID();
+    const instance = React.useMemo<OverlayInstance>(
+        () => ({
+            bringFocusInsideOverlay,
+            containerElement,
+            handleDocumentFocus,
+            id,
+            props: {
+                autoFocus,
+                enforceFocus,
+                hasBackdrop,
+                usePortal,
+            },
+        }),
+        [
+            autoFocus,
+            bringFocusInsideOverlay,
+            containerElement,
+            enforceFocus,
+            handleDocumentFocus,
+            hasBackdrop,
+            id,
+            usePortal,
+        ],
+    );
+
+    const prevIsOpen = usePrevious(isOpen) ?? false;
+    React.useEffect(() => {
+        if (!prevIsOpen && isOpen) {
+            // just opened
+            openOverlay(instance);
+        }
+
+        if (prevIsOpen && !isOpen) {
+            // just closed
+            closeOverlay(instance);
+        }
+    }, [isOpen, openOverlay, closeOverlay, prevIsOpen, instance]);
+
+    // run once on unmount
+    React.useEffect(() => {
+        return () => {
+            if (isOpen) {
+                closeOverlay(instance);
+            }
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const lastOpened = getLastOpened();
+    const prevLastOpened = usePrevious(lastOpened);
+    React.useEffect(() => {
+        if (prevLastOpened !== lastOpened) {
+            handleLastOpenedChange?.(lastOpened);
+        }
+    }, [handleLastOpenedChange, lastOpened, prevLastOpened]);
+
+    return <div ref={containerElement}>{children}</div>;
+};
+
+const TestComponentWithProvider: React.FC<TestComponentProps> = props => {
+    return (
+        <OverlaysProvider>
+            <TestComponentWithoutProvider {...props} />
+        </OverlaysProvider>
+    );
+};
+
+describe("useOverlayStack()", () => {
+    const handleLastOpenedChange = spy();
+    const containerRef = React.createRef<HTMLDivElement>();
+    const DEFAULT_PROPS: TestComponentProps = {
+        autoFocus: true,
+        containerRef,
+        enforceFocus: true,
+        handleLastOpenedChange,
+        hasBackdrop: true,
+        isOpen: false,
+        usePortal: true,
+    };
+
+    afterEach(() => {
+        handleLastOpenedChange.resetHistory();
+    });
+
+    describe("with <OverlaysProvider>", () => {
+        it("should render without crashing", () => {
+            render(<TestComponentWithProvider {...DEFAULT_PROPS} />);
+        });
+
+        it("opening an overlay should change the result of getLastOpened()", () => {
+            const { rerender } = render(<TestComponentWithProvider {...DEFAULT_PROPS} />);
+            rerender(<TestComponentWithProvider {...DEFAULT_PROPS} isOpen={true} />);
+            expect(
+                handleLastOpenedChange.calledOnce,
+                `expected getLastOpened() result to change after re-rendering with isOpen={true}`,
+            ).to.be.true;
+            const lastOpenedInstance = handleLastOpenedChange.getCall(0).args[0] as OverlayInstance;
+            expect(lastOpenedInstance).to.exist;
+            expect(containerRef.current).to.exist;
+            expect(lastOpenedInstance.containerElement.current).to.equal(containerRef.current);
+        });
+    });
+
+    describe("without <OverlaysProvider>", () => {
+        it("should render without crashing", () => {
+            render(<TestComponentWithoutProvider {...DEFAULT_PROPS} />);
+        });
+
+        it("opening an overlay should change the result of getLastOpened()", () => {
+            const { rerender } = render(<TestComponentWithoutProvider {...DEFAULT_PROPS} />);
+            rerender(<TestComponentWithoutProvider {...DEFAULT_PROPS} isOpen={true} />);
+            expect(
+                handleLastOpenedChange.calledOnce,
+                `expected getLastOpened() result to change after re-rendering with isOpen={true}`,
+            ).to.be.true;
+            const lastOpenedInstance = handleLastOpenedChange.getCall(0).args[0] as OverlayInstance;
+            expect(lastOpenedInstance).to.exist;
+            expect(containerRef.current).to.exist;
+            expect(lastOpenedInstance.containerElement.current).to.equal(containerRef.current);
+        });
+    });
+});

--- a/packages/core/test/hooks/useOverlayStackTests.tsx
+++ b/packages/core/test/hooks/useOverlayStackTests.tsx
@@ -24,6 +24,7 @@ import type { OverlayProps } from "../../src/components/overlay/overlayProps";
 import type { OverlayInstance } from "../../src/components/overlay2/overlay2";
 import { OverlaysProvider } from "../../src/context";
 import { useOverlayStack, usePrevious } from "../../src/hooks";
+import { dispatch as legacyOverlayStackDispatch } from "../../src/hooks/overlays/useLegacyOverlayStack";
 
 interface TestComponentProps extends OverlayProps {
     handleLastOpenedChange?: (lastOpened: OverlayInstance | undefined) => void;
@@ -155,6 +156,11 @@ describe("useOverlayStack()", () => {
     });
 
     describe("without <OverlaysProvider>", () => {
+        before(() => {
+            // ensure there is a clean global state that might be polluted by other test suites
+            legacyOverlayStackDispatch({ type: "RESET_STACK" });
+        });
+
         it("should render without crashing", () => {
             render(<TestComponentWithoutProvider {...DEFAULT_PROPS} />);
         });
@@ -169,7 +175,10 @@ describe("useOverlayStack()", () => {
             const lastOpenedInstance = handleLastOpenedChange.getCall(0).args[0] as OverlayInstance;
             expect(lastOpenedInstance).to.exist;
             expect(containerRef.current).to.exist;
-            expect(lastOpenedInstance.containerElement.current).to.equal(containerRef.current);
+            expect(
+                lastOpenedInstance.containerElement.current === containerRef.current,
+                "expected last opened overlay container element ref to be the same as the ref passed through props",
+            ).to.be.true;
         });
     });
 });

--- a/packages/core/test/hooks/useOverlayStackTests.tsx
+++ b/packages/core/test/hooks/useOverlayStackTests.tsx
@@ -43,11 +43,11 @@ const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
     const { openOverlay, getLastOpened, closeOverlay } = useOverlayStack();
 
     const bringFocusInsideOverlay = React.useCallback(() => {
-        // TODO: implement
+        // unimplemented since it's not tested in this suite
     }, []);
 
     const handleDocumentFocus = React.useCallback((_e: FocusEvent) => {
-        // TODO: implement
+        // unimplemented since it's not tested in this suite
     }, []);
 
     const id = useUID();
@@ -163,7 +163,7 @@ describe("useOverlayStack()", () => {
             const { rerender } = render(<TestComponentWithoutProvider {...DEFAULT_PROPS} />);
             rerender(<TestComponentWithoutProvider {...DEFAULT_PROPS} isOpen={true} />);
             expect(
-                handleLastOpenedChange.calledOnce,
+                handleLastOpenedChange.callCount > 0,
                 `expected getLastOpened() result to change after re-rendering with isOpen={true}`,
             ).to.be.true;
             const lastOpenedInstance = handleLastOpenedChange.getCall(0).args[0] as OverlayInstance;

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -86,3 +86,4 @@ import "./tree/treeTests";
 
 // hooks
 import "./hooks/useHotkeysTests";
+import "./hooks/useOverlayStackTests";

--- a/packages/core/test/isotest.mjs
+++ b/packages/core/test/isotest.mjs
@@ -92,6 +92,9 @@ describe("@blueprintjs/core isomorphic rendering", () => {
             Overlay2: {
                 props: { lazy: false, usePortal: false },
             },
+            OverlaysProvider: {
+                className: false,
+            },
             OverlayToaster: {
                 props: { usePortal: false },
                 children: React.createElement(Core.Toast2, { message: "Toast" }),

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { FocusStyleManager } from "@blueprintjs/core";
+import { FocusStyleManager, OverlaysProvider } from "@blueprintjs/core";
 
 import { Examples } from "./examples/Examples";
 
@@ -26,5 +26,10 @@ FocusStyleManager.onlyShowFocusOnTabs();
     // Wait until CSS is loaded before rendering components because some of them (like Table)
     // rely on those styles to take accurate DOM measurements.
     await import("./index.scss");
-    ReactDOM.render(<Examples />, document.querySelector("#blueprint-demo-app"));
+    ReactDOM.render(
+        <OverlaysProvider>
+            <Examples />
+        </OverlaysProvider>,
+        document.querySelector("#blueprint-demo-app"),
+    );
 })();

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -18,7 +18,15 @@ import { type HeadingNode, isPageNode, type PageData, type TsDocBase } from "@do
 import classNames from "classnames";
 import * as React from "react";
 
-import { AnchorButton, Classes, HotkeysProvider, type Intent, PortalProvider, Tag } from "@blueprintjs/core";
+import {
+    AnchorButton,
+    Classes,
+    HotkeysProvider,
+    type Intent,
+    OverlaysProvider,
+    PortalProvider,
+    Tag,
+} from "@blueprintjs/core";
 import type { DocsCompleteData } from "@blueprintjs/docs-data";
 import {
     Banner,
@@ -101,18 +109,20 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
         return (
             <HotkeysProvider>
                 <PortalProvider>
-                    <Documentation
-                        {...this.props}
-                        className={this.state.themeName}
-                        banner={banner}
-                        footer={footer}
-                        header={header}
-                        navigatorExclude={isNavSection}
-                        onComponentUpdate={this.handleComponentUpdate}
-                        renderNavMenuItem={this.renderNavMenuItem}
-                        renderPageActions={this.renderPageActions}
-                        renderViewSourceLinkText={this.renderViewSourceLinkText}
-                    />
+                    <OverlaysProvider>
+                        <Documentation
+                            {...this.props}
+                            className={this.state.themeName}
+                            banner={banner}
+                            footer={footer}
+                            header={header}
+                            navigatorExclude={isNavSection}
+                            onComponentUpdate={this.handleComponentUpdate}
+                            renderNavMenuItem={this.renderNavMenuItem}
+                            renderPageActions={this.renderPageActions}
+                            renderViewSourceLinkText={this.renderViewSourceLinkText}
+                        />
+                    </OverlaysProvider>
                 </PortalProvider>
             </HotkeysProvider>
         );

--- a/packages/select/src/components/omnibar/omnibar.md
+++ b/packages/select/src/components/omnibar/omnibar.md
@@ -10,6 +10,20 @@ The following example responds to a button and a hotkey.
 
 @## Usage
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+[OverlaysProvider](#core/context/overlays-provider) recommended
+
+</h5>
+
+This component renders an **Overlay2** which works best inside a React tree which includes an
+**OverlaysProvider**. Blueprint v5.x includes a backwards-compatibile shim which allows this context
+to be optional, but it will be required in a future major version. See the full
+[migration guide](https://github.com/palantir/blueprint/wiki/Overlay2-migration) on the wiki.
+
+</div>
+
 In TypeScript, `Omnibar<T>` is a _generic component_ where `<T>` represents the type of one item in the array of `items`.
 
 The component is fully controlled via the `isOpen` prop, which means you can decide exactly how to trigger it.

--- a/packages/table-dev-app/src/index.tsx
+++ b/packages/table-dev-app/src/index.tsx
@@ -17,8 +17,17 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import { HotkeysProvider, OverlaysProvider } from "@blueprintjs/core";
+
 import { MutableTable } from "./mutableTable";
 import { Nav } from "./nav";
 
 ReactDOM.render(<Nav selected="index" />, document.getElementById("nav"));
-ReactDOM.render(<MutableTable />, document.querySelector("#page-content"));
+ReactDOM.render(
+    <HotkeysProvider>
+        <OverlaysProvider>
+            <MutableTable />
+        </OverlaysProvider>
+    </HotkeysProvider>,
+    document.querySelector("#page-content"),
+);

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -27,7 +27,6 @@ import {
     FocusStyleManager,
     H4,
     H6,
-    HotkeysProvider,
     HTMLSelect,
     Intent,
     Menu,
@@ -352,26 +351,24 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
     public render() {
         const layoutBoundary = this.state.enableLayoutBoundary;
         return (
-            <HotkeysProvider>
-                <div className="container">
-                    <SlowLayoutStack
-                        depth={SLOW_LAYOUT_STACK_DEPTH}
-                        enabled={this.state.enableSlowLayout}
-                        rootClassName={classNames("table", { "is-inline": this.state.showInline })}
-                        branchClassName="layout-passthrough-fill"
+            <div className="container">
+                <SlowLayoutStack
+                    depth={SLOW_LAYOUT_STACK_DEPTH}
+                    enabled={this.state.enableSlowLayout}
+                    rootClassName={classNames("table", { "is-inline": this.state.showInline })}
+                    branchClassName="layout-passthrough-fill"
+                >
+                    <div
+                        className={layoutBoundary ? "layout-boundary" : "layout-passthrough-fill"}
+                        ref={this.refHandlers.tableWrapperRef}
+                        onMouseOver={event => this.checkScrolling(event)}
+                        onMouseLeave={this.cancelAnimation}
                     >
-                        <div
-                            className={layoutBoundary ? "layout-boundary" : "layout-passthrough-fill"}
-                            ref={this.refHandlers.tableWrapperRef}
-                            onMouseOver={event => this.checkScrolling(event)}
-                            onMouseLeave={this.cancelAnimation}
-                        >
-                            {this.renderTable()};
-                        </div>
-                    </SlowLayoutStack>
-                    {this.renderSidebar()}
-                </div>
-            </HotkeysProvider>
+                        {this.renderTable()};
+                    </div>
+                </SlowLayoutStack>
+                {this.renderSidebar()}
+            </div>
         );
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,6 +455,7 @@ __metadata:
     "@blueprintjs/test-commons": "workspace:^"
     "@popperjs/core": "npm:^2.11.8"
     "@testing-library/react": "npm:^12.1.5"
+    "@types/use-sync-external-store": "npm:0.0.6"
     classnames: "npm:^2.3.1"
     enzyme: "npm:^3.11.0"
     karma: "npm:^6.4.2"
@@ -469,6 +470,7 @@ __metadata:
     react-uid: "npm:^2.3.3"
     tslib: "npm:~2.6.2"
     typescript: "npm:~5.3.3"
+    use-sync-external-store: "npm:^1.2.0"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
     "@types/react": ^16.14.41 || 17 || 18
@@ -3147,6 +3149,13 @@ __metadata:
   version: 1.3.6
   resolution: "@types/svgo@npm:1.3.6"
   checksum: 688abfb0bd7b2689287055de98f02fe5c50807639e1de4e1fef7aae79a60f388bc48e0b5d96f082c6a371f3ab6b142fdd5ebd88dc5061332dcb7910176ce4d29
+  languageName: node
+  linkType: hard
+
+"@types/use-sync-external-store@npm:0.0.6":
+  version: 0.0.6
+  resolution: "@types/use-sync-external-store@npm:0.0.6"
+  checksum: 77c045a98f57488201f678b181cccd042279aff3da34540ad242f893acc52b358bd0a8207a321b8ac09adbcef36e3236944390e2df4fcedb556ce7bb2a88f2a8
   languageName: node
   linkType: hard
 
@@ -16439,6 +16448,15 @@ __metadata:
   version: 4.0.1
   resolution: "url-join@npm:4.0.1"
   checksum: ac65e2c7c562d7b49b68edddcf55385d3e922bc1dd5d90419ea40b53b6de1607d1e45ceb71efb9d60da02c681d13c6cb3a1aa8b13fc0c989dfc219df97ee992d
+  languageName: node
+  linkType: hard
+
+"use-sync-external-store@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: ac4814e5592524f242921157e791b022efe36e451fe0d4fd4d204322d5433a4fc300d63b0ade5185f8e0735ded044c70bcf6d2352db0f74d097a238cebd2da02
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,7 @@ __metadata:
     react-popper: "npm:^2.3.0"
     react-test-renderer: "npm:^16.14.0"
     react-transition-group: "npm:^4.4.5"
+    react-uid: "npm:^2.3.3"
     tslib: "npm:~2.6.2"
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
@@ -13783,6 +13784,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-uid@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "react-uid@npm:2.3.3"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 8aa30e92ee03561d25779c68ba6d9409ba4ea83386a8798729b6eb5977bbdc4a5ff199b758d2a29e958d7560b2a7517cab8671932b83e8fcd50092631c209b4c
+  languageName: node
+  linkType: hard
+
 "react@npm:^16.14.0":
   version: 16.14.0
   resolution: "react@npm:16.14.0"
@@ -15908,7 +15924,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2, tslib@npm:~2.6.2":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:^2.6.2, tslib@npm:~2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb


### PR DESCRIPTION
#### Follow-up to https://github.com/palantir/blueprint/pull/6656

#### Checklist

- [x] Includes tests
- [x] Update documentation
- [x] Backwards-compatibility for `<Dialog>`, `<Drawer>`, `<Popover>`, `<Omnibar>`

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Introduce `<OverlaysProvider>` component and `useOverlayStack()` hook to manage global overlay stack state
- Use `react-uid` library to generate ids for Overlay2 instances
- Update Overlay2 test suite to be compatible with new context/provider pattern
- Add backwards-compatibility for overlays used outside of an `<OverlayProvider>` by utilizing [`useSyncExternalStore()`](https://react.dev/reference/react/useSyncExternalStore) (requires shimming in React 16) to reference overlay state in a global variable
  - see tests for `useOverlayStack()` with and without the suggested provider context

#### Reviewers should focus on:

No regressions in overlay-based components
