### PR TITLE
Revert: Fix border overlap between Buttons in outlined ButtonGroup

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -142,23 +142,14 @@ Styleguide button-group
   }
 
   &.#{$ns}-outlined {
-    > .#{$ns}-popover-target > .#{$ns}-button,
     > .#{$ns}-button {
       @include pt-button-outlined();
     }
 
     &:not(.#{$ns}-vertical) {
-      > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         border-right: none;
       }
-    }
-  }
-
-  &:not(.#{$ns}-vertical) {
-    > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button.#{$ns}-outlined,
-    > .#{$ns}-button.#{$ns}-outlined:not(:last-child) {
-      border-right: none;
     }
   }
 
@@ -261,15 +252,9 @@ Styleguide button-group
     }
 
     &.#{$ns}-outlined {
-      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
         border-bottom: none;
       }
-    }
-
-    > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button.#{$ns}-outlined,
-    > .#{$ns}-button.#{$ns}-outlined:not(:last-child) {
-      border-bottom: none;
     }
   }
 

--- a/packages/core/src/components/popover/_popover-in-button-group.scss
+++ b/packages/core/src/components/popover/_popover-in-button-group.scss
@@ -15,12 +15,7 @@
     > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button {
       border-bottom-right-radius: 0;
       border-top-right-radius: 0;
-    }
-
-    &:not(.#{$ns}-outlined) {
-      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button:not(.#{$ns}-outlined) {
-        margin-right: -$button-border-width;
-      }
+      margin-right: -$button-border-width;
     }
   }
 
@@ -39,10 +34,8 @@
         border-radius: 0 0 $pt-border-radius $pt-border-radius;
       }
 
-      &:not(.#{$ns}-outlined) {
-        > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button:not(.#{$ns}-outlined) {
-          margin-bottom: -$button-border-width;
-        }
+      > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button {
+        margin-bottom: -$button-border-width;
       }
     }
   }

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -27,6 +27,7 @@ export interface ButtonGroupPopoverExampleState {
     fill: boolean;
     large: boolean;
     minimal: boolean;
+    outlined: boolean;
     vertical: boolean;
 }
 
@@ -36,6 +37,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
         fill: false,
         large: false,
         minimal: false,
+        outlined: false,
         vertical: false,
     };
 
@@ -44,6 +46,8 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
+
+    private handleOutlinedChange = handleBooleanChange(outlined => this.setState({ outlined }));
 
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
@@ -54,6 +58,7 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
                 <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
+                <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
                 <AlignmentSelect align={this.state.alignText} label="Align text" onChange={this.handleAlignChange} />
             </>

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -27,7 +27,6 @@ export interface ButtonGroupPopoverExampleState {
     fill: boolean;
     large: boolean;
     minimal: boolean;
-    outlined: boolean;
     vertical: boolean;
 }
 
@@ -37,7 +36,6 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
         fill: false,
         large: false,
         minimal: false,
-        outlined: false,
         vertical: false,
     };
 
@@ -46,8 +44,6 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 
     private handleMinimalChange = handleBooleanChange(minimal => this.setState({ minimal }));
-
-    private handleOutlinedChange = handleBooleanChange(outlined => this.setState({ outlined }));
 
     private handleVerticalChange = handleBooleanChange(vertical => this.setState({ vertical }));
 
@@ -58,7 +54,6 @@ export class ButtonGroupPopoverExample extends React.PureComponent<ExampleProps,
                 <Switch label="Fill" checked={this.state.fill} onChange={this.handleFillChange} />
                 <Switch label="Large" checked={this.state.large} onChange={this.handleLargeChange} />
                 <Switch label="Minimal" checked={this.state.minimal} onChange={this.handleMinimalChange} />
-                <Switch label="Outlined" checked={this.state.outlined} onChange={this.handleOutlinedChange} />
                 <Switch label="Vertical" checked={this.state.vertical} onChange={this.handleVerticalChange} />
                 <AlignmentSelect align={this.state.alignText} label="Align text" onChange={this.handleAlignChange} />
             </>


### PR DESCRIPTION
This reverts the changes added in #6966 (while retaining additions to the docs). The removal of borders between Buttons in ButtonGroup had the unintentional consequence of regressing styles for ButtonGroups that contain mixed intents or mixed types of buttons.