### PR TITLE
Add bordered prop to tree component

### DIFF
--- a/packages/core/changelog/@unreleased/pr-6963.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-6963.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add bordered prop to tree component
+  links:
+  - https://github.com/palantir/blueprint/pull/6963

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -35,6 +35,7 @@ if (typeof BLUEPRINT_NAMESPACE !== "undefined") {
 export const ACTIVE = `${NS}-active`;
 export const ALIGN_LEFT = `${NS}-align-left`;
 export const ALIGN_RIGHT = `${NS}-align-right`;
+export const BORDERED = `${NS}-bordered`;
 export const COMPACT = `${NS}-compact`;
 export const DARK = `${NS}-dark`;
 export const DISABLED = `${NS}-disabled`;

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -204,6 +204,25 @@ $tree-intent-icon-colors: (
   }
 }
 
+// Variant: bordered
+.#{$ns}-tree.#{$ns}-bordered {
+  border-bottom: 1px solid $pt-divider-black;
+
+  .#{$ns}-tree-node-content {
+    border: 1px solid $pt-divider-black;
+    border-bottom: none;
+  }
+
+  .#{$ns}-dark & {
+    border-bottom: 1px solid $pt-dark-divider-white;
+
+    .#{$ns}-tree-node-content {
+      border: 1px solid $pt-dark-divider-white;
+      border-bottom: none;
+    }
+  }
+}
+
 // Variant: dark theme
 .#{$ns}-dark {
   .#{$ns}-tree-node-content {

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -25,6 +25,13 @@ import type { TreeEventHandler, TreeNodeInfo } from "./treeTypes";
 // eslint-disable-next-line @typescript-eslint/ban-types
 export interface TreeProps<T = {}> extends Props {
     /**
+     * Whether to render borders around the nodes in the tree.
+     *
+     * @default false
+     */
+    bordered?: boolean;
+
+    /**
      * Whether to use a compact appearance which reduces the visual padding around node content.
      */
     compact?: boolean;
@@ -101,9 +108,14 @@ export class Tree<T = {}> extends React.Component<TreeProps<T>> {
     public render() {
         return (
             <div
-                className={classNames(Classes.TREE, this.props.className, {
-                    [Classes.COMPACT]: this.props.compact,
-                })}
+                className={classNames(
+                    Classes.TREE,
+                    this.props.className,
+                    {
+                        [Classes.COMPACT]: this.props.compact,
+                    },
+                    { [Classes.BORDERED]: this.props.bordered },
+                )}
             >
                 {this.renderNodes(this.props.contents, [], Classes.TREE_ROOT)}
             </div>

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -26,8 +26,6 @@ import type { TreeEventHandler, TreeNodeInfo } from "./treeTypes";
 export interface TreeProps<T = {}> extends Props {
     /**
      * Whether to render borders around the nodes in the tree.
-     *
-     * @default false
      */
     bordered?: boolean;
 

--- a/packages/docs-app/changelog/@unreleased/pr-6963.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-6963.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add bordered prop to tree component
+  links:
+  - https://github.com/palantir/blueprint/pull/6963

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import classNames from "classnames";
 import cloneDeep from "lodash/cloneDeep";
 import * as React from "react";
 
@@ -63,6 +64,7 @@ function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
 
 export const TreeExample: React.FC<ExampleProps> = props => {
     const [compact, setCompact] = React.useState(false);
+    const [bordered, setBordered] = React.useState(false);
     const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
 
     const handleNodeClick = React.useCallback(
@@ -97,18 +99,20 @@ export const TreeExample: React.FC<ExampleProps> = props => {
         <>
             <H5>Props</H5>
             <Switch label="Compact" checked={compact} onChange={handleBooleanChange(setCompact)} />
+            <Switch label="Bordered" checked={bordered} onChange={handleBooleanChange(setBordered)} />
         </>
     );
 
     return (
         <Example options={options} {...props}>
             <Tree
+                bordered={bordered}
                 compact={compact}
                 contents={nodes}
                 onNodeClick={handleNodeClick}
                 onNodeCollapse={handleNodeCollapse}
                 onNodeExpand={handleNodeExpand}
-                className={Classes.ELEVATION_0}
+                className={classNames({ [Classes.ELEVATION_0]: !bordered })}
             />
         </Example>
     );
@@ -127,6 +131,13 @@ const INITIAL_STATE: TreeNodeInfo[] = [
                 Folder 0
             </ContextMenu>
         ),
+    },
+    {
+        id: 2,
+        hasCaret: true,
+        icon: "folder-close",
+        label: "Super secret files",
+        disabled: true,
     },
     {
         id: 1,
@@ -186,13 +197,6 @@ const INITIAL_STATE: TreeNodeInfo[] = [
                 ],
             },
         ],
-    },
-    {
-        id: 2,
-        hasCaret: true,
-        icon: "folder-close",
-        label: "Super secret files",
-        disabled: true,
     },
 ];
 /* tslint:enable:object-literal-sort-keys */


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Added a prop to the tree component that allows the consumer to render borders around the nodes within the tree

https://github.com/user-attachments/assets/2ab66df2-94a8-4d1d-87d6-7d0b9e7a9f52

#### Testing
http://localhost:9001/#core/components/tree
