### PR TITLE
feat(Tabs): pass tabPanelId and tabTitleId to onChange

### DIFF
--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -26,6 +26,19 @@ import type { TagProps } from "../tag/tag";
 
 export type TabId = string | number;
 
+export interface TabIdProps {
+    /**
+     * `id` prop of the tab title.
+     * Can be used for `aria-labelledby` of the `tabpanel`.
+     */
+    tabTitleId: string;
+    /**
+     * `id` prop of the `tabpanel`.
+     * Is applied to `aria-controls` of the `tab` title, so panel's `id` prop should match.
+     */
+    tabPanelId: string;
+}
+
 export interface TabProps extends Props, Omit<HTMLDivProps, "id" | "title" | "onClick"> {
     /**
      * Content of tab title, rendered in a list above the active panel.
@@ -51,7 +64,7 @@ export interface TabProps extends Props, Omit<HTMLDivProps, "id" | "title" | "on
      * If omitted, no panel will be rendered for this tab.
      * Can either be an element or a renderer.
      */
-    panel?: React.JSX.Element | ((props: { tabTitleId: string; tabPanelId: string }) => React.JSX.Element);
+    panel?: React.JSX.Element | ((props: TabIdProps) => React.JSX.Element);
 
     /**
      * Space-delimited string of class names applied to tab panel container.

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -22,7 +22,7 @@ import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { Icon } from "../icon/icon";
 import { Tag } from "../tag/tag";
 
-import type { TabId, TabProps } from "./tab";
+import type { TabId, TabIdProps, TabProps } from "./tab";
 
 export interface TabTitleProps extends TabProps {
     /** Optional contents. */
@@ -55,18 +55,20 @@ export class TabTitle extends AbstractPureComponent<TabTitleProps> {
             tagProps,
             ...htmlProps
         } = this.props;
+
         const intent = selected ? Intent.PRIMARY : Intent.NONE;
+        const { tabPanelId, tabTitleId } = generateTabIds(parentId, id);
 
         return (
             <div
                 {...removeNonHTMLProps(htmlProps)}
-                aria-controls={generateTabPanelId(parentId, id)}
+                aria-controls={tabPanelId}
                 aria-disabled={disabled}
                 aria-expanded={selected}
                 aria-selected={selected}
                 className={classNames(Classes.TAB, className)}
                 data-tab-id={id}
-                id={generateTabTitleId(parentId, id)}
+                id={tabTitleId}
                 onClick={disabled ? undefined : this.handleClick}
                 role="tab"
                 tabIndex={disabled ? undefined : selected ? 0 : -1}
@@ -91,10 +93,9 @@ export class TabTitle extends AbstractPureComponent<TabTitleProps> {
     private handleClick = (e: React.MouseEvent<HTMLElement>) => this.props.onClick(this.props.id, e);
 }
 
-export function generateTabPanelId(parentId: TabId, tabId: TabId) {
-    return `${Classes.TAB_PANEL}_${parentId}_${tabId}`;
-}
-
-export function generateTabTitleId(parentId: TabId, tabId: TabId) {
-    return `${Classes.TAB}-title_${parentId}_${tabId}`;
+export function generateTabIds(parentId: TabId, tabId: TabId) {
+    return {
+        tabPanelId: `${Classes.TAB_PANEL}_${parentId}_${tabId}`,
+        tabTitleId: `${Classes.TAB}-title_${parentId}_${tabId}`,
+    } satisfies TabIdProps;
 }

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -19,8 +19,8 @@ import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props, Utils } from "../../common";
 
-import { Tab, type TabId, type TabProps } from "./tab";
-import { generateTabPanelId, generateTabTitleId, TabTitle } from "./tabTitle";
+import { Tab, type TabId, type TabIdProps, type TabProps } from "./tab";
+import { generateTabIds, TabTitle } from "./tabTitle";
 
 /**
  * Component that may be inserted between any two children of `<Tabs>` to right-align all subsequent children.
@@ -106,7 +106,12 @@ export interface TabsProps extends Props {
     /**
      * A callback function that is invoked when a tab in the tab list is clicked.
      */
-    onChange?(newTabId: TabId, prevTabId: TabId | undefined, event: React.MouseEvent<HTMLElement>): void;
+    onChange?(
+        newTabId: TabId,
+        prevTabId: TabId | undefined,
+        event: React.MouseEvent<HTMLElement>,
+        newTabProps: TabIdProps,
+    ): void;
 }
 
 export interface TabsState {
@@ -290,7 +295,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
     };
 
     private handleTabClick = (newTabId: TabId, event: React.MouseEvent<HTMLElement>) => {
-        this.props.onChange?.(newTabId, this.state.selectedTabId, event);
+        this.props.onChange?.(newTabId, this.state.selectedTabId, event, this.generateTabIds(newTabId));
         if (this.props.selectedTabId === undefined) {
             this.setState({ selectedTabId: newTabId });
         }
@@ -324,14 +329,15 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
         this.setState({ indicatorWrapperStyle });
     }
 
+    private generateTabIds = (tabId: TabId) => generateTabIds(this.props.id, tabId);
+
     private renderTabPanel = (tab: TabElement) => {
         const { className, panel, id, panelClassName } = tab.props;
         if (panel === undefined) {
             return undefined;
         }
 
-        const tabTitleId = generateTabTitleId(this.props.id, id);
-        const tabPanelId = generateTabPanelId(this.props.id, id);
+        const { tabTitleId, tabPanelId } = this.generateTabIds(id);
 
         return (
             <div


### PR DESCRIPTION
Need access to these props for proper a11y when rendering tab panels outside of the `Tabs` component