### PR TITLE
[core] feat(Tree): compact variant, caret hover style

### DIFF
--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -44,6 +44,10 @@ Styleguide tree
 
 $tree-row-height: $pt-grid-size * 3 !default;
 $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) * 0.5 !default;
+
+$tree-row-height-compact: 24px !default;
+$tree-icon-spacing-compact: ($tree-row-height-compact - $pt-icon-size-standard) * 0.5 !default;
+
 $tree-intent-icon-colors: (
   "primary": $blue5,
   "success": $green5,
@@ -111,6 +115,10 @@ $tree-intent-icon-colors: (
   padding: $tree-icon-spacing;
   transform: rotate(0deg);
   transition: transform ($pt-transition-duration * 2) $pt-transition-ease;
+
+  &:hover {
+    color: $pt-text-color;
+  }
 
   &.#{$ns}-tree-node-caret-open {
     transform: rotate(90deg);
@@ -183,6 +191,20 @@ $tree-intent-icon-colors: (
   }
 }
 
+// Variant: compact
+.#{$ns}-tree.#{$ns}-compact {
+  .#{$ns}-tree-node-content {
+    height: $tree-row-height-compact;
+  }
+
+  .#{$ns}-tree-node-caret {
+    margin-right: 3px;
+    min-width: $tree-row-height-compact;
+    padding: $tree-icon-spacing-compact;
+  }
+}
+
+// Variant: dark theme
 .#{$ns}-dark {
   .#{$ns}-tree-node-content {
     &:hover {
@@ -202,11 +224,19 @@ $tree-intent-icon-colors: (
     }
   }
 
-  .#{$ns}-tree-node.#{$ns}-tree-node-selected > .#{$ns}-tree-node-content {
-    background-color: $pt-intent-primary;
+  .#{$ns}-tree-node {
+    &:not(.#{$ns}-disabled) {
+      .#{$ns}-tree-node-caret:hover {
+        color: $pt-dark-text-color;
+      }
+    }
 
-    #{$icon-classes} {
-      color: $white;
+    &.#{$ns}-tree-node-selected > .#{$ns}-tree-node-content {
+      background-color: $pt-intent-primary;
+
+      #{$icon-classes} {
+        color: $white;
+      }
     }
   }
 }

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -25,6 +25,11 @@ import type { TreeEventHandler, TreeNodeInfo } from "./treeTypes";
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface TreeProps<T = {}> extends Props {
     /**
+     * Whether to use a compact appearance which reduces the visual padding around node content.
+     */
+    compact?: boolean;
+
+    /**
      * The data specifying the contents and appearance of the tree.
      */
     contents: ReadonlyArray<TreeNodeInfo<T>>;
@@ -95,7 +100,11 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
 
     public render() {
         return (
-            <div className={classNames(Classes.TREE, this.props.className)}>
+            <div
+                className={classNames(Classes.TREE, this.props.className, {
+                    [Classes.COMPACT]: this.props.compact,
+                })}
+            >
                 {this.renderNodes(this.props.contents, [], Classes.TREE_ROOT)}
             </div>
         );

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -17,8 +17,8 @@
 import cloneDeep from "lodash/cloneDeep";
 import * as React from "react";
 
-import { Classes, ContextMenu, Icon, Intent, Tooltip, Tree, type TreeNodeInfo } from "@blueprintjs/core";
-import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
+import { Classes, ContextMenu, H5, Icon, Intent, Switch, Tooltip, Tree, type TreeNodeInfo } from "@blueprintjs/core";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 type NodePath = number[];
 
@@ -62,6 +62,7 @@ function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
 }
 
 export const TreeExample: React.FC<ExampleProps> = props => {
+    const [compact, setCompact] = React.useState(false);
     const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
 
     const handleNodeClick = React.useCallback(
@@ -92,9 +93,17 @@ export const TreeExample: React.FC<ExampleProps> = props => {
         });
     }, []);
 
+    const options = (
+        <>
+            <H5>Props</H5>
+            <Switch label="Compact" checked={compact} onChange={handleBooleanChange(setCompact)} />
+        </>
+    );
+
     return (
-        <Example options={false} {...props}>
+        <Example options={options} {...props}>
             <Tree
+                compact={compact}
                 contents={nodes}
                 onNodeClick={handleNodeClick}
                 onNodeCollapse={handleNodeCollapse}


### PR DESCRIPTION
Part of https://github.com/palantir/blueprint/issues/6700

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Add a "compact" style variant for the `<Tree>` component
- Small interactive style improvement for the tree caret icon - it now has a hover click style affordance

#### Reviewers should focus on:

Compact tree row height (24px)

#### Screenshot

Compact:

![image](https://github.com/palantir/blueprint/assets/723999/2678132a-a9b6-421d-bb82-f5eb33d65e2c)

Caret hover style (doesn't do anything on disabled nodes):

![Screen Recording 2024-02-05 at 11 38 23 AM](https://github.com/palantir/blueprint/assets/723999/68dfcd4b-d8ab-4006-b0b3-1ed4417968e1)

