### PR TITLE
feat(section): added bordered prop to section component

### DIFF
--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -56,6 +56,13 @@ export interface CardProps extends Props, HTMLDivProps, React.RefAttributes<HTML
     compact?: boolean;
 
     /**
+     * Whether the card should have visual border styling.
+     *
+     * @default true
+     */
+    bordered?: boolean;
+
+    /**
      * Callback invoked when the card is clicked.
      * Recommended when `interactive` is `true`.
      */
@@ -68,8 +75,9 @@ export interface CardProps extends Props, HTMLDivProps, React.RefAttributes<HTML
  * @see https://blueprintjs.com/docs/#core/components/card
  */
 export const Card: React.FC<CardProps> = React.forwardRef((props, ref) => {
-    const { className, elevation, interactive, selected, compact, ...htmlProps } = props;
-    const classes = classNames(className, Classes.CARD, Classes.elevationClass(elevation!), {
+    const { className, elevation, interactive, selected, compact, bordered, ...htmlProps } = props;
+    const classes = classNames(className, Classes.CALLOUT, {
+        [Classes.elevationClass(elevation!)]: bordered,
         [Classes.INTERACTIVE]: interactive,
         [Classes.COMPACT]: compact,
         [Classes.SELECTED]: selected,
@@ -77,6 +85,7 @@ export const Card: React.FC<CardProps> = React.forwardRef((props, ref) => {
     return <div className={classes} ref={ref} {...htmlProps} />;
 });
 Card.defaultProps = {
+    bordered: true,
     elevation: Elevation.ZERO,
     interactive: false,
 };

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -113,6 +113,13 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
     title?: React.JSX.Element | string;
 
     /**
+     * Whether the section should have visual border styling.
+     *
+     * @default true
+     */
+    bordered?: boolean;
+
+    /**
      * Optional title renderer function. If provided, it is recommended to include a Blueprint `<H6>` element
      * as part of the title. The render function is supplied with `className` and `id` attributes which you must
      * forward to the DOM. The `title` prop is also passed along to this renderer via `props.children`.
@@ -140,6 +147,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
         subtitle,
         title,
         titleRenderer = H6,
+        bordered,
         ...htmlProps
     } = props;
     // Determine whether to use controlled or uncontrolled state.
@@ -162,6 +170,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
 
     const sectionId = uniqueId("section");
     const sectionTitleId = title ? uniqueId("section-title") : undefined;
+    console.log({ section: bordered });
 
     return (
         <Card
@@ -174,6 +183,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
             aria-labelledby={sectionTitleId}
             {...htmlProps}
             id={sectionId}
+            bordered={bordered}
         >
             {title && (
                 <div

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -45,6 +45,7 @@ export interface SectionExampleState {
     isControlled: boolean;
     isOpen: boolean;
     isPanelPadded: boolean;
+    isBordered: boolean;
 }
 
 const BASIL_DESCRIPTION_TEXT = dedent`
@@ -67,6 +68,7 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
         isControlled: false,
         isOpen: true,
         isPanelPadded: true,
+        isBordered: false,
     };
 
     private editableTextRef = React.createRef<HTMLDivElement>();
@@ -82,6 +84,7 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
             hasMultipleCards,
             isCompact,
             isPanelPadded,
+            isBordered,
         } = this.state;
 
         const options = (
@@ -92,6 +95,7 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
                 <Switch checked={hasDescription} label="Sub-title" onChange={this.toggleHasDescription} />
                 <Switch checked={hasRightElement} label="Right element" onChange={this.toggleHasRightElement} />
                 <Switch checked={collapsible} label="Collapsible" onChange={this.toggleCollapsible} />
+                <Switch checked={isBordered} label="Bordered" onChange={this.toggleIsBordered} />
                 <FormGroup label="Elevation">
                     Elevation
                     <Slider
@@ -186,7 +190,8 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
                         ) : undefined
                     }
                     subtitle={hasDescription ? "Ocimum basilicum" : undefined}
-                    title="Basil"
+                    title="Basils"
+                    bordered={isBordered}
                 >
                     <SectionCard padded={isPanelPadded}>{descriptionContent}</SectionCard>
                     {hasMultipleCards && <SectionCard padded={isPanelPadded}>{metadataContent}</SectionCard>}
@@ -214,6 +219,8 @@ export class SectionExample extends React.PureComponent<ExampleProps, SectionExa
     private toggleIsControlled = () => this.setState({ isControlled: !this.state.isControlled });
 
     private toggleIsOpen = () => this.setState({ isOpen: !this.state.isOpen });
+
+    private toggleIsBordered = () => this.setState({ isBordered: !this.state.isBordered });
 
     private handleElevationChange = (elevation: SectionElevation) => this.setState({ elevation });
 


### PR DESCRIPTION
#### Fixes #6577

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
- [x] Added section border prop

#### Reviewers should focus on:
- Section component
- Card component

#### Screenshot
![Screenshot 2024-05-14 at 19 02 16](https://github.com/palantir/blueprint/assets/166782331/927afcd2-6cf4-4835-a333-ddbca639dcb5)
![Screenshot 2024-05-14 at 19 02 23](https://github.com/palantir/blueprint/assets/166782331/4f971cb5-3ce2-4fa0-a082-3ee7eccd7f5a)

