### PR TITLE
Fix Overlay2 storing stale onClose callback

### DIFF
--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -195,35 +195,6 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         [getThisOverlayAndDescendants, id, onClose],
     );
 
-    // Important: clean up old document-level event listeners if their memoized values change (this is rare, but
-    // may happen, for example, if a user forgets to use `React.useCallback` in the `props.onClose` value).
-    // Otherwise, we will lose the reference to those values and create a memory leak since we won't be able
-    // to successfully detach them inside overlayWillClose.
-    React.useEffect(() => {
-        if (!isOpen || !(canOutsideClickClose && !hasBackdrop)) {
-            return;
-        }
-
-        document.addEventListener("mousedown", handleDocumentMousedown);
-
-        return () => {
-            document.removeEventListener("mousedown", handleDocumentMousedown);
-        };
-    }, [handleDocumentMousedown, isOpen, canOutsideClickClose, hasBackdrop]);
-    React.useEffect(() => {
-        if (!isOpen || !enforceFocus) {
-            return;
-        }
-
-        // Focus events do not bubble, but setting useCapture allows us to listen in and execute
-        // our handler before all others
-        document.addEventListener("focus", handleDocumentFocus, /* useCapture */ true);
-
-        return () => {
-            document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
-        }
-    }, [handleDocumentFocus, enforceFocus, isOpen]);
-
     // send this instance's imperative handle to the the forwarded ref as well as our local ref
     const ref = React.useMemo(() => mergeRefs(forwardedRef, instance), [forwardedRef]);
     React.useImperativeHandle(
@@ -334,6 +305,35 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
             overlayWillClose();
         }
     }, [isOpen, overlayWillOpen, overlayWillClose, prevIsOpen]);
+
+    // Important: clean up old document-level event listeners if their memoized values change (this is rare, but
+    // may happen, for example, if a user forgets to use `React.useCallback` in the `props.onClose` value).
+    // Otherwise, we will lose the reference to those values and create a memory leak since we won't be able
+    // to successfully detach them inside overlayWillClose.
+    React.useEffect(() => {
+        if (!isOpen || !(canOutsideClickClose && !hasBackdrop)) {
+            return;
+        }
+
+        document.addEventListener("mousedown", handleDocumentMousedown);
+
+        return () => {
+            document.removeEventListener("mousedown", handleDocumentMousedown);
+        };
+    }, [handleDocumentMousedown, isOpen, canOutsideClickClose, hasBackdrop]);
+    React.useEffect(() => {
+        if (!isOpen || !enforceFocus) {
+            return;
+        }
+
+        // Focus events do not bubble, but setting useCapture allows us to listen in and execute
+        // our handler before all others
+        document.addEventListener("focus", handleDocumentFocus, /* useCapture */ true);
+
+        return () => {
+            document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
+        }
+    }, [handleDocumentFocus, enforceFocus, isOpen]);
 
     React.useEffect(() => {
         // run cleanup code once on unmount, ensuring we call the most recent overlayWillClose callback

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -322,7 +322,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
 
         return () => {
             document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
-        }
+        };
     }, [handleDocumentFocus, enforceFocus, isOpen]);
 
     React.useEffect(() => {

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -254,17 +254,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         }
 
         setRef(lastActiveElementBeforeOpened, getActiveElement(getRef(containerElement)));
-    }, [
-        autoFocus,
-        bringFocusInsideOverlay,
-        canOutsideClickClose,
-        enforceFocus,
-        getLastOpened,
-        handleDocumentMousedown,
-        handleDocumentFocus,
-        hasBackdrop,
-        openOverlay,
-    ]);
+    }, [autoFocus, bringFocusInsideOverlay, getLastOpened, openOverlay]);
 
     const overlayWillClose = React.useCallback(() => {
         document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -276,8 +276,6 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
             }
         }
     }, [closeOverlay, getLastOpened, handleDocumentFocus, handleDocumentMousedown, id]);
-    const mostRecetOverlayWillClose = React.useRef(overlayWillClose);
-    mostRecetOverlayWillClose.current = overlayWillClose;
 
     const prevIsOpen = usePrevious(isOpen) ?? false;
     React.useEffect(() => {
@@ -325,11 +323,13 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         };
     }, [handleDocumentFocus, enforceFocus, isOpen]);
 
+    const overlayWillCloseRef = React.useRef(overlayWillClose);
+    overlayWillCloseRef.current = overlayWillClose;
     React.useEffect(() => {
         // run cleanup code once on unmount, ensuring we call the most recent overlayWillClose callback
         // by storing in a ref and keeping up to date
         return () => {
-            mostRecetOverlayWillClose.current();
+            overlayWillCloseRef.current();
         };
     }, []);
 

