### PR TITLE
fix(OverlayToaster): Don't dismiss excess toasts when updating a toast while maxToasts is set

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7048.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7048.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'fix(OverlayToaster): Don''t dismiss excess toasts when updating a
+    toast while maxToasts is set'
+  links:
+  - https://github.com/palantir/blueprint/pull/7048

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -146,21 +146,35 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
     };
 
     public show(props: ToastProps, key?: string) {
+        const options = this.createToastOptions(props, key);
+        const updatedExistingToast = this.maybeUpdateExistingToast(options, key);
+        if (updatedExistingToast) {
+            return options.key;
+        }
+
         if (this.props.maxToasts) {
             // check if active number of toasts are at the maxToasts limit
             this.dismissIfAtLimit();
         }
-        const options = this.createToastOptions(props, key);
+
+        this.updateToastsInState(toasts => [options, ...toasts]);
+        return options.key;
+    }
+
+    private maybeUpdateExistingToast(options: ToastOptions, key: string | undefined) {
+        if (key == null || this.isNewToastKey(key)) {
+            return false;
+        }
+
+        this.updateToastsInState(toasts => toasts.map(t => (t.key === key ? options : t)));
+        return true;
+    }
+
+    private updateToastsInState(getNewToasts: (toasts: ToastOptions[]) => ToastOptions[]) {
         this.setState(prevState => {
-            const toasts =
-                key === undefined || this.isNewToastKey(key)
-                    ? // prepend a new toast
-                      [options, ...prevState.toasts]
-                    : // update a specific toast
-                      prevState.toasts.map(t => (t.key === key ? options : t));
+            const toasts = getNewToasts(prevState.toasts);
             return { toasts, toastRefs: this.getToastRefs(toasts) };
         });
-        return options.key;
     }
 
     public dismiss(key: string, timeoutExpired = false) {

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -147,8 +147,8 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
 
     public show(props: ToastProps, key?: string) {
         const options = this.createToastOptions(props, key);
-        const updatedExistingToast = this.maybeUpdateExistingToast(options, key);
-        if (updatedExistingToast) {
+        const wasExistingToastUpdated = this.maybeUpdateExistingToast(options, key);
+        if (wasExistingToastUpdated) {
             return options.key;
         }
 

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -221,6 +221,14 @@ describe("OverlayToaster", () => {
                 toaster.show({ message: "oh no" });
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
             });
+
+            it("does not dismiss toasts when updating an existing toast at the limit", () => {
+                toaster.show({ message: "one" });
+                toaster.show({ message: "two" });
+                toaster.show({ message: "three" }, "3");
+                toaster.show({ message: "three updated" }, "3");
+                assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+            });
         });
 
         describe("with autoFocus set to true", () => {


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation (N/A)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Something of a niche case, but noticed it while iterating on a different toaster issue and wanted to quickly fix it. This issue occurs if there are a number of toasts on the screen equal to the `maxToasts` prop. Previously, if you updated one of those toasts, a toast would be dismissed unnecessarily (which could be bad if its meant to be an indefinitely present toast). Now, if a toast is updated, we don't do the max toasts check since the number of toasts hasn't changed.

This PR also contains some changes that will help with further refactors to the overlay toaster component.
