### PR TITLE
chore: Refactor Alert from a class to functional component

### DIFF
--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -23,6 +23,7 @@ import {
     ALERT_WARN_CANCEL_OUTSIDE_CLICK,
     ALERT_WARN_CANCEL_PROPS,
 } from "../../common/errors";
+import { useValidateProps } from "../../hooks/useValidateProps";
 import { Button } from "../button/buttons";
 import { Dialog } from "../dialog/dialog";
 import { Icon, type IconName } from "../icon/icon";
@@ -155,7 +156,7 @@ export const Alert: React.FC<AlertProps> = props => {
         ...overlayProps
     } = props;
 
-    React.useEffect(() => {
+    useValidateProps(() => {
         if (onClose == null && (cancelButtonText == null) !== (onCancel == null)) {
             console.warn(ALERT_WARN_CANCEL_PROPS);
         }

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import {
-    AbstractPureComponent,
-    Classes,
-    DISPLAYNAME_PREFIX,
-    type Intent,
-    type MaybeElement,
-    type Props,
-} from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, type Intent, type MaybeElement, type Props } from "../../common";
 import {
     ALERT_WARN_CANCEL_ESCAPE_KEY,
     ALERT_WARN_CANCEL_OUTSIDE_CLICK,
@@ -122,21 +115,21 @@ export interface AlertProps extends OverlayLifecycleProps, Props {
      *
      * If any of the `cancel` props are defined, then either `onCancel` or `onClose` must be defined.
      */
-    onCancel?(evt?: React.SyntheticEvent<HTMLElement>): void;
+    onCancel?: (event?: React.SyntheticEvent<HTMLElement>) => void;
 
     /**
      * Handler invoked when the confirm button is clicked. Alerts can be **confirmed** in the following ways:
      * - clicking the confirm button
      * - focusing on the confirm button and pressing `enter` or `space`
      */
-    onConfirm?(evt?: React.SyntheticEvent<HTMLElement>): void;
+    onConfirm?: (event?: React.SyntheticEvent<HTMLElement>) => void;
 
     /**
      * Handler invoked when the Alert is confirmed or canceled; see `onConfirm` and `onCancel` for more details.
      * First argument is `true` if confirmed, `false` otherwise.
      * This is an alternative to defining separate `onConfirm` and `onCancel` handlers.
      */
-    onClose?(confirmed: boolean, evt?: React.SyntheticEvent<HTMLElement>): void;
+    onClose?: (confirmed: boolean, event?: React.SyntheticEvent<HTMLElement>) => void;
 }
 
 /**
@@ -144,75 +137,76 @@ export interface AlertProps extends OverlayLifecycleProps, Props {
  *
  * @see https://blueprintjs.com/docs/#core/components/alert
  */
-export class Alert extends AbstractPureComponent<AlertProps> {
-    public static defaultProps: AlertProps = {
-        canEscapeKeyCancel: false,
-        canOutsideClickCancel: false,
-        confirmButtonText: "OK",
-        isOpen: false,
-        loading: false,
-    };
+export const Alert: React.FC<AlertProps> = props => {
+    const {
+        cancelButtonText,
+        canEscapeKeyCancel = false,
+        canOutsideClickCancel = false,
+        children,
+        className,
+        confirmButtonText = "OK",
+        icon,
+        intent,
+        isOpen = false,
+        loading = false,
+        onCancel,
+        onClose,
+        onConfirm,
+        ...overlayProps
+    } = props;
 
-    public static displayName = `${DISPLAYNAME_PREFIX}.Alert`;
-
-    public render() {
-        const {
-            canEscapeKeyCancel,
-            canOutsideClickCancel,
-            children,
-            className,
-            icon,
-            intent,
-            loading,
-            cancelButtonText,
-            confirmButtonText,
-            onClose,
-            ...overlayProps
-        } = this.props;
-        return (
-            <Dialog
-                {...overlayProps}
-                role="alertdialog"
-                className={classNames(Classes.ALERT, className)}
-                canEscapeKeyClose={canEscapeKeyCancel}
-                canOutsideClickClose={canOutsideClickCancel}
-                onClose={this.handleCancel}
-            >
-                <div className={Classes.ALERT_BODY}>
-                    <Icon icon={icon} size={40} intent={intent} />
-                    <div className={Classes.ALERT_CONTENTS}>{children}</div>
-                </div>
-                <div className={Classes.ALERT_FOOTER}>
-                    <Button loading={loading} intent={intent} text={confirmButtonText} onClick={this.handleConfirm} />
-                    {cancelButtonText && (
-                        <Button text={cancelButtonText} disabled={loading} onClick={this.handleCancel} />
-                    )}
-                </div>
-            </Dialog>
-        );
-    }
-
-    protected validateProps(props: AlertProps) {
-        if (props.onClose == null && (props.cancelButtonText == null) !== (props.onCancel == null)) {
+    React.useEffect(() => {
+        if (onClose == null && (cancelButtonText == null) !== (onCancel == null)) {
             console.warn(ALERT_WARN_CANCEL_PROPS);
         }
 
-        const hasCancelHandler = props.onCancel != null || props.onClose != null;
-        if (props.canEscapeKeyCancel && !hasCancelHandler) {
+        const hasCancelHandler = onCancel != null || onClose != null;
+        if (canEscapeKeyCancel && !hasCancelHandler) {
             console.warn(ALERT_WARN_CANCEL_ESCAPE_KEY);
         }
-        if (props.canOutsideClickCancel && !hasCancelHandler) {
+        if (canOutsideClickCancel && !hasCancelHandler) {
             console.warn(ALERT_WARN_CANCEL_OUTSIDE_CLICK);
         }
-    }
+    }, [canEscapeKeyCancel, canOutsideClickCancel, cancelButtonText, onCancel, onClose]);
 
-    private handleCancel = (evt?: React.SyntheticEvent<HTMLElement>) => this.internalHandleCallbacks(false, evt);
+    const internalHandleCallbacks = React.useCallback(
+        (confirmed: boolean, event?: React.SyntheticEvent<HTMLElement>) => {
+            (confirmed ? onConfirm : onCancel)?.(event);
+            onClose?.(confirmed, event);
+        },
+        [onCancel, onClose, onConfirm],
+    );
 
-    private handleConfirm = (evt: React.SyntheticEvent<HTMLElement>) => this.internalHandleCallbacks(true, evt);
+    const handleCancel = React.useCallback(
+        (event?: React.SyntheticEvent<HTMLElement>) => internalHandleCallbacks(false, event),
+        [internalHandleCallbacks],
+    );
 
-    private internalHandleCallbacks(confirmed: boolean, evt?: React.SyntheticEvent<HTMLElement>) {
-        const { onCancel, onClose, onConfirm } = this.props;
-        (confirmed ? onConfirm : onCancel)?.(evt);
-        onClose?.(confirmed, evt);
-    }
-}
+    const handleConfirm = React.useCallback(
+        (event: React.SyntheticEvent<HTMLElement>) => internalHandleCallbacks(true, event),
+        [internalHandleCallbacks],
+    );
+
+    return (
+        <Dialog
+            {...overlayProps}
+            role="alertdialog"
+            className={classNames(Classes.ALERT, className)}
+            canEscapeKeyClose={canEscapeKeyCancel}
+            canOutsideClickClose={canOutsideClickCancel}
+            isOpen={isOpen}
+            onClose={handleCancel}
+        >
+            <div className={Classes.ALERT_BODY}>
+                <Icon icon={icon} size={40} intent={intent} />
+                <div className={Classes.ALERT_CONTENTS}>{children}</div>
+            </div>
+            <div className={Classes.ALERT_FOOTER}>
+                <Button loading={loading} intent={intent} text={confirmButtonText} onClick={handleConfirm} />
+                {cancelButtonText && <Button text={cancelButtonText} disabled={loading} onClick={handleCancel} />}
+            </div>
+        </Dialog>
+    );
+};
+
+Alert.displayName = `${DISPLAYNAME_PREFIX}.Alert`;

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -274,7 +274,7 @@ describe("<Alert>", () => {
 
         function testWarn(alert: React.JSX.Element, warning: string) {
             // one warning
-            const wrapper = shallow(alert);
+            const wrapper = mount(alert);
             assert.strictEqual(warnSpy.callCount, 1);
             assert.isTrue(warnSpy.calledWithExactly(warning));
             // no more warnings


### PR DESCRIPTION
Part of #6289

#### Changes:

Refactors `Alert` from a class-based to functional component. All functionality should remain preserved.

**Example:** [Before](https://blueprintjs.com/docs/#core/components/alert) / [After](https://output.circle-artifacts.com/output/job/03816f11-6f5a-4068-b758-a61dc83a267f/artifacts/0/packages/docs-app/dist/index.html#core/components/alert)
