### PR TITLE
Ignore deprecated ReactDOM methods in Context Menu singleton

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -50,7 +50,9 @@ export function showContextMenu(
 ) {
     const {
         container = document.body,
+        // eslint-disable-next-line deprecation/deprecation
         domRenderer = ReactDOM.render,
+        // eslint-disable-next-line deprecation/deprecation
         domUnmounter = ReactDOM.unmountComponentAtNode,
     } = options;
 
@@ -65,6 +67,7 @@ export function showContextMenu(
         domUnmounter(contextMenuElement);
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     domRenderer(
         <OverlaysProvider>
             <UncontrolledContextMenuPopover {...props} />
@@ -81,6 +84,7 @@ export function showContextMenu(
  * @see https://blueprintjs.com/docs/#core/components/context-menu-popover.imperative-api
  */
 export function hideContextMenu(options: DOMMountOptions<ContextMenuPopoverProps> = {}) {
+    // eslint-disable-next-line deprecation/deprecation
     const { domUnmounter = ReactDOM.unmountComponentAtNode } = options;
 
     if (contextMenuElement !== undefined) {

--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -50,8 +50,10 @@ export function showContextMenu(
 ) {
     const {
         container = document.body,
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
         // eslint-disable-next-line deprecation/deprecation
         domRenderer = ReactDOM.render,
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
         // eslint-disable-next-line deprecation/deprecation
         domUnmounter = ReactDOM.unmountComponentAtNode,
     } = options;
@@ -67,6 +69,7 @@ export function showContextMenu(
         domUnmounter(contextMenuElement);
     }
 
+    // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
     // eslint-disable-next-line deprecation/deprecation
     domRenderer(
         <OverlaysProvider>
@@ -84,6 +87,7 @@ export function showContextMenu(
  * @see https://blueprintjs.com/docs/#core/components/context-menu-popover.imperative-api
  */
 export function hideContextMenu(options: DOMMountOptions<ContextMenuPopoverProps> = {}) {
+    // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
     // eslint-disable-next-line deprecation/deprecation
     const { domUnmounter = ReactDOM.unmountComponentAtNode } = options;
 


### PR DESCRIPTION
Cherry-picked from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

Part of #7165

Preemptively ignores linter errors in anticipation of internal React 18 upgrade. See above issue for more detail.
