### PR TITLE
chore: Refactor Navbar components from class to functional components

### DIFF
--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes } from "../../common";
+import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
 
 import { NavbarDivider } from "./navbarDivider";
@@ -40,22 +40,23 @@ export interface NavbarProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/navbar
  */
-export class Navbar extends AbstractPureComponent<NavbarProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.Navbar`;
+export const Navbar: React.FC<NavbarProps> & {
+    Divider: typeof NavbarDivider;
+    Group: typeof NavbarGroup;
+    Heading: typeof NavbarHeading;
+} = props => {
+    const { children, className, fixedToTop, ...htmlProps } = props;
+    const classes = classNames(Classes.NAVBAR, { [Classes.FIXED_TOP]: fixedToTop }, className);
+    return (
+        <div className={classes} {...htmlProps}>
+            {children}
+        </div>
+    );
+};
 
-    public static Divider = NavbarDivider;
+Navbar.displayName = `${DISPLAYNAME_PREFIX}.Navbar`;
 
-    public static Group = NavbarGroup;
-
-    public static Heading = NavbarHeading;
-
-    public render() {
-        const { children, className, fixedToTop, ...htmlProps } = this.props;
-        const classes = classNames(Classes.NAVBAR, { [Classes.FIXED_TOP]: fixedToTop }, className);
-        return (
-            <div className={classes} {...htmlProps}>
-                {children}
-            </div>
-        );
-    }
-}
+// compound components of Navbar
+Navbar.Divider = NavbarDivider;
+Navbar.Group = NavbarGroup;
+Navbar.Heading = NavbarHeading;

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes } from "../../common";
+import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
 
 // allow the empty interface so we can label it clearly in the docs
@@ -27,11 +27,8 @@ export interface NavbarDividerProps extends Props, HTMLDivProps {
 
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
-export class NavbarDivider extends AbstractPureComponent<NavbarDividerProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.NavbarDivider`;
+export const NavbarDivider: React.FC<NavbarDividerProps> = ({ className, ...htmlProps }) => {
+    return <div className={classNames(Classes.NAVBAR_DIVIDER, className)} {...htmlProps} />;
+};
 
-    public render() {
-        const { className, ...htmlProps } = this.props;
-        return <div className={classNames(Classes.NAVBAR_DIVIDER, className)} {...htmlProps} />;
-    }
-}
+NavbarDivider.displayName = `${DISPLAYNAME_PREFIX}.NavbarDivider`;

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes } from "../../common";
+import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
 
 export interface NavbarHeadingProps extends Props, HTMLDivProps {
@@ -26,15 +26,12 @@ export interface NavbarHeadingProps extends Props, HTMLDivProps {
 
 // this component is simple enough that tests would be purely tautological.
 /* istanbul ignore next */
-export class NavbarHeading extends AbstractPureComponent<NavbarHeadingProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.NavbarHeading`;
+export const NavbarHeading: React.FC<NavbarHeadingProps> = ({ children, className, ...htmlProps }) => {
+    return (
+        <div className={classNames(Classes.NAVBAR_HEADING, className)} {...htmlProps}>
+            {children}
+        </div>
+    );
+};
 
-    public render() {
-        const { children, className, ...htmlProps } = this.props;
-        return (
-            <div className={classNames(Classes.NAVBAR_HEADING, className)} {...htmlProps}>
-                {children}
-            </div>
-        );
-    }
-}
+NavbarHeading.displayName = `${DISPLAYNAME_PREFIX}.NavbarHeading`;


### PR DESCRIPTION
Part of #6289

#### Changes:

Refactors `Navbar` and its compound components (`NavbarDivider` & `NavbarHeading`) from class-based to functional components. All functionality should remain preserved.

Also allows `htmlProps` to be spread onto each component to allow passing of `data-*` props to components. (see #3763)

**Example:** [Before](https://blueprintjs.com/docs/#core/components/navbar) / [After](https://output.circle-artifacts.com/output/job/89b3717e-87fd-4184-899d-6b76f4b7cdcb/artifacts/0/packages/docs-app/dist/index.html#core/components/navbar)
