### PR TITLE
Ignore deprecated ReactDOM methods in tests

### DIFF
--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -61,6 +61,7 @@ describe("ContextMenu", () => {
         document.body.appendChild(containerElement);
     });
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(containerElement!);
         containerElement!.remove();

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -61,6 +61,7 @@ describe("ContextMenu", () => {
         document.body.appendChild(containerElement);
     });
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(containerElement!);
         containerElement!.remove();
     });

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -31,6 +31,7 @@ describe("<TextArea>", () => {
     });
 
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(containerElement!);
         containerElement!.remove();

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -31,6 +31,7 @@ describe("<TextArea>", () => {
     });
 
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(containerElement!);
         containerElement!.remove();
     });

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -47,6 +47,7 @@ describe("<MultiSlider>", () => {
     });
 
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
         testsContainerElement.remove();
     });

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -47,6 +47,7 @@ describe("<MultiSlider>", () => {
     });
 
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
         testsContainerElement.remove();

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -61,6 +61,7 @@ function unmountReact16Toaster(containerElement: HTMLElement) {
     if (toasterRenderRoot == null) {
         throw new Error("No elements were found under Toaster container.");
     }
+    // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
     // eslint-disable-next-line deprecation/deprecation
     ReactDOM.unmountComponentAtNode(toasterRenderRoot);
 }

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -61,6 +61,7 @@ function unmountReact16Toaster(containerElement: HTMLElement) {
     if (toasterRenderRoot == null) {
         throw new Error("No elements were found under Toaster container.");
     }
+    // eslint-disable-next-line deprecation/deprecation
     ReactDOM.unmountComponentAtNode(toasterRenderRoot);
 }
 

--- a/packages/core/test/toast/toasterTests.tsx
+++ b/packages/core/test/toast/toasterTests.tsx
@@ -27,6 +27,7 @@ describe("Toaster", () => {
     });
 
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
 

