### PR TITLE
Remove tab hotkey when in ROW FocusMode

### DIFF
--- a/packages/table/changelog/@unreleased/pr-7143.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-7143.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Remove tab hotkeys when in ROW FocusMode. Focus can be moved with the
+    arrow key hotkeys. This prevents focus from being trapped in the table, requiring
+    a user to tab through every row to access later elements with the tab key.
+  links:
+  - https://github.com/palantir/blueprint/pull/7143

--- a/packages/table/src/common/index.ts
+++ b/packages/table/src/common/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export type { CellCoordinates, FocusedCellCoordinates } from "./cellTypes";
+export type { CellCoordinates, FocusedCellCoordinates, FocusMode } from "./cellTypes";
 export { Clipboard } from "./clipboard";
 export { Grid } from "./grid";
 export { Rect, type AnyRect } from "./rect";

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -30,6 +30,7 @@ export {
     type AnyRect,
     type CellCoordinates,
     Clipboard,
+    type FocusMode,
     type FocusedCellCoordinates,
     Grid,
     Rect,

--- a/packages/table/src/table2Utils.ts
+++ b/packages/table/src/table2Utils.ts
@@ -110,20 +110,6 @@ function getFocusHotkeys(focusMode: FocusMode | undefined, hotkeysImpl: TableHot
                     label: "Move focus row down",
                     onKeyDown: hotkeysImpl.handleFocusMoveDown,
                 },
-                {
-                    allowInInput: true,
-                    combo: "tab",
-                    group: "Table",
-                    label: "Move focus row tab",
-                    onKeyDown: hotkeysImpl.handleFocusMoveDown,
-                },
-                {
-                    allowInInput: true,
-                    combo: "shift+tab",
-                    group: "Table",
-                    label: "Move focus row shift+tab",
-                    onKeyDown: hotkeysImpl.handleFocusMoveUp,
-                },
             ];
         case FocusMode.CELL:
             return [


### PR DESCRIPTION
#### Fixes no tracked issue

Quick follow on to the recent PR at https://github.com/palantir/blueprint/pull/7037 after testing an initial implementation.

#### Checklist
- [-] Includes tests
- [-] Update documentation

#### Changes proposed in this pull request:
Remove the tab and shift+tab hotkeys from Table2 ROW FocusMode. The reasoning is that with a table with a large number of rows, focus effectively becomes trapped in the table if navigating by tab key, since a user would need to tab through every row to proceed to later elements. Without these hotkeys, users will still see the focus indication, and can use the arrow keys to adjust the focused row.

#### Reviewers should focus on:
Do we need to expose a boolean toggle for this? I suppose for tables with small #s of rows this isn't really a problem and maybe someone would want tab to navigate through the rows

#### Screenshot
n/a