### PR TITLE
chore: Remove no-submodule-imports rule

### DIFF
--- a/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
@@ -15,7 +15,6 @@
  */
 
 import React from "react";
-// tslint:disable-next-line no-submodule-imports
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 import { Classes } from "../../common";

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -20,7 +20,6 @@ import * as React from "react";
 import { type SinonStub, stub } from "sinon";
 
 import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
-// tslint:disable-next-line no-submodule-imports
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 
 import { Classes, Icon, type IconProps, Intent } from "../../src";

--- a/packages/datetime/test/index.ts
+++ b/packages/datetime/test/index.ts
@@ -2,7 +2,6 @@
  * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
  */
 
-// tslint:disable-next-line no-submodule-imports
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "../lib/css/blueprint-datetime.css";
 import "./test-debugging-styles.scss";

--- a/packages/datetime2/test/components/dateInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateInput3Tests.tsx
@@ -32,7 +32,6 @@ import {
     TimezoneSelect,
     TimezoneUtils,
 } from "@blueprintjs/datetime";
-// tslint:disable-next-line no-submodule-imports
 import { TIMEZONE_ITEMS } from "@blueprintjs/datetime/lib/esm/common/timezoneItems";
 
 import { Datetime2Classes as Classes, DateInput3, type DateInput3Props, DatePicker3 } from "../../src";

--- a/packages/datetime2/test/index.ts
+++ b/packages/datetime2/test/index.ts
@@ -2,7 +2,6 @@
  * Copyright 2022 Palantir Technologies, Inc. All rights reserved.
  */
 
-// tslint:disable no-submodule-imports
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/datetime/lib/css/blueprint-datetime.css";
 import "../lib/css/blueprint-datetime2.css";

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -18,7 +18,6 @@ import * as React from "react";
 
 import { Classes, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { TimePicker, TimePrecision } from "@blueprintjs/datetime";
-// tslint:disable-next-line:no-submodule-imports
 import { getDefaultMaxTime, getDefaultMinTime } from "@blueprintjs/datetime/lib/esm/common/timeUnit";
 import { Example, type ExampleProps, handleNumberChange, handleValueChange } from "@blueprintjs/docs-theme";
 

--- a/packages/eslint-config/tslint.json
+++ b/packages/eslint-config/tslint.json
@@ -1,19 +1,6 @@
 {
     "defaultSeverity": "error",
     "rules": {
-        "no-submodule-imports": {
-            "options": [
-                "core-js",
-                "date-fns",
-                "lodash",
-                "react-dom",
-                "@blueprintjs/icons/icons.json",
-                "@blueprintjs/select/examples",
-                "@blueprintjs/table/src",
-                "@blueprintjs/test-commons/bootstrap",
-                "tsutils"
-            ]
-        },
         "object-literal-sort-keys": true
     }
 }

--- a/packages/landing-app/src/svgs/index.ts
+++ b/packages/landing-app/src/svgs/index.ts
@@ -15,7 +15,6 @@
  */
 
 /* eslint-disable @typescript-eslint/no-var-requires */
-// tslint:disable no-submodule-imports
 
 const HERO_SVGS: Record<string, string> = {
     alert: require("raw-loader!./alert.svg").default,

--- a/packages/select/test/index.ts
+++ b/packages/select/test/index.ts
@@ -4,10 +4,8 @@
 
 import "@blueprintjs/test-commons/bootstrap";
 
-// tslint:disable no-submodule-imports
 import "normalize.css/normalize.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
-// tslint:enable no-submodule-imports
 import "../lib/css/blueprint-select.css";
 
 import "./itemRendererTests";


### PR DESCRIPTION
There's no good eslint equivalent of this rule so removing it