### PR TITLE
Revert "[core] fix(Tabs): use gap instead of margin to fix RTL spacing (#6834)"

### DIFF
--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -88,9 +88,9 @@ $tab-indicator-width: 3px !default;
 .#{$ns}-tab-list {
   align-items: flex-end;
   border: none;
-  column-gap: $pt-grid-size * 2;
   display: flex;
   flex: 0 0 auto;
+  gap: $pt-grid-size * 2;
   list-style: none;
   margin: 0;
   padding: 0;

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -90,11 +90,16 @@ $tab-indicator-width: 3px !default;
   border: none;
   display: flex;
   flex: 0 0 auto;
-  gap: $pt-grid-size * 2;
   list-style: none;
   margin: 0;
   padding: 0;
   position: relative;
+
+  // this is fine.
+  /* stylelint-disable-next-line selector-no-universal */
+  > *:not(:last-child) {
+    margin-right: $pt-grid-size * 2;
+  }
 }
 
 .#{$ns}-tab {


### PR DESCRIPTION
## Changes

Reverts the following PRs

- https://github.com/palantir/blueprint/pull/6834
- https://github.com/palantir/blueprint/pull/6885

We saw a few problems rolling this out:

- A lot of users are overriding `margin` on `.bp5-tab-list` children. The new `gap` value adds additional spacing that's unexpected in this case.
- @evansjohnson caught a `<TabsExpander />` usage that overflowed items with the switch to `gap`.