### PR TITLE
Clarify showContextMenu docs example

### DIFF
--- a/packages/docs-app/src/examples/core-examples/contextMenuPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuPopoverExample.tsx
@@ -45,6 +45,8 @@ export const ContextMenuPopoverExample: React.FC<ExampleProps> = props => {
 
     const handleContextMenu = React.useCallback(
         (event: React.MouseEvent<HTMLElement>) => {
+            // ensure `preventDefault` is called just before `showContextMenu` and in the same event handler to prevent the
+            // default browser context menu from hiding your custom context menu
             event.preventDefault();
             showContextMenu({
                 content: menu,


### PR DESCRIPTION
#### Fixes no issue

This would have helped with debugging an internal issue. `preventDefault` was called in a `onContextMenu` event handler, but the context menu was opened from an `onMouseUp` handler. This was made harder to debug by the fact that we suspect different browsers/operating systems may order these callbacks differently causing different behavior where on some systems the `preventDefault` seemed to work as expected.

Fairly low effort attempt to improve this for now but at least wanted to capture this learning somewhere.

#### Checklist

- [-] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:
Update example usage of `showContextMenu`

#### Reviewers should focus on:
clarity of what this comment is trying to convey

#### Screenshot
n/a