### PR TITLE
feat(DateRangeInput3) Add keyboard accessibility

### DIFF
--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -554,6 +554,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     };
 
     private handleInputArrowKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, boundary: Boundary) => {
+        const { minDate, maxDate } = this.props;
         const { isOpen } = this.state;
         const inputElement = boundary === Boundary.START ? this.startInputElement : this.endInputElement;
 
@@ -561,29 +562,34 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             return;
         }
 
-        // We've commited to moving the selection, prevent the default arrow key interactions
-        e.preventDefault();
-
-        const newDate =
+        const shiftedDate =
             this.getNextDateForArrowKeyNavigation(e.key, boundary) ??
             this.getDefaultDateForArrowKeyNavigation(e.key, boundary);
 
+        if (shiftedDate == null) {
+            return;
+        }
+
+        // We've commited to moving the selection, prevent the default arrow key interactions
+        e.preventDefault();
+
+        const clampedDate = clampDate(shiftedDate, minDate, maxDate);
         const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
         const nextState: Partial<DateRangeInput3State> = {
-            [keys.inputString]: this.formatDate(newDate),
+            [keys.inputString]: this.formatDate(clampedDate),
             shouldSelectAfterUpdate: true,
         };
 
         if (!this.isControlled()) {
-            nextState[keys.selectedValue] = newDate;
+            nextState[keys.selectedValue] = clampedDate;
         }
 
-        this.props.onChange?.(this.getDateRangeForCallback(newDate, boundary));
+        this.props.onChange?.(this.getDateRangeForCallback(clampedDate, boundary));
         this.setState(nextState);
     };
 
     private getNextDateForArrowKeyNavigation(arrowKey: string, boundary: Boundary) {
-        const { allowSingleDayRange, maxDate, minDate } = this.props;
+        const { allowSingleDayRange } = this.props;
         const [selectedStart, selectedEnd] = this.getSelectedRange();
         const initialDate = boundary === Boundary.START ? selectedStart : selectedEnd;
         if (initialDate == null) {
@@ -598,17 +604,26 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
         const adjustedEnd = selectedEnd == null || allowSingleDayRange ? selectedEnd : shiftDateByDays(selectedEnd, -1);
 
         return boundary === Boundary.START
-            ? clampDate(relativeDate, minDate, adjustedEnd)
-            : clampDate(relativeDate, adjustedStart, maxDate);
+            ? clampDate(relativeDate, undefined, adjustedEnd)
+            : clampDate(relativeDate, adjustedStart, undefined);
     }
 
     private getDefaultDateForArrowKeyNavigation(arrowKey: string, boundary: Boundary) {
-        const { maxDate, minDate } = this.props;
         const [selectedStart, selectedEnd] = this.getSelectedRange();
         const otherBoundary = boundary === Boundary.START ? selectedEnd : selectedStart;
 
-        const selectedDate = otherBoundary == null ? new Date() : shiftDateByArrowKey(otherBoundary, arrowKey);
-        return clampDate(selectedDate, minDate, maxDate);
+        if (otherBoundary == null) {
+            return new Date();
+        }
+
+        const isForwardArrowKey = arrowKey === "ArrowRight" || arrowKey === "ArrowDown";
+        // If the arrow key direction is in the same direction as the boundary, then moving that way will not create an
+        // overlapping date range
+        if (isForwardArrowKey === (boundary === Boundary.END)) {
+            return shiftDateByArrowKey(otherBoundary, arrowKey);
+        }
+
+        return undefined;
     }
 
     private handleInputMouseDown = () => {

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -52,7 +52,13 @@ import type {
     DateRangeInput3PropsWithDefaults,
 } from "./dateRangeInput3Props";
 import type { DateRangeInput3State } from "./dateRangeInput3State";
-import { clampDate, isEntireInputSelected, shiftDateByArrowKey, shiftDateByDays } from "./dateRangeInputUilts";
+import {
+    clampDate,
+    getTodayAtMidnight,
+    isEntireInputSelected,
+    shiftDateByArrowKey,
+    shiftDateByDays,
+} from "./dateRangeInputUilts";
 
 export type { DateRangeInput3Props };
 
@@ -613,7 +619,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
         const otherBoundary = boundary === Boundary.START ? selectedEnd : selectedStart;
 
         if (otherBoundary == null) {
-            return new Date();
+            return getTodayAtMidnight();
         }
 
         const isForwardArrowKey = arrowKey === "ArrowRight" || arrowKey === "ArrowDown";
@@ -773,7 +779,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
                 return false;
             }
 
-            const fallbackDate = new Date(new Date().setHours(0, 0, 0, 0));
+            const fallbackDate = getTodayAtMidnight();
             const [selectedStart, selectedEnd] = this.getSelectedRange([fallbackDate, fallbackDate]);
 
             // case to check if the user has changed TimePicker values
@@ -1009,7 +1015,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             newDate = getDateFnsParser(format, locale)(dateString);
         }
 
