### PR TITLE
Fix icon compilation for developing on old/stale branches

### DIFF
--- a/packages/icons/scripts/common.mjs
+++ b/packages/icons/scripts/common.mjs
@@ -21,6 +21,7 @@ import iconsMetadataJson from "../icons.json" with { type: "json" };
 
 export const iconResourcesDir = resolve(import.meta.dirname, "../../../resources/icons");
 export const generatedSrcDir = resolve(import.meta.dirname, "../src/generated");
+export const generatedComponentsDir = join(generatedSrcDir, "components");
 export const NS = "bp5";
 /** @type { [16, 20] } */
 export const ICON_SIZES = [16, 20];

--- a/packages/icons/scripts/generate-icon-components.mjs
+++ b/packages/icons/scripts/generate-icon-components.mjs
@@ -23,7 +23,7 @@
 
 import { pascalCase } from "change-case";
 import Handlebars from "handlebars";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parse } from "svg-parser";
 
@@ -70,6 +70,10 @@ for (const iconSize of ICON_SIZES) {
     });
     console.info(`Parsed ${Object.keys(iconPaths[iconSize]).length} ${iconSize}px icons.`);
 }
+
+// clear existing icon components
+console.info(`Clearing existing icon modules...`);
+rmSync(join(generatedSrcDir, `components`), { recursive: true });
 
 // generate an ES module for each icon
 console.info(`Generating ES modules for each icon...`);

--- a/packages/icons/scripts/generate-icon-components.mjs
+++ b/packages/icons/scripts/generate-icon-components.mjs
@@ -27,7 +27,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { parse } from "svg-parser";
 
-import { generatedSrcDir, ICON_RASTER_SCALING_FACTOR, ICON_SIZES } from "./common.mjs";
+import { generatedComponentsDir, generatedSrcDir, ICON_RASTER_SCALING_FACTOR, ICON_SIZES } from "./common.mjs";
 
 Handlebars.registerHelper("pascalCase", iconName => pascalCase(iconName));
 
@@ -72,12 +72,12 @@ for (const iconSize of ICON_SIZES) {
 }
 
 // clear existing icon components
-console.info(`Clearing existing icon modules...`);
-rmSync(join(generatedSrcDir, `components`), { recursive: true });
+console.info("Clearing existing icon modules...");
+rmSync(generatedComponentsDir, { recursive: true, force: true });
 
 // generate an ES module for each icon
-console.info(`Generating ES modules for each icon...`);
-mkdirSync(join(generatedSrcDir, `components`), { recursive: true });
+console.info("Generating ES modules for each icon...");
+mkdirSync(generatedComponentsDir, { recursive: true });
 
 for (const [iconName, icon16pxPath] of Object.entries(iconPaths[16])) {
     const icon20pxPath = iconPaths[20][iconName];
@@ -86,7 +86,7 @@ for (const [iconName, icon16pxPath] of Object.entries(iconPaths[16])) {
         continue;
     }
     writeFileSync(
-        join(generatedSrcDir, `components/${iconName}.tsx`),
+        join(generatedComponentsDir, `${iconName}.tsx`),
         // Notes on icon component template implementation:
         //  - path "translation" transform must use "viewbox" dimensions, not "size", in order to avoid issues
         //    like https://github.com/palantir/blueprint/issues/6220
@@ -101,7 +101,7 @@ for (const [iconName, icon16pxPath] of Object.entries(iconPaths[16])) {
 
 console.info(`Writing index file for all icon modules...`);
 writeFileSync(
-    join(generatedSrcDir, `components/index.ts`),
+    join(generatedComponentsDir, "index.ts"),
     componentsIndexTemplate({
         iconNames: Object.keys(iconPaths[16]),
     }),
@@ -109,7 +109,7 @@ writeFileSync(
 
 console.info(`Writing index file for package...`);
 writeFileSync(
-    join(generatedSrcDir, `index.ts`),
+    join(generatedSrcDir, "index.ts"),
     indexTemplate({
         iconNames: Object.keys(iconPaths[16]),
     }),


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [N/A] Includes tests
- [N/A] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

**Fixes a build compilation error caused by generated icon components not being cleaned up.**

In the current world, it is possible to:

1. Compile icons on the latest version of Blueprint (i.e. running `yarn dev:docs` on `develop`)
2. Switch to an older branch/PR
3. Compile icons again while developing on that branch
4. Encounter a type error due to stale icons referencing an outdated `.ts` manifest

More specifically, I've encountered this while checking out an older PR for local development (e.g. #6894) and the build erroring out on icons that were added later on (such as the [`data-search`](https://github.com/palantir/blueprint/blame/7fcf8d0f05c801d6be01f0bc90434ae625461fc8/packages/icons/icons.json#L4356C3-L4362) icon added in #6921). The generated icon  at `icons/src/generated/components/data-search.tsx` still exists and references `iconName="data-search"`, even though that icon name isn't exported by the generated name union (e.g. `icons/src/generated/16px/blueprint-icons-16.ts`)

This causes an error like the following:
```
src/generated/components/data-search.tsx:27:27 - error TS2769: No overload matches this call.
  Overload 1 of 2, '(props: SVGIconContainerProps<any>): ReactElement<any, string | JSXElementConstructor<any>> | null', gave the following error.
    Type '"data-search"' is not assignable to type 'BlueprintIcons_16Id'. Did you mean '"path-search"'?
  Overload 2 of 2, '(props: PropsWithChildren<SVGIconContainerProps<Element>>, context?: any): ReactElement<any, any> | null', gave the following error.
    Type '"data-search"' is not assignable to type 'BlueprintIcons_16Id'. Did you mean '"path-search"'?

27         <SVGIconContainer iconName="data-search" ref={ref}  {...props}>
                             ~~~~~~~~

  src/svgIconContainer.tsx:29:5
```

This change fixes this issue by cleaning up the `icons/src/generated/components` directory before compilation, which ensures the generated icon components are kept in sync with the name type manifest.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
