### PR TITLE
use gap instead of margin for tab

### DIFF
--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -94,7 +94,7 @@ $tab-indicator-width: 3px !default;
   margin: 0;
   padding: 0;
   position: relative;
-  gap: $pt-grid-size * 2
+  gap: $pt-grid-size * 2;
 }
 
 .#{$ns}-tab {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -90,11 +90,11 @@ $tab-indicator-width: 3px !default;
   border: none;
   display: flex;
   flex: 0 0 auto;
+  gap: $pt-grid-size * 2;
   list-style: none;
   margin: 0;
   padding: 0;
   position: relative;
-  gap: $pt-grid-size * 2;
 }
 
 .#{$ns}-tab {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -94,12 +94,7 @@ $tab-indicator-width: 3px !default;
   margin: 0;
   padding: 0;
   position: relative;
-
-  // this is fine.
-  /* stylelint-disable-next-line selector-no-universal */
-  > *:not(:last-child) {
-    margin-right: $pt-grid-size * 2;
-  }
+  gap: $pt-grid-size * 2
 }
 
 .#{$ns}-tab {


### PR DESCRIPTION
By doing this, tabs can natively support RTL without breaking any LTR

#### Changes proposed in this pull request:

Instead of using margin for tab spacing use flex gap

#### Reviewers should focus on:

- [x] Checking that it looks the same in both LTR
- [x] That it's no longer broken in RTL

#### Screenshot

Looks identical
