### PR TITLE
Add minimal prop to Callout which hides the background fill color

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6952.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6952.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add minimal prop to Callout which hides the background fill color
+  links:
+  - https://github.com/palantir/blueprint/pull/6952

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -103,11 +103,11 @@ $callout-padding-compact: $pt-grid-size;
 
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
+      color: map-get($pt-intent-text-colors, $intent);
+
       &:not(.#{$ns}-minimal) {
         background-color: rgba($color, 0.1);
       }
-
-      color: map-get($pt-intent-text-colors, $intent);
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
         border: 1px solid $pt-high-contrast-mode-border-color;
@@ -120,11 +120,11 @@ $callout-padding-compact: $pt-grid-size;
       }
 
       .#{$ns}-dark & {
+        color: map-get($pt-dark-intent-text-colors, $intent);
+
         &:not(.#{$ns}-minimal) {
           background-color: rgba($color, 0.2);
         }
-
-        color: map-get($pt-dark-intent-text-colors, $intent);
 
         &[class*="#{$ns}-icon-"]::before,
         > .#{$ns}-icon:first-child,

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -27,11 +27,14 @@ $callout-padding-compact: $pt-grid-size;
 
 .#{$ns}-callout {
   @include running-typography();
-  background-color: rgba($gray3, 0.15);
   border-radius: $pt-border-radius;
   padding: $callout-padding;
   position: relative;
   width: 100%;
+
+  &:not(.#{$ns}-minimal) {
+    background-color: rgba($gray3, 0.15);
+  }
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
@@ -87,16 +90,10 @@ $callout-padding-compact: $pt-grid-size;
     }
   }
 
-  &.#{$ns}-minimal,
-  &.#{$ns}-minimal.#{$ns}-intent-primary,
-  &.#{$ns}-minimal.#{$ns}-intent-success,
-  &.#{$ns}-minimal.#{$ns}-intent-warning,
-  &.#{$ns}-minimal.#{$ns}-intent-danger {
-    background-color: transparent;
-  }
-
   .#{$ns}-dark & {
-    background-color: rgba($gray3, 0.2);
+    &:not(.#{$ns}-minimal) {
+      background-color: rgba($gray3, 0.2);
+    }
 
     &[class*="#{$ns}-icon-"]::before,
     &.#{$ns}-callout-icon > .#{$ns}-icon:first-child {
@@ -106,7 +103,10 @@ $callout-padding-compact: $pt-grid-size;
 
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
-      background-color: rgba($color, 0.1);
+      &:not(.#{$ns}-minimal) {
+        background-color: rgba($color, 0.1);
+      }
+
       color: map-get($pt-intent-text-colors, $intent);
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -120,7 +120,10 @@ $callout-padding-compact: $pt-grid-size;
       }
 
       .#{$ns}-dark & {
-        background-color: rgba($color, 0.2);
+        &:not(.#{$ns}-minimal) {
+          background-color: rgba($color, 0.2);
+        }
+
         color: map-get($pt-dark-intent-text-colors, $intent);
 
         &[class*="#{$ns}-icon-"]::before,

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -87,6 +87,14 @@ $callout-padding-compact: $pt-grid-size;
     }
   }
 
