### PR TITLE
Fix DateRangeInput3 focus with timePrecision

### DIFF
--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -39,6 +39,7 @@ import {
     Errors,
     type NonNullDateRange,
     type TimePrecision,
+    TimePicker,
 } from "@blueprintjs/datetime";
 
 import { Classes } from "../../classes";
@@ -292,7 +293,13 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private getTimePrecision = () => {
         // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
         const { timePickerProps, timePrecision } = this.props;
-        return timePickerProps?.precision ?? timePrecision;
+        const fromProps = timePickerProps?.precision ?? timePrecision;
+        if (fromProps != null) {
+            return fromProps;
+        }
+
+        // if timePickerProps is defined, the `TimePicker` will render with it's default `precision`
+        return timePickerProps != null ? TimePicker.defaultProps.precision : undefined;
     };
 
     private handleDateRangePickerChange = (selectedRange: DateRange, didSubmitWithEnter = false) => {

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -38,8 +38,8 @@ import {
     DateUtils,
     Errors,
     type NonNullDateRange,
-    type TimePrecision,
     TimePicker,
+    type TimePrecision,
 } from "@blueprintjs/datetime";
 
 import { Classes } from "../../classes";

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -38,6 +38,7 @@ import {
     DateUtils,
     Errors,
     type NonNullDateRange,
+    TimePrecision,
 } from "@blueprintjs/datetime";
 
 import { Classes } from "../../classes";
@@ -288,6 +289,15 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     // Callbacks - DateRangePicker3
     // ===========================
 
+    private getTimePrecision = () => {
+        // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
+        const { timePickerProps, timePrecision } = this.props;
+        if(timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
+            return undefined;
+        }
+        return timePickerProps?.precision ?? timePrecision;
+    }
+
     private handleDateRangePickerChange = (selectedRange: DateRange, didSubmitWithEnter = false) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
         if (!this.state.isOpen) {
@@ -306,9 +316,11 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
 
         let boundaryToModify: Boundary | undefined;
 
+        const timePrecision = this.getTimePrecision();
+
         if (selectedStart == null) {
             // focus the start field by default or if only an end date is specified
-            if (this.props.timePrecision == null) {
+            if (timePrecision == null) {
                 isStartInputFocused = true;
                 isEndInputFocused = false;
             } else {
@@ -321,7 +333,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             startHoverString = null;
         } else if (selectedEnd == null) {
             // focus the end field if a start date is specified
-            if (this.props.timePrecision == null) {
+            if (timePrecision == null) {
                 isStartInputFocused = false;
                 isEndInputFocused = true;
             } else {
@@ -335,7 +347,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             isOpen = this.getIsOpenValueWhenDateChanges(selectedStart, selectedEnd);
             isStartInputFocused = false;
 
-            if (this.props.timePrecision == null && didSubmitWithEnter) {
+            if (timePrecision == null && didSubmitWithEnter) {
                 // if we submit via click or Tab, the focus will have moved already.
                 // it we submit with Enter, the focus won't have moved, and setting
                 // the flag to false won't have an effect anyway, so leave it true.
@@ -346,7 +358,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             }
         } else if (this.state.lastFocusedField === Boundary.START) {
             // keep the start field focused
-            if (this.props.timePrecision == null) {
+            if (timePrecision == null) {
                 isStartInputFocused = true;
                 isEndInputFocused = false;
             } else {
@@ -354,7 +366,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
                 isEndInputFocused = false;
                 boundaryToModify = Boundary.START;
             }
-        } else if (this.props.timePrecision == null) {
+        } else if (timePrecision == null) {
             // keep the end field focused
             isStartInputFocused = false;
             isEndInputFocused = true;
@@ -560,6 +572,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             isValueControlled ? values.controlledValue : values.selectedValue,
             this.props,
             this.state.locale,
+            this.getTimePrecision(),
             true,
         );
 
@@ -593,7 +606,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             if (isValueControlled) {
                 nextState = {
                     ...nextState,
-                    [keys.inputString]: formatDateString(values.controlledValue, this.props, this.state.locale),
+                    [keys.inputString]: formatDateString(values.controlledValue, this.props, this.state.locale, this.getTimePrecision()),
                 };
             } else {
                 nextState = {
@@ -680,7 +693,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private getIsOpenValueWhenDateChanges = (nextSelectedStart: Date, nextSelectedEnd: Date): boolean => {
         if (this.props.closeOnSelection) {
             // trivial case when TimePicker is not shown
-            if (this.props.timePrecision == null) {
+            if (this.getTimePrecision() == null) {
                 return false;
             }
 
@@ -747,7 +760,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
         } else if (this.doesEndBoundaryOverlapStartBoundary(selectedValue, boundary)) {
             return this.props.overlappingDatesMessage;
         } else {
-            return formatDateString(selectedValue, this.props, this.state.locale);
+            return formatDateString(selectedValue, this.props, this.state.locale, this.getTimePrecision());
         }
     };
 
@@ -893,7 +906,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
         // N.B. this.state will be undefined in the constructor, so we need a fallback in that case
         const maybeLocale = this.state?.locale ?? typeof props.locale === "string" ? undefined : props.locale;
 
-        return formatDateString(date ?? defaultDate, this.props, maybeLocale);
+        return formatDateString(date ?? defaultDate, this.props, maybeLocale, this.getTimePrecision());
     };
 
     private parseDate = (dateString: string | undefined): Date | null => {
@@ -907,7 +920,8 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
 
         // HACKHACK: this code below is largely copied from the `useDateParser()` hook, which is the preferred
         // implementation that we can migrate to once DateRangeInput3 is a function component.
-        const { dateFnsFormat, locale: localeFromProps, parseDate, timePickerProps, timePrecision } = this.props;
+        const { dateFnsFormat, locale: localeFromProps, parseDate, timePickerProps } = this.props;
+        const timePrecision = this.getTimePrecision();
         const { locale } = this.state;
         let newDate: false | Date | null = null;
 
@@ -931,7 +945,8 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
 
         // HACKHACK: the code below is largely copied from the `useDateFormatter()` hook, which is the preferred
         // implementation that we can migrate to once DateRangeInput3 is a function component.
-        const { dateFnsFormat, formatDate, locale: localeFromProps, timePickerProps, timePrecision } = this.props;
+        const { dateFnsFormat, formatDate, locale: localeFromProps, timePickerProps } = this.props;
+        const timePrecision = this.getTimePrecision();
         const { locale } = this.state;
 
         if (formatDate !== undefined) {
@@ -950,6 +965,7 @@ function formatDateString(
     date: Date | false | null | undefined,
     props: DateRangeInput3Props,
     locale: Locale | undefined,
+    timePrecision: TimePrecision | undefined,
     ignoreRange = false,
 ) {
     const { invalidDateMessage, maxDate, minDate, outOfRangeMessage } = props as DateRangeInput3PropsWithDefaults;
@@ -961,7 +977,7 @@ function formatDateString(
     } else if (ignoreRange || DateUtils.isDayInRange(date, [minDate, maxDate])) {
         // HACKHACK: the code below is largely copied from the `useDateFormatter()` hook, which is the preferred
         // implementation that we can migrate to once DateRangeInput3 is a function component.
-        const { dateFnsFormat, formatDate, locale: localeFromProps, timePickerProps, timePrecision } = props;
+        const { dateFnsFormat, formatDate, locale: localeFromProps, timePickerProps } = props;
         if (formatDate !== undefined) {
             // user-provided date formatter
             return formatDate(date, locale?.code ?? getLocaleCodeFromProps(localeFromProps));

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -38,7 +38,7 @@ import {
     DateUtils,
     Errors,
     type NonNullDateRange,
-    TimePrecision,
+    type TimePrecision,
 } from "@blueprintjs/datetime";
 
 import { Classes } from "../../classes";
@@ -292,11 +292,11 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private getTimePrecision = () => {
         // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
         const { timePickerProps, timePrecision } = this.props;
-        if(timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
+        if (timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
             return undefined;
         }
         return timePickerProps?.precision ?? timePrecision;
-    }
+    };
 
     private handleDateRangePickerChange = (selectedRange: DateRange, didSubmitWithEnter = false) => {
         // ignore mouse events in the date-range picker if the popover is animating closed.
@@ -606,7 +606,12 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             if (isValueControlled) {
                 nextState = {
                     ...nextState,
-                    [keys.inputString]: formatDateString(values.controlledValue, this.props, this.state.locale, this.getTimePrecision()),
+                    [keys.inputString]: formatDateString(
+                        values.controlledValue,
+                        this.props,
+                        this.state.locale,
+                        this.getTimePrecision(),
+                    ),
                 };
             } else {
                 nextState = {

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -292,9 +292,6 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private getTimePrecision = () => {
         // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
         const { timePickerProps, timePrecision } = this.props;
-        if (timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
-            return undefined;
-        }
         return timePickerProps?.precision ?? timePrecision;
     };
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -235,7 +235,9 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
     private maybeRenderTimePickers(isShowingOneMonth: boolean) {
         const { timePickerProps } = this.props;
         const timePrecision = this.getTimePrecision();
-        if (timePrecision == null) {
+        // setting empty object `timePickerProps` is enough to get the time picker to render with default props
+        // as defined in the TimePicker
+        if (timePrecision == null && timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
             return null;
         }
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -229,9 +229,6 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
     private getTimePrecision = () => {
         // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
         const { timePickerProps, timePrecision } = this.props;
-        if (timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
-            return undefined;
-        }
         return timePickerProps?.precision ?? timePrecision;
     };
 

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -208,7 +208,7 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         }
 
         const { selectedShortcutIndex } = this.state;
-        const { allowSingleDayRange, maxDate, minDate, timePrecision } = this.props;
+        const { allowSingleDayRange, maxDate, minDate } = this.props;
         return [
             <DatePickerShortcutMenu
                 key="shortcuts"
@@ -218,7 +218,7 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
                     minDate,
                     selectedShortcutIndex,
                     shortcuts,
-                    timePrecision,
+                    timePrecision: this.getTimePrecision(),
                 }}
                 onShortcutClick={this.handleShortcutClick}
             />,
@@ -226,15 +226,23 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         ];
     }
 
-    private maybeRenderTimePickers(isShowingOneMonth: boolean) {
+    private getTimePrecision = () => {
         // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
-        const { timePickerProps, timePrecision = timePickerProps?.precision } = this.props;
-        if (timePrecision == null && timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
+        const { timePickerProps, timePrecision } = this.props;
+        if(timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
+            return undefined;
+        }
+        return timePickerProps?.precision ?? timePrecision;
+    }
+
+    private maybeRenderTimePickers(isShowingOneMonth: boolean) {
+        const timePrecision = this.getTimePrecision();
+        if (timePrecision == null) {
             return null;
         }
 
         const isLongTimePicker =
-            timePickerProps?.useAmPm ||
+            this.props.timePickerProps?.useAmPm ||
             timePrecision === TimePrecision.SECOND ||
             timePrecision === TimePrecision.MILLISECOND;
 
@@ -246,13 +254,13 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
             >
                 <TimePicker
                     precision={timePrecision}
-                    {...timePickerProps}
+                    {...this.props.timePickerProps}
                     onChange={this.handleTimeChangeLeftCalendar}
                     value={this.state.time[0]}
                 />
                 <TimePicker
                     precision={timePrecision}
-                    {...timePickerProps}
+                    {...this.props.timePickerProps}
                     onChange={this.handleTimeChangeRightCalendar}
                     value={this.state.time[1]}
                 />

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -233,13 +233,14 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
     };
 
     private maybeRenderTimePickers(isShowingOneMonth: boolean) {
+        const { timePickerProps } = this.props;
         const timePrecision = this.getTimePrecision();
         if (timePrecision == null) {
             return null;
         }
 
         const isLongTimePicker =
-            this.props.timePickerProps?.useAmPm ||
+            timePickerProps?.useAmPm ||
             timePrecision === TimePrecision.SECOND ||
             timePrecision === TimePrecision.MILLISECOND;
 
@@ -251,13 +252,13 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
             >
                 <TimePicker
                     precision={timePrecision}
-                    {...this.props.timePickerProps}
+                    {...timePickerProps}
                     onChange={this.handleTimeChangeLeftCalendar}
                     value={this.state.time[0]}
                 />
                 <TimePicker
                     precision={timePrecision}
-                    {...this.props.timePickerProps}
+                    {...timePickerProps}
                     onChange={this.handleTimeChangeRightCalendar}
                     value={this.state.time[1]}
                 />

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -229,11 +229,11 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
     private getTimePrecision = () => {
         // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
         const { timePickerProps, timePrecision } = this.props;
-        if(timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
+        if (timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
             return undefined;
         }
         return timePickerProps?.precision ?? timePrecision;
-    }
+    };
 
     private maybeRenderTimePickers(isShowingOneMonth: boolean) {
         const timePrecision = this.getTimePrecision();

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -177,45 +177,54 @@ describe("<DateRangeInput3>", () => {
         expectPropValidationError(DateRangeInput3, { ...DATE_FORMAT, value: null! });
     });
 
-    describe("timePrecision prop", () => {
-        it("<TimePicker /> should not lose focus on increment/decrement with up/down arrows", () => {
-            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
+    describe("<TimePicker /> focus", () => {
+        // there are multiple ways to render the underlying TimePicker component so run same tests on all
+        const toTest = [
+            { label: "timePrecision != null", props: { timePrecision: TimePrecision.MINUTE }},
+            { label: "timePickerProps.precision != null", props: { timePickerProps: { precision: TimePrecision.MINUTE }}},
+            { label: "timePickerProps is {}", props: { timePickerProps: {}}},
+        ];
 
-            root.setState({ isOpen: true }).update();
-            expect(root.find(Popover).prop("isOpen"), "Popover isOpen").to.be.true;
+        toTest.forEach(({ label, props }) => {
+            it(`when ${label}, <TimePicker /> should not lose focus on increment/decrement with up/down arrows`, () => {
+                const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...props} />, true);
 
-            keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
-            expect(isStartInputFocused(root), "start input is focused").to.be.false;
-            expect(isEndInputFocused(root), "end input is focused").to.be.false;
-        });
+                root.setState({ isOpen: true }).update();
+                expect(root.find(Popover).prop("isOpen"), "Popover isOpen").to.be.true;
 
-        it("when timePrecision != null && closeOnSelection=true && <TimePicker /> values is changed popover should not close", () => {
-            const { root, getDayElement } = wrap(
-                <DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
-                true,
-            );
+                keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
+                expect(isStartInputFocused(root), "start input is focused").to.be.false;
+                expect(isEndInputFocused(root), "end input is focused").to.be.false;
+            });
 
-            root.setState({ isOpen: true }).update();
+            it(`when ${label} && closeOnSelection=true && <TimePicker /> values is changed popover should not close`, () => {
+                const { root, getDayElement } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} {...props} />,
+                    true,
+                );
 
-            getDayElement(1).simulate("click");
-            getDayElement(10).simulate("click");
+                root.setState({ isOpen: true }).update();
 
-            root.setState({ isOpen: true }).update();
+                getDayElement(1).simulate("click");
+                getDayElement(10).simulate("click");
 
-            keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
-            root.update();
-            expect(root.find(Popover).prop("isOpen")).to.be.true;
-        });
+                root.setState({ isOpen: true }).update();
 
-        it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
-            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
+                keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
+                root.update();
+                expect(root.find(Popover).prop("isOpen")).to.be.true;
+            });
 
-            root.setState({ isOpen: true });
-            keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
-            root.update();
-            keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp", 1);
-            root.update();
-            expect(root.find(Popover).prop("isOpen")).to.be.true;
+            it(`when ${label} && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close`, () => {
+                const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...props} />, true);
+
+                root.setState({ isOpen: true });
+                keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
+                root.update();
+                keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp", 1);
+                root.update();
+                expect(root.find(Popover).prop("isOpen")).to.be.true;
+            });
         });
 
         function keyDownOnInput(className: string, key: string, inputElementIndex: number = 0) {

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -180,9 +180,12 @@ describe("<DateRangeInput3>", () => {
     describe("<TimePicker /> focus", () => {
         // there are multiple ways to render the underlying TimePicker component so run same tests on all
         const toTest = [
-            { label: "timePrecision != null", props: { timePrecision: TimePrecision.MINUTE }},
-            { label: "timePickerProps.precision != null", props: { timePickerProps: { precision: TimePrecision.MINUTE }}},
-            { label: "timePickerProps is {}", props: { timePickerProps: {}}},
+            { label: "timePrecision != null", props: { timePrecision: TimePrecision.MINUTE } },
+            {
+                label: "timePickerProps.precision != null",
+                props: { timePickerProps: { precision: TimePrecision.MINUTE } },
+            },
+            { label: "timePickerProps is {}", props: { timePickerProps: {} } },
         ];
 
         toTest.forEach(({ label, props }) => {
@@ -198,10 +201,7 @@ describe("<DateRangeInput3>", () => {
             });
 
             it(`when ${label} && closeOnSelection=true && <TimePicker /> values is changed popover should not close`, () => {
-                const { root, getDayElement } = wrap(
-                    <DateRangeInput3 {...DATE_FORMAT} {...props} />,
-                    true,
-                );
+                const { root, getDayElement } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...props} />, true);
 
                 root.setState({ isOpen: true }).update();
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6879

#### Checklist
- [x] Includes tests
- [n/a] Update documentation

#### Changes proposed in this pull request:
Respect `precision` passed to `timePickerProps` as well as the root `timePrecision` prop when considering for focus.

#### Reviewers should focus on:
- Any mistakes
- Anywhere else I may have missed
- Worth sharing the implementation between components?

#### Reproducer
See linked issue

#### Recordings
Develop:
https://github.com/palantir/blueprint/assets/14102129/5e07692f-f433-40aa-af95-3da76cbef0f3

This PR:
https://github.com/palantir/blueprint/assets/14102129/042d91bc-81a2-4198-8066-89484b771387


