### PR TITLE
fix(DateInput3): Fix wrong today date for timezone mismatch

### DIFF
--- a/packages/datetime2/karma.conf.js
+++ b/packages/datetime2/karma.conf.js
@@ -33,4 +33,5 @@ module.exports = async function (config) {
             },
         }),
     );
+    process.env.TZ = 'Etc/UTC';
 };

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -290,6 +290,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
                 onShortcutChange={handleShortcutChange}
                 selectedShortcutIndex={selectedShortcutIndex}
                 timePrecision={timePrecision}
+                timezone={timezoneValue}
                 // the rest of this component handles invalid dates gracefully (to show error messages),
                 // but DatePicker does not, so we must take care to filter those out
                 value={isErrorState ? null : valueAsDate}

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -241,9 +241,9 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
             shortcuts === true
                 ? true
                 : shortcuts.map(shortcut => ({
-                    ...shortcut,
-                    dateRange: [shortcut.date, null],
-                }));
+                      ...shortcut,
+                      dateRange: [shortcut.date, null],
+                  }));
         return [
             <DatePickerShortcutMenu
                 key="shortcuts"

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -28,6 +28,7 @@ import {
     DateUtils,
     Errors,
     TimePicker,
+    TimezoneUtils,
 } from "@blueprintjs/datetime";
 
 import { Classes, dayPickerClassNameOverrides } from "../../classes";
@@ -240,9 +241,9 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
             shortcuts === true
                 ? true
                 : shortcuts.map(shortcut => ({
-                      ...shortcut,
-                      dateRange: [shortcut.date, null],
-                  }));
+                    ...shortcut,
+                    dateRange: [shortcut.date, null],
+                }));
         return [
             <DatePickerShortcutMenu
                 key="shortcuts"
@@ -355,7 +356,9 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
     };
 
     private handleTodayClick = () => {
-        const value = new Date();
+        const { timezone } = this.props;
+        const today = new Date();
+        const value = timezone != null ? TimezoneUtils.convertLocalDateToTimezoneTime(today, timezone) : today;
         const displayMonth = value.getMonth();
         const displayYear = value.getFullYear();
         const selectedDay = value.getDate();

--- a/packages/datetime2/src/components/date-picker3/datePicker3Props.ts
+++ b/packages/datetime2/src/components/date-picker3/datePicker3Props.ts
@@ -45,4 +45,14 @@ export interface DatePicker3Props extends DatePickerSharedProps, DateFnsLocalePr
      * The currently selected day. If this prop is provided, the component acts in a controlled manner.
      */
     value?: Date | null;
+
+    /**
+     * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".
+     *
+     * This prop is only used to determine what date should be selected when clicking the "Today" button in the actions
+     * bar. If this value is omitted, the current date will be set using the user's local timezone.
+     *
+     * See [IANA Time Zones](https://www.iana.org/time-zones).
+     */
+    timezone?: string;
 }

--- a/packages/datetime2/test/components/datePicker3Tests.tsx
+++ b/packages/datetime2/test/components/datePicker3Tests.tsx
@@ -801,6 +801,16 @@ describe("<DatePicker3>", () => {
     });
 
     describe("clearing a selection", () => {
+        const MOCK_TODAY = new Date(2024, 11, 24, 16, 30);
+        let clock: sinon.SinonFakeTimers;
+        beforeEach(() => {
+            clock = sinon.useFakeTimers(MOCK_TODAY);
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
         it("onChange correctly passes a Date and never null when canClearSelection is false", () => {
             const onChange = sinon.spy();
             const { getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} canClearSelection={false} onChange={onChange} />);
@@ -843,6 +853,19 @@ describe("<DatePicker3>", () => {
             assert.equal(value!.getDate(), today.getDate());
             assert.equal(value!.getMonth(), today.getMonth());
             assert.equal(value!.getFullYear(), today.getFullYear());
+        });
+
+        it("selects the current day in the given timezone when Today is clicked", () => {
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} showActionsBar={true} timezone="Asia/Tokyo" />);
+            root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).first().simulate("click");
+
+            const value = root.state("value")!;
+            assert.isNotNull(value);
+            assert.equal(value.getDate(), MOCK_TODAY.getDate() + 1);
+            assert.equal(value.getMonth(), MOCK_TODAY.getMonth());
+            assert.equal(value.getFullYear(), MOCK_TODAY.getFullYear());
+            assert.equal(value.getHours(), 1);
+            assert.equal(value.getMinutes(), 30);
         });
 
         it("clears the value when Clear is clicked", () => {


### PR DESCRIPTION
#### Changes proposed in this pull request:

There was an issue that would occur if the current date in the selected timezone of the `DateInput3` component didn't match the current date in the user's local timezone. In such a case, selecting the "Today" option in the actions bar of the component would result in showing the current date in the user's local timezone rather than the selected timezone.

As of this PR, if the user clicks today and a timezone is selected, the current time will be translated into the selected timezone and thus read properly.

To try this out:

- Go to the `DateInput3` docs
- Turn on the "Show actions bar" toggle
- Change the timezone to something far in the future (e.g. Auckland, NZ).
- Open the popover and select today

Previously the date selected would appear to match the user's local date. Now, the date selected will be one day in the future (but represent the current actual time translated to that timezone).