### PR TITLE
fix(menu): remove negative margin to prevent horizontal scroll

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -305,8 +305,7 @@ $dark-menu-item-intent-colors: (
 @mixin menu-divider() {
   border-top: 1px solid $pt-divider-black;
   display: block;
-  // use negative margin to make dividers take up full menu width
-  margin: $half-grid-size (-$half-grid-size);
+  margin: $half-grid-size 0;
 
   .#{$ns}-dark & {
     border-top-color: $pt-dark-divider-white;


### PR DESCRIPTION
#### Fixes #6780

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Previously in this PR https://github.com/palantir/blueprint/pull/6269, `menu-header` (or `menu-divider`) had negative horizontal margin to make "dividers take up full menu width".

However this caused horizontal overflow and scroll. Removing the horizontal margin solves the scroll behavior.

#### Reviewers should focus on:

Previous PR doesn't really give the reason why it should have negative margin to achieve full width, while it already is taking full width.

If the negative margin was there just to make the header take the full width, negative margin is not needed and should be removed.

AS-IS

<img width="1276" alt="Screenshot 2024-05-03 at 15 18 42" src="https://github.com/palantir/blueprint/assets/48273875/a6325613-6f75-4e0f-bbee-3ad84dd14460">

TO-BE

<img width="1130" alt="Screenshot 2024-05-03 at 15 19 30" src="https://github.com/palantir/blueprint/assets/48273875/f628f688-bb99-402c-a988-1b7d9f020d72">

#### Screenshot

`<Select />` where negative margin header is removed.

<img width="1308" alt="Screenshot 2024-05-03 at 15 28 57" src="https://github.com/palantir/blueprint/assets/48273875/66ad3b28-b9be-46c4-b862-a379b9accc5a">

