### PR TITLE
style: tooltip props refactor

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -75,11 +75,6 @@ export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     backdropProps?: React.HTMLProps<HTMLDivElement>;
 
     /**
-     * The content displayed inside the popover.
-     */
-    content?: string | React.JSX.Element;
-
-    /**
      * The kind of interaction that triggers the display of the popover.
      *
      * @default "click"
@@ -301,7 +296,7 @@ export class Popover<
         }
     }
 
-    protected validateProps(props: PopoverProps<T> & { children?: React.ReactNode }) {
+    protected validateProps(props: PopoverProps<T>) {
         if (props.isOpen == null && props.onInteraction != null) {
             console.warn(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
         }
@@ -417,7 +412,7 @@ export class Popover<
                 tabIndex: targetTabIndex,
             });
         } else {
-            const childTarget = Utils.ensureElement(React.Children.toArray(children)[0])!;
+            const childTarget = Utils.ensureElement(React.Children.toArray(children)[0]);
 
             if (childTarget === undefined) {
                 return null;

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -91,6 +91,11 @@ export interface PopoverSharedProps<TProps extends DefaultPopoverTargetHTMLProps
     children?: React.ReactNode;
 
     /**
+     * The content displayed inside the popover.
+     */
+    content?: string | React.JSX.Element;
+
+    /**
      * A boundary element supplied to the "flip" and "preventOverflow" modifiers.
      * This is a shorthand for overriding Popper.js modifier options with the `modifiers` prop.
      *

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -93,7 +93,7 @@ export interface PopoverSharedProps<TProps extends DefaultPopoverTargetHTMLProps
     /**
      * The content displayed inside the popover.
      */
-    content?: string | React.JSX.Element;
+    content: string | React.JSX.Element;
 
     /**
      * A boundary element supplied to the "flip" and "preventOverflow" modifiers.

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -29,11 +29,6 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     extends Omit<PopoverSharedProps<TProps>, "shouldReturnFocusOnClose">,
         IntentProps {
     /**
-     * The content that will be displayed inside of the tooltip.
-     */
-    content: React.JSX.Element | string;
-
-    /**
      * Whether to use a compact appearance, which reduces the visual padding around
      * tooltip content.
      *
@@ -42,19 +37,11 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     compact?: boolean;
 
     /**
-     * The amount of time in milliseconds the tooltip should remain open after
-     * the user hovers off the trigger. The timer is canceled if the user mouses
-     * over the target before it expires.
-     *
      * @default 0
      */
     hoverCloseDelay?: number;
 
     /**
-     * The amount of time in milliseconds the tooltip should wait before opening
-     * after the user hovers over the trigger. The timer is canceled if the user
-     * mouses away from the target before it expires.
-     *
      * @default 100
      */
     hoverOpenDelay?: number;
@@ -68,12 +55,6 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     interactionKind?: typeof PopoverInteractionKind.HOVER | typeof PopoverInteractionKind.HOVER_TARGET_ONLY;
 
     /**
-     * Indicates how long (in milliseconds) the tooltip's appear/disappear
-     * transition takes. This is used by React `CSSTransition` to know when a
-     * transition completes and must match the duration of the animation in CSS.
-     * Only set this prop if you override Blueprint's default transitions with
-     * new transitions of a different length.
-     *
      * @default 100
      */
     transitionDuration?: number;

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -37,11 +37,19 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     compact?: boolean;
 
     /**
+     * The amount of time in milliseconds the tooltip should remain open after
+     * the user hovers off the trigger. The timer is canceled if the user mouses
+     * over the target before it expires.
+     *
      * @default 0
      */
     hoverCloseDelay?: number;
 
     /**
+     * The amount of time in milliseconds the tooltip should wait before opening
+     * after the user hovers over the trigger. The timer is canceled if the user
+     * mouses away from the target before it expires.
+     *
      * @default 100
      */
     hoverOpenDelay?: number;
@@ -55,6 +63,12 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     interactionKind?: typeof PopoverInteractionKind.HOVER | typeof PopoverInteractionKind.HOVER_TARGET_ONLY;
 
     /**
+     * Indicates how long (in milliseconds) the tooltip's appear/disappear
+     * transition takes. This is used by React `CSSTransition` to know when a
+     * transition completes and must match the duration of the animation in CSS.
+     * Only set this prop if you override Blueprint's default transitions with
+     * new transitions of a different length.
+     *
      * @default 100
      */
     transitionDuration?: number;

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -78,7 +78,7 @@ describe("<Popover>", () => {
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_TOO_MANY_CHILDREN));
         });
 
-        it("warns if given children and target prop", () => {
+        it("warns if given children and renderTarget prop", () => {
             shallow(<Popover renderTarget={() => <span>"boom"</span>}>pow</Popover>);
             assert.isTrue(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_TARGET));
         });


### PR DESCRIPTION
If you are just changing the `@default` value, don't need to re-write the whole description when the original is in the `extends`:

![image](https://github.com/palantir/blueprint/assets/87083504/715ec91c-c59e-436d-b2cc-158abf64d54b)

![image](https://github.com/palantir/blueprint/assets/87083504/ce3d9490-eb57-4a01-98e3-71669490451a)
