### PR TITLE
[Callout] Add rightElement prop

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6776.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6776.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Callout] Add rightElement prop'
+  links:
+  - https://github.com/palantir/blueprint/pull/6776

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -27,8 +27,11 @@ $callout-padding-compact: $pt-grid-size;
 
 .#{$ns}-callout {
   @include running-typography();
+  align-items: center;
   background-color: rgba($gray3, 0.15);
   border-radius: $pt-border-radius;
+  display: flex;
+  gap: $callout-padding;
   padding: $callout-padding;
   position: relative;
   width: 100%;

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -59,6 +59,11 @@ export interface CalloutProps extends IntentProps, Props, HTMLDivProps {
     intent?: Intent;
 
     /**
+     * Element to render on the right side.
+     */
+    rightElement?: React.ReactNode;
+
+    /**
      * String content of optional title element.
      *
      * Due to a conflict with the HTML prop types, to provide JSX content simply
@@ -78,10 +83,12 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Callout`;
 
     public render() {
-        const { className, children, icon, intent, title, compact, ...htmlProps } = this.props;
+        const { className, children, icon, intent, rightElement, title, compact, ...htmlProps } = this.props;
+        const hasBodyContent = !Utils.isReactNodeEmpty(children);
+
         const iconElement = this.renderIcon(icon, intent);
         const classes = classNames(Classes.CALLOUT, Classes.intentClass(intent), className, {
-            [Classes.CALLOUT_HAS_BODY_CONTENT]: !Utils.isReactNodeEmpty(children),
+            [Classes.CALLOUT_HAS_BODY_CONTENT]: hasBodyContent,
             [Classes.CALLOUT_ICON]: iconElement != null,
             [Classes.COMPACT]: compact,
         });
@@ -89,8 +96,13 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
         return (
             <div className={classes} {...htmlProps}>
                 {iconElement}
-                {title && <H5>{title}</H5>}
-                {children}
+                {(title != null || hasBodyContent) && (
+                    <div>
+                        {title && <H5>{title}</H5>}
+                        {children}
+                    </div>
+                )}
+                {rightElement != null && <div>{rightElement}</div>}
             </div>
         );
     }

--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 
 import { IconNames } from "@blueprintjs/icons";
 
-import { Callout, Classes, H5, Intent } from "../../src";
+import { Button, Callout, Classes, H5, Intent } from "../../src";
 
 describe("<Callout>", () => {
     let containerElement: HTMLElement | undefined;
@@ -66,5 +66,10 @@ describe("<Callout>", () => {
         // NOTE: JSX cannot be passed through `title` prop due to conflict with HTML props
         // @ts-expect-error
         mount(<Callout title={<em>typings fail</em>} />);
+    });
+
+    it("renders optional right element", () => {
+        const wrapper = mount(<Callout rightElement={<Button />} />, { attachTo: containerElement });
+        assert.isTrue(wrapper.find(`.${Classes.BUTTON}`).hostNodes().exists());
     });
 });

--- a/packages/docs-app/changelog/@unreleased/pr-6776.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-6776.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Callout] Add rightElement prop'
+  links:
+  - https://github.com/palantir/blueprint/pull/6776

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -29,6 +29,7 @@ export const CalloutExample: React.FC<DocsExampleProps> = props => {
     const [showTitle, setShowTitle] = React.useState(true);
     const [icon, setIcon] = React.useState<IconName>();
     const [intent, setIntent] = React.useState<Intent>();
+    const [isRightElementVisible, setIsRightElementVisible] = React.useState(false);
 
     /* eslint-disable react/jsx-key */
     const children = [
@@ -48,6 +49,11 @@ export const CalloutExample: React.FC<DocsExampleProps> = props => {
             <H5>Props</H5>
             <Switch checked={showTitle} label="Title" onChange={handleBooleanChange(setShowTitle)} />
             <Switch checked={compact} label="Compact" onChange={handleBooleanChange(setCompact)} />
+            <Switch
+                checked={isRightElementVisible}
+                label="Right element"
+                onChange={handleBooleanChange(setIsRightElementVisible)}
+            />
             <IntentSelect intent={intent} onChange={setIntent} showClearButton={true} />
             <IconSelect iconName={icon} onChange={setIcon} />
             <H5>Children</H5>
@@ -65,7 +71,11 @@ export const CalloutExample: React.FC<DocsExampleProps> = props => {
 
     return (
         <Example options={options} {...props}>
-            <Callout {...{ compact, intent, icon }} title={showTitle ? "Visually important content" : undefined}>
+            <Callout
+                {...{ compact, intent, icon }}
+                rightElement={isRightElementVisible ? <Button text="Button" /> : undefined}
+                title={showTitle ? "Visually important content" : undefined}
+            >
                 {children}
             </Callout>
         </Example>


### PR DESCRIPTION
#### Checklist

- [X] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `rightElement` prop to `Callout` component.

#### Screenshot

|Before|After|
|-|-|
|![image](https://github.com/palantir/blueprint/assets/54866207/9944aa7e-7ece-4ef1-ac5a-2d5e4ccec540)|![image](https://github.com/palantir/blueprint/assets/54866207/15f0d960-e9f1-4ad6-b20a-cb5c85e81ca7)|
|![image](https://github.com/palantir/blueprint/assets/54866207/603898fb-0a8a-4d8e-b7d0-0a67487fb1ff)|![image](https://github.com/palantir/blueprint/assets/54866207/d43ddd69-6858-4387-b622-dea973a78d5c)|
|![image](https://github.com/palantir/blueprint/assets/54866207/b81dc86b-3714-437e-a456-40c9eb778245)|![image](https://github.com/palantir/blueprint/assets/54866207/6c271709-59c8-4434-9303-c5c0de5a4fd5)|
|![image](https://github.com/palantir/blueprint/assets/54866207/9413123c-b067-447e-a0c4-123c196bc99a)|![image](https://github.com/palantir/blueprint/assets/54866207/84740f44-2f92-4818-b1f0-f9cd66b088c9)|

**`rightElement` as a button wrapped in a tooltip:**

![image](https://github.com/palantir/blueprint/assets/54866207/bd742da6-a923-4c82-9acf-9616062238d7)

**`rightElement` as long text:**

![image](https://github.com/palantir/blueprint/assets/54866207/ae771ce6-d8fc-49a0-902a-2f2d9a206432)