### PR TITLE
Update return types for Icon and SVGIconContainer

### DIFF
--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -101,6 +101,11 @@ export interface DefaultIconProps extends IntentProps, Props, DefaultSVGIconProp
  * @see https://stackoverflow.com/a/73795494/7406866
  */
 export interface IconComponent extends React.FC<IconProps<Element>> {
+    /**
+     * ReturnType here preserves type compatability with React 16 while we migrate to React 18.
+     * see: https://github.com/palantir/blueprint/pull/7142/files#r1915691062
+     */
+    // TODO(React 18): Replace return type with `React.ReactNode` once we drop support for React 16.
     <T extends Element = Element>(props: IconProps<T>): ReturnType<React.FC<IconProps<Element>>> | null;
 }
 

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -101,7 +101,7 @@ export interface DefaultIconProps extends IntentProps, Props, DefaultSVGIconProp
  * @see https://stackoverflow.com/a/73795494/7406866
  */
 export interface IconComponent extends React.FC<IconProps<Element>> {
-    <T extends Element = Element>(props: IconProps<T>): React.ReactElement | null;
+    <T extends Element = Element>(props: IconProps<T>): ReturnType<React.FC<IconProps<Element>>> | null;
 }
 
 /**

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -42,7 +42,9 @@ export type SVGIconContainerProps<T extends Element> = Omit<SVGIconProps<T>, "ch
  * @see https://stackoverflow.com/a/73795494/7406866
  */
 export interface SVGIconContainerComponent extends React.FC<SVGIconContainerProps<Element>> {
-    <T extends Element = Element>(props: SVGIconContainerProps<T>): React.ReactElement | null;
+    <T extends Element = Element>(
+        props: SVGIconContainerProps<T>,
+    ): ReturnType<React.FC<SVGIconContainerProps<Element>>> | null;
 }
 
 // eslint-disable-next-line prefer-arrow-callback

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -42,6 +42,11 @@ export type SVGIconContainerProps<T extends Element> = Omit<SVGIconProps<T>, "ch
  * @see https://stackoverflow.com/a/73795494/7406866
  */
 export interface SVGIconContainerComponent extends React.FC<SVGIconContainerProps<Element>> {
+    /**
+     * ReturnType here preserves type compatability with React 16 while we migrate to React 18.
+     * see: https://github.com/palantir/blueprint/pull/7142/files#r1915691062
+     */
+    // TODO(React 18): Replace return type with `React.ReactNode` once we drop support for React 16.
     <T extends Element = Element>(
         props: SVGIconContainerProps<T>,
     ): ReturnType<React.FC<SVGIconContainerProps<Element>>> | null;


### PR DESCRIPTION
Copied from **React 18 Upgrade feature branch** https://github.com/palantir/blueprint/pull/7142

#### Proposed changes:

Modifies the return type of Icon and SVGIconContainer for compatibility with React 16/17/18.