### PR TITLE
fix(Icon): Support null tagName in Icon component

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -171,7 +171,7 @@ export const Icon: IconComponent = React.forwardRef(function <T extends Element>
                 : size === IconSize.LARGE
                   ? Classes.ICON_LARGE
                   : undefined;
-        return React.createElement(tagName!, {
+        return React.createElement(tagName || "span", {
             "aria-hidden": title ? undefined : true,
             ...removeNonHTMLProps(htmlProps),
             className: classNames(

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -132,7 +132,8 @@ describe("<Icon>", () => {
 
     it("allows specifying the root element as <svg> when tagName={null}", () => {
         const handleClick: React.MouseEventHandler<SVGSVGElement> = () => undefined;
-        mount(<Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />);
+        const wrapper = mount(<Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />);
+        assert.isFalse(wrapper.find("span").exists());
     });
 
     /** Asserts that rendered icon has an SVG path. */


### PR DESCRIPTION
#### Fixes #6974

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Fixes a condition where a null element gets passed into `React.createElement` while the icon is loading paths asynchronously. This prevents an error in the Icon component when `null` is passed in as the `tagName`.