--- a/packages/core/test/overlay2/overlay2Tests.tsx
+++ b/packages/core/test/overlay2/overlay2Tests.tsx
@@ -184,8 +184,13 @@ describe("<Overlay2>", () => {
                     {createOverlayContents()}
                 </OverlayWrapper>,
             );
+
+            // ensure onClose can be updated
+            const onClose2 = spy();
+            overlay.setProps({ onClose: onClose2 });
             overlay.find(BACKDROP_SELECTOR).simulate("mousedown");
-            assert.isTrue(onClose.calledOnce);
+            assert.isTrue(onClose.notCalled);
+            assert.isTrue(onClose2.calledOnce);
         });
 
         it("not invoked on backdrop mousedown when canOutsideClickClose=false", () => {
@@ -201,15 +206,18 @@ describe("<Overlay2>", () => {
 
         it("invoked on document mousedown when hasBackdrop=false", () => {
             const onClose = spy();
-            // mounting cuz we need document events + lifecycle
-            mountWrapper(
-                <OverlayWrapper hasBackdrop={false} isOpen={true} onClose={onClose} usePortal={false}>
+            const overlay = mountWrapper(
+                <OverlayWrapper isOpen={true} onClose={onClose} usePortal={false} hasBackdrop={false}>
                     {createOverlayContents()}
                 </OverlayWrapper>,
             );
 
+            // ensure onClose can be updated
+            const onClose2 = spy();
+            overlay.setProps({ onClose: onClose2 });
             dispatchMouseEvent(document.documentElement, "mousedown");
-            assert.isTrue(onClose.calledOnce);
+            assert.isTrue(onClose.notCalled);
+            assert.isTrue(onClose2.calledOnce);
         });
 
         it("not invoked on document mousedown when hasBackdrop=false and canOutsideClickClose=false", () => {
@@ -249,13 +257,18 @@ describe("<Overlay2>", () => {
 
         it("invoked on escape key", () => {
             const onClose = spy();
-            mountWrapper(
+            const overlay = mountWrapper(
                 <OverlayWrapper isOpen={true} onClose={onClose} usePortal={false}>
                     {createOverlayContents()}
                 </OverlayWrapper>,
             );
+
+            // ensure onClose can be updated
+            const onClose2 = spy();
+            overlay.setProps({ onClose: onClose2 });
             wrapper.simulate("keydown", { key: "Escape" });
-            assert.isTrue(onClose.calledOnce);
+            assert.isTrue(onClose.notCalled);
+            assert.isTrue(onClose2.calledOnce);
         });
 
         it("not invoked on escape key when canEscapeKeyClose=false", () => {
@@ -278,20 +291,6 @@ describe("<Overlay2>", () => {
             const portal = overlay.find(Portal);
             assert.isTrue(portal.exists(), "missing Portal");
             assert.lengthOf(portal.find("strong"), 1, "missing h1");
-        });
-
-        it("calls the latest version of onClose", () => {
-            const onClose = spy();
-            const overlay = mountWrapper(
-                <OverlayWrapper isOpen={true} onClose={onClose} usePortal={false}>
-                    {createOverlayContents()}
-                </OverlayWrapper>,
-            );
-            const onClose2 = spy();
-            overlay.setProps({ onClose: onClose2 });
-            wrapper.simulate("keydown", { key: "Escape" });
-            assert.isTrue(onClose.notCalled);
-            assert.isTrue(onClose2.calledOnce);
         });
     });
 

--- a/packages/core/test/overlay2/overlay2Tests.tsx
+++ b/packages/core/test/overlay2/overlay2Tests.tsx
@@ -279,6 +279,20 @@ describe("<Overlay2>", () => {
             assert.isTrue(portal.exists(), "missing Portal");
             assert.lengthOf(portal.find("strong"), 1, "missing h1");
         });
+
+        it("calls the latest version of onClose", () => {
+            const onClose = spy();
+            const overlay = mountWrapper(
+                <OverlayWrapper isOpen={true} onClose={onClose} usePortal={false}>
+                    {createOverlayContents()}
+                </OverlayWrapper>,
+            );
+            const onClose2 = spy();
+            overlay.setProps({ onClose: onClose2 });
+            wrapper.simulate("keydown", { key: "Escape" });
+            assert.isTrue(onClose.notCalled);
+            assert.isTrue(onClose2.calledOnce);
+        });
     });
 
     describe("Focus management", () => {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6748

#### Checklist

- [x] Includes tests
- [-] Update documentation

#### Changes proposed in this pull request:
There are 3 changes in this PR, will split to separate PRs on request but figured they are closely related:
1. Fix cleaning up event listeners - previously we'd always be trying to remove the current version of the event listener that will have never been set yet.
2. Ensure we re-attach latest version of event listeners if for example `onClose` updates. We handle `onClose` updating for esc key and backdrop click because the latest callback versions are always passed to the element those are attached to, but did not do a similar update to the document listeners. A test case has been added for this behavior.
3. Ensure we don't call a stale version of the `overlayWillClose` callback on component unmount: [`evanj/overlay-fix?expand=1`#diff-50ceef9007](https://github.com/palantir/blueprint/compare/evanj/overlay-fix?expand=1#diff-50ceef90072c82bdf126a28d4f90f718d8a384f60d4ac90e7b1a9d2c4f4e57d4R342)

#### Reviewers should focus on:
- Any possible breaking changes
- Any possible mistakes when translating logic from `overlayWillOpen` callback directly into `useEffect` hooks

#### Screenshot
n/a