### PR TITLE
Fix: Table not keeping focused cell visible

### DIFF
--- a/packages/table/changelog/@unreleased/pr-6882.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-6882.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+
+  `Table` and `Table2` now keep the focused cell cell visible if the focused cell is changed by:
+
+  - The `focusedCell` prop (provided that `enableFocusedCell` is `true`), OR
+  - The built-in navigation key handlers for arrow, tab and enter keys
+  links:
+  - https://github.com/palantir/blueprint/pull/6882

--- a/packages/table/src/common/TableHeaderDimensions.ts
+++ b/packages/table/src/common/TableHeaderDimensions.ts
@@ -1,0 +1,8 @@
+/* !
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ */
+
+export interface TableHeaderDimensions {
+    readonly columnHeaderHeight: number;
+    readonly rowHeaderWidth: number;
+}

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -287,6 +287,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
 
         this.state = {
             childrenArray,
+            columnHeaderHeight: 0,
             columnIdToIndex,
             columnWidths: newColumnWidths,
             didHeadersMount: false,
@@ -296,6 +297,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
             isReordering: false,
             numFrozenColumnsClamped: clampNumFrozenColumns(props),
             numFrozenRowsClamped: clampNumFrozenRows(props),
+            rowHeaderWidth: 0,
             rowHeights: newRowHeights,
             selectedRegions,
             verticalGuides: [],

--- a/packages/table/src/tableState.ts
+++ b/packages/table/src/tableState.ts
@@ -20,6 +20,8 @@ import type { ScrollDirection } from "./common/scrollDirection";
 import type { Region } from "./regions";
 
 export interface TableState {
+    columnHeaderHeight: number;
+
     /**
      * An array of column widths. These are initialized from the column props
      * and updated when the user drags column header resize handles.
@@ -69,6 +71,8 @@ export interface TableState {
      */
     numFrozenRowsClamped: number;
 
+    rowHeaderWidth: number;
+
     /**
      * An array of row heights. These are initialized updated when the user
      * drags row header resize handles.
@@ -87,8 +91,28 @@ export interface TableState {
     verticalGuides: number[];
 
     /**
-     * The `Rect` bounds of the viewport used to perform virtual viewport
-     * performance enhancements.
+     * The bounds of the table. This includes:
+     * - Column and row headers,
+     * - Cell grid
+     *
+     * ```
+     * +---VIEWPORT RECT---+
+     * |   | H | H | H | H |
+     * +---+---+---+---+---+
+     * | H | F | F | F | F |
+     * +---+---+---+---+---+
+     * | H | F | S | S | S |
+     * +---+---+---+---+---+
+     * | H | F | S | S | S |
+     * +---+---+---+---+---+
+     * | H | F | S | S | S |
+     * +---+---+---+---+---+
+     *
+     *
+     * H = header
+     * F = frozen cell
+     * S = cell in the scrollable area
+     * ```
      */
     viewportRect?: Rect;
 

--- a/packages/table/src/tableState.ts
+++ b/packages/table/src/tableState.ts
@@ -20,8 +20,6 @@ import type { ScrollDirection } from "./common/scrollDirection";
 import type { Region } from "./regions";
 
 export interface TableState {
-    columnHeaderHeight: number;
-
     /**
      * An array of column widths. These are initialized from the column props
      * and updated when the user drags column header resize handles.
@@ -71,8 +69,6 @@ export interface TableState {
      */
     numFrozenRowsClamped: number;
 
-    rowHeaderWidth: number;
-
     /**
      * An array of row heights. These are initialized updated when the user
      * drags row header resize handles.
@@ -91,28 +87,8 @@ export interface TableState {
     verticalGuides: number[];
 
     /**
-     * The bounds of the table. This includes:
-     * - Column and row headers,
-     * - Cell grid
-     *
-     * ```
-     * +---VIEWPORT RECT---+
-     * |   | H | H | H | H |
-     * +---+---+---+---+---+
-     * | H | F | F | F | F |
-     * +---+---+---+---+---+
-     * | H | F | S | S | S |
-     * +---+---+---+---+---+
-     * | H | F | S | S | S |
-     * +---+---+---+---+---+
-     * | H | F | S | S | S |
-     * +---+---+---+---+---+
-     *
-     *
-     * H = header
-     * F = frozen cell
-     * S = cell in the scrollable area
-     * ```
+     * The `Rect` bounds of the viewport used to perform virtual viewport
+     * performance enhancements.
      */
     viewportRect?: Rect;
 


### PR DESCRIPTION
#### Fixes #1609. Partially addresses https://github.com/palantir/blueprint/issues/5114.

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Make sure the focused cell is visible on click or keyboard navigation (including when controlled via props)
- Improve internal docs
- Add pointers for other improvements uncovered as part of the work here (see end of PR)

#### Reviewers should focus on:

#### Screenshot

Before:


https://github.com/palantir/blueprint/assets/40673216/fef9d318-f6da-46d2-9032-d0248940d2fe



After:


https://github.com/palantir/blueprint/assets/40673216/322ce3ec-afee-4abe-8839-3f9db9b13318



### Not addressed in this PR

- Polishing interactions with frozen cells. The scrollable part of the table should only scroll if the frozen cell would otherwise not be visible. I file a FR after this merges and maybe FLUP.

  https://github.com/palantir/blueprint/assets/40673216/1a637d89-9d2a-4f01-b509-fae83533a3d4

- `getColumnIndicesInRect` operates on viewport rect but does not ignore headers or take frozen cells into account; this might be feeding into https://github.com/palantir/blueprint/issues/4780 and potentially contaminating the response of `onVisibleCellsChange`. Again, this is a side observation rather than a regression.