### PR TITLE
[core] fix(Text): use isomorphic layout effect

### DIFF
--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 
 import { Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
+import { useIsomorphicLayoutEffect } from "../../hooks";
 
 export interface TextProps
     extends Props,
@@ -61,7 +62,7 @@ export const Text: React.FC<TextProps> = React.forwardRef<HTMLElement, TextProps
 
         // try to be conservative about running this effect, since querying scrollWidth causes the browser to reflow / recalculate styles,
         // which can be very expensive for long lists (for example, in long Menus)
-        React.useLayoutEffect(() => {
+        useIsomorphicLayoutEffect(() => {
             if (contentMeasuringRef.current?.textContent != null) {
                 setIsContentOverflowing(
                     ellipsize! && contentMeasuringRef.current.scrollWidth > contentMeasuringRef.current.clientWidth,

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
-import { useIsomorphicLayoutEffect } from "../../hooks";
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
 
 export interface TextProps
     extends Props,


### PR DESCRIPTION

#### Changes proposed in this pull request:

This makes the component no longer emit a warning when rendered in tests or in a server environment (where `React.useLayoutEffect` is not available)

#### Reviewers should focus on:

no regressions in text measuring / ellipsizing

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