+  &.#{$ns}-minimal,
+  &.#{$ns}-minimal.#{$ns}-intent-primary,
+  &.#{$ns}-minimal.#{$ns}-intent-success,
+  &.#{$ns}-minimal.#{$ns}-intent-warning,
+  &.#{$ns}-minimal.#{$ns}-intent-danger {
+    background-color: transparent;
+  }
+
   .#{$ns}-dark & {
     background-color: rgba($gray3, 0.2);
 

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -59,7 +59,9 @@ export interface CalloutProps extends IntentProps, Props, HTMLDivProps {
     intent?: Intent;
 
     /**
-     * Whether the callout should render the background
+     * Whether the callout should have a minimal appearance with no background color fill.
+     *
+     * @default false
      */
     minimal?: boolean;
 
@@ -83,7 +85,7 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Callout`;
 
     public render() {
-        const { className, children, icon, intent, title, compact, minimal, ...htmlProps } = this.props;
+        const { className, children, icon, intent, title, compact, minimal = false, ...htmlProps } = this.props;
         const iconElement = this.renderIcon(icon, intent);
         const classes = classNames(Classes.CALLOUT, Classes.intentClass(intent), className, {
             [Classes.CALLOUT_HAS_BODY_CONTENT]: !Utils.isReactNodeEmpty(children),

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -59,6 +59,11 @@ export interface CalloutProps extends IntentProps, Props, HTMLDivProps {
     intent?: Intent;
 
     /**
+     * Whether the callout should render the background
+     */
+    minimal?: boolean;
+
+    /**
      * String content of optional title element.
      *
      * Due to a conflict with the HTML prop types, to provide JSX content simply
@@ -78,12 +83,13 @@ export class Callout extends AbstractPureComponent<CalloutProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Callout`;
 
     public render() {
-        const { className, children, icon, intent, title, compact, ...htmlProps } = this.props;
+        const { className, children, icon, intent, title, compact, minimal, ...htmlProps } = this.props;
         const iconElement = this.renderIcon(icon, intent);
         const classes = classNames(Classes.CALLOUT, Classes.intentClass(intent), className, {
             [Classes.CALLOUT_HAS_BODY_CONTENT]: !Utils.isReactNodeEmpty(children),
             [Classes.CALLOUT_ICON]: iconElement != null,
             [Classes.COMPACT]: compact,
+            [Classes.MINIMAL]: minimal,
         });
 
         return (

--- a/packages/docs-app/changelog/@unreleased/pr-6952.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-6952.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add minimal prop to Callout which hides the background fill color
+  links:
+  - https://github.com/palantir/blueprint/pull/6952

--- a/packages/docs-app/src/examples/core-examples/calloutExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExample.tsx
@@ -29,6 +29,7 @@ export const CalloutExample: React.FC<DocsExampleProps> = props => {
     const [showTitle, setShowTitle] = React.useState(true);
     const [icon, setIcon] = React.useState<IconName>();
     const [intent, setIntent] = React.useState<Intent>();
+    const [minimal, setMinimal] = React.useState(false);
 
     /* eslint-disable react/jsx-key */
     const children = [
@@ -48,6 +49,7 @@ export const CalloutExample: React.FC<DocsExampleProps> = props => {
             <H5>Props</H5>
             <Switch checked={showTitle} label="Title" onChange={handleBooleanChange(setShowTitle)} />
             <Switch checked={compact} label="Compact" onChange={handleBooleanChange(setCompact)} />
+            <Switch checked={minimal} label="Minimal" onChange={handleBooleanChange(setMinimal)} />
             <IntentSelect intent={intent} onChange={setIntent} showClearButton={true} />
             <IconSelect iconName={icon} onChange={setIcon} />
             <H5>Children</H5>
@@ -65,7 +67,10 @@ export const CalloutExample: React.FC<DocsExampleProps> = props => {
 
     return (
         <Example options={options} {...props}>
-            <Callout {...{ compact, intent, icon }} title={showTitle ? "Visually important content" : undefined}>
+            <Callout
+                {...{ compact, intent, icon, minimal }}
+                title={showTitle ? "Visually important content" : undefined}
+            >
                 {children}
             </Callout>
         </Example>


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
New minimal prop on the Callout component that hides the background fill color

![Screenshot 2024-08-27 at 2 34 50 PM](https://github.com/user-attachments/assets/9665b1df-7f0f-45ee-935a-09661240a807)

<!-- Fill this out. -->

#### Reviewers should focus on:
1. Go to http://localhost:9001/#core/components/callout
2. Toggle the minimal option and observe that the background color turns on and off.