### PR TITLE
Fix internal state consistency of control cards in controlled mode

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6771.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6771.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: Fix a case where a control card component (e.g. `<RadioCard>`) may
+    have rendered with a `checked` state that does not match its `checked` prop. This
+    can happen if that prop was changed outside of an `onChange` handler and in an
+    `onClick` handler instead.
+  links:
+  - https://github.com/palantir/blueprint/pull/6771

--- a/packages/core/src/components/control-card/useCheckedControl.ts
+++ b/packages/core/src/components/control-card/useCheckedControl.ts
@@ -22,12 +22,13 @@ import type { CheckedControlProps } from "../forms/controlProps";
  * Keep track of a control's checked state in both controlled and uncontrolled modes
  */
 export function useCheckedControl(props: CheckedControlProps) {
-    const [checked, setChecked] = React.useState(() => props.defaultChecked ?? false);
-    React.useEffect(() => {
-        if (props.checked !== undefined) {
-            setChecked(props.checked);
-        }
-    }, [props.checked]);
+    const [checkedStateForUncontrolledMode, setChecked] = React.useState(() => props.defaultChecked ?? false);
+
+    // If the checked prop is passed, this input is in "controlled mode" and
+    // should always reflect the value of the controlled prop. Any internal
+    // state tracked for "uncontrolled mode" should be ignored.
+    const checked = props.checked ?? checkedStateForUncontrolledMode;
+
     const onChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
         e => {
             setChecked(c => !c);


### PR DESCRIPTION
## Problem

### Repro

In an application using React 18 with the `createRoot` API, a `<RadioCard>` in controlled mode may not reflect the current controlled `checked` prop value. Note in the video below how two clicks are required to get the radio button in its checked state.

https://github.com/palantir/blueprint/assets/906558/a62f7ecb-c724-4719-8c75-700681164d5b

Here's the code for the video above.

```tsx
import { RadioCard } from '@blueprintjs/core'
import React from 'react'

function App() {
  const [testState, setTestState] = React.useState<"toast" | "bread">("toast")

  return (
    <div>
      {testState}
      <RadioCard checked={testState === "toast"} onClick={() => { setTestState("toast"); }}>
        toast
      </RadioCard>
      <RadioCard checked={testState === "bread"} onClick={() => { setTestState("bread"); }}>
        bread
      </RadioCard>
    </div>
  )
}

export default App
```

### Explanation

The repro code above contains buggy code. It's passing a controlled `checked` prop, but using `onClick` instead of `onChange` to toggle that prop.

This causes `<RadioCard>`'s internal state tracking to be inconsistent, which is arguably still a Blueprint bug despite the buggy usage this component.

#### With the concurrent renderer

1. The `onClick` handler on `<RadioCard>` fires.
2. This changes the `props.checked` value, and triggers the `useEffect` here. The effect changes the button's `checked` state from `false` to `true`.
  https://github.com/palantir/blueprint/blob/daebef2d64be41bfd55b22b505f8965bf4ee506b/packages/core/src/components/control-card/useCheckedControl.ts#L25-L30
3. The `<RadioCard>`'s `onChange` handler then fires, **toggling the updated `checked` state from `true` back to `false`.** 🤦🏻‍♂️
  https://github.com/palantir/blueprint/blob/daebef2d64be41bfd55b22b505f8965bf4ee506b/packages/core/src/components/control-card/useCheckedControl.ts#L31-L33

#### Legacy renderer

With the **legacy React 17 renderer**, this happened to work because the order of these event handlers are reversed.

1. The `onClick` handler on `<RadioCard>` fires.
2. The internal `onChange` handler fires first.
3. Then the `useEffect` fires second.

I believe the order is different with the concurrent renderer due to [an intentional change to make `useEffect`'s timing more consistent](https://github.com/reactwg/react-18/discussions/128).

### Summary

In summary of the explanation above, Blueprint's uncontrolled state handling is fighting with the controlled state handling of the application.

## Changes

The `useEffect` here is an example of ["_you might not need an effect_"](https://react.dev/learn/you-might-not-need-an-effect).

https://github.com/palantir/blueprint/blob/daebef2d64be41bfd55b22b505f8965bf4ee506b/packages/core/src/components/control-card/useCheckedControl.ts#L26-L30

I think we can simplify this with a value that's ["_calculated during rendering_"](https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state).

> When something can be calculated from the existing props or state, [don’t put it in state.](https://react.dev/learn/choosing-the-state-structure#avoid-redundant-state) Instead, calculate it during rendering. This makes your code faster (you avoid the extra “cascading” updates), simpler (you remove some code), and less error-prone (you avoid bugs caused by different state variables getting out of sync with each other). If this approach feels new to you, [Thinking in React](https://react.dev/learn/thinking-in-react#step-3-find-the-minimal-but-complete-representation-of-ui-state) explains what should go into state.

```ts
const checked = props.checked ?? checkedStateForUncontrolledMode;
```