### PR TITLE
fix(EntityTitle): Fill should apply 100% width

### DIFF
--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -10,6 +10,10 @@
   gap: 0.7 * $pt-grid-size;
   min-width: 0;
 
+  &.#{$ns}-fill {
+    width: 100%;
+  }
+
   &-icon-container {
     &.#{$ns}-entity-title-has-subtitle {
       align-self: flex-start;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Fixes a case where EntityTitle does not take up full width when the `fill={true}` when it is contained within a flexbox.

By default, EntityTitle will fill the space of a non-flexbox container since it is itself a flexbox:

https://codesandbox.io/p/sandbox/entitytitle-fill-example-noflex-5f9l5x

However, when contained within a flexbox container, EntityTitle **does not** expand to fill the width. This is because it lacks a `flex-grow` or set `width`.

https://codesandbox.io/p/sandbox/entitytitle-fill-example-flex-7jdvmk

While this can be fixed by applying a custom class/styles, we would rather have this behavior be native to the component such that consumers don't need to apply their own styles to achieve the desired behavior. Setting `width: 100%` when `fill` is applied is also more in line with the behavior of other Blueprint components like Button, ButtonGroup, and Popover.

The `fill` property was originally added to EntityTitle in #6973