--- a/packages/core/test/toast/toasterTests.tsx
+++ b/packages/core/test/toast/toasterTests.tsx
@@ -27,6 +27,7 @@ describe("Toaster", () => {
     });
 
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -32,6 +32,7 @@ describe("<Tree>", () => {
     });
 
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
 

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -32,6 +32,7 @@ describe("<Tree>", () => {
     });
 
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -75,6 +75,7 @@ describe("<DateRangeInput>", () => {
     });
     afterEach(() => {
         if (containerElement !== undefined) {
+            // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
         }

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -75,6 +75,7 @@ describe("<DateRangeInput>", () => {
     });
     afterEach(() => {
         if (containerElement !== undefined) {
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
             // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -43,6 +43,7 @@ describe("<TimePicker>", () => {
     });
 
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
@@ -748,6 +749,7 @@ describe("<TimePicker>", () => {
     }
 
     function renderTimePicker(props?: Partial<TimePickerProps>) {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         timePicker = ReactDOM.render<TimePickerProps>(
             <TimePicker onChange={onTimePickerChange} {...props} />,

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -43,6 +43,7 @@ describe("<TimePicker>", () => {
     });
 
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
 
@@ -747,6 +748,7 @@ describe("<TimePicker>", () => {
     }
 
     function renderTimePicker(props?: Partial<TimePickerProps>) {
+        // eslint-disable-next-line deprecation/deprecation
         timePicker = ReactDOM.render<TimePickerProps>(
             <TimePicker onChange={onTimePickerChange} {...props} />,
             testsContainerElement,

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -88,6 +88,7 @@ describe("<DateRangeInput3>", () => {
 
     afterEach(() => {
         if (containerElement !== undefined) {
+            // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
         }

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -88,6 +88,7 @@ describe("<DateRangeInput3>", () => {
 
     afterEach(() => {
         if (containerElement !== undefined) {
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
             // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();

--- a/packages/table/test/common/internal/scrollUtilsTests.tsx
+++ b/packages/table/test/common/internal/scrollUtilsTests.tsx
@@ -339,6 +339,7 @@ describe("scrollUtils", () => {
 
         function mountElementsWithContentSize(contentWidth: number, contentHeight: number) {
             // HACKHACK: `as unknown as HTMLElement` cast is sketchy
+            // eslint-disable-next-line deprecation/deprecation
             return ReactDOM.render<React.HTMLProps<HTMLDivElement>>(
                 <div style={parentStyle}>
                     <div style={{ ...baseStyles, width: contentWidth, height: contentHeight }} />

--- a/packages/table/test/common/internal/scrollUtilsTests.tsx
+++ b/packages/table/test/common/internal/scrollUtilsTests.tsx
@@ -339,6 +339,7 @@ describe("scrollUtils", () => {
 
         function mountElementsWithContentSize(contentWidth: number, contentHeight: number) {
             // HACKHACK: `as unknown as HTMLElement` cast is sketchy
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
             // eslint-disable-next-line deprecation/deprecation
             return ReactDOM.render<React.HTMLProps<HTMLDivElement>>(
                 <div style={parentStyle}>

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -215,11 +215,13 @@ export class ReactHarness {
 
     public mount(component: React.ReactElement<any>) {
         // wrap in a root provider to avoid console warnings
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.render(React.createElement(BlueprintProvider, { children: component }), this.container);
         return new ElementHarness(this.container);
     }
 
     public unmount() {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(this.container);
     }
 

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -215,12 +215,14 @@ export class ReactHarness {
 
     public mount(component: React.ReactElement<any>) {
         // wrap in a root provider to avoid console warnings
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.render(React.createElement(BlueprintProvider, { children: component }), this.container);
         return new ElementHarness(this.container);
     }
 
     public unmount() {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(this.container);
     }

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -55,6 +55,7 @@ describe("Locator", () => {
         // ".body" will be the scrollable region.
         containerElement = document.createElement("div");
         document.body.appendChild(containerElement);
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.render(
             <div className="table-wrapper" style={style}>
                 <div className="body" style={style}>
@@ -75,6 +76,7 @@ describe("Locator", () => {
     });
 
     afterEach(() => {
+        // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(containerElement);
     });
 

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -55,6 +55,7 @@ describe("Locator", () => {
         // ".body" will be the scrollable region.
         containerElement = document.createElement("div");
         document.body.appendChild(containerElement);
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.render(
             <div className="table-wrapper" style={style}>
@@ -76,6 +77,7 @@ describe("Locator", () => {
     });
 
     afterEach(() => {
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         ReactDOM.unmountComponentAtNode(containerElement);
     });

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -559,6 +559,7 @@ describe("TableQuadrantStack", () => {
         });
 
         afterEach(() => {
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
             // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(container);
             onScroll.resetHistory();
@@ -716,6 +717,7 @@ describe("TableQuadrantStack", () => {
     function renderIntoDom(element: React.JSX.Element) {
         const containerElement = document.createElement("div");
         document.body.appendChild(containerElement);
+        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
         // eslint-disable-next-line deprecation/deprecation
         const component = ReactDOM.render<any>(element, containerElement);
         return {

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -559,6 +559,7 @@ describe("TableQuadrantStack", () => {
         });
 
         afterEach(() => {
+            // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(container);
             onScroll.resetHistory();
         });
@@ -715,6 +716,7 @@ describe("TableQuadrantStack", () => {
     function renderIntoDom(element: React.JSX.Element) {
         const containerElement = document.createElement("div");
         document.body.appendChild(containerElement);
+        // eslint-disable-next-line deprecation/deprecation
         const component = ReactDOM.render<any>(element, containerElement);
         return {
             component: component as TableQuadrantStack,

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -61,6 +61,7 @@ describe("<Table2>", function (this) {
     afterEach(() => {
         harness.unmount();
         if (containerElement !== undefined) {
+            // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
         }
@@ -1498,6 +1499,7 @@ describe("<Table2>", function (this) {
             // get native DOM nodes
             const tableNode = table.getDOMNode();
             const tableBodySelector = `.${Classes.TABLE_BODY_VIRTUAL_CLIENT}`;
+            // eslint-disable-next-line deprecation/deprecation
             const tableBodyNode = ReactDOM.findDOMNode(tableNode.querySelector(tableBodySelector));
 
             // trigger a drag-selection starting at the center of the activation cell

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -61,6 +61,7 @@ describe("<Table2>", function (this) {
     afterEach(() => {
         harness.unmount();
         if (containerElement !== undefined) {
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
             // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
@@ -1499,6 +1500,7 @@ describe("<Table2>", function (this) {
             // get native DOM nodes
             const tableNode = table.getDOMNode();
             const tableBodySelector = `.${Classes.TABLE_BODY_VIRTUAL_CLIENT}`;
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
             // eslint-disable-next-line deprecation/deprecation
             const tableBodyNode = ReactDOM.findDOMNode(tableNode.querySelector(tableBodySelector));
 


### PR DESCRIPTION
Cherry-picked from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

Part of #7167

Preemptively ignores linter errors in anticipation of internal React 18 upgrade. See above issue for more detail.
