### PR TITLE
[core] refactor: Use `isTimeoutEnabled` constant in other parts of `<Toast2>`

### DIFF
--- a/packages/core/src/components/toast/toast2.tsx
+++ b/packages/core/src/components/toast/toast2.tsx
@@ -56,13 +56,13 @@ export const Toast2 = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) 
 
     // start timeout on mount or change, cancel on unmount
     React.useEffect(() => {
-        if (timeout != null && timeout > 0) {
+        if (isTimeoutEnabled) {
             startTimeout();
         } else {
             clearTimeout();
         }
         return clearTimeout;
-    }, [clearTimeout, startTimeout, timeout]);
+    }, [clearTimeout, startTimeout, isTimeoutEnabled, timeout]);
 
     const triggerDismiss = React.useCallback(
         (didTimeoutExpire: boolean) => {


### PR DESCRIPTION
Optional change on top of https://github.com/palantir/blueprint/pull/6783. This should be a no-op.