### PR TITLE
core fix(Menu Item): Add subMenuCaretTitle field to MenuItemProps

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6791.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6791.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow "Open Sub Menu" title overrides
+  links:
+  - https://github.com/palantir/blueprint/pull/6791

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -166,11 +166,11 @@ export interface MenuItemProps
     htmlTitle?: string;
 
     /**
-     * HTML title for the submenu's <CaretRight> component
-     * 
+     * HTML title for the `<CaretRight>` icon that indicates this item has a submenu.
+     *
      * @default "Open Sub Menu"
      */
-    openSubMenuTitle?: string;
+    subMenuCaretTitle?: string;
 }
 
 /**
@@ -198,7 +198,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
         textClassName,
         tagName = "a",
         htmlTitle,
-        openSubMenuTitle = "Open Sub Menu",
+        subMenuCaretTitle = "Open Sub Menu",
         ...htmlProps
     } = props;
 
@@ -280,7 +280,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             {text}
         </Text>,
         maybeLabel,
-        hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title={openSubMenuTitle} /> : undefined,
+        hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title={subMenuCaretTitle} /> : undefined,
     );
 
     const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -164,6 +164,13 @@ export interface MenuItemProps
      * HTML title to be passed to the <Text> component
      */
     htmlTitle?: string;
+
+    /**
+     * HTML title for the submenu's <CaretRight> component
+     * 
+     * @default "Open Sub Menu"
+     */
+    openSubMenuTitle?: string;
 }
 
 /**
@@ -191,6 +198,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
         textClassName,
         tagName = "a",
         htmlTitle,
+        openSubMenuTitle = "Open Sub Menu",
         ...htmlProps
     } = props;
 
@@ -272,7 +280,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             {text}
         </Text>,
         maybeLabel,
-        hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" /> : undefined,
+        hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title={openSubMenuTitle} /> : undefined,
     );
 
     const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -19,6 +19,7 @@ import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
 import * as React from "react";
 import { spy } from "sinon";
 
+import { CaretRight } from "@blueprintjs/icons";
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
 import {
@@ -198,6 +199,16 @@ describe("MenuItem", () => {
         assert.match(label.text(), /^label text/);
         assert.strictEqual(label.find("article").text(), "label element");
     });
+
+    it("submenu caret icon recieves overriden title", () => {
+        const overridenCaretTitle = "Open The Sub Menu";
+        const wrapper = shallow(
+            <MenuItem text="text" subMenuCaretTitle={overridenCaretTitle} >
+                <MenuItem icon="bold" text="Bold" />
+            </MenuItem>
+        );
+        assert.strictEqual(wrapper.find(CaretRight).prop("title"), overridenCaretTitle);
+    })
 });
 
 function findSubmenu(wrapper: ShallowWrapper<any, any>) {

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -203,12 +203,12 @@ describe("MenuItem", () => {
     it("submenu caret icon recieves overriden title", () => {
         const overridenCaretTitle = "Open The Sub Menu";
         const wrapper = shallow(
-            <MenuItem text="text" subMenuCaretTitle={overridenCaretTitle} >
+            <MenuItem text="text" subMenuCaretTitle={overridenCaretTitle}>
                 <MenuItem icon="bold" text="Bold" />
-            </MenuItem>
+            </MenuItem>,
         );
         assert.strictEqual(wrapper.find(CaretRight).prop("title"), overridenCaretTitle);
-    })
+    });
 });
 
 function findSubmenu(wrapper: ShallowWrapper<any, any>) {


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:
The `Open Sub Menu` title is not derived from any user controlled props. This means we can't internationalize it.

A new `subMenuCaretTitle` prop was added to the MenuItemsProp.

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

New Docs: 
<img width="778" alt="Screenshot 2024-05-10 at 4 46 19 PM" src="https://github.com/palantir/blueprint/assets/51128541/dea05eb7-6f2e-4c11-85f9-faa5460a507d">

Caret title in question:
<img width="833" alt="Screenshot 2024-05-10 at 4 21 40 PM" src="https://github.com/palantir/blueprint/assets/51128541/6e971148-054e-46be-85da-da8dba1f51b5">


