### PR TITLE
Prevent tooltip scroll propagation to parent containers by adding an …

### DIFF
--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -191,6 +191,7 @@ export class Cell extends React.Component<CellProps> {
                 className={classes}
                 title={tooltip}
                 ref={cellRef}
+                onWheel={(e: React.WheelEvent) => e.stopPropagation()}
                 {...{ style, tabIndex, onKeyDown, onKeyUp, onKeyPress }}
             >
                 <LoadableContent loading={loading ?? false} variableLength={true}>


### PR DESCRIPTION
**Fix for #7057: Duplicated Scrolling Behavior from a Popover in Table2**

**Issue Description:**
When scrolling over a popover from a Table2 *Cell* component, the table can scroll as well. This occurs because the scroll event from the popover is propagating to the parent table element.

**Reproduction & Verification:**

Created two sandboxes to demonstrate both the issue and insight into a solution:
- Custom Sandbox1 (modified from *issue 5469*): [Link](https://codesandbox.io/p/sandbox/test-with-dropdown-whether-app-css-is-the-issue-7r5szf?file=%2Fsrc%2FTable2Example.tsx%3A24%2C1)
- Custom Sandbox2 (TruncatedFormat and JSONFormat example): [Link]( https://codesandbox.io/p/sandbox/truncatedformat-jsonformat-test-773fdj?file=%2Fsrc%2FTable2Example.tsx%3A41%2C1)

The first sandbox demonstrates the issue without using TruncatedFormat and JSONFormat. The second sandbox demonstrates the issue with TruncatedFormat and JSONFormat.

Adding an onWheel handler using a div tag to the *Cell* component solves the issue. For both sandboxes, there is an onWheel handler and div tag commented out for each *Cell* component. By uncommenting the onWheel handler and div tag, the scrolling issue is resolved.

**Proposed Solution:**

Added an onWheel event handler to the *Cell* component implementation with a stopPropogation call. This solution worked on my local machine.

**Reviewers:**

Please check if this change resolves the scrolling issue in your environment. 

