### PR TITLE
feat(Breadcrumbs): use ol instead of ul

### DIFF
--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -8,13 +8,13 @@
 Breadcrumbs
 
 Markup:
-<ul class="#{$ns}-breadcrumbs">
+<ol class="#{$ns}-breadcrumbs">
   <li><a class="#{$ns}-breadcrumbs-collapsed" href="#"></a></li>
   <li><a class="#{$ns}-breadcrumb #{$ns}-disabled">Folder one</a></li>
   <li><a class="#{$ns}-breadcrumb" href="#">Folder two</a></li>
   <li><a class="#{$ns}-breadcrumb" href="#">Folder three</a></li>
   <li><span class="#{$ns}-breadcrumb #{$ns}-breadcrumb-current">File</span></li>
-</ul>
+</ol>
 
 Styleguide breadcrumbs
 */
@@ -30,7 +30,7 @@ Styleguide breadcrumbs
   margin: 0;
   padding: 0;
 
-  // descendant selector because nothing should come between ul and li
+  // descendant selector because nothing should come between ol and li
   > li {
     align-items: center;
     display: flex;

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -97,7 +97,7 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
             <OverflowList
                 collapseFrom={collapseFrom}
                 minVisibleItems={minVisibleItems}
-                tagName="ul"
+                tagName="ol"
                 {...overflowListProps}
                 className={classNames(Classes.BREADCRUMBS, overflowListProps.className, className)}
                 items={items}


### PR DESCRIPTION
Breadcrumbs _are_ ordered so they should be tagged as such.

Here is the aria example: https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/

It uses `ol`.