### PR TITLE
[core] fix: toasters closing immediately on hover if `timeout` is set to 0

### DIFF
--- a/packages/core/src/components/toast/toast2.tsx
+++ b/packages/core/src/components/toast/toast2.tsx
@@ -43,12 +43,15 @@ export const Toast2 = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) 
     const startTimeout = React.useCallback(() => setIsTimeoutStarted(true), []);
     const clearTimeout = React.useCallback(() => setIsTimeoutStarted(false), []);
 
+    // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
+    const isTimeoutEnabled = timeout != null && timeout > 0;
+
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state
     useTimeout(
         () => {
             triggerDismiss(true);
         },
-        isTimeoutStarted && timeout !== undefined ? timeout : null,
+        isTimeoutStarted && isTimeoutEnabled ? timeout : null,
     );
 
     // start timeout on mount or change, cancel on unmount


### PR DESCRIPTION
Fixes https://github.com/palantir/blueprint/issues/6742, which was a regression from https://github.com/palantir/blueprint/pull/6656 / `@blueprintjs/core@5.9.0`.

## Context

The [docs](https://github.com/palantir/blueprint/assets/906558/7d20f9cd-4066-4e75-b5e0-1a36a15e8f12) specify that a `timeout` prop of `0` will cause toasts to persist until a user manually dismisses it.

> Milliseconds to wait before automatically dismissing toast. Providing a value less than or equal to 0 will disable the timeout (this is discouraged).

<img width="804" alt="Screenshot 2024-05-02 at 11 29 05 PM" src="https://github.com/palantir/blueprint/assets/906558/cbf14a54-0b6b-4091-9406-792f2d819ad4">

## Problem

In a semi-recent refactor of the `<OverlayToaster>` component, a `timeout` value of `0` caused the toaster to instead be immediately dismissed. Note how hovering in and out of a progress toast causes it to disappear.

https://github.com/palantir/blueprint/assets/906558/7d20f9cd-4066-4e75-b5e0-1a36a15e8f12

## Explanation

The new `<Toast2>` implementation does properly check if the `timeout` prop is `0` or negative on initial mount.

https://github.com/palantir/blueprint/blob/488658d901b2704673450c9c7d9fb923660e3c6e/packages/core/src/components/toast/toast2.tsx#L54-L57

However, it's incorrect on the pause/resume timeout logic that happens when users mouse over a toaster. This logic always starts a timeout on mouse out, even if the timeout is `0`. The original `<Toast>` implementation didn't do this.

https://github.com/palantir/blueprint/blob/488658d901b2704673450c9c7d9fb923660e3c6e/packages/core/src/components/toast/toast2.tsx#L87-L88

## Changes

Copying the logic from the original implementation, which doesn't schedule a timeout at all if it's `0`.

https://github.com/palantir/blueprint/blob/9dfba77ec5094c7752e5b73eb49a7e72dced9dcb/packages/core/src/components/toast/toast.tsx#L117-LL122

https://github.com/palantir/blueprint/assets/906558/3f40ffb9-609c-40a7-a50f-8cb86b937356

