### PR TITLE
style: HTMLElement casting style

### DIFF
--- a/packages/core/src/common/utils/domUtils.ts
+++ b/packages/core/src/common/utils/domUtils.ts
@@ -37,7 +37,7 @@ export function elementIsTextInput(elem: HTMLElement) {
         return false;
     }
 
-    const editable = elem.closest("input, textarea, [contenteditable=true]");
+    const editable = elem.closest<HTMLInputElement>("input, textarea, [contenteditable=true]");
 
     if (editable == null) {
         return false;
@@ -45,14 +45,14 @@ export function elementIsTextInput(elem: HTMLElement) {
 
     // don't let checkboxes, switches, and radio buttons prevent hotkey behavior
     if (editable.tagName.toLowerCase() === "input") {
-        const inputType = (editable as HTMLInputElement).type;
+        const inputType = editable.type;
         if (inputType === "checkbox" || inputType === "radio") {
             return false;
         }
     }
 
     // don't let read-only fields prevent hotkey behavior
-    if ((editable as HTMLInputElement).readOnly) {
+    if (editable.readOnly) {
         return false;
     }
 
@@ -63,12 +63,8 @@ export function elementIsTextInput(elem: HTMLElement) {
  * Gets the active element in the document or shadow root (if an element is provided, and it's in the shadow DOM).
  */
 export function getActiveElement(element?: HTMLElement | null, options?: GetRootNodeOptions) {
-    if (element == null) {
-        return document.activeElement;
-    }
-
-    const rootNode = (element.getRootNode(options) ?? document) as DocumentOrShadowRoot & Node;
-    return rootNode.activeElement;
+    const rootNode = (element?.getRootNode(options) ?? document) as DocumentOrShadowRoot & Node;
+    return rootNode.activeElement as HTMLElement | null;
 }
 
 /**

--- a/packages/core/src/common/utils/domUtils.ts
+++ b/packages/core/src/common/utils/domUtils.ts
@@ -63,8 +63,9 @@ export function elementIsTextInput(elem: HTMLElement) {
  * Gets the active element in the document or shadow root (if an element is provided, and it's in the shadow DOM).
  */
 export function getActiveElement(element?: HTMLElement | null, options?: GetRootNodeOptions) {
-    const rootNode = (element?.getRootNode(options) ?? document) as DocumentOrShadowRoot & Node;
-    return rootNode.activeElement as HTMLElement | null;
+    const rootNode = (element?.getRootNode(options) ?? document) as unknown as DocumentOrShadowRoot;
+    const activeElement = rootNode.activeElement;
+    return activeElement instanceof HTMLElement ? activeElement : null;
 }
 
 /**

--- a/packages/core/src/components/overlay/overlayUtils.ts
+++ b/packages/core/src/components/overlay/overlayUtils.ts
@@ -23,13 +23,13 @@ import { getRef } from "../../common/refs";
  */
 export function getKeyboardFocusableElements(container: HTMLElement | React.RefObject<HTMLElement>): HTMLElement[] {
     const containerElement = getRef(container);
-    const focusableElements: HTMLElement[] =
+    const focusableElements =
         containerElement != null
             ? Array.from(
                   // Order may not be correct if children elements use tabindex values > 0.
                   // Selectors derived from this SO question:
                   // https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus
-                  containerElement.querySelectorAll(
+                  containerElement.querySelectorAll<HTMLElement>(
                       [
                           'a[href]:not([tabindex="-1"])',
                           'button:not([disabled]):not([tabindex="-1"])',

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -250,14 +250,14 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
         if (this.tablistElement == null) {
             return [];
         }
-        return Array.from(this.tablistElement.querySelectorAll(TAB_SELECTOR + subselector));
+        return Array.from(this.tablistElement.querySelectorAll<HTMLElement>(TAB_SELECTOR + subselector));
     }
 
     private handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
         const direction = getArrowKeyDirection(e, true);
         if (direction === undefined) return;
 
-        const focusedElement = Utils.getActiveElement(this.tablistElement)?.closest(TAB_SELECTOR);
+        const focusedElement = Utils.getActiveElement(this.tablistElement)?.closest<HTMLElement>(TAB_SELECTOR);
         // rest of this is potentially expensive and futile, so bail if no tab is focused
         if (focusedElement == null) {
             return;
@@ -272,7 +272,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
         const { length } = enabledTabElements;
         // auto-wrapping at 0 and `length`
         const nextFocusedIndex = (focusedIndex + direction + length) % length;
-        (enabledTabElements[nextFocusedIndex] as HTMLElement).focus();
+        enabledTabElements[nextFocusedIndex].focus();
     };
 
     private handleKeyPress = (e: React.KeyboardEvent<HTMLDivElement>) => {

--- a/packages/core/src/legacy/hotkeysEvents.ts
+++ b/packages/core/src/legacy/hotkeysEvents.ts
@@ -126,7 +126,7 @@ export class HotkeysEvents {
             return false;
         }
 
-        const editable = elem.closest("input, textarea, [contenteditable=true]");
+        const editable = elem.closest<HTMLInputElement>("input, textarea, [contenteditable=true]");
 
         if (editable == null) {
             return false;
@@ -134,14 +134,14 @@ export class HotkeysEvents {
 
         // don't let checkboxes, switches, and radio buttons prevent hotkey behavior
         if (editable.tagName.toLowerCase() === "input") {
-            const inputType = (editable as HTMLInputElement).type;
+            const inputType = editable.type;
             if (inputType === "checkbox" || inputType === "radio") {
                 return false;
             }
         }
 
         // don't let read-only fields prevent hotkey behavior
-        if ((editable as HTMLInputElement).readOnly) {
+        if (editable.readOnly) {
             return false;
         }
 

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -30,7 +30,7 @@ describe("<InputGroup>", () => {
 
     it("supports custom props", () => {
         const input = mount(<InputGroup leftIcon="star" style={{ background: "yellow" }} tabIndex={4} />);
-        const inputElement = input.find("input").getDOMNode() as HTMLElement;
+        const inputElement = input.find("input").getDOMNode<HTMLElement>();
         assert.equal(inputElement.style.background, "yellow");
         assert.equal(inputElement.tabIndex, 4);
     });

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -888,7 +888,7 @@ describe("<Popover>", () => {
             it("when autoFocus={true}", done => {
                 wrapper = renderPopover({ autoFocus: true });
                 const button = wrapper.find(BUTTON_ID_SELECTOR).hostNodes();
-                (button.getDOMNode() as HTMLElement).focus();
+                button.getDOMNode<HTMLElement>().focus();
                 button.simulate("keyDown", SPACE_KEYSTROKE);
                 // Wait for focus to change
                 wrapper.then(wrap => {
@@ -905,7 +905,7 @@ describe("<Popover>", () => {
             it("when autoFocus={false}", done => {
                 wrapper = renderPopover({ autoFocus: false });
                 const button = wrapper.find(BUTTON_ID_SELECTOR).hostNodes();
-                (button.getDOMNode() as HTMLElement).focus();
+                button.getDOMNode<HTMLElement>().focus();
                 button.simulate("keyDown", SPACE_KEYSTROKE);
 
                 // Wait for focus to change (it shouldn't)

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -183,7 +183,7 @@ describe("<Tabs>", () => {
         ));
         const wrapper = mount(<Tabs id={ID}>{tabs}</Tabs>);
         wrapper.find(TAB_SELECTOR).forEach(title => {
-            assert.strictEqual((title.getDOMNode() as HTMLElement).getAttribute("data-arbitrary-attr"), "foo");
+            assert.strictEqual(title.getDOMNode<HTMLElement>().getAttribute("data-arbitrary-attr"), "foo");
         });
     });
 

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -724,7 +724,7 @@ function getInitialTimezoneValue({ defaultTimezone, timezone }: DateInputProps) 
 }
 
 function getRelatedTargetWithFallback(e: React.FocusEvent<HTMLElement>) {
-    return (e.relatedTarget ?? Utils.getActiveElement(e.currentTarget)) as HTMLElement;
+    return e.relatedTarget ?? Utils.getActiveElement(e.currentTarget);
 }
 
 function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<HTMLDivElement | null>) {
@@ -732,8 +732,10 @@ function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<
         return [];
     }
 
-    const elements: HTMLElement[] = Array.from(
-        popoverContentRef.current.querySelectorAll("button:not([disabled]),input,[tabindex]:not([tabindex='-1'])"),
+    const elements = Array.from(
+        popoverContentRef.current.querySelectorAll<HTMLElement>(
+            "button:not([disabled]),input,[tabindex]:not([tabindex='-1'])",
+        ),
     );
     // Remove focus boundary div elements
     elements.pop();

--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -258,7 +258,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
             ArrowDown: () => this.decrementTime(unit),
             ArrowUp: () => this.incrementTime(unit),
             Enter: () => {
-                (e.currentTarget as HTMLInputElement).blur();
+                e.currentTarget.blur();
             },
         });
         this.props.onKeyDown?.(e, unit);

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -113,7 +113,7 @@ describe("<DateInput>", () => {
             const wrapper = mount(
                 <DateInput {...DEFAULT_PROPS} inputProps={{ style: { background: "yellow" }, tabIndex: 4 }} />,
             );
-            const inputElement = wrapper.find("input").getDOMNode() as HTMLInputElement;
+            const inputElement = wrapper.find("input").getDOMNode<HTMLInputElement>();
             assert.equal(inputElement.style.background, "yellow");
             assert.equal(inputElement.tabIndex, 4);
         });

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -272,7 +272,7 @@ describe("<DateRangeInput>", () => {
 
             it("supports custom style", () => {
                 const root = mountFn({ style: { background: "yellow" } });
-                const inputElement = inputGetterFn(root).getDOMNode() as HTMLElement;
+                const inputElement = inputGetterFn(root).getDOMNode<HTMLElement>();
                 expect(inputElement.style.background).to.equal("yellow");
             });
 

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -330,7 +330,7 @@ describe("<TimePicker>", () => {
 
             const hourInput = wrapper
                 .find(`.${Classes.TIMEPICKER_INPUT}.${Classes.TIMEPICKER_HOUR}`)
-                .getDOMNode() as HTMLInputElement;
+                .getDOMNode<HTMLInputElement>();
 
             changeInputThenBlur(hourInput, "22");
 
@@ -348,7 +348,7 @@ describe("<TimePicker>", () => {
 
             const hourInput = wrapper
                 .find(`.${Classes.TIMEPICKER_INPUT}.${Classes.TIMEPICKER_HOUR}`)
-                .getDOMNode() as HTMLInputElement;
+                .getDOMNode<HTMLInputElement>();
 
             changeInputThenBlur(hourInput, "16");
 

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -602,7 +602,7 @@ function getInitialTimezoneValue({ defaultTimezone, timezone }: DateInput3Props)
 }
 
 function getRelatedTargetWithFallback(e: React.FocusEvent<HTMLElement>) {
-    return (e.relatedTarget ?? Utils.getActiveElement(e.currentTarget)) as HTMLElement;
+    return e.relatedTarget ?? Utils.getActiveElement(e.currentTarget);
 }
 
 function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<HTMLDivElement | null>) {
@@ -610,8 +610,10 @@ function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<
         return [];
     }
 
-    const elements: HTMLElement[] = Array.from(
-        popoverContentRef.current.querySelectorAll("button:not([disabled]),input,[tabindex]:not([tabindex='-1'])"),
+    const elements = Array.from(
+        popoverContentRef.current.querySelectorAll<HTMLElement>(
+            "button:not([disabled]),input,[tabindex]:not([tabindex='-1'])",
+        ),
     );
     // Remove focus boundary div elements
     elements.pop();

--- a/packages/datetime2/test/components/dateInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateInput3Tests.tsx
@@ -113,7 +113,7 @@ describe("<DateInput3>", () => {
             const wrapper = mount(
                 <DateInput3 {...DEFAULT_PROPS} inputProps={{ style: { background: "yellow" }, tabIndex: 4 }} />,
             );
-            const inputElement = wrapper.find("input").getDOMNode() as HTMLInputElement;
+            const inputElement = wrapper.find("input").getDOMNode<HTMLInputElement>();
             assert.equal(inputElement.style.background, "yellow");
             assert.equal(inputElement.tabIndex, 4);
         });

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -283,7 +283,7 @@ describe("<DateRangeInput3>", () => {
 
             it("supports custom style", () => {
                 const root = mountFn({ style: { background: "yellow" } });
-                const inputElement = inputGetterFn(root).getDOMNode() as HTMLElement;
+                const inputElement = inputGetterFn(root).getDOMNode<HTMLElement>();
                 expect(inputElement.style.background).to.equal("yellow");
             });
 

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -395,18 +395,18 @@ export class Documentation extends React.PureComponent<DocumentationProps, Docum
 
 /** Shorthand for element.querySelector() + cast to HTMLElement */
 function queryHTMLElement(parent: Element, selector: string) {
-    return parent.querySelector(selector) as HTMLElement;
+    return parent.querySelector<HTMLElement>(selector);
 }
 
 /**
  * Returns the reference of the closest section within `offset` pixels of the top of the viewport.
  */
 function getScrolledReference(offset: number, scrollContainer: HTMLElement = document.documentElement) {
-    const headings = Array.from(scrollContainer.querySelectorAll(".docs-title"));
+    const headings = Array.from(scrollContainer.querySelectorAll<HTMLElement>(".docs-title"));
     while (headings.length > 0) {
         // iterating in reverse order (popping from end / bottom of page)
         // so the first element below the threshold is the one we want.
-        const element = headings.pop() as HTMLElement;
+        const element = headings.pop()!;
         if (element.offsetTop < scrollContainer.scrollTop + offset) {
             // relying on DOM structure to get reference
             return element.querySelector("[data-route]")?.getAttribute("data-route");

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -406,8 +406,8 @@ function getScrolledReference(offset: number, scrollContainer: HTMLElement = doc
     while (headings.length > 0) {
         // iterating in reverse order (popping from end / bottom of page)
         // so the first element below the threshold is the one we want.
-        const element = headings.pop()!;
-        if (element.offsetTop < scrollContainer.scrollTop + offset) {
+        const element = headings.pop();
+        if (element && element.offsetTop < scrollContainer.scrollTop + offset) {
             // relying on DOM structure to get reference
             return element.querySelector("[data-route]")?.getAttribute("data-route");
         }

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -315,7 +315,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
     private handlePopoverOpening = (node: HTMLElement) => {
         // save currently focused element before popover steals focus, so we can restore it when closing.
-        this.previousFocusedElement = (Utils.getActiveElement(this.inputElement) as HTMLElement | null) ?? undefined;
+        this.previousFocusedElement = Utils.getActiveElement(this.inputElement) ?? undefined;
 
         if (this.props.resetOnClose) {
             this.resetQuery();

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -65,14 +65,14 @@ describe("<MultiSelect>", () => {
         const placeholder = "look here";
 
         const input = multiselect({ placeholder }).find("input");
-        assert.equal((input.getDOMNode() as HTMLInputElement).placeholder, placeholder);
+        assert.equal(input.getDOMNode<HTMLInputElement>().placeholder, placeholder);
     });
 
     it("placeholder can be controlled with TagInput's inputProps", () => {
         const placeholder = "look here";
 
         const input = multiselect({ tagInputProps: { placeholder } }).find("input");
-        assert.equal((input.getDOMNode() as HTMLInputElement).placeholder, placeholder);
+        assert.equal(input.getDOMNode<HTMLInputElement>().placeholder, placeholder);
     });
 
     it("tagRenderer can return JSX", () => {

--- a/packages/table/src/interactions/resizeSensor.ts
+++ b/packages/table/src/interactions/resizeSensor.ts
@@ -32,7 +32,7 @@ export class ResizeSensor {
     public static attach(element: HTMLElement, callback: () => void) {
         const lifecycle = ResizeSensor.debounce(callback);
 
-        const resizeSensor = document.createElement("div") as HTMLElement;
+        const resizeSensor = document.createElement("div");
         resizeSensor.className = Classes.TABLE_RESIZE_SENSOR;
         resizeSensor.style.cssText = ResizeSensor.RESIZE_SENSOR_STYLE;
         resizeSensor.innerHTML = ResizeSensor.RESIZE_SENSOR_HTML;

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -85,7 +85,7 @@ describe("TableQuadrantStack", () => {
 
         const isMainQuadrantChild = (refSpy: sinon.SinonSpy) => {
             const refElement = refSpy.firstCall.args[0] as HTMLElement;
-            const quadrantElement = refElement.closest(`.${Classes.TABLE_QUADRANT_MAIN}`) as HTMLElement;
+            const quadrantElement = refElement.closest<HTMLElement>(`.${Classes.TABLE_QUADRANT_MAIN}`);
             return quadrantElement != null;
         };
 
@@ -188,7 +188,7 @@ describe("TableQuadrantStack", () => {
         it("renders four quadrants (one of each type)", () => {
             const bodyRenderer = sinon.spy();
             const component = mount(<TableQuadrantStack grid={grid} bodyRenderer={bodyRenderer} />);
-            const element = component.getDOMNode() as HTMLElement;
+            const element = component.getDOMNode<HTMLElement>();
             expect(element.classList.contains(Classes.TABLE_QUADRANT_STACK));
             expect(element.children.item(0)?.classList.contains(Classes.TABLE_QUADRANT_MAIN));
             expect(element.children.item(1)?.classList.contains(Classes.TABLE_QUADRANT_TOP));
@@ -502,17 +502,12 @@ describe("TableQuadrantStack", () => {
             assertStyleEquals(topLeftQuadrant, "height", expectedHeightString);
         }
 
-        function assertStyleEquals(element: HTMLElement, key: keyof React.CSSProperties, expectedValue: any) {
-            // key's type should be okay, but TS was throwing error TS7015, hence the `any` cast
-            expect(toHtmlElement(element).style[key as any]).to.equal(expectedValue);
+        function assertStyleEquals(element: HTMLElement, key: keyof CSSStyleDeclaration, expectedValue: any) {
+            expect(element.style[key]).to.equal(expectedValue);
         }
 
         function toPxString(value: number) {
             return `${value}px`;
-        }
-
-        function toHtmlElement(element: Element) {
-            return element as HTMLElement;
         }
     });
 
@@ -705,15 +700,14 @@ describe("TableQuadrantStack", () => {
         }
     });
 
-    function findQuadrants(element: Element) {
-        const htmlElement = element as HTMLElement;
+    function findQuadrants(element: HTMLElement) {
         // this order is clearer than alphabetical order
         // tslint:disable:object-literal-sort-keys
         return {
-            mainQuadrant: htmlElement.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_MAIN}`)!,
-            leftQuadrant: htmlElement.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_LEFT}`)!,
-            topQuadrant: htmlElement.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_TOP}`)!,
-            topLeftQuadrant: htmlElement.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`)!,
+            mainQuadrant: element.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_MAIN}`)!,
+            leftQuadrant: element.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_LEFT}`)!,
+            topQuadrant: element.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_TOP}`)!,
+            topLeftQuadrant: element.querySelector<HTMLElement>(`.${Classes.TABLE_QUADRANT_TOP_LEFT}`)!,
         };
         // tslint:enable:object-literal-sort-keys
     }

--- a/packages/table/test/quadrants/tableQuadrantTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantTests.tsx
@@ -102,7 +102,7 @@ describe("TableQuadrant", () => {
             const style = { background: "rgb(1, 2, 3)", color: "rgb(4, 5, 6)" };
             const component = mountTableQuadrant({ style });
 
-            const renderedStyle = (component.getDOMNode() as HTMLElement).style;
+            const renderedStyle = component.getDOMNode<HTMLElement>().style;
             expect(renderedStyle.background).to.deep.equal(style.background);
             expect(renderedStyle.color).to.deep.equal(style.color);
         });
@@ -261,7 +261,7 @@ describe("TableQuadrant", () => {
     });
 
     function getDomNode(component: ReactWrapper<any, any>) {
-        return component.getDOMNode() as HTMLElement;
+        return component.getDOMNode<HTMLElement>();
     }
 
     function mountTableQuadrant(props: Partial<TableQuadrantProps> = {}) {

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -587,7 +587,7 @@ describe("<Table2>", function (this) {
                 .find(`.${Classes.TABLE_QUADRANT_MAIN}`)
                 .find(`.${Classes.TABLE_BOTTOM_CONTAINER}`)
                 .hostNodes()
-                .getDOMNode() as HTMLElement;
+                .getDOMNode<HTMLElement>();
             const { width: expectedWidth, height: expectedHeight } = bottomContainer.style;
             const [expectedWidthAsNumber, expectedHeightAsNumber] = [expectedWidth, expectedHeight].map(n =>
                 parseInt(n, BASE_10),
@@ -600,7 +600,7 @@ describe("<Table2>", function (this) {
                 .find(`.${Classes.TABLE_QUADRANT_BODY_CONTAINER}`)
                 .find(`.${Classes.TABLE_SELECTION_REGION}`)
                 .hostNodes()
-                .getDOMNode() as HTMLElement;
+                .getDOMNode<HTMLElement>();
             const { width: actualWidth, height: actualHeight } = selectionOverlay.style;
             const [actualWidthAsNumber, actualHeightAsNumber] = [actualWidth, actualHeight].map(n =>
                 parseInt(n, BASE_10),

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -547,7 +547,7 @@ describe("<Table>", function (this) {
                 .find(`.${Classes.TABLE_QUADRANT_MAIN}`)
                 .find(`.${Classes.TABLE_BOTTOM_CONTAINER}`)
                 .hostNodes()
-                .getDOMNode() as HTMLElement;
+                .getDOMNode<HTMLElement>();
             const { width: expectedWidth, height: expectedHeight } = bottomContainer.style;
             const [expectedWidthAsNumber, expectedHeightAsNumber] = [expectedWidth, expectedHeight].map(n =>
                 parseInt(n, BASE_10),
@@ -560,7 +560,7 @@ describe("<Table>", function (this) {
                 .find(`.${Classes.TABLE_QUADRANT_BODY_CONTAINER}`)
                 .find(`.${Classes.TABLE_SELECTION_REGION}`)
                 .hostNodes()
-                .getDOMNode() as HTMLElement;
+                .getDOMNode<HTMLElement>();
             const { width: actualWidth, height: actualHeight } = selectionOverlay.style;
             const [actualWidthAsNumber, actualHeightAsNumber] = [actualWidth, actualHeight].map(n =>
                 parseInt(n, BASE_10),


### PR DESCRIPTION
Better to use say, `elem.closest<HTMLInputElement>("input")` than `elem.closest("input") as HTMLInputElement`