### PR TITLE
[Button Group] Add outlined prop

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6788.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6788.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Button Group] Add outlined prop'
+  links:
+  - https://github.com/palantir/blueprint/pull/6788

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -35,6 +35,7 @@ Markup:
 .#{$ns}-fill - Buttons expand equally to fill container
 .#{$ns}-large - Use large buttons
 .#{$ns}-minimal - Use minimal buttons
+.#{$ns}-outlined - Use outlined buttons
 .#{$ns}-vertical - Vertical layout
 
 Styleguide button-group
@@ -96,7 +97,7 @@ Styleguide button-group
   }
 
   // support wrapping buttons in a tooltip, which adds a wrapper element
-  &:not(.#{$ns}-minimal) {
+  &:not(.#{$ns}-minimal), &.#{$ns}-outlined  {
     > .#{$ns}-popover-wrapper:not(:first-child) .#{$ns}-button,
     > .#{$ns}-button:not(:first-child) {
       border-bottom-left-radius: 0;
@@ -111,7 +112,7 @@ Styleguide button-group
     }
   }
 
-  &.#{$ns}-minimal {
+  &.#{$ns}-minimal, &.#{$ns}-outlined {
     .#{$ns}-button {
       @include pt-button-minimal();
     }
@@ -131,6 +132,12 @@ Styleguide button-group
         border-top-right-radius: 0;
         margin-right: -$button-border-width;
       }
+    }
+  }
+
+  &.#{$ns}-outlined {
+    .#{$ns}-button {
+      @include pt-button-outlined();
     }
   }
 
@@ -213,7 +220,7 @@ Styleguide button-group
       width: 100%;
     }
 
-    &:not(.#{$ns}-minimal) {
+    &:not(.#{$ns}-minimal), &.#{$ns}-outlined {
       > .#{$ns}-popover-wrapper:first-child .#{$ns}-button,
       > .#{$ns}-button:first-child {
         border-radius: $pt-border-radius $pt-border-radius 0 0;

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -108,6 +108,12 @@ Styleguide button-group
     > .#{$ns}-button:not(:last-child) {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
+    }
+  }
+
+  &:not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
+    > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
+    > .#{$ns}-button:not(:last-child) {
       margin-right: -$button-border-width;
     }
   }
@@ -138,6 +144,12 @@ Styleguide button-group
   &.#{$ns}-outlined {
     .#{$ns}-button {
       @include pt-button-outlined();
+    }
+
+    &:not(.#{$ns}-vertical) {
+      .#{$ns}-button:not(:last-child) {
+        border-right: none;
+      }
     }
   }
 
@@ -218,6 +230,10 @@ Styleguide button-group
       margin-right: 0 !important; /* stylelint-disable-line declaration-no-important */
       // needed to ensure buttons take up the full width when wrapped in a Popover:
       width: 100%;
+
+      &:not(:last-child) {
+        border-bottom: none;
+      }
     }
 
     &:not(.#{$ns}-minimal), &.#{$ns}-outlined {
@@ -230,7 +246,9 @@ Styleguide button-group
       > .#{$ns}-button:last-child {
         border-radius: 0 0 $pt-border-radius $pt-border-radius;
       }
+    }
 
+    &:not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         margin-bottom: -$button-border-width;

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -97,7 +97,7 @@ Styleguide button-group
   }
 
   // support wrapping buttons in a tooltip, which adds a wrapper element
-  &:not(.#{$ns}-minimal), &.#{$ns}-outlined  {
+  &:not(.#{$ns}-minimal), &.#{$ns}-outlined {
     > .#{$ns}-popover-wrapper:not(:first-child) .#{$ns}-button,
     > .#{$ns}-button:not(:first-child) {
       border-bottom-left-radius: 0;

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -142,12 +142,12 @@ Styleguide button-group
   }
 
   &.#{$ns}-outlined {
-    .#{$ns}-button {
+    > .#{$ns}-button {
       @include pt-button-outlined();
     }
 
     &:not(.#{$ns}-vertical) {
-      .#{$ns}-button:not(:last-child) {
+      > .#{$ns}-button:not(:last-child) {
         border-right: none;
       }
     }
@@ -230,10 +230,6 @@ Styleguide button-group
       margin-right: 0 !important; /* stylelint-disable-line declaration-no-important */
       // needed to ensure buttons take up the full width when wrapped in a Popover:
       width: 100%;
