### PR TITLE
fix cleanup for overlay2 component

### DIFF
--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -328,11 +328,10 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     // run once on unmount
     React.useEffect(() => {
         return () => {
-            if (isOpen) {
-                // if the overlay is still open, we need to run cleanup code to remove some event handlers
-                overlayWillClose();
-            }
+            // we need to run cleanup code to remove some event handlers from the overlay element
+            overlayWillClose();
         };
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/packages/core/test/overlay2/overlay2Tests.tsx
+++ b/packages/core/test/overlay2/overlay2Tests.tsx
@@ -628,6 +628,47 @@ describe("<Overlay2>", () => {
             });
         });
 
+        describe("after closing by navigating out of the view", () => {
+            it("doesn't keep scrolling disabled if user navigated from the component where Overlay was opened", () => {
+                function WrapperWithNavigation(props: { renderOverlayView: boolean; isOverlayOpen: boolean }) {
+                    return (
+                        <div>
+                            {/* Emulating the router behavior */}
+                            {props.renderOverlayView ? (
+                                <OverlayWrapper isOpen={props.isOverlayOpen}>{createOverlayContents()}</OverlayWrapper>
+                            ) : (
+                                <div>Another View</div>
+                            )}
+                        </div>
+                    );
+                }
+
+                // Rendering the component with closed overlay (how it will happen in most of the real apps)
+                const wrapperWithNavigation = mount(
+                    <WrapperWithNavigation renderOverlayView={true} isOverlayOpen={false} />,
+                    {
+                        attachTo: testsContainerElement,
+                    },
+                );
+
+                // Opening the overlay manually to emulate the real app behavior
+                wrapperWithNavigation.setProps({ isOverlayOpen: true });
+                assert.isTrue(
+                    document.body.classList.contains(Classes.OVERLAY_OPEN),
+                    `expected overlay element to have ${Classes.OVERLAY_OPEN} class`,
+                );
+                assertBodyScrollingDisabled(true);
+
+                // Emulating the user navigation to another view
+                wrapperWithNavigation.setProps({ renderOverlayView: false });
+                assert.isFalse(
+                    document.body.classList.contains(Classes.OVERLAY_OPEN),
+                    `expected overlay element to not have ${Classes.OVERLAY_OPEN} class`,
+                );
+                assertBodyScrollingDisabled(false);
+            });
+        });
+
         function renderBackdropOverlay(hasBackdrop?: boolean, usePortal?: boolean) {
             return (
                 <OverlayWrapper hasBackdrop={hasBackdrop} isOpen={true} usePortal={usePortal}>


### PR DESCRIPTION
#### Fixes #6752

#### Checklist

- [x ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

TLDR `isOpen` is almost never `true` inside the useEffect callback.

Removed the if statement which was using an outdated state variable inside of the `useEffect` and prevented from cleanup on component unmount, which could happen if user forced the modal to close (e.g. navigating from the parent view). In this case `useEffect` doesn't have any dependencies and only returns a callback that will run on the component unmount, but since the `useEffect` doesn't have any dependencies, body of the useEffect won't be re-evaluated on the subsequent component re-renders. So the callback function will only keep in its scope the initial component's values (`isOpen` and `overlayWillClose` in this case). It might be okay to keep the initial value of the overlayWillClose function, but if the component was initialized with `isOpen === false` then the `overlayWillClose` function will never be called.  


#### Reviewers should focus on:

Double checking for potential side-effects of the if statement removal

