### PR TITLE
[core] fix(BlueprintProvider): HotkeysProvider inherited types are optional

### DIFF
--- a/packages/core/src/context/blueprintProvider.tsx
+++ b/packages/core/src/context/blueprintProvider.tsx
@@ -23,7 +23,7 @@ import { type PortalContextOptions, PortalProvider } from "./portal/portalProvid
 // for some props interfaces, it helps to prefix their property names with the name of the provider
 // to avoid any ambiguity in the API
 type HotkeysProviderPrefix<T> = {
-    [Property in keyof T as `hotkeysProvider${Capitalize<string & Property>}`]: T[Property];
+    [Property in keyof T as `hotkeysProvider${Capitalize<string & Property>}`]?: T[Property];
 };
 
 export interface BlueprintProviderProps

--- a/packages/core/src/context/blueprintProvider.tsx
+++ b/packages/core/src/context/blueprintProvider.tsx
@@ -23,13 +23,13 @@ import { type PortalContextOptions, PortalProvider } from "./portal/portalProvid
 // for some props interfaces, it helps to prefix their property names with the name of the provider
 // to avoid any ambiguity in the API
 type HotkeysProviderPrefix<T> = {
-    [Property in keyof T as `hotkeysProvider${Capitalize<string & Property>}`]?: T[Property];
+    [Property in keyof T as `hotkeysProvider${Capitalize<string & Property>}`]: T[Property];
 };
 
 export interface BlueprintProviderProps
     extends OverlaysProviderProps,
         PortalContextOptions,
-        HotkeysProviderPrefix<HotkeysProviderProps> {
+        Partial<HotkeysProviderPrefix<HotkeysProviderProps>> {
     // no props of its own, `children` comes from `OverlaysProviderProps`
 }
 


### PR DESCRIPTION
Fixes a small type bug in #6692 

Before:

<img width="803" alt="image" src="https://github.com/palantir/blueprint/assets/723999/beebbb62-d22f-4b9a-91fd-3eadb23ff905">


After:

> TODO