### PR TITLE
Reduce opacity of disabled checkbox control indicator

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -265,6 +265,10 @@ $control-indicator-spacing: $pt-grid-size !default;
       @include indicator-inline-icon("small-minus");
     }
 
+    input:disabled ~ .#{$ns}-control-indicator::before {
+      opacity: 0.5;
+    }
+
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       input:checked:not(:disabled) ~ .#{$ns}-control-indicator {
         @include indicator-inline-icon("small-tick", $black);


### PR DESCRIPTION
#### Fixes #6734

#### Changes proposed in this pull request:

Updates checkbox control indicators (tick and indeterminate dash) on disabled checkbox controls to use a reduced opacity. This aligns with design intent and provides better signal that the checkbox control is disabled.

#### Reviewers should focus on:

Checkbox and Checkbox card

#### Screenshot

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/173cf6ef-7403-481c-ad43-1f307483d883) | ![after](https://github.com/user-attachments/assets/d2fbebbd-be9f-41c3-b18d-13c59cc5135e) |

#### Accessibility / Contrast Check

**Light Mode**
![Screenshot 2024-09-05 at 11 42 09@2x](https://github.com/user-attachments/assets/de198127-cf29-49a6-b3da-ff1db2b5c278)
https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF80&bcolor=99B8E9
WCAG AA:  **Fail** (Graphical Objects and User Interface Components)

**Dark Mode**
![Screenshot 2024-09-05 at 11 42 03@2x](https://github.com/user-attachments/assets/0d35c621-bce0-4d33-b343-2088ccb7c7cd)
https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF80&bcolor=25497D
WCAG AA:  **Pass** (Graphical Objects and User Interface Components)
