### PR TITLE
Remove reference to old Cobalt colours in docs

### DIFF
--- a/packages/docs-app/changelog/@unreleased/pr-7131.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-7131.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove reference to old Cobalt colours in docs
+  links:
+  - https://github.com/palantir/blueprint/pull/7131

--- a/packages/docs-app/src/components/colorSchemes.tsx
+++ b/packages/docs-app/src/components/colorSchemes.tsx
@@ -27,7 +27,7 @@ const MIN_STEPS = 3;
 const MAX_STEPS = 20;
 
 const QUALITATIVE = [
-    "cobalt3",
+    "cerulean3",
     "forest3",
     "gold3",
     "vermilion3",


### PR DESCRIPTION
I haven't filed an issue, but I think this is a pretty simple change.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

The qualitative colour array used to reference the Cobalt3, but is [rendering empty](https://blueprintjs.com/docs/#core/colors.qualitative-color-schemes) now that it's been removed. This replaces it with cerulean, which seems like the closest option now.
