### PR TITLE
chore: Refactor Spinner from a class-based to functional component

### DIFF
--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -85,21 +85,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
         }
     }, [className, size]);
 
-    /**
-     * Resolve size to a pixel value.
-     * Size can be set by className, props, default, or minimum constant.
-     */
-    const sizePx = React.useMemo(() => {
-        if (size == null) {
-            if (className.indexOf(Classes.SMALL) >= 0) {
-                return SpinnerSize.SMALL;
-            } else if (className.indexOf(Classes.LARGE) >= 0) {
-                return SpinnerSize.LARGE;
-            }
-            return SpinnerSize.STANDARD;
-        }
-        return Math.max(MIN_SIZE, size);
-    }, [className, size]);
+    const sizePx = getSize(size, className);
 
     // keep spinner track width consistent at all sizes (down to about 10px).
     const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / sizePx);
@@ -152,3 +138,19 @@ export const Spinner: React.FC<SpinnerProps> = props => {
 };
 
 Spinner.displayName = `${DISPLAYNAME_PREFIX}.Spinner`;
+
+/**
+ * Resolve size to a pixel value.
+ * Size can be set by className, props, default, or minimum constant.
+ */
+const getSize = (size: number | undefined, className: string): number => {
+    if (size == null) {
+        if (className.indexOf(Classes.SMALL) >= 0) {
+            return SpinnerSize.SMALL;
+        } else if (className.indexOf(Classes.LARGE) >= 0) {
+            return SpinnerSize.LARGE;
+        }
+        return SpinnerSize.STANDARD;
+    }
+    return Math.max(MIN_SIZE, size);
+};

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes } from "../../common";
+import { Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
 import { clamp } from "../../common/utils";
@@ -76,96 +76,79 @@ export interface SpinnerProps<T extends HTMLElement = HTMLElement> extends Props
  *
  * @see https://blueprintjs.com/docs/#core/components/spinner
  */
-export class Spinner extends AbstractPureComponent<SpinnerProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.Spinner`;
+export const Spinner: React.FC<SpinnerProps> = props => {
+    const { className = "", intent, value, tagName = "div", size, ...htmlProps } = props;
 
-    public componentDidUpdate(prevProps: SpinnerProps) {
-        if (prevProps.value !== this.props.value) {
-            // IE/Edge: re-render after changing value to force SVG update
-            this.forceUpdate();
-        }
-    }
-
-    public render() {
-        const { className, intent, value, tagName = "div", ...htmlProps } = this.props;
-        const size = this.getSize();
-
-        const classes = classNames(
-            Classes.SPINNER,
-            Classes.intentClass(intent),
-            { [Classes.SPINNER_NO_SPIN]: value != null },
-            className,
-        );
-
-        // keep spinner track width consistent at all sizes (down to about 10px).
-        const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / size);
-        const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
-
-        // multiple DOM elements around SVG are necessary to properly isolate animation:
-        // - SVG elements in IE do not support anim/trans so they must be set on a parent HTML element.
-        // - SPINNER_ANIMATION isolates svg from parent display and is always centered inside root element.
-        return React.createElement(
-            tagName,
-            {
-                "aria-label": "loading",
-                "aria-valuemax": 100,
-                "aria-valuemin": 0,
-                "aria-valuenow": value === undefined ? undefined : value * 100,
-                className: classes,
-                role: "progressbar",
-                ...htmlProps,
-            },
-            React.createElement(
-                tagName,
-                { className: Classes.SPINNER_ANIMATION },
-                <svg
-                    width={size}
-                    height={size}
-                    strokeWidth={strokeWidth.toFixed(2)}
-                    viewBox={this.getViewBox(strokeWidth)}
-                >
-                    <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
-                    <path
-                        className={Classes.SPINNER_HEAD}
-                        d={SPINNER_TRACK}
-                        pathLength={PATH_LENGTH}
-                        strokeDasharray={`${PATH_LENGTH} ${PATH_LENGTH}`}
-                        strokeDashoffset={strokeOffset}
-                    />
-                </svg>,
-            ),
-        );
-    }
-
-    protected validateProps({ className = "", size }: SpinnerProps) {
+    React.useEffect(() => {
         if (size != null && (className.indexOf(Classes.SMALL) >= 0 || className.indexOf(Classes.LARGE) >= 0)) {
             console.warn(SPINNER_WARN_CLASSES_SIZE);
         }
-    }
+    }, [className, size]);
 
     /**
      * Resolve size to a pixel value.
      * Size can be set by className, props, default, or minimum constant.
      */
-    private getSize() {
-        const { className = "", size } = this.props;
+    const sizePx = React.useMemo(() => {
         if (size == null) {
-            // allow Classes constants to determine default size.
-            if (className.indexOf(Classes.SMALL) >= 0) {
+            if (className?.indexOf(Classes.SMALL) >= 0) {
                 return SpinnerSize.SMALL;
-            } else if (className.indexOf(Classes.LARGE) >= 0) {
+            } else if (className?.indexOf(Classes.LARGE) >= 0) {
                 return SpinnerSize.LARGE;
             }
             return SpinnerSize.STANDARD;
         }
         return Math.max(MIN_SIZE, size);
-    }
+    }, [className, size]);
 
     /** Compute viewbox such that stroked track sits exactly at edge of image frame. */
-    private getViewBox(strokeWidth: number) {
-        const radius = R + strokeWidth / 2;
+    const getViewBox = React.useCallback((newStrokeWidth: number) => {
+        const radius = R + newStrokeWidth / 2;
         const viewBoxX = (50 - radius).toFixed(2);
         const viewBoxWidth = (radius * 2).toFixed(2);
         return `${viewBoxX} ${viewBoxX} ${viewBoxWidth} ${viewBoxWidth}`;
-    }
-}
+    }, []);
+
+    const classes = classNames(
+        Classes.SPINNER,
+        Classes.intentClass(intent),
+        { [Classes.SPINNER_NO_SPIN]: value != null },
+        className,
+    );
+
+    // keep spinner track width consistent at all sizes (down to about 10px).
+    const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / sizePx);
+    const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
+
+    // multiple DOM elements around SVG are necessary to properly isolate animation:
+    // - SVG elements in IE do not support anim/trans so they must be set on a parent HTML element.
+    // - SPINNER_ANIMATION isolates svg from parent display and is always centered inside root element.
+    return React.createElement(
+        tagName,
+        {
+            "aria-label": "loading",
+            "aria-valuemax": 100,
+            "aria-valuemin": 0,
+            "aria-valuenow": value === undefined ? undefined : value * 100,
+            className: classes,
+            role: "progressbar",
+            ...htmlProps,
+        },
+        React.createElement(
+            tagName,
+            { className: Classes.SPINNER_ANIMATION },
+            <svg width={sizePx} height={sizePx} strokeWidth={strokeWidth.toFixed(2)} viewBox={getViewBox(strokeWidth)}>
+                <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
+                <path
+                    className={Classes.SPINNER_HEAD}
+                    d={SPINNER_TRACK}
+                    pathLength={PATH_LENGTH}
+                    strokeDasharray={`${PATH_LENGTH} ${PATH_LENGTH}`}
+                    strokeDashoffset={strokeOffset}
+                />
+            </svg>,
+        ),
+    );
+};
+
+Spinner.displayName = `${DISPLAYNAME_PREFIX}.Spinner`;

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -91,14 +91,6 @@ export const Spinner: React.FC<SpinnerProps> = props => {
     const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / sizePx);
     const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
 
-    /** Compute viewbox such that stroked track sits exactly at edge of image frame. */
-    const viewBox = React.useMemo(() => {
-        const radius = R + strokeWidth / 2;
-        const viewBoxX = (50 - radius).toFixed(2);
-        const viewBoxWidth = (radius * 2).toFixed(2);
-        return `${viewBoxX} ${viewBoxX} ${viewBoxWidth} ${viewBoxWidth}`;
-    }, [strokeWidth]);
-
     const classes = classNames(
         Classes.SPINNER,
         Classes.intentClass(intent),
@@ -123,7 +115,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
         React.createElement(
             tagName,
             { className: Classes.SPINNER_ANIMATION },
-            <svg width={sizePx} height={sizePx} strokeWidth={strokeWidth.toFixed(2)} viewBox={viewBox}>
+            <svg width={sizePx} height={sizePx} strokeWidth={strokeWidth.toFixed(2)} viewBox={getViewBox(strokeWidth)}>
                 <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
                 <path
                     className={Classes.SPINNER_HEAD}
@@ -153,4 +145,12 @@ const getSize = (size: number | undefined, className: string): number => {
         return SpinnerSize.STANDARD;
     }
     return Math.max(MIN_SIZE, size);
+};
+
+/** Compute viewbox such that stroked track sits exactly at edge of image frame. */
+const getViewBox = (strokeWidth: number): string => {
+    const radius = R + strokeWidth / 2;
+    const viewBoxX = (50 - radius).toFixed(2);
+    const viewBoxWidth = (radius * 2).toFixed(2);
+    return `${viewBoxX} ${viewBoxX} ${viewBoxWidth} ${viewBoxWidth}`;
 };

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -21,6 +21,7 @@ import { Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
 import { clamp } from "../../common/utils";
+import { useValidateProps } from "../../hooks/useValidateProps";
 
 export enum SpinnerSize {
     SMALL = 20,
@@ -79,8 +80,10 @@ export interface SpinnerProps<T extends HTMLElement = HTMLElement> extends Props
 export const Spinner: React.FC<SpinnerProps> = props => {
     const { className = "", intent, value, tagName = "div", size, ...htmlProps } = props;
 
-    React.useEffect(() => {
-        if (size != null && (className.indexOf(Classes.SMALL) >= 0 || className.indexOf(Classes.LARGE) >= 0)) {
+    useValidateProps(() => {
+        const isSizePropSet = size != null;
+        const isSizeClassSet = className.indexOf(Classes.SMALL) >= 0 || className.indexOf(Classes.LARGE) >= 0;
+        if (isSizePropSet && isSizeClassSet) {
             console.warn(SPINNER_WARN_CLASSES_SIZE);
         }
     }, [className, size]);

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -91,9 +91,9 @@ export const Spinner: React.FC<SpinnerProps> = props => {
      */
     const sizePx = React.useMemo(() => {
         if (size == null) {
-            if (className?.indexOf(Classes.SMALL) >= 0) {
+            if (className.indexOf(Classes.SMALL) >= 0) {
                 return SpinnerSize.SMALL;
-            } else if (className?.indexOf(Classes.LARGE) >= 0) {
+            } else if (className.indexOf(Classes.LARGE) >= 0) {
                 return SpinnerSize.LARGE;
             }
             return SpinnerSize.STANDARD;

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -101,13 +101,17 @@ export const Spinner: React.FC<SpinnerProps> = props => {
         return Math.max(MIN_SIZE, size);
     }, [className, size]);
 
+    // keep spinner track width consistent at all sizes (down to about 10px).
+    const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / sizePx);
+    const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
+
     /** Compute viewbox such that stroked track sits exactly at edge of image frame. */
-    const getViewBox = React.useCallback((newStrokeWidth: number) => {
-        const radius = R + newStrokeWidth / 2;
+    const viewBox = React.useMemo(() => {
+        const radius = R + strokeWidth / 2;
         const viewBoxX = (50 - radius).toFixed(2);
         const viewBoxWidth = (radius * 2).toFixed(2);
         return `${viewBoxX} ${viewBoxX} ${viewBoxWidth} ${viewBoxWidth}`;
-    }, []);
+    }, [strokeWidth]);
 
     const classes = classNames(
         Classes.SPINNER,
@@ -115,10 +119,6 @@ export const Spinner: React.FC<SpinnerProps> = props => {
         { [Classes.SPINNER_NO_SPIN]: value != null },
         className,
     );
-
-    // keep spinner track width consistent at all sizes (down to about 10px).
-    const strokeWidth = Math.min(MIN_STROKE_WIDTH, (STROKE_WIDTH * SpinnerSize.LARGE) / sizePx);
-    const strokeOffset = PATH_LENGTH - PATH_LENGTH * (value == null ? 0.25 : clamp(value, 0, 1));
 
     // multiple DOM elements around SVG are necessary to properly isolate animation:
     // - SVG elements in IE do not support anim/trans so they must be set on a parent HTML element.
@@ -137,7 +137,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
         React.createElement(
             tagName,
             { className: Classes.SPINNER_ANIMATION },
-            <svg width={sizePx} height={sizePx} strokeWidth={strokeWidth.toFixed(2)} viewBox={getViewBox(strokeWidth)}>
+            <svg width={sizePx} height={sizePx} strokeWidth={strokeWidth.toFixed(2)} viewBox={viewBox}>
                 <path className={Classes.SPINNER_TRACK} d={SPINNER_TRACK} />
                 <path
                     className={Classes.SPINNER_HEAD}

--- a/packages/core/src/hooks/useValidateProps.ts
+++ b/packages/core/src/hooks/useValidateProps.ts
@@ -1,0 +1,29 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import * as React from "react";
+
+import { isNodeEnv } from "../common/utils";
+
+/**
+ * Custom hook for validating component props during development.
+ * This hook runs validation checks only in non-production environments,
+ * following the same pattern as AbstractComponent.
+ *
+ * @param validator - Function that performs the validation checks
+ * @param dependencies - Optional array of dependencies that trigger validation when changed
+ *
+ * @example
+ * useValidateProps(() => {
+ *     if (value < 0) console.warn("Value must be positive");
+ * }, [value]);
+ */
+export function useValidateProps(validator: () => void, dependencies: React.DependencyList = []) {
+    React.useEffect(() => {
+        if (!isNodeEnv("production")) {
+            validator();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, dependencies);
+}

--- a/packages/core/test/hooks/useValidatePropsTests.tsx
+++ b/packages/core/test/hooks/useValidatePropsTests.tsx
@@ -1,0 +1,47 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import * as React from "react";
+import * as sinon from "sinon";
+
+import { useValidateProps } from "../../src/hooks/useValidateProps";
+
+describe("useValidateProps", () => {
+    const validatorSpy = sinon.spy();
+
+    beforeEach(() => {
+        validatorSpy.resetHistory();
+    });
+
+    const TestComponent: React.FC<{ value?: number }> = ({ value }) => {
+        useValidateProps(validatorSpy, [value]);
+        return null;
+    };
+
+    it("calls validator in development environment", () => {
+        render(<TestComponent />);
+        expect(validatorSpy.called).to.be.true;
+    });
+
+    it.skip("does not call validator in production environment", () => {
+        // TODO: figure out how to test this
+    });
+
+    it("calls validator when dependencies change", () => {
+        const { rerender } = render(<TestComponent value={1} />);
+        expect(validatorSpy.callCount).to.equal(1);
+
+        rerender(<TestComponent value={2} />);
+        expect(validatorSpy.callCount).to.equal(2);
+    });
+
+    it("does not call validator when dependencies haven't changed", () => {
+        const { rerender } = render(<TestComponent value={1} />);
+
+        rerender(<TestComponent value={1} />);
+        expect(validatorSpy.callCount).to.equal(1);
+    });
+});

--- a/packages/core/test/index.ts
+++ b/packages/core/test/index.ts
@@ -88,3 +88,4 @@ import "./tree/treeTests";
 // hooks
 import "./hooks/useHotkeysTests";
 import "./hooks/useOverlayStackTests";
+import "./hooks/useValidatePropsTests";

--- a/packages/demo-app/src/examples/Examples.tsx
+++ b/packages/demo-app/src/examples/Examples.tsx
@@ -37,6 +37,7 @@ import { MenuExample } from "./MenuExample";
 import { NonIdealStateExample } from "./NonIdealStateExample";
 import { PopoverExample } from "./PopoverExample";
 import { SliderExample } from "./SliderExample";
+import { SpinnerExample } from "./SpinnerExample";
 import { SwitchExample } from "./SwitchExample";
 import { TableExample } from "./TableExample";
 import { TabsExample } from "./TabsExample";
@@ -80,6 +81,7 @@ const ExamplesContainer: React.FC<{ isDark?: boolean }> = ({ isDark = false }) =
             <NonIdealStateExample />
             <PopoverExample />
             <SliderExample />
+            <SpinnerExample />
             <SwitchExample />
             <TableExample />
             <TabsExample />

--- a/packages/demo-app/src/examples/SpinnerExample.tsx
+++ b/packages/demo-app/src/examples/SpinnerExample.tsx
@@ -1,0 +1,21 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import * as React from "react";
+
+import { Intent, Spinner, SpinnerSize } from "@blueprintjs/core";
+
+import { ExampleCard } from "./ExampleCard";
+
+export const SpinnerExample = React.memo(() => {
+    return (
+        <ExampleCard label="Spinner">
+            {Object.values(Intent).map(intent => (
+                <Spinner key={`${intent}-spinner`} intent={intent} size={SpinnerSize.STANDARD} />
+            ))}
+        </ExampleCard>
+    );
+});
+
+SpinnerExample.displayName = "DemoApp.SpinnerExample";

--- a/packages/demo-app/src/examples/TooltipExample.tsx
+++ b/packages/demo-app/src/examples/TooltipExample.tsx
@@ -31,7 +31,6 @@ export const TooltipExample = React.memo(() => {
                         Always open tooltip
                     </span>
                 }
-                isOpen={true}
             >
                 Always open target
             </Tooltip>


### PR DESCRIPTION
Part of #6289

#### Changes:

Refactors `Spinner` from a class-based to functional component. All functionality should remain preserved.

**Example:** [Before](https://blueprintjs.com/docs/#core/components/spinner) / [After](https://output.circle-artifacts.com/output/job/3b3263af-6c0c-45b5-bdd0-77eb0b146340/artifacts/0/packages/docs-app/dist/index.html#core/components/spinner)