### PR TITLE
[core] fix(Overlay2): use mutable stack ref, fix document event listeners

### DIFF
--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -54,6 +54,9 @@ export interface OverlayInstance {
     /** Document "focus" event handler which needs to be attached & detached appropriately. */
     handleDocumentFocus: (e: FocusEvent) => void;
 
+    /** Document "mousedown" event handler which needs to be attached & detached appropriately. */
+    handleDocumentMousedown: (e: MouseEvent) => void;
+
     /** Unique ID for this overlay which helps to identify it across prop changes. */
     id: string;
 
@@ -115,8 +118,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     } = props;
 
     useOverlay2Validation(props);
-    const { closeOverlay, getLastOpened, getThisOverlayAndDescendants, openOverlay, getStack } = useOverlayStack();
-    const stack = getStack();
+    const { closeOverlay, getLastOpened, getThisOverlayAndDescendants, openOverlay } = useOverlayStack();
 
     const [isAutoFocusing, setIsAutoFocusing] = React.useState(false);
     const [hasEverOpened, setHasEverOpened] = React.useState(false);
@@ -148,7 +150,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
             const container = getRef(containerElement);
             const activeElement = getActiveElement(container);
 
-            if (container == null || activeElement == null || !isOpen) {
+            if (container == null || activeElement == null) {
                 return;
             }
 
@@ -159,11 +161,18 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
                 setIsAutoFocusing(false);
             }
         });
