### PR TITLE
chore: Refactor ProgressBar from a class to functional component

### DIFF
--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -17,11 +17,11 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
+import { Classes } from "../../common";
+import { DISPLAYNAME_PREFIX, type HTMLDivProps, type IntentProps, type Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 
-export interface ProgressBarProps extends Props, IntentProps {
+export interface ProgressBarProps extends Props, IntentProps, HTMLDivProps {
     /**
      * Whether the background should animate.
      *
@@ -49,31 +49,33 @@ export interface ProgressBarProps extends Props, IntentProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/progress-bar
  */
-export class ProgressBar extends AbstractPureComponent<ProgressBarProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.ProgressBar`;
+export const ProgressBar: React.FC<ProgressBarProps> = props => {
+    const { animate = true, className, intent, stripes = true, value, ...htmlProps } = props;
+    const classes = classNames(
+        Classes.PROGRESS_BAR,
+        Classes.intentClass(intent),
+        {
+            [Classes.PROGRESS_NO_ANIMATION]: !animate,
+            [Classes.PROGRESS_NO_STRIPES]: !stripes,
+        },
+        className,
+    );
+    const percent = value == null ? undefined : 100 * clamp(value, 0, 1);
+    // don't set width if value is null (rely on default CSS value)
+    const width = percent == null ? undefined : percent + "%";
 
-    public render() {
-        const { animate = true, className, intent, stripes = true, value } = this.props;
-        const classes = classNames(
-            Classes.PROGRESS_BAR,
-            Classes.intentClass(intent),
-            { [Classes.PROGRESS_NO_ANIMATION]: !animate, [Classes.PROGRESS_NO_STRIPES]: !stripes },
-            className,
-        );
-        const percent = value == null ? undefined : 100 * clamp(value, 0, 1);
-        // don't set width if value is null (rely on default CSS value)
-        const width = percent == null ? undefined : percent + "%";
+    return (
+        <div
+            {...htmlProps}
+            aria-valuemax={100}
+            aria-valuemin={0}
+            aria-valuenow={percent == null ? undefined : Math.round(percent)}
+            className={classes}
+            role="progressbar"
+        >
+            <div className={Classes.PROGRESS_METER} style={{ width }} />
+        </div>
+    );
+};
 
-        return (
-            <div
-                aria-valuemax={100}
-                aria-valuemin={0}
-                aria-valuenow={percent == null ? undefined : Math.round(percent)}
-                className={classes}
-                role="progressbar"
-            >
-                <div className={Classes.PROGRESS_METER} style={{ width }} />
-            </div>
-        );
-    }
-}
+ProgressBar.displayName = `${DISPLAYNAME_PREFIX}.ProgressBar`;


### PR DESCRIPTION
Part of #6289

#### Changes:

Refactors `ProgressBar` from a class-based to functional component. All functionality should remain preserved.

Also allows `htmlProps` to be spread to component to allow passing of `data-*` props. (see #3763)

**Example:** [Before](https://blueprintjs.com/docs/#core/components/progress-bar) / [After](https://output.circle-artifacts.com/output/job/565af5a7-8830-4196-b9db-1b43dc45c20b/artifacts/0/packages/docs-app/dist/index.html#core/components/progress-bar)