### PR TITLE
fix: prevent PanelStack2 from opening in the wrong direction

### DIFF
--- a/packages/core/src/components/panel-stack2/panelStack2.tsx
+++ b/packages/core/src/components/panel-stack2/panelStack2.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
+import { usePrevious } from "../../hooks";
 
 import type { Panel } from "./panelTypes";
 import { PanelView2 } from "./panelView2";
@@ -103,12 +104,8 @@ export const PanelStack2: PanelStack2Component = <T extends Panel<object>>(props
         () => (isControlled ? propsStack.slice().reverse() : localStack),
         [localStack, isControlled, propsStack],
     );
-    const stackLength = React.useRef<number>(stack.length);
-    // Adjust the direction in case the stack size has changed, controlled or uncontrolled
-    const direction = stack.length - stackLength.current < 0 ? "pop" : "push";
-    React.useEffect(() => {
-        stackLength.current = stack.length;
-    }, [stack]);
+    const prevStackLength = usePrevious(stack.length) ?? stack.length;
+    const direction = stack.length - prevStackLength < 0 ? "pop" : "push";
 
     const handlePanelOpen = React.useCallback(
         (panel: T) => {

--- a/packages/core/src/components/panel-stack2/panelStack2.tsx
+++ b/packages/core/src/components/panel-stack2/panelStack2.tsx
@@ -97,7 +97,6 @@ export const PanelStack2: PanelStack2Component = <T extends Panel<object>>(props
         stack: propsStack,
     } = props;
     const isControlled = propsStack != null;
-    const [direction, setDirection] = React.useState("push");
 
     const [localStack, setLocalStack] = React.useState<T[]>(initialPanel !== undefined ? [initialPanel] : []);
     const stack = React.useMemo(
@@ -105,11 +104,9 @@ export const PanelStack2: PanelStack2Component = <T extends Panel<object>>(props
         [localStack, isControlled, propsStack],
     );
     const stackLength = React.useRef<number>(stack.length);
+    // Adjust the direction in case the stack size has changed, controlled or uncontrolled
+    const direction = stack.length - stackLength.current < 0 ? "pop" : "push";
     React.useEffect(() => {
-        if (stack.length !== stackLength.current) {
-            // Adjust the direction in case the stack size has changed, controlled or uncontrolled
-            setDirection(stack.length - stackLength.current < 0 ? "pop" : "push");
-        }
         stackLength.current = stack.length;
     }, [stack]);
 


### PR DESCRIPTION
#### Fixes #6723 

As additional context that was not described in the original issue, I realized that the problem only exists when using react 18, not with react 16.

I did an example of the issue in an application running with react 18 in stackblitz, one without the fix, the other with the fix. By testing the example as described in #6723, you can verify the fix.

Before the fix: https://stackblitz.com/edit/vitejs-vite-4d5jhz
After the fix: https://stackblitz.com/edit/vitejs-vite-txizds

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

The changes removes one of the state that can be derived from other values directly, preventing unnecessary re-renders.

#### Reviewers should focus on:

Making sure the change does not break any existing behaviour.
