### PR TITLE
Fix `TagInput` adding a tag when `Enter` is pressed while composing

### DIFF
--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -421,7 +421,8 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
 
         let activeIndexToEmit = activeIndex;
 
-        if (event.key === "Enter" && value.length > 0) {
+        // do not process adding a new tag if the user is composing (eg for Asian language input)
+        if (event.key === "Enter" && !event.nativeEvent.isComposing && value.length > 0) {
             this.addTags(value, "default");
         } else if (selectionEnd === 0 && this.props.values.length > 0) {
             // cursor at beginning of input allows interaction with tags.

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -421,7 +421,7 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
 
         let activeIndexToEmit = activeIndex;
 
-        // do not process adding a new tag if the user is composing (eg for Asian language input)
+        // do not add a new tag if the user is composing (e.g. for Japanese or Chinese)
         if (event.key === "Enter" && !event.nativeEvent.isComposing && value.length > 0) {
             this.addTags(value, "default");
         } else if (selectionEnd === 0 && this.props.values.length > 0) {

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -116,6 +116,13 @@ describe("<TagInput>", () => {
             assert.isTrue(onAdd.notCalled);
         });
 
+        it("is not invoked on enter when input is composing", () => {
+            const onAdd = sinon.stub();
+            const wrapper = mountTagInput(onAdd);
+            pressEnterInInputWhenComposing(wrapper, "");
+            assert.isTrue(onAdd.notCalled);
+        });
+
         it("is invoked on enter", () => {
             const onAdd = sinon.stub();
             const wrapper = mountTagInput(onAdd);
@@ -455,7 +462,7 @@ describe("<TagInput>", () => {
         it("pressing backspace does not remove item", () => {
             const onRemove = sinon.spy();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
-            wrapper.find("input").simulate("keydown", createInputKeydownEventMetadata("text", "Backspace"));
+            wrapper.find("input").simulate("keydown", createInputKeydownEventMetadata("text", "Backspace", false));
             assert.isTrue(onRemove.notCalled);
         });
     });
@@ -576,13 +583,20 @@ describe("<TagInput>", () => {
     });
 
     function pressEnterInInput(wrapper: ReactWrapper<any, any>, value: string) {
-        wrapper.find("input").prop("onKeyDown")?.(createInputKeydownEventMetadata(value, "Enter") as any);
+        wrapper.find("input").prop("onKeyDown")?.(createInputKeydownEventMetadata(value, "Enter", false) as any);
     }
 
-    function createInputKeydownEventMetadata(value: string, key: string) {
+    function pressEnterInInputWhenComposing(wrapper: ReactWrapper<any, any>, value: string) {
+        wrapper.find("input").prop("onKeyDown")?.(createInputKeydownEventMetadata(value, "Enter", true) as any);
+    }
+
+    function createInputKeydownEventMetadata(value: string, key: string, isComposing: boolean) {
         return {
             currentTarget: { value },
             key,
+            nativeEvent: {
+                isComposing,
+            },
             // Enzyme throws errors if we don't mock the stopPropagation method.
             stopPropagation: () => {
                 return;

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -119,7 +119,7 @@ describe("<TagInput>", () => {
         it("is not invoked on enter when input is composing", () => {
             const onAdd = sinon.stub();
             const wrapper = mountTagInput(onAdd);
-            pressEnterInInputWhenComposing(wrapper, "");
+            pressEnterInInputWhenComposing(wrapper, "构成");
             assert.isTrue(onAdd.notCalled);
         });
 


### PR DESCRIPTION
#### Fixes

The `TagInput` component has a built-in `Enter` handler for adding a tag based on the current input value. This key is hit when composing languages such as Korean or Japanese, but not for the reason of adding a tag.

The current implementation will both add a tag of the current value and keep the current value, which is unexpected behavior.

This implementation should ignore `Enter` keystrokes when the user is in the middle of composing.

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

See above description.

#### Reviewers should focus on:

Whether or not we need to fix this in other places in Blueprint.

#### Screenshot

<img width="248" alt="Screenshot 2024-04-12 at 11 30 15 AM" src="https://github.com/palantir/blueprint/assets/1316699/3fa86bd8-6d25-4663-85cf-91753bd34d7a">
<img width="162" alt="Screenshot 2024-04-12 at 11 30 19 AM" src="https://github.com/palantir/blueprint/assets/1316699/e5e3e422-937a-4bb6-83cd-a2cafb137924">

