### PR TITLE
chore: Remove remaining tslint references

### DIFF
--- a/packages/core/src/components/html/html.md
+++ b/packages/core/src/components/html/html.md
@@ -40,12 +40,8 @@ See the [Running text](#core/typography.running-text) documentation for more inf
 @## Linting
 
 The [**@blueprintjs/eslint-config**](https://www.npmjs.com/package/@blueprintjs/eslint-config)
-NPM package provides advanced configuration for [ESLint](https://eslint.org/). Blueprint is
-currently transitioning from [TSLint](https://palantir.github.io/tslint/) to ESLint, and as
-such, rules are being migrated from TSLint to ESLint. In the meantime, some TSLint rules are
-being run using ESLint.
-
-The [**@blueprintjs/eslint-plugin**](https://www.npmjs.com/package/@blueprintjs/eslint-plugin)
+NPM package provides advanced configuration for [ESLint](https://eslint.org/). The
+[**@blueprintjs/eslint-plugin**](https://www.npmjs.com/package/@blueprintjs/eslint-plugin)
 package includes a custom `blueprint-html-components` rule that will warn on usages of
 JSX intrinsic elements (`<h1>`) that have a Blueprint alternative (`<H1>`). See
 the package's [README](https://www.npmjs.com/package/@blueprintjs/eslint-plugin)

--- a/packages/core/src/docs/classes.md
+++ b/packages/core/src/docs/classes.md
@@ -169,12 +169,8 @@ plugins: [
 @## Linting
 
 The [**@blueprintjs/eslint-config**](https://www.npmjs.com/package/@blueprintjs/eslint-config)
-NPM package provides advanced configuration for [ESLint](https://eslint.org/). Blueprint is
-currently transitioning from [TSLint](https://palantir.github.io/tslint/) to ESLint, and as
-such, rules are being migrated from TSLint to ESLint. In the meantime, some TSLint rules are
-being run using ESLint.
-
-The [**@blueprintjs/eslint-plugin**](https://www.npmjs.com/package/@blueprintjs/eslint-plugin)
+NPM package provides advanced configuration for [ESLint](https://eslint.org/). The
+[**@blueprintjs/eslint-plugin**](https://www.npmjs.com/package/@blueprintjs/eslint-plugin)
 NPM package includes a custom `blueprint-html-components` rule that will warn on usages of
 JSX intrinsic elements (`<h1>`) that have a Blueprint alternative (`<H1>`). See
 the package's [README](https://www.npmjs.com/package/@blueprintjs/eslint-plugin)

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -64,7 +64,6 @@ export class PopoverDismissExample extends React.PureComponent<
                                     content={POPOVER_CONTENTS}
                                     placement="right"
                                     usePortal={false}
-                                    // tslint:disable-next-line jsx-no-lambda
                                     renderTarget={({ isOpen, ...p }) => (
                                         <Button {...p} active={isOpen} text="Nested" rightIcon="caret-right" />
                                     )}
@@ -72,7 +71,6 @@ export class PopoverDismissExample extends React.PureComponent<
                             </div>
                         </>
                     }
-                    // tslint:disable-next-line jsx-no-lambda
                     renderTarget={({ isOpen, ...p }) => (
                         <Button {...p} active={isOpen} intent="primary" text="Try it out" />
                     )}

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -47,7 +47,6 @@ export class PopoverInteractionKindExample extends React.PureComponent<ExamplePr
                 placement="bottom-end"
                 interactionKind={interactionKind}
                 content={<FileMenu shouldDismissPopover={false} />}
-                // tslint:disable-next-line jsx-no-lambda
                 renderTarget={({ isOpen, ...p }) => (
                     <Button {...p} active={isOpen} intent={Intent.PRIMARY} text={interactionKind} />
                 )}

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -32,14 +32,12 @@ export class PopoverMinimalExample extends React.PureComponent<ExampleProps> {
                 <Popover
                     {...baseProps}
                     minimal={true}
-                    // tslint:disable-next-line jsx-no-lambda
                     renderTarget={({ isOpen, ...p }) => (
                         <Button {...p} active={isOpen} intent={Intent.PRIMARY} text="Minimal" />
                     )}
                 />
                 <Popover
                     {...baseProps}
-                    // tslint:disable-next-line jsx-no-lambda
                     renderTarget={({ isOpen, ...p }) => <Button {...p} active={isOpen} text="Default" />}
                 />
             </Example>

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -78,7 +78,6 @@ export class PopoverPortalExample extends React.PureComponent<ExampleProps, Popo
                             isOpen={this.state.isOpen}
                             usePortal={true}
                             // strip out `isOpen` so that it is not rendered to HTML element
-                            // tslint:disable-next-line jsx-no-lambda
                             renderTarget={({ isOpen, ...p }) => <Code {...p}>{`usePortal={true}`}</Code>}
                         />
                     </div>
@@ -98,7 +97,6 @@ export class PopoverPortalExample extends React.PureComponent<ExampleProps, Popo
                                 preventOverflow: { enabled: false },
                             }}
                             // strip out `isOpen` so that it is not rendered to HTML element
-                            // tslint:disable-next-line jsx-no-lambda
                             renderTarget={({ isOpen, ...p }) => <Code {...p}>{`usePortal={false}`}</Code>}
                         />
                     </div>

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -30,7 +30,6 @@ export class PopoverSizingExample extends React.PureComponent<ExampleProps> {
                 <Popover
                     content={<FileMenu className="docs-popover-sizing-example" />}
                     placement="bottom-end"
-                    // tslint:disable-next-line jsx-no-lambda
                     renderTarget={({ isOpen, ...p }) => <Button {...p} active={isOpen} text="Open..." />}
                 />
             </Example>

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -178,7 +178,6 @@ export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExam
     }
 
     private renderToastDemo = (toast: ToastDemo, index: number) => {
-        // tslint:disable-next-line:jsx-no-lambda
         return <Button intent={toast.intent} key={index} text={toast.button} onClick={() => this.addToast(toast)} />;
     };
 

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -158,7 +158,6 @@ class RecordSortableColumn extends AbstractSortableColumn {
                 />
             </Menu>
         );
-        // tslint:enable:jsx-no-lambda
     }
 
     private transformCompare(transform: (a: any) => any, reverse: boolean) {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -56,20 +56,13 @@ module.exports = {
             env: {
                 browser: true,
             },
-            plugins: ["@typescript-eslint", "@typescript-eslint/tslint", "deprecation"],
+            plugins: ["@typescript-eslint", "deprecation"],
             parser: "@typescript-eslint/parser",
             parserOptions: {
                 sourceType: "module",
                 project: ["{src,test}/tsconfig.json"],
             },
             rules: {
-                // run the tslint rules which are not yet converted (run inside eslint)
-                "@typescript-eslint/tslint/config": [
-                    "error",
-                    {
-                        lintFile: path.resolve(__dirname, "./tslint.json"),
-                    },
-                ],
                 ...tsEslintRules,
                 "deprecation/deprecation": "error",
             },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,9 +4,7 @@
     "description": "ESLint configuration for @blueprintjs packages",
     "dependencies": {
         "@blueprintjs/eslint-plugin": "workspace:^",
-        "@blueprintjs/tslint-config": "workspace:^",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
-        "@typescript-eslint/eslint-plugin-tslint": "^6.19.1",
         "@typescript-eslint/parser": "^6.19.1",
         "eslint": "^8.56.0",
         "eslint-plugin-deprecation": "^2.0.0",

--- a/packages/eslint-config/tslint.json
+++ b/packages/eslint-config/tslint.json
@@ -1,4 +1,0 @@
-{
-    "defaultSeverity": "error",
-    "rules": {}
-}

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -613,7 +613,6 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
                 />
             </Menu>
         );
-        // tslint:enable:jsx-no-multiline-js jsx-no-lambda
     };
 
     private getCellValue = (rowIndex: number, columnIndex: number) => {

--- a/packages/table-dev-app/src/sparseGridMutableStore.ts
+++ b/packages/table-dev-app/src/sparseGridMutableStore.ts
@@ -27,9 +27,6 @@ class GridEntry<T> {
         public value: T,
     ) {}
 
-    // there are two things here called `key` but they're certainly not overloaded (one being static)
-    // TSLint bug report: https://github.com/palantir/tslint/issues/2139
-    // eslint-disable-line @typescript-eslint/adjacent-overload-signatures
     public get key() {
         return GridEntry.key(this.i, this.j);
     }

--- a/packages/table/src/common/rect.ts
+++ b/packages/table/src/common/rect.ts
@@ -18,9 +18,6 @@ import type * as React from "react";
 
 export type AnyRect = Rect | DOMRect;
 
-// HACKHACK: workaround for https://github.com/palantir/tslint/issues/1768
-// eslint-disable  @typescript-eslint/adjacent-overload-signatures
-
 /**
  * A simple object for storing the client bounds of HTMLElements. Since
  * ClientRects are immutable, this object enables editing and some simple

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,9 +671,7 @@ __metadata:
   resolution: "@blueprintjs/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@blueprintjs/eslint-plugin": "workspace:^"
-    "@blueprintjs/tslint-config": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^6.19.1"
-    "@typescript-eslint/eslint-plugin-tslint": "npm:^6.19.1"
     "@typescript-eslint/parser": "npm:^6.19.1"
     eslint: "npm:^8.56.0"
     eslint-plugin-deprecation: "npm:^2.0.0"
@@ -1015,7 +1013,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@blueprintjs/tslint-config@workspace:^, @blueprintjs/tslint-config@workspace:packages/tslint-config":
+"@blueprintjs/tslint-config@workspace:packages/tslint-config":
   version: 0.0.0-use.local
   resolution: "@blueprintjs/tslint-config@workspace:packages/tslint-config"
   dependencies:
@@ -3432,19 +3430,6 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "npm:*"
   checksum: 2095e8aad8a4e66b86147415364266b8d607a3b95b4239623423efd7e29df93ba81bb862784a6e08664f645cc1981b25fd598f532019174cd3e5e1e689e1cccf
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/eslint-plugin-tslint@npm:^6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/eslint-plugin-tslint@npm:6.19.1"
-  dependencies:
-    "@typescript-eslint/utils": "npm:6.19.1"
-  peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
-    tslint: ^5.0.0 || ^6.0.0
-    typescript: "*"
-  checksum: db74498c74ef052c040b3cd89fc2b3382007ab6cb36122c250de23194105aa116b2871713124096836339aee409473869c05108411c59ef7256a57ae285a2b06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This removes remaining tslint references with the exception of not removing the `tslint-config` package. We will do that when we major version bump