### PR TITLE
[docs] Update/fix broken links in datetime docs

### DIFF
--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -189,7 +189,7 @@ export interface DateInputProps extends DatePickerBaseProps, DateFormatProps, Da
      *
      * Mutually exclusive with `defaultTimezone` prop.
      *
-     * @see https://www.iana.org/time-zones
+     * See [IANA Time Zones](https://www.iana.org/time-zones).
      */
     timezone?: string;
 

--- a/packages/datetime2/README.md
+++ b/packages/datetime2/README.md
@@ -8,7 +8,7 @@ This package contains next-generation components for interacting with dates & ti
 
 Compared to the "V1" components in @blueprintjs/datetime, the "V3" components in this package:
 
--   use [react-day-picker](https://react-day-picker.js.org/) v8 instead of v7 (this unblocks React 18 compatibility)
+-   use [react-day-picker](https://daypicker.dev/v8) v8 instead of v7 (this unblocks React 18 compatibility)
 -   are easier to internationalize & localize since date-fns is now a dependency (instead of `localeUtils`, you can specify a locale code and we'll automatically load the date-fns locale object)
 
 This package also contains legacy APIs which are re-exported aliases for components from @blueprintjs/datetime v5.x.

--- a/packages/datetime2/src/common/dateFnsLocaleProps.ts
+++ b/packages/datetime2/src/common/dateFnsLocaleProps.ts
@@ -37,9 +37,9 @@ export interface DateFnsLocaleProps {
      *
      * If you provide a locale code string and receive a loading error, please make sure it is included in the list of
      * date-fns' [supported locales](https://github.com/date-fns/date-fns/tree/main/src/locale).
+     * See date-fns [Locale](https://date-fns.org/v2.28.0/docs/Locale).
      *
      * @default "en-US"
-     * @see https://date-fns.org/docs/Locale
      */
     locale?: Locale | string;
 }

--- a/packages/datetime2/src/common/reactDayPickerProps.ts
+++ b/packages/datetime2/src/common/reactDayPickerProps.ts
@@ -41,7 +41,7 @@ export type DayPickerProps = Omit<DayPickerBase, ReactDayPickerOmittedProps>;
 export interface ReactDayPickerRangeProps {
     /**
      * Props to pass to react-day-picker's day range picker. See API documentation
-     * [here](https://react-day-picker.js.org/api/interfaces/DayPickerRangeProps).
+     * [here](https://daypicker.dev/v8/api/interfaces/DayPickerRangeProps).
      *
      * Some properties are unavailable since they are set by the component design and cannot be changed:
      *  - "captionLayout"
@@ -62,7 +62,7 @@ export interface ReactDayPickerRangeProps {
 export interface ReactDayPickerSingleProps {
     /**
      * Props to pass to react-day-picker's single day picker. See API documentation
-     * [here](https://react-day-picker.js.org/api/interfaces/DayPickerSingleProps).
+     * [here](https://daypicker.dev/v8/api/interfaces/DayPickerSingleProps).
      *
      * Some properties are unavailable since they are set by the component design and cannot be changed:
      *  - "captionLayout"

--- a/packages/datetime2/src/components/date-input3/date-input3.md
+++ b/packages/datetime2/src/components/date-input3/date-input3.md
@@ -19,7 +19,7 @@ on the wiki.
 </div>
 
 **DateInput3** has the same functionality as [DateInput](#datetime/date-input) but uses
-[react-day-picker v8](https://react-day-picker.js.org/) instead of [v7](https://react-day-picker-v7.netlify.app/)
+[react-day-picker v8](https://daypicker.dev/v8) instead of [v7](https://react-day-picker-v7.netlify.app/)
 to render its calendar. It renders an interactive [**InputGroup**](#core/components/input-group)
 which, when focussed, displays a [**DatePicker3**](#datetime2/date-picker3) inside a
 [**Popover**](#core/components/popover). It optionally renders a [**TimezoneSelect**](#datetime/timezone-select)
@@ -42,7 +42,7 @@ and the `onChange` callback.
 
 In addition to top-level **DateInput3** props, you may forward some props to `<DayPicker mode="single">` to customize
 react-day-picker's behavior via `dayPickerProps` (the full list is
-[documented here](https://react-day-picker.js.org/api/interfaces/DayPickerSingleProps)).
+[documented here](https://daypicker.dev/v8/api/interfaces/DayPickerSingleProps)).
 
 Shortcuts and modifiers are also configurable via the same API as [**DatePicker3**](#datetime2/date-picker3); see those
 docs for more info.

--- a/packages/datetime2/src/components/date-input3/dateInput3Props.ts
+++ b/packages/datetime2/src/components/date-input3/dateInput3Props.ts
@@ -40,7 +40,7 @@ export interface DateInput3Props
      *
      * Mutually exclusive with the `formatDate` and `parseDate` props.
      *
-     * @see https://date-fns.org/docs/format
+     * See date-fns [format](https://date-fns.org/docs/format).
      */
     dateFnsFormat?: string;
 }

--- a/packages/datetime2/src/components/date-picker3/date-picker3.md
+++ b/packages/datetime2/src/components/date-picker3/date-picker3.md
@@ -19,7 +19,7 @@ on the wiki.
 </div>
 
 **DatePicker3** has the same functionality as [DatePicker](#datetime/datepicker) but uses
-[react-day-picker v8](https://react-day-picker.js.org/) instead of [v7](https://react-day-picker-v7.netlify.app/)
+[react-day-picker v8](https://daypicker.dev/v8) instead of [v7](https://react-day-picker-v7.netlify.app/)
 to render its calendar. It renders a UI to choose a single date and (optionally) a time of day. Time selection
 is enabled by the [TimePicker](#datetime/timepicker) component.
 
@@ -35,7 +35,7 @@ prop to listen for changes to the selected day.
 
 In addition to top-level **DatePicker3** props, you may forward some props to `<DayPicker mode="single">` to customize
 react-day-picker's behavior via `dayPickerProps` (the full list is
-[documented here](https://react-day-picker.js.org/api/interfaces/DayPickerSingleProps)).
+[documented here](https://daypicker.dev/v8/api/interfaces/DayPickerSingleProps)).
 
 @interface DatePicker3Props
 
@@ -63,22 +63,22 @@ The built-in **preset shortcuts** can be seen in the example above. They are as 
 
 @## Modifiers
 
-**DatePicker3** utilizes react-day-picker's built-in [modifiers](https://react-day-picker.js.org/basics/modifiers) for
+**DatePicker3** utilizes react-day-picker's built-in [modifiers](https://daypicker.dev/guides/custom-modifiers#built-in-modifiers) for
 various functionality (highlighting the current day, showing selected days, etc.).
 
 You may extend and customize the default modifiers by specifying various properties in the `dayPickerProps` prop object.
 In the example below, we add a custom class name to every odd-numbered day in the calendar using a simple
-[Matcher](https://react-day-picker.js.org/api/types/matcher).
+[Matcher](https://daypicker.dev/api/type-aliases/Matcher).
 
 @reactExample DatePicker3ModifierExample
 
-See [react-day-picker's "Custom modifiers" documentation](https://react-day-picker.js.org/basics/modifiers#custom-modifiers)
+See [react-day-picker's "Custom modifiers" documentation](https://daypicker.dev/guides/custom-modifiers)
 for more info.
 
 @## Localization
 
 **DatePicker3**, **DateInput3**, **DateRangePicker3**, and **DateRangeInput3** support calendar
-localization using date-fns's [Locale](https://date-fns.org/docs/Locale) features. The `locale` prop on each
+localization using date-fns's [Locale](https://date-fns.org/v2.28.0/docs/Locale) features. The `locale` prop on each
 of these components accepts two types of values, either a `Locale` object or a locale code `string`.
 
 ### Using a locale code

--- a/packages/datetime2/src/components/date-range-input3/date-range-input3.md
+++ b/packages/datetime2/src/components/date-range-input3/date-range-input3.md
@@ -19,7 +19,7 @@ on the wiki.
 </div>
 
 **DateRangeInput3** has the same functionality as [DateRangeInput](#datetime/date-range-input) but uses
-[react-day-picker v8](https://react-day-picker.js.org/) instead of [v7](https://react-day-picker-v7.netlify.app/)
+[react-day-picker v8](https://daypicker.dev/v8) instead of [v7](https://react-day-picker-v7.netlify.app/)
 to render its calendar(s). It renders a [**ControlGroup**](#core/components/control-group) composed
 of two [**InputGroups**](#core/components/input-group) and shows a [**DateRangePicker3**](#datetime2/date-range-picker3)
 inside a [**Popover**](#core/components/popover) upon focus.

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3Props.ts
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3Props.ts
@@ -40,7 +40,7 @@ export interface DateRangeInput3Props
      *
      * Mutually exclusive with the `formatDate` and `parseDate` props.
      *
-     * @see https://date-fns.org/docs/format
+     * See date-fns [format](https://date-fns.org/docs/format).
      */
     dateFnsFormat?: string;
 }

--- a/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
+++ b/packages/datetime2/src/components/react-day-picker/datePicker3Caption.tsx
@@ -33,7 +33,7 @@ import { DatePicker3Context } from "../date-picker3/datePicker3Context";
  * We need to override the whole caption instead of its lower-level components because react-day-picker
  * does not have built-in support for non-contiguous range pickers.
  *
- * @see https://react-day-picker.js.org/guides/custom-components
+ * @see https://daypicker.dev/guides/custom-components
  */
 export const DatePicker3Caption: React.FC<CaptionProps> = props => {
     const { classNames: rdpClassNames, formatters, fromDate, toDate, labels } = useDayPicker();

--- a/packages/datetime2/src/components/react-day-picker/datePicker3Dropdown.tsx
+++ b/packages/datetime2/src/components/react-day-picker/datePicker3Dropdown.tsx
@@ -25,7 +25,7 @@ import { useMonthSelectRightOffset } from "../../common/useMonthSelectRightOffse
  * Custom react-day-picker dropdown component which implements Blueprint's datepicker design
  * for month and year dropdowns.
  *
- * @see https://react-day-picker.js.org/guides/custom-components
+ * @see https://daypicker.dev/guides/custom-components
  */
 export function DatePicker3Dropdown({ caption, children, ...props }: DropdownProps) {
     const containerElement = React.useRef<HTMLDivElement>(null);

--- a/packages/datetime2/src/index.md
+++ b/packages/datetime2/src/index.md
@@ -27,7 +27,7 @@ up for forward compatibility in the Blueprint ecosystem.
 
 Compared to their "V1" and "V2" counterparts, these components:
 
--   use [react-day-picker](https://react-day-picker.js.org/) v8 instead of v7 (this unblocks React 18 compatibility)
+-   use [react-day-picker](https://daypicker.dev/v8) v8 instead of v7 (this unblocks React 18 compatibility)
 -   are easier to internationalize & localize since date-fns is now a dependency (instead of `localeUtils`, you can specify a locale code and we'll automatically load the date-fns locale object)
 
 ### Installation


### PR DESCRIPTION
**Fixes** #7001

#### Proposed changes:

Updates some outdated/broken links specific to the datetime docs. Includes:

- Updates [react-day-picker.js.org](https://react-day-picker.js.org) to new [daypicker.dev](https://daypicker.dev) domain.
- References v8 version of daypicker docs for deprecated typings like `DayPickerSingleProps` and `DayPickerRangeProps`
- References v2.x version of date-fns for Locale docs
- Converts some `@see` tags to markdown format to preserve parsing/rendering in docs

**References:**
- https://daypicker.dev/upgrading#deprecated-types

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Reviewers should focus on:

Check links on Datetime2 pages in preview and verify accuracy of links relative to documentation.