### PR TITLE
[core] break(Portal): stop using legacy context in React 18

### DIFF
--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -123,3 +123,7 @@ export function isElementOfType<P = {}>(
         element.type.displayName === ComponentType.displayName
     );
 }
+
+export function isReact18(): boolean {
+    return React.version.startsWith("18");
+}

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -20,6 +20,7 @@ import * as ReactDOM from "react-dom";
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import type { ValidationMap } from "../../common/context";
 import * as Errors from "../../common/errors";
+import { isReact18 } from "../../common/utils/reactUtils";
 import { PortalContext } from "../../context/portal/portalProvider";
 
 export interface PortalProps extends Props {
@@ -155,8 +156,11 @@ export function Portal(
 }
 
 Portal.displayName = `${DISPLAYNAME_PREFIX}.Portal`;
-// eslint-disable-next-line deprecation/deprecation
-Portal.contextTypes = PORTAL_LEGACY_CONTEXT_TYPES;
+// only use legacy context in React 16 or 17
+if (!isReact18()) {
+    // eslint-disable-next-line deprecation/deprecation
+    Portal.contextTypes = PORTAL_LEGACY_CONTEXT_TYPES;
+}
 
 function maybeRemoveClass(classList: DOMTokenList, className?: string) {
     if (className != null && className !== "") {


### PR DESCRIPTION
#### Fixes #6572

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- ❗ break(`Portal`): stop using legacy context API in React 18

#### Reviewers should focus on:

We assume that React 18 users of Blueprint are not using legacy APIs. The `<Portal>` component currently has support for both the new context API and the legacy one. The backwards-compatible implementation (initialized via `Portal.contextTypes = ...`) triggers a warning in React 18 strict mode which we would like to avoid (see #6572).

This is a breaking change but likely a welcome one for React 18 users. Open to feedback; leave a comment below.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
