### PR TITLE
fix: Respect icon intent color passed to Dialog

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6947.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6947.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Respect icon intent color passed to Dialog
+  links:
+  - https://github.com/palantir/blueprint/pull/6947

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -111,11 +111,8 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     margin-right: $dialog-padding * 0.5;
 
     // only apply light color to icons that are not intent-specific
-    :not([class*="#{$ns}-intent"]) {
-      &.#{$ns}-icon-large,
-      &.#{$ns}-icon {
-        color: $pt-icon-color;
-      }
+    &:not([class*="#{$ns}-intent"]) {
+      color: $pt-icon-color;
     }
   }
 

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -110,6 +110,12 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     flex: 0 0 auto;
     margin-left: -3px;
     margin-right: $dialog-padding * 0.5;
+
+    @each $intent, $color in $pt-intent-colors {
+      &.#{$ns}-intent-#{$intent} {
+        color: $color;
+      }
+    }
   }
 
   .#{$ns}-heading {
@@ -130,6 +136,12 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     .#{$ns}-icon-large,
     .#{$ns}-icon {
       color: $pt-dark-icon-color;
+
+      @each $intent, $color in $pt-intent-colors {
+        &.#{$ns}-intent-#{$intent} {
+          color: $color;
+        }
+      }
     }
   }
 

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -106,14 +106,15 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
 
   .#{$ns}-icon-large,
   .#{$ns}-icon {
-    color: $pt-icon-color;
     flex: 0 0 auto;
     margin-left: -3px;
     margin-right: $dialog-padding * 0.5;
 
-    @each $intent, $color in $pt-intent-colors {
-      &.#{$ns}-intent-#{$intent} {
-        color: $color;
+    // only apply light color to icons that are not intent-specific
+    .#{$ns}-icon:not([class*="#{$ns}-intent"]) {
+      &.#{$ns}-icon-large,
+      &.#{$ns}-icon {
+        color: $pt-icon-color;
       }
     }
   }
@@ -133,14 +134,11 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     background: $dark-gray3;
     box-shadow: inset 0 0 0 1px $pt-dark-divider-white;
 
-    .#{$ns}-icon-large,
-    .#{$ns}-icon {
-      color: $pt-dark-icon-color;
-
-      @each $intent, $color in $pt-dark-intent-text-colors {
-        &.#{$ns}-intent-#{$intent} {
-          color: $color;
-        }
+    // only apply dark color to icons that are not intent-specific
+    .#{$ns}-icon:not([class*="#{$ns}-intent"]) {
+      &.#{$ns}-icon-large,
+      &.#{$ns}-icon {
+        color: $pt-dark-icon-color;
       }
     }
   }

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -137,7 +137,7 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     .#{$ns}-icon {
       color: $pt-dark-icon-color;
 
-      @each $intent, $color in $pt-intent-colors {
+      @each $intent, $color in $pt-dark-intent-text-colors {
         &.#{$ns}-intent-#{$intent} {
           color: $color;
         }

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -111,7 +111,7 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     margin-right: $dialog-padding * 0.5;
 
     // only apply light color to icons that are not intent-specific
-    .#{$ns}-icon:not([class*="#{$ns}-intent"]) {
+    :not([class*="#{$ns}-intent"]) {
       &.#{$ns}-icon-large,
       &.#{$ns}-icon {
         color: $pt-icon-color;
@@ -135,7 +135,7 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
     box-shadow: inset 0 0 0 1px $pt-dark-divider-white;
 
     // only apply dark color to icons that are not intent-specific
-    .#{$ns}-icon:not([class*="#{$ns}-intent"]) {
+    :not([class*="#{$ns}-intent"]) {
       &.#{$ns}-icon-large,
       &.#{$ns}-icon {
         color: $pt-dark-icon-color;

--- a/packages/docs-app/changelog/@unreleased/pr-6947.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-6947.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Respect icon intent color passed to Dialog
+  links:
+  - https://github.com/palantir/blueprint/pull/6947

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -25,10 +25,13 @@ import {
     DialogFooter,
     type DialogProps,
     H5,
+    Icon,
+    Intent,
     Switch,
     Tooltip,
 } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { IconNames } from "@blueprintjs/icons";
 
 import type { BlueprintExampleData } from "../../tags/types";
 
@@ -75,7 +78,7 @@ export class DialogExample extends React.PureComponent<ExampleProps<BlueprintExa
                 />
                 <ButtonWithDialog
                     className={this.props.data.themeName}
-                    icon="info-sign"
+                    icon={<Icon icon={IconNames.INFO_SIGN} intent={Intent.PRIMARY} />}
                     title="Palantir Foundry"
                     buttonText="Show dialog with title"
                     footerStyle="none"
@@ -83,7 +86,7 @@ export class DialogExample extends React.PureComponent<ExampleProps<BlueprintExa
                 />
                 <ButtonWithDialog
                     className={this.props.data.themeName}
-                    icon="info-sign"
+                    icon={IconNames.INFO_SIGN}
                     title="Palantir Foundry"
                     buttonText="Show dialog with title and footer"
                     footerStyle="default"
@@ -91,7 +94,7 @@ export class DialogExample extends React.PureComponent<ExampleProps<BlueprintExa
                 />
                 <ButtonWithDialog
                     className={this.props.data.themeName}
-                    icon="info-sign"
+                    icon={IconNames.INFO_SIGN}
                     title="Palantir Foundry"
                     buttonText="Show dialog with title and minimal footer"
                     footerStyle="minimal"


### PR DESCRIPTION
#### Fixes #6824

#### Checklist

- [N/A] Includes tests
- [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes an issue where dialog header would always overwrite the intent of an icon passed into the dialog, either though the `icon` prop:
```tsx
<Dialog icon={<Icon icon={IconNames.INFO_SIGN} intent={Intent.PRIMARY} ... />}
```
or embedded in the title:
```tsx
<Dialog title={<>Info <Icon icon={IconNames.INFO_SIGN} intent={Intent.PRIMARY} /></>} ... />}
```

> **Note:** Icons with the `color` property set (e.g. `<Icon icon={IconNames.INFO_SIGN} color={Colors.BLUE3} />`) are not affected by this bug since they set color on the fill of the icon's SVG directly.

#### Screenshot

##### Light Mode
| Before | After    |
| ------  | ------  |
| ![before-light](https://github.com/user-attachments/assets/e4de808e-0dcc-45a0-ab3d-dae1399c6eef) | ![after-light](https://github.com/user-attachments/assets/e4558f0a-9f5d-466d-9471-8c7b90b24298) |

##### Dark Mode
| Before | After    |
| ------  | ------  |
| ![before-dark](https://github.com/user-attachments/assets/9973eea4-1262-483c-9bb8-b09834fc9756) | ![after-dark](https://github.com/user-attachments/assets/16b9ac43-6aff-46e1-822a-d88c5977cafe) |
