### PR TITLE
Don't show slider fill before value equal to initial value

### DIFF
--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -70,7 +70,7 @@ export class Slider extends AbstractPureComponent<SliderProps> {
                 <MultiSlider.Handle
                     value={value!}
                     intentAfter={value! < initialValue! ? intent : undefined}
-                    intentBefore={value! >= initialValue! ? intent : undefined}
+                    intentBefore={value! > initialValue! ? intent : undefined}
                     onChange={onChange}
                     onRelease={onRelease}
                     htmlProps={handleHtmlProps}

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -53,6 +53,21 @@ describe("<Slider>", () => {
         assert.equal(tracks.getDOMNode().getBoundingClientRect().width, STEP_SIZE * 3);
     });
 
+    it("renders primary track segment between initialValue and value when value is less than initial value", () => {
+        const tracks = renderSlider(<Slider showTrackFill={true} initialValue={5} value={2} />).find(
+            `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
+        );
+        assert.lengthOf(tracks, 1);
+        assert.equal(tracks.getDOMNode().getBoundingClientRect().width, STEP_SIZE * 3);
+    });
+
+    it("renders no primary track segment when value equals initial value", () => {
+        const tracks = renderSlider(<Slider showTrackFill={true} initialValue={2} value={2} min={0} max={5} />).find(
+            `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
+        );
+        assert.lengthOf(tracks, 0);
+    });
+
     it("renders result of labelRenderer() in each label and differently in handle", () => {
         const labelRenderer = (val: number, opts?: { isHandleTooltip: boolean }) =>
             val + (opts?.isHandleTooltip ? "!" : "#");


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6844

#### Checklist

- [x] Includes tests
- [n/a] Update documentation

#### Changes proposed in this pull request:

I can't think of a reason a user would want the track to be filled from min to value when value === initial value, but then have value to initial value filled when value is just slightly less.

I imagine this case just wasn't explicitly considered, since often min may equal initial value and this issue is not apparent.

#### Reviewers should focus on:

If there's any valid use case for this track fill behavior.

#### Screenshot

Issue observable on slider example if showing fill for bottom example
<img width="828" alt="Screenshot 2024-06-18 at 10 19 00 AM" src="https://github.com/palantir/blueprint/assets/14102129/815c3c80-aff2-451f-95f8-ebc0a7fd637e">
<img width="819" alt="Screenshot 2024-06-18 at 10 18 57 AM" src="https://github.com/palantir/blueprint/assets/14102129/59662212-c568-41ab-8e4e-4c632761d4c3">
<img width="792" alt="Screenshot 2024-06-18 at 10 18 54 AM" src="https://github.com/palantir/blueprint/assets/14102129/a457c746-dc7d-438e-9e50-c6e49cc81ba3">



