### PR TITLE
Fix node-build-scripts-test failing in validate

### DIFF
--- a/packages/node-build-scripts/src/__tests__/cssVariables.test.ts
+++ b/packages/node-build-scripts/src/__tests__/cssVariables.test.ts
@@ -4,11 +4,15 @@
 
 import { describe, expect, test } from "@jest/globals";
 import { readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { generateLessVariables, generateScssVariables, getParsedVars } from "../cssVariables.mjs";
 
-const FIXTURES_DIR = join(import.meta.dirname, "__fixtures__");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const FIXTURES_DIR = join(__dirname, "__fixtures__");
 const INPUT_DIR = resolve(FIXTURES_DIR, "input");
 const EXPECTED_DIR = resolve(FIXTURES_DIR, "expected");
 


### PR DESCRIPTION
#### Fixes #6926

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This PR resolves failing tests encountered while running the introductory `yarn validate` command (from the [README](https://github.com/palantir/blueprint/blob/1a5c82bcdfec804b9b65d44e4ac75b3af9aafe1e/README.md?plain=1#L94)).

> **tl;dr** The test uses a variable that should exist in the version of Node we're running but doesn't exist during the build.

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/7badf393-d6ab-4b2d-bf09-4779183ff066) | ![after](https://github.com/user-attachments/assets/a5db4540-6350-421b-815a-709f2c2a4634) |

The "fix" involved here replaces the use of `import.meta.dirname` in `cssVariables.test.ts` with an alternative method of accessing the current folder path. This method was considered one of the ways to expose `__dirname` in an ES module prior to it being added in [v20.11.0](https://nodejs.org/en/blog/release/v20.11.0) (see [this article](https://www.sonarsource.com/blog/dirname-node-js-es-modules/) for more context). 

For some reason, `import.meta.dirname` is `undefined` when running the test scripts. According to the [docs](https://nodejs.org/docs/latest-v20.x/api/esm.html#importmetadirname) it _should_ be there. The typings assume that it is, but in reality only `import.meta.url` is defined.

It might be worth investigating why the build system doesn't expose these variables at runtime when they're supposed to exist. Perhaps there is something deeper in webpack config that needs addressing.

I did not encounter the scrollbar test flake described in #6926, so those tests are not addressed here.