### PR TITLE
Apply outline styles to outlined ButtonGroups with Popover children

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -144,7 +144,8 @@ Styleguide button-group
   }
 
   &.#{$ns}-outlined {
-    > .#{$ns}-button {
+    > .#{$ns}-button,
+    > .#{$ns}-popover-target > .#{$ns}-button {
       @include pt-button-outlined();
     }
 


### PR DESCRIPTION
#### Fixes #0000

Related to #6966

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Fixes a case where ButtonGroups that have Buttons nested in Popovers would not apply outlined styles when `outlined={true}` was applied to the ButtonGroup parent. For example:

```tsx
<ButtonGroup outlined={true}>
    <Popover content={<FileMenu />}>
        <Button text="Click Me" />
    </Popover>
</ButtonGroup>
```

This behavior can be seen when toggling the `outlined` prop on the the [Usage with popovers ](http://localhost:9001/#core/components/button-group.usage-with-popovers)section of the Button docs:

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/6fe74bc0-da1c-48bc-8f49-9eb61ee6e9f0) | ![after](https://github.com/user-attachments/assets/44d156b1-56b4-4575-8641-1d6404c48581) |