### PR TITLE
[core] fix(EditableText): Update dimensions on placeholder change

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -301,7 +301,8 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
             this.props.maxLines !== prevProps.maxLines ||
             this.props.minLines !== prevProps.minLines ||
             this.props.minWidth !== prevProps.minWidth ||
-            this.props.multiline !== prevProps.multiline
+            this.props.multiline !== prevProps.multiline ||
+            this.props.placeholder !== prevProps.placeholder
         ) {
             this.updateInputDimensions();
         }


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Makes sure `EditableText` updates its dimensions when `placeholder` is modified.

[This sandbox](https://codesandbox.io/p/devbox/eloquent-cache-kxrl6r?workspaceId=6ec47632-333b-4c0d-9887-f6ed8ca344a7&file=src%2FApp.tsx) highlights the issue. Change the placeholder (via the top input) to something that doesn't match the input's current width, then focus either of the `EditableText`s below to see the difference.

#### Reviewers should focus on:

If I missed something?

The current tests don't include any for the resizing, so I don't think it's in scope for such a small PR to add those.

#### Screenshot

![image](https://github.com/palantir/blueprint/assets/130545871/02453b7b-2b05-4263-99d2-ad50f818d32e)
![image](https://github.com/palantir/blueprint/assets/130545871/ae039373-8d1c-45e6-8a91-7242e28615c8)

