### PR TITLE
feat(DateTime2): export TimePicker

### DIFF
--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -31,6 +31,7 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     type InputGroupProps,
+    Intent,
     mergeRefs,
     Popover,
     type PopoverClickTargetHandlers,
@@ -629,7 +630,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function _DateInpu
                 <InputGroup
                     autoComplete="off"
                     className={classNames(targetProps.className, inputProps.className)}
-                    intent={shouldShowErrorStyling && isErrorState ? "danger" : "none"}
+                    intent={shouldShowErrorStyling && isErrorState ? Intent.DANGER : Intent.NONE}
                     placeholder={placeholder}
                     rightElement={
                         <>

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -21,6 +21,7 @@ import {
     type ButtonProps,
     DISPLAYNAME_PREFIX,
     InputGroup,
+    Intent,
     mergeRefs,
     Popover,
     type PopoverClickTargetHandlers,
@@ -500,7 +501,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
                 <InputGroup
                     autoComplete="off"
                     className={classNames(targetProps.className, inputProps.className)}
-                    intent={shouldShowErrorStyling && isErrorState ? "danger" : "none"}
+                    intent={shouldShowErrorStyling && isErrorState ? Intent.DANGER : Intent.NONE}
                     placeholder={placeholder}
                     rightElement={
                         <>

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -42,6 +42,8 @@ export {
     /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateRangeShortcut,
     /** @deprecated import from `@blueprintjs/datetime` instead */
+    type DatePickerShortcut,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     getTimezoneMetadata,
     TimePrecision,
     /** @deprecated import from `@blueprintjs/datetime` instead */

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -27,28 +27,46 @@ export { Classes as Datetime2Classes, ReactDayPickerClasses } from "./classes";
 /* eslint-disable deprecation/deprecation */
 
 export {
-    /** @deprecated use `Datetime2Classes` instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead, or use `Datetime2Classes` */
     Classes,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateInput as DateInput2,
-    /** @deprecated use `DateInput3Props` instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateInputProps as DateInput2Props,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateRangeInput as DateRangeInput2,
-    /** @deprecated use `DateRangeInput3Props` instead */
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateRangeInputProps as DateRangeInput2Props,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneSelect,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type TimezoneSelectProps,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimePicker,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type TimePickerProps,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateRangeShortcut,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DatePickerShortcut,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateFormatProps,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateRange,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type NonNullDateRange,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     MonthAndYear,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     Months,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     getTimezoneMetadata,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimePrecision,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimeUnit,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneDisplayFormat,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DatePickerLocaleUtils,
 } from "@blueprintjs/datetime";

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -48,4 +48,8 @@ export {
     type TimezoneSelectProps,
     /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneDisplayFormat,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
+    TimePicker,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
+    type TimePickerProps,
 } from "@blueprintjs/datetime";

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -27,33 +27,23 @@ export { Classes as Datetime2Classes, ReactDayPickerClasses } from "./classes";
 /* eslint-disable deprecation/deprecation */
 
 export {
-    /** @deprecated import from `@blueprintjs/datetime` or use `Datetime2Classes` instead */
+    /** @deprecated use `Datetime2Classes` instead */
     Classes,
     type DateFormatProps,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateInput as DateInput2,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
+    /** @deprecated use `DateInput3Props` instead */
     type DateInputProps as DateInput2Props,
     type DateRange,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     DateRangeInput as DateRangeInput2,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
+    /** @deprecated use `DateRangeInput3Props` instead */
     type DateRangeInputProps as DateRangeInput2Props,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateRangeShortcut,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     type DatePickerShortcut,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     getTimezoneMetadata,
     TimePrecision,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneSelect,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     type TimezoneSelectProps,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimezoneDisplayFormat,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     TimePicker,
-    /** @deprecated import from `@blueprintjs/datetime` instead */
     type TimePickerProps,
 } from "@blueprintjs/datetime";

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -29,21 +29,26 @@ export { Classes as Datetime2Classes, ReactDayPickerClasses } from "./classes";
 export {
     /** @deprecated use `Datetime2Classes` instead */
     Classes,
-    type DateFormatProps,
     DateInput as DateInput2,
     /** @deprecated use `DateInput3Props` instead */
     type DateInputProps as DateInput2Props,
-    type DateRange,
     DateRangeInput as DateRangeInput2,
     /** @deprecated use `DateRangeInput3Props` instead */
     type DateRangeInputProps as DateRangeInput2Props,
-    type DateRangeShortcut,
-    type DatePickerShortcut,
-    getTimezoneMetadata,
-    TimePrecision,
     TimezoneSelect,
     type TimezoneSelectProps,
-    TimezoneDisplayFormat,
     TimePicker,
     type TimePickerProps,
+    type DateRangeShortcut,
+    type DatePickerShortcut,
+    type DateFormatProps,
+    type DateRange,
+    type NonNullDateRange,
+    MonthAndYear,
+    Months,
+    getTimezoneMetadata,
+    TimePrecision,
+    TimeUnit,
+    TimezoneDisplayFormat,
+    type DatePickerLocaleUtils,
 } from "@blueprintjs/datetime";

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -40,6 +40,8 @@ export {
     /** @deprecated import from `@blueprintjs/datetime` instead */
     type DateRangeInputProps as DateRangeInput2Props,
     /** @deprecated import from `@blueprintjs/datetime` instead */
+    type DateRangeShortcut,
+    /** @deprecated import from `@blueprintjs/datetime` instead */
     getTimezoneMetadata,
     TimePrecision,
     /** @deprecated import from `@blueprintjs/datetime` instead */

--- a/packages/datetime2/test/isotest.mjs
+++ b/packages/datetime2/test/isotest.mjs
@@ -31,7 +31,13 @@ describe("@blueprintjs/datetime2 isomorphic rendering", () => {
             DateRangePicker3: {},
         },
         {
-            excludedSymbols: ["DateInput2", "DateInput2MigrationUtils", "DateRangeInput2", "TimezoneSelect"],
+            excludedSymbols: [
+                "DateInput2",
+                "DateInput2MigrationUtils",
+                "DateRangeInput2",
+                "MonthAndYear",
+                "TimezoneSelect",
+            ],
         },
     );
 });


### PR DESCRIPTION
#### Fixes #6739

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Export `TimePicker` from `datetime2` package, from the original `datetime` package, like is already being done for `TimezoneSelect` as well as other componentes/ types.

#### Reviewers should focus on:

Other components/types are exported this way in the same file