### PR TITLE
Horizontally center map-marker icon

### DIFF
--- a/resources/icons/16px/map-marker.svg
+++ b/resources/icons/16px/map-marker.svg
@@ -1,13 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
-<g id="map_marker_1_">
-	<g>
-		<path fill-rule="evenodd" clip-rule="evenodd" d="M8.46,0C5.42,0,2.95,2.39,2.95,5.33C2.95,8.28,8.46,16,8.46,16
-			s5.51-7.72,5.51-10.67C13.96,2.39,11.5,0,8.46,0z M8.46,8c-1.38,0-2.5-1.12-2.5-2.5c0-1.38,1.12-2.5,2.5-2.5
-			c1.38,0,2.5,1.12,2.5,2.5C10.96,6.88,9.84,8,8.46,8z"/>
-	</g>
-</g>
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.99999 0C4.95999 0 2.48999 2.39 2.48999 5.33C2.48999 8.28 7.99999 16 7.99999 16C7.99999 16 13.51 8.28 13.51 5.33C13.5 2.39 11.04 0 7.99999 0ZM7.99999 8C6.61999 8 5.49999 6.88 5.49999 5.5C5.49999 4.12 6.61999 3 7.99999 3C9.37999 3 10.5 4.12 10.5 5.5C10.5 6.88 9.37999 8 7.99999 8Z"/>
 </svg>

--- a/resources/icons/20px/map-marker.svg
+++ b/resources/icons/20px/map-marker.svg
@@ -1,12 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve">
-<g id="map_marker">
-	<g>
-		<path fill-rule="evenodd" clip-rule="evenodd" d="M9.98,0c-3.87,0-7,2.98-7,6.67c0,3.68,7,13.33,7,13.33s7-9.65,7-13.33
-			C16.98,2.99,13.84,0,9.98,0z M9.98,10c-1.66,0-3-1.34-3-3s1.34-3,3-3s3,1.34,3,3S11.64,10,9.98,10z"/>
-	</g>
-</g>
+<svg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 0C6.13 0 3 2.98 3 6.67C3 10.35 10 20 10 20C10 20 17 10.35 17 6.67C17 2.99 13.86 0 10 0ZM10 10C8.34 10 7 8.66 7 7C7 5.34 8.34 4 10 4C11.66 4 13 5.34 13 7C13 8.66 11.66 10 10 10Z"/>
 </svg>


### PR DESCRIPTION
#### Fixes #7064

Centers the 16px `map-marker` icon and cleans up SVG markup on both icons (16px and 20px).

#### Screenshot

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/ba56de98-e453-439c-8016-49de34c3c02a) | ![after](https://github.com/user-attachments/assets/04191938-d27e-4f9f-bcd1-c26461064673) |
