### PR TITLE
feat(Popover): contentProps

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -40,7 +40,6 @@ import { Overlay2 } from "../overlay2/overlay2";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
 // eslint-disable-next-line import/no-cycle
 import { Tooltip } from "../tooltip/tooltip";
-
 import { matchReferenceWidthModifier } from "./customModifiers";
 import { POPOVER_ARROW_SVG_SIZE, PopoverArrow } from "./popoverArrow";
 import { positionToPlacement } from "./popoverPlacementUtils";
@@ -73,11 +72,6 @@ export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = Def
 
     /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
     backdropProps?: React.HTMLProps<HTMLDivElement>;
-
-    /**
-     * The content displayed inside the popover.
-     */
-    content?: string | React.JSX.Element;
 
     /**
      * The kind of interaction that triggers the display of the popover.
@@ -301,7 +295,7 @@ export class Popover<
         }
     }
 
-    protected validateProps(props: PopoverProps<T> & { children?: React.ReactNode }) {
+    protected validateProps(props: PopoverProps<T>) {
         if (props.isOpen == null && props.onInteraction != null) {
             console.warn(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
         }
@@ -417,7 +411,7 @@ export class Popover<
                 tabIndex: targetTabIndex,
             });
         } else {
-            const childTarget = Utils.ensureElement(React.Children.toArray(children)[0])!;
+            const childTarget = Utils.ensureElement(React.Children.toArray(children)[0]);
 
             if (childTarget === undefined) {
                 return null;
@@ -451,8 +445,16 @@ export class Popover<
     };
 
     private renderPopover = (popperProps: PopperChildrenProps) => {
-        const { autoFocus, enforceFocus, backdropProps, canEscapeKeyClose, hasBackdrop, interactionKind, usePortal } =
-            this.props;
+        const {
+            autoFocus,
+            enforceFocus,
+            backdropProps,
+            contentProps,
+            canEscapeKeyClose,
+            hasBackdrop,
+            interactionKind,
+            usePortal,
+        } = this.props;
         const { isClosingViaEscapeKeypress, isOpen } = this.state;
 
         // compute an appropriate transform origin so the scale animation points towards target
@@ -547,7 +549,9 @@ export class Popover<
                             {this.isArrowEnabled() && (
                                 <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
                             )}
-                            <div className={Classes.POPOVER_CONTENT}>{this.props.content}</div>
+                            <div {...contentProps} className={Classes.POPOVER_CONTENT}>
+                                {this.props.content}
+                            </div>
                         </div>
                     </ResizeSensor>
                 </div>

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -91,6 +91,16 @@ export interface PopoverSharedProps<TProps extends DefaultPopoverTargetHTMLProps
     children?: React.ReactNode;
 
     /**
+     * The content displayed inside the popover.
+     */
+    content?: string | React.JSX.Element;
+
+    /**
+     * HTML attributes to spread to the popover content container element.
+     */
+    contentProps?: React.HTMLAttributes<HTMLDivElement>;
+
+    /**
      * A boundary element supplied to the "flip" and "preventOverflow" modifiers.
      * This is a shorthand for overriding Popper.js modifier options with the `modifiers` prop.
      *

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -20,7 +20,7 @@ import * as React from "react";
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
 // eslint-disable-next-line import/no-cycle
-import { Popover, type PopoverInteractionKind } from "../popover/popover";
+import { Popover, PopoverInteractionKind } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
@@ -28,11 +28,6 @@ import { TooltipContext, type TooltipContextState, TooltipProvider } from "../po
 export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
     extends Omit<PopoverSharedProps<TProps>, "shouldReturnFocusOnClose">,
         IntentProps {
-    /**
-     * The content that will be displayed inside of the tooltip.
-     */
-    content: React.JSX.Element | string;
-
     /**
      * Whether to use a compact appearance, which reduces the visual padding around
      * tooltip content.
@@ -42,19 +37,11 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     compact?: boolean;
 
     /**
-     * The amount of time in milliseconds the tooltip should remain open after
-     * the user hovers off the trigger. The timer is canceled if the user mouses
-     * over the target before it expires.
-     *
      * @default 0
      */
     hoverCloseDelay?: number;
 
     /**
-     * The amount of time in milliseconds the tooltip should wait before opening
-     * after the user hovers over the trigger. The timer is canceled if the user
-     * mouses away from the target before it expires.
-     *
      * @default 100
      */
     hoverOpenDelay?: number;
