### PR TITLE
fix(KeyComboTag): Better rendering on non-Mac operating systems

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7025.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7025.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'fix(KeyComboTag): No longer render modifier key icons on non-Mac operating
+    systems'
+  links:
+  - https://github.com/palantir/blueprint/pull/7025

--- a/packages/core/changelog/@unreleased/pr-7025.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7025.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: 'fix(KeyComboTag): No longer render modifier key icons on non-Mac operating
-    systems'
+  description: The KeyComboTag component no longer renders modifier key icons on non-Mac
+    operating systems
   links:
   - https://github.com/palantir/blueprint/pull/7025

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -4,7 +4,10 @@
 @import "../../common/mixins";
 
 .#{$ns}-key-combo {
-  @include pt-flex-container(row, $pt-grid-size * 0.5);
+  &:not(.#{$ns}-minimal) {
+    @include pt-flex-container(row, $pt-grid-size * 0.5);
+  }
+
   align-items: center;
 }
 

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -240,7 +240,7 @@ export const normalizeKeyCombo = (combo: string, platformOverride?: string): str
     });
 };
 
-function isMac(platformOverride?: string) {
+export function isMac(platformOverride?: string) {
     // HACKHACK: see https://github.com/palantir/blueprint/issues/5174
     // eslint-disable-next-line deprecation/deprecation
     const platform = platformOverride ?? (typeof navigator !== "undefined" ? navigator.platform : undefined);

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -50,7 +50,7 @@ export const CONFIG_ALIASES: KeyMap = {
     esc: "escape",
     escape: "escape",
     minus: "-",
-    mod: isMac() ? "meta" : "ctrl",
+    mod: isMac(undefined) ? "meta" : "ctrl",
     option: "alt",
     plus: "+",
     return: "enter",
@@ -232,7 +232,7 @@ export const getKeyCombo = (e: KeyboardEvent): KeyCombo => {
  * Unlike the parseKeyCombo method, this method does NOT convert shifted
  * action keys. So `"@"` will NOT be converted to `["shift", "2"]`).
  */
-export const normalizeKeyCombo = (combo: string, platformOverride?: string): string[] => {
+export const normalizeKeyCombo = (combo: string, platformOverride: string | undefined): string[] => {
     const keys = combo.replace(/\s/g, "").split("+");
     return keys.map(key => {
         const keyName = CONFIG_ALIASES[key] != null ? CONFIG_ALIASES[key] : key;
@@ -240,7 +240,7 @@ export const normalizeKeyCombo = (combo: string, platformOverride?: string): str
     });
 };
 
-export function isMac(platformOverride?: string) {
+export function isMac(platformOverride: string | undefined) {
     // HACKHACK: see https://github.com/palantir/blueprint/issues/5174
     // eslint-disable-next-line deprecation/deprecation
     const platform = platformOverride ?? (typeof navigator !== "undefined" ? navigator.platform : undefined);

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -71,12 +71,17 @@ export interface KeyComboTagProps extends Props {
     minimal?: boolean;
 }
 
-export class KeyComboTag extends AbstractPureComponent<KeyComboTagProps> {
+interface KeyComboTagInternalProps extends KeyComboTagProps {
+    /** Override the oeprating system rendering for internal testing purposes */
+    platformOverride?: string;
+}
+
+export class KeyComboTagInternal extends AbstractPureComponent<KeyComboTagInternalProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.KeyComboTag`;
 
     public render() {
-        const { className, combo, minimal } = this.props;
-        const normalizedKeys = normalizeKeyCombo(combo);
+        const { className, combo, minimal, platformOverride } = this.props;
+        const normalizedKeys = normalizeKeyCombo(combo, platformOverride);
         const keys = normalizedKeys
             .map(key => (key.length === 1 ? key.toUpperCase() : key))
             .map((key, index) =>
@@ -89,7 +94,7 @@ export class KeyComboTag extends AbstractPureComponent<KeyComboTagProps> {
 
     private renderKey = (key: string, index: number) => {
         const keyString = DISPLAY_ALIASES[key] ?? key;
-        const icon = getKeyIcon(key);
+        const icon = this.getKeyIcon(key);
         const reactKey = `key-${index}`;
         return (
             <kbd className={classNames(Classes.KEY, { [Classes.MODIFIER_KEY]: icon != null })} key={reactKey}>
@@ -100,18 +105,21 @@ export class KeyComboTag extends AbstractPureComponent<KeyComboTagProps> {
     };
 
     private renderMinimalKey = (key: string, index: number, isLastKey: boolean) => {
-        const icon = getKeyIcon(key);
+        const icon = this.getKeyIcon(key);
         if (icon == null) {
             return isLastKey ? key : <>{key}&nbsp;+&nbsp;</>;
         }
         return <Icon icon={icon.icon} title={icon.iconTitle} key={`key-${index}`} />;
     };
+
+    private getKeyIcon(key: string) {
+        const { platformOverride } = this.props;
+        const icon = KEY_ICONS[key];
+        if (icon?.isMacOnly && !isMac(platformOverride)) {
+            return undefined;
+        }
+        return icon;
+    }
 }
 
-function getKeyIcon(key: string) {
-    const icon = KEY_ICONS[key];
-    if (icon?.isMacOnly && !isMac()) {
-        return undefined;
-    }
-    return icon;
-}
+export const KeyComboTag: React.ComponentType<KeyComboTagProps> = KeyComboTagInternal;

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -107,7 +107,7 @@ export class KeyComboTagInternal extends AbstractPureComponent<KeyComboTagIntern
     private renderMinimalKey = (key: string, index: number, isLastKey: boolean) => {
         const icon = this.getKeyIcon(key);
         if (icon == null) {
-            return isLastKey ? key : <>{key}&nbsp;+&nbsp;</>;
+            return isLastKey ? key : <React.Fragment key={`key-${index}`}>{key}&nbsp;+&nbsp;</React.Fragment>;
         }
         return <Icon icon={icon.icon} title={icon.iconTitle} key={`key-${index}`} />;
     };

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -89,7 +89,7 @@ export class KeyComboTagInternal extends AbstractPureComponent<KeyComboTagIntern
                     ? this.renderMinimalKey(key, index, index === normalizedKeys.length - 1)
                     : this.renderKey(key, index),
             );
-        return <span className={classNames(Classes.KEY_COMBO, className)}>{keys}</span>;
+        return <span className={classNames(Classes.KEY_COMBO, className, { [Classes.MINIMAL]: minimal })}>{keys}</span>;
     }
 
     private renderKey = (key: string, index: number) => {

--- a/packages/core/test/hotkeys/keyComboTagTests.tsx
+++ b/packages/core/test/hotkeys/keyComboTagTests.tsx
@@ -34,6 +34,9 @@ describe("KeyCombo", () => {
 
     it("should render minimal key combos on non-Macs using text", () => {
         render(<KeyComboTagInternal combo="mod+C" minimal={true} platformOverride="Win32" />);
-        expect(screen.getByText("ctrl + C", { exact: false }).innerText).to.equal("ctrl + C");
+        const text = screen.getByText("ctrl + C", { exact: false }).innerText;
+        expect(text).to.contain("ctrl");
+        expect(text).to.contain("+");
+        expect(text).to.contain("C");
     });
 });

--- a/packages/core/test/hotkeys/keyComboTagTests.tsx
+++ b/packages/core/test/hotkeys/keyComboTagTests.tsx
@@ -18,11 +18,22 @@ import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
 import * as React from "react";
 
-import { KeyComboTag } from "../../src/components/hotkeys";
+import { KeyComboTagInternal } from "../../src/components/hotkeys/keyComboTag";
 
 describe("KeyCombo", () => {
     it("renders key combo", () => {
-        render(<KeyComboTag combo="cmd+C" />);
+        render(<KeyComboTagInternal combo="cmd+C" platformOverride="Mac" />);
         expect(screen.getByText("C")).not.to.be.undefined;
+    });
+
+    describe("should render minimal key combos on Mac using icons", () => {
+        render(<KeyComboTagInternal combo="mod+C" minimal={true} platformOverride="Mac" />);
+        expect(() => screen.getByText("cmd + C", { exact: false })).to.throw;
+        expect(screen.findAllByAltText("Command key")).not.to.be.undefined;
+    });
+
+    it("should render minimal key combos on non-Macs using text", () => {
+        render(<KeyComboTagInternal combo="mod+C" minimal={true} platformOverride="Win32" />);
+        expect(screen.getByText("ctrl + C", { exact: false }).innerText).to.equal("ctrl + C");
     });
 });

--- a/packages/core/test/hotkeys/keyComboTagTests.tsx
+++ b/packages/core/test/hotkeys/keyComboTagTests.tsx
@@ -29,7 +29,6 @@ describe("KeyCombo", () => {
     it("should render minimal key combos on Mac using icons", () => {
         render(<KeyComboTagInternal combo="mod+C" minimal={true} platformOverride="Mac" />);
         expect(() => screen.getByText("cmd + C", { exact: false })).to.throw;
-        expect(screen.findAllByAltText("Command key")).not.to.be.undefined;
     });
 
     it("should render minimal key combos on non-Macs using text", () => {

--- a/packages/core/test/hotkeys/keyComboTagTests.tsx
+++ b/packages/core/test/hotkeys/keyComboTagTests.tsx
@@ -26,7 +26,7 @@ describe("KeyCombo", () => {
         expect(screen.getByText("C")).not.to.be.undefined;
     });
 
-    describe("should render minimal key combos on Mac using icons", () => {
+    it("should render minimal key combos on Mac using icons", () => {
         render(<KeyComboTagInternal combo="mod+C" minimal={true} platformOverride="Mac" />);
         expect(() => screen.getByText("cmd + C", { exact: false })).to.throw;
         expect(screen.findAllByAltText("Command key")).not.to.be.undefined;

--- a/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'fix(KeyComboTag): No longer render modifier key icons on non-Mac operating
+    systems'
+  links:
+  - https://github.com/palantir/blueprint/pull/7025

--- a/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: The KeyComboTag component no longer renders modifier key icons on non-Mac
-    operating systems
+  description: The useHotkeys docuementation now shows minimal and non-minimal states
+    for the KeyComboTag component.
   links:
   - https://github.com/palantir/blueprint/pull/7025

--- a/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: 'fix(KeyComboTag): No longer render modifier key icons on non-Mac operating
-    systems'
+  description: The KeyComboTag component no longer renders modifier key icons on non-Mac
+    operating systems
   links:
   - https://github.com/palantir/blueprint/pull/7025

--- a/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-7025.v2.yml
@@ -1,6 +1,6 @@
 type: fix
 fix:
-  description: The useHotkeys docuementation now shows minimal and non-minimal states
+  description: The useHotkeys documentation now shows minimal and non-minimal states
     for the KeyComboTag component.
   links:
   - https://github.com/palantir/blueprint/pull/7025

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -51,6 +51,7 @@ export class HotkeyTesterExample extends React.PureComponent<ExampleProps, Hotke
             return (
                 <>
                     <KeyComboTag combo={combo} />
+                    <KeyComboTag combo={combo} minimal={true} />
                     <Code>{combo}</Code>
                 </>
             );


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/6211

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

In this PR we update the `KeyComboTag` component to render properly in non-Mac environments. Namely, all modifier keys no longer show their icons (which are mac specific). In addition the minimal state has been updated to show a more windows friendly UI. Finally, the arrow keys were broken and not showing their icons, they do now.


#### Reviewers should focus on:
I implemented a `KeyComboTagInternal` component for testing purposes. What do we think of this pattern?

#### Screenshot

Previously, this is how the `mod+shift+x` key combo looked like on all platforms. This is still how it looks on Mac. (Minimal state on bottom)
<img width="173" alt="Screenshot 2024-10-24 at 12 26 24 PM" src="https://github.com/user-attachments/assets/e65b2d64-22b6-463e-9073-03967d322200">


This is how it looks non-Mac platforms now:
<img width="149" alt="Screenshot 2024-10-24 at 12 26 15 PM" src="https://github.com/user-attachments/assets/b6215b97-5667-4a08-b187-2e9bb190547d">

