### PR TITLE
Fix border overlap between Buttons in outlined ButtonGroup

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -142,12 +142,13 @@ Styleguide button-group
   }
 
   &.#{$ns}-outlined {
-    .#{$ns}-button {
+    > .#{$ns}-popover-target > .#{$ns}-button,
+    > .#{$ns}-button {
       @include pt-button-outlined();
     }
 
     &:not(.#{$ns}-vertical) {
-      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button,
+      > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         border-right: none;
       }

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -265,6 +265,11 @@ Styleguide button-group
         border-bottom: none;
       }
     }
+
+    > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button.#{$ns}-outlined,
+    > .#{$ns}-button.#{$ns}-outlined:not(:last-child) {
+      border-bottom: none;
+    }
   }
 
   &.#{$ns}-align-left .#{$ns}-button {

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -142,14 +142,22 @@ Styleguide button-group
   }
 
   &.#{$ns}-outlined {
-    > .#{$ns}-button {
+    .#{$ns}-button {
       @include pt-button-outlined();
     }
 
     &:not(.#{$ns}-vertical) {
+      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         border-right: none;
       }
+    }
+  }
+
+  &:not(.#{$ns}-vertical) {
+    > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button.#{$ns}-outlined,
+    > .#{$ns}-button.#{$ns}-outlined:not(:last-child) {
+      border-right: none;
     }
   }
 
@@ -252,6 +260,7 @@ Styleguide button-group
     }
 
     &.#{$ns}-outlined {
+      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         border-bottom: none;
       }

--- a/packages/core/src/components/popover/_popover-in-button-group.scss
+++ b/packages/core/src/components/popover/_popover-in-button-group.scss
@@ -15,7 +15,12 @@
     > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
-      margin-right: -$button-border-width;
+    }
+
+    &:not(.#{$ns}-outlined) {
+      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button:not(.#{$ns}-outlined) {
+        margin-right: -$button-border-width;
+      }
     }
   }
 
@@ -34,8 +39,10 @@
         border-radius: 0 0 $pt-border-radius $pt-border-radius;
       }
 
-      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button {
-        margin-bottom: -$button-border-width;
+      &:not(.#{$ns}-outlined) {
+        > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button:not(.#{$ns}-outlined) {
+          margin-bottom: -$button-border-width;
+        }
       }
     }
   }

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -27,6 +27,7 @@ export interface ButtonGroupPopoverExampleState {
     fill: boolean;
     large: boolean;
     minimal: boolean;
+    outlined: boolean;
     vertical: boolean;
 }
 
@@ -36,6 +37,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
         fill: false,
         large: false,
         minimal: false,
+        outlined: false,
         vertical: false,
     };
 
@@ -44,6 +46,8 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
+
+    private handleOutlinedChange = handleBooleanChange(outlined => this.setState({ outlined }));
 
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
@@ -54,6 +58,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
                 <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
+                <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
                 <AlignmentSelect align={this.state.alignText} label="Align text" onChange={this.handleAlignChange} />
             </>


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes an issue where outlined button styles were not rendering properly when wrapped in a Popover inside of ButtonGroup. Also adds an `outlined` variant prop example to the "Usage with popovers" ButtonGroup example to allow for visual testing of this issue in the future.

#### New `outlined` prop toggle on ButtonGroup's ["Usage with popovers" ](https://blueprintjs.com/docs/#core/components/button-group.usage-with-popovers) example.

![Screenshot 2024-09-09 at 21 30 56](https://github.com/user-attachments/assets/4bfb1596-a679-475a-8add-451f58477589)

This change fixes borders on outlined buttons with popovers in two instances:

1. The first is where the `outlined` prop is applied to the `ButtonGroup` parent container:
```tsx
<ButtonGroup outlined>
  <Popover content={...}>
    <Button icon="git-branch" rightIcon="caret-down" text="Main" />
  </Popover>
  <Button icon="more" />
</ButtonGroup>
```
In this case, buttons surrounded by popovers weren't being styled as outlined at all. The `.bp5-popover-target` class breaks the selector applying the outlined styling.
| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/6d107361-fc78-4382-a9a1-17a7799f4f6b) | ![after](https://github.com/user-attachments/assets/0269a5ef-9f2f-4f92-bfca-99136d598201) |

2. The other is where the `outlined` prop is applied to the individual buttons within the group
```tsx
<ButtonGroup>
  <Popover content={...}>
    <Button icon="git-branch" rightIcon="caret-down" text="Main" outlined />
  </Popover>
  <Button icon="more" outlined />
</ButtonGroup>
```
In this case, the outline styles render, but there is a slight overlap between the intermediate borders of the button group. This overlap is noticeable due to the semi-transparent styling of the borders on outlined buttons.

![Screenshot 2024-09-09 at 21 29 04@2x](https://github.com/user-attachments/assets/2c742115-7576-4fea-a3f0-347c50a4a88c)

#### Reviewers should focus on:

- Various possible Button variants/permutations that can be contained within a ButtonGroup wrapper
- Buttons surrounded by Popovers
- Buttons surrounded by Tooltips