@@ -68,12 +55,6 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     interactionKind?: typeof PopoverInteractionKind.HOVER | typeof PopoverInteractionKind.HOVER_TARGET_ONLY;
 
     /**
-     * Indicates how long (in milliseconds) the tooltip's appear/disappear
-     * transition takes. This is used by React `CSSTransition` to know when a
-     * transition completes and must match the duration of the animation in CSS.
-     * Only set this prop if you override Blueprint's default transitions with
-     * new transitions of a different length.
-     *
      * @default 100
      */
     transitionDuration?: number;
@@ -93,7 +74,7 @@ export class Tooltip<
         compact: false,
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
-        interactionKind: "hover-target",
+        interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY,
         minimal: false,
         transitionDuration: 100,
     };

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -78,7 +78,7 @@ describe("<Popover>", () => {
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_TOO_MANY_CHILDREN));
         });
 
-        it("warns if given children and target prop", () => {
+        it("warns if given children and renderTarget prop", () => {
             shallow(<Popover renderTarget={() => <span>"boom"</span>}>pow</Popover>);
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_TARGET));
         });

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -21,14 +21,63 @@ import { spy, stub } from "sinon";
 
 import { Classes } from "../../src/common";
 import { Button, Overlay2 } from "../../src/components";
+import * as Errors from "../../src/common/errors";
 import { Popover } from "../../src/components/popover/popover";
 import { Tooltip, type TooltipProps } from "../../src/components/tooltip/tooltip";
 
 const TARGET_SELECTOR = `.${Classes.POPOVER_TARGET}`;
 const TOOLTIP_SELECTOR = `.${Classes.TOOLTIP}`;
-const TEST_TARGET_ID = "test-target";
 
 describe("<Tooltip>", () => {
+    describe("validation", () => {
+        let warnSpy: sinon.SinonStub;
+
+        // use sinon.stub to prevent warnings from appearing in the test logs
+        before(() => (warnSpy = stub(console, "warn")));
+        beforeEach(() => warnSpy.resetHistory());
+        after(() => warnSpy.restore());
+
+        it("throws error if given no target", () => {
+            mount(<Tooltip content={<p>Text</p>} usePortal={false} />);
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_REQUIRES_TARGET));
+        });
+
+        it("warns if given > 1 target elements", () => {
+            mount(
+                <Tooltip>
+                    <Button />
+                    <Button />
+                </Tooltip>,
+            );
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_TOO_MANY_CHILDREN));
+        });
+
+        it("warns if given children and renderTarget prop", () => {
+            mount(<Tooltip renderTarget={() => <span>"boom"</span>}>pow</Tooltip>);
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_TARGET));
+        });
+
+        it("warns if given targetProps and renderTarget", () => {
+            mount(<Tooltip targetProps={{ role: "none" }} renderTarget={() => <span>"boom"</span>} />);
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_TARGET_PROPS_WITH_RENDER_TARGET));
+        });
+
+        it("warns if attempting to open with empty content", () => {
+            renderTooltip({content:undefined,isOpen:true})
+            assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_EMPTY_CONTENT));
+        });
+
+        it("warns and disables if given empty content", () => {
+            const tooltip = renderTooltip({content:undefined,isOpen:true})
+            assert.isFalse(tooltip.find(Overlay2).exists(), "not open for undefined content");
+            assert.equal(warnSpy.callCount, 1);
+
+            tooltip.setProps({ content: "    " });
+            assert.isFalse(tooltip.find(Overlay2).exists(), "not open for white-space string content");
+            assert.equal(warnSpy.callCount, 2);
+        });
+    });
+
     describe("rendering", () => {
         it("propogates class names correctly", () => {
             const tooltip = renderTooltip({
@@ -159,7 +208,7 @@ describe("<Tooltip>", () => {
     function renderTooltip(props?: Partial<TooltipProps>) {
         return mount<TooltipProps>(
             <Tooltip content={<p>Text</p>} hoverOpenDelay={0} {...props} usePortal={false}>
-                <Button id={TEST_TARGET_ID} text="target" />
+                <Button text="target" />
             </Tooltip>,
         );
     }


### PR DESCRIPTION
#### Changes proposed in this pull request:

- add `contentProps` prop to allow for props to content div
- copy validation tests from `Popover` to `Tooltip`
- move more shared props to `PopoverSharedProps`