### PR TITLE
Docs: Update examples that reference ReactDOM.render

### DIFF
--- a/packages/core/src/components/portal/portal.md
+++ b/packages/core/src/components/portal/portal.md
@@ -40,15 +40,16 @@ components which use portals (popovers, tooltips, dialogs, etc.). You can do so 
 ```tsx
 import { Button, Popover, PortalProvider } from "@blueprintjs/core";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
     <PortalProvider portalClassName="my-custom-class">
         <Popover content="My portal has a custom class">
             <Button text="Example" />
         </Popover>
-    </PortalProvider>
-    document.querySelector("#app"),
+    </PortalProvider>,
 );
 ```
 

--- a/packages/core/src/context/blueprint-provider.md
+++ b/packages/core/src/context/blueprint-provider.md
@@ -22,13 +22,14 @@ To use **BlueprintProvider**, wrap your application with it at the root level:
 ```tsx
 import { BlueprintProvider } from "@blueprintjs/core";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
     <BlueprintProvider>
         <div>My app has overlays, hotkeys, and portal customization 😎</div>
     </BlueprintProvider>,
-    document.querySelector("#app"),
 );
 ```
 

--- a/packages/core/src/context/overlays/overlays-provider.md
+++ b/packages/core/src/context/overlays/overlays-provider.md
@@ -42,13 +42,14 @@ To use **OverlaysProvider**, wrap your application with it at the root level:
 ```tsx
 import { OverlaysProvider } from "@blueprintjs/core";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
     <OverlaysProvider>
         <div>My app has overlays 😎</div>
     </OverlaysProvider>,
-    document.querySelector("#app"),
 );
 ```
 

--- a/packages/core/src/context/portal/portal-provider.md
+++ b/packages/core/src/context/portal/portal-provider.md
@@ -26,15 +26,16 @@ To use **PortalProvider**, wrap your application with it at the root level:
 ```tsx
 import { PortalProvider, Dialog } from "@blueprintjs/core";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
     <PortalProvider portalClassName="my-portal">
         <Dialog isOpen={true}>
             <span>This dialog will have a custom class on its portal element.</span>
         </Dialog>
     </PortalProvider>,
-    document.querySelector("#app"),
 );
 ```
 

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -110,31 +110,27 @@ For more information, see [Understanding TypeScript](#blueprint/reading-the-docs
 @## Vanilla JS APIs
 
 JS components are built using React, but that does not limit their usage to only React applications.
-You can render any component in any JavaScript application with `ReactDOM.render`. Think of it like
+You can render any component in any JavaScript application with `render`. Think of it like
 using a jQuery plugin.
 
 ```tsx
 import { Classes, Spinner } from "@blueprintjs/core";
+import { createRoot } from "react-dom/client";
 
-const myContainerElement = document.getElementById("container");
+const domNode = document.getElementById("root");
+const root = createRoot(domNode);
 
 // with JSX
-ReactDOM.render(<Spinner className={Classes.SMALL} intent="primary" />, myContainerElement);
+root.render(<Spinner className={Classes.SMALL} intent="primary" />);
 
 // with vanilla JS, use React.createElement
-ReactDOM.render(
-    React.createElement(Spinner, {
-        className: Classes.SMALL,
-        intent: "primary",
-    }),
-    myContainerElement,
-);
+root.render(React.createElement(Spinner, { className: Classes.SMALL, intent: "primary" }));
 ```
 
 To remove the component from the DOM and clean up, unmount it:
 
 ```tsx
-ReactDOM.unmountComponentAtNode(myContainerElement);
+root.unmount();
 ```
 
 Check out the [React API docs](https://facebook.github.io/react/docs/react-api.html) for more details.
@@ -182,7 +178,8 @@ These bundles _do not include_ external dependencies; your application will need
                 icon: "cloud",
                 text: "CDN Blueprint is go!",
             });
-            ReactDOM.render(button, document.querySelector("#btn"));
+            const root = ReactDOM.createRoot(document.getElementById("btn"));
+            root.render(button);
         </script>
     </body>
 </html>

