### PR TITLE
Fix new color alias

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7085.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7085.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Remove duplicate variables which overrides new dark theme secondary
+    and elevated colors with old values.
+  links:
+  - https://github.com/palantir/blueprint/pull/7085

--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -24,12 +24,6 @@ $pt-dark-app-secondary-background-color: $black !default;
 $pt-app-elevated-background-color: $light-gray4 !default;
 $pt-dark-app-elevated-background-color: $dark-gray2 !default;
 
-$pt-app-secondary-background-color: $white !default;
-$pt-dark-app-secondary-background-color: $dark-gray1 !default;
-
-$pt-app-elevated-background-color: $light-gray4 !default;
-$pt-dark-app-elevated-background-color: $dark-gray3 !default;
-
 $pt-outline-color: rgba($blue3, 0.6) !default;
 // 0.752 opacity to meet WCCAG 2.2 minimum contrast guidelines with all light-gray backgrounds in light theme
 // and all dark-gray backgrounds in dark theme


### PR DESCRIPTION
#### Fixes #0000
Just bumped Blueprint core to 5.15.0 and noticed there was some duplicate to the color alias where the new values were being overridden by the old duplicated variables.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:
Remove the duplicate variables that use the old dark colors

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
