### PR TITLE
[DateRangePicker] Allow date picker popover to be closed by esc key press

### DIFF
--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -636,13 +636,8 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
         const { selectedStart, selectedEnd } = this.state;
 
         if (isEscapeKeyPressed) {
-            const { isStartInputFocused, isEndInputFocused } = this.state;
-            if (isStartInputFocused) {
-                this.startInputElement?.blur();
-            }
-            if (isEndInputFocused) {
-                this.endInputElement?.blur();
-            }
+            this.startInputElement?.blur();
+            this.endInputElement?.blur();
             this.setState({ isOpen: false, isStartInputFocused: false, isEndInputFocused: false });
             return;
         }

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -630,9 +630,22 @@ export class DateRangeInput extends AbstractPureComponent<DateRangeInputProps, D
     private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         const isTabPressed = e.key === "Tab";
         const isEnterPressed = e.key === "Enter";
+        const isEscapeKeyPressed = e.key === "Escape";
         const isShiftPressed = e.shiftKey;
 
         const { selectedStart, selectedEnd } = this.state;
+
+        if (isEscapeKeyPressed) {
+            const { isStartInputFocused, isEndInputFocused } = this.state;
+            if (isStartInputFocused) {
+                this.startInputElement?.blur();
+            }
+            if (isEndInputFocused) {
+                this.endInputElement?.blur();
+            }
+            this.setState({ isOpen: false, isStartInputFocused: false, isEndInputFocused: false });
+            return;
+        }
 
         // order of JS events is our enemy here. when tabbing between fields,
         // this handler will fire in the middle of a focus exchange when no

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -602,6 +602,21 @@ describe("<DateRangeInput>", () => {
             expect(root.state("isOpen"), "popover closed at end").to.be.false;
         });
 
+        it("pressing Escape closes the popover", () => {
+            const { root } = wrap(<DateRangeInput {...DATE_FORMAT} value={[null, null]} />);
+            root.setState({ isOpen: true });
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            expect(root.state("isOpen")).to.be.true;
+
+            startInput.simulate("keydown", { key: "Escape" });
+
+            expect(root.state("isOpen")).to.be.false;
+            expect(isStartInputFocused(root)).to.be.false;
+        });
+
         it("Clicking a date invokes onChange with the new date range and updates the input fields", () => {
             const defaultValue = [START_DATE, null] as DateRange;
 

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -484,9 +484,22 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         const isTabPressed = e.key === "Tab";
         const isEnterPressed = e.key === "Enter";
+        const isEscapeKeyPressed = e.key === "Escape";
         const isShiftPressed = e.shiftKey;
 
         const { selectedStart, selectedEnd } = this.state;
+
+        if (isEscapeKeyPressed) {
+            const { isStartInputFocused, isEndInputFocused } = this.state;
+            if (isStartInputFocused) {
+                this.startInputElement?.blur();
+            }
+            if (isEndInputFocused) {
+                this.endInputElement?.blur();
+            }
+            this.setState({ isOpen: false, isStartInputFocused: false, isEndInputFocused: false });
+            return;
+        }
 
         // order of JS events is our enemy here. when tabbing between fields,
         // this handler will fire in the middle of a focus exchange when no

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -490,13 +490,8 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
         const { selectedStart, selectedEnd } = this.state;
 
         if (isEscapeKeyPressed) {
-            const { isStartInputFocused, isEndInputFocused } = this.state;
-            if (isStartInputFocused) {
-                this.startInputElement?.blur();
-            }
-            if (isEndInputFocused) {
-                this.endInputElement?.blur();
-            }
+            this.startInputElement?.blur();
+            this.endInputElement?.blur();
             this.setState({ isOpen: false, isStartInputFocused: false, isEndInputFocused: false });
             return;
         }

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -2343,6 +2343,21 @@ describe("<DateRangeInput3>", () => {
             assertDateRangesEqual(onChange.args[1][0], [START_STR, null]);
         });
 
+        it("pressing Escape closes the popover", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[null, null]} />);
+            root.setState({ isOpen: true });
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            expect(root.state("isOpen")).to.be.true;
+
+            startInput.simulate("keydown", { key: "Escape" });
+
+            expect(root.state("isOpen")).to.be.false;
+            expect(isStartInputFocused(root)).to.be.false;
+        });
+
         it("Clicking a date invokes onChange with the new date range and updates the input field text", () => {
             const onChange = sinon.spy();
             const { root, getDayElement } = wrap(


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Closes the `<DatePicker>` popover on `<DateRangeInput>` when the `"Escape"` key is pressed.
- Aligns `<DateRangeInput>` popover behavior with the existing Escape-to-close functionality already implemented in [DateInput](https://blueprintjs.com/docs/#datetime2/date-input3)
- Ensures users can close the DatePicker without requiring a mouse click, enhancing accessibility and user experience.

#### Screenshot

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/1d2a14e8-a8aa-495c-938d-0d548e02215b) | ![after](https://github.com/user-attachments/assets/07492f4b-6b9f-4d31-afa0-617e0c8d787a) |




