### PR TITLE
PanelStack2: Prevent extra render due to updated previous panel

### DIFF
--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -60,12 +60,13 @@ export const PanelView2: PanelView2Component = <T extends Panel<object>>({
     previousPanel,
     showHeader,
 }: PanelView2Props<T>) => {
+    const hasPreviousPanel = previousPanel !== undefined;
     const handleClose = React.useCallback(() => {
         // only remove this panel if it is not the only one.
-        if (previousPanel !== undefined) {
+        if (hasPreviousPanel) {
             onClose(panel);
         }
-    }, [onClose, panel, previousPanel]);
+    }, [onClose, panel, hasPreviousPanel]);
 
     const maybeBackButton =
         previousPanel === undefined ? null : (


### PR DESCRIPTION
Hi,

I had a `TextArea` component with a jumping cursor from the moment I updated to Blueprint 5 from 4.

This component is located in a second panel within a `PanelStack2`  but the first one had changing props at every render.
When digging through the differences between v4 and v5, I found out that `handleClose` has been added to the `useMemo` dependencies of `PanelWrapper` triggering a render every time `previousPanel` changes.

So for now, to go around this, I wrap the previous panel with a `useMemo` as well.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Extracting `previousPanel !== undefined` outside the callback prevent extra renders by using a boolean instead.