### PR TITLE
Ignore deprecated ReactDOM methods in OverlayToaster

### DIFF
--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -76,6 +76,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
         // eslint-disable-next-line deprecation/deprecation
         const toaster = ReactDOM.render<OverlayToasterProps>(
             <OverlayToaster {...props} usePortal={false} />,
@@ -101,6 +102,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         }
 
         const container = options?.container ?? document.body;
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
         // eslint-disable-next-line deprecation/deprecation
         const domRenderer = options?.domRenderer ?? ReactDOM.render;
 
@@ -109,6 +111,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
 
         return new Promise<Toaster>((resolve, reject) => {
             try {
+                // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
                 // eslint-disable-next-line deprecation/deprecation
                 domRenderer(<OverlayToaster {...props} ref={handleRef} usePortal={false} />, toasterComponentRoot);
             } catch (error) {
@@ -303,6 +306,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
      */
     private renderChildren() {
         return React.Children.map(this.props.children, child => {
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
             // eslint-disable-next-line deprecation/deprecation
             if (isElementOfType(child, Toast)) {
                 return <Toast2 {...child.props} />;

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -76,6 +76,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         }
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
+        // eslint-disable-next-line deprecation/deprecation
         const toaster = ReactDOM.render<OverlayToasterProps>(
             <OverlayToaster {...props} usePortal={false} />,
             containerElement,
@@ -100,6 +101,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         }
 
         const container = options?.container ?? document.body;
+        // eslint-disable-next-line deprecation/deprecation
         const domRenderer = options?.domRenderer ?? ReactDOM.render;
 
         const toasterComponentRoot = document.createElement("div");
@@ -107,6 +109,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
 
         return new Promise<Toaster>((resolve, reject) => {
             try {
+                // eslint-disable-next-line deprecation/deprecation
                 domRenderer(<OverlayToaster {...props} ref={handleRef} usePortal={false} />, toasterComponentRoot);
             } catch (error) {
                 // Note that we're catching errors from the domRenderer function


### PR DESCRIPTION
Cherry-picked from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

Part of #7166

Preemptively ignores linter errors in anticipation of internal React 18 upgrade. See above issue for more detail.
