### PR TITLE
[core] fix: FormGroup sub label dark theme

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6810.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6810.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[core] fix: FormGroup sub label dark theme'
+  links:
+  - https://github.com/palantir/blueprint/pull/6810

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -109,6 +109,7 @@ Styleguide form-group
       }
     }
 
+    .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
       color: $pt-dark-text-color-muted;
     }


### PR DESCRIPTION
#### Fixes #6807

#### Changes proposed in this pull request:

Update the sub label text colour to match the helper text when using dark theme.

#### Screenshot

**Before**

![image](https://github.com/palantir/blueprint/assets/56115125/6d427283-1c39-45a5-bb38-0ee4086b7687)


**After**

![image](https://github.com/palantir/blueprint/assets/56115125/06d6a717-30bc-492d-bc7f-4e0c9299d4f5)

