### PR TITLE
[core] style: comment why start/clear timeout handlers are attached to mouse events

### DIFF
--- a/packages/core/src/components/toast/toast2.tsx
+++ b/packages/core/src/components/toast/toast2.tsx
@@ -82,6 +82,9 @@ export const Toast2 = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) 
     return (
         <div
             className={classNames(Classes.TOAST, Classes.intentClass(intent), className)}
+            // Pause timeouts if users are hovering over or click on the toast. The toast may have
+            // actions the user wants to click. It'd be a poor experience to "pull the toast" out
+            // from under them.
             onBlur={startTimeout}
             onFocus={clearTimeout}
             onMouseEnter={clearTimeout}


### PR DESCRIPTION
While looking at https://github.com/palantir/blueprint/pull/6783, It took me a minute to realize why `onMouseEnter`/`onMouseLeave` events were being registered for toasters in the first place.