### PR TITLE
Respect showOutsideDays prop for single month date range

### DIFF
--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -45,6 +45,7 @@ export const DATERANGEPICKER = `${NS}-daterangepicker`;
 export const DATERANGEPICKER_CALENDARS = `${DATERANGEPICKER}-calendars`;
 export const DATERANGEPICKER_CONTIGUOUS = `${DATERANGEPICKER}-contiguous`;
 export const DATERANGEPICKER_SINGLE_MONTH = `${DATERANGEPICKER}-single-month`;
+export const DATERANGEPICKER_SHOWING_OUTSIDE_DAYS = `${DATERANGEPICKER}-showing-outside-days`;
 export const DATERANGEPICKER_DAY_SELECTED_RANGE = `${DATEPICKER_DAY}--selected-range`;
 export const DATERANGEPICKER_DAY_HOVERED_RANGE = `${DATEPICKER_DAY}--hovered-range`;
 export const DATERANGEPICKER_SHORTCUTS = `${DATERANGEPICKER}-shortcuts`;

--- a/packages/datetime2/src/common/errors.ts
+++ b/packages/datetime2/src/common/errors.ts
@@ -1,2 +1,2 @@
 export const WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP =
-    "dayPickerProps.showOutsideDays will only be applied if the DateRangePicker is displaying a single month, either through the singleMonthOnly propm, or with a minDate and maxDate of the same month."
+    "dayPickerProps.showOutsideDays will only be applied if the DateRangePicker is displaying a single month, either through the singleMonthOnly propm, or with a minDate and maxDate of the same month.";

--- a/packages/datetime2/src/common/errors.ts
+++ b/packages/datetime2/src/common/errors.ts
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP =
     "dayPickerProps.showOutsideDays will only be applied if the DateRangePicker3 is displaying a single month, either through the singleMonthOnly prop, or with a minDate and maxDate of the same month.";

--- a/packages/datetime2/src/common/errors.ts
+++ b/packages/datetime2/src/common/errors.ts
@@ -1,1 +1,2 @@
-export const WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP = "showOutsideDays will only be applied if the DateRangePicker is displaying a single month."
+export const WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP =
+    "dayPickerProps.showOutsideDays will only be applied if the DateRangePicker is displaying a single month, either through the singleMonthOnly propm, or with a minDate and maxDate of the same month."

--- a/packages/datetime2/src/common/errors.ts
+++ b/packages/datetime2/src/common/errors.ts
@@ -1,0 +1,1 @@
+export const WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP = "showOutsideDays will only be applied if the DateRangePicker is displaying a single month."

--- a/packages/datetime2/src/common/errors.ts
+++ b/packages/datetime2/src/common/errors.ts
@@ -1,2 +1,2 @@
 export const WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP =
-    "dayPickerProps.showOutsideDays will only be applied if the DateRangePicker is displaying a single month, either through the singleMonthOnly propm, or with a minDate and maxDate of the same month.";
+    "dayPickerProps.showOutsideDays will only be applied if the DateRangePicker3 is displaying a single month, either through the singleMonthOnly prop, or with a minDate and maxDate of the same month.";

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -60,12 +60,11 @@
   }
 
   // showing outside days is allowed for single months
-  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days {
-    .rdp-day_outside {
-      visibility: visible;
-      // weird interactions happen if allowing outside days to be clicked
-      pointer-events: none;
-    }
+  /* stylelint-disable max-line-length */
+  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day_outside {
+    // weird interactions happen if allowing outside days to be clicked
+    pointer-events: none;
+    visibility: visible;
   }
 
   // need some extra specificity to override DatePicker styles

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -60,11 +60,12 @@
   }
 
   // showing outside days is allowed for single months
