### PR TITLE
Handle flex-expander case in tabs gap

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6894.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6894.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove extra space added after a `TabsExpander` component
+  links:
+  - https://github.com/palantir/blueprint/pull/6894

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -95,6 +95,13 @@ $tab-indicator-width: 3px !default;
   margin: 0;
   padding: 0;
   position: relative;
+
+  > .#{$ns}-flex-expander {
+    // offset column-gap from parent component above
+    // since flex-expander is taking up _available_ space, we don't want to add a double gap
+    // between the elements before and after the expander
+    margin-right: -$pt-grid-size * 2;
+  }
 }
 
 .#{$ns}-tab {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -96,7 +96,7 @@ $tab-indicator-width: 3px !default;
   padding: 0;
   position: relative;
 
-  .#{$ns}-tabs:not(.#{$ns}-vertical) & > .#{$ns}-flex-expander {
+  .#{$ns}-tabs:not(.#{$ns}-vertical) > .#{$ns}-flex-expander {
     // offset column-gap from parent component above
     // since flex-expander is taking up _available_ space, we don't want to add a double gap
     // between the elements before and after the expander

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -96,7 +96,7 @@ $tab-indicator-width: 3px !default;
   padding: 0;
   position: relative;
 
-  > .#{$ns}-flex-expander {
+  .#{$ns}-tabs:not(.#{$ns}-vertical) & > .#{$ns}-flex-expander {
     // offset column-gap from parent component above
     // since flex-expander is taking up _available_ space, we don't want to add a double gap
     // between the elements before and after the expander

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -353,6 +353,12 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
             return (
                 <TabTitle
                     {...child.props}
+                    // add margin-right as inline style to reduce chance of double spacing between tabs
+                    // after switching from margin-right to gap in #6834
+                    // some consumers may have targeted the default margin-right to override it and this
+                    // should wipe out their override and at least reset them to the default gap style
+                    // instead of applying both the gap style and whatever margin-right they have defined
+                    style={{ ...child.props.style, marginRight: 0 }}
                     parentId={this.props.id}
                     onClick={this.handleTabClick}
                     selected={id === this.state.selectedTabId}

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -353,12 +353,6 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
             return (
                 <TabTitle
                     {...child.props}
-                    // add margin-right as inline style to reduce chance of double spacing between tabs
-                    // after switching from margin-right to gap in #6834
-                    // some consumers may have targeted the default margin-right to override it and this
-                    // should wipe out their override and at least reset them to the default gap style
-                    // instead of applying both the gap style and whatever margin-right they have defined
-                    style={{ ...child.props.style, marginRight: 0 }}
                     parentId={this.props.id}
                     onClick={this.handleTabClick}
                     selected={id === this.state.selectedTabId}


### PR DESCRIPTION
See Tabs docs: https://blueprintjs.com/docs/#core/components/tabs - there's currently 40px between the search input and the last tab, because of a double gap on the flex-expander. This was an existing issue before [the change from margin-right -> gap](https://github.com/palantir/blueprint/pull/6834).

This PR adds a style targeting the flex-expander with a negative margin to remove the gap added due to the expander component.