-    }, [isOpen]);
+    }, []);
+
+    /** Unique ID for this overlay in the global stack */
+    const id = useOverlay2ID();
+
+    // N.B. use `null` here and not simply `undefined` because `useImperativeHandle` will set `null` on unmount,
+    // and we need the following code to be resilient to that value.
+    const instance = React.useRef<OverlayInstance>(null);
 
     /**
-     * When multiple Overlays are open, this event handler is only active for the most recently
-     * opened one to avoid Overlays competing with each other for focus.
+     * When multiple `enforceFocus` Overlays are open, this event handler is only active for the most
+     * recently opened one to avoid Overlays competing with each other for focus.
      */
     const handleDocumentFocus = React.useCallback(
         (e: FocusEvent) => {
@@ -171,45 +180,17 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
             // see https://github.com/palantir/blueprint/issues/4220
             const eventTarget = e.composed ? e.composedPath()[0] : e.target;
             const container = getRef(containerElement);
-            if (
-                enforceFocus &&
-                container != null &&
-                eventTarget instanceof Node &&
-                !container.contains(eventTarget as HTMLElement)
-            ) {
+            if (container != null && eventTarget instanceof Node && !container.contains(eventTarget as HTMLElement)) {
                 // prevent default focus behavior (sometimes auto-scrolls the page)
                 e.preventDefault();
                 e.stopImmediatePropagation();
                 bringFocusInsideOverlay();
             }
         },
-        [bringFocusInsideOverlay, enforceFocus],
+        [bringFocusInsideOverlay],
     );
 
-    const id = useOverlay2ID();
-
-    // N.B. use `null` here and not simply `undefined` because `useImperativeHandle` will set `null` on unmount,
-    // and we need the following code to be resilient to that value.
-    const instance = React.useRef<OverlayInstance>(null);
-    // send this instance's imperative handle to the the forwarded ref as well as our local ref
-    const ref = React.useMemo(() => mergeRefs(forwardedRef, instance), [forwardedRef]);
-    React.useImperativeHandle(
-        ref,
-        () => ({
-            bringFocusInsideOverlay,
-            containerElement,
-            handleDocumentFocus,
-            id,
-            props: {
-                autoFocus,
-                enforceFocus,
-                hasBackdrop,
-                usePortal,
-            },
-        }),
-        [autoFocus, bringFocusInsideOverlay, enforceFocus, handleDocumentFocus, hasBackdrop, id, usePortal],
-    );
-
+    // N.B. this listener is only kept attached when `isOpen={true}` and `canOutsideClickClose={true}`
     const handleDocumentMousedown = React.useCallback(
         (e: MouseEvent) => {
             if (instance.current == null) {
@@ -230,12 +211,52 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
                 },
             );
 
-            if (isOpen && !isClickInThisOverlayOrDescendant && canOutsideClickClose) {
+            if (!isClickInThisOverlayOrDescendant) {
                 // casting to any because this is a native event
                 onClose?.(e as any);
             }
         },
-        [canOutsideClickClose, getThisOverlayAndDescendants, isOpen, onClose],
+        [getThisOverlayAndDescendants, onClose],
+    );
+
+    // Important: clean up old document-level event listeners if their memoized values change (this is rare, but
+    // may happen, for example, if a user forgets to use `React.useCallback` in the `props.onClose` value).
+    // Otherwise, we will lose the reference to those values and create a memory leak since we won't be able
+    // to successfully detach them inside overlayWillClose.
+    React.useEffect(() => {
+        document.removeEventListener("mousedown", handleDocumentMousedown);
+    }, [handleDocumentMousedown]);
+    React.useEffect(() => {
+        document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
+    }, [handleDocumentFocus]);
+
+    // send this instance's imperative handle to the the forwarded ref as well as our local ref
+    const ref = React.useMemo(() => mergeRefs(forwardedRef, instance), [forwardedRef]);
+    React.useImperativeHandle(
+        ref,
+        () => ({
+            bringFocusInsideOverlay,
+            containerElement,
+            handleDocumentFocus,
+            handleDocumentMousedown,
+            id,
+            props: {
+                autoFocus,
+                enforceFocus,
+                hasBackdrop,
+                usePortal,
+            },
+        }),
+        [
+            autoFocus,
+            bringFocusInsideOverlay,
+            enforceFocus,
+            handleDocumentFocus,
+            handleDocumentMousedown,
+            hasBackdrop,
+            id,
+            usePortal,
+        ],
     );
 
     const handleContainerKeyDown = React.useCallback(
@@ -274,7 +295,6 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         }
 
         if (canOutsideClickClose && !hasBackdrop) {
-            console.log("adding document mousedown listener, stack is: ", stack);
             document.addEventListener("mousedown", handleDocumentMousedown);
         }
 
@@ -289,7 +309,6 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         handleDocumentFocus,
         hasBackdrop,
         openOverlay,
-        stack,
     ]);
 
     const overlayWillClose = React.useCallback(() => {
@@ -300,7 +319,6 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
         document.removeEventListener("mousedown", handleDocumentMousedown);
 
-        console.log("closing overlay", instance.current);
         closeOverlay(instance.current);
         const lastOpenedOverlay = getLastOpened();
         if (lastOpenedOverlay !== undefined) {
@@ -312,7 +330,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
                 document.addEventListener("focus", lastOpenedOverlay.handleDocumentFocus, /* useCapture */ true);
             }
         }
-    }, [closeOverlay, getLastOpened, handleDocumentMousedown, handleDocumentFocus]);
+    }, [closeOverlay, getLastOpened, handleDocumentFocus, handleDocumentMousedown]);
 
     const prevIsOpen = usePrevious(isOpen) ?? false;
     React.useEffect(() => {
@@ -336,7 +354,6 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         return () => {
             if (isOpen) {
                 // if the overlay is still open, we need to run cleanup code to remove some event handlers
-                console.log("----- unmounting, running overlayWillClose");
                 overlayWillClose();
             }
         };

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -55,7 +55,7 @@ export interface OverlayInstance {
     handleDocumentFocus: (e: FocusEvent) => void;
 
     /** Document "mousedown" event handler which needs to be attached & detached appropriately. */
-    handleDocumentMousedown: (e: MouseEvent) => void;
+    handleDocumentMousedown?: (e: MouseEvent) => void;
 
     /** Unique ID for this overlay which helps to identify it across prop changes. */
     id: string;

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -36,7 +36,8 @@ import {
     setRef,
 } from "../../common/utils";
 import { hasDOMEnvironment } from "../../common/utils/domUtils";
-import { useOverlayStack, usePrevious } from "../../hooks";
+import { useOverlayStack } from "../../hooks/overlays/useOverlayStack";
+import { usePrevious } from "../../hooks/usePrevious";
 import type { OverlayProps } from "../overlay/overlayProps";
 import { getKeyboardFocusableElements } from "../overlay/overlayUtils";
 import { Portal } from "../portal/portal";

--- a/packages/core/src/components/popover/popover.md
+++ b/packages/core/src/components/popover/popover.md
@@ -426,7 +426,7 @@ performance. If your components are not updating in a synchronous fashion as exp
 `setTimeout` to wait for asynchronous Popover rendering to catch up:
 
 ```tsx
-import { Classes, Overlay, Popover } from "@blueprintjs/core";
+import { Classes, Overlay2, Popover } from "@blueprintjs/core";
 import { assert } from "chai";
 import { mount } from "enzyme";
 import { Target } from "react-popper";
@@ -445,7 +445,7 @@ wrapper.find(`.${Classes.POPOVER}`).hostNodes().simulate("mouseleave");
 
 setTimeout(() => {
     // Popover delays closing using setTimeout, so need to defer this check too.
-    const isOpen = wrapper.find(Overlay).prop("isOpen");
+    const isOpen = wrapper.find(Overlay2).prop("isOpen");
     assert.equal(isOpen, false);
 });
 ```

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -206,7 +206,7 @@ export class Popover<
     public targetRef = React.createRef<HTMLElement>();
 
     /**
-     * Overlay transition container element ref.
+     * Overlay2 transition container element ref.
      */
     private transitionContainerElement = React.createRef<HTMLDivElement>();
 

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -1,19 +1,19 @@
 @# Portal
 
-The __Portal__ component renders its children into a new DOM "subtree" outside of the current component
-hierarchy. It is an essential piece of the [Overlay](#core/components/overlay) component, responsible for
+The **Portal** component renders its children into a new DOM "subtree" outside of the current component
+hierarchy. It is an essential piece of the [Overlay2](#core/components/overlay2) component, responsible for
 ensuring that the overlay contents appear above the rest of the application. In most cases, you do not
 need to use a Portal directly; this documentation is provided only for reference.
 
 @## DOM Behavior
 
-__Portal__ component functions like a declarative `appendChild()`. The children of a __Portal__ are inserted into a *new child* of the target element. This target element is determined in the following order:
+**Portal** component functions like a declarative `appendChild()`. The children of a **Portal** are inserted into a _new child_ of the target element. This target element is determined in the following order:
+
 1. The `container` prop, if specified
 2. The `portalContainer` from the closest [PortalProvider](#core/context/portal-provider), if specified
 3. Otherwise `document.body`
 
-
-__Portal__ is used inside [Overlay](#core/components/overlay) to actually overlay the content on the
+**Portal** is used inside [Overlay2](#core/components/overlay2) to actually overlay the content on the
 application.
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-move @ns-callout-has-body-content">
@@ -31,7 +31,7 @@ apply `position: absolute` to the `<body>` tag.
 
 @## React context options
 
-__Portal__ supports some customization through [React context](https://react.dev/learn/passing-data-deeply-with-context).
+**Portal** supports some customization through [React context](https://react.dev/learn/passing-data-deeply-with-context).
 Using this API can be helpful if you need to apply some custom styling or logic to _all_ Blueprint
 components which use portals (popovers, tooltips, dialogs, etc.). You can do so by rendering a
 [PortalProvider](#core/context/portal-provider) in your React tree
@@ -63,7 +63,7 @@ This feature uses React's legacy context API. Support for this API will be remov
 
 </div>
 
-__Portal__ supports the following options via the [React legacy context API](https://reactjs.org/docs/legacy-context.html).
+**Portal** supports the following options via the [React legacy context API](https://reactjs.org/docs/legacy-context.html).
 To use them, supply a child context to a subtree that contains the Portals you want to customize.
 
 @interface PortalLegacyContext

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -235,7 +235,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
     }
 
     /**
-     * If provided `Toast` children, automaticaly upgrade them to `Toast2` elements so that `Overlay` can inject
+     * If provided `Toast` children, automaticaly upgrade them to `Toast2` elements so that `Overlay2` can inject
      * refs into them for use by `CSSTransition`. This is a bit hacky but ensures backwards compatibility for
      * `OverlayToaster`. It should be an uncommon code path in most applications, since we expect most usage to
      * occur via the imperative toaster APIs.

--- a/packages/core/src/components/toast/overlayToasterProps.ts
+++ b/packages/core/src/components/toast/overlayToasterProps.ts
@@ -45,7 +45,7 @@ export interface OverlayToasterProps extends Props {
      */
     canEscapeKeyClear?: boolean;
 
-    /** Toasts to display inside the Overlay. */
+    /** Toasts to display inside the Overlay2. */
     children?: React.ReactNode;
 
     /**

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -23,7 +23,7 @@ export {
 export {
     OverlaysContext,
     OverlaysProvider,
-    type OverlaysContextInstance,
+    type OverlaysContextState,
     type OverlaysProviderProps,
 } from "./overlays/overlaysProvider";
 export { PortalContext, type PortalContextOptions, PortalProvider } from "./portal/portalProvider";

--- a/packages/core/src/context/overlays/overlaysProvider.tsx
+++ b/packages/core/src/context/overlays/overlaysProvider.tsx
@@ -41,7 +41,8 @@ export type OverlayStackAction =
 
 export type OverlaysContextInstance = readonly [OverlaysContextState, React.Dispatch<OverlayStackAction>];
 
-const initialOverlaysState: OverlaysContextState = { hasProvider: false, stack: [] };
+const initialStateWithoutProvider: OverlaysContextState = { hasProvider: false, stack: [] };
+const initialStateWithProvider: OverlaysContextState = { hasProvider: true, stack: [] };
 const noOpDispatch: React.Dispatch<OverlayStackAction> = () => null;
 
 /**
@@ -54,7 +55,10 @@ const noOpDispatch: React.Dispatch<OverlayStackAction> = () => null;
  *
  * For more information, see the [OverlaysProvider documentation](https://blueprintjs.com/docs/#core/context/overlays-provider).
  */
-export const OverlaysContext = React.createContext<OverlaysContextInstance>([initialOverlaysState, noOpDispatch]);
+export const OverlaysContext = React.createContext<OverlaysContextInstance>([
+    initialStateWithoutProvider,
+    noOpDispatch,
+]);
 
 /**
  * N.B. this is exported in order for `useOverlayStack()` to implement backwards-compatibility for overlays
@@ -73,7 +77,7 @@ export const overlaysReducer = (state: OverlaysContextState, action: OverlayStac
             newStack.splice(index, 1);
             return { ...state, stack: newStack };
         case "RESET_STACK":
-            return initialOverlaysState;
+            return { ...state, stack: [] };
         default:
             return state;
     }
@@ -90,6 +94,6 @@ export interface OverlaysProviderProps {
  * @see https://blueprintjs.com/docs/#core/context/overlays-provider
  */
 export const OverlaysProvider = ({ children }: OverlaysProviderProps) => {
-    const contextValue = React.useReducer(overlaysReducer, { ...initialOverlaysState, hasProvider: true });
+    const contextValue = React.useReducer(overlaysReducer, initialStateWithProvider);
     return <OverlaysContext.Provider value={contextValue}>{children}</OverlaysContext.Provider>;
 };

--- a/packages/core/src/docs/variables.md
+++ b/packages/core/src/docs/variables.md
@@ -89,7 +89,7 @@ without writing much CSS. Here are some resources for learning flexbox:
 @## Layering
 
 Blueprint provides variables for three z-index layers. This should be enough for most use cases,
-especially if you make correct use of [stacking context][MDN]. [Overlay](#core/components/overlay)
+especially if you make correct use of [stacking context][MDN]. [Overlay2](#core/components/overlay2)
 components such as dialogs and popovers use these z-index values to configure their stacking
 contexts.
 

--- a/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
@@ -99,9 +99,12 @@ export function useLegacyOverlayStack(): UseOverlayStackReturnValue {
         [stack],
     );
 
+    const getStack = React.useCallback(() => stack, [stack]);
+
     return {
         closeOverlay,
         getLastOpened,
+        getStack,
         getThisOverlayAndDescendants,
         openOverlay,
         resetStack,

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -63,12 +63,17 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
     const { stack, hasProvider } = React.useContext(OverlaysContext);
     const legacyOverlayStack = useLegacyOverlayStack();
 
-    const getLastOpened = React.useCallback(() => stack.current.at(-1), [stack]);
+    const getLastOpened = React.useCallback(() => {
+        return stack.current.at(-1);
+    }, [stack]);
 
     const getThisOverlayAndDescendants = React.useCallback(
         (overlay: OverlayInstance) => {
-            const stackIndex = stack.current.findIndex(o => o.id === overlay.id);
-            return stack.current.slice(stackIndex);
+            const index = stack.current.findIndex(o => o.id === overlay.id);
+            if (index === -1) {
+                return [];
+            }
+            return stack.current.slice(index);
         },
         [stack],
     );

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -35,6 +35,8 @@ export interface UseOverlayStackReturnValue {
      */
     getLastOpened: () => OverlayInstance | undefined;
 
+    getStack: () => OverlayInstance[];
+
     /**
      * @param overlay current overlay
      * @returns a list of the current overlay and all overlays which are descendants of it.
@@ -68,6 +70,7 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
 
     const getThisOverlayAndDescendants = React.useCallback(
         (overlay: OverlayInstance) => {
+            console.log("looking for overlay and descendants in stack:", stack, overlay.containerElement.current);
             const stackIndex = stack.findIndex(o => o.id === overlay.id);
             return stack.slice(stackIndex);
         },
@@ -103,6 +106,12 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
         [dispatch, stack],
     );
 
+    const getStack = React.useCallback(() => stack, [stack]);
+
+    React.useEffect(() => {
+        console.info("overlay stack", stack);
+    }, [stack]);
+
     if (!state.hasProvider) {
         if (isNodeEnv("development")) {
             console.error(OVERLAY2_REQUIRES_OVERLAY_PROVDER);
@@ -113,6 +122,7 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
     return {
         closeOverlay,
         getLastOpened,
+        getStack,
         getThisOverlayAndDescendants,
         openOverlay,
         resetStack,

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -197,7 +197,7 @@ describe("<Dialog>", () => {
         });
     });
 
-    // N.B. everything else about Dialog is tested by Overlay
+    // N.B. everything else about Dialog is tested by Overlay2
 
     function renderDialogBodyAndFooter(): React.JSX.Element[] {
         return [

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -107,9 +107,9 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
             />
         );
         return (
-            <HotkeysProvider>
-                <PortalProvider>
-                    <OverlaysProvider>
+            <PortalProvider>
+                <OverlaysProvider>
+                    <HotkeysProvider>
                         <Documentation
                             {...this.props}
                             className={this.state.themeName}
@@ -122,9 +122,9 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
                             renderPageActions={this.renderPageActions}
                             renderViewSourceLinkText={this.renderViewSourceLinkText}
                         />
-                    </OverlaysProvider>
-                </PortalProvider>
-            </HotkeysProvider>
+                    </HotkeysProvider>
+                </OverlaysProvider>
+            </PortalProvider>
         );
     }
 

--- a/packages/docs-theme/src/components/scrollbar.ts
+++ b/packages/docs-theme/src/components/scrollbar.ts
@@ -18,7 +18,7 @@ import { Classes } from "@blueprintjs/core";
 
 /**
  * Inject some CSS style rules into a new `<style>` element to add padding equal to the
- * width of the scrollbar when an `Overlay` is open, such that page content will not
+ * width of the scrollbar when an overlay is open, such that page content will not
  * shift due to the disappearing vertical scrollbar.
  */
 export function addScrollbarStyle() {

--- a/packages/table-dev-app/src/index.tsx
+++ b/packages/table-dev-app/src/index.tsx
@@ -24,10 +24,10 @@ import { Nav } from "./nav";
 
 ReactDOM.render(<Nav selected="index" />, document.getElementById("nav"));
 ReactDOM.render(
-    <HotkeysProvider>
-        <OverlaysProvider>
+    <OverlaysProvider>
+        <HotkeysProvider>
             <MutableTable />
-        </OverlaysProvider>
-    </HotkeysProvider>,
+        </HotkeysProvider>
+    </OverlaysProvider>,
     document.querySelector("#page-content"),
 );


### PR DESCRIPTION
#### Fixes #6679

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- fix(`Overlay2`): improve overlay stack state management to fix document mousedown event handler

#### Reviewers should focus on:

Fixes the linked bug

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
