### PR TITLE
Fix DateRangeInput3 closing on time change in Examples

### DIFF
--- a/packages/datetime2/changelog/@unreleased/pr-6782.v2.yml
+++ b/packages/datetime2/changelog/@unreleased/pr-6782.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix DateRangeInput3 closing on time change
+  links:
+  - https://github.com/palantir/blueprint/pull/6782

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -308,7 +308,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
 
         if (selectedStart == null) {
             // focus the start field by default or if only an end date is specified
-            if (this.props.timePickerProps?.precision == null) {
+            if (this.props.timePrecision == null) {
                 isStartInputFocused = true;
                 isEndInputFocused = false;
             } else {
@@ -321,7 +321,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             startHoverString = null;
         } else if (selectedEnd == null) {
             // focus the end field if a start date is specified
-            if (this.props.timePickerProps?.precision == null) {
+            if (this.props.timePrecision == null) {
                 isStartInputFocused = false;
                 isEndInputFocused = true;
             } else {
@@ -335,7 +335,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             isOpen = this.getIsOpenValueWhenDateChanges(selectedStart, selectedEnd);
             isStartInputFocused = false;
 
-            if (this.props.timePickerProps?.precision == null && didSubmitWithEnter) {
+            if (this.props.timePrecision == null && didSubmitWithEnter) {
                 // if we submit via click or Tab, the focus will have moved already.
                 // it we submit with Enter, the focus won't have moved, and setting
                 // the flag to false won't have an effect anyway, so leave it true.
@@ -346,7 +346,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             }
         } else if (this.state.lastFocusedField === Boundary.START) {
             // keep the start field focused
-            if (this.props.timePickerProps?.precision == null) {
+            if (this.props.timePrecision == null) {
                 isStartInputFocused = true;
                 isEndInputFocused = false;
             } else {
@@ -354,7 +354,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
                 isEndInputFocused = false;
                 boundaryToModify = Boundary.START;
             }
-        } else if (this.props.timePickerProps?.precision == null) {
+        } else if (this.props.timePrecision == null) {
             // keep the end field focused
             isStartInputFocused = false;
             isEndInputFocused = true;
@@ -680,7 +680,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private getIsOpenValueWhenDateChanges = (nextSelectedStart: Date, nextSelectedEnd: Date): boolean => {
         if (this.props.closeOnSelection) {
             // trivial case when TimePicker is not shown
-            if (this.props.timePickerProps?.precision == null) {
+            if (this.props.timePrecision == null) {
                 return false;
             }
 

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -308,7 +308,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
 
         if (selectedStart == null) {
             // focus the start field by default or if only an end date is specified
-            if (this.props.timePrecision == null) {
+            if (this.props.timePickerProps?.precision == null) {
                 isStartInputFocused = true;
                 isEndInputFocused = false;
             } else {
@@ -321,7 +321,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             startHoverString = null;
         } else if (selectedEnd == null) {
             // focus the end field if a start date is specified
-            if (this.props.timePrecision == null) {
+            if (this.props.timePickerProps?.precision == null) {
                 isStartInputFocused = false;
                 isEndInputFocused = true;
             } else {
@@ -335,7 +335,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             isOpen = this.getIsOpenValueWhenDateChanges(selectedStart, selectedEnd);
             isStartInputFocused = false;
 
-            if (this.props.timePrecision == null && didSubmitWithEnter) {
+            if (this.props.timePickerProps?.precision == null && didSubmitWithEnter) {
                 // if we submit via click or Tab, the focus will have moved already.
                 // it we submit with Enter, the focus won't have moved, and setting
                 // the flag to false won't have an effect anyway, so leave it true.
@@ -346,7 +346,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             }
         } else if (this.state.lastFocusedField === Boundary.START) {
             // keep the start field focused
-            if (this.props.timePrecision == null) {
+            if (this.props.timePickerProps?.precision == null) {
                 isStartInputFocused = true;
                 isEndInputFocused = false;
             } else {
@@ -354,7 +354,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
                 isEndInputFocused = false;
                 boundaryToModify = Boundary.START;
             }
-        } else if (this.props.timePrecision == null) {
+        } else if (this.props.timePickerProps?.precision == null) {
             // keep the end field focused
             isStartInputFocused = false;
             isEndInputFocused = true;
@@ -680,7 +680,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private getIsOpenValueWhenDateChanges = (nextSelectedStart: Date, nextSelectedEnd: Date): boolean => {
         if (this.props.closeOnSelection) {
             // trivial case when TimePicker is not shown
-            if (this.props.timePrecision == null) {
+            if (this.props.timePickerProps?.precision == null) {
                 return false;
             }
 

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -105,14 +105,14 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateRangeChange}
-                    timePrecision={
-                        showTimePicker
-                            ? timePrecision
-                            : undefined
-                    }
                     timePickerProps={
                         showTimePicker
                             ? { precision: timePrecision, showArrowButtons: showTimeArrowButtons, useAmPm }
+                            : undefined
+                    }
+                    timePrecision={
+                        showTimePicker
+                            ? timePrecision
                             : undefined
                     }
                 />

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -105,6 +105,11 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateRangeChange}
+                    timePrecision={
+                        showTimePicker
+                            ? timePrecision
+                            : undefined
+                    }
                     timePickerProps={
                         showTimePicker
                             ? { precision: timePrecision, showArrowButtons: showTimeArrowButtons, useAmPm }

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -110,11 +110,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                             ? { precision: timePrecision, showArrowButtons: showTimeArrowButtons, useAmPm }
                             : undefined
                     }
-                    timePrecision={
-                        showTimePicker
-                            ? timePrecision
-                            : undefined
-                    }
+                    timePrecision={showTimePicker ? timePrecision : undefined}
                 />
                 <FormattedDateRange range={dateRange} showTime={showTimePicker} />
             </Example>


### PR DESCRIPTION
`this.props.timePrecision` which is supposed to be an alias for `this.props.timePickerProps.precision` seems to be never set and is always null.

I tried going down the rabbit hole to figure out how to update it properly, but it's just a can of worms.
Contributing a solution to the docs: it's not elegant, but it works