### PR TITLE
No scrollbar in Select component when menu has dividers

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -305,8 +305,14 @@ $dark-menu-item-intent-colors: (
 @mixin menu-divider() {
   border-top: 1px solid $pt-divider-black;
   display: block;
-  // use negative margin to make dividers take up full menu width
+  // use negative margin to make dividers take up full menu width... (see below)
   margin: $half-grid-size (-$half-grid-size);
+
+  // ... unless inside a select popover, which needs to provide negative margin on the
+  // parent menu component to offset padding added inside the select popover
+  .#{$ns}-select-popover & {
+    margin: $half-grid-size 0;
+  }
 
   .#{$ns}-dark & {
     border-top-color: $pt-dark-divider-white;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -305,14 +305,8 @@ $dark-menu-item-intent-colors: (
 @mixin menu-divider() {
   border-top: 1px solid $pt-divider-black;
   display: block;
-  // use negative margin to make dividers take up full menu width... (see below)
+  // use negative margin to make dividers take up full menu width
   margin: $half-grid-size (-$half-grid-size);
-
-  // ... unless inside a select popover, which needs to provide negative margin on the
-  // parent menu component to offset padding added inside the select popover
-  .#{$ns}-select-popover & {
-    margin: $half-grid-size 0;
-  }
 
   .#{$ns}-dark & {
     border-top-color: $pt-dark-divider-white;

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -3,11 +3,13 @@
 
 @import "../../common/variables";
 
+$select-padding: $pt-grid-size * 0.5;
+
 .#{$ns}-select-popover {
   .#{$ns}-popover-content {
     // use padding on container rather than margin on input group
     // because top margin leaves some empty space with no background color.
-    padding: $pt-grid-size * 0.5;
+    padding: $select-padding;
   }
 
   .#{$ns}-input-group {
@@ -19,10 +21,13 @@
     max-width: $select-popover-max-width;
     overflow: auto;
     padding: 0;
+    margin-left: -$select-padding;
+    margin-right: -$select-padding;
+    margin-bottom: -$select-padding;
 
     &:not(:first-child) {
       // adjust padding to account for that on .#{$ns}-popover-content above
-      padding-top: $pt-grid-size * 0.5;
+      padding-top: $select-padding;
     }
   }
 

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -17,25 +17,19 @@ $select-padding: $pt-grid-size * 0.5;
   }
 
   .#{$ns}-menu {
-    // offset the padding added by the select componenent so menu dividers can remain full width
+    // offset the padding added by the select componenent so menu can remain full width with padding on either side
+    // for menu items
     margin-left: -$select-padding;
     margin-right: -$select-padding;
     max-height: $select-popover-max-height;
     max-width: $select-popover-max-width;
     overflow: auto;
-    padding: 0;
+    padding: 0 5px;
 
     &:not(:first-child) {
       // adjust padding to account for that on .#{$ns}-popover-content above
       padding-top: $select-padding;
     }
-  }
-
-  .#{$ns}-menu-item {
-    // re-apply margin unset on menu to the actual menu items. unlike menu dividers, menu items are not intended
-    // to be full width
-    margin-left: $select-padding;
-    margin-right: $select-padding;
   }
 
   &.#{$ns}-popover-match-target-width {

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -24,7 +24,7 @@ $select-padding: $pt-grid-size * 0.5;
     max-height: $select-popover-max-height;
     max-width: $select-popover-max-width;
     overflow: auto;
-    padding: 0 5px;
+    padding: 0 $select-padding;
 
     &:not(:first-child) {
       // adjust padding to account for that on .#{$ns}-popover-content above

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -17,13 +17,13 @@ $select-padding: $pt-grid-size * 0.5;
   }
 
   .#{$ns}-menu {
+    margin-bottom: -$select-padding;
+    margin-left: -$select-padding;
+    margin-right: -$select-padding;
     max-height: $select-popover-max-height;
     max-width: $select-popover-max-width;
     overflow: auto;
     padding: 0;
-    margin-left: -$select-padding;
-    margin-right: -$select-padding;
-    margin-bottom: -$select-padding;
 
     &:not(:first-child) {
       // adjust padding to account for that on .#{$ns}-popover-content above

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -18,6 +18,7 @@ $select-padding: $pt-grid-size * 0.5;
 
   .#{$ns}-menu {
     // offset the padding added by the select componenent so menu can remain full width with padding on either side
+    // this is important so menu dividers can be full width, and so that menu items can have padding to the left and right
     // for menu items
     margin-left: -$select-padding;
     margin-right: -$select-padding;

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -17,7 +17,7 @@ $select-padding: $pt-grid-size * 0.5;
   }
 
   .#{$ns}-menu {
-    margin-bottom: -$select-padding;
+    // offset the padding added by the select componenent so menu dividers can remain full width
     margin-left: -$select-padding;
     margin-right: -$select-padding;
     max-height: $select-popover-max-height;
@@ -29,6 +29,13 @@ $select-padding: $pt-grid-size * 0.5;
       // adjust padding to account for that on .#{$ns}-popover-content above
       padding-top: $select-padding;
     }
+  }
+
+  .#{$ns}-menu-item {
+    // re-apply margin unset on menu to the actual menu items. unlike menu dividers, menu items are not intended
+    // to be full width
+    margin-left: $select-padding;
+    margin-right: $select-padding;
   }
 
   &.#{$ns}-popover-match-target-width {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6780

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

I don't think these are relevant for this PR

#### Changes proposed in this pull request:

For a menu divider inside of a select-popover, we already have applied a 5px padding inside the popover. This means to get to full popover width we need to apply the -5px margin to the outer list element, and therefor also undo the -5px margin on the menu divider.

This PR is a variation on https://github.com/palantir/blueprint/pull/6786, which correctly identified that the -5px margin on the menu divider is responsible for the scrollbar being added, but this PR additionally applies this -5px margin on the list element so that the divider continues to take up the full width.

#### Reviewers should focus on:

- Any other styling options I'm not thinking of that may be negatively impacted
- Any concerns of this fix itself being a breaking change, since this style issue has likely existed since https://github.com/palantir/blueprint/pull/6269 was merged almost a year ago?

#### Screenshot

Before
<img width="448" alt="Screenshot 2024-05-15 at 2 20 22 PM" src="https://github.com/palantir/blueprint/assets/14102129/e195627f-5755-4fd8-9b6a-4cc153ec545d">

After
<img width="443" alt="Screenshot 2024-05-15 at 2 19 48 PM" src="https://github.com/palantir/blueprint/assets/14102129/b5e54a35-d9ae-474e-bd5c-e4664cb2c08c">
*note right and bottom padding outside of list are now also removed. this seems to match what we do in the menu popover