-
-      &:not(:last-child) {
-        border-bottom: none;
-      }
     }
 
     &:not(.#{$ns}-minimal), &.#{$ns}-outlined {
@@ -252,6 +248,12 @@ Styleguide button-group
       > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         margin-bottom: -$button-border-width;
+      }
+    }
+
+    &.#{$ns}-outlined {
+      > .#{$ns}-button:not(:last-child) {
+        border-bottom: none;
       }
     }
   }

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -47,6 +47,13 @@ export interface ButtonGroupProps extends Props, HTMLDivProps, React.RefAttribut
     minimal?: boolean;
 
     /**
+     * Whether the child buttons should use outlined styles.
+     *
+     * @default false
+     */
+    outlined?: boolean;
+
+    /**
      * Whether the child buttons should appear with large styling.
      *
      * @default false
@@ -70,13 +77,14 @@ export interface ButtonGroupProps extends Props, HTMLDivProps, React.RefAttribut
  */
 export const ButtonGroup: React.FC<ButtonGroupProps> = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
     (props, ref) => {
-        const { alignText, className, fill, minimal, large, vertical, ...htmlProps } = props;
+        const { alignText, className, fill, minimal, outlined, large, vertical, ...htmlProps } = props;
         const buttonGroupClasses = classNames(
             Classes.BUTTON_GROUP,
             {
                 [Classes.FILL]: fill,
                 [Classes.LARGE]: large,
                 [Classes.MINIMAL]: minimal,
+                [Classes.OUTLINED]: outlined,
                 [Classes.VERTICAL]: vertical,
             },
             Classes.alignmentClass(alignText),

--- a/packages/docs-app/changelog/@unreleased/pr-6788.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-6788.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: '[Button Group] Add outlined prop'
+  links:
+  - https://github.com/palantir/blueprint/pull/6788

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExample.tsx
@@ -39,6 +39,7 @@ export interface ButtonGroupExampleState {
     iconOnly: boolean;
     intent: Intent;
     minimal: boolean;
+    outlined: boolean;
     large: boolean;
     vertical: boolean;
 }
@@ -51,6 +52,7 @@ export class ButtonGroupExample extends React.PureComponent<ExampleProps, Button
         intent: Intent.NONE,
         large: false,
         minimal: false,
+        outlined: false,
         vertical: false,
     };
 
@@ -63,6 +65,8 @@ export class ButtonGroupExample extends React.PureComponent<ExampleProps, Button
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
+
+    private handleOutlinedChange = handleBooleanChange(outlined => this.setState({ outlined }));
 
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
@@ -96,6 +100,7 @@ export class ButtonGroupExample extends React.PureComponent<ExampleProps, Button
                 <Switch checked={this.state.fill} label="Fill" onChange={this.handleFillChange} />
                 <Switch checked={this.state.large} label="Large" onChange={this.handleLargeChange} />
                 <Switch checked={this.state.minimal} label="Minimal" onChange={this.handleMinimalChange} />
+                <Switch checked={this.state.outlined} label="Outlined" onChange={this.handleOutlinedChange} />
                 <Switch checked={this.state.vertical} label="Vertical" onChange={this.handleVerticalChange} />
                 <IntentSelect intent={this.state.intent} label={intentLabelInfo} onChange={this.handleIntentChange} />
                 <AlignmentSelect align={this.state.alignText} onChange={this.handleAlignChange} />


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `outlined` prop to `ButtonGroup` component.

#### Screenshot

|No outline|Outlined (new changes)|Regular Button|
|-|-|-|
|<img width="796" alt="image" src="https://github.com/palantir/blueprint/assets/54866207/ecc3a597-e18a-4117-a075-790648e739d6">|![image](https://github.com/palantir/blueprint/assets/54866207/a50d1bb9-0afa-4018-ab97-840cae63734f)|<img width="796" alt="image" src="https://github.com/palantir/blueprint/assets/54866207/7676cbe2-23b0-46fb-9983-4a3315197ae4">|
|<img width="796" alt="image" src="https://github.com/palantir/blueprint/assets/54866207/e8712928-1c29-44cd-a1b7-69dc774354e6">|![image](https://github.com/palantir/blueprint/assets/54866207/96001b70-9027-44d8-9552-0446fd83e459)||
|<img width="796" alt="image" src="https://github.com/palantir/blueprint/assets/54866207/838110cc-ef3f-413c-82f7-8cb52c139eca">|![image](https://github.com/palantir/blueprint/assets/54866207/dd40e35c-b159-4c26-96ef-6c6572bfd83e)|<img width="796" alt="image" src="https://github.com/palantir/blueprint/assets/54866207/0c506be0-6902-442f-aa8a-6732d1f9ad1f">|
