### PR TITLE
fix #6734 checkbox icon opacity issue

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -58,7 +58,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   input:disabled#{$selector} ~ .#{$ns}-control-indicator {
     background: $control-checked-background-color-disabled;
     box-shadow: none;
-    color: rgba($white, 0.6);
+    color: rgba($white, 0.5);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       background-color: $pt-high-contrast-mode-disabled-border-color;


### PR DESCRIPTION
#### Fixes #6734

This pull request addresses an issue with the opacity of the checkbox icon in its disabled state. Previously, the opacity was set to 0.6, which did not provide enough contrast against the background, making it hard to distinguish for some users.

Changes proposed in this pull request:
Adjust the opacity of the checkbox icon in the disabled state from 0.6 to 0.5, improving visibility and design consistency.
Reviewers should focus on:
The change in _controls.scss for the checkbox icon opacity. Ensure this adjustment does not affect other components or create visual regressions in different states.
Screenshot:
No visual change significant enough to require a screenshot, but the difference can be observed in disabled checkboxes across the application where this change applies.

This minor adjustment ensures better consistency with the design language and improves the user experience by making the disabled state more distinguishable.