### PR TITLE
Allow hotkeys to have multiple alphanumeric keys pressed down at the same time

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6938.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6938.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Allow hotkeys to have multiple alphanumeric keys pressed down at the
+    same time
+  links:
+  - https://github.com/palantir/blueprint/pull/6938

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -108,7 +108,7 @@ function compareSets<T>(set1: Set<T>, set2: Set<T>) {
 export const parseKeyCombo = (combo: string): KeyCombo => {
     const pieces = combo.replace(/\s/g, "").toLowerCase().split("+");
     let modifiers = 0;
-    let keys = new Set<string>();
+    const keys = new Set<string>();
     for (let piece of pieces) {
         if (piece === "") {
             throw new Error(`Failed to parse key combo "${combo}".

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -215,7 +215,13 @@ export const getKeyCombo = (pressedKeys: Set<string>, e: KeyboardEvent): KeyComb
     if (e.shiftKey) {
         modifiers += MODIFIER_BIT_MASKS.shift;
     }
-    return { modifiers, keys: new Set(pressedKeys) };
+
+    const keys = new Set(pressedKeys);
+    if (e.key != null && !MODIFIER_KEYS.has(e.key)) {
+        keys.add(e.key.toLowerCase());
+    }
+
+    return { modifiers, keys };
 };
 
 /**

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -98,10 +98,10 @@ function compareSets<T>(set1: Set<T>, set2: Set<T>) {
 
 /**
  * Converts a key combo string into a key combo object. Key combos include
- * zero or more modifier keys, such as `shift` or `alt`, and exactly one
- * action key, such as `A`, `enter`, or `left`.
+ * zero or more modifier keys, such as `shift` or `alt`, and exactly one or more
+ * action keys, such as `A`, `enter`, or `left`.
  *
- * For action keys that require a shift, e.g. `@` or `|`, we inlude the
+ * For action keys that require a shift, e.g. `@` or `|`, we include the
  * necessary `shift` modifier and automatically convert the action key to the
  * unshifted version. For example, `@` is equivalent to `shift+2`.
  */
@@ -195,7 +195,7 @@ function maybeGetKeyFromEventCode(e: KeyboardEvent) {
 
 /**
  * Determines the key combo object from the given keyboard event. A key combo includes zero or more modifiers
- * (represented by a bitmask) and one physical key. For most keys, we prefer dealing with the `code` property of the
+ * (represented by a bitmask) and one or more physical key. For most keys, we prefer dealing with the `code` property of the
  * event, since this is not altered by keyboard layout or the state of modifier keys. Fall back to using the `key`
  * property.
  *

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -217,6 +217,11 @@ export const getKeyCombo = (pressedKeys: Set<string>, e: KeyboardEvent): KeyComb
     }
 
     const keys = new Set(pressedKeys);
+    if (e.code === "Space") {
+        keys.add("space");
+        return { modifiers, keys };
+    }
+
     if (e.key != null && !MODIFIER_KEYS.has(e.key)) {
         keys.add(e.key.toLowerCase());
     }

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -88,7 +88,7 @@ second parameter which can customize some of its default behavior.
 @## Key combos
 
 Each hotkey must be assigned a key combo that will trigger its events. A key combo consists of zero or more modifier
-keys (`alt`, `ctrl`, `shift`, `meta`, `cmd`) and exactly one action key, such as `A`, `return`, or `up`.
+keys (`alt`, `ctrl`, `shift`, `meta`, `cmd`) and one or more action keys, such as `A`, `return`, or `up`.
 
 Some key combos have aliases. For example, `shift + 1` can equivalently be expressed as `!` and `cmd` is equal to
 `meta`. However, normal alphabetic characters do not have this aliasing, so `X` is equivalent to `x` but is not
@@ -101,6 +101,7 @@ Examples of valid key combos:
 -   `return` or, equivalently `enter`
 -   `alt + shift + x`
 -   `ctrl + left`
+-   `a + b`
 
 Note that spaces are ignored.
 

--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -123,6 +123,7 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
     const handleGlobalKeyDown = React.useCallback(
         (e: KeyboardEvent) => {
             pressedKeys.current.add(e.key.toLowerCase());
+            // special case for global keydown: if '?' is pressed, open the hotkeys dialog
             const combo = getKeyCombo(pressedKeys.current, e);
             const isTextInput = elementIsTextInput(e.target as HTMLElement);
             if (!isTextInput && comboMatches(parseKeyCombo(showDialogKeyCombo), combo)) {

--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -145,7 +145,12 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
     const handleLocalKeyDown = React.useCallback(
         (e: React.KeyboardEvent<HTMLElement>) => {
             pressedKeys.current.add(e.key.toLowerCase());
-            invokeNamedCallbackIfComboRecognized(false, getKeyCombo(pressedKeys.current, e.nativeEvent), "onKeyDown", e.nativeEvent);
+            invokeNamedCallbackIfComboRecognized(
+                false,
+                getKeyCombo(pressedKeys.current, e.nativeEvent),
+                "onKeyDown",
+                e.nativeEvent,
+            );
         },
         [invokeNamedCallbackIfComboRecognized],
     );
@@ -153,7 +158,12 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
     const handleLocalKeyUp = React.useCallback(
         (e: React.KeyboardEvent<HTMLElement>) => {
             pressedKeys.current.delete(e.key.toLowerCase());
-            invokeNamedCallbackIfComboRecognized(false, getKeyCombo(pressedKeys.current, e.nativeEvent), "onKeyUp", e.nativeEvent);
+            invokeNamedCallbackIfComboRecognized(
+                false,
+                getKeyCombo(pressedKeys.current, e.nativeEvent),
+                "onKeyUp",
+                e.nativeEvent,
+            );
         },
         [invokeNamedCallbackIfComboRecognized],
     );

--- a/packages/core/src/hooks/hotkeys/useHotkeys.ts
+++ b/packages/core/src/hooks/hotkeys/useHotkeys.ts
@@ -118,32 +118,43 @@ export function useHotkeys(keys: readonly HotkeyConfig[], options: UseHotkeysOpt
         [globalKeys, localKeys],
     );
 
+    const pressedKeys = React.useRef(new Set<string>());
+
     const handleGlobalKeyDown = React.useCallback(
         (e: KeyboardEvent) => {
-            // special case for global keydown: if '?' is pressed, open the hotkeys dialog
-            const combo = getKeyCombo(e);
+            pressedKeys.current.add(e.key.toLowerCase());
+            const combo = getKeyCombo(pressedKeys.current, e);
             const isTextInput = elementIsTextInput(e.target as HTMLElement);
             if (!isTextInput && comboMatches(parseKeyCombo(showDialogKeyCombo), combo)) {
                 dispatch({ type: "OPEN_DIALOG" });
             } else {
-                invokeNamedCallbackIfComboRecognized(true, getKeyCombo(e), "onKeyDown", e);
+                invokeNamedCallbackIfComboRecognized(true, combo, "onKeyDown", e);
             }
         },
         [dispatch, invokeNamedCallbackIfComboRecognized, showDialogKeyCombo],
     );
+
     const handleGlobalKeyUp = React.useCallback(
-        (e: KeyboardEvent) => invokeNamedCallbackIfComboRecognized(true, getKeyCombo(e), "onKeyUp", e),
+        (e: KeyboardEvent) => {
+            pressedKeys.current.delete(e.key.toLowerCase());
+            invokeNamedCallbackIfComboRecognized(true, getKeyCombo(pressedKeys.current, e), "onKeyUp", e);
+        },
         [invokeNamedCallbackIfComboRecognized],
     );
 
     const handleLocalKeyDown = React.useCallback(
-        (e: React.KeyboardEvent<HTMLElement>) =>
-            invokeNamedCallbackIfComboRecognized(false, getKeyCombo(e.nativeEvent), "onKeyDown", e.nativeEvent),
+        (e: React.KeyboardEvent<HTMLElement>) => {
+            pressedKeys.current.add(e.key.toLowerCase());
+            invokeNamedCallbackIfComboRecognized(false, getKeyCombo(pressedKeys.current, e.nativeEvent), "onKeyDown", e.nativeEvent);
+        },
         [invokeNamedCallbackIfComboRecognized],
     );
+
     const handleLocalKeyUp = React.useCallback(
-        (e: React.KeyboardEvent<HTMLElement>) =>
-            invokeNamedCallbackIfComboRecognized(false, getKeyCombo(e.nativeEvent), "onKeyUp", e.nativeEvent),
+        (e: React.KeyboardEvent<HTMLElement>) => {
+            pressedKeys.current.delete(e.key.toLowerCase());
+            invokeNamedCallbackIfComboRecognized(false, getKeyCombo(pressedKeys.current, e.nativeEvent), "onKeyUp", e.nativeEvent);
+        },
         [invokeNamedCallbackIfComboRecognized],
     );
 

--- a/packages/core/src/legacy/hotkeysEvents.ts
+++ b/packages/core/src/legacy/hotkeysEvents.ts
@@ -68,7 +68,7 @@ export class HotkeysEvents {
     }
 
     public handleKeyDown = (e: KeyboardEvent) => {
-        const combo = getKeyCombo(e);
+        const combo = getKeyCombo(new Set(), e);
         const isTextInput = this.isTextInput(e);
 
         if (!isTextInput && comboMatches(parseKeyCombo(SHOW_DIALOG_KEY), combo)) {
@@ -89,7 +89,7 @@ export class HotkeysEvents {
         if (isHotkeysDialogShowing()) {
             return;
         }
-        this.invokeNamedCallbackIfComboRecognized(getKeyCombo(e), "onKeyUp", e);
+        this.invokeNamedCallbackIfComboRecognized(getKeyCombo(new Set(), e), "onKeyUp", e);
     };
 
     private invokeNamedCallbackIfComboRecognized(

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -1,17 +1,5 @@
-/*
- * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/* !
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -30,6 +18,7 @@ import { useHotkeys } from "../../src/hooks";
 interface TestComponentProps extends TestComponentContainerProps {
     onKeyA: () => void;
     onKeyB: () => void;
+    onKeyCombo: () => void;
 }
 
 interface TestComponentContainerProps {
@@ -37,7 +26,13 @@ interface TestComponentContainerProps {
     isInputReadOnly?: boolean;
 }
 
-const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputReadOnly, onKeyA, onKeyB }) => {
+const TestComponent: React.FC<TestComponentProps> = ({
+    bindExtraKeys,
+    isInputReadOnly,
+    onKeyA,
+    onKeyB,
+    onKeyCombo,
+}) => {
     const hotkeys = React.useMemo(() => {
         const keys = [
             {
@@ -50,6 +45,18 @@ const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputRea
                 global: true,
                 label: "B",
                 onKeyDown: onKeyB,
+            },
+            {
+                combo: "A + B",
+                global: true,
+                label: "A + B",
+                onKeyDown: onKeyCombo,
+            },
+            {
+                combo: "ctrl + A + B",
+                global: true,
+                label: "ctrl + A + B",
+                onKeyDown: onKeyCombo,
             },
         ];
         if (bindExtraKeys) {
@@ -68,7 +75,7 @@ const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputRea
             );
         }
         return keys;
-    }, [bindExtraKeys, onKeyA, onKeyB]);
+    }, [bindExtraKeys, onKeyA, onKeyB, onKeyCombo]);
 
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys);
 
@@ -83,12 +90,13 @@ const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputRea
 describe("useHotkeys", () => {
     const onKeyASpy = spy();
     const onKeyBSpy = spy();
+    const onKeyComboSpy = spy();
 
     const TestComponentContainer = (props: TestComponentContainerProps) => {
         return (
             <>
                 <div data-testid="target-outside-component" />
-                <TestComponent {...props} onKeyA={onKeyASpy} onKeyB={onKeyBSpy} />
+                <TestComponent {...props} onKeyA={onKeyASpy} onKeyB={onKeyBSpy} onKeyCombo={onKeyComboSpy} />
             </>
         );
     };
@@ -96,6 +104,7 @@ describe("useHotkeys", () => {
     afterEach(() => {
         onKeyASpy.resetHistory();
         onKeyBSpy.resetHistory();
+        onKeyComboSpy.resetHistory();
     });
 
     it("binds local hotkey", () => {
@@ -156,6 +165,30 @@ describe("useHotkeys", () => {
         const target = screen.getByTestId("input-target");
         dispatchTestKeyboardEvent(target, "keydown", "a");
         expect(onKeyASpy.callCount).to.equal(1, "hotkey A should be called once");
+    });
+
+    it("binds and triggers multiple keys hotkey (A + B)", () => {
+        render(<TestComponentContainer />);
+        const target = screen.getByTestId("target-outside-component");
+
+        // Simulate pressing 'A'
+        dispatchTestKeyboardEvent(target, "keydown", "a");
+        // Simulate pressing 'B' while 'A' is still pressed
+        dispatchTestKeyboardEvent(target, "keydown", "b");
+
+        expect(onKeyComboSpy.callCount).to.equal(1, "hotkey A + B should be called once");
+    });
+
+    it("binds and triggers multiple keys hotkey with modifier (shift + A + B)", () => {
+        render(<TestComponentContainer />);
+        const target = screen.getByTestId("target-outside-component");
+
+        // Simulate pressing 'A'
+        dispatchTestKeyboardEvent(target, "keydown", "a", true);
+        // Simulate pressing 'B' while 'A' and 'shift' are still pressed
+        dispatchTestKeyboardEvent(target, "keydown", "b");
+
+        expect(onKeyComboSpy.callCount).to.equal(1, "hotkey shift + A + B should be called once");
     });
 
     describe("working with HotkeysProvider", () => {

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -1,5 +1,17 @@
-/* !
- * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+/*
+ * Copyright 2021 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { render, screen } from "@testing-library/react";

--- a/packages/core/test/hotkeys/hotkeysParserTests.ts
+++ b/packages/core/test/hotkeys/hotkeysParserTests.ts
@@ -38,7 +38,7 @@ describe("HotkeysParser", () => {
         const makeComboTest = (combo: string, event: Partial<KeyboardEvent>) => {
             return {
                 combo,
-                eventKeyCombo: getKeyCombo(event as KeyboardEvent),
+                eventKeyCombo: getKeyCombo(new Set(), event as KeyboardEvent),
                 parsedKeyCombo: parseKeyCombo(combo),
                 stringKeyCombo: getKeyComboString(event as KeyboardEvent),
             };

--- a/packages/core/test/hotkeys/hotkeysParserTests.ts
+++ b/packages/core/test/hotkeys/hotkeysParserTests.ts
@@ -35,10 +35,10 @@ describe("HotkeysParser", () => {
             parsedKeyCombo: KeyCombo;
         }
 
-        const makeComboTest = (combo: string, event: Partial<KeyboardEvent>) => {
+        const makeComboTest = (combo: string, event: Partial<KeyboardEvent>, pressedKeys: Set<string> = new Set()): ComboTest => {
             return {
                 combo,
-                eventKeyCombo: getKeyCombo(new Set(), event as KeyboardEvent),
+                eventKeyCombo: getKeyCombo(pressedKeys, event as KeyboardEvent),
                 parsedKeyCombo: parseKeyCombo(combo),
                 stringKeyCombo: getKeyComboString(event as KeyboardEvent),
             };
@@ -56,7 +56,7 @@ describe("HotkeysParser", () => {
         it("matches lowercase alphabet chars", () => {
             const alpha = 65;
             verifyCombos(
-                Array.apply(null, Array(26)).map((_: any, i: number) => {
+                Array.from({ length: 26 }).map((_, i) => {
                     const charString = String.fromCharCode(alpha + i).toLowerCase();
                     const combo = charString;
                     return makeComboTest(combo, { key: charString, code: `Key${charString.toUpperCase()}` });
@@ -67,7 +67,7 @@ describe("HotkeysParser", () => {
         it("bare alphabet chars ignore case", () => {
             const alpha = 65;
             verifyCombos(
-                Array.apply(null, Array(26)).map((_: any, i: number) => {
+                Array.from({ length: 26 }).map((_, i) => {
                     const charString = String.fromCharCode(alpha + i).toLowerCase();
                     const combo = charString.toUpperCase();
                     return makeComboTest(combo, { key: charString, code: `Key${charString.toUpperCase()}` });
@@ -79,7 +79,7 @@ describe("HotkeysParser", () => {
         it("matches uppercase alphabet chars using shift", () => {
             const alpha = 65;
             verifyCombos(
-                Array.apply(null, Array(26)).map((_: any, i: number) => {
+                Array.from({ length: 26 }).map((_, i) => {
                     const charString = String.fromCharCode(alpha + i).toLowerCase();
                     const combo = "shift + " + charString;
                     return makeComboTest(combo, {
@@ -136,6 +136,20 @@ describe("HotkeysParser", () => {
             const tests = [] as ComboTest[];
             tests.push(makeComboTest("alt + a", { altKey: true, key: "a", code: "KeyA" }));
             verifyCombos(tests);
+        });
+
+        it("handles multiple alphanumeric keys", () => {
+            const tests = [] as ComboTest[];
+            const pressedKeys = new Set(["a", "b"]);
+            tests.push(makeComboTest("a + b", { key: "a", code: "KeyA" }, pressedKeys));
+            verifyCombos(tests, false);
+        });
+
+        it("handles multiple alphanumeric keys with modifiers", () => {
+            const tests = [] as ComboTest[];
+            const pressedKeys = new Set(["a", "b"]);
+            tests.push(makeComboTest("ctrl + a + b", { ctrlKey: true, key: "a", code: "KeyA" }, pressedKeys));
+            verifyCombos(tests, false);
         });
     });
 

--- a/packages/core/test/hotkeys/hotkeysParserTests.ts
+++ b/packages/core/test/hotkeys/hotkeysParserTests.ts
@@ -35,7 +35,11 @@ describe("HotkeysParser", () => {
             parsedKeyCombo: KeyCombo;
         }
 
-        const makeComboTest = (combo: string, event: Partial<KeyboardEvent>, pressedKeys: Set<string> = new Set()): ComboTest => {
+        const makeComboTest = (
+            combo: string,
+            event: Partial<KeyboardEvent>,
+            pressedKeys: Set<string> = new Set(),
+        ): ComboTest => {
             return {
                 combo,
                 eventKeyCombo: getKeyCombo(pressedKeys, event as KeyboardEvent),

--- a/packages/docs-app/changelog/@unreleased/pr-6938.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-6938.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Allow hotkeys to have multiple alphanumeric keys pressed down at the
+    same time
+  links:
+  - https://github.com/palantir/blueprint/pull/6938

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -16,16 +16,18 @@
 
 import * as React from "react";
 
-import { Code, getKeyComboString, KeyComboTag } from "@blueprintjs/core";
+import { Code, getKeyCombo, KeyComboTag } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export interface HotkeyTesterState {
     combo: string;
+    pressedKeys: Set<string>;
 }
 
 export class HotkeyTesterExample extends React.PureComponent<ExampleProps, HotkeyTesterState> {
     public state: HotkeyTesterState = {
         combo: null,
+        pressedKeys: new Set(),
     };
 
     public render() {
@@ -60,8 +62,9 @@ export class HotkeyTesterExample extends React.PureComponent<ExampleProps, Hotke
     private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
         e.preventDefault();
         e.stopPropagation();
-
-        const combo = getKeyComboString(e.nativeEvent);
+        this.setState({pressedKeys: this.state.pressedKeys.add(e.key)});
+        const keys = getKeyCombo(this.state.pressedKeys, e.nativeEvent).keys;
+        const combo = Array.from(keys).join(" + ");
         this.setState({ combo });
     };
 

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -36,6 +36,7 @@ export class HotkeyTesterExample extends React.PureComponent<ExampleProps, Hotke
                 <div
                     className="docs-hotkey-tester"
                     onKeyDown={this.handleKeyDown}
+                    onKeyUp={this.handleKeyUp}
                     onBlur={this.handleBlur}
                     tabIndex={0}
                 >
@@ -62,8 +63,26 @@ export class HotkeyTesterExample extends React.PureComponent<ExampleProps, Hotke
     private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
         e.preventDefault();
         e.stopPropagation();
+
         this.setState({pressedKeys: this.state.pressedKeys.add(e.key)});
         const keys = getKeyCombo(this.state.pressedKeys, e.nativeEvent).keys;
+        const combo = Array.from(keys).join(" + ");
+        this.setState({ combo });
+    };
+
+    private handleKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.state.pressedKeys.delete(e.key)
+        this.setState({pressedKeys: this.state.pressedKeys });
+
+        const keys = getKeyCombo(this.state.pressedKeys, e.nativeEvent).keys;
+        if (keys.size === 0) {
+            this.setState({ combo: null });
+            return;
+        }
+
         const combo = Array.from(keys).join(" + ");
         this.setState({ combo });
     };

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -64,27 +64,18 @@ export class HotkeyTesterExample extends React.PureComponent<ExampleProps, Hotke
         e.preventDefault();
         e.stopPropagation();
 
-        this.setState({pressedKeys: this.state.pressedKeys.add(e.key)});
-        const keys = getKeyCombo(this.state.pressedKeys, e.nativeEvent).keys;
+        const newPressedKeys = new Set(this.state.pressedKeys);
+        newPressedKeys.add(e.key);
+        const keys = getKeyCombo(newPressedKeys, e.nativeEvent).keys;
         const combo = Array.from(keys).join(" + ");
-        this.setState({ combo });
+        this.setState({ combo, pressedKeys: newPressedKeys });
     };
 
     private handleKeyUp = (e: React.KeyboardEvent<HTMLDivElement>) => {
         e.preventDefault();
         e.stopPropagation();
 
-        this.state.pressedKeys.delete(e.key)
-        this.setState({pressedKeys: this.state.pressedKeys });
-
-        const keys = getKeyCombo(this.state.pressedKeys, e.nativeEvent).keys;
-        if (keys.size === 0) {
-            this.setState({ combo: null });
-            return;
-        }
-
-        const combo = Array.from(keys).join(" + ");
-        this.setState({ combo });
+        this.setState({ combo: null, pressedKeys: new Set() });
     };
 
     private handleBlur = () => this.setState({ combo: null });

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -216,6 +216,32 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
                 onKeyDown: () => setKeyState(23, true),
                 onKeyUp: () => setKeyState(23, false),
             },
+            {
+                combo: "Q + W",
+                group: "useHotkeys Example",
+                label: "Play a C5 + D5",
+                onKeyDown: () => {
+                    setKeyState(0, true);
+                    setKeyState(2, true);
+                },
+                onKeyUp: () => {
+                    setKeyState(0, false);
+                    setKeyState(2, false);
+                },
+            },
+            {
+                combo: "W + E",
+                group: "useHotkeys Example",
+                label: "Play a D5 + E5",
+                onKeyDown: () => {
+                    setKeyState(2, true);
+                    setKeyState(4, true);
+                },
+                onKeyUp: () => {
+                    setKeyState(2, false);
+                    setKeyState(4, false);
+                },
+            },
         ],
         [focusPiano, setKeyState],
     );


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
For my hackweek project, I wanted to implement throughout hotkeys in Apollo for power users. We copied a lot of the hotkeys commonly used in other apps, and one of the common page navigation hotkeys is "g + some character" to denote "Go to some page". For example, if I want to "Go to Dashboard", I would type "g + d".

However, useHotkeys in Blueprint currently does not support having multiple alphanumeric keys pressed down at the same time. This PR changes the key combo to hold a set of keys rather than a singular key and enables this functionality.

#### DOWNSIDE
The piano example for hotkeys becomes kind of broken with this PR. Now we need to manually encode the combinations of q + w, w + e, etc. Otherwise the example just breaks for multiple hotkey combinations. Currently I added hotkey combinations for q + w and w + e but it doesnt make sense to hardcode each of these because the number of ways to choose 1 - 10 keys out of 24 is 4,687,385. 

If the decision is to just disallow pressing multiple keys within this example, I can remove the hotkey combinations for q + w and w + e that I added.

#### Testing
Added unit tests, can also test using the key-combo-tester

1. Go to http://localhost:9001/#core/hooks/use-hotkeys.key-combo-tester
2. Use the key combo tester and verify you can use keys such as "a + b", "g + c", etc.
3. Also check the piano key example above and ensure that pressing singular keys works as expected.

#### Screenshot

![2024-08-09 12 05 33](https://github.com/user-attachments/assets/f175c55f-326f-410b-b374-2c4b47f7c140)
