### PR TITLE
[core] fix(tabs): remove large gap between vertical tabs

### DIFF
--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -88,9 +88,9 @@ $tab-indicator-width: 3px !default;
 .#{$ns}-tab-list {
   align-items: flex-end;
   border: none;
+  column-gap: $pt-grid-size * 2;
   display: flex;
   flex: 0 0 auto;
-  gap: $pt-grid-size * 2;
   list-style: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Changes

Fixes an issue reported here https://github.com/palantir/blueprint/pull/6834#issuecomment-2200436245. This was a recent regression in a fix to better support RTL tabs.

### Before

<img width="500" alt="Screenshot 2024-07-01 at 5 08 06 PM" src="https://github.com/palantir/blueprint/assets/906558/36f3987c-4fb0-4a30-a0d6-939afe1cadea">

### After

<img width="499" alt="Screenshot 2024-07-01 at 5 08 29 PM" src="https://github.com/palantir/blueprint/assets/906558/c8f76775-71f0-4952-afd2-ec7f441ec71d">
