### PR TITLE
Do not set `tabIndex` when no popover will show

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -344,7 +344,7 @@ export class Popover<
     public reposition = () => this.popperScheduleUpdate?.();
 
     private renderTarget = ({ ref: popperChildRef }: ReferenceChildrenProps) => {
-        const { children, className, fill, openOnTargetFocus, renderTarget } = this.props;
+        const { children, className, content, disabled, fill, openOnTargetFocus, renderTarget } = this.props;
         const { isOpen } = this.state;
         const isControlled = this.isControlled();
         const isHoverInteractionKind = this.isHoverInteractionKind();
@@ -375,7 +375,8 @@ export class Popover<
                       onKeyDown: this.handleKeyDown,
                   };
         // Ensure target is focusable if relevant prop enabled
-        const targetTabIndex = openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
+        const targetTabIndex =
+            content != null && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const ownTargetProps = {
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -249,11 +249,10 @@ export class Popover<
     }
 
     public render() {
-        const { disabled, content, placement, position = "auto", positioningStrategy } = this.props;
+        const { disabled, placement, position = "auto", positioningStrategy } = this.props;
         const { isOpen } = this.state;
 
-        const isContentEmpty = content == null || (typeof content === "string" && content.trim() === "");
-        if (isContentEmpty) {
+        if (this.getIsContentEmpty()) {
             // need to do this check in render(), because `isOpen` is derived from
             // state, and state can't necessarily be accessed in validateProps.
             if (!disabled && isOpen !== false && !Utils.isNodeEnv("production")) {
@@ -344,7 +343,7 @@ export class Popover<
     public reposition = () => this.popperScheduleUpdate?.();
 
     private renderTarget = ({ ref: popperChildRef }: ReferenceChildrenProps) => {
-        const { children, className, content, disabled, fill, openOnTargetFocus, renderTarget } = this.props;
+        const { children, className, disabled, fill, openOnTargetFocus, renderTarget } = this.props;
         const { isOpen } = this.state;
         const isControlled = this.isControlled();
         const isHoverInteractionKind = this.isHoverInteractionKind();
@@ -376,7 +375,7 @@ export class Popover<
                   };
         // Ensure target is focusable if relevant prop enabled
         const targetTabIndex =
-            content != null && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
+            !this.getIsContentEmpty() && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
         const ownTargetProps = {
             // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
             // If, instead, renderTarget is undefined and the target is provided as a child, this.props.className is
@@ -788,6 +787,11 @@ export class Popover<
 
     private isElementInPopover(element: Element) {
         return this.getPopoverElement()?.contains(element) ?? false;
+    }
+
+    private getIsContentEmpty() {
+        const { content } = this.props;
+        return content == null || (typeof content === "string" && content.trim() === "");
     }
 }
 

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -34,6 +34,9 @@ import { PopoverArrow } from "../../src/components/popover/popoverArrow";
 import { PopupKind } from "../../src/components/popover/popupKind";
 import { Tooltip } from "../../src/components/tooltip/tooltip";
 
+const BUTTON_WITH_TEST_ID = <Button data-testid="target-button" text="Target" />;
+const BUTTON_ID_SELECTOR = "[data-testid='target-button']";
+
 describe("<Popover>", () => {
     let testsContainerElement: HTMLElement;
     let wrapper: PopoverWrapper | undefined;
@@ -325,6 +328,14 @@ describe("<Popover>", () => {
                 });
             });
 
+            it("does not add tabindex to target's child node when disabled=true", () => {
+                assertPopoverTargetTabIndex(false, {
+                    disabled: true,
+                    interactionKind: "hover",
+                    openOnTargetFocus: true,
+                });
+            });
+
             it("opens popover on target focus when interactionKind is HOVER", () => {
                 assertPopoverOpenStateForInteractionKind("hover", true);
             });
@@ -418,17 +429,6 @@ describe("<Popover>", () => {
             const targetElement = wrapper.findClass(Classes.POPOVER_TARGET);
             targetElement.simulate("focus");
             assert.equal(wrapper.state("isOpen"), isOpen);
-        }
-
-        function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<PopoverProps>) {
-            wrapper = renderPopover({ ...popoverProps, usePortal: true });
-            const targetElement = wrapper.find("[data-testid='target-button']").hostNodes().getDOMNode();
-
-            if (shouldTabIndexExist) {
-                assert.equal(targetElement.getAttribute("tabindex"), "0");
-            } else {
-                assert.isNull(targetElement.getAttribute("tabindex"));
-            }
         }
     });
 
@@ -668,15 +668,14 @@ describe("<Popover>", () => {
     });
 
     describe("when composed with <Tooltip>", () => {
-        let root: ReactWrapper<any, any>;
+        let root: PopoverWrapper;
         beforeEach(() => {
-            root = mount(
-                <Popover content="popover" hoverOpenDelay={0} hoverCloseDelay={0} usePortal={false}>
-                    <Tooltip content="tooltip" hoverOpenDelay={0} hoverCloseDelay={0} usePortal={false}>
-                        <Button text="Target" />
-                    </Tooltip>
-                </Popover>,
-                { attachTo: testsContainerElement },
+            root = renderPopover(
+                { hoverOpenDelay: 0, hoverCloseDelay: 0, usePortal: false },
+                "popover",
+                <Tooltip content="tooltip" hoverOpenDelay={0} hoverCloseDelay={0} usePortal={false}>
+                    {BUTTON_WITH_TEST_ID}
+                </Tooltip>,
             );
         });
         afterEach(() => root.detach());
@@ -689,6 +688,78 @@ describe("<Popover>", () => {
         it("shows popover on click", () => {
             root.find(`.${Classes.POPOVER_TARGET}`).first().simulate("click");
             assert.lengthOf(root.find(`.${Classes.POPOVER}`), 1);
+        });
+
+        it("the target is focusable", () => {
+            assertTargetElementTabIndex(true, root.last().find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode());
+        });
+
+        describe("when disabled=true", () => {
+            beforeEach(() => {
+                root.setProps({ disabled: true });
+            });
+
+            it("shows tooltip on hover", () => {
+                root.find(`.${Classes.POPOVER_TARGET}`).last().simulate("mouseenter");
+                assert.lengthOf(root.find(`.${Classes.TOOLTIP}`), 1);
+            });
+
+            it("does not show popover on click", () => {
+                root.find(`.${Classes.POPOVER_TARGET}`).last().simulate("click");
+                assert.lengthOf(root.find(`.${Classes.POPOVER}`), 0);
+            });
+
+            it("the target is focusable", () => {
+                assertTargetElementTabIndex(true, root.last().find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode());
+            });
+        });
+    });
+
+    describe("when composed with a disabled <Tooltip>", () => {
+        let root: PopoverWrapper;
+        beforeEach(() => {
+            root = renderPopover(
+                { hoverOpenDelay: 0, hoverCloseDelay: 0, usePortal: false },
+                "popover",
+                <Tooltip content="tooltip" disabled={true} hoverOpenDelay={0} hoverCloseDelay={0} usePortal={false}>
+                    {BUTTON_WITH_TEST_ID}
+                </Tooltip>,
+            );
+        });
+        afterEach(() => root.detach());
+
+        it("does not show tooltip on hover", () => {
+            root.find(`.${Classes.POPOVER_TARGET}`).last().simulate("mouseenter");
+            assert.lengthOf(root.find(`.${Classes.TOOLTIP}`), 0);
+        });
+
+        it("shows popover on click", () => {
+            root.find(`.${Classes.POPOVER_TARGET}`).first().simulate("click");
+            assert.lengthOf(root.find(`.${Classes.POPOVER}`), 1);
+        });
+
+        it("the target is not focusable", () => {
+            assertTargetElementTabIndex(false, root.last().find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode());
+        });
+
+        describe("when disabled=true", () => {
+            beforeEach(() => {
+                root.setProps({ disabled: true });
+            });
+
+            it("does not show tooltip on hover", () => {
+                root.find(`.${Classes.POPOVER_TARGET}`).last().simulate("mouseenter");
+                assert.lengthOf(root.find(`.${Classes.TOOLTIP}`), 0);
+            });
+
+            it("does not show popover on click", () => {
+                root.find(`.${Classes.POPOVER_TARGET}`).last().simulate("click");
+                assert.lengthOf(root.find(`.${Classes.POPOVER}`), 0);
+            });
+
+            it("the target is not focusable", () => {
+                assertTargetElementTabIndex(false, root.last().find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode());
+            });
         });
     });
 
@@ -710,7 +781,7 @@ describe("<Popover>", () => {
 
         it("matches target width via custom modifier", () => {
             wrapper = renderPopover({ matchTargetWidth: true, isOpen: true, placement: "bottom" });
-            const targetElement = wrapper.find("[data-testid='target-button']").hostNodes().getDOMNode();
+            const targetElement = wrapper.find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode();
             const popoverElement = wrapper.find(`.${Classes.POPOVER}`).hostNodes().getDOMNode();
             assert.closeTo(
                 popoverElement.clientWidth,
@@ -816,7 +887,7 @@ describe("<Popover>", () => {
         describe("Enter key down opens click interaction popover", () => {
             it("when autoFocus={true}", done => {
                 wrapper = renderPopover({ autoFocus: true });
-                const button = wrapper.find("[data-testid='target-button']").hostNodes();
+                const button = wrapper.find(BUTTON_ID_SELECTOR).hostNodes();
                 (button.getDOMNode() as HTMLElement).focus();
                 button.simulate("keyDown", SPACE_KEYSTROKE);
                 // Wait for focus to change
@@ -833,7 +904,7 @@ describe("<Popover>", () => {
 
             it("when autoFocus={false}", done => {
                 wrapper = renderPopover({ autoFocus: false });
-                const button = wrapper.find("[data-testid='target-button']").hostNodes();
+                const button = wrapper.find(BUTTON_ID_SELECTOR).hostNodes();
                 (button.getDOMNode() as HTMLElement).focus();
                 button.simulate("keyDown", SPACE_KEYSTROKE);
 
@@ -875,6 +946,20 @@ describe("<Popover>", () => {
         });
     });
 
+    function assertPopoverTargetTabIndex(shouldTabIndexExist: boolean, popoverProps: Partial<PopoverProps>) {
+        wrapper = renderPopover({ ...popoverProps, usePortal: true });
+        const targetElement = wrapper?.find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode();
+        assertTargetElementTabIndex(shouldTabIndexExist, targetElement);
+    }
+
+    function assertTargetElementTabIndex(shouldTabIndexExist: boolean, targetElement: Element | undefined) {
+        if (shouldTabIndexExist) {
+            assert.equal(targetElement?.getAttribute("tabindex"), "0");
+        } else {
+            assert.isNull(targetElement?.getAttribute("tabindex"));
+        }
+    }
+
     interface PopoverWrapper extends ReactWrapper<PopoverProps, PopoverState> {
         popoverElement: HTMLElement;
         targetElement: HTMLElement;
@@ -890,7 +975,11 @@ describe("<Popover>", () => {
         then(next: (wrap: PopoverWrapper) => void, done: Mocha.Done): this;
     }
 
-    function renderPopover(props: Partial<PopoverProps> = {}, content?: any) {
+    function renderPopover(
+        props: Partial<PopoverProps> = {},
+        content?: any,
+        children: React.JSX.Element = BUTTON_WITH_TEST_ID,
+    ) {
         const contentElement = (
             <div tabIndex={0} className="test-content">
                 Text {content}
@@ -899,7 +988,7 @@ describe("<Popover>", () => {
 
         wrapper = mount(
             <Popover usePortal={false} {...props} hoverCloseDelay={0} hoverOpenDelay={0} content={contentElement}>
-                <Button data-testid="target-button" text="Target" />
+                {children}
             </Popover>,
             { attachTo: testsContainerElement },
         ) as PopoverWrapper;
@@ -907,10 +996,7 @@ describe("<Popover>", () => {
         const instance = wrapper.instance() as Popover<React.HTMLProps<HTMLButtonElement>>;
         wrapper.popoverElement = instance.popoverElement!;
         wrapper.targetElement = instance.targetRef.current!;
-        wrapper.targetButton = wrapper
-            .find("[data-testid='target-button']")
-            .hostNodes()
-            .getDOMNode<HTMLButtonElement>();
+        wrapper.targetButton = wrapper.find(BUTTON_ID_SELECTOR).hostNodes().getDOMNode<HTMLButtonElement>();
         wrapper.assertFindClass = (className: string, expected = true, msg = className) => {
             const actual = wrapper!.findClass(className);
             if (expected) {


### PR DESCRIPTION
#### Fixes no ticket

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

This PR makes `Popover`s not add a `tabIndex` to the target when the `Popover` will not render due to `disabled={true}` or `content={undefined}`. This has been done by making sure that we do _not_ override `tabIndex` on the popover target in those scenarios even if `openOnTargetFocus` is also true.

This is useful when rendering shared components that have conditional `Tooltips` implemented via the `content` or `disabled` props. Before this change, those components would always be focusable.

This PR does not address `Popover`s that are rendered in control mode and not open, though they exhibit similar behavior. This could be a follow-up change if desired.

#### Popover -> Tooltip nesting

This PR is consistent with previous behavior regarding nesting a `Tooltip` in a `Popover`.

For context, default `Popover`s do not apply a `tabIndex=0` to their targets. This is because `Popover`s are by default `PopoverInteractionKind.CLICK`, which does not meet the pre-requisite for getting `tabIndex=0` applied to the target of `PopoverInteractionKind.HOVER`.

Previously, a `Popover` with a nested `Tooltip` would always have a focusable target. Now, that will only be true if the `Tooltip` is both not disabled and has content.

This behavior has been codified in the test suite.

#### Reviewers should focus on:

- If the tests make sense
    - Is sharing the button reference brittle? Should I extract the props instead, or make it a `getButton` function of some sort?
- Does this need a docs update? A further comment on the `openOnTargetFocus` TSDoc?

#### After

> ⚠️ Note that I've added new lines here for demonstration purposes to exhibit the new behavior. No changes to the docs are being proposed in this PR.

https://github.com/palantir/blueprint/assets/12519846/43efdbb4-da3d-45cd-bcd9-7f7aa4237e0d

Lines that are no longer focusable: 
- Tooltip with no content
- Disabled Tooltip
- Popover with a nested disabled Tooltip
- Disabled Popover with a nested disabled Tooltip

Lines that were never focusable:
- Popover (not disabled)

Lines that are notably still focusable:
- Popover with nested Tooltip
- Disabled Popover with a nested Tooltip


