### PR TITLE
[docs] Rewrite Breadcrumbs docs

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.md
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.md
@@ -1,47 +1,47 @@
 @# Breadcrumbs
 
-**Breadcrumbs** identify the path to the current resource in an application.
-
-@reactExample BreadcrumbsExample
+**Breadcrumbs** represent the path to the current resource within an application's hierarchical structure.
 
 @## Usage
 
-The **Breadcrumbs** component requires an `items` array of [breadcrumb props](#core/components/breadcrumbs.breadcrumb)
-and renders them in an [**OverflowList**](#core/components/overflow-list) to automatically collapse breadcrumbs that
-do not fit in the available space.
-
-```tsx
-import { Breadcrumbs, Breadcrumb, BreadcrumbProps, Icon } from "@blueprintjs/core";
-import * as React from "react";
-
-const BREADCRUMBS: BreadcrumbProps[] = [
-    { href: "/users", icon: "folder-close", text: "Users" },
-    { href: "/users/janet", icon: "folder-close", text: "Janet" },
-    { icon: "document", text: "image.jpg" },
-];
-
-export const BreadcrumbsExample: React.FC = () => {
-    const renderCurrentBreadcrumb = ({ text, ...restProps }: BreadcrumbProps) => {
-        // customize rendering of last breadcrumb
-        return (
-            <Breadcrumb {...restProps}>
-                {text} <Icon icon="star" />
-            </Breadcrumb>
-        );
-    };
-
-    return <Breadcrumbs currentBreadcrumbRenderer={renderCurrentBreadcrumb} items={BREADCRUMBS} />;
-};
+```ts
+import { Breadcrumbs } from "@blueprintjs/core";
 ```
+
+@## Basic breadcrumbs
+
+The **Breadcrumbs** component accepts an `items` array of
+[breadcrumb props](#core/components/breadcrumbs.breadcrumb) and renders them as an ordered list.
+
+@reactCodeExample BreadcrumbsBasicExample
+
+@## Overflow
+
+**Breadcrumbs** uses an [**OverflowList**](#core/components/overflow-list)
+to collapse breadcrumbs that exceed the available space.
+
+@reactCodeExample BreadcrumbsOverflowExample
+
+@## Customizing breadcrumbs
+
+The **Breadcrumbs** component supports customization through the `breadcrumbRenderer`
+and `currentBreadcrumbRenderer` props, which allow custom rendering of individual breadcrumbs.
+
+@reactCodeExample BreadcrumbsRendererExample
+
+@## Interactive Playground
+
+@reactExample BreadcrumbsPlaygroundExample
 
 @## Props interface
 
 @interface BreadcrumbsProps
 
-@### Breadcrumb
+@## Breadcrumb
 
-The **Breadcrumb** component renders an `a.@ns-breadcrumb` if given an `href` or `onClick` and a `span.@ns-breadcrumb`
-otherwise. Typically you will supply an array of `BreadcrumbProps` to the `<Breadcrumbs items>` prop and only need to
-render this component directly when defining a custom `breadcrumbRenderer`.
+The **Breadcrumb** component renders an `a.@ns-breadcrumb` if an `href` or `onClick`
+is provided; otherwise, it renders a `span.@ns-breadcrumb`. Typically, breadcrumbs
+are supplied as an array of `BreadcrumbProps` to the `items` prop of **Breadcrumbs**,
+but the component can also be used directly when implementing a custom `breadcrumbRenderer`.
 
 @interface BreadcrumbProps

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExamples.tsx
@@ -1,0 +1,92 @@
+/* !
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ */
+
+import dedent from "dedent";
+import * as React from "react";
+
+import { Breadcrumb, Breadcrumbs, Icon } from "@blueprintjs/core";
+import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";
+
+export const BreadcrumbsBasicExample: React.FC<ExampleProps> = props => {
+    const code = dedent`
+        <Breadcrumbs
+        items={[
+            { text: "Blueprint" },
+            { text: "Docs" },
+            { text: "Components" },
+            { text: "Breadcrumbs" },
+        ]}
+        />`;
+    return (
+        <CodeExample code={code} {...props}>
+            <Breadcrumbs
+                items={[{ text: "Blueprint" }, { text: "Docs" }, { text: "Components" }, { text: "Breadcrumbs" }]}
+            />
+        </CodeExample>
+    );
+};
+
+export const BreadcrumbsRendererExample: React.FC<ExampleProps> = props => {
+    const code = dedent`
+        <Breadcrumbs
+            currentBreadcrumbRenderer={({ text, ...rest }) => (
+                <Breadcrumb {...rest}>
+                    {text}&nbsp;
+                    <Icon icon="star" />
+                </Breadcrumb>
+            )}
+            items={[
+                { href: "/users", icon: "folder-close", text: "Users" },
+                { href: "/users/janet", icon: "folder-close", text: "Janet" },
+                { icon: "document", text: "image.jpg" },
+            ]}
+        />`;
+    return (
+        <CodeExample code={code} {...props}>
+            <Breadcrumbs
+                currentBreadcrumbRenderer={({ text, ...rest }) => (
+                    <Breadcrumb {...rest}>
+                        {text}&nbsp;
+                        <Icon icon="star" />
+                    </Breadcrumb>
+                )}
+                items={[
+                    { href: "/users", icon: "folder-close", text: "Users" },
+                    { href: "/users/janet", icon: "folder-close", text: "Janet" },
+                    { icon: "document", text: "image.jpg" },
+                ]}
+            />
+        </CodeExample>
+    );
+};
+
+export const BreadcrumbsOverflowExample: React.FC<ExampleProps> = props => {
+    const code = dedent`
+        <Breadcrumbs
+            items={[
+                { text: "All files" },
+                { text: "Users" },
+                { text: "Janet" },
+                { text: "Photos" },
+                { text: "Wednesday" },
+                { text: "image.jpg", current: true },
+            ]}
+            minVisibleItems={3}
+        />`;
+    return (
+        <CodeExample code={code} {...props}>
+            <Breadcrumbs
+                items={[
+                    { text: "All files" },
+                    { text: "Users" },
+                    { text: "Janet" },
+                    { text: "Photos" },
+                    { text: "Wednesday" },
+                    { text: "image.jpg", current: true },
+                ]}
+                minVisibleItems={3}
+            />
+        </CodeExample>
+    );
+};

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsPlaygroundExample.tsx
@@ -58,7 +58,7 @@ const ITEMS_FOR_ALWAYS_RENDER: BreadcrumbProps[] = [
 
 const breadcrumbWidthLabelId = "num-visible-items-label";
 
-export const BreadcrumbsExample: React.FC<ExampleProps> = props => {
+export const BreadcrumbsPlaygroundExample: React.FC<ExampleProps> = props => {
     const [alwaysRenderOverflow, setAlwaysRenderOverflow] = React.useState(false);
     const [collapseFrom, setCollapseFrom] = React.useState<Boundary>(Boundary.START);
     const [renderCurrentAsInput, setRenderCurrentAsInput] = React.useState(false);

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -15,7 +15,8 @@
  */
 
 export * from "./alertExample";
-export * from "./breadcrumbsExample";
+export * from "./breadcrumbsExamples";
+export * from "./breadcrumbsPlaygroundExample";
 export * from "./buttonExamples";
 export * from "./buttonPlaygroundExample";
 export * from "./buttonGroupExample";

--- a/packages/docs-app/src/examples/core-examples/overflowListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overflowListExample.tsx
@@ -16,4 +16,4 @@
 
 // The `Breadcrumbs` component contains an `OverflowList`, which is why its example can be used for
 // both.
-export { BreadcrumbsExample as OverflowListExample } from "./breadcrumbsExample";
+export { BreadcrumbsPlaygroundExample as OverflowListExample } from "./breadcrumbsPlaygroundExample";

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -60,6 +60,12 @@
   width: $pt-grid-size * 35;
 }
 
+#{example("BreadcrumbsOverflow")} {
+  .#{$ns}-breadcrumbs {
+    max-width: 300px;
+  }
+}
+
 #{example("ButtonPlayground")} {
   .docs-example {
     flex-direction: column;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Rewrites ButtonGroup docs with additional examples: [Before](https://blueprintjs.com/docs/#core/components/breadcrumbs) / [After](https://output.circle-artifacts.com/output/job/e4ec5e5f-968e-4bd1-b91d-180c58c14ea9/artifacts/0/packages/docs-app/dist/index.html#core/components/breadcrumbs)
