### PR TITLE
[core] fix(OverlayToaster): correct type for createAsync domRenderer

### DIFF
--- a/packages/core/src/common/utils/mountOptions.ts
+++ b/packages/core/src/common/utils/mountOptions.ts
@@ -16,9 +16,6 @@
 
 import type * as React from "react";
 
-/** Identical to `import("react-dom").Container`, copied here to avoid an unncessary type dependency. */
-type Container = Element | Document | DocumentFragment;
-
 /**
  * Generic options interface for Blueprint APIs which imperatively mount a React component to the
  * DOM using `"react-dom"`: `OverlayToaster.create`, `showContextMenu`, etc.
@@ -42,7 +39,7 @@ export interface DOMMountOptions<P> {
      */
     domRenderer?: (
         element: React.ReactElement<P>,
-        container: Container | null,
+        container: Element | DocumentFragment,
     ) => React.Component<P, any> | Element | void;
 
     /**


### PR DESCRIPTION
#### Before this PR

with the latest core v5.9.0 release:

![image](https://github.com/palantir/blueprint/assets/723999/ab61af65-7a01-45f1-91de-738e82a48412)


#### Changes proposed in this pull request:

Fix the type of `domRenderer` to be compatible with `createRoot()`
