### PR TITLE
fix(KeyComboTag): Style regression

### DIFF
--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -9,6 +9,10 @@
   &:not(.#{$ns}-minimal) {
     @include pt-flex-container(row, $pt-grid-size * 0.5);
   }
+
+  &.#{$ns}-minimal {
+    @include pt-flex-container(row);
+  }
 }
 
 .#{$ns}-hotkey-dialog {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/pull/7025 

#### Changes proposed in this pull request:

Fixed a regression from a previous PR where we removed the flex container from minimal keycombo tags meaning that UIs could be misaligned.

<!-- Fill this out. -->

#### Screenshot

Confirmed that keycombos look good for both platforms still:
<img width="236" alt="Screenshot 2024-11-13 at 1 00 53 PM" src="https://github.com/user-attachments/assets/d67219ba-61aa-4227-8f09-dddc11b28999">
