### PR TITLE
fix(Tag) Ensure that non-interactive tags DOM props don't change

### DIFF
--- a/packages/core/src/accessibility/useInteractiveAttributes.ts
+++ b/packages/core/src/accessibility/useInteractiveAttributes.ts
@@ -19,12 +19,20 @@ interface InteractiveAttributes<E extends HTMLElement> extends InteractiveHTMLAt
     ref: React.Ref<E>;
 }
 
+interface UseInteractiveAttributesOptions {
+    defaultTabIndex: number | undefined;
+    disabledTabIndex: number | undefined;
+}
+
+const DEFAULT_OPTIONS: UseInteractiveAttributesOptions = { defaultTabIndex: undefined, disabledTabIndex: -1 };
+
 export function useInteractiveAttributes<E extends HTMLElement>(
     interactive: boolean,
     props: InteractiveComponentProps,
     ref: React.Ref<E>,
-    defaultTabIndex?: number,
+    options: UseInteractiveAttributesOptions = DEFAULT_OPTIONS,
 ): [active: boolean, interactiveProps: InteractiveAttributes<E>] {
+    const { defaultTabIndex, disabledTabIndex } = options;
     const { active, onClick, onFocus, onKeyDown, onKeyUp, onBlur, tabIndex = defaultTabIndex } = props;
     // the current key being pressed
     const [currentKeyPressed, setCurrentKeyPressed] = React.useState<string | undefined>();
@@ -82,7 +90,7 @@ export function useInteractiveAttributes<E extends HTMLElement>(
             onKeyDown: handleKeyDown,
             onKeyUp: handleKeyUp,
             ref: mergeRefs(elementRef, ref),
-            tabIndex: interactive ? tabIndex : -1,
+            tabIndex: interactive ? tabIndex : disabledTabIndex,
         },
     ];
 }

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -92,7 +92,7 @@ export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
 
     const isRemovable = Utils.isFunction(onRemove);
 
-    const [active, interactiveProps] = useInteractiveAttributes(interactive, props, ref, 0);
+    const [active, interactiveProps] = useInteractiveAttributes(interactive, props, ref, interactive ? 0 : undefined);
 
     const tagClasses = classNames(
         Classes.TAG,

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -92,7 +92,10 @@ export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
 
     const isRemovable = Utils.isFunction(onRemove);
 
-    const [active, interactiveProps] = useInteractiveAttributes(interactive, props, ref, interactive ? 0 : undefined);
+    const [active, interactiveProps] = useInteractiveAttributes(interactive, props, ref, {
+        defaultTabIndex: 0,
+        disabledTabIndex: undefined,
+    });
 
     const tagClasses = classNames(
         Classes.TAG,


### PR DESCRIPTION
Fixes https://github.com/palantir/blueprint/pull/7060

In that PR, we made interactive tags have a new `tabIndex` prop but also added it in the case of non-interactive tags (setting it to -1 and therefore making it not accessible as expected). However, some places test for the DOM structure of tags and we can simply omit the tab index in these cases. This change is functionally the same as before but preserves the old structure to make tests pass.