### PR TITLE
Make sure toast max width doesn't exceed screen size on mobile devices

### DIFF
--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -104,7 +104,7 @@ $toast-intent-colors: (
   display: flex;
   margin: $toast-margin 0 0;
   max-width: min($toast-max-width, 100%);
-  min-width: min($toast-min-width, 100%));
+  min-width: min($toast-min-width, 100%);
 
   // toast is interactive even though container isn't
   pointer-events: all;

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -103,7 +103,7 @@ $toast-intent-colors: (
   box-shadow: $pt-toast-box-shadow;
   display: flex;
   margin: $toast-margin 0 0;
-  max-width: $toast-max-width;
+  max-width: min($toast-max-width, calc(100vw - $toast-margin));
   min-width: $toast-min-width;
 
   // toast is interactive even though container isn't

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -104,7 +104,7 @@ $toast-intent-colors: (
   display: flex;
   margin: $toast-margin 0 0;
   max-width: min($toast-max-width, calc(100vw - $toast-margin));
-  min-width: $toast-min-width;
+  min-width: max($toast-min-width, calc(100vw - $toast-margin));
 
   // toast is interactive even though container isn't
   pointer-events: all;

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -103,8 +103,8 @@ $toast-intent-colors: (
   box-shadow: $pt-toast-box-shadow;
   display: flex;
   margin: $toast-margin 0 0;
-  max-width: min($toast-max-width, calc(100vw - $toast-margin));
-  min-width: min($toast-min-width, calc(100vw - $toast-margin));
+  max-width: min($toast-max-width, 100%);
+  min-width: min($toast-min-width, 100%));
 
   // toast is interactive even though container isn't
   pointer-events: all;

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -104,7 +104,7 @@ $toast-intent-colors: (
   display: flex;
   margin: $toast-margin 0 0;
   max-width: min($toast-max-width, calc(100vw - $toast-margin));
-  min-width: max($toast-min-width, calc(100vw - $toast-margin));
+  min-width: min($toast-min-width, calc(100vw - $toast-margin));
 
   // toast is interactive even though container isn't
   pointer-events: all;


### PR DESCRIPTION
#### Fixes no existing issue: https://github.com/palantir/blueprint/issues?q=is%3Aissue+is%3Aopen+toast

#### Checklist

- [-] Includes tests
- [-] Update documentation

I could try to update the tests to avoid regressing but think this may be pretty hard to test for, particularly given how long this went without being a big issue

#### Changes proposed in this pull request:

Modify toast "max-width" to be the minimum of page width - 20px and 500px, rather than the max width always being 500px which may exceed the screen size, particularly on mobile devices.

#### Reviewers should focus on:

any concerns/ possible negative impact from this change

#### Screenshot
## this PR
![Screenshot 2024-09-13 at 10 12 49 AM](https://github.com/user-attachments/assets/9cd18f21-d55c-4478-962e-6812e7fad51a)

layout gets messed up but I think this is an improvement over current behavior, particularly for toasts that don't have an action button

## current
![Screenshot 2024-09-13 at 10 13 56 AM](https://github.com/user-attachments/assets/91c48d88-8f69-4119-987a-17b4b46e7095)
