### PR TITLE
Fix invalid code snippet example in Select documentation

### DIFF
--- a/packages/select/changelog/@unreleased/pr-7105.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-7105.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix invalid code snippet example in Select documentation
+  links:
+  - https://github.com/palantir/blueprint/pull/7105

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -71,7 +71,7 @@ const FilmSelect: React.FC = () => {
             noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
             onItemSelect={setSelectedFilm}
         >
-            <Button text={selectedFilm?.title ?? Select a film} rightIcon="double-caret-vertical" />
+            <Button text={selectedFilm?.title ?? "Select a film"} rightIcon="double-caret-vertical" />
         </Select>
     );
 };

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -71,7 +71,7 @@ const FilmSelect: React.FC = () => {
             noResults={<MenuItem disabled={true} text="No results." roleStructure="listoption" />}
             onItemSelect={setSelectedFilm}
         >
-            <Button text={selectedFilm?.title} rightIcon="double-caret-vertical" placeholder="Select a film" />
+            <Button text={selectedFilm?.title ?? Select a film} rightIcon="double-caret-vertical" />
         </Select>
     );
 };


### PR DESCRIPTION
#### Changes proposed in this pull request:

Prop `placeholder` does not exist on `Button`

#### Screenshot

Error when copy-pasting the example:
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/d9b12696-3940-4163-8202-67d7aba9083b">

