### PR TITLE
[core] fix(NumericInput): improve performance on Firefox (#5466)

### DIFF
--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -244,15 +244,17 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
         const value = props.value?.toString() ?? state.value;
         const stepMaxPrecision = NumericInput.getStepMaxPrecision(props);
 
-        const sanitizedValue =
-            value !== NumericInput.VALUE_EMPTY
-                ? NumericInput.roundAndClampValue(value, stepMaxPrecision, props.min, props.max, 0, props.locale)
-                : NumericInput.VALUE_EMPTY;
+        if (didBoundsChange) {
+            const sanitizedValue =
+                value !== NumericInput.VALUE_EMPTY
+                    ? NumericInput.roundAndClampValue(value, stepMaxPrecision, props.min, props.max, 0, props.locale)
+                    : NumericInput.VALUE_EMPTY;
 
-        // if a new min and max were provided that cause the existing value to fall
-        // outside of the new bounds, then clamp the value to the new valid range.
-        if (didBoundsChange && sanitizedValue !== state.value) {
-            return { ...nextState, stepMaxPrecision, value: sanitizedValue };
+            // if a new min and max were provided that cause the existing value to fall
+            // outside of the new bounds, then clamp the value to the new valid range.
+            if (sanitizedValue !== state.value) {
+                return { ...nextState, stepMaxPrecision, value: sanitizedValue };
+            }
         }
         return { ...nextState, stepMaxPrecision, value };
     }


### PR DESCRIPTION
#### Fixes #5466

#### Checklist

- [ ] Includes tests: passes existing tests, no functionality changes
- [ ] Update documentation: no functionality changes

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

`Number.prototype.toLocaleString` is relatively slow on Firefox, and is currently heavily used by `NumericInput.getDerivedStateFromProps` (which further calls `isFloatingPointNumericCharacter` on each character of the current value). This means that if you have a bunch of `NumericInput`s on a form, it slows renders down to a crawl *even if the `NumericInput` isn't being updated itself*.

This PR improves the situation in two ways:

- Caches the regexes generated by `isFloatingPointNumericCharacter` per locale. I don't think there's a reasonable situation where the representation of numbers would change during page load.
- Only calls `roundAndClampValue` when necessary in `getDerivedStateFromProps` - essentially, moves the computation of `sanitizedValue` within the if statement it's used in.

You can see the difference in this Codepen (try using Firefox): https://codesandbox.io/p/devbox/condescending-vaughan-qysyk7

#### Reviewers should focus on:

Whether this changes behavior in any way.

I'm not sure whether  `Map` is in the current "browser support level" of Blueprint, but its only use in the repo is [`uniqueId`](https://github.com/palantir/blueprint/blob/ce6b05fabda5148027da40c84380cc7ee8f12348/packages/core/src/common/utils/jsUtils.ts#L75-L81) which `NumericInput` also uses, so I assumed it's fine.
