### PR TITLE
Remove `componentDidMount` and `componentDidUpdate` hooks from `<Popover>`

### DIFF
--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -204,9 +204,9 @@ export interface PopoverSharedProps<TProps extends DefaultPopoverTargetHTMLProps
 
     /**
      * Callback invoked in controlled mode when the popover open state *would*
-     * change due to user interaction.
+     * change due to user interaction. Should change the `isOpen` value.
      */
-    onInteraction?: (nextOpenState: boolean, e?: React.SyntheticEvent<HTMLElement>) => void;
+    onInteraction?: (nextOpenState: boolean, e: React.SyntheticEvent<HTMLElement>) => void;
 
     /**
      * Whether the popover should open when its target is focused. If `true`,

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -455,36 +455,25 @@ describe("<Popover>", () => {
                 renderPopover({ disabled: true, isOpen: true }).assertIsOpen(false);
             });
 
-            it("onInteraction not called if changing from closed to open (b/c popover is still closed)", () => {
+            it("when changing from closed to open", () => {
                 renderPopover({ disabled: true, isOpen: false, onInteraction: onInteractionSpy })
-                    .assertOnInteractionCalled(false)
-                    .setProps({ isOpen: true })
                     .assertIsOpen(false)
-                    .assertOnInteractionCalled(false);
+                    .setProps({ isOpen: true })
+                    .assertIsOpen(false);
             });
 
-            it("onInteraction not called if changing from open to closed (b/c popover was already closed)", () => {
-                renderPopover({ disabled: true, isOpen: true, onInteraction: onInteractionSpy })
-                    .assertOnInteractionCalled(false)
-                    .setProps({ isOpen: false })
-                    .assertOnInteractionCalled(false);
-            });
-
-            it("onInteraction called if open and changing to disabled (b/c popover will close)", () => {
+            it("when changing open to disabled (so popover will close)", () => {
                 renderPopover({ disabled: false, isOpen: true, onInteraction: onInteractionSpy })
                     .assertIsOpen()
-                    .assertOnInteractionCalled(false)
                     .setProps({ disabled: true })
-                    .assertOnInteractionCalled();
+                    .assertIsOpen(false);
             });
 
-            it("onInteraction called if open and changing to not-disabled (b/c popover will open)", () => {
+            it("when changing open to not-disabled (so popover will open)", () => {
                 renderPopover({ disabled: true, isOpen: true, onInteraction: onInteractionSpy })
-                    .assertOnInteractionCalled(false)
+                    .assertIsOpen(false)
                     .setProps({ disabled: false })
-                    .update()
-                    .assertIsOpen()
-                    .assertOnInteractionCalled();
+                    .assertIsOpen();
             });
         });
 
@@ -649,7 +638,6 @@ describe("<Popover>", () => {
                 .simulateTarget("click")
                 .assertIsOpen()
                 .setProps({ disabled: true })
-                .update()
                 .assertIsOpen(false);
         });
 
@@ -881,7 +869,6 @@ describe("<Popover>", () => {
         targetButton: HTMLButtonElement;
         assertFindClass(className: string, expected?: boolean, msg?: string): this;
         assertIsOpen(isOpen?: boolean): this;
-        assertOnInteractionCalled(called?: boolean): this;
         simulateContent(eventName: string, ...args: any[]): this;
         /** Careful: simulating "focus" is unsupported by Enzyme, see https://stackoverflow.com/a/56892875/7406866 */
         simulateTarget(eventName: string, ...args: any[]): this;
@@ -923,10 +910,6 @@ describe("<Popover>", () => {
         wrapper.assertIsOpen = (isOpen = true, index = 0) => {
             const overlay = wrapper!.find(Overlay2).at(index);
             assert.equal(overlay.prop("isOpen"), isOpen, "PopoverWrapper#assertIsOpen()");
-            return wrapper!;
-        };
-        wrapper.assertOnInteractionCalled = (called = true) => {
-            assert.strictEqual(onInteractionSpy.called, called, "PopoverWrapper#assertOnInteractionCalled()");
             return wrapper!;
         };
         wrapper.findClass = (className: string) => wrapper!.find(`.${className}`).hostNodes();

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -332,7 +332,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
 
     // Popover interaction kind is CLICK, so this only handles click events.
     // Note that we defer to the next animation frame in order to get the latest activeElement
-    private handlePopoverInteraction = (nextOpenState: boolean, evt?: React.SyntheticEvent<HTMLElement>) =>
+    private handlePopoverInteraction = (nextOpenState: boolean, evt: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
             const isInputFocused = this.input === Utils.getActiveElement(this.input);
 

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -299,7 +299,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         this.props.onItemSelect?.(item, event);
     };
 
-    private handlePopoverInteraction = (isOpen: boolean, event?: React.SyntheticEvent<HTMLElement>) => {
+    private handlePopoverInteraction = (isOpen: boolean, event: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isOpen });
         this.props.popoverProps?.onInteraction?.(isOpen, event);
     };

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -333,7 +333,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
 
     // Popover interaction kind is CLICK, so this only handles click events.
     // Note that we defer to the next animation frame in order to get the latest activeElement
-    private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) =>
+    private handlePopoverInteraction = (nextOpenState: boolean, event: React.SyntheticEvent<HTMLElement>) =>
         this.requestAnimationFrame(() => {
             const isInputFocused = this.inputElement === Utils.getActiveElement(this.inputElement);
             if (this.inputElement != null && !isInputFocused) {


### PR DESCRIPTION
While using `<Popover>` in controlled mode to work around #6171, I noticed that it always renders twice when `onInteraction` changes my `isOpen` state. On first render, `renderTarget` is called with outdated arguments (closed instead of open), only immediately after in the second render it gets passed the correct values.
You can repro with something like
```jsx

<Popover
	…
	isOpen={isOpen}
	onInteraction={(nextOpenState, event) => {
		console.log('interaction', nextOpenState, event);
		setIsOpen(nextOpenState);
	}}
	renderTarget={props => {
		console.log('Rendering popover target', isOpen, props);
		return …;
	}}
/>
```
I traced the problem down to `setState` being called from `componentDidUpdate`. Instead the component should simply take the `isOpen` value from the props and ignore its local state altogether in controlled mode.

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

* avoid calling `setState` from `componentDidUpdate`, which leads to the component rendering twice in controlled mode
* instead, just ignore local state when the component is in controlled mode
* remove `componentDidMount` and `componentDidUpdate` hooks from `<Popover>` altogether
* assert that `onInteraction` is always called with an event
* also remove `hasDarkParent` and `isClosingViaEscapeKeypress` from react component state, put them in class properties instead and update them whenever the overlay is opening/closing

#### Reviewers should focus on:

* dark mode and esc key behavior
* coding style (I'm unfamiliar with Bluprint guidelines)
* testing (I've only done this in the web editor, haven't actually installed the dev environment and ran any tooling)
* whether no longer calling `onInteraction` due to props change is a bugfix or a compatibility issue