### PR TITLE
chore: Refactor FormGroup from a class to a functional component

### DIFF
--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes, type Intent } from "../../common";
-import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
+import { Classes, type Intent } from "../../common";
+import { DISPLAYNAME_PREFIX, type HTMLDivProps, type IntentProps, type Props } from "../../common/props";
 
-export interface FormGroupProps extends IntentProps, Props {
+export interface FormGroupProps extends IntentProps, Props, HTMLDivProps {
     /** Group contents. */
     children?: React.ReactNode;
 
@@ -86,38 +86,49 @@ export interface FormGroupProps extends IntentProps, Props {
  *
  * @see https://blueprintjs.com/docs/#core/components/form-group
  */
-export class FormGroup extends AbstractPureComponent<FormGroupProps> {
-    public static displayName = `${DISPLAYNAME_PREFIX}.FormGroup`;
+export const FormGroup: React.FC<FormGroupProps> = props => {
+    const {
+        children,
+        className,
+        contentClassName,
+        disabled,
+        fill,
+        helperText,
+        inline,
+        intent,
+        label,
+        labelFor,
+        labelInfo,
+        style,
+        subLabel,
+        ...htmlProps
+    } = props;
 
-    public render() {
-        const { children, contentClassName, helperText, label, labelFor, labelInfo, style, subLabel } = this.props;
-        return (
-            <div className={this.getClassName()} style={style}>
-                {label && (
-                    <label className={Classes.LABEL} htmlFor={labelFor}>
-                        {label} <span className={Classes.TEXT_MUTED}>{labelInfo}</span>
-                    </label>
-                )}
-                {subLabel && <div className={Classes.FORM_GROUP_SUB_LABEL}>{subLabel}</div>}
-                <div className={classNames(Classes.FORM_CONTENT, contentClassName)}>
-                    {children}
-                    {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}
-                </div>
+    const classes = classNames(
+        Classes.FORM_GROUP,
+        Classes.intentClass(intent),
+        {
+            [Classes.DISABLED]: disabled,
+            [Classes.FILL]: fill,
+            [Classes.INLINE]: inline,
+        },
+        className,
+    );
+
+    return (
+        <div className={classes} style={style} {...htmlProps}>
+            {label && (
+                <label className={Classes.LABEL} htmlFor={labelFor}>
+                    {label} <span className={Classes.TEXT_MUTED}>{labelInfo}</span>
+                </label>
+            )}
+            {subLabel && <div className={Classes.FORM_GROUP_SUB_LABEL}>{subLabel}</div>}
+            <div className={classNames(Classes.FORM_CONTENT, contentClassName)}>
+                {children}
+                {helperText && <div className={Classes.FORM_HELPER_TEXT}>{helperText}</div>}
             </div>
-        );
-    }
+        </div>
+    );
+};
 
-    private getClassName() {
-        const { className, disabled, fill, inline, intent } = this.props;
-        return classNames(
-            Classes.FORM_GROUP,
-            Classes.intentClass(intent),
-            {
-                [Classes.DISABLED]: disabled,
-                [Classes.FILL]: fill,
-                [Classes.INLINE]: inline,
-            },
-            className,
-        );
-    }
-}
+FormGroup.displayName = `${DISPLAYNAME_PREFIX}.FormGroup`;


### PR DESCRIPTION
Part of #6289

#### Changes:

Refactors `FormGroup` from a class-based to functional component. All functionality should remain preserved.

Also allows `htmlProps` to be spread to component to allow passing of `data-*` props. (see #3763)

**Example:** [Before](https://blueprintjs.com/docs/#core/components/form-group) / [After](https://output.circle-artifacts.com/output/job/9aa049ab-4835-49fa-86d2-e5eb982d9be6/artifacts/0/packages/docs-app/dist/index.html#core/components/form-group)
