### PR TITLE
Add affordance to icon selector in docs and fix selection state

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -129,7 +129,7 @@ export interface MenuItemProps
     /**
      * Whether this item should appear selected - `roleStructure` must be `"listoption"` for this to be
      * applied. Defining this will set the `aria-selected` attribute and apply a small tick icon if `true`,
-     * and space for a small tick icon if `false`.
+     * and empty space for a small tick icon if `false` or `undefined`.
      *
      * @default undefined
      */

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -127,10 +127,9 @@ export interface MenuItemProps
     popoverProps?: Partial<Omit<PopoverProps, "content" | "minimal">>;
 
     /**
-     * Whether this item should appear selected.
-     * Defining this  will set the `aria-selected` attribute and apply a
-     * "check" or "blank" icon on the item (unless the `icon` prop is set,
-     * which always takes precedence).
+     * Whether this item should appear selected - `roleStructure` must be `"listoption"` for this to be
+     * applied. Defining this will set the `aria-selected` attribute and apply a small tick icon if `true`,
+     * and space for a small tick icon if `false`.
      *
      * @default undefined
      */

--- a/packages/docs-app/src/examples/core-examples/common/iconNames.ts
+++ b/packages/docs-app/src/examples/core-examples/common/iconNames.ts
@@ -16,7 +16,7 @@
 
 import { type IconName, IconNames } from "@blueprintjs/icons";
 
