### PR TITLE
[core] fix(ContextMenu): create PopoverOverlay to avoid using popper.js

### DIFF
--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -40,7 +40,7 @@ export function setRef<T>(refTarget: React.Ref<T> | undefined, ref: T | null): v
  * Utility for merging refs into one singular callback ref.
  * If using in a functional component, would recomend using `useMemo` to preserve function identity.
  */
-export function mergeRefs<T>(...refs: Array<React.Ref<T>>): React.RefCallback<T> {
+export function mergeRefs<T>(...refs: Array<React.Ref<T> | undefined>): React.RefCallback<T> {
     return value => {
         refs.forEach(ref => {
             setRef(ref, value);

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -235,6 +235,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
             <PopoverOverlay
                 containerRef={popoverElement}
                 content={<div onContextMenu={cancelContextMenu}>{menuContent}</div>}
+                interactionKind="click"
                 isOpen={isOpen}
                 minimal={true}
                 onClose={handlePopoverClose}

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -14,16 +14,19 @@
  * limitations under the License.
  */
 
-import type { Placement } from "@popperjs/core";
 import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, type Props, Utils } from "../../common";
 import { PopoverOverlay } from "../popover/popoverOverlay";
-import { getTransformOrigin } from "../popover/popperUtils";
 import { TooltipContext, TooltipProvider } from "../popover/tooltipContext";
 
-import type { ContextMenuPopoverOptions, Offset } from "./contextMenuShared";
+import {
+    CONTEXT_MENU_PLACEMENT,
+    CONTEXT_MENU_TRANSFORM_ORIGIN,
+    type ContextMenuPopoverOptions,
+    type Offset,
+} from "./contextMenuShared";
 
 /**
  * Render props relevant to the _content_ of a context menu (rendered as the underlying Popover's content).
@@ -111,8 +114,6 @@ export interface ContextMenuProps
      */
     tagName?: keyof React.JSX.IntrinsicElements;
 }
-
-const CONTEXT_MENU_PLACEMENT: Placement = "right-start";
 
 /**
  * Context menu component.
@@ -225,8 +226,6 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
     const popoverClasses = classNames(Classes.CONTEXT_MENU_POPOVER, popoverProps?.popoverClassName, {
         [Classes.DARK]: isDarkTheme,
     });
-    // compute an appropriate transform origin so the scale animation points towards target
-    const transformOrigin = getTransformOrigin(CONTEXT_MENU_PLACEMENT, undefined);
 
     // only render the popover if there is content in the context menu;
     // this avoid doing unnecessary rendering & computation
@@ -235,15 +234,15 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
             <PopoverOverlay
                 containerRef={popoverElement}
                 content={<div onContextMenu={cancelContextMenu}>{menuContent}</div>}
-                interactionKind="click"
+                interactionKind="click" // allows outside click to close
                 isOpen={isOpen}
                 minimal={true}
                 onClose={handlePopoverClose}
-                placement="right-start"
+                placement={CONTEXT_MENU_PLACEMENT}
                 popoverClassName={popoverClasses}
                 popoverRef={popoverElement}
                 style={targetOffset ?? {}}
-                transformOrigin={transformOrigin}
+                transformOrigin={CONTEXT_MENU_TRANSFORM_ORIGIN}
             />
         );
 

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -18,11 +18,14 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
-import { Popover } from "../popover/popover";
-import type { PopoverTargetProps } from "../popover/popoverSharedProps";
-import { Portal } from "../portal/portal";
+import { PopoverOverlay } from "../popover/popoverOverlay";
 
-import type { ContextMenuPopoverOptions, Offset } from "./contextMenuShared";
+import {
+    CONTEXT_MENU_PLACEMENT,
+    CONTEXT_MENU_TRANSFORM_ORIGIN,
+    type ContextMenuPopoverOptions,
+    type Offset,
+} from "./contextMenuShared";
 
 export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
     isOpen: boolean;
@@ -46,42 +49,25 @@ export const ContextMenuPopover = React.memo(function _ContextMenuPopover(props:
         popoverClassName,
         onClose,
         isDarkTheme = false,
-        rootBoundary = "viewport",
         targetOffset,
         transitionDuration = 100,
         ...popoverProps
     } = props;
+
     const cancelContextMenu = React.useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
-
-    // Popover should attach its ref to the virtual target we render inside a Portal, not the "inline" child target
-    const renderTarget = React.useCallback(
-        ({ ref }: PopoverTargetProps) => (
-            <Portal>
-                <div className={Classes.CONTEXT_MENU_VIRTUAL_TARGET} style={targetOffset} ref={ref} />
-            </Portal>
-        ),
-        [targetOffset],
-    );
-
-    const handleInteraction = React.useCallback(
-        (nextOpenState: boolean) => {
-            if (!nextOpenState) {
-                onClose?.();
-            }
-        },
-        [onClose],
-    );
+    const popoverElement = React.useRef<HTMLDivElement | null>(null);
 
     return (
-        <Popover
-            placement="right-start"
-            rootBoundary={rootBoundary}
+        <PopoverOverlay
+            containerRef={popoverElement}
+            placement={CONTEXT_MENU_PLACEMENT}
             transitionDuration={transitionDuration}
             {...popoverProps}
             content={
                 // this prevents right-clicking inside our context menu
                 <div onContextMenu={cancelContextMenu}>{content}</div>
             }
+            interactionKind="click" // allows outside click to close
             enforceFocus={false}
             // Generate key based on offset so that a new Popover instance is created
             // when offset changes, to force recomputing position.
@@ -89,12 +75,12 @@ export const ContextMenuPopover = React.memo(function _ContextMenuPopover(props:
             hasBackdrop={true}
             backdropProps={{ className: Classes.CONTEXT_MENU_BACKDROP }}
             minimal={true}
-            onInteraction={handleInteraction}
-            popoverClassName={classNames(Classes.CONTEXT_MENU_POPOVER, popoverClassName, {
-                [Classes.DARK]: isDarkTheme,
-            })}
-            positioningStrategy="fixed"
-            renderTarget={renderTarget}
+            onClose={onClose}
+            popoverClassName={classNames(Classes.CONTEXT_MENU_POPOVER, popoverClassName)}
+            popoverRef={popoverElement}
+            style={targetOffset ?? {}}
+            transformOrigin={CONTEXT_MENU_TRANSFORM_ORIGIN}
+            useDarkTheme={isDarkTheme}
         />
     );
 });

--- a/packages/core/src/components/context-menu/contextMenuShared.ts
+++ b/packages/core/src/components/context-menu/contextMenuShared.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
+import type { Placement } from "@popperjs/core";
+
 import type { OverlayLifecycleProps } from "../overlay/overlayProps";
 import type { PopoverProps } from "../popover/popover";
+import { getTransformOrigin } from "../popover/popperUtils";
 
 export type Offset = {
     left: number;
@@ -29,6 +32,13 @@ export type Offset = {
  * of their cursor, which is the default placement. However, this option is provided to help with rare cases where
  * the menu is triggered at the bottom and/or right edge of a window and the built-in popover flipping behavior does
  * not work effectively.
+ *
+ * N.B. As of @blueprintjs/core v5.10.x, the `rootBoundary` prop is ignored; the new behavior is equivalent to "viewport".
  */
 export type ContextMenuPopoverOptions = OverlayLifecycleProps &
     Pick<PopoverProps, "placement" | "popoverClassName" | "transitionDuration" | "popoverRef" | "rootBoundary">;
+
+export const CONTEXT_MENU_PLACEMENT: Placement = "right-start";
+
+// compute an appropriate transform origin so the scale animation points towards target
+export const CONTEXT_MENU_TRANSFORM_ORIGIN = getTransformOrigin(CONTEXT_MENU_PLACEMENT, undefined);

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -82,7 +82,8 @@ export { PanelStack, type PanelStackProps } from "./panel-stack/panelStack";
 export type { IPanel, IPanelProps } from "./panel-stack/panelProps";
 export { PanelStack2, type PanelStack2Props } from "./panel-stack2/panelStack2";
 export type { Panel, PanelProps } from "./panel-stack2/panelTypes";
-export { type PopoverProps, Popover, PopoverInteractionKind } from "./popover/popover";
+export { type PopoverProps, Popover } from "./popover/popover";
+export { PopoverInteractionKind } from "./popover/popoverInteractionKind";
 export { PopoverPosition } from "./popover/popoverPosition";
 export type {
     DefaultPopoverTargetHTMLProps,

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -84,6 +84,7 @@ export { PanelStack2, type PanelStack2Props } from "./panel-stack2/panelStack2";
 export type { Panel, PanelProps } from "./panel-stack2/panelTypes";
 export { type PopoverProps, Popover } from "./popover/popover";
 export { PopoverInteractionKind } from "./popover/popoverInteractionKind";
+export { type PopoverOverlayProps, PopoverOverlay } from "./popover/popoverOverlay";
 export { PopoverPosition } from "./popover/popoverPosition";
 export type {
     DefaultPopoverTargetHTMLProps,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -34,6 +34,8 @@ import { Tooltip } from "../tooltip/tooltip";
 
 import { matchReferenceWidthModifier } from "./customModifiers";
 import { POPOVER_ARROW_SVG_SIZE, PopoverArrow } from "./popoverArrow";
+import { PopoverInteractionKind } from "./popoverInteractionKind";
+import { PopoverOverlay } from "./popoverOverlay";
 import { positionToPlacement } from "./popoverPlacementUtils";
 import type {
     DefaultPopoverTargetHTMLProps,
@@ -43,8 +45,6 @@ import type {
 } from "./popoverSharedProps";
 import { getTransformOrigin } from "./popperUtils";
 import type { PopupKind } from "./popupKind";
-import { PopoverInteractionKind } from "./popoverInteractionKind";
-import { PopoverOverlay } from "./popoverOverlay";
 
 export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
     extends PopoverSharedProps<TProps> {

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -444,6 +444,7 @@ export class Popover<
             hasBackdrop,
             interactionKind,
             lazy,
+            minimal,
             onClosed,
             onClosing,
             onOpened,
@@ -476,6 +477,7 @@ export class Popover<
                     hasBackdrop,
                     interactionKind,
                     lazy,
+                    minimal,
                     onClosed,
                     onClosing,
                     onOpened,
@@ -506,6 +508,7 @@ export class Popover<
                 ref={popperProps.ref}
                 style={popperProps.style}
                 transformOrigin={transformOrigin}
+                useDarkTheme={this.props.inheritDarkTheme && this.state.hasDarkParent}
             />
         );
     };

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { State as PopperState, PositioningStrategy } from "@popperjs/core";
+import { type State as PopperState, type PositioningStrategy } from "@popperjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import {
@@ -444,10 +444,17 @@ export class Popover<
         // need to update our reference to this function on every render as it will change.
         this.popperScheduleUpdate = popperProps.update;
 
+        const popoverClassName = classNames(this.props.popoverClassName, {
+            [Classes.POPOVER_CAPTURING_DISMISS]: this.props.captureDismiss,
+            [Classes.POPOVER_MATCH_TARGET_WIDTH]: this.props.matchTargetWidth,
+            [Classes.POPOVER_REFERENCE_HIDDEN]: popperProps.isReferenceHidden === true,
+            [Classes.POPOVER_POPPER_ESCAPED]: popperProps.hasPopperEscaped === true,
+        });
+
         return (
             <PopoverOverlay
                 {...this.props}
-                {...popperProps} // ref, style, placement, isReferenceHidden, hasPopperEscaped
+                {...popperProps} // ref, style, placement
                 arrowElement={
                     this.isArrowEnabled() ? (
                         <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
@@ -461,6 +468,7 @@ export class Popover<
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
                 onResize={this.reposition}
+                popoverClassName={popoverClassName}
                 popoverRef={this.popoverRef}
                 portalStopPropagationEvents={this.props.portalStopPropagationEvents} // eslint-disable-line deprecation/deprecation
                 transformOrigin={transformOrigin}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -435,28 +435,6 @@ export class Popover<
     };
 
     private renderPopover = (popperProps: PopperChildrenProps) => {
-        const {
-            autoFocus,
-            backdropProps,
-            canEscapeKeyClose,
-            content,
-            enforceFocus,
-            hasBackdrop,
-            interactionKind,
-            lazy,
-            minimal,
-            onClosed,
-            onClosing,
-            onOpened,
-            onOpening,
-            popoverClassName,
-            portalClassName,
-            portalContainer,
-            shouldReturnFocusOnClose,
-            transitionDuration,
-            usePortal,
-        } = this.props;
-
         // compute an appropriate transform origin so the scale animation points towards target
         const transformOrigin = getTransformOrigin(
             popperProps.placement,
@@ -468,27 +446,8 @@ export class Popover<
 
         return (
             <PopoverOverlay
-                {...{
-                    autoFocus,
-                    backdropProps,
-                    canEscapeKeyClose,
-                    content,
-                    enforceFocus,
-                    hasBackdrop,
-                    interactionKind,
-                    lazy,
-                    minimal,
-                    onClosed,
-                    onClosing,
-                    onOpened,
-                    onOpening,
-                    popoverClassName,
-                    portalClassName,
-                    portalContainer,
-                    shouldReturnFocusOnClose,
-                    transitionDuration,
-                    usePortal,
-                }}
+                {...this.props}
+                {...popperProps} // ref, style, placement, isReferenceHidden, hasPopperEscaped
                 arrowElement={
                     this.isArrowEnabled() ? (
                         <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
@@ -502,11 +461,8 @@ export class Popover<
                 onMouseEnter={this.handleMouseEnter}
                 onMouseLeave={this.handleMouseLeave}
                 onResize={this.reposition}
-                placement={popperProps.placement}
                 popoverRef={this.popoverRef}
                 portalStopPropagationEvents={this.props.portalStopPropagationEvents} // eslint-disable-line deprecation/deprecation
-                ref={popperProps.ref}
-                style={popperProps.style}
                 transformOrigin={transformOrigin}
                 useDarkTheme={this.props.inheritDarkTheme && this.state.hasDarkParent}
             />

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -452,6 +452,7 @@ export class Popover<
             portalClassName,
             portalContainer,
             shouldReturnFocusOnClose,
+            transitionDuration,
             usePortal,
         } = this.props;
 
@@ -483,6 +484,7 @@ export class Popover<
                     portalClassName,
                     portalContainer,
                     shouldReturnFocusOnClose,
+                    transitionDuration,
                     usePortal,
                 }}
                 arrowElement={
@@ -504,7 +506,6 @@ export class Popover<
                 ref={popperProps.ref}
                 style={popperProps.style}
                 transformOrigin={transformOrigin}
-                transitionDuration={this.props.transitionDuration}
             />
         );
     };

--- a/packages/core/src/components/popover/popoverInteractionKind.ts
+++ b/packages/core/src/components/popover/popoverInteractionKind.ts
@@ -1,0 +1,8 @@
+export const PopoverInteractionKind = {
+    CLICK: "click" as const,
+    CLICK_TARGET_ONLY: "click-target" as const,
+    HOVER: "hover" as const,
+    HOVER_TARGET_ONLY: "hover-target" as const,
+};
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type PopoverInteractionKind = (typeof PopoverInteractionKind)[keyof typeof PopoverInteractionKind];

--- a/packages/core/src/components/popover/popoverInteractionKind.ts
+++ b/packages/core/src/components/popover/popoverInteractionKind.ts
@@ -1,3 +1,7 @@
+/* !
+* (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+*/
+
 export const PopoverInteractionKind = {
     CLICK: "click" as const,
     CLICK_TARGET_ONLY: "click-target" as const,

--- a/packages/core/src/components/popover/popoverInteractionKind.ts
+++ b/packages/core/src/components/popover/popoverInteractionKind.ts
@@ -1,6 +1,6 @@
 /* !
-* (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
-*/
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ */
 
 export const PopoverInteractionKind = {
     CLICK: "click" as const,

--- a/packages/core/src/components/popover/popoverOverlay.tsx
+++ b/packages/core/src/components/popover/popoverOverlay.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import type { Placement } from "@popperjs/core";
+import classNames from "classnames";
+import type { PopperChildrenProps } from "react-popper";
+
+import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "./popoverSharedProps";
+import { Overlay2, type Overlay2Props } from "../overlay2/overlay2";
+import { ResizeSensor } from "../resize-sensor/resizeSensor";
+
+import { Classes, Utils, type HTMLDivProps, mergeRefs, DISPLAYNAME_PREFIX } from "../../common";
+import { PopoverInteractionKind } from "./popoverInteractionKind";
+import { getBasePlacement } from "./popperUtils";
+
+export interface PopoverOverlayProps<TProps extends DefaultPopoverTargetHTMLProps>
+    extends PopoverSharedProps<TProps>,
+        Pick<Overlay2Props, "canOutsideClickClose" | "backdropProps" | "backdropClassName" | "hasBackdrop">,
+        Pick<PopperChildrenProps, "isReferenceHidden" | "hasPopperEscaped" | "style"> {
+    /**
+     * Optional arrow element for the popover.
+     */
+    arrowElement?: React.ReactElement;
+
+    /**
+     * Ref attached to the Overlay2 child element (transition container). This is similar to, but slightly
+     * different from, `ref`, since the latter will be a ref callback (provided by popper.js) while Overlay2
+     * needs a ref object (to pass to `CSSTransition`). Yes, it's a confusing implementation quirk.
+     */
+    containerRef: React.RefObject<HTMLElement>;
+
+    /**
+     * Ref attached to the Overlay2 child element (transition container). Popper.js needs to attach
+     * this ref for its positioning logic in the `<Popover>` component.
+     */
+    ref?: React.Ref<HTMLDivElement>;
+
+    /**
+     * The content displayed inside the popover.
+     */
+    content?: string | React.JSX.Element;
+
+    /** Popover click handler */
+    onClick?: (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
+
+    /** Popover mouse enter handler */
+    onMouseEnter?: (e: React.MouseEvent<HTMLElement>) => void;
+
+    /** Popover mouse leave handler */
+    onMouseLeave?: (e: React.MouseEvent<HTMLElement>) => void;
+
+    /** Optional - provide this if your target may move and you need to reposition the popover */
+    onResize?: () => void;
+
+    /** Popover interaction kind */
+    interactionKind?: PopoverInteractionKind;
+
+    /**
+     * Whether the popover is currently closing due to an 'Escape' key press.
+     */
+    isClosingViaEscapeKeypress?: boolean;
+
+    /**
+     * Controlled open state.
+     */
+    isOpen: boolean;
+
+    /**
+     * Popover placement.
+     */
+    placement: Placement;
+
+    /**
+     * Ref attached to the `Classes.POPOVER` element (deeper in the DOM than the transition container).
+     */
+    popoverRef: React.Ref<HTMLDivElement>;
+
+    /**
+     * CSS transition transform origin used to scale animations relative to the popover target.
+     */
+    transformOrigin: string;
+
+    /**
+     * Whether to use the dark theme.
+     */
+    useDarkTheme?: boolean;
+}
+
+function isHoverInteraction(interactionKind: PopoverInteractionKind | undefined) {
+    return (
+        interactionKind === PopoverInteractionKind.HOVER || interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY
+    );
+}
+
+/**
+ * Popover overlay component.
+ *
+ * This component encapsulates the presentational behavior of a popover rendered inside an overlay.
+ * It does not position the popover on the page; that must be done explicitly using the `style` prop.
+ *
+ * This component may be used with (see `Popover`) or without (see `ContextMenu`) the help of popper.js
+ * positioning logic.
+ */
+export const PopoverOverlay = React.forwardRef<HTMLDivElement, PopoverOverlayProps<any>>((props, ref) => {
+    const { autoFocus, enforceFocus, backdropProps, canEscapeKeyClose, hasBackdrop, transformOrigin, usePortal } =
+        props;
+
+    const popoverHandlers: HTMLDivProps = {
+        // always check popover clicks for dismiss class
+        onClick: props.onClick,
+        // treat ENTER/SPACE keys the same as a click for accessibility
+        onKeyDown: event => Utils.isKeyboardClick(event) && props.onClick?.(event),
+    };
+    if (
+        props.interactionKind === PopoverInteractionKind.HOVER ||
+        (!usePortal && props.interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY)
+    ) {
+        popoverHandlers.onMouseEnter = props.onMouseEnter;
+        popoverHandlers.onMouseLeave = props.onMouseLeave;
+    }
+
+    const basePlacement = getBasePlacement(props.placement);
+    const popoverClasses = classNames(
+        Classes.POPOVER,
+        {
+            [Classes.DARK]: props.useDarkTheme,
+            [Classes.MINIMAL]: props.minimal,
+            [Classes.POPOVER_CAPTURING_DISMISS]: props.captureDismiss,
+            [Classes.POPOVER_MATCH_TARGET_WIDTH]: props.matchTargetWidth,
+            [Classes.POPOVER_REFERENCE_HIDDEN]: props.isReferenceHidden === true,
+            [Classes.POPOVER_POPPER_ESCAPED]: props.hasPopperEscaped === true,
+        },
+        `${Classes.POPOVER_CONTENT_PLACEMENT}-${basePlacement}`,
+        props.popoverClassName,
+    );
+
+    const defaultAutoFocus = isHoverInteraction(props.interactionKind) ? false : undefined;
+    // if hover interaction, it doesn't make sense to take over focus control
+    const shouldReturnFocusOnClose = isHoverInteraction(props.interactionKind)
+        ? false
+        : props.isClosingViaEscapeKeypress
+          ? true
+          : props.shouldReturnFocusOnClose;
+
+    const popoverElement = (
+        <div className={popoverClasses} style={{ transformOrigin }} ref={props.popoverRef} {...popoverHandlers}>
+            {props.arrowElement}
+            <div className={Classes.POPOVER_CONTENT}>{props.content}</div>
+        </div>
+    );
+
+    return (
+        <Overlay2
+            autoFocus={autoFocus ?? defaultAutoFocus}
+            backdropClassName={Classes.POPOVER_BACKDROP}
+            backdropProps={backdropProps}
+            canEscapeKeyClose={canEscapeKeyClose}
+            canOutsideClickClose={props.interactionKind === PopoverInteractionKind.CLICK}
+            childRef={props.containerRef}
+            enforceFocus={enforceFocus}
+            hasBackdrop={hasBackdrop}
+            isOpen={props.isOpen}
+            lazy={props.lazy}
+            onClose={props.onClose}
+            onClosed={props.onClosed}
+            onClosing={props.onClosing}
+            onOpened={props.onOpened}
+            onOpening={props.onOpening}
+            transitionDuration={props.transitionDuration}
+            transitionName={Classes.POPOVER}
+            usePortal={usePortal}
+            portalClassName={props.portalClassName}
+            portalContainer={props.portalContainer}
+            // eslint-disable-next-line deprecation/deprecation
+            portalStopPropagationEvents={props.portalStopPropagationEvents}
+            shouldReturnFocusOnClose={shouldReturnFocusOnClose}
+        >
+            <div
+                className={Classes.POPOVER_TRANSITION_CONTAINER}
+                // We need to attach a ref that notifies both react-popper and our Popover component about the DOM
+                // element inside the Overlay2. We cannot re-use `PopperChildrenProps.ref` because Overlay2 only
+                // accepts a ref object (not a callback) due to a CSSTransition API limitation.
+                // N.B. react-popper has a wide type for this ref, but we can narrow it based on the source,
+                // see https://github.com/floating-ui/react-popper/blob/beac280d61082852c4efc302be902911ce2d424c/src/Popper.js#L94
+                ref={mergeRefs(ref as React.RefCallback<HTMLElement>, props.containerRef)}
+                style={props.style}
+            >
+                {/* only wrap the contents in a Resize sensor if we have a reposition handler */}
+                {props.onResize == null ? (
+                    popoverElement
+                ) : (
+                    <ResizeSensor onResize={props.onResize}>{popoverElement}</ResizeSensor>
+                )}
+            </div>
+        </Overlay2>
+    );
+});
+PopoverOverlay.displayName = `${DISPLAYNAME_PREFIX}.PopoverOverlay`;

--- a/packages/core/src/components/popover/popoverOverlay.tsx
+++ b/packages/core/src/components/popover/popoverOverlay.tsx
@@ -28,8 +28,8 @@ import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "./popove
 import { getBasePlacement } from "./popperUtils";
 
 export interface PopoverOverlayProps<TProps extends DefaultPopoverTargetHTMLProps>
-    extends PopoverSharedProps<TProps>,
-        Pick<Overlay2Props, "canOutsideClickClose" | "backdropProps" | "backdropClassName" | "hasBackdrop">,
+    extends Omit<Overlay2Props, "ref">,
+        Pick<PopoverSharedProps<TProps>, "minimal" | "popoverClassName">,
         Pick<PopperChildrenProps, "isReferenceHidden" | "hasPopperEscaped" | "style"> {
     /**
      * Optional arrow element for the popover.
@@ -139,10 +139,6 @@ export const PopoverOverlay = React.forwardRef<HTMLDivElement, PopoverOverlayPro
         {
             [Classes.DARK]: props.useDarkTheme,
             [Classes.MINIMAL]: props.minimal,
-            [Classes.POPOVER_CAPTURING_DISMISS]: props.captureDismiss,
-            [Classes.POPOVER_MATCH_TARGET_WIDTH]: props.matchTargetWidth,
-            [Classes.POPOVER_REFERENCE_HIDDEN]: props.isReferenceHidden === true,
-            [Classes.POPOVER_POPPER_ESCAPED]: props.hasPopperEscaped === true,
         },
         `${Classes.POPOVER_CONTENT_PLACEMENT}-${basePlacement}`,
         props.popoverClassName,

--- a/packages/core/src/components/popover/popoverOverlay.tsx
+++ b/packages/core/src/components/popover/popoverOverlay.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import * as React from "react";
 import type { Placement } from "@popperjs/core";
 import classNames from "classnames";
+import * as React from "react";
 import type { PopperChildrenProps } from "react-popper";
 
-import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "./popoverSharedProps";
+import { Classes, DISPLAYNAME_PREFIX, type HTMLDivProps, mergeRefs, Utils } from "../../common";
 import { Overlay2, type Overlay2Props } from "../overlay2/overlay2";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
 
-import { Classes, Utils, type HTMLDivProps, mergeRefs, DISPLAYNAME_PREFIX } from "../../common";
 import { PopoverInteractionKind } from "./popoverInteractionKind";
+import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "./popoverSharedProps";
 import { getBasePlacement } from "./popperUtils";
 
 export interface PopoverOverlayProps<TProps extends DefaultPopoverTargetHTMLProps>

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -114,10 +114,12 @@ export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
      * re-observe.
      */
     private observeElement(force = false) {
+        /* istanbul ignore next */
         if (this.observer === undefined) {
             return;
         }
 
+        /* istanbul ignore next */
         if (!(this.targetRef.current instanceof Element)) {
             // stop everything if not defined
             this.observer.disconnect();

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -20,8 +20,9 @@ import * as React from "react";
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
 // eslint-disable-next-line import/no-cycle
-import { Popover, type PopoverInteractionKind } from "../popover/popover";
+import { Popover } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
+import { PopoverInteractionKind } from "../popover/popoverInteractionKind";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
 

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -22,7 +22,7 @@ import * as Classes from "../../common/classes";
 // eslint-disable-next-line import/no-cycle
 import { Popover } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
-import { PopoverInteractionKind } from "../popover/popoverInteractionKind";
+import { type PopoverInteractionKind } from "../popover/popoverInteractionKind";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
 

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -24,13 +24,9 @@ import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 import { Classes } from "../../src/common";
 import * as Errors from "../../src/common/errors";
 import { Button, Overlay2, Portal } from "../../src/components";
-import {
-    Popover,
-    PopoverInteractionKind,
-    type PopoverProps,
-    type PopoverState,
-} from "../../src/components/popover/popover";
+import { Popover, type PopoverProps, type PopoverState } from "../../src/components/popover/popover";
 import { PopoverArrow } from "../../src/components/popover/popoverArrow";
+import { PopoverInteractionKind } from "../../src/components/popover/popoverInteractionKind";
 import { PopupKind } from "../../src/components/popover/popupKind";
 import { Tooltip } from "../../src/components/tooltip/tooltip";
 

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -705,7 +705,11 @@ describe("<Popover>", () => {
         });
 
         it("matches target width via custom modifier", () => {
-            wrapper = renderPopover({ matchTargetWidth: true, isOpen: true, placement: "bottom" });
+            wrapper = renderPopover({
+                isOpen: true,
+                matchTargetWidth: true,
+                placement: "bottom",
+            });
             const targetElement = wrapper.find("[data-testid='target-button']").hostNodes().getDOMNode();
             const popoverElement = wrapper.find(`.${Classes.POPOVER}`).hostNodes().getDOMNode();
             assert.closeTo(


### PR DESCRIPTION
#### Fixes #5503

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Refactor Popover's overlay functionality into a new component called __PopoverOverlay__ which must be absolutely positioned on the page via `props.style`
- Use __PopoverOverlay__ in __Popover__, __ContextMenu__, and __ContextMenuPopover__
- This removes popper.js behavior from __ContextMenu__ and __ContextMenuPopover__, since we already have all the information we need to position the menu on the page with fixed positioning
  - I was never able to fully get to the bottom of the issue here, but for some reason `@popperjs/core` would not position our context menu "virtual target" element correctly in React 18 strict mode. Perhaps it's violating the rules somehow. I bet their advice would be to migrate to Floating UI, which we're not going to do any time soon (see #5739). So I figure the best approach is to stop using popper.js -- we don't even need any of its features for our context menu implementation.
- This fixes #5503, but that's only testable on a branch with React 18 used throughout the whole monorepo: https://github.com/palantir/blueprint/pull/6702
- Note that there is a small breaking change to __ContextMenuPopover__: the `rootBoundary` prop is now ignored, as it doesn't make sense to have this be anything other than `"viewport"`

#### Reviewers should focus on:

No regressions in any popover-related components + context menu

#### Screenshot

![Screen Recording 2024-02-26 at 10 17 54 AM](https://github.com/palantir/blueprint/assets/723999/3bca7093-c63e-4e50-b90d-45c85bd03b08)

![Screen Recording 2024-02-26 at 10 17 33 AM](https://github.com/palantir/blueprint/assets/723999/a4b243a0-a191-49d8-988d-bfbd4a283aa0)

