### PR TITLE
[core] fix: do not colour FormGroup sub label based on intent

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6811.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6811.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Do not colour FormGroup sub label based on intent
+  links:
+  - https://github.com/palantir/blueprint/pull/6811

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -62,7 +62,6 @@ Styleguide form-group
   /* stylelint-disable-next-line order/declaration-block-order */
   @each $intent, $color in $pt-intent-text-colors {
     &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-form-group-sub-label,
       .#{$ns}-form-helper-text {
         color: $color;
       }
@@ -102,7 +101,6 @@ Styleguide form-group
   .#{$ns}-dark & {
     @each $intent, $color in $pt-dark-intent-text-colors {
       &.#{$ns}-intent-#{$intent} {
-        .#{$ns}-form-group-sub-label,
         .#{$ns}-form-helper-text {
           color: $color;
         }

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -76,8 +76,7 @@ export interface FormGroupProps extends IntentProps, Props {
 
     /**
      * Optional text for `label`. The given content will be wrapped in
-     * `Classes.FORM_GROUP_SUB_LABEL` and displayed beneath `label`. The text color
-     * is determined by the `intent`.
+     * `Classes.FORM_GROUP_SUB_LABEL` and displayed beneath `label`.
      */
     subLabel?: React.ReactNode;
 }


### PR DESCRIPTION
#### Fixes #6808

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

No longer derive the sub label colour of FromGroup from the intent.

#### Screenshot

**Before**

![image](https://github.com/palantir/blueprint/assets/56115125/b4d14e07-6481-4f0b-939b-3924e93f0637)

![image](https://github.com/palantir/blueprint/assets/56115125/44905a14-7632-4580-9be7-6cae0aabba8f)

**After**

![image](https://github.com/palantir/blueprint/assets/56115125/45b4cd4a-7dc3-4df2-bdd4-1cc11cd05716)


![image](https://github.com/palantir/blueprint/assets/56115125/9d298a52-13b9-4f4d-9549-d583ac251367)

