### PR TITLE
fix(OverlayToaster): Fix toasts being cut off if show() called too quickly

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7049.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7049.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'fix(OverlayToaster): Fix toasts being cut off if show() called too
+    quickly'
+  links:
+  - https://github.com/palantir/blueprint/pull/7049

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -49,7 +49,8 @@ interface OverlayToasterQueueState {
     toasts: ToastOptions[];
 }
 
-const QUEUE_TIMEOUT_MS = 50;
+export const OVERLAY_TOASTER_DELAY_MS = 50;
+
 /**
  * OverlayToaster component.
  *
@@ -174,7 +175,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         } else {
             // If we have not recently shown a toast, we can immediately show the given toast
             this.immediatelyShowToast(options);
-            this.maybeStartQueueTimeout();
+            this.startQueueTimeout();
         }
 
         return options.key;
@@ -209,21 +210,18 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         this.updateToastsInState(toasts => [options, ...toasts]);
     }
 
-    private maybeStartQueueTimeout() {
-        if (this.queue.isRunning) {
-            return;
-        }
-
+    private startQueueTimeout() {
         this.queue.isRunning = true;
-        this.queue.cancel = this.setTimeout(this.handleQueueTimeout, QUEUE_TIMEOUT_MS);
+        this.queue.cancel = this.setTimeout(this.handleQueueTimeout, OVERLAY_TOASTER_DELAY_MS);
     }
 
     private handleQueueTimeout = () => {
         const nextToast = this.queue.toasts.shift();
-        this.queue.isRunning = false;
         if (nextToast != null) {
             this.immediatelyShowToast(nextToast);
-            this.maybeStartQueueTimeout();
+            this.startQueueTimeout();
+        } else {
+            this.queue.isRunning = false;
         }
     };
 

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -43,6 +43,13 @@ export interface OverlayToasterState {
 
 export type OverlayToasterCreateOptions = DOMMountOptions<OverlayToasterProps>;
 
+interface OverlayToasterQueueState {
+    cancel: (() => void) | undefined;
+    isRunning: boolean;
+    toasts: ToastOptions[];
+}
+
+const QUEUE_TIMEOUT_MS = 50;
 /**
  * OverlayToaster component.
  *
@@ -132,6 +139,14 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         toasts: [],
     };
 
+    // Queue of toasts to be displayed. If toasts are shown to quickly with each other it can result in cut off toasts
+    // so we ensure that toasts are only displayed in QUEUE_TIMEOUT_MS increments
+    private queue: OverlayToasterQueueState = {
+        cancel: undefined,
+        isRunning: false,
+        toasts: [],
+    };
+
     // auto-incrementing identifier for un-keyed toasts
     private toastId = 0;
 
@@ -152,23 +167,65 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
             return options.key;
         }
 
+        if (this.queue.isRunning) {
+            // If a toast has been shown recently, push to the queued toasts to prevent toasts from being shown too
+            // quickly for the animations to keep up
+            this.queue.toasts.push(options);
+        } else {
+            // If we have not recently shown a toast, we can immediately show the given toast
+            this.immediatelyShowToast(options);
+            this.maybeStartQueueTimeout();
+        }
+
+        return options.key;
+    }
+
+    private maybeUpdateExistingToast(options: ToastOptions, key: string | undefined) {
+        if (key == null) {
+            return false;
+        }
+
+        const isExistingQueuedToast = this.queue.toasts.some(toast => toast.key === key);
+        if (isExistingQueuedToast) {
+            this.queue.toasts = this.queue.toasts.map(t => (t.key === key ? options : t));
+            return true;
+        }
+
+        const isExistingShownToast = this.state.toasts.some(toast => toast.key === key);
+        if (isExistingShownToast) {
+            this.updateToastsInState(toasts => toasts.map(t => (t.key === key ? options : t)));
+            return true;
+        }
+
+        return false;
+    }
+
+    private immediatelyShowToast(options: ToastOptions) {
         if (this.props.maxToasts) {
             // check if active number of toasts are at the maxToasts limit
             this.dismissIfAtLimit();
         }
 
         this.updateToastsInState(toasts => [options, ...toasts]);
-        return options.key;
     }
 
-    private maybeUpdateExistingToast(options: ToastOptions, key: string | undefined) {
-        if (key == null || this.isNewToastKey(key)) {
-            return false;
+    private maybeStartQueueTimeout() {
+        if (this.queue.isRunning) {
+            return;
         }
 
-        this.updateToastsInState(toasts => toasts.map(t => (t.key === key ? options : t)));
-        return true;
+        this.queue.isRunning = true;
+        this.queue.cancel = this.setTimeout(this.handleQueueTimeout, QUEUE_TIMEOUT_MS);
     }
+
+    private handleQueueTimeout = () => {
+        const nextToast = this.queue.toasts.shift();
+        this.queue.isRunning = false;
+        if (nextToast != null) {
+            this.immediatelyShowToast(nextToast);
+            this.maybeStartQueueTimeout();
+        }
+    };
 
     private updateToastsInState(getNewToasts: (toasts: ToastOptions[]) => ToastOptions[]) {
         this.setState(prevState => {
@@ -191,6 +248,8 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
     }
 
     public clear() {
+        this.queue.cancel?.();
+        this.queue = { cancel: undefined, isRunning: false, toasts: [] };
         this.state.toasts.forEach(t => t.onDismiss?.(false));
         this.setState({ toasts: [], toastRefs: {} });
     }
@@ -250,10 +309,6 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
                 return child;
             }
         });
-    }
-
-    private isNewToastKey(key: string) {
-        return this.state.toasts.every(toast => toast.key !== key);
     }
 
     private dismissIfAtLimit() {

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -139,8 +139,8 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         toasts: [],
     };
 
-    // Queue of toasts to be displayed. If toasts are shown to quickly with each other it can result in cut off toasts
-    // so we ensure that toasts are only displayed in QUEUE_TIMEOUT_MS increments
+    // Queue of toasts to be displayed. If toasts are shown too quickly back to back, it can result in cut off toasts.
+    // The queue ensures that toasts are only displayed in QUEUE_TIMEOUT_MS increments.
     private queue: OverlayToasterQueueState = {
         cancel: undefined,
         isRunning: false,

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -108,11 +108,29 @@ describe("OverlayToaster", () => {
                 });
             });
 
-            it("multiple show()s renders them all", () => {
+            it("multiple show()s renders them all", async () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "six" });
+                await delay(150);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+            });
+
+            it("multiple shows() get queued if provided too quickly", async () => {
+                toaster.show({ message: "one" });
+                toaster.show({ message: "two" });
+                toaster.show({ message: "three" });
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                await delay(150);
+                assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts after delay");
+            });
+
+            it("show() immediately displays a toast when waiting after the previous show()", async () => {
+                toaster.show({ message: "one" });
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                await delay(100);
+                toaster.show({ message: "two" });
+                assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
             });
 
             it("show() updates existing toast", () => {
@@ -123,10 +141,20 @@ describe("OverlayToaster", () => {
                 assert.deepEqual(toaster.getToasts()[0].message, "two");
             });
 
-            it("dismiss() removes just the toast in question", () => {
+            it("show() updates existing toast in queue", async () => {
+                toaster.show({ message: "one" });
+                const key = toaster.show({ message: "two" });
+                toaster.show({ message: "two updated" }, key);
+                await delay(100);
+                assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
+                assert.deepEqual(toaster.getToasts()[0].message, "two updated");
+            });
+
+            it("dismiss() removes just the toast in question", async () => {
                 toaster.show({ message: "one" });
                 const key = toaster.show({ message: "two" });
                 toaster.show({ message: "six" });
+                await delay(150);
                 toaster.dismiss(key);
                 assert.deepEqual(
                     toaster.getToasts().map(t => t.message),
@@ -134,12 +162,16 @@ describe("OverlayToaster", () => {
                 );
             });
 
-            it("clear() removes all toasts", () => {
+            it("clear() removes all toasts", async () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "six" });
-                assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+                await delay(50);
+                assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
                 toaster.clear();
+                assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
+                // Ensure the queue is cleared
+                await delay(100);
                 assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
             });
 
@@ -214,19 +246,21 @@ describe("OverlayToaster", () => {
                 document.documentElement.removeChild(testsContainerElement);
             });
 
-            it("does not exceed the maximum toast limit set", () => {
+            it("does not exceed the maximum toast limit set", async () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "three" });
                 toaster.show({ message: "oh no" });
+                await delay(200);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
             });
 
-            it("does not dismiss toasts when updating an existing toast at the limit", () => {
+            it("does not dismiss toasts when updating an existing toast at the limit", async () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "three" }, "3");
                 toaster.show({ message: "three updated" }, "3");
+                await delay(200);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
             });
         });
@@ -282,3 +316,7 @@ describe("OverlayToaster", () => {
         });
     });
 });
+
+function delay(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -24,6 +24,7 @@ import { expectPropValidationError } from "@blueprintjs/test-commons";
 
 import { Classes, OverlayToaster, type OverlayToasterProps, type Toaster } from "../../src";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
+import { OVERLAY_TOASTER_DELAY_MS } from "../../src/components/toast/overlayToaster";
 
 const SPECS = [
     {
@@ -64,6 +65,7 @@ function unmountReact16Toaster(containerElement: HTMLElement) {
 }
 
 describe("OverlayToaster", () => {
+    let clock: sinon.SinonFakeTimers;
     let testsContainerElement: HTMLElement;
     let toaster: Toaster;
 
@@ -75,7 +77,12 @@ describe("OverlayToaster", () => {
                 toaster = await spec.create({}, testsContainerElement);
             });
 
+            beforeEach(() => {
+                clock = sinon.useFakeTimers();
+            });
+
             afterEach(() => {
+                clock.restore();
                 toaster.clear();
             });
 
@@ -93,11 +100,11 @@ describe("OverlayToaster", () => {
             });
 
             it("show() renders toast on next tick", done => {
+                clock.restore();
                 toaster.show({
                     message: "Hello world",
                 });
                 assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-
                 // setState needs a tick to flush DOM updates
                 setTimeout(() => {
                     assert.isNotNull(
@@ -108,27 +115,27 @@ describe("OverlayToaster", () => {
                 });
             });
 
-            it("multiple show()s renders them all", async () => {
+            it("multiple show()s renders them all", () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "six" });
-                await delay(150);
+                clock.tick(3 * OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
             });
 
-            it("multiple shows() get queued if provided too quickly", async () => {
+            it("multiple shows() get queued if provided too quickly", () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "three" });
                 assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-                await delay(150);
+                clock.tick(3 * OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts after delay");
             });
 
-            it("show() immediately displays a toast when waiting after the previous show()", async () => {
+            it("show() immediately displays a toast when waiting after the previous show()", () => {
                 toaster.show({ message: "one" });
                 assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-                await delay(100);
+                clock.tick(2 * OVERLAY_TOASTER_DELAY_MS);
                 toaster.show({ message: "two" });
                 assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
             });
@@ -141,20 +148,20 @@ describe("OverlayToaster", () => {
                 assert.deepEqual(toaster.getToasts()[0].message, "two");
             });
 
-            it("show() updates existing toast in queue", async () => {
+            it("show() updates existing toast in queue", () => {
                 toaster.show({ message: "one" });
                 const key = toaster.show({ message: "two" });
                 toaster.show({ message: "two updated" }, key);
-                await delay(100);
+                clock.tick(2 * OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
                 assert.deepEqual(toaster.getToasts()[0].message, "two updated");
             });
 
-            it("dismiss() removes just the toast in question", async () => {
+            it("dismiss() removes just the toast in question", () => {
                 toaster.show({ message: "one" });
                 const key = toaster.show({ message: "two" });
                 toaster.show({ message: "six" });
-                await delay(150);
+                clock.tick(3 * OVERLAY_TOASTER_DELAY_MS);
                 toaster.dismiss(key);
                 assert.deepEqual(
                     toaster.getToasts().map(t => t.message),
@@ -162,16 +169,16 @@ describe("OverlayToaster", () => {
                 );
             });
 
-            it("clear() removes all toasts", async () => {
+            it("clear() removes all toasts", () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "six" });
-                await delay(50);
+                clock.tick(OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
                 toaster.clear();
                 assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
                 // Ensure the queue is cleared
-                await delay(100);
+                clock.tick(2 * OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
             });
 
@@ -241,17 +248,24 @@ describe("OverlayToaster", () => {
                 toaster = await spec.create({ maxToasts: 3 }, testsContainerElement);
             });
 
+            beforeEach(() => {
+                clock = sinon.useFakeTimers();
+            });
+
             after(() => {
                 unmountReact16Toaster(testsContainerElement);
                 document.documentElement.removeChild(testsContainerElement);
             });
+            afterEach(() => {
+                clock.restore();
+            });
 
-            it("does not exceed the maximum toast limit set", async () => {
+            it("does not exceed the maximum toast limit set", () => {
                 toaster.show({ message: "one" });
                 toaster.show({ message: "two" });
                 toaster.show({ message: "three" });
                 toaster.show({ message: "oh no" });
-                await delay(200);
+                clock.tick(4 * OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
             });
 
@@ -260,7 +274,7 @@ describe("OverlayToaster", () => {
                 toaster.show({ message: "two" });
                 toaster.show({ message: "three" }, "3");
                 toaster.show({ message: "three updated" }, "3");
-                await delay(200);
+                clock.tick(4 * OVERLAY_TOASTER_DELAY_MS);
                 assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
             });
         });
@@ -316,7 +330,3 @@ describe("OverlayToaster", () => {
         });
     });
 });
-
-function delay(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7034

#### Checklist

- [x] Includes tests
- [ ] Update documentation (N/A)

#### Changes proposed in this pull request:

This issue appears to be a react css transition group issue, but we can mitigate it on our side by effectively debouncing the `show()` call. Now when a user calls `show()` if there's been a toasted shown in the last 50ms, the new toast will be added to a queue and only shown after that time has elapsed. Any other `show()` calls that happen within that window will also be added to the queue and only one new toast will be shown after each 50ms increment.
#### Screenshots

Without this change we get this ugly behavior:
<img width="359" alt="Screenshot 2024-11-07 at 1 29 05 PM" src="https://github.com/user-attachments/assets/7e9afb1c-3133-49d7-9123-aeb709355f5f">

With the change it animates in properly:
<img width="342" alt="Screenshot 2024-11-07 at 1 29 16 PM" src="https://github.com/user-attachments/assets/ae63f2ed-1470-4517-b4fc-8b071d53ae3f">
