### PR TITLE
link to select component from multiselect docs

### DIFF
--- a/packages/select/src/components/multi-select/multi-select.md
+++ b/packages/select/src/components/multi-select/multi-select.md
@@ -13,7 +13,7 @@ You may react to user interactions with the `onItemSelect` and `onRemove` callba
     <h5 class="@ns-heading">Generic components and custom filtering</h5>
 
 For more information on controlled usage, generic components, creating new items, and custom filtering,
-please visit the documentation for [__Select__](#select/select).
+please visit the documentation for [__Select__](#select/select-component).
 
 </div>
 


### PR DESCRIPTION
The previous link wasn't working for me and I believe it should redirect to the select component instead of the generic select docs. 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
