### PR TITLE
Replace types deprecated in React 18

### DIFF
--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -92,7 +92,7 @@ export function isReactElement<T = any>(child: React.ReactNode): child is React.
     );
 }
 
-function isReactFragment(child: React.ReactNode): child is React.ReactFragment {
+function isReactFragment(child: React.ReactNode): child is Iterable<React.ReactNode> {
     // bit hacky, but generally works
     return typeof (child as any).type === "symbol";
 }

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -97,7 +97,7 @@ function isReactFragment(child: React.ReactNode): child is React.ReactFragment {
     return typeof (child as any).type === "symbol";
 }
 
-function isReactNodeArray(child: React.ReactNode): child is React.ReactNodeArray {
+function isReactNodeArray(child: React.ReactNode): child is React.ReactNode[] {
     return Array.isArray(child);
 }
 

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -44,7 +44,7 @@ export interface NonIdealStateProps extends Props {
      * A longer description of the non-ideal state.
      * A string or number value will be wrapped in a `<div>` to preserve margins.
      */
-    description?: React.ReactChild;
+    description?: React.ReactNode;
 
     /** The name of a Blueprint icon or a JSX element (such as `<Spinner/>`) to render above the title. */
     icon?: IconName | MaybeElement;

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -99,7 +99,7 @@ export interface OverflowListProps<T> extends Props {
      * Callback invoked to render each visible item.
      * Remember to set a `key` on the rendered element!
      */
-    visibleItemRenderer: (item: T, index: number) => React.ReactChild;
+    visibleItemRenderer: (item: T, index: number) => React.ReactNode;
 }
 
 export interface OverflowListState<T> {

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -861,7 +861,7 @@ describe("<DateInput>", () => {
         input.simulate("blur");
     }
 
-    function changeSelectDropdown(wrapper: ReactWrapper<DateInputProps>, className: string, value: React.ReactText) {
+    function changeSelectDropdown(wrapper: ReactWrapper<DateInputProps>, className: string, value: string | number) {
         wrapper
             .find(`.${className}`)
             .find("select")

--- a/packages/datetime2/test/components/dateInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateInput3Tests.tsx
@@ -941,7 +941,7 @@ describe("<DateInput3>", () => {
         input.simulate("blur");
     }
 
-    function changeSelectDropdown(wrapper: ReactWrapper<DateInput3Props>, className: string, value: React.ReactText) {
+    function changeSelectDropdown(wrapper: ReactWrapper<DateInput3Props>, className: string, value: string | number) {
         wrapper
             .find(`.${className}`)
             .find("select")

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -104,7 +104,7 @@ export class Navigator extends React.PureComponent<NavigatorProps> {
         }
 
         // insert caret-right between each path element
-        const pathElements = section.path.reduce<React.ReactChild[]>((elems, el) => {
+        const pathElements = section.path.reduce<React.ReactNode[]>((elems, el) => {
             elems.push(el, <CaretRight key={el} />);
             return elems;
         }, []);


### PR DESCRIPTION
Copied from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

#### Proposed changes:

Replaces types deprecated in React 18 for forward compatibility.