### PR TITLE
[core] feat: make compound tag mixins available in Sass API

### DIFF
--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -4,6 +4,9 @@
 @import "../../common/variables";
 @import "../../common/variables-extended";
 
+// Variables
+// ---------------------------------------------------------------------------------------------------------------------
+
 $tag-default-color: $gray1 !default;
 $dark-tag-default-color: $gray5 !default;
 
@@ -42,6 +45,9 @@ $minimal-dark-tag-intent-colors: (
   "warning": ($pt-intent-warning, $orange5, $orange6),
   "danger": ($pt-intent-danger, $red5, $red6)
 ) !default;
+
+// Mixins - Tag component
+// ---------------------------------------------------------------------------------------------------------------------
 
 @mixin pt-tag() {
   @include pt-flex-container(row, $tag-icon-spacing, inline);
@@ -333,4 +339,62 @@ $minimal-dark-tag-intent-colors: (
       color: $dark-gray1;
     }
   }
+}
+
+// Mixins - CompoundTag component
+// ---------------------------------------------------------------------------------------------------------------------
+
+@mixin compound-tag-colors(
+  /* each list is a (default, hover, active) tuple of background colors */
+  $left-colors,
+  $right-colors
+) {
+  // override default tag background styles: this is important for minimal tags with opacity values
+  // which we want to define _absolutely_ in our design system and not by stacking opacities on top of each other.
+  background: none;
+
+  .#{$ns}-compound-tag-left {
+    background-color: nth($left-colors, 1);
+  }
+
+  .#{$ns}-compound-tag-right {
+    background-color: nth($right-colors, 1);
+  }
+
+  &.#{$ns}-interactive {
+    &:hover {
+      .#{$ns}-compound-tag-left {
+        background-color: nth($left-colors, 2);
+      }
+
+      .#{$ns}-compound-tag-right {
+        background-color: nth($right-colors, 2);
+      }
+    }
+
+    &:active,
+    &.#{$ns}-active {
+      .#{$ns}-compound-tag-left {
+        background-color: nth($left-colors, 3);
+      }
+
+      .#{$ns}-compound-tag-right {
+        background-color: nth($right-colors, 3);
+      }
+    }
+  }
+}
+
+@mixin minimal-compound-tag-colors($base-color) {
+  $left-colors: (rgba($base-color, 0.2), rgba($base-color, 0.3), rgba($base-color, 0.4));
+  $right-colors: (rgba($base-color, 0.1), rgba($base-color, 0.2), rgba($base-color, 0.3));
+
+  @include compound-tag-colors($left-colors, $right-colors);
+}
+
+@mixin dark-minimal-compound-tag-colors($base-color) {
+  $left-colors: (rgba($base-color, 0.4), rgba($base-color, 0.5), rgba($base-color, 0.55));
+  $right-colors: (rgba($base-color, 0.2), rgba($base-color, 0.3), rgba($base-color, 0.35));
+
+  @include compound-tag-colors($left-colors, $right-colors);
 }

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -24,61 +24,6 @@ $compound-tag-left-intent-colors: (
   "danger": ($red2, $red1, $red0),
 ) !default;
 
-@mixin compound-tag-colors(
-  /* each list is a (default, hover, active) tuple of background colors */
-  $left-colors,
-  $right-colors
-) {
-  // override default tag background styles: this is important for minimal tags with opacity values
-  // which we want to define _absolutely_ in our design system and not by stacking opacities on top of each other.
-  background: none;
-
-  .#{$ns}-compound-tag-left {
-    background-color: nth($left-colors, 1);
-  }
-
-  .#{$ns}-compound-tag-right {
-    background-color: nth($right-colors, 1);
-  }
-
-  &.#{$ns}-interactive {
-    &:hover {
-      .#{$ns}-compound-tag-left {
-        background-color: nth($left-colors, 2);
-      }
-
-      .#{$ns}-compound-tag-right {
-        background-color: nth($right-colors, 2);
-      }
-    }
-
-    &:active,
-    &.#{$ns}-active {
-      .#{$ns}-compound-tag-left {
-        background-color: nth($left-colors, 3);
-      }
-
-      .#{$ns}-compound-tag-right {
-        background-color: nth($right-colors, 3);
-      }
-    }
-  }
-}
-
-@mixin minimal-compound-tag-colors($base-color) {
-  $left-colors: (rgba($base-color, 0.2), rgba($base-color, 0.3), rgba($base-color, 0.4));
-  $right-colors: (rgba($base-color, 0.1), rgba($base-color, 0.2), rgba($base-color, 0.3));
-
-  @include compound-tag-colors($left-colors, $right-colors);
-}
-
-@mixin dark-minimal-compound-tag-colors($base-color) {
-  $left-colors: (rgba($base-color, 0.4), rgba($base-color, 0.5), rgba($base-color, 0.55));
-  $right-colors: (rgba($base-color, 0.2), rgba($base-color, 0.3), rgba($base-color, 0.35));
-
-  @include compound-tag-colors($left-colors, $right-colors);
-}
-
 .#{$ns}-compound-tag {
   // Variants: default & interactive
   @include compound-tag-colors(


### PR DESCRIPTION

#### Changes proposed in this pull request:

Moving compound tag styling mixins to the `_common.scss` module so that they can be imported / `@use`'d in a Sass code base without pulling in a duplicate copy of the `.bp5-compound-tag` CSS

#### Reviewers should focus on:

No regressions for CompoundTag styling

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
