### PR TITLE
Fix Typos In Comments

### DIFF
--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -138,7 +138,7 @@ describe("<OverflowList>", function (this) {
         it("invoked once per resize", async () => {
             // initial render shows all items (empty overflow)
             await overflowList(200).waitForResize();
-            // assert that at given width, onOverflow receives given Ds
+            // assert that at given width, onOverflow receives given IDs
             const tests = [
                 { width: 15, overflowIds: [0, 1, 2, 3, 4] },
                 { width: 55, overflowIds: [0] },
@@ -216,7 +216,7 @@ describe("<OverflowList>", function (this) {
             return wrapper;
         };
 
-        /** Asserts that the last call to `onOverflow` received the given item Ds. */
+        /** Asserts that the last call to `onOverflow` received the given item IDs. */
         wrapper.assertLastOnOverflowArgs = (ids: number[]) => {
             assert.sameMembers(
                 onOverflowSpy.lastCall.args[0].map((i: TestItemProps) => i.id),
@@ -227,7 +227,7 @@ describe("<OverflowList>", function (this) {
 
         /**
          * Invokes both assertions below with the expected visible and
-         * overflow Dsassuming `collapseFrom="start"`.
+         * overflow IDs assuming `collapseFrom="start"`.
          */
         wrapper.assertVisibleItemSplit = (visibleCount: number) => {
             const ids = (props.items ?? ITEMS).map(it => it.id);
@@ -236,7 +236,7 @@ describe("<OverflowList>", function (this) {
                 .assertVisibleItems(...ids.slice(-visibleCount));
         };
 
-        /** Assert ordered Dsof overflow items. */
+        /** Assert ordered IDs of overflow items. */
         wrapper.assertOverflowItems = (...ids: number[]) => {
             const overflowItems = wrapper.find(TestOverflow).prop("items");
             assert.sameMembers(
@@ -247,7 +247,7 @@ describe("<OverflowList>", function (this) {
             return wrapper;
         };
 
-        /** Assert ordered Dsof visible items. */
+        /** Assert ordered IDs of visible items. */
         wrapper.assertVisibleItems = (...ids: number[]) => {
             const visibleItems = wrapper.find(TestItem).map(div => div.prop("id"));
             assert.sameMembers(visibleItems, ids, "visible items");

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -25,7 +25,7 @@ import { generateTabIds } from "../../src/components/tabs/tabTitle";
 
 describe("<Tabs>", () => {
     const ID = "tabsTests";
-    // default tabs content is generated from these Dsin each test
+    // default tabs content is generated from these IDs in each test
     const TAB_IDS = ["first", "second", "third"];
 
     // selectors using ARIA role

--- a/packages/select/test/listItemsPropsTests.ts
+++ b/packages/select/test/listItemsPropsTests.ts
@@ -107,7 +107,7 @@ describe("ListItemsProps Utils", () => {
         });
 
         describe("itemsEqual is a function", () => {
-            // Simple equality comparator that compares Dsof ItemObjects.
+            // Simple equality comparator that compares IDs of ItemObjects.
             const equalityComparator = sinon.spy((itemA: ItemObject, itemB: ItemObject): boolean => {
                 return itemA.id === itemB.id;
             });

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -27,7 +27,7 @@ export interface ColumnProps extends ColumnNameProps, Props {
     /**
      * A unique ID, similar to React's `key`. This is used, for example, to
      * maintain the width of a column between re-ordering and rendering. If no
-     * Dsare provided, widths will be persisted across renders using a
+     * IDs are provided, widths will be persisted across renders using a
      * column's index only. Columns widths can also be persisted outside the
      * `Table` component, then passed in with the `columnWidths` prop.
      */


### PR DESCRIPTION
Fixes typos in some comments due to interfaces dropping the 'I' prefix in #4580.

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Updates comments in various places affected by a previous change. Notably places where the word "IDs" was found.

#### Reviewers should focus on:

Affected code comments should now be as per the previous revision where applicable. 

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
