### PR TITLE
Darken zebra stripes in table dev mode

### DIFF
--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -141,11 +141,11 @@ body {
 }
 
 .tbl-zebra-stripe {
-  background: $light-gray5;
-}
+  background-color: $light-gray5;
 
-.#{$ns}-dark .tbl-zebra-stripe {
-  background-color: $dark-gray5;
+  .#{$ns}-dark & {
+    background-color: $dark-gray5;
+  }
 }
 
 .tbl-styled-region-success {

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -144,6 +144,10 @@ body {
   background: $light-gray5;
 }
 
+.#{$ns}-dark .tbl-zebra-stripe {
+  background-color: $dark-gray5;
+}
+
 .tbl-styled-region-success {
   background-color: rgba($pt-intent-success, 0.1);
   border: 1px solid $pt-intent-success;


### PR DESCRIPTION
#### Fixes #5164

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add a dark variant to the zebra stripes mode of table-dev-app.

#### Screenshot

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/cbd65443-3ffb-4a62-8a1a-4040dbdd5739) | ![after](https://github.com/user-attachments/assets/580ea0e6-dba3-4dd3-91ed-dadf8caa8b06) |