-        return newDate === false ? new Date() : newDate;
+        return newDate === false ? getTodayAtMidnight() : newDate;
     };
 
     // called on date hover & selection

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -52,6 +52,7 @@ import type {
     DateRangeInput3PropsWithDefaults,
 } from "./dateRangeInput3Props";
 import type { DateRangeInput3State } from "./dateRangeInput3State";
+import { clampDate, isEntireInputSelected, shiftDateByArrowKey, shiftDateByDays } from "./dateRangeInputUilts";
 
 export type { DateRangeInput3Props };
 
@@ -465,7 +466,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
                 break;
             case "keydown":
                 e = e as React.KeyboardEvent<HTMLInputElement>;
-                this.handleInputKeyDown(e);
+                this.handleInputKeyDown(e, boundary);
                 inputProps?.onKeyDown?.(e);
                 break;
             case "mousedown":
@@ -481,13 +482,20 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
     // add a keydown listener to persistently change focus when tabbing:
     // - if focused in start field, Tab moves focus to end field
     // - if focused in end field, Shift+Tab moves focus to start field
-    private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, boundary: Boundary) => {
+        const isArrowKeyPresssed =
+            e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "ArrowLeft" || e.key === "ArrowRight";
         const isTabPressed = e.key === "Tab";
         const isEnterPressed = e.key === "Enter";
         const isEscapeKeyPressed = e.key === "Escape";
         const isShiftPressed = e.shiftKey;
 
         const { selectedStart, selectedEnd } = this.state;
+
+        if (isArrowKeyPresssed) {
+            this.handleInputArrowKeyDown(e, boundary);
+            return;
+        }
 
         if (isEscapeKeyPressed) {
             this.startInputElement?.blur();
@@ -544,6 +552,64 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             return;
         }
     };