-export const NONE = "(none)";
+export const NONE = "None";
 export type IconNameOrNone = IconName | typeof NONE;
 
 export function getIconNames(): IconNameOrNone[] {

--- a/packages/docs-app/src/examples/core-examples/common/iconNames.ts
+++ b/packages/docs-app/src/examples/core-examples/common/iconNames.ts
@@ -16,14 +16,10 @@
 
 import { type IconName, IconNames } from "@blueprintjs/icons";
 
-export const NONE = "None";
-export type IconNameOrNone = IconName | typeof NONE;
-
-export function getIconNames(): IconNameOrNone[] {
-    const iconNames = new Set<IconNameOrNone>();
+export function getIconNames(): IconName[] {
+    const iconNames = new Set<IconName>();
     for (const [, name] of Object.entries(IconNames)) {
         iconNames.add(name);
     }
-    iconNames.add(NONE);
     return Array.from(iconNames.values());
 }

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -43,6 +43,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
                     itemPredicate={this.filterIconName}
                     itemRenderer={this.renderIconItem}
                     noResults={<MenuItem disabled={true} text="No results" />}
+                    placeholder="Start typing to search…"
                     onItemSelect={this.handleIconChange}
                     popoverProps={{ minimal: true }}
                 >
@@ -77,9 +78,6 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
     };
 
     private filterIconName = (query: string, iconName: IconName | typeof NONE) => {
-        if (iconName === NONE) {
-            return true;
-        }
         if (query === "") {
             return iconName === this.props.iconName;
         }

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -35,7 +35,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
     public render() {
         const { disabled, iconName } = this.props;
         return (
-            <label className={classNames(Classes.LABEL, { [Classes.DISABLED]: disabled })}>
+            <label className={classNames("icon-select", Classes.LABEL, { [Classes.DISABLED]: disabled })}>
                 Icon
                 <Select<IconNameOrNone>
                     disabled={disabled}
@@ -49,7 +49,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
                 >
                     <Button
                         alignText={Alignment.LEFT}
-                        className={Classes.TEXT_OVERFLOW_ELLIPSIS}
+                        textClassName={Classes.TEXT_OVERFLOW_ELLIPSIS}
                         disabled={disabled}
                         fill={true}
                         icon={iconName}
@@ -86,5 +86,12 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
         return iconName.toLowerCase().indexOf(query.toLowerCase()) >= 0;
     };
 
-    private handleIconChange = (icon: IconNameOrNone) => this.props.onChange(icon === NONE ? undefined : icon);
+    private handleIconChange = (icon: IconNameOrNone) => {
+        if (icon === this.props.iconName) {
+            this.props.onChange(undefined);
+            return;
+        }
+
+        this.props.onChange(icon === NONE ? undefined : icon);
+    };
 }

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -21,7 +21,7 @@ import { Alignment, Button, Classes, MenuItem } from "@blueprintjs/core";
 import type { IconName } from "@blueprintjs/icons";
 import { type ItemRenderer, Select } from "@blueprintjs/select";
 
-import { getIconNames, type IconNameOrNone, NONE } from "./iconNames";
+import { getIconNames } from "./iconNames";
 
 const ICON_NAMES = getIconNames();
 
@@ -37,7 +37,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
         return (
             <label className={classNames("icon-select", Classes.LABEL, { [Classes.DISABLED]: disabled })}>
                 Icon
-                <Select<IconNameOrNone>
+                <Select<IconName>
                     disabled={disabled}
                     items={ICON_NAMES}
                     itemPredicate={this.filterIconName}
@@ -53,7 +53,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
                         disabled={disabled}
                         fill={true}
                         icon={iconName}
-                        text={iconName || NONE}
+                        text={iconName || "None"}
                         rightIcon="caret-down"
                     />
                 </Select>
@@ -61,7 +61,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
         );
     }
 
-    private renderIconItem: ItemRenderer<IconName | typeof NONE> = (icon, { handleClick, handleFocus, modifiers }) => {
+    private renderIconItem: ItemRenderer<IconName | undefined> = (icon, { handleClick, handleFocus, modifiers }) => {
         if (!modifiers.matchesPredicate) {
             return null;
         }
@@ -70,7 +70,7 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
                 roleStructure="listoption"
                 active={modifiers.active}
                 selected={this.props.iconName === icon}
-                icon={icon === NONE ? undefined : icon}
+                icon={icon}
                 key={icon}
                 onClick={handleClick}
                 onFocus={handleFocus}
@@ -79,19 +79,14 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
         );
     };
 
-    private filterIconName = (query: string, iconName: IconName | typeof NONE) => {
+    private filterIconName = (query: string, iconName: IconName | undefined) => {
         if (query === "") {
             return iconName === this.props.iconName;
         }
         return iconName.toLowerCase().indexOf(query.toLowerCase()) >= 0;
     };
 
-    private handleIconChange = (icon: IconNameOrNone) => {
-        if (icon === this.props.iconName) {
-            this.props.onChange(undefined);
-            return;
-        }
-
-        this.props.onChange(icon === NONE ? undefined : icon);
+    private handleIconChange = (icon: IconName) => {
+        this.props.onChange(icon === this.props.iconName ? undefined : icon);
     };
 }

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -67,7 +67,9 @@ export class IconSelect extends React.PureComponent<IconSelectProps> {
         }
         return (
             <MenuItem
-                selected={modifiers.active}
+                roleStructure="listoption"
+                active={modifiers.active}
+                selected={this.props.iconName === icon}
                 icon={icon === NONE ? undefined : icon}
                 key={icon}
                 onClick={handleClick}

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -683,6 +683,10 @@ $docs-hotkey-piano-height: 510px;
   flex-direction: row;
 }
 
+.icon-select {
+  width: 170px;
+}
+
 //
 // DATETIME2
 //

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -82,6 +82,14 @@ export interface SelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
     menuProps?: React.HTMLAttributes<HTMLUListElement>;
 
     /**
+     * A placeholder string passed to the filter text input.
+     * Applicable only when `filterable` is `true`.
+     *
+     * @default "Filter..."
+     */
+    placeholder?: string;
+
+    /**
      * Whether the active item should be reset to the first matching item _when
      * the popover closes_. The query will also be reset to the empty string.
      *
@@ -159,6 +167,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
             filterable = true,
             disabled = false,
             inputProps = {},
+            placeholder = "Filter...",
             popoverContentProps = {},
             popoverProps = {},
             popoverRef,
@@ -168,7 +177,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
             <InputGroup
                 aria-autocomplete="list"
                 leftIcon={<Search />}
-                placeholder="Filter..."
+                placeholder={placeholder}
                 rightElement={this.maybeRenderClearButton(listProps.query)}
                 {...inputProps}
                 inputRef={this.handleInputRef}


### PR DESCRIPTION
#### Fixes no issue

#### Checklist

- [n/a] Includes tests
- [n/a] Update documentation

#### Changes proposed in this pull request:
- Add better affordance that something needs to be typed for icons to show. I thought the docs were broken and didn't initially try typing anything here.
- Fix selection/active state. https://github.com/palantir/blueprint/commit/f0a9b09f715cfcc36ba237dcbcd4c1c90dfd21f2#diff-8194812817b7f429b5320bb9be65c267dea2308f9a5b914411859fc8d61d18b0R222 seems to be a breaking change (see how some other docs examples were updated). Maybe this was only part of the initial BP 5 release, but didn't seem to be mentioned in the upgrade guide. In any case this has been out long enough that it should be considered expected behavior at this point
- Update docs to mention `selected` only applies with the `"listoption"` role - I had to dig into the code to figure out what was going wrong here and initially thought selection state was entirely broken.

#### Reviewers should focus on:
- Anything else related that should be fixed
- Any unintended breaking changes from this PR

#### Screenshot
Current:
I found this to be confusing - [this looks like it came up in the PR that introduced but it](https://github.com/palantir/blueprint/pull/2028#issuecomment-362153856) was a big one and I suppose was never addressed
![Screenshot 2024-06-27 at 3 01 48 PM](https://github.com/palantir/blueprint/assets/14102129/6c858e52-2409-4cfa-b3d3-35a67b554dc3)
no indication of selection within menu - note selected icon shown in button:
![Screenshot 2024-06-27 at 3 01 55 PM](https://github.com/palantir/blueprint/assets/14102129/0f5382d0-e904-4a8b-8487-59ddfd6c1269)

This PR:
custom placeholder text:
![Screenshot 2024-06-27 at 3 02 10 PM](https://github.com/palantir/blueprint/assets/14102129/58f78548-115b-475e-92d8-38b8c50459c8)
selection state:
![Screenshot 2024-06-27 at 3 02 15 PM](https://github.com/palantir/blueprint/assets/14102129/bd834b58-f487-4ac6-adfa-6047053ab505)
