### PR TITLE
[core] fix: constrain DialogFooter children width

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6812.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6812.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: '[core] fix: constrain DialogFooter children width'
-  links:
-  - https://github.com/palantir/blueprint/pull/6812

--- a/packages/core/changelog/@unreleased/pr-6812.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6812.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '[core] fix: constrain DialogFooter children width'
+  links:
+  - https://github.com/palantir/blueprint/pull/6812

--- a/packages/core/src/components/dialog/_dialog-footer.scss
+++ b/packages/core/src/components/dialog/_dialog-footer.scss
@@ -27,7 +27,7 @@
 }
 
 .#{$ns}-dialog-footer-main-section {
-  flex: 1 0 auto;
+  flex: 1 1 auto;
 }
 
 .#{$ns}-dialog-footer-actions {


### PR DESCRIPTION
#### Fixes #6809

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This pull request adds `flex-shrink: 1` to the DialogFooter's main section to fix an issue where providing content such as long text would cause the actions to be pushed out of the footer.

#### Screenshot

**Before**

![image](https://github.com/palantir/blueprint/assets/56115125/af91760d-fb50-4855-8724-a475a1455ff2)


**After**

![image](https://github.com/palantir/blueprint/assets/56115125/2d05746a-9ec2-4289-bf5a-2871c4c48b3e)
