### PR TITLE
[core] fix: get toasters timeout Infinity to match behavior of timeout 0

### DIFF
--- a/packages/core/src/components/toast/toast2.tsx
+++ b/packages/core/src/components/toast/toast2.tsx
@@ -44,7 +44,8 @@ export const Toast2 = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) 
     const clearTimeout = React.useCallback(() => setIsTimeoutStarted(false), []);
 
     // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
-    const isTimeoutEnabled = timeout != null && timeout > 0;
+    // Per github, issue 6742: "timeout: Infinity should also behave the same as timeout: 0"
+    const isTimeoutEnabled = timeout != null && timeout > 0 && timeout !== Infinity;
 
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state
     useTimeout(

--- a/packages/core/src/components/toast/toast2.tsx
+++ b/packages/core/src/components/toast/toast2.tsx
@@ -43,8 +43,6 @@ export const Toast2 = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) 
     const startTimeout = React.useCallback(() => setIsTimeoutStarted(true), []);
     const clearTimeout = React.useCallback(() => setIsTimeoutStarted(false), []);
 
-    // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
-    // Per github, issue 6742: "timeout: Infinity should also behave the same as timeout: 0"
     const isTimeoutEnabled = timeout != null && timeout > 0 && timeout !== Infinity;
 
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state

--- a/packages/core/src/components/toast/toastProps.ts
+++ b/packages/core/src/components/toast/toastProps.ts
@@ -47,7 +47,7 @@ export interface ToastProps extends Props, IntentProps {
 
     /**
      * Milliseconds to wait before automatically dismissing toast.
-     * Providing a value less than or equal to 0 will disable the timeout (this is discouraged).
+     * Providing a value less than or equal to 0 or Infinity will disable the timeout (this is discouraged).
      *
      * @default 5000
      */

--- a/packages/core/test/toast/toast2Tests.tsx
+++ b/packages/core/test/toast/toast2Tests.tsx
@@ -98,5 +98,13 @@ describe("<Toast2>", () => {
                 done();
             }, 20);
         });
+
+        it("timeout={Infinity} behaves same as timeout={0} and does not trigger onDismiss", done => {
+            mount(<Toast2 message="Hello" onDismiss={handleDismiss} timeout={Infinity} />);
+            setTimeout(() => {
+                assert.isTrue(handleDismiss.notCalled, "onDismiss was called when it should not have been");
+                done();
+            }, 20);
+        });
     });
 });


### PR DESCRIPTION
#### Fixes #6742 

A toast with timeout: Infinity closes immediately. 

See this sandbox https://codesandbox.io/p/sandbox/blueprint-toast-issue-forked-4t9r9t?file=%2Fsrc%2FApp.js%3A17%2C4.

However, a Toast with timeout: Infinity should disable the timeout, just like a Toast with timeout: 0.

Additionally, a test case for timeout: Infinity is needed.

#### The Issue

The error is in blueprint/packages/core/src/components/toast/toast2.tsx, specifically the line: 

_**isTimeoutEnabled = timeout != null && timeout > 0;**_ 

Currently, when **timeout = Infinity**, then **isTimeoutEnabled = True**. When Infinity is passed as the timeout, due to useTimeout's functionality, the toast closes immediately with a 0 second delay.

This code needs to be fixed so when **timeout = Infinity**, then **isTimeoutEnabled = False** (i.e. the timeout is disabled).

#### Changes proposed in this pull request:

Three changes:

1. Adding an extra line as a comment to share where I found that "timeout: Infinity" should disable the timeout.
2. Fix **isTimeoutEnabled** so that for timeout = Infinity, **isTimeoutEnabled** is False, not True. In addition, the **isTimeoutEnabled** value is preserved for all other inputs of **timeout**.
3. Creating a test case that sees whether a toaster with timeout: Infinity has received a dismiss, returning a False if it has. 

These changes produced correct functionality on my local computer. 

#### Tests 
- [ ] Passes tests for packages\core

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Reviewers should focus on:

1. If the added comment line should be modified or deleted
2. If the new **isTimeoutEnabled** matches the wanted functionality, such that **isTImeoutEnabled** is True when the timeout is greater than 0, and False when the timeout is either null, less than or equal to 0, and Infinity.
3. Whether the test case achieves what was requested for in the open issue. 

#### Screenshots

![image](https://github.com/user-attachments/assets/afc2eafb-20d0-44d8-8239-2c203f74a6b8)
![image](https://github.com/user-attachments/assets/84872434-c2d2-468f-8236-babb727293d9)
