### PR TITLE
Fix hotkeys dialog having 2 scrollbars

### DIFF
--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -24,8 +24,6 @@
 
 .#{$ns}-hotkey-column {
   margin: auto;
-  max-height: 80vh;
-  overflow-y: auto;
   padding: $pt-grid-size * 3;
 
   .#{$ns}-heading {

--- a/packages/core/src/legacy/hotkeysDialogLegacy.tsx
+++ b/packages/core/src/legacy/hotkeysDialogLegacy.tsx
@@ -26,7 +26,7 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 
 import { Classes } from "../common";
-import { Dialog, type DialogProps, Hotkey, type HotkeyProps, Hotkeys } from "../components";
+import { Dialog, DialogBody, type DialogProps, Hotkey, type HotkeyProps, Hotkeys } from "../components";
 
 interface HotkeysDialogProps extends DialogProps {
     /**
@@ -125,7 +125,7 @@ class HotkeysDialogLegacy {
                 isOpen={this.isDialogShowing}
                 onClose={this.hide}
             >
-                <div className={Classes.DIALOG_BODY}>{this.renderHotkeys()}</div>
+                <DialogBody>{this.renderHotkeys()}</DialogBody>
             </Dialog>
         );
     }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fix hotkey dialog having 2 scrollbars.

#### Reviewers should focus on:

Both `hotkey-column` and `dialog-body-scroll-container` have `overflow: auto` property. Add `DialogBody` to `HotkeysDialogLegacy` and remove `overflow: scroll` from `hotkey-column`.

#### Screenshot
| Before | After    |
| ------  | ------  |
| ![image](https://github.com/palantir/blueprint/assets/40804093/8b97d039-39a7-44d8-9698-7e111cfeab27) | <img width="604" alt="image" src="https://github.com/palantir/blueprint/assets/40804093/becc76b2-123c-4c27-9051-03f10e506360"> |
