### PR TITLE
Add isComposing check to EditableText toggleEdit

### DIFF
--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -357,7 +357,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
         }
 
         const hasModifierKey = altKey || ctrlKey || metaKey || shiftKey;
-        if (event.key === "Enter" && !event.isComposing) {
+        if (event.key === "Enter" && !event.nativeEvent.isComposing) {
             // prevent browsers (Edge?) from full screening with alt + enter
             // shift + enter adds a newline by default
             if (altKey || shiftKey) {

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -357,7 +357,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
         }
 
         const hasModifierKey = altKey || ctrlKey || metaKey || shiftKey;
-        if (event.key === "Enter") {
+        if (event.key === "Enter" && !event.isComposing) {
             // prevent browsers (Edge?) from full screening with alt + enter
             // shift + enter adds a newline by default
             if (altKey || shiftKey) {


### PR DESCRIPTION


#### Checklist

- [x] Includes tests (no need for update)
- [x] Update documentation (no need for update)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

EditableText will check that the user is not composing before sending out onConfirm event.
This is necessary because in some IMEs, such as Japanese, users will press Enter to convert text (ie from hiragana to kanji). In these cases, we don't want EditableText to exit from editing mode.  

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
