### PR TITLE
feat (DateIinput3): added left element prop to date input 3

### DIFF
--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -156,6 +156,11 @@ export interface DateInputProps extends DatePickerBaseProps, DateFormatProps, Da
     rightElement?: React.JSX.Element;
 
     /**
+     * Element to render on left side of input.
+     */
+    leftElement?: React.JSX.Element;
+
+    /**
      * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown below the calendar.
      *
      * @default false

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -94,6 +94,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
         popoverProps = {},
         popoverRef,
         rightElement,
+        leftElement,
         showTimezoneSelect,
         timePrecision,
         timezone: controlledTimezone,
@@ -502,6 +503,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
                     className={classNames(targetProps.className, inputProps.className)}
                     intent={shouldShowErrorStyling && isErrorState ? "danger" : "none"}
                     placeholder={placeholder}
+                    leftElement={leftElement}
                     rightElement={
                         <>
                             {rightElement}
@@ -545,6 +547,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
             popoverId,
             popoverProps.targetTagName,
             rightElement,
+            leftElement,
             shouldShowErrorStyling,
         ],
     );

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
@@ -39,6 +39,7 @@ interface DateInput3ExampleState {
     reverseMonthAndYearMenus: boolean;
     shortcuts: boolean;
     showActionsBar: boolean;
+    showLeftElement: boolean;
     showRightElement: boolean;
     showTimePickerArrows: boolean;
     showTimezoneSelect: boolean;
@@ -58,6 +59,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
         reverseMonthAndYearMenus: false,
         shortcuts: false,
         showActionsBar: false,
+        showLeftElement: false,
         showRightElement: false,
         showTimePickerArrows: false,
         showTimezoneSelect: true,
@@ -83,6 +85,8 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
 
     private toggleReverseMenus = handleBooleanChange(reverse => this.setState({ reverseMonthAndYearMenus: reverse }));
 
+    private toggleLeftElement = handleBooleanChange(showLeftElement => this.setState({ showLeftElement }));
+
     private toggleRightElement = handleBooleanChange(showRightElement => this.setState({ showRightElement }));
 
     private toggleTimePickerArrows = handleBooleanChange(showTimePickerArrows =>
@@ -102,7 +106,8 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
     );
 
     public render() {
-        const { date, localeCode, showRightElement, showTimePickerArrows, useAmPm, ...spreadProps } = this.state;
+        const { date, localeCode, showRightElement, showLeftElement, showTimePickerArrows, useAmPm, ...spreadProps } =
+            this.state;
 
         return (
             <Example options={this.renderOptions()} {...this.props}>
@@ -113,6 +118,11 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
                     popoverProps={{ placement: "bottom" }}
                     rightElement={
                         showRightElement && <Icon icon="globe" intent="primary" style={{ padding: "7px 5px" }} />
+                    }
+                    leftElement={
+                        showLeftElement ? (
+                            <Icon icon="calendar" intent="primary" style={{ padding: "0px 2px" }} />
+                        ) : undefined
                     }
                     timePickerProps={
                         this.state.timePrecision === undefined
@@ -136,6 +146,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
             reverseMonthAndYearMenus: reverse,
             shortcuts,
             showActionsBar,
+            showLeftElement,
             showRightElement,
             showTimePickerArrows,
             showTimezoneSelect,
@@ -186,6 +197,15 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
                 </PropCodeTooltip>
                 <PropCodeTooltip snippet={`fill={${fill.toString()}}`}>
                     <Switch label="Fill container width" checked={fill} onChange={this.toggleFill} />
+                </PropCodeTooltip>
+                <PropCodeTooltip
+                    content={
+                        <>
+                            <Code>leftElement</Code> is {showLeftElement ? "defined" : "undefined"}
+                        </>
+                    }
+                >
+                    <Switch label="Show left element" checked={showLeftElement} onChange={this.toggleLeftElement} />
                 </PropCodeTooltip>
                 <PropCodeTooltip
                     content={


### PR DESCRIPTION
#### Fixes #6773 

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
- [x] Add Left element to date input 3

#### Reviewers should focus on:
- dateInput.tsx
- dateInput3.tsx
- dateInput3Example.tsx


#### Screenshot
![Screenshot 2024-04-22 at 08 07 01](https://github.com/palantir/blueprint/assets/166782331/4ab23ac3-e17c-4571-a3ff-cb883ddde52e)
![Screenshot 2024-04-22 at 08 07 15](https://github.com/palantir/blueprint/assets/166782331/b1b3642e-c671-449d-ba77-8675a3ad8c92)

