### PR TITLE
Patch react-day-picker@7.4.9 in datetime devDependencies

### DIFF
--- a/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch
+++ b/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch
@@ -1,0 +1,31 @@
+diff --git a/types/Props.d.ts b/types/Props.d.ts
+index f8fcd45ab3048d9b34709eba1797597ac2facdec..3afa05a42f485ff23899f20df2ff9d85bf588eed 100644
+--- a/types/Props.d.ts
++++ b/types/Props.d.ts
+@@ -44,7 +44,7 @@ export interface DayPickerProps {
+   captionElement?:
+     | React.ReactElement<Partial<CaptionElementProps>>
+     | React.ComponentClass<CaptionElementProps>
+-    | React.SFC<CaptionElementProps>;
++    | React.FC<CaptionElementProps>;
+   className?: string;
+   classNames?: ClassNames;
+   containerProps?: React.DetailedHTMLProps<
+@@ -69,7 +69,7 @@ export interface DayPickerProps {
+   navbarElement?:
+     | React.ReactElement<Partial<NavbarElementProps>>
+     | React.ComponentClass<NavbarElementProps>
+-    | React.SFC<NavbarElementProps>;
++    | React.FC<NavbarElementProps>;
+   numberOfMonths?: number;
+   onBlur?: (e: React.FocusEvent<HTMLDivElement>) => void;
+   onCaptionClick?: (month: Date, e: React.MouseEvent<HTMLDivElement>) => void;
+@@ -142,7 +142,7 @@ export interface DayPickerProps {
+   weekdayElement?:
+     | React.ReactElement<Partial<WeekdayElementProps>>
+     | React.ComponentClass<WeekdayElementProps>
+-    | React.SFC<WeekdayElementProps>;
++    | React.FC<WeekdayElementProps>;
+   weekdaysLong?: string[];
+   weekdaysShort?: string[];
+   tabIndex?: number;

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -69,6 +69,7 @@
         "mocha": "^10.2.0",
         "npm-run-all": "^4.1.5",
         "react": "^16.14.0",
+        "react-day-picker": "patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch",
         "react-dom": "^16.14.0",
         "react-test-renderer": "^16.14.0",
         "typescript": "~5.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -540,7 +540,7 @@ __metadata:
     mocha: "npm:^10.2.0"
     npm-run-all: "npm:^4.1.5"
     react: "npm:^16.14.0"
-    react-day-picker: "npm:7.4.9"
+    react-day-picker: "patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch"
     react-dom: "npm:^16.14.0"
     react-test-renderer: "npm:^16.14.0"
     tslib: "npm:~2.6.2"
@@ -13782,6 +13782,17 @@ __metadata:
     date-fns: ^2.28.0 || ^3.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: e9868aced1e40b4cb7d6cf8d50e250226b38ec7ebea944b65aa9db20a0f36d0581b8a501297d09dcbf2d812de852168952b3fb27990915381629d6e314c2a4d8
+  languageName: node
+  linkType: hard
+
+"react-day-picker@patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch":
+  version: 7.4.9
+  resolution: "react-day-picker@patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch::version=7.4.9&hash=5478a6"
+  dependencies:
+    prop-types: "npm:^15.6.2"
+  peerDependencies:
+    react: ~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 8a64e55f67a824d2a1bea0691ea082b710049ab07e747dbf9bd647e921ba22884597155514e08a6d60ff4231c788d51ac35870fa11573bd550aa803e7b223bc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Copied from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

#### Proposed changes:

This change patches `react-day-picker@v7.4.9` **as a devDependency** in the `@blueprint/datetime` package. This prevents type compilation errors when upgrading Blueprint packages to use React 18 internally.

```
../../node_modules/react-day-picker/types/Props.d.ts:47:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.
       47     | React.SFC<CaptionElementProps>;
                      ~~~
       ../../node_modules/react-day-picker/types/Props.d.ts:72:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.

       72     | React.SFC<NavbarElementProps>;
                      ~~~
       ../../node_modules/react-day-picker/types/Props.d.ts:145:13 - error TS2694: Namespace 'React' has no exported member 'SFC'.

       145     | React.SFC<WeekdayElementProps>;
                       ~~~
```

The original version of this change, #7146 was reverted in #7173 because it caused issues with downstream consumers installing the datetime packages (see #7172). This change differs by keeping the wider entry for `react-day-picker@v7.4.9` in `dependencies` and specifying the patched version for local development/builds in `devDependencies`.