### PR TITLE
Fix additional types for React 18

### DIFF
--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -238,6 +238,8 @@ describe("<OverflowList>", function (this) {
 
         /** Assert ordered IDs of overflow items. */
         wrapper.assertOverflowItems = (...ids: number[]) => {
+            // enzyme's wrapper.find returns `any` type here, so we need to cast to the correct type
+            // see: https://github.com/palantir/blueprint/pull/7161/files#r1915372750
             const overflowItems: TestItemProps[] = wrapper.find(TestOverflow).prop("items");
             assert.sameMembers(
                 overflowItems.map(it => it.id),

--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -238,7 +238,7 @@ describe("<OverflowList>", function (this) {
 
         /** Assert ordered IDs of overflow items. */
         wrapper.assertOverflowItems = (...ids: number[]) => {
-            const overflowItems = wrapper.find(TestOverflow).prop("items");
+            const overflowItems: TestItemProps[] = wrapper.find(TestOverflow).prop("items");
             assert.sameMembers(
                 overflowItems.map(it => it.id),
                 ids,

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -16,7 +16,7 @@
 
 import { ReactWrapper } from "enzyme";
 
-import { Portal } from "../src";
+import { Portal, type PortalProps } from "../src";
 
 export function findInPortal<P>(overlay: ReactWrapper<P>, selector: string) {
     // React 16: createPortal preserves React tree so simple find works.
@@ -27,7 +27,9 @@ export function findInPortal<P>(overlay: ReactWrapper<P>, selector: string) {
 
     // React 15: unstable_renderSubtree does not preserve tree so we must create new wrapper.
     const portal = overlay.find(Portal).instance();
-    const portalChildren = new ReactWrapper(portal.props.children as React.JSX.Element[]);
+    const portalChildren = new ReactWrapper(
+        (portal as React.Component<PortalProps>).props.children as React.JSX.Element[],
+    );
     if (portalChildren.is(selector)) {
         return portalChildren;
     }

--- a/packages/core/test/utils.tsx
+++ b/packages/core/test/utils.tsx
@@ -15,6 +15,7 @@
  */
 
 import { ReactWrapper } from "enzyme";
+import * as React from "react";
 
 import { Portal, type PortalProps } from "../src";
 
@@ -26,10 +27,8 @@ export function findInPortal<P>(overlay: ReactWrapper<P>, selector: string) {
     }
 
     // React 15: unstable_renderSubtree does not preserve tree so we must create new wrapper.
-    const portal = overlay.find(Portal).instance();
-    const portalChildren = new ReactWrapper(
-        (portal as React.Component<PortalProps>).props.children as React.JSX.Element[],
-    );
+    const portal = overlay.find(Portal).instance() as React.Component<PortalProps>;
+    const portalChildren = new ReactWrapper(<>{portal.props.children}</>);
     if (portalChildren.is(selector)) {
         return portalChildren;
     }

--- a/packages/table/test/resizableTests.tsx
+++ b/packages/table/test/resizableTests.tsx
@@ -21,12 +21,12 @@ import sinon from "sinon";
 
 import * as Classes from "../src/common/classes";
 import { Resizable, type ResizableProps, type ResizeableState } from "../src/interactions/resizable";
-import { Orientation, type ResizeHandle } from "../src/interactions/resizeHandle";
+import { Orientation } from "../src/interactions/resizeHandle";
 
 import { ReactHarness } from "./harness";
 
 interface ResizableDivProps {
-    resizeHandle?: ResizeHandle;
+    resizeHandle?: React.JSX.Element;
     style?: React.CSSProperties;
 }
 


### PR DESCRIPTION
Cherry-picked from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

Fixes some additional remaining type compile breaks in anticipation of internal React 18 upgrade.