### PR TITLE
Fix focus hang on MultiSelect/Suggest inputs in Firefox

### DIFF
--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -419,8 +419,8 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
             if (e.key === "Escape" || e.key === "Tab") {
                 // By default the escape key will not trigger a blur on the
                 // input element. It must be done explicitly.
-                if (this.input != null) {
-                    this.input.blur();
+                if (e.key === "Escape") {
+                    this.input?.blur();
                 }
                 this.setState({ isOpen: false });
             } else if (!(e.key === "Backspace" || e.key === "ArrowLeft" || e.key === "ArrowRight")) {

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -365,7 +365,11 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
     ) => {
         return (e: React.KeyboardEvent<HTMLInputElement>) => {
             if (e.key === "Escape" || e.key === "Tab") {
-                this.inputElement?.blur();
+                // By default the escape key will not trigger a blur on the
+                // input element. It must be done explicitly.
+                if (e.key === "Escape") {
+                    this.inputElement?.blur();
+                }
                 this.setState({ isOpen: false });
             } else if (
                 this.props.openOnKeyDown &&


### PR DESCRIPTION
#### Fixes #7055

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Fixes an issue where MultiSelect/Suggest component input fields would inadvertently capture tab focus in Firefox, preventing focus from moving to the rest of the document.

#### Reviewers should focus on:

Ensure that tab focus works as expected on MultiSelect/Suggest components in both Chrome and Firefox.

#### Screenshot

| Before | After |
| ------ | ----- |
| ![before](https://github.com/user-attachments/assets/4dd2befd-0b13-4623-8c89-bf3c4ef6dd36) | ![after](https://github.com/user-attachments/assets/74a731c6-9c73-40b4-9773-195f3de26fb0) |





