### PR TITLE
Fix docs crash when navigating with hotkeys

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isPageNode, type PageData, type TsDocBase } from "@documentalist/client";
+import { isPageNode, type HeadingNode, type PageData, type TsDocBase } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -26,7 +26,6 @@ import {
     type DocumentationProps,
     NavMenuItem,
     type NavMenuItemProps,
-    isNavSection,
 } from "@blueprintjs/docs-theme";
 
 import { highlightCodeBlocks } from "../styles/syntaxHighlighting";
@@ -40,6 +39,18 @@ const THEME_LOCAL_STORAGE_KEY = "blueprint-docs-theme";
 
 const GITHUB_SOURCE_URL = "https://github.com/palantir/blueprint/blob/develop";
 const NPM_URL = "https://www.npmjs.com/package";
+
+// HACKHACK: this is brittle
+// detect Components page and subheadings
+const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
+const CONTEXT_PATTERN = /\/context(\.[\w-]+)?$/;
+const HOOKS_PATTERN = /\/hooks(\.[\w-]+)?$/;
+const LEGACY_PATTERN = /\/legacy(\.[\w-]+)?$/;
+export const isNavSection = ({ route }: HeadingNode) =>
+    COMPONENTS_PATTERN.test(route) ||
+    CONTEXT_PATTERN.test(route) ||
+    HOOKS_PATTERN.test(route) ||
+    LEGACY_PATTERN.test(route);
 
 /** Return the current theme className. */
 export function getTheme(): string {

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { type HeadingNode, isPageNode, type PageData, type TsDocBase } from "@documentalist/client";
+import { isPageNode, type PageData, type TsDocBase } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -26,6 +26,7 @@ import {
     type DocumentationProps,
     NavMenuItem,
     type NavMenuItemProps,
+    isNavSection,
 } from "@blueprintjs/docs-theme";
 
 import { highlightCodeBlocks } from "../styles/syntaxHighlighting";
@@ -39,18 +40,6 @@ const THEME_LOCAL_STORAGE_KEY = "blueprint-docs-theme";
 
 const GITHUB_SOURCE_URL = "https://github.com/palantir/blueprint/blob/develop";
 const NPM_URL = "https://www.npmjs.com/package";
-
-// HACKHACK: this is brittle
-// detect Components page and subheadings
-const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
-const CONTEXT_PATTERN = /\/context(\.[\w-]+)?$/;
-const HOOKS_PATTERN = /\/hooks(\.[\w-]+)?$/;
-const LEGACY_PATTERN = /\/legacy(\.[\w-]+)?$/;
-const isNavSection = ({ route }: HeadingNode) =>
-    COMPONENTS_PATTERN.test(route) ||
-    CONTEXT_PATTERN.test(route) ||
-    HOOKS_PATTERN.test(route) ||
-    LEGACY_PATTERN.test(route);
 
 /** Return the current theme className. */
 export function getTheme(): string {

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isPageNode, type HeadingNode, type PageData, type TsDocBase } from "@documentalist/client";
+import { type HeadingNode, isPageNode, type PageData, type TsDocBase } from "@documentalist/client";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -46,7 +46,7 @@ const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
 const CONTEXT_PATTERN = /\/context(\.[\w-]+)?$/;
 const HOOKS_PATTERN = /\/hooks(\.[\w-]+)?$/;
 const LEGACY_PATTERN = /\/legacy(\.[\w-]+)?$/;
-export const isNavSection = ({ route }: HeadingNode) =>
+const isNavSection = ({ route }: HeadingNode) =>
     COMPONENTS_PATTERN.test(route) ||
     CONTEXT_PATTERN.test(route) ||
     HOOKS_PATTERN.test(route) ||

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -158,6 +158,8 @@ export class Documentation extends React.PureComponent<DocumentationProps, Docum
         eachLayoutNode(this.props.docs.nav, (node, parents) => {
             if (isPageNode(node)) {
                 if (this.props.navigatorExclude?.(node)) {
+                    // if node is excluded from navigation, don't store it in the route to page map
+                    // to ensure the user cannnot navigate to it with hotkeys or through the URL
                     return;
                 }
                 this.routeToPage[node.route] = node.reference;

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -122,18 +122,6 @@ export interface DocumentationProps extends Props {
     tagRenderers: TagRendererMap;
 }
 
-// HACKHACK: this is brittle
-// detect Components page and subheadings
-const COMPONENTS_PATTERN = /\/components(\.[\w-]+)?$/;
-const CONTEXT_PATTERN = /\/context(\.[\w-]+)?$/;
-const HOOKS_PATTERN = /\/hooks(\.[\w-]+)?$/;
-const LEGACY_PATTERN = /\/legacy(\.[\w-]+)?$/;
-export const isNavSection = ({ route }: HeadingNode) =>
-    COMPONENTS_PATTERN.test(route) ||
-    CONTEXT_PATTERN.test(route) ||
-    HOOKS_PATTERN.test(route) ||
-    LEGACY_PATTERN.test(route);
-
 export interface DocumentationState {
     activeApiMember: string;
     activePageId: string;
@@ -168,9 +156,10 @@ export class Documentation extends React.PureComponent<DocumentationProps, Docum
         // build up static map of all references to their page, for navigation / routing
         this.routeToPage = {};
         eachLayoutNode(this.props.docs.nav, (node, parents) => {
-            if (isNavSection(node)) {
-                return;
-            } else if (isPageNode(node)) {
+            if (isPageNode(node)) {
+                if (this.props.navigatorExclude?.(node)) {
+                    return;
+                }
                 this.routeToPage[node.route] = node.reference;
             } else if (parents[0] != null) {
                 this.routeToPage[node.route] = parents[0].reference;


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6381

#### Checklist
- [n/a] Includes tests
- [n/a] Update documentation

#### Changes proposed in this pull request:
Ignore non-navigational headers so that navigating with hotkeys does not crash the page, and users cannot get to a page with no useful info.

#### Reviewers should focus on:
- Unintended changes
- Any ideas on improving the targeting of non-navigational headers

#### Also considered
Allowing these headers to be navigated to, but you end up on a useless page
![Screenshot 2024-06-24 at 2 40 15 PM](https://github.com/palantir/blueprint/assets/14102129/1616c768-fbdf-4d16-acde-8101a961604c)

#### Screenshot
Current:
![Screenshot 2024-06-24 at 2 38 05 PM](https://github.com/palantir/blueprint/assets/14102129/473dcf73-a841-4f4b-8d3a-1f8b43e2bcd8)

This PR:
![Screenshot 2024-06-24 at 2 38 15 PM](https://github.com/palantir/blueprint/assets/14102129/17cc2ad4-a68b-4db7-93e8-0de7128a3248)