### PR TITLE
chore: update pinned Chrome version used in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
+  browser-tools: circleci/browser-tools@1.4.8
 
 aliases:
   - &docker-node-image
@@ -148,11 +148,10 @@ jobs:
       - restore_cache: *restore-node-modules-cache
       - attach_workspace: { at: "." }
       - run: sudo corepack enable
-      # HACKHACK: pin Chrome version to work around bug in v115
-      # see https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: "114.0.5735.90"
+          chrome-version: "124.0.6367.201"
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:


### PR DESCRIPTION
This version pin was added in https://github.com/palantir/blueprint/pull/6287. I think the originally referenced issue is fixed now.