### PR TITLE
Avoid trapping focus in Table

### DIFF
--- a/packages/table/src/tableHotkeys.ts
+++ b/packages/table/src/tableHotkeys.ts
@@ -144,9 +144,6 @@ export class TableHotkeys {
     // no good way to call arrow-key keyboard events from tests
     /* istanbul ignore next */
     private handleFocusMove = (e: KeyboardEvent, direction: "up" | "down" | "left" | "right") => {
-        e.preventDefault();
-        e.stopPropagation();
-
         const { focusedCell } = this.state;
         if (focusedCell == null) {
             // halt early if we have a selectedRegionTransform or something else in play that nixes
@@ -186,6 +183,9 @@ export class TableHotkeys {
             return;
         }
 
+        e.preventDefault();
+        e.stopPropagation();
+
         // change selection to match new focus cell location
         const newSelectionRegions = [Regions.cell(newFocusedCell.row, newFocusedCell.col)];
         const { selectedRegionTransform } = this.props;
@@ -203,9 +203,6 @@ export class TableHotkeys {
     // no good way to call arrow-key keyboard events from tests
     /* istanbul ignore next */
     private handleFocusMoveInternal = (e: KeyboardEvent, direction: "up" | "down" | "left" | "right") => {
-        e.preventDefault();
-        e.stopPropagation();
-
         const { focusedCell, selectedRegions } = this.state;
 
         if (focusedCell == null) {
@@ -280,6 +277,9 @@ export class TableHotkeys {
         ) {
             return;
         }
+
+        e.preventDefault();
+        e.stopPropagation();
 
         this.tableHandlers.handleFocus(newFocusedCell);
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/3834

#### Checklist

- [ ] Includes tests
- [x] Update documentation
  - testable in existing table docs

#### Changes proposed in this pull request:

Immediately preventing default on tab key presses seems problematic since sometimes we return early and do nothing on the tab key press. This happens when the selection is already at the edge of the table and will not move further. This PR proposes that in these cases we should allow focus to freely leave the table.

I considered other solutions including:
- Making this a new optional option.
    - In the next major version, this option could be defaulted to true, and possibly removed in the future if we see no valid cases where trapping focus is desired.
- Introducing a new pattern to move focus into the table, such as Enter when the table is focused to switch to current behavior, and otherwise have the table be a single element in the tab order.
    - Esc would "exit" this interaction mode
    - Big downside of not being very discoverable
- Are there other best practices for table interaction to consider?

#### Reviewers should focus on:

- Is this the interaction pattern we want?
- Should this be applied as a fix, or a new option?

#### Screenshot

n/a