### PR TITLE
feat(EntityTitle): Add fill to EntityTitle

### DIFF
--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -24,6 +24,10 @@
   &-text {
     display: flex;
     flex-direction: column;
+
+    .#{$ns}-fill & {
+      flex-grow: 1;
+    }
   }
 
   &-title-and-tags {
@@ -43,6 +47,10 @@
     margin-bottom: 0;
     min-width: 0;
     overflow-wrap: break-word;
+
+    .#{$ns}-fill & {
+      flex-grow: 1;
+    }
   }
 
   &-subtitle {

--- a/packages/core/src/components/entity-title/entityTitle.tsx
+++ b/packages/core/src/components/entity-title/entityTitle.tsx
@@ -32,6 +32,9 @@ export interface EntityTitleProps extends Props {
      */
     ellipsize?: boolean;
 
+    /** Whether the component should expand to fill its container. */
+    fill?: boolean;
+
     /**
      * React component to render the main title heading. This defaults to
      * Blueprint's `<Text>` component, * which inherits font size from its
@@ -82,6 +85,7 @@ export const EntityTitle: React.FC<EntityTitleProps> = React.forwardRef<HTMLDivE
         const {
             className,
             ellipsize = false,
+            fill = false,
             heading = Text,
             icon,
             loading = false,
@@ -135,6 +139,7 @@ export const EntityTitle: React.FC<EntityTitleProps> = React.forwardRef<HTMLDivE
             <div
                 className={classNames(className, Classes.ENTITY_TITLE, getClassNameFromHeading(heading), {
                     [Classes.ENTITY_TITLE_ELLIPSIZE]: ellipsize,
+                    [Classes.FILL]: fill,
                 })}
                 ref={ref}
             >

--- a/packages/core/test/entity-title/entityTitleTests.tsx
+++ b/packages/core/test/entity-title/entityTitleTests.tsx
@@ -95,6 +95,11 @@ describe("<EntityTitle>", () => {
         assert.isTrue(wrapper.find(H5).hasClass(Classes.TEXT_OVERFLOW_ELLIPSIS));
     });
 
+    it("supports fill", () => {
+        const wrapper = mount(<EntityTitle title="title" fill={true} />, { attachTo: containerElement });
+        assert.isTrue(wrapper.find(`.${Classes.FILL}`).exists());
+    });
+
     it("supports loading", () => {
         const wrapper = mount(<EntityTitle title="title" loading={true} />, {
             attachTo: containerElement,

--- a/packages/demo-app/src/examples/EntityTitleExample.tsx
+++ b/packages/demo-app/src/examples/EntityTitleExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Classes, EntityTitle, H4, UL } from "@blueprintjs/core";
+import { Classes, EntityTitle, H4, Intent, Tag, UL } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 
 import { ExampleCard } from "./ExampleCard";
@@ -43,6 +43,44 @@ export function EntityTitleExample() {
                     />
                 </li>
             </UL>
+            <div>
+                <EntityTitle
+                    icon={IconNames.CITATION}
+                    fill={true}
+                    title="Id"
+                    tags={[
+                        <Tag key="1" icon={IconNames.KEY} intent={Intent.SUCCESS} minimal={true}>
+                            Primary key
+                        </Tag>,
+                        <Tag key="2" minimal={true}>
+                            1
+                        </Tag>,
+                    ]}
+                />
+                <EntityTitle
+                    icon={IconNames.CITATION}
+                    fill={true}
+                    title="Title"
+                    tags={[
+                        <Tag key="1" minimal={true}>
+                            Title
+                        </Tag>,
+                        <Tag key="2" minimal={true}>
+                            2
+                        </Tag>,
+                    ]}
+                />
+                <EntityTitle
+                    icon={IconNames.ARRAY_STRING}
+                    fill={true}
+                    title="Tags"
+                    tags={
+                        <Tag key="1" minimal={true}>
+                            3
+                        </Tag>
+                    }
+                />
+            </div>
         </ExampleCard>
     );
 }

--- a/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
@@ -43,6 +43,7 @@ const HEADINGS = ["Default", "H1", "H2", "H3", "H4", "H5", "H6"].map(value => ({
 
 export const EntityTitleExample: React.FC<ExampleProps> = props => {
     const [ellipsize, setEllipsize] = React.useState<boolean>(false);
+    const [fill, setFill] = React.useState<boolean>(false);
     const [heading, setHeading] = React.useState<string>("Default");
     const [icon, setIcon] = React.useState<boolean>(true);
     const [loading, setLoading] = React.useState<boolean>(false);
@@ -62,6 +63,7 @@ export const EntityTitleExample: React.FC<ExampleProps> = props => {
                 </ControlGroup>
             </FormGroup>
             <Switch checked={ellipsize} label="Ellipsize" onChange={handleBooleanChange(setEllipsize)} />
+            <Switch checked={fill} label="Fill" onChange={handleBooleanChange(setFill)} />
             <Switch checked={icon} label="Display icon" onChange={handleBooleanChange(setIcon)} />
             <Switch checked={loading} label="Loading" onChange={handleBooleanChange(setLoading)} />
             <Switch checked={withSubtitle} label="Display subtitle" onChange={handleBooleanChange(setWithSubtitle)} />
@@ -69,11 +71,19 @@ export const EntityTitleExample: React.FC<ExampleProps> = props => {
         </>
     );
 
+    let width;
+    if (ellipsize) {
+        width = WIDTH_LIMIT;
+    } else if (fill) {
+        width = "100%";
+    }
+
     return (
         <Example options={options} {...props}>
-            <div style={{ width: ellipsize ? WIDTH_LIMIT : undefined }}>
+            <div style={{ width }}>
                 <EntityTitle
                     ellipsize={ellipsize}
+                    fill={fill}
                     heading={getHeading(heading)}
                     icon={icon ? IconNames.Shop : undefined}
                     loading={loading}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adds a new boolean `fill` property to [EntityTitle](https://blueprintjs.com/docs/#core/components/entity-title) that controls whether or not the title inside of the EntityTitle component will expand and cause it to horizontally fill its container. This is useful in situations where the icon/title/subtitle and label element should be separated from each other, such as when multiple entity titles are displayed next to each other in a vertical list.

![Screenshot 2024-09-12 at 15 35 14](https://github.com/user-attachments/assets/ba12b435-61bc-4001-9f16-d74b2e0fb209)

![Screenshot 2024-09-12 at 15 37 10@2x](https://github.com/user-attachments/assets/232006ba-8e36-429c-a868-aa7310b572bc)

![Screenshot 2024-09-12 at 15 51 44@2x](https://github.com/user-attachments/assets/c13b1ddf-7952-430e-b794-a44fafc5629c)