### PR TITLE
a11y(DocsApp): fix version selector a11y

### DIFF
--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -17,7 +17,7 @@
 import type { NpmPackageInfo } from "@documentalist/client";
 import * as React from "react";
 
-import { Classes, HotkeysTarget2, type Intent, Menu, MenuItem, NavbarHeading, Popover, PopupKind, Tag } from "@blueprintjs/core";
+import { Classes, HotkeysTarget2, type Intent, Menu, MenuItem, NavbarHeading, Popover, Tag } from "@blueprintjs/core";
 import { NavButton } from "@blueprintjs/docs-theme";
 
 import { Logo } from "./logo";
@@ -109,7 +109,6 @@ export class NavHeader extends React.PureComponent<NavHeaderProps> {
                     </Menu>
                 }
                 placement="bottom"
-                popupKind={PopupKind.MENU}
             >
                 <Tag
                     interactive={true}

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -17,7 +17,7 @@
 import type { NpmPackageInfo } from "@documentalist/client";
 import * as React from "react";
 
-import { Classes, HotkeysTarget2, type Intent, Menu, MenuItem, NavbarHeading, Popover, Tag } from "@blueprintjs/core";
+import { Classes, HotkeysTarget2, type Intent, Menu, MenuItem, NavbarHeading, Popover, PopupKind, Tag } from "@blueprintjs/core";
 import { NavButton } from "@blueprintjs/docs-theme";
 
 import { Logo } from "./logo";
@@ -104,11 +104,12 @@ export class NavHeader extends React.PureComponent<NavHeaderProps> {
         return (
             <Popover
                 content={
-                    <Menu className="docs-version-list" id={VERSION_MENU_ID} aria-label="docs version">
+                    <Menu aria-label="docs version" className="docs-version-list" id={VERSION_MENU_ID}>
                         {releaseItems}
                     </Menu>
                 }
                 placement="bottom"
+                popupKind={PopupKind.MENU}
             >
                 <Tag
                     interactive={true}
@@ -116,7 +117,6 @@ export class NavHeader extends React.PureComponent<NavHeaderProps> {
                     round={true}
                     rightIcon="caret-down"
                     role="button"
-                    aria-haspopup="menu"
                     aria-label={`Version ${major(currentVersion)}`}
                     aria-controls={VERSION_MENU_ID}
                 >

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -74,6 +74,7 @@ export class NavHeader extends React.PureComponent<NavHeaderProps> {
     }
 
     private renderVersionsMenu() {
+        const VERSION_MENU_ID = "version-menu";
         const { useNextVersion } = this.props;
         const { version, nextVersion, versions } = this.props.packageInfo;
         if (versions.length === 1) {
@@ -101,8 +102,24 @@ export class NavHeader extends React.PureComponent<NavHeaderProps> {
                 return <MenuItem href={href} intent={intent} key={v} text={v} />;
             });
         return (
-            <Popover content={<Menu className="docs-version-list">{releaseItems}</Menu>} placement="bottom">
-                <Tag interactive={true} minimal={true} round={true} rightIcon="caret-down">
+            <Popover
+                content={
+                    <Menu className="docs-version-list" id={VERSION_MENU_ID} aria-label="docs version">
+                        {releaseItems}
+                    </Menu>
+                }
+                placement="bottom"
+            >
+                <Tag
+                    interactive={true}
+                    minimal={true}
+                    round={true}
+                    rightIcon="caret-down"
+                    role="button"
+                    aria-haspopup="menu"
+                    aria-label={`Version ${major(currentVersion)}`}
+                    aria-controls={VERSION_MENU_ID}
+                >
                     v{major(currentVersion)}
                 </Tag>
             </Popover>


### PR DESCRIPTION
The version selector in the docs app causes aXe a11y failure. Fix with this PR.

Replaces [this PR](https://github.com/palantir/blueprint/pull/6886) with simpler changes to accomplish the a11y failure fix.