### PR TITLE
Fix IME bug in QueryList

### DIFF
--- a/packages/select/changelog/@unreleased/pr-7028.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-7028.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix buggy behavior with IME input in QueryList component
+  links:
+  - https://github.com/palantir/blueprint/pull/7028

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -519,16 +519,18 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
     };
 
     private handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-        const { key } = event;
-        const direction = Utils.getArrowKeyDirection(event, ["ArrowUp"], ["ArrowDown"]);
-        if (direction !== undefined) {
-            event.preventDefault();
-            const nextActiveItem = this.getNextActiveItem(direction);
-            if (nextActiveItem != null) {
-                this.setActiveItem(nextActiveItem);
+        if (!event.nativeEvent.isComposing) {
+            const { key } = event;
+            const direction = Utils.getArrowKeyDirection(event, ["ArrowUp"], ["ArrowDown"]);
+            if (direction !== undefined) {
+                event.preventDefault();
+                const nextActiveItem = this.getNextActiveItem(direction);
+                if (nextActiveItem != null) {
+                    this.setActiveItem(nextActiveItem);
+                }
+            } else if (key === "Enter") {
+                this.isEnterKeyPressed = true;
             }
-        } else if (key === "Enter") {
-            this.isEnterKeyPressed = true;
         }
 
         this.props.onKeyDown?.(event);


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

This PR fixes a bug in the query list component (as used in Select) where IME enter and arrow key keyboard events are not ignored, as they should be, causing IME confirmation to result in selecting a value and other sadness.

#### Reviewers should focus on:

It's a little weird that we already had the `isEnterKeyPressed` logic mostly in place to catch IME events, but didn't have the actual "is composing" check needed to make it actually do what it was supposed to do. Maybe just an oversight?

#### Before

https://github.com/user-attachments/assets/301433eb-af58-4739-bd6d-99fffeb9c7f0

#### After

https://github.com/user-attachments/assets/f340609b-2fee-47a2-a15b-3a958028c99c