-  /* stylelint-disable max-line-length */
-  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day_outside {
-    visibility: visible;
-    // weird interactions happen if allowing outside days to be clicked
-    pointer-events: none;
+  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days {
+    .rdp-day_outside {
+      visibility: visible;
+      // weird interactions happen if allowing outside days to be clicked
+      pointer-events: none;
+    }
   }
 
   // need some extra specificity to override DatePicker styles

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -61,10 +61,8 @@
 
   // showing outside days is allowed for single months
   /* stylelint-disable max-line-length */
-  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day {
-    &_outside {
-      visibility: visible;
-    }
+  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day_outside {
+    visibility: visible;
   }
 
   // need some extra specificity to override DatePicker styles

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -65,6 +65,7 @@
     pointer-events: none; // weird interactions happen if allowing outside days to be clicked
     visibility: visible; // showing outside days is allowed for single months
   }
+  /* stylelint-enable max-line-length */
 
   // need some extra specificity to override DatePicker styles
   &.#{$ns}-datepicker .rdp-day {

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -60,6 +60,7 @@
   }
 
   // showing outside days is allowed for single months
+  /* stylelint-disable max-line-length */
   &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day {
     &_outside {
       visibility: visible;

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -59,12 +59,11 @@
     }
   }
 
-  // showing outside days is allowed for single months
+
   /* stylelint-disable max-line-length */
   &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day_outside {
-    // weird interactions happen if allowing outside days to be clicked
-    pointer-events: none;
-    visibility: visible;
+    pointer-events: none; // weird interactions happen if allowing outside days to be clicked
+    visibility: visible; // showing outside days is allowed for single months
   }
 
   // need some extra specificity to override DatePicker styles

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -59,6 +59,13 @@
     }
   }
 
+  // showing outside days is allowed for single months
+  &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day {
+    &_outside {
+      visibility: visible;
+    }
+  }
+
   // need some extra specificity to override DatePicker styles
   &.#{$ns}-datepicker .rdp-day {
     // we only want outside days to be shown when displaying one month at a time

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -63,6 +63,8 @@
   /* stylelint-disable max-line-length */
   &.#{$ns}-datepicker.#{$ns}-daterangepicker-single-month.#{$ns}-daterangepicker-showing-outside-days .rdp-day_outside {
     visibility: visible;
+    // weird interactions happen if allowing outside days to be clicked
+    pointer-events: none;
   }
 
   // need some extra specificity to override DatePicker styles

--- a/packages/datetime2/src/components/date-range-picker3/date-range-picker3.md
+++ b/packages/datetime2/src/components/date-range-picker3/date-range-picker3.md
@@ -64,6 +64,9 @@ The **preset shortcuts** can be seen in the example above. They are as follows:
 
 @## Props interface
 
+The `showOutsideDays` prop on `dayPickerProps` will only be respected when a single month is shown.
+This is to avoid a possible double representation of a selected date range.
+
 @interface DateRangePicker3Props
 
 @## Localization

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -131,6 +131,7 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
             [Classes.DATERANGEPICKER_CONTIGUOUS]: contiguousCalendarMonths,
             [Classes.DATERANGEPICKER_SINGLE_MONTH]: isSingleMonthOnly,
             [Classes.DATERANGEPICKER3_REVERSE_MONTH_AND_YEAR]: this.props.reverseMonthAndYearMenus,
+            [Classes.DATERANGEPICKER_SHOWING_OUTSIDE_DAYS]: this.props.dayPickerProps?.showOutsideDays,
         });
 
         // use the left DayPicker when we only need one

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -122,7 +122,7 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
             value,
         };
 
-        if (!getIsSingleMonthOnly(this.props) && this.props.dayPickerProps.showOutsideDays) {
+        if (!getIsSingleMonthOnly(this.props) && this.props.dayPickerProps?.showOutsideDays) {
             console.warn(WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP);
         }
     }

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -42,6 +42,7 @@ import { ContiguousDayRangePicker } from "./contiguousDayRangePicker";
 import type { DateRangePicker3DefaultProps, DateRangePicker3Props } from "./dateRangePicker3Props";
 import type { DateRangePicker3State } from "./dateRangePicker3State";
 import { NonContiguousDayRangePicker } from "./nonContiguousDayRangePicker";
+import { WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP } from "../../common/errors";
 
 export type { DateRangePicker3Props };
 
@@ -120,6 +121,10 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
             time,
             value,
         };