--- a/packages/icons/src/loading-icons.md
+++ b/packages/icons/src/loading-icons.md
@@ -22,47 +22,47 @@ from the icons package.
 ```tsx
 import { Button } from "@blueprintjs/core";
 import { Download } from "@blueprintjs/icons";
-import * as ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
-    <Button text="Download" icon={<Download size={16} />} />,
-    document.querySelector(".my-app")
-)
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(<Button text="Download" icon={<Download size={16} />} />);
 ```
 
 This approach has benefits and tradeoffs:
 
-- Bundling only the icons you need is trivial with a properly-configured bundler which supports tree-shaking.
-- You do have to explicitly import each icon you use as an ES import.
-- You do have to take care to specify the correct icon size (if it is not the default 16px size) depending on the usage context.
+-   Bundling only the icons you need is trivial with a properly-configured bundler which supports tree-shaking.
+-   You do have to explicitly import each icon you use as an ES import.
+-   You do have to take care to specify the correct icon size (if it is not the default 16px size) depending on the usage context.
 
 @## Using dynamic imports
 
 Blueprint's icon props APIs _also_ accept a type-safe icon name string literal. This approach has some benefits:
 
-- You _do not_ have to explicitly import each icon you use as an ES import
-- The icon will usually be automatically sized for you depending on its usage context
+-   You _do not_ have to explicitly import each icon you use as an ES import
+-   The icon will usually be automatically sized for you depending on its usage context
 
 It looks like this in your render code path:
 
 ```tsx
 import { Button } from "@blueprintjs/core";
-import * as ReactDOM from "react-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
-    <Button text="Download" icon="download" />,
-    document.querySelector(".my-app")
-)
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(<Button text="Download" icon="download" />);
 ```
 
 These usability benefits do come at the cost of some some extra work for Blueprint (and some extra configuration for you, the
 Blueprint user) in order for these icons to be available at runtime. With the string literal API, **Blueprint code is
-importing icon modules for you**.  Let's take a look at this required configuration.
+importing icon modules for you**. Let's take a look at this required configuration.
 
 1. Use the default dynamic import API to bundle icon paths into two chunks (standard & large sizes) separate from your
-    entry point. This requires a bundler or module loader which can handle `await import()` statements. These statements
-    are annotated with [Webpack magic comments](https://webpack.js.org/api/module-methods/#magic-comments), but they do
-    not explicitly require Webpack to function.
+   entry point. This requires a bundler or module loader which can handle `await import()` statements. These statements
+   are annotated with [Webpack magic comments](https://webpack.js.org/api/module-methods/#magic-comments), but they do
+   not explicitly require Webpack to function.
 
     With this API, the first usage of any icon in a given size (standard or large) will trigger a request to fetch a
     bundle containing all the icon paths of that size. This behavior is enabled by default since the standard icon size
@@ -91,17 +91,17 @@ importing icon modules for you**.  Let's take a look at this required configurat
         return (
             size === IconSize.STANDARD
                 ? await import(
-                    /* webpackChunkName: "blueprint-icons" */
-                    /* webpackInclude: /\.js$/ */
-                    /* webpackMode: "eager" */
-                    `@blueprintjs/icons/lib/esm/generated/16px/paths/${name}`
-                )
+                      /* webpackChunkName: "blueprint-icons" */
+                      /* webpackInclude: /\.js$/ */
+                      /* webpackMode: "eager" */
+                      `@blueprintjs/icons/lib/esm/generated/16px/paths/${name}`
+                  )
                 : await import(
-                    /* webpackChunkName: "blueprint-icons" */
-                    /* webpackInclude: /\.js$/ */
-                    /* webpackMode: "eager" */
-                    `@blueprintjs/icons/lib/esm/generated/20px/paths/${name}`
-                )
+                      /* webpackChunkName: "blueprint-icons" */
+                      /* webpackInclude: /\.js$/ */
+                      /* webpackMode: "eager" */
+                      `@blueprintjs/icons/lib/esm/generated/20px/paths/${name}`
+                  )
         ).default;
     };
 
