### PR TITLE
Patch upcoming React 18 SFC compile breaks in react-day-picker@7.4.9

### DIFF
--- a/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch
+++ b/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch
@@ -1,0 +1,31 @@
+diff --git a/types/Props.d.ts b/types/Props.d.ts
+index f8fcd45ab3048d9b34709eba1797597ac2facdec..3afa05a42f485ff23899f20df2ff9d85bf588eed 100644
+--- a/types/Props.d.ts
++++ b/types/Props.d.ts
+@@ -44,7 +44,7 @@ export interface DayPickerProps {
+   captionElement?:
+     | React.ReactElement<Partial<CaptionElementProps>>
+     | React.ComponentClass<CaptionElementProps>
+-    | React.SFC<CaptionElementProps>;
++    | React.FC<CaptionElementProps>;
+   className?: string;
+   classNames?: ClassNames;
+   containerProps?: React.DetailedHTMLProps<
+@@ -69,7 +69,7 @@ export interface DayPickerProps {
+   navbarElement?:
+     | React.ReactElement<Partial<NavbarElementProps>>
+     | React.ComponentClass<NavbarElementProps>
+-    | React.SFC<NavbarElementProps>;
++    | React.FC<NavbarElementProps>;
+   numberOfMonths?: number;
+   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
+   onCaptionClick?: (month: Date, e: React.MouseEvent<HTMLDivElement>) => void;
+@@ -142,7 +142,7 @@ export interface DayPickerProps {
+   weekdayElement?:
+     | React.ReactElement<Partial<WeekdayElementProps>>
+     | React.ComponentClass<WeekdayElementProps>
+-    | React.SFC<WeekdayElementProps>;
++    | React.FC<WeekdayElementProps>;
+   weekdaysLong?: string[];
+   weekdaysShort?: string[];
+   tabIndex?: number;

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -46,7 +46,7 @@
         "classnames": "^2.3.1",
         "date-fns": "^2.28.0",
         "date-fns-tz": "^2.0.0",
-        "react-day-picker": "7.4.9",
+        "react-day-picker": "patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch",
         "tslib": "~2.6.2"
     },
     "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,7 +540,7 @@ __metadata:
     mocha: "npm:^10.2.0"
     npm-run-all: "npm:^4.1.5"
     react: "npm:^16.14.0"
-    react-day-picker: "npm:7.4.9"
+    react-day-picker: "patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch"
     react-dom: "npm:^16.14.0"
     react-test-renderer: "npm:^16.14.0"
     tslib: "npm:~2.6.2"
@@ -13571,12 +13571,23 @@ __metadata:
   linkType: hard
 
 "react-day-picker@npm:^8.10.0":
-  version: 8.10.0
-  resolution: "react-day-picker@npm:8.10.0"
+  version: 8.10.1
+  resolution: "react-day-picker@npm:8.10.1"
   peerDependencies:
     date-fns: ^2.28.0 || ^3.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: e9868aced1e40b4cb7d6cf8d50e250226b38ec7ebea944b65aa9db20a0f36d0581b8a501297d09dcbf2d812de852168952b3fb27990915381629d6e314c2a4d8
+  checksum: a0ff28c4b61b3882e6a825b19e5679e2fdf3256cf1be8eb0a0c028949815c1ae5a6561474c2c19d231c010c8e0e0b654d3a322610881e0655abca05a2e03d9df
+  languageName: node
+  linkType: hard
+
+"react-day-picker@patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch":
+  version: 7.4.9
+  resolution: "react-day-picker@patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch::version=7.4.9&hash=5478a6"
+  dependencies:
+    prop-types: "npm:^15.6.2"
+  peerDependencies:
+    react: ~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 8a64e55f67a824d2a1bea0691ea082b710049ab07e747dbf9bd647e921ba22884597155514e08a6d60ff4231c788d51ac35870fa11573bd550aa803e7b223bc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Copied from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

#### Proposed changes:

This change patches the `react-day-picker@v7.4.9` used in the `@blueprint/datetime` library in order to prevent type compile breaks by some deprecated types included with the library. Specifically, it fixes the following:
```
../../node_modules/react-day-picker/types/Props.d.ts:47:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.
       47     | React.SFC<CaptionElementProps>;
                      ~~~
       ../../node_modules/react-day-picker/types/Props.d.ts:72:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.

       72     | React.SFC<NavbarElementProps>;
                      ~~~
       ../../node_modules/react-day-picker/types/Props.d.ts:145:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.

       145     | React.SFC<WeekdayElementProps>;
                       ~~~
```

This patch was generated via [`yarn patch`](https://yarnpkg.com/cli/patch).