### PR TITLE
Wrap tests in TestUtils.act(...)

### DIFF
--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -22,6 +22,7 @@ import {
     shallow as untypedShallow,
 } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import { type SinonStub, spy, stub } from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
@@ -1097,8 +1098,11 @@ describe("<NumericInput>", () => {
             incrementButton.simulate("mousedown", { shiftKey: true });
             expect(component.find("input").prop("value")).to.equal("1.101");
 
-            // one significant digit too many
-            setNextValue(component, "1.0001");
+            TestUtils.act(() => {
+                // one significant digit too many
+                setNextValue(component, "1.0001");
+            });
+
             incrementButton.simulate("mousedown", { altKey: true });
             expect(component.find("input").prop("value")).to.equal("1.001");
         });
@@ -1361,7 +1365,9 @@ describe("<NumericInput>", () => {
                 minorStepSize: null,
             });
 
-            setNextValue(component, "3e2"); // i.e. 300
+            TestUtils.act(() => {
+                setNextValue(component, "3e2"); // i.e. 300
+            });
 
             simulateIncrement(component);
 

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import { spy } from "sinon";
 
 import { EditableText } from "../../src";
@@ -228,15 +229,21 @@ describe("<EditableText>", () => {
             const confirmSpy = spy();
             const wrapper = mount(<EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} />);
             simulateHelper(wrapper, "control", { ctrlKey: true, key: "Enter" });
-            wrapper.setState({ isEditing: true });
+            TestUtils.act(() => {
+                wrapper.setState({ isEditing: true });
+            });
             simulateHelper(wrapper, "meta", { metaKey: true, key: "Enter" });
-            wrapper.setState({ isEditing: true });
+            TestUtils.act(() => {
+                wrapper.setState({ isEditing: true });
+            });
             simulateHelper(wrapper, "shift", {
                 key: "Enter",
                 preventDefault: (): void => undefined,
                 shiftKey: true,
             });
-            wrapper.setState({ isEditing: true });
+            TestUtils.act(() => {
+                wrapper.setState({ isEditing: true });
+            });
             simulateHelper(wrapper, "alt", {
                 altKey: true,
                 key: "Enter",

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
@@ -178,7 +179,9 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const step = dialog.find(`.${Classes.DIALOG_STEP}`);
         step.at(0).simulate("focus");
-        dispatchTestKeyboardEvent(step.at(0).getDOMNode(), "keydown", "Enter");
+        TestUtils.act(() => {
+            dispatchTestKeyboardEvent(step.at(0).getDOMNode(), "keydown", "Enter");
+        });
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         dialog.unmount();
         testsContainerElement.remove();

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
@@ -153,7 +154,9 @@ describe("<Popover>", () => {
         it("adds POPOVER_OPEN class to target when the popover is open", () => {
             wrapper = renderPopover();
             assert.isFalse(wrapper.findClass(Classes.POPOVER_TARGET).hasClass(Classes.POPOVER_OPEN));
-            wrapper.setState({ isOpen: true });
+            TestUtils.act(() => {
+                wrapper?.setState({ isOpen: true });
+            });
             assert.isTrue(wrapper.findClass(Classes.POPOVER_TARGET).hasClass(Classes.POPOVER_OPEN));
         });
 

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -16,6 +16,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import { spy } from "sinon";
 
 import { Classes } from "../../src/common";
@@ -81,7 +82,9 @@ describe("<Tabs>", () => {
     it("renders all Tab children, active is not aria-hidden", () => {
         const activeIndex = 1;
         const wrapper = mount(<Tabs id={ID}>{getTabsContents()}</Tabs>);
-        wrapper.setState({ selectedTabId: TAB_IDS[activeIndex] });
+        TestUtils.act(() => {
+            wrapper.setState({ selectedTabId: TAB_IDS[activeIndex] });
+        });
         const tabPanels = wrapper.find(TAB_PANEL_SELECTOR);
         assert.lengthOf(tabPanels, 3);
         for (let i = 0; i < TAB_IDS.length; i++) {
@@ -160,7 +163,9 @@ describe("<Tabs>", () => {
             </Tabs>,
         );
         for (const selectedTabId of TAB_IDS) {
-            wrapper.setState({ selectedTabId });
+            TestUtils.act(() => {
+                wrapper.setState({ selectedTabId });
+            });
             assert.lengthOf(wrapper.find("strong"), 1);
         }
     });

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -17,6 +17,7 @@
 import { assert, expect } from "chai";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { Button, Classes, Intent, Tag, TagInput, type TagInputProps } from "../../src";
@@ -211,24 +212,30 @@ describe("<TagInput>", () => {
         it("does not clear the input if onAdd returns false", () => {
             const onAdd = sinon.stub().returns(false);
             const wrapper = mountTagInput(onAdd);
-            wrapper.setState({ inputValue: NEW_VALUE });
-            pressEnterInInput(wrapper, NEW_VALUE);
+            TestUtils.act(() => {
+                wrapper.setState({ inputValue: NEW_VALUE });
+                pressEnterInInput(wrapper, NEW_VALUE);
+            });
             assert.strictEqual(wrapper.state().inputValue, NEW_VALUE);
         });
 
         it("clears the input if onAdd returns true", () => {
             const onAdd = sinon.stub().returns(true);
             const wrapper = mountTagInput(onAdd);
-            wrapper.setState({ inputValue: NEW_VALUE });
-            pressEnterInInput(wrapper, NEW_VALUE);
+            TestUtils.act(() => {
+                wrapper.setState({ inputValue: NEW_VALUE });
+                pressEnterInInput(wrapper, NEW_VALUE);
+            });
             assert.strictEqual(wrapper.state().inputValue, "");
         });
 
         it("clears the input if onAdd returns nothing", () => {
             const onAdd = sinon.stub();
             const wrapper = mountTagInput(onAdd);
-            wrapper.setState({ inputValue: NEW_VALUE });
-            pressEnterInInput(wrapper, NEW_VALUE);
+            TestUtils.act(() => {
+                wrapper.setState({ inputValue: NEW_VALUE });
+                pressEnterInInput(wrapper, NEW_VALUE);
+            });
             assert.strictEqual(wrapper.state().inputValue, "");
         });
 
@@ -382,24 +389,30 @@ describe("<TagInput>", () => {
         it("does not clear the input if onChange returns false", () => {
             const onChange = sinon.stub().returns(false);
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            wrapper.setState({ inputValue: NEW_VALUE });
-            pressEnterInInput(wrapper, NEW_VALUE);
+            TestUtils.act(() => {
+                wrapper.setState({ inputValue: NEW_VALUE });
+                pressEnterInInput(wrapper, NEW_VALUE);
+            });
             assert.strictEqual(wrapper.state().inputValue, NEW_VALUE);
         });
 
         it("clears the input if onChange returns true", () => {
             const onChange = sinon.stub().returns(true);
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            wrapper.setState({ inputValue: NEW_VALUE });
-            pressEnterInInput(wrapper, NEW_VALUE);
+            TestUtils.act(() => {
+                wrapper.setState({ inputValue: NEW_VALUE });
+                pressEnterInInput(wrapper, NEW_VALUE);
+            });
             assert.strictEqual(wrapper.state().inputValue, "");
         });
 
         it("clears the input if onChange returns nothing", () => {
             const onChange = sinon.spy();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            wrapper.setState({ inputValue: NEW_VALUE });
-            pressEnterInInput(wrapper, NEW_VALUE);
+            TestUtils.act(() => {
+                wrapper.setState({ inputValue: NEW_VALUE });
+                pressEnterInInput(wrapper, NEW_VALUE);
+            });
             assert.strictEqual(wrapper.state().inputValue, "");
         });
 
@@ -610,7 +623,9 @@ function runKeyPressTest(callbackName: "onKeyDown" | "onKeyUp", startIndex: numb
     const inputProps = { [callbackName]: sinon.spy() };
     const wrapper = mount(<TagInput values={VALUES} inputProps={inputProps} {...{ [callbackName]: callbackSpy }} />);
 
-    wrapper.setState({ activeIndex: startIndex });
+    TestUtils.act(() => {
+        wrapper.setState({ activeIndex: startIndex });
+    });
 
     const eventName = callbackName === "onKeyDown" ? "keydown" : "keyup";
     wrapper.find("input").simulate("focus").simulate(eventName, { key: "Enter" });

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -139,7 +139,9 @@ describe("<DateRangeInput>", () => {
                 popoverProps={{ className: CLASS_2, usePortal: false }}
             />,
         );
-        wrapper.setState({ isOpen: true });
+        TestUtils.act(() => {
+            wrapper.setState({ isOpen: true });
+        });
 
         const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_TARGET}`).hostNodes();
         expect(popoverTarget.hasClass(CLASS_1)).to.be.true;
@@ -148,7 +150,9 @@ describe("<DateRangeInput>", () => {
 
     it("inner DateRangePicker receives all supported props", () => {
         const component = mount(<DateRangeInput {...DATE_FORMAT} locale="uk" contiguousCalendarMonths={false} />);
-        component.setState({ isOpen: true });
+        TestUtils.act(() => {
+            component.setState({ isOpen: true });
+        });
         component.update();
         const picker = component.find(DateRangePicker);
         expect(picker.prop("locale")).to.equal("uk");
@@ -168,7 +172,9 @@ describe("<DateRangeInput>", () => {
         it("<TimePicker /> should not lose focus on increment/decrement with up/down arrows", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             expect(root.find(Popover).prop("isOpen")).to.be.true;
 
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
@@ -182,13 +188,17 @@ describe("<DateRangeInput>", () => {
                 true,
             );
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
 
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
 
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
@@ -199,7 +209,9 @@ describe("<DateRangeInput>", () => {
         it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
             root.update();
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp", 1);
@@ -372,7 +384,9 @@ describe("<DateRangeInput>", () => {
     describe("closeOnSelection", () => {
         it("if closeOnSelection=false, popover stays open when full date range is selected", () => {
             const { root, getDayElement } = wrap(<DateRangeInput {...DATE_FORMAT} closeOnSelection={false} />, true);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
@@ -382,7 +396,9 @@ describe("<DateRangeInput>", () => {
 
         it("if closeOnSelection=true, popover closes when full date range is selected", () => {
             const { root, getDayElement } = wrap(<DateRangeInput {...DATE_FORMAT} />, true);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
@@ -395,7 +411,9 @@ describe("<DateRangeInput>", () => {
                 <DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
                 true,
             );
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
@@ -407,21 +425,27 @@ describe("<DateRangeInput>", () => {
 
     it("accepts contiguousCalendarMonths prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} contiguousCalendarMonths={false} />);
-        root.setState({ isOpen: true });
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
         root.update();
         expect(root.find(DateRangePicker).prop("contiguousCalendarMonths")).to.be.false;
     });
 
     it("accepts singleMonthOnly prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} singleMonthOnly={false} />);
-        root.setState({ isOpen: true });
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
         root.update();
         expect(root.find(DateRangePicker).prop("singleMonthOnly")).to.be.false;
     });
 
     it("accepts shortcuts prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} shortcuts={false} />);
-        root.setState({ isOpen: true });
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
         root.update();
         expect(root.find(DateRangePicker).prop("shortcuts")).to.be.false;
     });
@@ -430,7 +454,9 @@ describe("<DateRangeInput>", () => {
         const selectedShortcut = 1;
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} />);
 
-        root.setState({ isOpen: true });
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
         root.update();
         root.find(DateRangePicker)
             .find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`)
@@ -491,7 +517,9 @@ describe("<DateRangeInput>", () => {
                 true,
             );
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             // getDay is 0-indexed, but getDayElement is 1-indexed
             getDayElement(START_DATE_2.getDay() + 1).simulate("mouseenter");
 
@@ -577,7 +605,9 @@ describe("<DateRangeInput>", () => {
             const startInputProps = { onKeyDown: sinon.spy() };
             const endInputProps = { onKeyDown: sinon.spy() };
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} {...{ startInputProps, endInputProps }} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
 
             // Don't save the input elements into variables; they can become
             // stale across React updates.
@@ -604,7 +634,9 @@ describe("<DateRangeInput>", () => {
 
         it("pressing Escape closes the popover", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} value={[null, null]} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
 
             const startInput = getStartInput(root);
             startInput.simulate("focus");
@@ -629,7 +661,9 @@ describe("<DateRangeInput>", () => {
                     onChange={onChange}
                 />,
             );
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
 
             getDayElement(END_DAY).simulate("click");
@@ -1107,7 +1141,9 @@ describe("<DateRangeInput>", () => {
 
             beforeEach(() => {
                 // need to set wasLastFocusChangeDueToHover=false to fully reset state between tests.
-                root.setState({ isOpen: true, wasLastFocusChangeDueToHover: false });
+                TestUtils.act(() => {
+                    root.setState({ isOpen: true, wasLastFocusChangeDueToHover: false });
+                });
                 // clear the inputs to start from a fresh state, but do so
                 // *after* opening the popover so that the calendar doesn't
                 // move away from the view we expect for these tests.
@@ -2288,6 +2324,7 @@ describe("<DateRangeInput>", () => {
         });
     });
 
+    // HERE
     describe("when controlled", () => {
         it("Setting value causes defaultValue to be ignored", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} defaultValue={DATE_RANGE_2} value={DATE_RANGE} />);
@@ -2321,7 +2358,9 @@ describe("<DateRangeInput>", () => {
 
         it("Updating value changes the text accordingly in both fields", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} value={DATE_RANGE} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             root.update();
             root.setProps({ value: DATE_RANGE_2 });
             root.update();
@@ -2333,7 +2372,9 @@ describe("<DateRangeInput>", () => {
         it.skip("Pressing Enter saves the inputted date and closes the popover", () => {
             const onChange = sinon.spy();
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} onChange={onChange} value={[null, null]} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
 
             const startInput = getStartInput(root);
             startInput.simulate("focus");

--- a/packages/datetime/test/components/timezoneSelectTests.tsx
+++ b/packages/datetime/test/components/timezoneSelectTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
 import {
@@ -78,7 +79,9 @@ describe("<TimezoneSelect>", () => {
 
     it("if query is not empty, shows all items", () => {
         const timezoneSelect = mountTS();
-        timezoneSelect.setState({ query: "not empty" });
+        TestUtils.act(() => {
+            timezoneSelect.setState({ query: "not empty" });
+        });
         timezoneSelect.update();
         const items = timezoneSelect.find(Select).prop("items");
         assert.lengthOf(items, TIMEZONE_ITEMS.length);

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -153,7 +153,9 @@ describe("<DateRangeInput3>", () => {
                 popoverProps={{ className: CLASS_2, usePortal: false }}
             />,
         );
-        wrapper.setState({ isOpen: true });
+        TestUtils.act(() => {
+            wrapper.setState({ isOpen: true });
+        });
 
         const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_TARGET}`).hostNodes();
         expect(popoverTarget.hasClass(CLASS_1)).to.be.true;
@@ -162,7 +164,9 @@ describe("<DateRangeInput3>", () => {
 
     it("inner DateRangePicker3 receives all supported props", () => {
         const component = mount(<DateRangeInput3 {...DATE_FORMAT} locale="uk" contiguousCalendarMonths={false} />);
-        component.setState({ isOpen: true });
+        TestUtils.act(() => {
+            component.setState({ isOpen: true });
+        });
         component.update();
         const picker = component.find(DateRangePicker3);
         expect(picker.prop("locale")).to.equal("uk");
@@ -182,7 +186,10 @@ describe("<DateRangeInput3>", () => {
         it("<TimePicker /> should not lose focus on increment/decrement with up/down arrows", () => {
             const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
             expect(root.find(Popover).prop("isOpen"), "Popover isOpen").to.be.true;
 
             keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
@@ -196,12 +203,18 @@ describe("<DateRangeInput3>", () => {
                 true,
             );
 
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
 
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
 
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
 
             keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
             root.update();
@@ -211,7 +224,9 @@ describe("<DateRangeInput3>", () => {
         it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
             const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp");
             root.update();
             keyDownOnInput(DatetimeClasses.TIMEPICKER_HOUR, "ArrowUp", 1);
@@ -384,7 +399,10 @@ describe("<DateRangeInput3>", () => {
     describe("closeOnSelection", () => {
         it("if closeOnSelection=false, popover stays open when full date range is selected", () => {
             const { root, getDayElement } = wrap(<DateRangeInput3 {...DATE_FORMAT} closeOnSelection={false} />, true);
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
             expect(root.state("isOpen")).to.be.true;
@@ -393,7 +411,10 @@ describe("<DateRangeInput3>", () => {
 
         it("if closeOnSelection=true, popover closes when full date range is selected", () => {
             const { root, getDayElement } = wrap(<DateRangeInput3 {...DATE_FORMAT} />, true);
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
             expect(root.state("isOpen")).to.be.false;
@@ -405,7 +426,10 @@ describe("<DateRangeInput3>", () => {
                 <DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
                 true,
             );
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
             root.update();
@@ -416,19 +440,28 @@ describe("<DateRangeInput3>", () => {
 
     it("accepts contiguousCalendarMonths prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} contiguousCalendarMonths={false} />);
-        root.setState({ isOpen: true }).update();
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
         expect(root.find(DateRangePicker3).prop("contiguousCalendarMonths")).to.be.false;
     });
 
     it("accepts singleMonthOnly prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} singleMonthOnly={false} />);
-        root.setState({ isOpen: true }).update();
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
         expect(root.find(DateRangePicker3).prop("singleMonthOnly")).to.be.false;
     });
 
     it("accepts shortcuts prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} shortcuts={false} />);
-        root.setState({ isOpen: true }).update();
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
         expect(root.find(DateRangePicker3).prop("shortcuts")).to.be.false;
     });
 
@@ -436,7 +469,10 @@ describe("<DateRangeInput3>", () => {
         const selectedShortcut = 1;
         const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} />);
 
-        root.setState({ isOpen: true }).update();
+        TestUtils.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
         root.find(DateRangePicker3)
             .find(`.${DatetimeClasses.DATERANGEPICKER_SHORTCUTS}`)
             .find("a")
@@ -496,7 +532,9 @@ describe("<DateRangeInput3>", () => {
                 true,
             );
 
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
             // getDay is 0-indexed, but getDayElement is 1-indexed
             getDayElement(START_DATE_2.getDay() + 1).simulate("mouseenter");
 
@@ -582,7 +620,9 @@ describe("<DateRangeInput3>", () => {
             const startInputProps = { onKeyDown: sinon.spy() };
             const endInputProps = { onKeyDown: sinon.spy() };
             const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...{ startInputProps, endInputProps }} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
 
             // Don't save the input elements into variables; they can become
             // stale across React updates.
@@ -619,7 +659,10 @@ describe("<DateRangeInput3>", () => {
                     onChange={onChange}
                 />,
             );
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
 
             getDayElement(END_DAY).simulate("click");
             assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, END_STR]);
@@ -1381,7 +1424,9 @@ describe("<DateRangeInput3>", () => {
 
             beforeEach(() => {
                 // need to set wasLastFocusChangeDueToHover=false to fully reset state between tests.
-                root.setState({ isOpen: true, wasLastFocusChangeDueToHover: false });
+                TestUtils.act(() => {
+                    root.setState({ isOpen: true, wasLastFocusChangeDueToHover: false });
+                });
                 // clear the inputs to start from a fresh state, but do so
                 // *after* opening the popover so that the calendar doesn't
                 // move away from the view we expect for these tests.
@@ -2595,7 +2640,10 @@ describe("<DateRangeInput3>", () => {
 
         it("Updating value changes the text accordingly in both fields", () => {
             const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={DATE_RANGE} />);
-            root.setState({ isOpen: true }).update();
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
             root.setProps({ value: DATE_RANGE_2 }).update();
             assertInputValuesEqual(root, START_STR_2, END_STR_2);
         });
@@ -2605,7 +2653,9 @@ describe("<DateRangeInput3>", () => {
         it.skip("Pressing Enter saves the inputted date and closes the popover", () => {
             const onChange = sinon.spy();
             const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={[null, null]} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
 
             const startInput = getStartInput(root);
             startInput.simulate("focus");
@@ -2631,7 +2681,9 @@ describe("<DateRangeInput3>", () => {
 
         it("pressing Escape closes the popover", () => {
             const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[null, null]} />);
-            root.setState({ isOpen: true });
+            TestUtils.act(() => {
+                root.setState({ isOpen: true });
+            });
 
             const startInput = getStartInput(root);
             startInput.simulate("focus");

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { type HTMLAttributes, mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { Button, Classes as CoreClasses, Popover, Tag } from "@blueprintjs/core";
@@ -174,7 +175,9 @@ describe("<MultiSelect>", () => {
             </MultiSelect>,
         );
         if (query !== undefined) {
-            wrapper.setState({ query });
+            TestUtils.act(() => {
+                wrapper.setState({ query });
+            });
         }
         return wrapper;
     }

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { Menu } from "@blueprintjs/core";
@@ -117,8 +118,12 @@ describe("<QueryList>", () => {
             const filmQueryList = mount(
                 <QueryList<Film> {...testProps} items={[myItem]} activeItem={myItem} query="" />,
             );
-            filmQueryList.setState({ query: "query" });
-            filmQueryList.setState({ activeItem: undefined });
+            TestUtils.act(() => {
+                filmQueryList.setState({ query: "query" });
+            });
+            TestUtils.act(() => {
+                filmQueryList.setState({ activeItem: undefined });
+            });
             assert.equal(testProps.onActiveItemChange.callCount, 0);
         });
 
@@ -272,7 +277,9 @@ describe("<QueryList>", () => {
             const pastedValue2 = item2.title;
             const pastedValue3 = item3.title;
 
-            handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+            TestUtils.act(() => {
+                handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+            });
 
             assert.isTrue(onItemsPaste.calledOnce);
             // Emits all three items.
@@ -293,7 +300,9 @@ describe("<QueryList>", () => {
             const pastedValue3 = "unrecognized2";
             const pastedValue4 = item4.title;
 
-            handlePaste([pastedValue1, pastedValue2, pastedValue3, pastedValue4]);
+            TestUtils.act(() => {
+                handlePaste([pastedValue1, pastedValue2, pastedValue3, pastedValue4]);
+            });
 
             assert.isTrue(onItemsPaste.calledOnce);
             // Emits just the 2 valid items.
@@ -325,7 +334,10 @@ describe("<QueryList>", () => {
             // Paste this item last.
             const pastedValue3 = "unrecognized";
 
-            handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+            TestUtils.act(() => {
+                handlePaste([pastedValue1, pastedValue2, pastedValue3]);
+            });
+
             const createdItem = { title: "unrecognized", rank: createdRank, year: createdYear };
 
             assert.isTrue(onItemsPaste.calledOnce);

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { type HTMLAttributes, mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
 import { Button, Classes, InputGroup, MenuItem, Popover } from "@blueprintjs/core";
@@ -187,7 +188,9 @@ describe("<Select>", () => {
             { attachTo: testsContainerElement },
         );
         if (query !== undefined) {
-            wrapper.setState({ query });
+            TestUtils.act(() => {
+                wrapper.setState({ query });
+            });
         }
         return wrapper;
     }

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -17,6 +17,7 @@
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
 import { InputGroup, MenuItem, Popover, type PopoverProps } from "@blueprintjs/core";
@@ -107,9 +108,13 @@ describe("Suggest", () => {
             const wrapper = suggest();
             const queryList = (wrapper.instance() as Suggest<Film> as any).queryList; // private ref
             const scrollActiveItemIntoViewSpy = sinon.spy(queryList, "scrollActiveItemIntoView");
-            wrapper.setState({ isOpen: false });
+            TestUtils.act(() => {
+                wrapper.setState({ isOpen: false });
+            });
             assert.isFalse(scrollActiveItemIntoViewSpy.called);
-            wrapper.setState({ isOpen: true });
+            TestUtils.act(() => {
+                wrapper.setState({ isOpen: true });
+            });
             assert.strictEqual(scrollActiveItemIntoViewSpy.callCount, 1, "should call scrollActiveItemIntoView");
         });
 

--- a/packages/table/test/editableCell2Tests.tsx
+++ b/packages/table/test/editableCell2Tests.tsx
@@ -17,6 +17,7 @@
 import { expect } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";
@@ -74,7 +75,9 @@ describe("<EditableCell2>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        });
         const input = elem.find("input");
         expect(input).to.have.lengthOf(1);
 
@@ -101,7 +104,9 @@ describe("<EditableCell2>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        });
         const input = elem.find(`.${TableClasses.TABLE_EDITABLE_TEXT} input`);
         expect(input).to.have.lengthOf(1);
 
@@ -145,7 +150,9 @@ describe("<EditableCell2>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "" });
+        });
 
         // change value
         elem.find("input").simulate("change", { target: { value: CHANGED_VALUE } });
@@ -186,7 +193,9 @@ describe("<EditableCell2>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        });
         const input = elem.find("input");
         // input props that EditableCell2 does not care about should pass through unchanged
         expect(input.prop("maxLength")).to.equal(345);

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -22,6 +22,7 @@
 import { expect } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
+import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";
@@ -81,7 +82,9 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        });
         const input = elem.find("input");
         expect(input).to.have.lengthOf(1);
 
@@ -108,7 +111,9 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        });
         const input = elem.find(`.${TableClasses.TABLE_EDITABLE_TEXT} input`);
         expect(input).to.have.lengthOf(1);
 
@@ -152,7 +157,9 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "" });
+        });
 
         // change value
         elem.find("input").simulate("change", { target: { value: CHANGED_VALUE } });
@@ -193,7 +200,9 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        TestUtils.act(() => {
+            elem.setState({ isEditing: true, dirtyValue: "test-value-5000" });
+        });
         const input = elem.find("input");
         // input props that EditableCell does not care about should pass through unchanged
         expect(input.prop("maxLength")).to.equal(345);

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -637,7 +637,9 @@ describe("<Table2>", function (this) {
                     <Column />
                 </Table2>,
             );
-            table.setState({ selectedRegions: [Regions.column(0)] });
+            TestUtils.act(() => {
+                table.setState({ selectedRegions: [Regions.column(0)] });
+            });
             table.setProps({ selectionModes: [] });
             expect(table.state("selectedRegions")).to.have.lengthOf(0);
         });
@@ -1895,14 +1897,18 @@ describe("<Table2>", function (this) {
         describe("clears all uncontrolled selections", () => {
             it("when numRows becomes 0", () => {
                 table = mountTable(1, 1);
-                table.setState({ selectedRegions: SELECTED_REGIONS });
+                TestUtils.act(() => {
+                    table.setState({ selectedRegions: SELECTED_REGIONS });
+                });
                 table.setProps({ numRows: 0 });
                 expectNoSelectedRegions();
             });
 
             it("when numCols becomes 0", () => {
                 table = mountTable(1, 1);
-                table.setState({ selectedRegions: SELECTED_REGIONS });
+                TestUtils.act(() => {
+                    table.setState({ selectedRegions: SELECTED_REGIONS });
+                });
                 table.setProps({ children: [] });
                 expectNoSelectedRegions();
             });

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -25,6 +25,7 @@ import { expect } from "chai";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
@@ -596,7 +597,9 @@ describe("<Table>", function (this) {
                 <Column />
             </Table>,
         );
-        table.setState({ selectedRegions: [Regions.column(0)] });
+        TestUtils.act(() => {
+            table.setState({ selectedRegions: [Regions.column(0)] });
+        });
         table.setProps({ selectionModes: [] });
         expect(table.state("selectedRegions")).to.have.lengthOf(0);
     });
@@ -1404,8 +1407,10 @@ describe("<Table>", function (this) {
             const viewportTop = DEFAULT_FOCUSED_CELL_COORDS.row * ROW_HEIGHT;
             const viewportWidth = COL_WIDTH;
             const viewportHeight = ROW_HEIGHT;
-            component.setState({
-                viewportRect: new Rect(viewportLeft, viewportTop, viewportWidth, viewportHeight),
+            TestUtils.act(() => {
+                component.setState({
+                    viewportRect: new Rect(viewportLeft, viewportTop, viewportWidth, viewportHeight),
+                });
             });
 
             return { attachTo, component };
@@ -1838,14 +1843,18 @@ describe("<Table>", function (this) {
         describe("clears all uncontrolled selections", () => {
             it("when numRows becomes 0", () => {
                 table = mountTable(1, 1);
-                table.setState({ selectedRegions: SELECTED_REGIONS });
+                TestUtils.act(() => {
+                    table.setState({ selectedRegions: SELECTED_REGIONS });
+                });
                 table.setProps({ numRows: 0 });
                 expectNoSelectedRegions();
             });
 
             it("when numCols becomes 0", () => {
                 table = mountTable(1, 1);
-                table.setState({ selectedRegions: SELECTED_REGIONS });
+                TestUtils.act(() => {
+                    table.setState({ selectedRegions: SELECTED_REGIONS });
+                });
                 table.setProps({ children: [] });
                 expectNoSelectedRegions();
             });


### PR DESCRIPTION
Copied from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

#### Changes proposed in this pull request:

Updates instances where we call `setState` in tests that lead to warnings such as this:
```
When testing, code that causes React state updates should be wrapped into act(...):

act(() => {
  /* fire events that update state */
});
/* assert on the output */

This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
```
as well as failures on the main feature branch when running in React 18.