+
+        if (!getIsSingleMonthOnly(this.props) && this.props.dayPickerProps.showOutsideDays) {
+            console.warn(WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP);
+        }
     }
 
     public render() {

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -35,6 +35,7 @@ import {
 
 import { Classes, dayPickerClassNameOverrides } from "../../classes";
 import { combineModifiers, HOVERED_RANGE_MODIFIER } from "../../common/dayPickerModifiers";
+import { WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP } from "../../common/errors";
 import { DatePicker3Provider } from "../date-picker3/datePicker3Context";
 import { DateFnsLocalizedComponent } from "../dateFnsLocalizedComponent";
 
@@ -42,7 +43,6 @@ import { ContiguousDayRangePicker } from "./contiguousDayRangePicker";
 import type { DateRangePicker3DefaultProps, DateRangePicker3Props } from "./dateRangePicker3Props";
 import type { DateRangePicker3State } from "./dateRangePicker3State";
 import { NonContiguousDayRangePicker } from "./nonContiguousDayRangePicker";
-import { WARNING_IGNORED_SHOW_OUTSIDE_DAYS_PROP } from "../../common/errors";
 
 export type { DateRangePicker3Props };
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
@@ -22,21 +22,23 @@ import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps"
 /** Props shared between DateRangePicker v1 and v3 */
 type DateRangePickerSharedProps = Omit<DateRangePickerProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
 
-export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps & {
-    dayPickerProps: ReactDayPickerRangeProps["dayPickerProps"] & {
-         /**
-         * Show the outside days.  An outside day is a day falling in the next or the
-         * previous month.
-         *
-         * Note that his prop is only respected if the date range is displaying a single month,
-         * outside days will not be shown when this component displays multiple months, as it
-         * could cause some days to be represented multiple times in different places.
-         *
-         * @defaultValue false
-         */
-        showOutsideDays?: boolean;
+export type DateRangePicker3Props = DateRangePickerSharedProps &
+    DateFnsLocaleProps &
+    ReactDayPickerRangeProps & {
+        dayPickerProps: ReactDayPickerRangeProps["dayPickerProps"] & {
+            /**
+             * Show the outside days.  An outside day is a day falling in the next or the
+             * previous month.
+             *
+             * Note that his prop is only respected if the date range is displaying a single month,
+             * outside days will not be shown when this component displays multiple months, as it
+             * could cause some days to be represented multiple times in different places.
+             *
+             * @defaultValue false
+             */
+            showOutsideDays?: boolean;
+        };
     };
-};
 
 export type DateRangePicker3DefaultProps = Required<
     Pick<

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
@@ -22,23 +22,7 @@ import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps"
 /** Props shared between DateRangePicker v1 and v3 */
 type DateRangePickerSharedProps = Omit<DateRangePickerProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
 
-export type DateRangePicker3Props = DateRangePickerSharedProps &
-    DateFnsLocaleProps &
-    ReactDayPickerRangeProps & {
-        dayPickerProps: ReactDayPickerRangeProps["dayPickerProps"] & {
-            /**
-             * Show the outside days.  An outside day is a day falling in the next or the
-             * previous month.
-             *
-             * Note that his prop is only respected if the date range is displaying a single month,
-             * outside days will not be shown when this component displays multiple months, as it
-             * could cause some days to be represented multiple times in different places.
-             *
-             * @defaultValue false
-             */
-            showOutsideDays?: boolean;
-        };
-    };
+export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;
 
 export type DateRangePicker3DefaultProps = Required<
     Pick<

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3Props.ts
@@ -22,7 +22,21 @@ import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps"
 /** Props shared between DateRangePicker v1 and v3 */
 type DateRangePickerSharedProps = Omit<DateRangePickerProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
 
-export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;
+export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps & {
+    dayPickerProps: ReactDayPickerRangeProps["dayPickerProps"] & {
+         /**
+         * Show the outside days.  An outside day is a day falling in the next or the
+         * previous month.
+         *
+         * Note that his prop is only respected if the date range is displaying a single month,
+         * outside days will not be shown when this component displays multiple months, as it
+         * could cause some days to be represented multiple times in different places.
+         *
+         * @defaultValue false
+         */
+        showOutsideDays?: boolean;
+    };
+};
 
 export type DateRangePicker3DefaultProps = Required<
     Pick<

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -20,7 +20,7 @@ import enUSLocale from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
 import { type DayModifiers, DayPicker, type ModifiersClassNames } from "react-day-picker";
-import sinon from "sinon";
+import sinon, { stub } from "sinon";
 
 import { Button, Classes, Menu, MenuItem } from "@blueprintjs/core";
 import {
@@ -1334,10 +1334,12 @@ describe("<DateRangePicker3>", () => {
 
     describe("outside days", () => {
         it("visually hides outside days when contiguous months are shown, even if showOutsideDays is true", () => {
+            const warnSpy = stub(console, "warn");
             const { left } = render({
                 dayPickerProps: { showOutsideDays: true },
                 initialMonth: new Date(2015, Months.DECEMBER, 2),
             });
+            assert.strictEqual(warnSpy.callCount, 1);
             assert.equal(
                 left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(),
                 "hidden",

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -1334,19 +1334,39 @@ describe("<DateRangePicker3>", () => {
 
     describe("outside days", () => {
         it("visually hides outside days when contiguous months are shown, even if showOutsideDays is true", () => {
-            const { left } = render({ initialMonth: new Date(2015, Months.DECEMBER, 2), dayPickerProps: { showOutsideDays: true } });
-            assert.equal(left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(), "hidden");
+            const { left } = render({
+                initialMonth: new Date(2015, Months.DECEMBER, 2),
+                dayPickerProps: { showOutsideDays: true },
+            });
+            assert.equal(
+                left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(),
+                "hidden",
+            );
         });
 
         it("allows outside days to be shown for single month date range", () => {
-            const { left } = render({ initialMonth: new Date(2015, Months.DECEMBER, 2), singleMonthOnly: true, dayPickerProps: { showOutsideDays: true } });
-            assert.equal(left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(), "visible");
+            const { left } = render({
+                initialMonth: new Date(2015, Months.DECEMBER, 2),
+                singleMonthOnly: true,
+                dayPickerProps: { showOutsideDays: true },
+            });
+            assert.equal(
+                left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(),
+                "visible",
+            );
         });
 
         it("does not allow outside days to be selected even when visible", () => {
-            const { left } = render({ initialMonth: new Date(2015, Months.DECEMBER, 2), singleMonthOnly: true, dayPickerProps: { showOutsideDays: true } });
+            const { left } = render({
+                initialMonth: new Date(2015, Months.DECEMBER, 2),
+                singleMonthOnly: true,
+                dayPickerProps: { showOutsideDays: true },
+            });
 
-            assert.equal(left.findOutsideDays().first().getDOMNode().computedStyleMap().get("pointer-events")?.toString(), "none");
+            assert.equal(
+                left.findOutsideDays().first().getDOMNode().computedStyleMap().get("pointer-events")?.toString(),
+                "none",
+            );
 
             // simulated clicks appear to not respect pointerEvents style or else would test with below
             //

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -1335,8 +1335,8 @@ describe("<DateRangePicker3>", () => {
     describe("outside days", () => {
         it("visually hides outside days when contiguous months are shown, even if showOutsideDays is true", () => {
             const { left } = render({
-                initialMonth: new Date(2015, Months.DECEMBER, 2),
                 dayPickerProps: { showOutsideDays: true },
+                initialMonth: new Date(2015, Months.DECEMBER, 2),
             });
             assert.equal(
                 left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(),
@@ -1346,9 +1346,9 @@ describe("<DateRangePicker3>", () => {
 
         it("allows outside days to be shown for single month date range", () => {
             const { left } = render({
+                dayPickerProps: { showOutsideDays: true },
                 initialMonth: new Date(2015, Months.DECEMBER, 2),
                 singleMonthOnly: true,
-                dayPickerProps: { showOutsideDays: true },
             });
             assert.equal(
                 left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(),
@@ -1358,9 +1358,9 @@ describe("<DateRangePicker3>", () => {
 
         it("does not allow outside days to be selected even when visible", () => {
             const { left } = render({
+                dayPickerProps: { showOutsideDays: true },
                 initialMonth: new Date(2015, Months.DECEMBER, 2),
                 singleMonthOnly: true,
-                dayPickerProps: { showOutsideDays: true },
             });
 
             assert.equal(

--- a/packages/datetime2/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangePicker3Tests.tsx
@@ -44,7 +44,7 @@ import { loadDateFnsLocaleFake } from "../common/loadDateFnsLocaleFake";
 // Change the default for testability
 (DateRangePicker3.defaultProps as DateRangePicker3Props).dateFnsLocaleLoader = loadDateFnsLocaleFake;
 
-describe.only("<DateRangePicker3>", () => {
+describe("<DateRangePicker3>", () => {
     let testsContainerElement: HTMLElement;
     let drpWrapper: ReactWrapper<DateRangePicker3Props, DateRangePicker3State>;
 
@@ -1332,7 +1332,7 @@ describe.only("<DateRangePicker3>", () => {
         });
     });
 
-    describe.only("outside days", () => {
+    describe("outside days", () => {
         it("visually hides outside days when contiguous months are shown, even if showOutsideDays is true", () => {
             const { left } = render({ initialMonth: new Date(2015, Months.DECEMBER, 2), dayPickerProps: { showOutsideDays: true } });
             assert.equal(left.findOutsideDays().first().getDOMNode().computedStyleMap().get("visibility")?.toString(), "hidden");

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -140,7 +140,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     />
                     <Tooltip content="Only respected when showing a single month calendar">
                         <Switch
-                            className="tooltip-target"
+                            className="keep-bottom-margin"
                             checked={this.state.showOutsideDays}
                             disabled={!this.state.singleMonthOnly && !DateUtils.isSameMonth(this.state.minDate, this.state.maxDate)}
                             label="Show outside days"

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -16,8 +16,8 @@
 
 import * as React from "react";
 
-import { Classes, FormGroup, Switch } from "@blueprintjs/core";
-import type { DateRange, TimePrecision } from "@blueprintjs/datetime";
+import { Classes, FormGroup, Switch, Tooltip } from "@blueprintjs/core";
+import { DateUtils, type DateRange, type TimePrecision } from "@blueprintjs/datetime";
 import { DateRangePicker3 } from "@blueprintjs/datetime2";
 import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
@@ -41,6 +41,7 @@ interface DateRangePicker3ExampleState {
     showTimeArrowButtons: boolean;
     timePrecision: TimePrecision | undefined;
     useAmPm: boolean;
+    showOutsideDays: boolean;
 }
 
 export class DateRangePicker3Example extends React.PureComponent<ExampleProps, DateRangePicker3ExampleState> {
@@ -57,6 +58,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
         singleMonthOnly: false,
         timePrecision: undefined,
         useAmPm: false,
+        showOutsideDays: true,
     };
 
     private handleDateRangeChange = (dateRange: DateRange) => this.setState({ dateRange });
@@ -91,6 +93,8 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
         this.setState({ contiguousCalendarMonths });
     });
 
+    private toggleShowOutsideDays = handleBooleanChange(showOutsideDays => this.setState({ showOutsideDays }));
+
     public render() {
         const { dateRange, localeCode, maxDate, minDate, showTimeArrowButtons, timePrecision, useAmPm, ...props } =
             this.state;
@@ -106,7 +110,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     minDate={minDate}
                     onChange={this.handleDateRangeChange}
                     dayPickerProps={{
-                        showOutsideDays: true,
+                        showOutsideDays: this.state.showOutsideDays,
                     }}
                     timePickerProps={
                         showTimePicker
@@ -134,6 +138,15 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                         label="Single month only"
                         onChange={this.toggleSingleMonth}
                     />
+                    <Tooltip content="Only respected when showing a single month calendar">
+                        <Switch
+                            className="tooltip-target"
+                            checked={this.state.showOutsideDays}
+                            disabled={!this.state.singleMonthOnly && !DateUtils.isSameMonth(this.state.minDate, this.state.maxDate)}
+                            label="Show outside days"
+                            onChange={this.toggleShowOutsideDays}
+                        />
+                    </Tooltip>
                     <Switch
                         checked={this.state.contiguousCalendarMonths}
                         disabled={this.state.singleMonthOnly}

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -105,6 +105,9 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     maxDate={maxDate}
                     minDate={minDate}
                     onChange={this.handleDateRangeChange}
+                    dayPickerProps={{
+                        showOutsideDays: true
+                    }}
                     timePickerProps={
                         showTimePicker
                             ? { precision: timePrecision, showArrowButtons: showTimeArrowButtons, useAmPm }

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -54,11 +54,11 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
         minDate: undefined,
         reverseMonthAndYearMenus: false,
         shortcuts: true,
+        showOutsideDays: true,
         showTimeArrowButtons: false,
         singleMonthOnly: false,
         timePrecision: undefined,
         useAmPm: false,
-        showOutsideDays: true,
     };
 
     private handleDateRangeChange = (dateRange: DateRange) => this.setState({ dateRange });
@@ -140,9 +140,12 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     />
                     <Tooltip content="Only respected when showing a single month calendar">
                         <Switch
-                            className="keep-bottom-margin"
                             checked={this.state.showOutsideDays}
-                            disabled={!this.state.singleMonthOnly && !DateUtils.isSameMonth(this.state.minDate, this.state.maxDate)}
+                            className="keep-bottom-margin"
+                            disabled={
+                                !this.state.singleMonthOnly &&
+                                !DateUtils.isSameMonth(this.state.minDate, this.state.maxDate)
+                            }
                             label="Show outside days"
                             onChange={this.toggleShowOutsideDays}
                         />

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -106,7 +106,7 @@ export class DateRangePicker3Example extends React.PureComponent<ExampleProps, D
                     minDate={minDate}
                     onChange={this.handleDateRangeChange}
                     dayPickerProps={{
-                        showOutsideDays: true
+                        showOutsideDays: true,
                     }}
                     timePickerProps={
                         showTimePicker

--- a/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateRangePicker3Example.tsx
@@ -17,7 +17,7 @@
 import * as React from "react";
 
 import { Classes, FormGroup, Switch, Tooltip } from "@blueprintjs/core";
-import { DateUtils, type DateRange, type TimePrecision } from "@blueprintjs/datetime";
+import { type DateRange, DateUtils, type TimePrecision } from "@blueprintjs/datetime";
 import { DateRangePicker3 } from "@blueprintjs/datetime2";
 import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -79,9 +79,9 @@ $example-spacing: $pt-grid-size * 4;
     font-size: $pt-font-size-small;
   }
 
-  .#{$ns}-control:last-child,
-  .#{$ns}-form-group:last-child,
-  .#{$ns}-label:last-child {
+  .#{$ns}-control:last-child:not(.tooltip-target),
+  .#{$ns}-form-group:last-child:not(.tooltip-target),
+  .#{$ns}-label:last-child:not(.tooltip-target) {
     margin-bottom: 0;
   }
 

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -79,9 +79,10 @@ $example-spacing: $pt-grid-size * 4;
     font-size: $pt-font-size-small;
   }
 
-  .#{$ns}-control:last-child:not(.tooltip-target),
-  .#{$ns}-form-group:last-child:not(.tooltip-target),
-  .#{$ns}-label:last-child:not(.tooltip-target) {
+  // add a "keep-bottom-margin" class to avoid removing the bottom margin due to the tooltip wrapper
+  .#{$ns}-control:last-child:not(.keep-bottom-margin),
+  .#{$ns}-form-group:last-child:not(.keep-bottom-margin),
+  .#{$ns}-label:last-child:not(.keep-bottom-margin) {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/4373

#### Checklist
- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:
When a DateRangePicker3 is limited to a single month, respect the `showOutsideDays` passed on `dayPickerProps`. Per https://github.com/palantir/blueprint/pull/586/files#r98813760 it was explicitly decided that showing outside days when multiple months are shown is not intended, and I agree that it still leads to some weird questions, but for a single month these issues do not exist.

#### Reviewers should focus on:
- Is this the behavior we want?
- Do the updated docs look good?
- Only fixing on `DateRangePicker3` since DateRangePicker is deprecated and frozen.

#### Alternate option
Simply document that `showOutsideDays` is never respected for `DateRangePicker3`

#### Screenshot
![Screenshot 2024-06-24 at 4 06 48 PM](https://github.com/palantir/blueprint/assets/14102129/e5ff25b5-9c76-49be-900b-338dc6e2b808)
![Screenshot 2024-06-24 at 4 06 43 PM](https://github.com/palantir/blueprint/assets/14102129/d258d7cd-64fd-45ee-8eb8-5ff7c6022595)
