### PR TITLE
Add new Tabs option to enable tab navigation to non-active tabs

### DIFF
--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -36,6 +36,9 @@ export interface TabTitleProps extends TabProps {
 
     /** Whether the tab is currently selected. */
     selected: boolean;
+
+    /** Whether to enable tab navigation to non-disabled, non-active, tabs. */
+    enableTabbedNavigation: boolean;
 }
 
 export class TabTitle extends AbstractPureComponent<TabTitleProps> {
@@ -53,6 +56,7 @@ export class TabTitle extends AbstractPureComponent<TabTitleProps> {
             icon,
             tagContent,
             tagProps,
+            enableTabbedNavigation,
             ...htmlProps
         } = this.props;
         const intent = selected ? Intent.PRIMARY : Intent.NONE;
@@ -69,7 +73,7 @@ export class TabTitle extends AbstractPureComponent<TabTitleProps> {
                 id={generateTabTitleId(parentId, id)}
                 onClick={disabled ? undefined : this.handleClick}
                 role="tab"
-                tabIndex={disabled ? undefined : selected ? 0 : -1}
+                tabIndex={disabled ? undefined : selected ? 0 : enableTabbedNavigation ? 0 : -1}
             >
                 {icon != null && <Icon icon={icon} intent={intent} className={Classes.TAB_ICON} />}
                 {title}

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -104,6 +104,18 @@ export interface TabsProps extends Props {
     fill?: boolean;
 
     /**
+     * Whether to enable tab navigation to all non-disabled tabs.
+     *
+     * By default, only the active tab will be inserted into the tab order, with index 0, and keyboard navigation
+     * to non active tabs may be done using the left and right arrow keys.
+     * This option includes every non-disabled tab in the tab order, with index 0, so that all non-disabled tabs
+     * can be reached through tab navigation, in addition to the arrow navigation.
+     *
+     * @default false
+     */
+    enableTabbedNavigation?: boolean;
+
+    /**
      * A callback function that is invoked when a tab in the tab list is clicked.
      */
     onChange?(newTabId: TabId, prevTabId: TabId | undefined, event: React.MouseEvent<HTMLElement>): void;
@@ -356,6 +368,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
                     parentId={this.props.id}
                     onClick={this.handleTabClick}
                     selected={id === this.state.selectedTabId}
+                    enableTabbedNavigation={this.props.enableTabbedNavigation ?? false}
                 />
             );
         }


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6759

Note that current behavior follows the [W3 guidance for the tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/), so we should consider closing out the filed issue without making any fixes or adding any features. At a minimum, I think the default behavior should follow the guidance, possibly with an opt-in option to add this additional tab navigation pattern to use as consumers of the Tabs component feels is appropriate.

Ex one use case for this is if the usage of the `Tabs` component, for whatever reason, feels or looks more like a button group, and users expect to be able to tab to all tabs.

#### Checklist

Can consider tests pending decision to support or not

- [ ] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Add a new prop `enableTabbedNavigation` to the `Tabs` component, which allows using the tab key to access non-active tabs

#### Reviewers should focus on:

- Do we want to add this option?
- Prop naming - also considered `insertNonActiveTabsInTabOrder` and `addNonActiveTabsToTabOrder`

#### Screenshot

<img width="530" alt="Screenshot 2024-05-15 at 2 04 05 PM" src="https://github.com/palantir/blueprint/assets/14102129/60a4cf39-fe82-4de0-86ee-7575bc14eb08">