### PR TITLE
Fix end time selection before selecting date

### DIFF
--- a/packages/datetime2/changelog/@unreleased/pr-6858.v2.yml
+++ b/packages/datetime2/changelog/@unreleased/pr-6858.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `DateRangePicker` end time selection before selecting end date
+  links:
+  - https://github.com/palantir/blueprint/pull/6858

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { format, addDays } from "date-fns";
+import { addDays, format } from "date-fns";
 import * as React from "react";
 import type { DateFormatter, DayModifiers, DayMouseEventHandler, ModifiersClassNames } from "react-day-picker";
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -292,7 +292,7 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         }
 
         return otherDate;
-    }
+    };
 
     private handleTimeChangeLeftCalendar = (time: Date) => {
         this.handleTimeChange(time, 0);

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -277,10 +277,9 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         this.setState({ value: newDateRange, time: newTimeRange });
     };
 
-    // When a user sets the time value before choosing a date, we need to pick a date for
-    // them to have something to store the time on.
+    // When a user sets the time value before choosing a date, we need to pick a date for them
     // The default depends on the value of the other date since there's an invariant
-    // that the left/0 date is always less than the right/1 date.
+    // that the left/0 date is always less than the right/1 date
     private getDefaultDate = (dateIndex: number) => {
         const { value } = this.state;
         const otherIndex = dateIndex === 0 ? 1 : 0;

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { format } from "date-fns";
+import { format, addDays } from "date-fns";
 import * as React from "react";
 import type { DateFormatter, DayModifiers, DayMouseEventHandler, ModifiersClassNames } from "react-day-picker";
 
@@ -265,16 +265,34 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
 
         const { value, time } = this.state;
         const newValue = DateUtils.getDateTime(
-            value[dateIndex] != null ? DateUtils.clone(value[dateIndex]!) : new Date(),
+            value[dateIndex] != null ? DateUtils.clone(value[dateIndex]!) : this.getDefaultDate(dateIndex),
             newTime,
         );
         const newDateRange: DateRange = [value[0], value[1]];
         newDateRange[dateIndex] = newValue;
         const newTimeRange: DateRange = [time[0], time[1]];
         newTimeRange[dateIndex] = newTime;
+
         this.props.onChange?.(newDateRange);
         this.setState({ value: newDateRange, time: newTimeRange });
     };
+
+    private getDefaultDate = (dateIndex: number) => {
+        const { value } = this.state;
+        const otherIndex = dateIndex === 0 ? 1 : 0;
+        const otherDate = value[otherIndex];
+        if (otherDate == null) {
+            return new Date();
+        }
+
+        const { allowSingleDayRange } = this.props;
+        if (!allowSingleDayRange) {
+            const dateDiff = dateIndex === 0 ? -1 : 1;
+            return addDays(otherDate, dateDiff);
+        }
+
+        return otherDate;
+    }
 
     private handleTimeChangeLeftCalendar = (time: Date) => {
         this.handleTimeChange(time, 0);

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -277,6 +277,10 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         this.setState({ value: newDateRange, time: newTimeRange });
     };
 
+    // When a user sets the time value before choosing a date, we need to pick a date for
+    // them to have something to store the time on.
+    // The default depends on the value of the other date since there's an invariant
+    // that the left/0 date is always less than the right/1 date.
     private getDefaultDate = (dateIndex: number) => {
         const { value } = this.state;
         const otherIndex = dateIndex === 0 ? 1 : 0;

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import { format, parse, addDays } from "date-fns";
+import { addDays, format, parse } from "date-fns";
 import enUSLocale from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -1319,7 +1319,7 @@ describe("<DateRangePicker3>", () => {
 
             assert.isNotNull(start);
             assert.isNotNull(end);
-            assert.isTrue(DateUtils.isSameDay(start!, addDays(end!, 1)));
+            assert.isTrue(DateUtils.isSameDay(start!, addDays(start!, 1)));
         });
 
         it("clicking a shortcut with includeTime=false doesn't change time", () => {

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -1319,7 +1319,7 @@ describe("<DateRangePicker3>", () => {
 
             assert.isNotNull(start);
             assert.isNotNull(end);
-            assert.isTrue(DateUtils.isSameDay(start!, addDays(start!, 1)));
+            assert.isTrue(DateUtils.isSameDay(end!, addDays(start!, 1)));
         });
 
         it("clicking a shortcut with includeTime=false doesn't change time", () => {

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import { format, parse } from "date-fns";
+import { format, parse, addDays } from "date-fns";
 import enUSLocale from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -1293,9 +1293,33 @@ describe("<DateRangePicker3>", () => {
             assert.equal(parseInt(minuteInputText, 10), newLeftMinute);
         });
 
-        it("changing time without date uses today", () => {
+        it("changing time without date uses today, when other date not selected", () => {
             render({ timePrecision: "minute" }).setTimeInput("minute", "left", 45);
             assert.isTrue(DateUtils.isSameDay(onChangeSpy.firstCall.args[0][0] as Date, new Date()));
+        });
+
+        it("changing time without date uses other date if selected and `allowSingleDayRange` is true", () => {
+            const dateRange = render({ timePrecision: "minute", allowSingleDayRange: true });
+
+            dateRange.left.clickDay(10);
+            dateRange.setTimeInput("minute", "right", 45);
+            const [start, end] = dateRange.wrapper.state("value");
+
+            assert.isNotNull(start);
+            assert.isNotNull(end);
+            assert.isTrue(DateUtils.isSameDay(start!, end!));
+        });
+
+        it("changing time without date uses 1 day offset from other date if selected and `allowSingleDayRange` is false", () => {
+            const dateRange = render({ timePrecision: "minute", allowSingleDayRange: false });
+
+            dateRange.left.clickDay(10);
+            dateRange.setTimeInput("minute", "right", 45);
+            const [start, end] = dateRange.wrapper.state("value");
+
+            assert.isNotNull(start);
+            assert.isNotNull(end);
+            assert.isTrue(DateUtils.isSameDay(start!, addDays(end!, 1)));
         });
 
         it("clicking a shortcut with includeTime=false doesn't change time", () => {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6863
#### Fixes https://github.com/palantir/blueprint/issues/6856

Previously, users could end up with a reversed selection range if modifying the time input of the end date before selecting a date. Today's date was used as the default in these cases, leaving the user with a reversed range if the start date was later than today's date.

#### Checklist
- [x] Includes tests
- [-] Update documentation

#### Changes proposed in this pull request:
- Fix behavior of default date such that selected range cannot end up reversed.
- When `allowSingleDayRange` is not `true`, ensure the default date is 1 day off from the already selected date (otherwise keep today's date as default if no dates are selected).

#### Reviewers should focus on:
- There's a slight behavior break in that users could previously select a single day range by modifying the time with today's date selected as the start date. This seems like a bug that's okay to fix but would like a second opinion on this.
- Any better solutions than to add/subtract a day from the default when `allowSingleDayRange` is not `true`?
- Would you prefer to see the `allowSingleDayRange` change split out?