+
+    private handleInputArrowKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, boundary: Boundary) => {
+        const { isOpen } = this.state;
+        const inputElement = boundary === Boundary.START ? this.startInputElement : this.endInputElement;
+
+        if (!isOpen || !isEntireInputSelected(inputElement)) {
+            return;
+        }
+
+        // We've commited to moving the selection, prevent the default arrow key interactions
+        e.preventDefault();
+
+        const newDate =
+            this.getNextDateForArrowKeyNavigation(e.key, boundary) ??
+            this.getDefaultDateForArrowKeyNavigation(e.key, boundary);
+
+        const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
+        const nextState: Partial<DateRangeInput3State> = {
+            [keys.inputString]: this.formatDate(newDate),
+            shouldSelectAfterUpdate: true,
+        };
+
+        if (!this.isControlled()) {
+            nextState[keys.selectedValue] = newDate;
+        }
+
+        this.props.onChange?.(this.getDateRangeForCallback(newDate, boundary));
+        this.setState(nextState);
+    };
+
+    private getNextDateForArrowKeyNavigation(arrowKey: string, boundary: Boundary) {
+        const { allowSingleDayRange, maxDate, minDate } = this.props;
+        const [selectedStart, selectedEnd] = this.getSelectedRange();
+        const initialDate = boundary === Boundary.START ? selectedStart : selectedEnd;
+        if (initialDate == null) {
+            return undefined;
+        }
+
+        const relativeDate = shiftDateByArrowKey(initialDate, arrowKey);
+
+        // Ensure that we don't move onto a single day range selection if that is disallowed
+        const adjustedStart =
+            selectedStart == null || allowSingleDayRange ? selectedStart : shiftDateByDays(selectedStart, 1);
+        const adjustedEnd = selectedEnd == null || allowSingleDayRange ? selectedEnd : shiftDateByDays(selectedEnd, -1);
+
+        return boundary === Boundary.START
+            ? clampDate(relativeDate, minDate, adjustedEnd)
+            : clampDate(relativeDate, adjustedStart, maxDate);
+    }
+
+    private getDefaultDateForArrowKeyNavigation(arrowKey: string, boundary: Boundary) {
+        const { maxDate, minDate } = this.props;
+        const [selectedStart, selectedEnd] = this.getSelectedRange();
+        const otherBoundary = boundary === Boundary.START ? selectedEnd : selectedStart;
+
+        const selectedDate = otherBoundary == null ? new Date() : shiftDateByArrowKey(otherBoundary, arrowKey);
+        return clampDate(selectedDate, minDate, maxDate);
+    }
 
     private handleInputMouseDown = () => {
         // clicking in the field constitutes an explicit focus change. we update

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInputUilts.ts
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInputUilts.ts
@@ -5,6 +5,10 @@
 const DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
 const WEEK_IN_MILLIS = 7 * DAY_IN_MILLIS;
 
+export function getTodayAtMidnight() {
+    return new Date(new Date().setHours(0, 0, 0, 0));
+}
+
 export function shiftDateByDays(date: Date, days: number): Date {
     return new Date(date.valueOf() + days * DAY_IN_MILLIS);
 }

--- a/packages/datetime2/src/components/date-range-input3/dateRangeInputUilts.ts
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInputUilts.ts
@@ -1,0 +1,48 @@
+/* !
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ */
+
+const DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
+const WEEK_IN_MILLIS = 7 * DAY_IN_MILLIS;
+
+export function shiftDateByDays(date: Date, days: number): Date {
+    return new Date(date.valueOf() + days * DAY_IN_MILLIS);
+}
+
+export function shiftDateByWeeks(date: Date, weeks: number): Date {
+    return new Date(date.valueOf() + weeks * WEEK_IN_MILLIS);
+}
+
+export function shiftDateByArrowKey(date: Date, key: string): Date {
+    switch (key) {
+        case "ArrowUp":
+            return shiftDateByWeeks(date, -1);
+        case "ArrowDown":
+            return shiftDateByWeeks(date, 1);
+        case "ArrowLeft":
+            return shiftDateByDays(date, -1);
+        case "ArrowRight":
+            return shiftDateByDays(date, 1);
+        default:
+            return date;
+    }
+}
+
+export function clampDate(date: Date, minDate: Date | null | undefined, maxDate: Date | null | undefined) {
+    let result = date;
+    if (minDate != null && date < minDate) {
+        result = minDate;
+    }
+    if (maxDate != null && date > maxDate) {
+        result = maxDate;
+    }
+    return result;
+}
+
+export function isEntireInputSelected(element: HTMLInputElement | null) {
+    if (element == null) {
+        return false;
+    }
+
+    return element.selectionStart === 0 && element.selectionEnd === element.value.length;
+}

--- a/packages/datetime2/src/components/date-range-picker3/contiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/contiguousDayRangePicker.tsx
@@ -147,6 +147,7 @@ function useContiguousCalendarViews(
 
             const nextRangeStart = MonthAndYear.fromDate(selectedRange[0]);
             const nextRangeEnd = MonthAndYear.fromDate(selectedRange[1]);
+            const hasSelectionEndChanged = prevSelectedRange.current[0]?.valueOf() === selectedRange[0]?.valueOf();
 
             if (nextRangeStart == null && nextRangeEnd != null) {
                 // Only end date selected.
@@ -175,8 +176,11 @@ function useContiguousCalendarViews(
                     } else {
                         newDisplayMonth = nextRangeStart;
                     }
+                } else if (hasSelectionEndChanged) {
+                    // If the selection end has changed, adjust the view to show the new end date
+                    newDisplayMonth = singleMonthOnly ? nextRangeEnd : nextRangeEnd.getPreviousMonth();
                 } else {
-                    // Different start and end date months, adjust display months.
+                    // Otherwise, the selection start must have changed, show that
                     newDisplayMonth = nextRangeStart;
                 }
             }

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -93,18 +93,19 @@ describe("<DateRangeInput3>", () => {
         }
     });
 
+    const YEAR = 2022;
     const START_DAY = 22;
-    const START_DATE = new Date(2022, Months.JANUARY, START_DAY);
+    const START_DATE = new Date(YEAR, Months.JANUARY, START_DAY);
     const START_STR = DATE_FORMAT.formatDate(START_DATE);
     const END_DAY = 24;
-    const END_DATE = new Date(2022, Months.JANUARY, END_DAY);
+    const END_DATE = new Date(YEAR, Months.JANUARY, END_DAY);
     const END_STR = DATE_FORMAT.formatDate(END_DATE);
     const DATE_RANGE = [START_DATE, END_DATE] as DateRange;
 
-    const START_DATE_2 = new Date(2022, Months.JANUARY, 1);
+    const START_DATE_2 = new Date(YEAR, Months.JANUARY, 1);
     const START_STR_2 = DATE_FORMAT.formatDate(START_DATE_2);
     const START_STR_2_ES_LOCALE = "1 de enero de 2022";
-    const END_DATE_2 = new Date(2022, Months.JANUARY, 31);
+    const END_DATE_2 = new Date(YEAR, Months.JANUARY, 31);
     const END_STR_2 = DATE_FORMAT.formatDate(END_DATE_2);
     const END_STR_2_ES_LOCALE = "31 de enero de 2022";
     const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
@@ -1017,6 +1018,265 @@ describe("<DateRangeInput3>", () => {
                     getEndInput(root).simulate("blur");
                     assertInputValueEquals(getEndInput(root), END_STR);
                 });