@@ -119,24 +119,24 @@ importing icon modules for you**.  Let's take a look at this required configurat
         return (
             size === IconSize.STANDARD
                 ? await import(
-                    /* webpackChunkName: "blueprint-icons-16px" */
-                    /* webpackInclude: /\.js$/ */
-                    /* webpackMode: "lazy" */
-                    `@blueprintjs/icons/lib/esm/generated/16px/paths/${name}`
-                )
+                      /* webpackChunkName: "blueprint-icons-16px" */
+                      /* webpackInclude: /\.js$/ */
+                      /* webpackMode: "lazy" */
+                      `@blueprintjs/icons/lib/esm/generated/16px/paths/${name}`
+                  )
                 : await import(
-                    /* webpackChunkName: "blueprint-icons-20px" */
-                    /* webpackInclude: /\.js$/ */
-                    /* webpackMode: "lazy" */
-                    `@blueprintjs/icons/lib/esm/generated/20px/paths/${name}`
-                )
+                      /* webpackChunkName: "blueprint-icons-20px" */
+                      /* webpackInclude: /\.js$/ */
+                      /* webpackMode: "lazy" */
+                      `@blueprintjs/icons/lib/esm/generated/20px/paths/${name}`
+                  )
         ).default;
     };
 
     Icons.setLoaderOptions({ loader: lazyLoader });
     ```
 
-4. Load some icon paths up front (dynamically) with network requests, and the rest lazily/on-demand.
+5. Load some icon paths up front (dynamically) with network requests, and the rest lazily/on-demand.
 
     ```ts
     import { Icons } from "@blueprintjs/icons";
@@ -145,7 +145,7 @@ importing icon modules for you**.  Let's take a look at this required configurat
     await Icons.load(["download", "caret-down", "endorsed", "help", "lock"]);
     ```
 
-5. Use a custom loaders with other bundlers, for example Vite ([see demo Code Sandbox here](https://codesandbox.io/p/sandbox/blueprint-v5-x-sandbox-react-16-wy0ojy)).
+6. Use a custom loaders with other bundlers, for example Vite ([see demo Code Sandbox here](https://codesandbox.io/p/sandbox/blueprint-v5-x-sandbox-react-16-wy0ojy)).
 
     ```ts
     import { Icons, IconPaths } from "@blueprintjs/icons";

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -18,7 +18,7 @@ without transformation steps, but most props are required as a result.
 import { Button, MenuItem } from "@blueprintjs/core";
 import { ItemPredicate, ItemRenderer, Select } from "@blueprintjs/select";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
 export interface Film {
     title: string;
@@ -76,7 +76,8 @@ const FilmSelect: React.FC = () => {
     );
 };
 
-ReactDOM.render(<FilmSelect />, document.querySelector("#root"));
+const root = ReactDOM.createRoot(document.getElementById("root"));
+root.render(<FilmSelect />);
 ```
 
 @## Props interface

--- a/packages/table/src/docs/table2.md
+++ b/packages/table/src/docs/table2.md
@@ -15,9 +15,11 @@ configure a [HotkeysProvider](#core/context/hotkeys-provider) in your applicatio
 import { HotkeysProvider } from "@blueprintjs/core";
 import { Column, Table2 } from "@blueprintjs/table";
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOM from "react-dom/client";
 
-ReactDOM.render(
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
     <HotkeysProvider>
         <Table2 numRows={5}>
             <Column />
@@ -25,7 +27,6 @@ ReactDOM.render(
             <Column />
         </Table2>
     </HotkeysProvider>,
-    document.querySelector("#app"),
 );
 ```
 


### PR DESCRIPTION
#### Proposed Changes

Updates stale documentation that references old/deprecated ReactDOM API methods to have better documented support for use with React 18.

There are no actual changes to working code in this PR, only examples in docs.

#### Checklist

- [ ] Includes tests
- [x] Update documentation