### PR TITLE
Add focus styles to FileInput

### DIFF
--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -65,6 +65,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
       }
     }
 
+    // borrows focus styles from pt-input and pt-dark-input mixins (see _common.scss)
     &:focus + .#{$ns}-file-upload-input {
       box-shadow: input-transition-shadow($input-shadow-color-focus, true),
         $input-box-shadow-focus;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -64,6 +64,16 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
         }
       }
     }
+
+    &:focus + .#{$ns}-file-upload-input {
+      box-shadow: input-transition-shadow($input-shadow-color-focus, true),
+        $input-box-shadow-focus;
+
+      .#{$ns}-dark & {
+        box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true),
+          $pt-dark-input-box-shadow;
+      }
+    }
   }
 
   &.#{$ns}-file-input-has-selection {


### PR DESCRIPTION
#### Fixes #6859

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add visual focus styles to [FileInput](https://blueprintjs.com/docs/#core/components/file-input) to match other input components.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

##### Focus (light mode)
| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/c04bf787-f2dc-4f32-b7a0-9ddba4cd8c9f) | ![after](https://github.com/user-attachments/assets/0eddb4e5-c346-48bd-85bf-f6fa7fd686da) |

##### Focus (dark mode)
| Before | After |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/e48b4afe-14b6-4901-8b1c-bfb662a5af55) | ![after](https://github.com/user-attachments/assets/bc6f3685-4bd8-470e-82ea-5f02a0f0058e) |

![Screenshot 2024-08-26 at 10 11 32](https://github.com/user-attachments/assets/d8b2cd82-1131-45fe-a848-47a4a2b41ed8)


