### PR TITLE
[core] feat(BlueprintProvider): new composite context provider

### DIFF
--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -24,6 +24,8 @@ module.exports = async function (config) {
                 // focus mangement is difficult to test, and this function may no longer be required
                 // if we use the react-focus-lock library in Overlay2.
                 "src/components/overlay/overlayUtils.ts",
+                // simple wrapper component
+                "src/context/blueprintProvider.tsx",
 
                 // HACKHACK: for karma upgrade only
                 "src/common/refs.ts",

--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -10,7 +10,7 @@ need to use a Portal directly; this documentation is provided only for reference
 **Portal** component functions like a declarative `appendChild()`. The children of a **Portal** are inserted into a _new child_ of the target element. This target element is determined in the following order:
 
 1. The `container` prop, if specified
-2. The `portalContainer` from the closest [PortalProvider](#core/context/portal-provider), if specified
+2. The `portalContainer` from the closest [**PortalProvider**](#core/context/portal-provider), if specified
 3. Otherwise `document.body`
 
 **Portal** is used inside [Overlay2](#core/components/overlay2) to actually overlay the content on the
@@ -34,7 +34,7 @@ apply `position: absolute` to the `<body>` tag.
 **Portal** supports some customization through [React context](https://react.dev/learn/passing-data-deeply-with-context).
 Using this API can be helpful if you need to apply some custom styling or logic to _all_ Blueprint
 components which use portals (popovers, tooltips, dialogs, etc.). You can do so by rendering a
-[PortalProvider](#core/context/portal-provider) in your React tree
+[**PortalProvider**](#core/context/portal-provider) in your React tree
 (usually, this should be done near the root of your application).
 
 ```tsx

--- a/packages/core/src/context/blueprint-provider.md
+++ b/packages/core/src/context/blueprint-provider.md
@@ -1,0 +1,37 @@
+---
+tag: new
+---
+
+@# BlueprintProvider
+
+**BlueprintProvider** is a compound [React context](https://react.dev/learn/passing-data-deeply-with-context)
+provider which enables & manages various global behaviors of Blueprint applications. It must be rendered
+at the root of your application and may only be used once as a singleton provider.
+
+Concretely, this provider renders the following provider components _in the correct nesting order_
+and allows customization of their options via props:
+
+-   [**OverlaysProvider**](#core/context/overlays-provider)
+-   [**HotkeysProvider**](#core/context/hotkeys-provider)
+-   [**PortalProvider**](#core/context/portal-provider)
+
+## Usage
+
+To use **BlueprintProvider**, wrap your application with it at the root level:
+
+```tsx
+import { BlueprintProvider } from "@blueprintjs/core";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+ReactDOM.render(
+    <BlueprintProvider>
+        <div>My app has overlays, hotkeys, and portal customization 😎</div>
+    </BlueprintProvider>,
+    document.querySelector("#app"),
+);
+```
+
+## Props interface
+
+@interface BlueprintProviderProps

--- a/packages/core/src/context/blueprintProvider.tsx
+++ b/packages/core/src/context/blueprintProvider.tsx
@@ -30,7 +30,7 @@ export interface BlueprintProviderProps
     extends OverlaysProviderProps,
         PortalContextOptions,
         HotkeysProviderPrefix<HotkeysProviderProps> {
-    // no props of its own
+    // no props of its own, `children` comes from `OverlaysProviderProps`
 }
 
 /**

--- a/packages/core/src/context/blueprintProvider.tsx
+++ b/packages/core/src/context/blueprintProvider.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { HotkeysProvider, type HotkeysProviderProps } from "./hotkeys/hotkeysProvider";
+import { OverlaysProvider, type OverlaysProviderProps } from "./overlays/overlaysProvider";
+import { type PortalContextOptions, PortalProvider } from "./portal/portalProvider";
+
+// for some props interfaces, it helps to prefix their property names with the name of the provider
+// to avoid any ambiguity in the API
+type HotkeysProviderPrefix<T> = {
+    [Property in keyof T as `hotkeysProvider${Capitalize<string & Property>}`]: T[Property];
+};
+
+export interface BlueprintProviderProps
+    extends OverlaysProviderProps,
+        PortalContextOptions,
+        HotkeysProviderPrefix<HotkeysProviderProps> {
+    // no props of its own
+}
+
+/**
+ * Composite Blueprint context provider which enables & manages various global behaviors of Blueprint applications.
+ *
+ * @see https://blueprintjs.com/docs/#core/context/blueprint-provider
+ */
+export const BlueprintProvider = ({ children, hotkeysProviderValue, ...props }: BlueprintProviderProps) => {
+    return (
+        <PortalProvider {...props}>
+            <OverlaysProvider>
+                <HotkeysProvider value={hotkeysProviderValue} {...props}>
+                    {children}
+                </HotkeysProvider>
+            </OverlaysProvider>
+        </PortalProvider>
+    );
+};

--- a/packages/core/src/context/context.md
+++ b/packages/core/src/context/context.md
@@ -2,6 +2,7 @@
 
 <!-- Exact ordering of items in the navbar: -->
 
+@page blueprint-provider
 @page hotkeys-provider
 @page overlays-provider
 @page portal-provider

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -3,7 +3,7 @@
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">
 
-Migrating from [HotkeysTarget](#core/legacy/hotkeys-legacy)?
+Migrating from [**HotkeysTarget**](#core/legacy/hotkeys-legacy)?
 
 </h5>
 
@@ -22,6 +22,20 @@ by navigating around and triggering the dialog with the <kbd>?</kbd> key.
 
 @## Usage
 
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Consider [**BlueprintProvider**](#core/context/blueprint-provider)
+
+</h5>
+
+**BlueprintProvider** is a new composite React context provider for Blueprint applications which
+enables & configures multiple providers automatically and is simpler to use than individual lower-level providers.
+
+</div>
+
+To use **HotkeysProvider**, wrap your application with it at the root level:
+
 ```tsx
 import { HotkeysProvider } from "@blueprintjs/core";
 import * as React from "react";
@@ -37,11 +51,11 @@ ReactDOM.render(
 
 @## Advanced usage
 
-HotkeysProvider should not be nested, except in special cases. If you have a rendering boundary within your application
+**HotkeysProvider** should not be nested, except in special cases. If you have a rendering boundary within your application
 through which React context is not preserved (for example, a plugin system which uses `ReactDOM.render()`) and you wish
 to use hotkeys in a descendant part of the tree below such a boundary, you may render a descendant provider and initialize
 it with the root context instance. This ensures that there will only be one "global" hotkeys dialogs in an application
-which has multiple HotkeysProviders.
+which has multiple **HotkeysProviders**.
 
 ```tsx
 import { HotkeyConfig, HotkeysContext, HotkeysProvider, HotkeysTarget2 } from "@blueprintjs/core";

--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -89,9 +89,6 @@ const hotkeysReducer = (state: HotkeysContextState, action: HotkeysAction) => {
 };
 
 export interface HotkeysProviderProps {
-    /** The component subtree which will have access to this hotkeys context. */
-    children: React.ReactChild;
-
     /** Optional props to customize the rendered hotkeys dialog. */
     dialogProps?: Partial<Omit<HotkeysDialogProps, "hotkeys">>;
 
@@ -107,7 +104,12 @@ export interface HotkeysProviderProps {
  *
  * @see https://blueprintjs.com/docs/#core/context/hotkeys-provider
  */
-export const HotkeysProvider = ({ children, dialogProps, renderDialog, value }: HotkeysProviderProps) => {
+export const HotkeysProvider = ({
+    children,
+    dialogProps,
+    renderDialog,
+    value,
+}: React.PropsWithChildren<HotkeysProviderProps>) => {
     const hasExistingContext = value != null;
     const fallbackReducer = React.useReducer(hotkeysReducer, { ...initialHotkeysState, hasProvider: true });
     const [state, dispatch] = value ?? fallbackReducer;

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { BlueprintProvider, type BlueprintProviderProps } from "./blueprintProvider";
 export {
     HotkeysContext,
     type HotkeysContextInstance,

--- a/packages/core/src/context/overlays/overlays-provider.md
+++ b/packages/core/src/context/overlays/overlays-provider.md
@@ -25,6 +25,18 @@ specifically the stack of all overlays which are currently open. It provides the
 
 ## Usage
 
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Consider [**BlueprintProvider**](#core/context/blueprint-provider)
+
+</h5>
+
+**BlueprintProvider** is a new composite React context provider for Blueprint applications which
+enables & configures multiple providers automatically and is simpler to use than individual lower-level providers.
+
+</div>
+
 To use **OverlaysProvider**, wrap your application with it at the root level:
 
 ```tsx
@@ -39,3 +51,7 @@ ReactDOM.render(
     document.querySelector("#app"),
 );
 ```
+
+@## Props interface
+
+**OverlaysProvider** has no props other than `children`.

--- a/packages/core/src/context/portal/portal-provider.md
+++ b/packages/core/src/context/portal/portal-provider.md
@@ -9,6 +9,20 @@ options. It uses the [React context API](https://reactjs.org/docs/context.html).
 
 @## Usage
 
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Consider [**BlueprintProvider**](#core/context/blueprint-provider)
+
+</h5>
+
+**BlueprintProvider** is a new composite React context provider for Blueprint applications which
+enables & configures multiple providers automatically and is simpler to use than individual lower-level providers.
+
+</div>
+
+To use **PortalProvider**, wrap your application with it at the root level:
+
 ```tsx
 import { PortalProvider, Dialog } from "@blueprintjs/core";
 import * as React from "react";

--- a/packages/core/test/isotest.mjs
+++ b/packages/core/test/isotest.mjs
@@ -32,6 +32,9 @@ describe("@blueprintjs/core isomorphic rendering", () => {
             Alert: {
                 props: { isOpen: true, lazy: false, usePortal: false },
             },
+            BlueprintProvider: {
+                className: false,
+            },
             Breadcrumbs: {
                 props: { items: [] },
             },

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -16,7 +16,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { FocusStyleManager, OverlaysProvider } from "@blueprintjs/core";
+import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
 
 import { Examples } from "./examples/Examples";
 
@@ -27,9 +27,9 @@ FocusStyleManager.onlyShowFocusOnTabs();
     // rely on those styles to take accurate DOM measurements.
     await import("./index.scss");
     ReactDOM.render(
-        <OverlaysProvider>
+        <BlueprintProvider>
             <Examples />
-        </OverlaysProvider>,
+        </BlueprintProvider>,
         document.querySelector("#blueprint-demo-app"),
     );
 })();

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -18,15 +18,7 @@ import { type HeadingNode, isPageNode, type PageData, type TsDocBase } from "@do
 import classNames from "classnames";
 import * as React from "react";
 
-import {
-    AnchorButton,
-    Classes,
-    HotkeysProvider,
-    type Intent,
-    OverlaysProvider,
-    PortalProvider,
-    Tag,
-} from "@blueprintjs/core";
+import { AnchorButton, BlueprintProvider, Classes, type Intent, Tag } from "@blueprintjs/core";
 import type { DocsCompleteData } from "@blueprintjs/docs-data";
 import {
     Banner,
@@ -69,7 +61,6 @@ export function getTheme(): string {
 export function setTheme(themeName: string) {
     localStorage.setItem(THEME_LOCAL_STORAGE_KEY, themeName);
 }
-
 export interface BlueprintDocsProps {
     docs: DocsCompleteData;
     defaultPageId: DocumentationProps["defaultPageId"];
@@ -107,24 +98,20 @@ export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeNa
             />
         );
         return (
-            <PortalProvider>
-                <OverlaysProvider>
-                    <HotkeysProvider>
-                        <Documentation
-                            {...this.props}
-                            className={this.state.themeName}
-                            banner={banner}
-                            footer={footer}
-                            header={header}
-                            navigatorExclude={isNavSection}
-                            onComponentUpdate={this.handleComponentUpdate}
-                            renderNavMenuItem={this.renderNavMenuItem}
-                            renderPageActions={this.renderPageActions}
-                            renderViewSourceLinkText={this.renderViewSourceLinkText}
-                        />
-                    </HotkeysProvider>
-                </OverlaysProvider>
-            </PortalProvider>
+            <BlueprintProvider>
+                <Documentation
+                    {...this.props}
+                    className={this.state.themeName}
+                    banner={banner}
+                    footer={footer}
+                    header={header}
+                    navigatorExclude={isNavSection}
+                    onComponentUpdate={this.handleComponentUpdate}
+                    renderNavMenuItem={this.renderNavMenuItem}
+                    renderPageActions={this.renderPageActions}
+                    renderViewSourceLinkText={this.renderViewSourceLinkText}
+                />
+            </BlueprintProvider>
         );
     }
 

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -19,7 +19,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { HotkeysProvider } from "@blueprintjs/core";
+import { BlueprintProvider } from "@blueprintjs/core";
 
 export type MouseEventType = "click" | "mousedown" | "mouseup" | "mousemove" | "mouseenter" | "mouseleave";
 export type KeyboardEventType = "keypress" | "keydown" | "keyup";
@@ -214,8 +214,8 @@ export class ReactHarness {
     }
 
     public mount(component: React.ReactElement<any>) {
-        // wrap in a <HotkeysProvider> to avoid console warnings
-        ReactDOM.render(React.createElement(HotkeysProvider, { children: component }), this.container);
+        // wrap in a root provider to avoid console warnings
+        ReactDOM.render(React.createElement(BlueprintProvider, { children: component }), this.container);
         return new ElementHarness(this.container);
     }
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/pull/6674#discussion_r1465636124, https://github.com/palantir/blueprint/pull/6681#discussion_r1470373936

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

New `<BlueprintProvider>` composite React context provider API which enables the 3 common providers used in Blueprint applications.

#### Reviewers should focus on:

No regressions in behavior - the new provider is used in docs-app and demo-app

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/723999/54b561de-2bcc-4911-8e64-af2ed147e228)