+            });
+        });
+
+        describe("Arrow key navigation", () => {
+            it("Pressing an arrow key has no effect when the input is not fully selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={DATE_RANGE} />,
+                );
+
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                expect(onChange.called).to.be.false;
+            });
+
+            it("Pressing the left arrow key moves the date back by a day", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedStartDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 1));
+                const expectedStartDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 2));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowLeft" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate1, END_STR]);
+
+                getStartInput(root).simulate("keydown", { key: "ArrowLeft" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [expectedStartDate2, END_STR]);
+            });
+
+            it("Pressing the right arrow key moves the date forward by a day", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedEndDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY + 1));
+                const expectedEndDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY + 2));
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowRight" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, expectedEndDate1]);
+
+                getEndInput(root).simulate("keydown", { key: "ArrowRight" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, expectedEndDate2]);
+            });
+
+            it("Pressing the up arrow key moves the date back by a week", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedStartDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 7));
+                const expectedStartDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 14));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate1, END_STR]);
+
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [expectedStartDate2, END_STR]);
+            });
+
+            it("Pressing the down arrow key moves the date forward by a week", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedEndDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY + 7));
+                const expectedEndDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.FEBRUARY, 7));
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, expectedEndDate1]);
+
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, expectedEndDate2]);
+            });
+
+            it("Will not move past the end boundary", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedStartDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY - 1));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate, END_STR]);
+            });
+
+            it("Will not move past the end boundary when allowSingleDayRange={true}", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        allowSingleDayRange={true}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), END_STR);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [END_STR, END_STR]);
+            });
+
+            it("Will not move past the start boundary", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedEndDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY + 1));
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, expectedEndDate]);
+            });
+
+            it("Will not move past the start boundary when allowSingleDayRange={true}", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        allowSingleDayRange={true}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getEndInput(root), START_STR);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, START_STR]);
+            });
+
+            it("Will not move past the min date", () => {
+                const minDate = new Date(YEAR, Months.JANUARY, START_DAY - 3);
+                const minDateStr = DATE_FORMAT.formatDate(minDate);
+
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        minDate={minDate}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), minDateStr);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [minDateStr, END_STR]);
+            });
+
+            it("Will not move past the max date", () => {
+                const maxDate = new Date(YEAR, Months.JANUARY, END_DAY + 3);
+                const maxDateStr = DATE_FORMAT.formatDate(maxDate);
+
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        maxDate={maxDate}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getEndInput(root), maxDateStr);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, maxDateStr]);
+            });
+
+            it("Will select today's date by default", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} />);
+
+                const today = DATE_FORMAT.formatDate(new Date());
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), today);
+            });
+
+            it("Will choose a reasonable end date when only the start is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[START_DATE, null]} />,
+                );
+
+                const expectedEndDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY + 1));
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowRight" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate);
+            });
+
+            it("Will choose a reasonable start date when only the end is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[null, END_DATE]} />,
+                );
+
+                const expectedEndDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY - 7));
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), expectedEndDate);
             });
         });
 
@@ -2588,6 +2848,22 @@ describe("<DateRangeInput3>", () => {
                     endInput.simulate("blur");
                     expect(onChange.called).to.be.false;
                 });
+            });
+        });
+
+        describe("Arrow key navigation", () => {
+            it("Pressing the left arrow key moves the date back by a day", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={DATE_RANGE} selectAllOnFocus={true} />,
+                );
+
+                const expectedStartDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 1));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowLeft" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate1, END_STR]);
             });
         });
 

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -1278,6 +1278,32 @@ describe("<DateRangeInput3>", () => {
                 getStartInput(root).simulate("keydown", { key: "ArrowUp" });
                 assertInputValueEquals(getStartInput(root), expectedEndDate);
             });
+
+            it("Will not make a selection when trying to move backward and only the start is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[START_DATE, null]} />,
+                );
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowLeft" });
+                getEndInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getEndInput(root), "");
+                expect(onChange.called).to.be.false;
+            });
+
+            it("Will not make a selection when trying to move forward and only the end is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[null, END_DATE]} />,
+                );
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowRight" });
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), "");
+                expect(onChange.called).to.be.false;
+            });
         });
 
         describe("Hovering over dates", () => {


### PR DESCRIPTION
#### Changes proposed in this pull request:

This PR adds improved keyboard accessibility to the `DateRangeInput3` component. In particular we align with other date range picker so that when one of the input fields is focused, the user can then use their arrow keys to navigate the calendar and make selections. This properly respects min and max dates and allow single selection only and properly navigates the calendar view based on user selections.

#### Screenshot


https://github.com/user-attachments/assets/6f09a85f-25d3-403f-9d07-16a46750c7ee

