### PR TITLE
chore: reduce Webpack log noise due to missing source maps in external deps

### DIFF
--- a/packages/webpack-build-scripts/webpack.config.base.mjs
+++ b/packages/webpack-build-scripts/webpack.config.base.mjs
@@ -157,7 +157,18 @@ export default {
         rules: [
             {
                 test: /\.js$/,
-                use: fileURLToPath(import.meta.resolve("source-map-loader")),
+                loader: fileURLToPath(import.meta.resolve("source-map-loader")),
+                options: {
+                    filterSourceMappingUrl: (_url, resourcePath) => {
+                        // These external modules (e.g. parse5) contain #sourceMappingUrl comments that point towards
+                        // non-existent files. Skip them to reduce Webpack noise.
+                        if (/\/node_modules\/(parse5|parse5-htmlparser2-tree-adapter)\//i.test(resourcePath)) {
+                            return "skip";
+                        }
+
+                        return true;
+                    },
+                },
             },
             {
                 test: /\.tsx?$/,

--- a/packages/webpack-build-scripts/webpack.config.karma.mjs
+++ b/packages/webpack-build-scripts/webpack.config.karma.mjs
@@ -35,7 +35,18 @@ export default {
         rules: [
             {
                 test: /\.js$/,
-                use: fileURLToPath(import.meta.resolve("source-map-loader")),
+                loader: fileURLToPath(import.meta.resolve("source-map-loader")),
+                options: {
+                    filterSourceMappingUrl: (_url, resourcePath) => {
+                        // These external modules (e.g. parse5) contain #sourceMappingUrl comments that point towards
+                        // non-existent files. Skip them to reduce Webpack noise.
+                        if (/\/node_modules\/(parse5|parse5-htmlparser2-tree-adapter)\//i.test(resourcePath)) {
+                            return "skip";
+                        }
+
+                        return true;
+                    },
+                },
             },
             {
                 test: /\.tsx?$/,


### PR DESCRIPTION
## Problem

I was running `yarn test:karma` locally in `packages/core` and was confused by whether I was running tests correctly due to the long (500+) lines of errors.

<details>
<summary> Click to expand logs

```
❯ yarn test:karma
```

</summary>

```
13 05 2024 14:32:22.780:WARN [filelist]: Pattern "/Volumes/git/blueprint/packages/core/resources/**/*" does not match any file.
13 05 2024 14:32:22.782:WARN [filelist]: All files matched by "/Volumes/git/blueprint/packages/core/lib/css/blueprint.css" were excluded or matched by prior matchers.
Webpack bundling...
[
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js',
    moduleName: '../../node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map'",
    moduleId: '../../node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js',
    moduleName: '../../node_modules/parse5/dist/cjs/common/doctype.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/common/doctype.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js',
    moduleName: '../../node_modules/parse5/dist/cjs/common/error-codes.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/common/error-codes.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js',
    moduleName: '../../node_modules/parse5/dist/cjs/common/foreign-content.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/common/foreign-content.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js',
    moduleName: '../../node_modules/parse5/dist/cjs/common/html.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/common/html.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js',
    moduleName: '../../node_modules/parse5/dist/cjs/common/token.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/common/token.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js',
    moduleName: '../../node_modules/parse5/dist/cjs/common/unicode.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/common/unicode.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js',
    moduleName: '../../node_modules/parse5/dist/cjs/index.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/index.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js',
    moduleName: '../../node_modules/parse5/dist/cjs/parser/formatting-element-list.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/parser/formatting-element-list.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js',
    moduleName: '../../node_modules/parse5/dist/cjs/parser/index.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/parser/index.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js',
    moduleName: '../../node_modules/parse5/dist/cjs/parser/open-element-stack.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/parser/open-element-stack.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js',
    moduleName: '../../node_modules/parse5/dist/cjs/serializer/index.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/serializer/index.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js',
    moduleName: '../../node_modules/parse5/dist/cjs/tokenizer/index.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/tokenizer/index.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js',
    moduleName: '../../node_modules/parse5/dist/cjs/tokenizer/preprocessor.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/tokenizer/preprocessor.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  },
  {
    moduleIdentifier: 'javascript/dynamic|/Volumes/git/blueprint/node_modules/source-map-loader/dist/cjs.js!/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js',
    moduleName: '../../node_modules/parse5/dist/cjs/tree-adapters/default.js',
    message: 'Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map'",
    moduleId: '../../node_modules/parse5/dist/cjs/tree-adapters/default.js',
    moduleTrace: [
      [Object], [Object],
      [Object], [Object],
      [Object], [Object],
      [Object], [Object]
    ],
    details: "Error: Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map'\n" +
      '    at fetchFromFilesystem (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:115:11)\n' +
      '    at async fetchFromURL (/Volumes/git/blueprint/node_modules/source-map-loader/dist/utils.js:208:9)\n' +
      '    at async Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:51:9)',
    stack: 'ModuleWarning: Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):\n' +
      "Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map'\n" +
      '    at Object.emitWarning (/Volumes/git/blueprint/node_modules/webpack/lib/NormalModule.js:604:6)\n' +
      '    at Object.loader (/Volumes/git/blueprint/node_modules/source-map-loader/dist/index.js:53:10)'
  }
]
asset commons.js 38 MiB [emitted] (name: commons) (id hint: commons)
asset runtime.js 18.6 KiB [emitted] (name: runtime)
asset index.2009024626.js 496 bytes [emitted] (name: index.2009024626)
Entrypoint index.2009024626 38 MiB = runtime.js 18.6 KiB commons.js 38 MiB index.2009024626.js 496 bytes

WARNING in ../../node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5-htmlparser2-tree-adapter/dist/cjs/index.js.map'
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 15:40-82
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/common/doctype.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/doctype.js.map'
 @ ../../node_modules/parse5/dist/cjs/parser/index.js 8:16-47
 @ ../../node_modules/parse5/dist/cjs/index.js 4:19-47 7:17-45
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/common/error-codes.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/error-codes.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 12:23-57
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/common/foreign-content.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/foreign-content.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 15:0-63
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/common/html.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/html.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 17:0-42
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/common/token.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/token.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 19:0-44
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/common/unicode.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/common/unicode.js.map'
 @ ../../node_modules/parse5/dist/cjs/tokenizer/index.js 5:21-52
 @ ../../node_modules/parse5/dist/cjs/index.js 21:17-48
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/index.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/index.js.map'
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/parser/formatting-element-list.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/formatting-element-list.js.map'
 @ ../../node_modules/parse5/dist/cjs/parser/index.js 6:37-76
 @ ../../node_modules/parse5/dist/cjs/index.js 4:19-47 7:17-45
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/parser/index.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/index.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 4:19-47 7:17-45
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/parser/open-element-stack.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/parser/open-element-stack.js.map'
 @ ../../node_modules/parse5/dist/cjs/parser/index.js 5:32-66
 @ ../../node_modules/parse5/dist/cjs/index.js 4:19-47 7:17-45
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/serializer/index.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/serializer/index.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 9:17-49
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/tokenizer/index.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/index.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 21:17-48
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/tokenizer/preprocessor.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tokenizer/preprocessor.js.map'
 @ ../../node_modules/parse5/dist/cjs/tokenizer/index.js 4:26-54
 @ ../../node_modules/parse5/dist/cjs/index.js 21:17-48
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

WARNING in ../../node_modules/parse5/dist/cjs/tree-adapters/default.js
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map' file: Error: ENOENT: no such file or directory, open '/Volumes/git/blueprint/node_modules/parse5/dist/cjs/tree-adapters/default.js.map'
 @ ../../node_modules/parse5/dist/cjs/index.js 5:19-56
 @ ../../node_modules/cheerio/lib/parsers/parse5-adapter.js 14:15-32
 @ ../../node_modules/cheerio/lib/index.js 41:26-64
 @ ../../node_modules/enzyme/build/Utils.js 80:15-33
 @ ../../node_modules/enzyme/build/ReactWrapper.js 23:13-31
 @ ../../node_modules/enzyme/build/index.js 3:20-45
 @ ./test/alert/alertTests.tsx 20:14-31
 @ ./test/index.ts 24:0-25:21

15 warnings have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.90.0 compiled with 15 warnings in 12799 ms
13 05 2024 14:32:37.848:WARN [filelist]: Pattern "/Volumes/git/blueprint/packages/core/resources/**/*" does not match any file.
13 05 2024 14:32:37.849:WARN [filelist]: All files matched by "/Volumes/git/blueprint/packages/core/lib/css/blueprint.css" were excluded or matched by prior matchers.
13 05 2024 14:32:38.051:INFO [karma-server]: Karma v6.4.2 server started at http://localhost:9876/
13 05 2024 14:32:38.051:INFO [launcher]: Launching browsers ChromeHeadless with concurrency unlimited
13 05 2024 14:32:38.055:INFO [launcher]: Starting browser ChromeHeadless
13 05 2024 14:32:39.044:INFO [Chrome Headless 124.0.6367.201 (Mac OS 10.15.7)]: Connected on socket oiWgZA8BEmjPfc-nAAAB with id 32547597
     ______________________________________________________________________________
 ⠦   o
     ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
```

</details>

## Changes

I realized this isn't unique to my local setup since this happens on CI too.

Let's [configure `source-map-loader](https://webpack.js.org/loaders/source-map-loader/) to ignore `parse5` and `parse5-htmlparser2-tree-adapter` so developers working on Blueprint in the future aren't as confused by this.