### PR TITLE
chore: Run prettier over markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -7,9 +7,9 @@ about: Something not working as expected?
 
 #### Environment
 
-- __Package version(s)__: <!-- fill this out -->
-- __Operating System__: <!-- fill this out -->
-- __Browser name and version__: <!-- fill this out -->
+-   **Package version(s)**: <!-- fill this out -->
+-   **Operating System**: <!-- fill this out -->
+-   **Browser name and version**: <!-- fill this out -->
 
 #### Code Sandbox
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -7,8 +7,8 @@ about: Propose a new feature or suggest an idea
 
 #### Environment
 
-- __Package version(s)__: <!-- fill this out -->
-- __Browser and OS versions__: <!-- fill this out -->
+-   **Package version(s)**: <!-- fill this out -->
+-   **Browser and OS versions**: <!-- fill this out -->
 
 #### Feature request
 

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -7,8 +7,8 @@ about: Need help with Blueprint?
 
 #### Environment
 
-- __Package version(s)__: <!-- fill this out -->
-- __Browser and OS versions__: <!-- fill this out -->
+-   **Package version(s)**: <!-- fill this out -->
+-   **Browser and OS versions**: <!-- fill this out -->
 
 #### Question
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 #### Checklist
 
-- [ ] Includes tests
-- [ ] Update documentation
+-   [ ] Includes tests
+-   [ ] Update documentation
 
 <!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-Changelog
----------
+# Changelog
 
 Changelogs for `@blueprintjs/*` packages currently live in the project's Github wiki:
 
-- [5.x Changelog](https://github.com/palantir/blueprint/wiki/5.x-Changelog)
-- [4.x Changelog](https://github.com/palantir/blueprint/wiki/4.x-Changelog)
-- [3.x Changelog](https://github.com/palantir/blueprint/wiki/3.x-Changelog)
+-   [5.x Changelog](https://github.com/palantir/blueprint/wiki/5.x-Changelog)
+-   [4.x Changelog](https://github.com/palantir/blueprint/wiki/4.x-Changelog)
+-   [3.x Changelog](https://github.com/palantir/blueprint/wiki/3.x-Changelog)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ A typical contributor workflow looks like this:
 
 1. Create a new feature branch. We like to use a format like `[your-initials]/[short-name]`:
    for example, `bd/refactor-buttons`.
-1. Run development build tasks - follow the ["Developing libraries" steps in the README](https://github.com/palantir/blueprint/blob/develop/README.md#developing-libraries).
-1. Visit http://localhost:9000 in your web browser to see the interactive docs web app.
+2. Run development build tasks - follow the ["Developing libraries" steps in the README](https://github.com/palantir/blueprint/blob/develop/README.md#developing-libraries).
+3. Visit http://localhost:9000 in your web browser to see the interactive docs web app.
 4. Write some code. :hammer: **Refer to the wiki in this repo for detailed instructions on:**
     - [Development practices](https://github.com/palantir/blueprint/wiki/Development-practices)
     - [Coding guidelines](https://github.com/palantir/blueprint/wiki/Coding-guidelines)
@@ -45,26 +45,15 @@ A typical contributor workflow looks like this:
 5. Ensure your code **compiles properly** and is **tested**, **linted**, and **formatted**.
     - Run `yarn compile` at the repo root to build all libraries.
     - Run `yarn bundle` at the repo root to build the Blueprint documentation and other bundles.
-    - Add unit tests as necessary when fixing bugs or adding features; run them with `yarn test`
-      in the relevant package directory.
-    - Linting is best handled by your editor for real-time feedback (see
-      [Editor integration](https://github.com/palantir/blueprint/wiki/Editor-integration)). Run
-      `yarn lint` to be 100% safe.
+    - Add unit tests as necessary when fixing bugs or adding features; run them with `yarn test` in the relevant package directory.
+    - Linting is best handled by your editor for real-time feedback (see [Editor integration](https://github.com/palantir/blueprint/wiki/Editor-integration)). Run `yarn lint` to be 100% safe.
     - TypeScript lint errors can often be automatically fixed by ESLint. Run lint fixes with `yarn lint-fix`.
-    - Code formatting is enforced using [Prettier](https://prettier.io/). These errors can be fixed in your editor
-      through the Prettier extension (make sure you have set up the editor integrations linked above).
-      __Formatting checks will not run__ during the `yarn lint` package script.
-      Instead, when using the CLI or in a CI environment, you should run the `yarn format` script to fix all
-      formatting issues across the Blueprint monorepo.
-1. Submit a Pull Request on GitHub and fill out the template.
-    - ⚠️ __DO NOT enable CircleCI for your fork of Blueprint.__ When you open a PR, your branch will be checked out
-      and built in palantir's CI pipeline automatically. There is no need to enable the CI build for your fork's
-      pipeline. If you do, this may cause problems in the CI build.
-      - If you have already opened a PR where CircleCI built the code in your own personal or organization pipeline,
-        you will likely have to disable the project from building at app.circleci.com/settings/project/github/\<your-username\>/website
-        and open a new PR.
-1. Team members will review your code and merge it after approvals.
+    - Code formatting is enforced using [Prettier](https://prettier.io/). These errors can be fixed in your editor through the Prettier extension (make sure you have set up the editor integrations linked above). **Formatting checks will not run** during the `yarn lint` package script. Instead, when using the CLI or in a CI environment you should run the `yarn format` script to fix all formatting issues across the Blueprint monorepo.
+6. Submit a Pull Request on GitHub and fill out the template.
+    - ⚠️ **DO NOT enable CircleCI for your fork of Blueprint.** When you open a PR, your branch will be checked out and built in palantir's CI pipeline automatically. There is no need to enable the CI build for your fork's pipeline. If you do, this may cause problems in the CI build.
+        - If you have already opened a PR where CircleCI built the code in your own personal or organization pipeline, you will likely have to disable the project from building at app.circleci.com/settings/project/github/\<your-username\>/website and open a new PR.
+7. Team members will review your code and merge it after approvals.
     - You may be asked to make modifications to code style or to fix bugs you may have not noticed.
     - Please respond to comments in a timely fashion (even if to tell us you need more time).
     - _Do not_ amend commits and `push --force` as they break the PR history. Please add more commits; we squash each PR to a single commit on merge.
-1. Hooray, you contributed! :tophat:
+8. Hooray, you contributed! :tophat:

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ First, ensure you have `nvm` ([Node Version Manager](https://github.com/nvm-sh/n
 After cloning this repo, run:
 
 1. `nvm use` to use the supported Node version for Blueprint development.
-1. `corepack enable` to activate [Yarn](https://yarnpkg.com/getting-started) as the Node package manager.
-1. `yarn` to install all dependencies for the monorepo.
-   1. If seeing an error like "Error when performing the request ...", you may be using a VPN that needs to be disabled to install the dependencies.
-1. If running on Windows:
+2. `corepack enable` to activate [Yarn](https://yarnpkg.com/getting-started) as the Node package manager.
+3. `yarn` to install all dependencies for the monorepo.
+    1. If seeing an error like "Error when performing the request ...", you may be using a VPN that needs to be disabled to install the dependencies.
+4. If running on Windows:
     1. `npm install -g windows-build-tools` to install build tools globally
-    1. Ensure `bash` is your configured script-shell by running:<br />
+    2. Ensure `bash` is your configured script-shell by running:<br />
        `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`
-1. `yarn verify` to ensure you have all the build tooling working properly.
-    1. There may currently be some errors when running this step, even though everything is set up properly, see https://github.com/palantir/blueprint/issues/6926 for more info. 
+5. `yarn verify` to ensure you have all the build tooling working properly.
+    1. There may currently be some errors when running this step, even though everything is set up properly, see https://github.com/palantir/blueprint/issues/6926 for more info.
 
 ### Incorporating upstream changes
 
@@ -101,47 +101,33 @@ If you were previously in a working state and have just pulled new code from `de
 -   If there were package dependency changes, run `yarn` at the root.
     -   This command is very quick if there are no new things to install.
 -   Run `yarn compile` to get the latest built versions of the library packages in this repo.
-    -   This command is quicker than `yarn verify` since it doesn't build the application packages (`docs-app`,
-        `landing-app`, etc.) or run tests
+    -   This command is quicker than `yarn verify` since it doesn't build the application packages (`docs-app`,`landing-app`, etc.) or run tests
 
 ### Developing libraries
 
 There are a few ways to run development scripts, here they are listed from simplest to more advanced usage:
 
--   Run `yarn dev` from the root directory to watch changes across all packages and run the docs application with
-    webpack-dev-server.
+-   Run `yarn dev` from the root directory to watch changes across all packages and run the docs application with webpack-dev-server.
 -   Alternately, most libraries have a dev script to run the docs app _and_ watch changes to only that package:
     -   `yarn dev:core`
     -   `yarn dev:docs`
     -   `yarn dev:datetime`
     -   `yarn dev:select`
     -   `yarn dev:table`
--   Lastly, if you want to control exactly which dev scripts are run and view the console output in the cleanest way,
-    we recommend opening separate terminal windows or splits and running local package dev tasks in each one. This is
-    the recommended workflow for frequent contributors and advanced developers. For example, to test changes in the core
-    and icons packages, you would run the following in separate terminals:
+-   Lastly, if you want to control exactly which dev scripts are run and view the console output in the cleanest way, we recommend opening separate terminal windows or splits and running local package dev tasks in each one. This is the recommended workflow for frequent contributors and advanced developers. For example, to test changes in the core and icons packages, you would run the following in separate terminals:
     -   `cd packages/core && yarn dev`
     -   `cd packages/icons && yarn dev`
     -   `cd packages/docs-app && yarn dev`
 
 ### Updating documentation
 
-Much of Blueprint's documentation lives inside source code as JSDoc comments in `.tsx` files and KSS markup in `.scss`
-files. This documentation is extracted and converted into static JSON data using
-[documentalist](https://github.com/palantir/documentalist/).
-
-If you are updating documentation sources (_not_ the docs UI code which lives in `packages/docs-app` or the docs theme
-in `packages/docs-theme`), you'll need to run `yarn compile` from `packages/docs-data` to see changes reflected in the
-application. For simplicity, an alias script `yarn docs-data` exists in the root to minimize directory hopping.
+Much of Blueprint's documentation lives inside source code as JSDoc comments in `.tsx` files and KSS markup in `.scss` files. This documentation is extracted and converted into static JSON data using [documentalist](https://github.com/palantir/documentalist/). If you are updating documentation sources (_not_ the docs UI code which lives in `packages/docs-app` or the docs theme in `packages/docs-theme`), you'll need to run `yarn compile` from `packages/docs-data` to see changes reflected in the application. For simplicity, an alias script `yarn docs-data` exists in the root to minimize directory hopping.
 
 ### Updating icons
 
-The [One-time setup](#one-time-setup) and [Incorporating upstream changes](#incorporating-upstream-changes) steps should
-produce the generated source code in this repo used to build the icons documentation. This is sufficient for most
-development workflows.
+The [One-time setup](#one-time-setup) and [Incorporating upstream changes](#incorporating-upstream-changes) steps should produce the generated source code in this repo used to build the icons documentation. This is sufficient for most development workflows.
 
-If you are updating icons or adding new ones, you'll need to run `yarn compile` in `packages/icons` to see those changes
-reflected before running any of the dev scripts.
+If you are updating icons or adding new ones, you'll need to run `yarn compile` in `packages/icons` to see those changes reflected before running any of the dev scripts.
 
 ## License
 

--- a/packages/core/src/components/alert/alert.md
+++ b/packages/core/src/components/alert/alert.md
@@ -1,8 +1,8 @@
 @# Alert
 
-__Alerts__ notify users of important information and force them to acknowledge the alert content before continuing.
+**Alerts** notify users of important information and force them to acknowledge the alert content before continuing.
 
-Although similar to [__Dialog__](#core/components/dialog), an alert is more restrictive and should only be used for
+Although similar to [**Dialog**](#core/components/dialog), an alert is more restrictive and should only be used for
 important information. By default, the user can only exit the alert by clicking one of the confirmation buttons;
 clicking the overlay or pressing the `esc` key will not close the alert. These interactions can be enabled via props.
 
@@ -10,7 +10,7 @@ clicking the overlay or pressing the `esc` key will not close the alert. These i
 
 @## Props interface
 
-__Alert__ only supports controlled usage through the `isOpen` prop. Use the `onConfirm` and `onCancel` props to respond
+**Alert** only supports controlled usage through the `isOpen` prop. Use the `onConfirm` and `onCancel` props to respond
 to those interactions separately, or use `onClose` to handle both at the same time.
 
 @interface AlertProps

--- a/packages/core/src/components/dialog/dialog.md
+++ b/packages/core/src/components/dialog/dialog.md
@@ -16,7 +16,7 @@ We use the term "dialog" in Blueprint to avoid confusion with the adjective.
 Blueprint provides two types of dialogs:
 
 1.  Standard dialog: show single view using the `<Dialog>` component
-1.  Multi-step dialog: show multiple sequential views using the `<MultistepDialog>` component.
+2.  Multi-step dialog: show multiple sequential views using the `<MultistepDialog>` component.
 
 @## Dialog
 

--- a/packages/core/src/components/editable-text/editable-text.md
+++ b/packages/core/src/components/editable-text/editable-text.md
@@ -1,6 +1,6 @@
 @# Editable text
 
-__EditableText__ is an interactive component which appears as normal UI text. It transforms into an interactive
+**EditableText** is an interactive component which appears as normal UI text. It transforms into an interactive
 text input field when a user hovers and/or focuses on it.
 
 The text input inherits all font styling from its ancestors, making for a seamless transition between reading and
@@ -8,8 +8,8 @@ editing text.
 
 You might use this component for inline renaming, or for an
 [editable multiline description](#core/components/editable-text.multiline-mode).
-You should not use __EditableText__ when a more static, always-editable
-[__InputGroup__](#core/components/input-group) or [__TextArea__](#core/components/text-area)
+You should not use **EditableText** when a more static, always-editable
+[**InputGroup**](#core/components/input-group) or [**TextArea**](#core/components/text-area)
 component would suffice.
 
 @reactExample EditableTextExample
@@ -23,10 +23,9 @@ you should center the component via flexbox or with `position` and `transform: t
 
 </div>
 
-
 @## Multiline mode
 
-By default, __EditableText__ supports _exactly one line of text_ and will grow or shrink horizontally based on the
+By default, **EditableText** supports _exactly one line of text_ and will grow or shrink horizontally based on the
 length of text.
 
 You may enable the `multiline` prop to use a `<textarea>` which spans multiple lines instead of a single-line
@@ -43,7 +42,7 @@ can be inverted with the `confirmOnEnterKey` prop.
 
 @## Usage
 
-__EditableText__ is used like an [`<input>` element](https://facebook.github.io/react/docs/forms.html) and supports
+**EditableText** is used like an [`<input>` element](https://facebook.github.io/react/docs/forms.html) and supports
 controlled or uncontrolled usage through the `value` or `defaultValue` props, respectively. Use `onChange` to listen to
 ongoing updates and use `onConfirm` and `onCancel` to listen only to completed or canceled edits.
 

--- a/packages/core/src/components/forms/control-group.md
+++ b/packages/core/src/components/forms/control-group.md
@@ -1,6 +1,6 @@
 @# Control group
 
-A __ControlGroup__ renders multiple distinct form controls as one unit, with a small margin between elements. It
+A **ControlGroup** renders multiple distinct form controls as one unit, with a small margin between elements. It
 supports any number of buttons, text inputs, input groups, numeric inputs, and HTML selects as direct children.
 
 <div class="@ns-callout @ns-intent-success @ns-icon-comparison @ns-callout-has-body-content">
@@ -8,9 +8,9 @@ supports any number of buttons, text inputs, input groups, numeric inputs, and H
 
 Both components group multiple elements into a single unit, but their usage patterns are quite different.
 
-Think of __ControlGroup__ as a parent with multiple children, with each one a separate control.
+Think of **ControlGroup** as a parent with multiple children, with each one a separate control.
 
-Conversely, an [__InputGroup__](#core/components/input-group) is a single control, and should behave like
+Conversely, an [**InputGroup**](#core/components/input-group) is a single control, and should behave like
 so. A button inside of an input group should only affect that input; if its reach is further, then it should be
 promoted to live in a control group.
 
@@ -20,15 +20,13 @@ promoted to live in a control group.
 
 @## Flex layout
 
-__ControlGroup__ is a CSS inline flex row (or column if vertical) and provides some modifer props for common flexbox
+**ControlGroup** is a CSS inline flex row (or column if vertical) and provides some modifer props for common flexbox
 patterns:
 
-- Enable the `fill` prop on a control group to make all controls expand equally to fill the available space.
-    - Controls will expand horizontally by default, or vertically if the `vertical` prop is enabled.
-    - Add the class `Classes.FIXED` to individual controls to revert them to their initial sizes.
-
-- In addition, you may enable the `fill` prop on specific controls inside the group to expand them fill more space while
- other controls retain their original sizes.
+-   Enable the `fill` prop on a control group to make all controls expand equally to fill the available space.
+    -   Controls will expand horizontally by default, or vertically if the `vertical` prop is enabled.
+    -   Add the class `Classes.FIXED` to individual controls to revert them to their initial sizes.
+-   In addition, you may enable the `fill` prop on specific controls inside the group to expand them fill more space while other controls retain their original sizes.
 
 You can adjust the specific size of a control with the `flex-basis` or `width` CSS properties.
 
@@ -66,4 +64,3 @@ Note that `.@ns-control-group` does not cascade any modifiers to its children. F
 child must be marked individually as `.@ns-large` for uniform large appearance.
 
 @css control-group
-

--- a/packages/core/src/components/forms/file-input.md
+++ b/packages/core/src/components/forms/file-input.md
@@ -1,6 +1,6 @@
 @# File input
 
-__FileInput__ is a lightweight wrapper around a `<label>` container element which contains an `<input type="file">`.
+**FileInput** is a lightweight wrapper around a `<label>` container element which contains an `<input type="file">`.
 
 @reactExample FileInputExample
 
@@ -20,7 +20,7 @@ To get this behavior, you must update the `text` prop.
 
 @## Props interface
 
-__FileInput__ supports the full range of HTML `<label>` DOM attributes.
+**FileInput** supports the full range of HTML `<label>` DOM attributes.
 Use `inputProps` to forward props to the `<input>` element.
 
 @interface FileInputProps

--- a/packages/core/src/components/forms/form-group.md
+++ b/packages/core/src/components/forms/form-group.md
@@ -12,12 +12,7 @@ This component is a lightweight wrapper around its children with props for the
 label above and helper text below.
 
 ```tsx
-<FormGroup
-    helperText="Helper text with details..."
-    label="Label A"
-    labelFor="text-input"
-    labelInfo="(required)"
->
+<FormGroup helperText="Helper text with details..." label="Label A" labelFor="text-input" labelInfo="(required)">
     <InputGroup id="text-input" placeholder="Placeholder text" />
 </FormGroup>
 ```
@@ -26,14 +21,9 @@ label above and helper text below.
 
 @## CSS
 
-- Link each label to its respective control element with a `for={#id}` attribute on the `<label>` and
-`id={#id}` on the control.
-
-- Add `.@ns-intent-*` or `.@ns-disabled` to `.@ns-form-group` to style the label and helper text.
-Similar to labels, nested controls need to be styled separately.
-
-- Add `.@ns-inline` to `.@ns-form-group` to place the label to the left of the control.
-
-- Add `.@ns-large` to `.@ns-form-group` to align the label when used with large inline Blueprint controls.
+-   Link each label to its respective control element with a `for={#id}` attribute on the `<label>` and `id={#id}` on the control.
+-   Add `.@ns-intent-*` or `.@ns-disabled` to `.@ns-form-group` to style the label and helper text. Similar to labels, nested controls need to be styled separately.
+-   Add `.@ns-inline` to `.@ns-form-group` to place the label to the left of the control.
+-   Add `.@ns-large` to `.@ns-form-group` to align the label when used with large inline Blueprint controls.
 
 @css form-group

--- a/packages/core/src/components/forms/label.md
+++ b/packages/core/src/components/forms/label.md
@@ -1,6 +1,6 @@
 @# Label
 
-__Labels__ enhance the usability of your forms.
+**Labels** enhance the usability of your forms.
 
 Wrapping a `<label>` element around a form input effectively increases the area where the user can click to activate
 the control. Notice how in the examples below, clicking a label focuses its `<input>`.
@@ -8,8 +8,8 @@ the control. Notice how in the examples below, clicking a label focuses its `<in
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Prefer form groups over labels</h5>
 
-The [__FormGroup__ component](#core/components/form-group) provides additional functionality such as helper text and
-modifier props as well as full label support. __FormGroup__ supports both simple and complex use cases, therefore we
+The [**FormGroup** component](#core/components/form-group) provides additional functionality such as helper text and
+modifier props as well as full label support. **FormGroup** supports both simple and complex use cases, therefore we
 recommend using it exclusively when constructing forms.
 
 </div>

--- a/packages/core/src/components/forms/switch.md
+++ b/packages/core/src/components/forms/switch.md
@@ -1,7 +1,7 @@
 @# Switch
 
-__Switch__ is a form control for toggling between boolean states. It is similar to
-[__Checkbox__](#core/components/checkbox), but presents a more skeuomorphic appearance that mimics a physical switch.
+**Switch** is a form control for toggling between boolean states. It is similar to
+[**Checkbox**](#core/components/checkbox), but presents a more skeuomorphic appearance that mimics a physical switch.
 
 Its whole label is interactive and it supports a few visual modifiers for different UI layouts.
 

--- a/packages/core/src/components/hotkeys/hotkeys-target2.md
+++ b/packages/core/src/components/hotkeys/hotkeys-target2.md
@@ -7,15 +7,14 @@ Migrating from [HotkeysTarget](#core/legacy/hotkeys-legacy)?
 
 </h5>
 
-__HotkeysTarget2__ is a replacement for HotkeysTarget. You are encouraged to use this new API, or
+**HotkeysTarget2** is a replacement for HotkeysTarget. You are encouraged to use this new API, or
 the `useHotkeys` hook directly in your function components, as they will become the standard
 APIs in a future major version of Blueprint. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/HotkeysTarget-&-useHotkeys-migration) on the wiki.
 
 </div>
 
-
-The __HotkeysTarget2__ component is a utility component which allows you to use the
+The **HotkeysTarget2** component is a utility component which allows you to use the
 [`useHotkeys` hook](#core/hooks/use-hotkeys) inside a React component class. It's useful if you want to switch to the
 new hotkeys API without refactoring your class components into functional components.
 
@@ -25,7 +24,7 @@ Focus on the piano below to try its hotkeys. The global hotkeys dialog can be sh
 
 @## Usage
 
-First, make sure [__HotkeysProvider__](#core/context/hotkeys-provider) is configured correctly at the root of your
+First, make sure [**HotkeysProvider**](#core/context/hotkeys-provider) is configured correctly at the root of your
 React application.
 
 Then, to register hotkeys and generate the relevant event handlers, use the component like so:
@@ -62,7 +61,7 @@ export default class extends React.PureComponent {
                     </div>
                 )}
             </HotkeysTarget2>
-        )
+        );
     }
 }
 ```

--- a/packages/core/src/components/html-select/html-select.md
+++ b/packages/core/src/components/html-select/html-select.md
@@ -1,11 +1,11 @@
 @# HTML select
 
 Styling HTML `<select>` tags requires a wrapper element to customize the dropdown caret, so Blueprint provides
-a __HTMLSelect__ component to streamline this process.
+a **HTMLSelect** component to streamline this process.
 
 <div class="@ns-callout @ns-intent-success @ns-icon-info-sign @ns-callout-has-body-content">
 
-The [__Select__](#select/select-component) component in the [**@blueprintjs/select**](#select)
+The [**Select**](#select/select-component) component in the [**@blueprintjs/select**](#select)
 package provides a more full-features alternative to the native HTML `<select>` tag. Notably, it
 supports custom filtering logic and item rendering.
 
@@ -13,7 +13,7 @@ supports custom filtering logic and item rendering.
 
 @## Usage
 
-Use __HTMLSelect__ exactly like you would use a native `<select>` with `value` (or `defaultValue`) and `onChange`.
+Use **HTMLSelect** exactly like you would use a native `<select>` with `value` (or `defaultValue`) and `onChange`.
 Options can be passed as `<option>` children for full flexibility or via the `options` prop for simple shorthand.
 
 @reactExample HTMLSelectExample

--- a/packages/core/src/components/html-table/html-table.md
+++ b/packages/core/src/components/html-table/html-table.md
@@ -1,6 +1,6 @@
 @# HTML table
 
-__HTMLTable__ provides Blueprint styling to native HTML tables.
+**HTMLTable** provides Blueprint styling to native HTML tables.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">This is not @blueprintjs/table</h5>

--- a/packages/core/src/components/html/html.md
+++ b/packages/core/src/components/html/html.md
@@ -8,8 +8,8 @@ In order to avoid conflicts with other stylesheets, Blueprint does not style
 most HTML elements directly. Instead, we provide several ways to style basic elements:
 
 1. Use Blueprint React components: `<H1>`.
-1. Apply the Blueprint `Classes` constant to an HTML tag: `<h1 className={Classes.HEADING}>`.
-1. Nest HTML tags inside a container with `Classes.RUNNING_TEXT` (see below).
+2. Apply the Blueprint `Classes` constant to an HTML tag: `<h1 className={Classes.HEADING}>`.
+3. Nest HTML tags inside a container with `Classes.RUNNING_TEXT` (see below).
 
 The following elements should be used in this manner:
 

--- a/packages/core/src/components/icon/icon.md
+++ b/packages/core/src/components/icon/icon.md
@@ -20,7 +20,7 @@ the name as a string, these components render `<Icon icon="..." />` under the ho
 
 @## Usage
 
-Use the `<Icon>` component to easily render __SVG icons__ in React. The `icon`
+Use the `<Icon>` component to easily render **SVG icons** in React. The `icon`
 prop is typed such that editors can offer autocomplete for known icon names. The
 optional `size` prop determines the exact width and height of the icon
 image; the icon element itself can be also be sized using CSS.
@@ -34,7 +34,7 @@ Icons may be configured to load in various ways, see ["Loading icons"](#icons/lo
 The HTML element rendered by `<Icon>` can be customized with the `tagName` prop
 (defaults to `span`), and additional props are passed to this element.
 
-Data files in the __@blueprintjs/icons__ package provide SVG path information
+Data files in the **@blueprintjs/icons** package provide SVG path information
 for Blueprint's 500+ icons for 16px and 20px grids. The `icon` prop specifies
 which SVG is rendered and the `size` prop determines which pixel grid is used:
 `size >= 20` will use the 20px grid and smaller icons will use the 16px grid.
@@ -82,8 +82,8 @@ The `<Icon>` component forwards extra HTML attributes to its root DOM element. B
 the root element is a `<span>` wrapper around the icon `<svg>`. The tag name of this element
 may be customized via the `tagName` prop as either:
 
-- a custom HTML tag name (for example `<div>` instead of the default `<span>` wrapper), or
-- `null`, which makes the component omit the wrapper element and only render the `<svg>` as its root element
+-   a custom HTML tag name (for example `<div>` instead of the default `<span>` wrapper), or
+-   `null`, which makes the component omit the wrapper element and only render the `<svg>` as its root element
 
 By default, `<Icon>` supports a limited set of DOM attributes which are assignable to _all_ HTML and SVG
 elements. In some cases, you may want to use more specific attributes which are only available on HTML elements
@@ -109,7 +109,9 @@ import { Icon } from "@blueprintjs/core";
 import * as React from "react";
 
 function Example() {
-    const handleClick: React.MouseEventHandler<SVGSVGElement> = () => { /* ... */ };
+    const handleClick: React.MouseEventHandler<SVGSVGElement> = () => {
+        /* ... */
+    };
     // explicitly declare type of the root element so that we can narrow the type of the event handler
     return <Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />;
 }
@@ -118,7 +120,7 @@ function Example() {
 @## Static components
 
 The `<Icon>` component loads icon paths via dynamic module imports by default. An alternative API
-is available in the __@blueprintjs/icons__ package which provides static imports of each icon as
+is available in the **@blueprintjs/icons** package which provides static imports of each icon as
 a React component. The example below uses the `<Calendar>` component.
 
 Note that some `<Icon>` props are not yet supported for these components, such as `intent`.
@@ -129,14 +131,15 @@ Note that some `<Icon>` props are not yet supported for these components, such a
 
 @## CSS API
 
-The CSS-only icons API uses the __icon fonts__ from the __@blueprintjs/icons__ package.
+The CSS-only icons API uses the **icon fonts** from the **@blueprintjs/icons** package.
 Note that _none of Blueprint's React components use the icon font_; it is only provided
 for convenience to Blueprint consumers for rare situations where an icon font may be
 preferred over icon SVGs.
 
 To use Blueprint UI icons via CSS, you must apply two classes to a `<span>` element:
-- a __sizing class__, either `@ns-icon-standard` (16px) or `@ns-icon-large` (20px)
-- an __icon name class__, such as `@ns-icon-projects`
+
+-   a **sizing class**, either `@ns-icon-standard` (16px) or `@ns-icon-large` (20px)
+-   an **icon name class**, such as `@ns-icon-projects`
 
 Icon classes also support the four `.@ns-intent-*` modifiers to color the image.
 

--- a/packages/core/src/components/menu/menu.md
+++ b/packages/core/src/components/menu/menu.md
@@ -1,16 +1,16 @@
 @# Menu
 
-__Menu__ displays a list of interactive menu items.
+**Menu** displays a list of interactive menu items.
 
 @reactExample MenuExample
 
 @## Usage
 
-Blueprint's __Menu__ API includes three React components:
+Blueprint's **Menu** API includes three React components:
 
-* [__Menu__](#core/components/menu)
-* [__MenuItem__](#core/components/menu.menu-item)
-* [__MenuDivider__](#core/components/menu.menu-divider)
+-   [**Menu**](#core/components/menu)
+-   [**MenuItem**](#core/components/menu.menu-item)
+-   [**MenuDivider**](#core/components/menu.menu-divider)
 
 ```tsx
 <Menu>
@@ -33,13 +33,13 @@ Blueprint's __Menu__ API includes three React components:
 
 @## Menu item
 
-__MenuItem__ is a single interactive item in a [__Menu__](#core/components/menu).
+**MenuItem** is a single interactive item in a [**Menu**](#core/components/menu).
 
-This component renders an `<li>` containing an `<a>`. You can make the __MenuItem__ interactive by defining the
+This component renders an `<li>` containing an `<a>`. You can make the **MenuItem** interactive by defining the
 `href`, `target`, and `onClick` props as necessary.
 
-Create submenus by nesting __MenuItem__ elements inside each other as `children`. Remember to use the required `text`
-prop to define __MenuItem__ content.
+Create submenus by nesting **MenuItem** elements inside each other as `children`. Remember to use the required `text`
+prop to define **MenuItem** content.
 
 @reactExample MenuItemExample
 
@@ -47,14 +47,14 @@ prop to define __MenuItem__ content.
 
 @## Menu divider
 
-__MenuDivider__ is a decorative component used to group sets of items into sections which may optionally have a title.
+**MenuDivider** is a decorative component used to group sets of items into sections which may optionally have a title.
 
 @interface MenuDividerProps
 
 @## Dropdowns
 
-__Menu__ only renders a static list container element. To make an interactive dropdown menu, you may leverage
-[__Popover__](#core/components/popover) and specify a __Menu__ as the `content` property:
+**Menu** only renders a static list container element. To make an interactive dropdown menu, you may leverage
+[**Popover**](#core/components/popover) and specify a **Menu** as the `content` property:
 
 ```tsx
 <Popover content={<Menu>...</Menu>} placement="bottom">
@@ -64,19 +64,19 @@ __Menu__ only renders a static list container element. To make an interactive dr
 
 Some tips for designing dropdown menus:
 
-* __Appearance__: it's often useful to style the target Button with `fill={true}`, `alignText="left"`, and
-  `rightIcon="caret-down"`. This makes it appear more like an [HTML `<select>`](#core/components/html-select) dropdown.
+-   **Appearance**: it's often useful to style the target Button with `fill={true}`, `alignText="left"`, and
+    `rightIcon="caret-down"`. This makes it appear more like an [HTML `<select>`](#core/components/html-select) dropdown.
 
-* __Interactions__: by default, the popover is automatically dismissed when the user clicks a menu
-  item ([Popover docs](#core/components/popover.closing-on-click) have more details). If you want to opt out of this
-  behavior, set `shouldDismissPopover={false}` on a __MenuItem__. For example, clicking the "Table" item in this
-  dropdown menu will not dismiss the `Popover`:
+-   **Interactions**: by default, the popover is automatically dismissed when the user clicks a menu
+    item ([Popover docs](#core/components/popover.closing-on-click) have more details). If you want to opt out of this
+    behavior, set `shouldDismissPopover={false}` on a **MenuItem**. For example, clicking the "Table" item in this
+    dropdown menu will not dismiss the `Popover`:
 
 @reactExample DropdownMenuExample
 
 @## Submenus
 
-To add a submenu to a __Menu__, you may nest one or more __MenuItem__ elements within another __MenuItem__.
+To add a submenu to a **Menu**, you may nest one or more **MenuItem** elements within another **MenuItem**.
 The submenu opens to the right of its parent by default, but will adjust and flip to the left if there is not enough
 room to the right.
 
@@ -107,27 +107,15 @@ often fall out of sync as the design system is updated. You should use the React
 Menus can be constructed manually using the following HTML markup and `@ns-menu-*` classes
 (available in JS/TS as `Classes.MENU_*`):
 
-* Begin with a `ul.@ns-menu`. Each `li` child denotes a single entry in the menu.
-
-* Put a `.@ns-menu-item` element inside an `li` to create a clickable entry. Use either `<button>` or `<a>` tags for
-  menu items to denote interactivity.
-
-* Add icons to menu items the same way you would to buttons: add the appropriate `@ns-icon-<name>` class\*.
-
-* Make menu items active with the class `@ns-active` (along with `@ns-intent-*` if suitable).
-
-* Make menu items non-interactive with the class `@ns-disabled`.
-
-* Wrap menu item text in a `<span>` element for proper alignment. (Note that React automatically does this.)
-
-* Add a right-aligned label to a menu item by adding a `span.@ns-menu-item-label` inside the
-  `.@ns-menu-item`, after the content. Add an icon to the label by adding icon classes to the label
-  element (`@ns-icon-standard` size is recommended).
-
-* Add a divider between items with `li.@ns-menu-divider`.
-
-* If you want the popover to close when the user clicks a menu item, add the class `@ns-popover-dismiss` to any
-  relevant menu items.
+-   Begin with a `ul.@ns-menu`. Each `li` child denotes a single entry in the menu.
+-   Put a `.@ns-menu-item` element inside an `li` to create a clickable entry. Use either `<button>` or `<a>` tags for menu items to denote interactivity.
+-   Add icons to menu items the same way you would to buttons: add the appropriate `@ns-icon-<name>` class\*.
+-   Make menu items active with the class `@ns-active` (along with `@ns-intent-*` if suitable).
+-   Make menu items non-interactive with the class `@ns-disabled`.
+-   Wrap menu item text in a `<span>` element for proper alignment. (Note that React automatically does this.)
+-   Add a right-aligned label to a menu item by adding a `span.@ns-menu-item-label` inside the `.@ns-menu-item`, after the content. Add an icon to the label by adding icon classes to the label element (`@ns-icon-standard` size is recommended).
+-   Add a divider between items with `li.@ns-menu-divider`.
+-   If you want the popover to close when the user clicks a menu item, add the class `@ns-popover-dismiss` to any relevant menu items.
 
 <small>\* You do not need to add a `@ns-icon-<sizing>` class to menu items—icon sizing is
 defined as part of `.@ns-menu-item`.</small>

--- a/packages/core/src/components/navbar/navbar.md
+++ b/packages/core/src/components/navbar/navbar.md
@@ -1,17 +1,17 @@
 @# Navbar
 
-__Navbar__ presents useful navigation controls at the top of an application.
+**Navbar** presents useful navigation controls at the top of an application.
 
 @reactExample NavbarExample
 
 @## Usage
 
-The __Navbar__ API includes four stateless React components:
+The **Navbar** API includes four stateless React components:
 
-*   __Navbar__
-*   __NavbarGroup__ (aliased as `Navbar.Group`)
-*   __NavbarHeading__ (aliased as `Navbar.Heading`)
-*   __NavbarDivider__ (aliased as `Navbar.Divider`)
+-   **Navbar**
+-   **NavbarGroup** (aliased as `Navbar.Group`)
+-   **NavbarHeading** (aliased as `Navbar.Heading`)
+-   **NavbarDivider** (aliased as `Navbar.Divider`)
 
 These components are simple containers for their children. Each of them supports the full range of HTML `<div>`
 DOM attributes.
@@ -76,9 +76,9 @@ often fall out of sync as the design system is updated. You should use the React
 
 Use the following classes to construct a navbar:
 
-*   `nav.@ns-navbar` &ndash; The parent element. Use a `<nav>` element for accessibility.
-*   `.@ns-navbar-group.@ns-align-(left|right)` &ndash; Left- or right-aligned group.
-*   `.@ns-navbar-heading` &ndash; Larger text for your application title.
-*   `.@ns-navbar-divider` &ndash; Thin vertical line that can be placed between groups of elements.
+-   `nav.@ns-navbar` &ndash; The parent element. Use a `<nav>` element for accessibility.
+-   `.@ns-navbar-group.@ns-align-(left|right)` &ndash; Left- or right-aligned group.
+-   `.@ns-navbar-heading` &ndash; Larger text for your application title.
+-   `.@ns-navbar-divider` &ndash; Thin vertical line that can be placed between groups of elements.
 
 @css navbar

--- a/packages/core/src/components/non-ideal-state/non-ideal-state.md
+++ b/packages/core/src/components/non-ideal-state/non-ideal-state.md
@@ -7,23 +7,23 @@ parent: components
 Non-ideal UI states inform the user that some content is unavailable. There are several types of non-ideal states,
 including:
 
-*   **Empty state:** a container has just been created and has no data in it yet, or a container's contents have been
+-   **Empty state:** a container has just been created and has no data in it yet, or a container's contents have been
     intentionally removed.
-*   **Loading state:** a container is awaiting data. A good practice is to show a spinner for this state with optional
+-   **Loading state:** a container is awaiting data. A good practice is to show a spinner for this state with optional
     explanatory text below the spinner.
-*   **Error state:** something went wrong (for instance, 404 and 500 HTTP errors). In this case, a good practice is to
+-   **Error state:** something went wrong (for instance, 404 and 500 HTTP errors). In this case, a good practice is to
     add a call to action directing the user what to do next.
 
 @reactExample NonIdealStateExample
 
 @## Usage
 
-__NonIdealState__ component props are rendered in this order in the DOM, with comfortable spacing between each child:
+**NonIdealState** component props are rendered in this order in the DOM, with comfortable spacing between each child:
 
 1. `icon`
-1. text (`title` + optional `description`)
-1. `action`
-1. `children`
+2. text (`title` + optional `description`)
+3. `action`
+4. `children`
 
 By default, a vertical layout is used, but you can make it horizontal with `layout="horizontal"`.
 
@@ -48,7 +48,7 @@ often fall out of sync as the design system is updated. You should use the React
 Note that you are required to set the `font-size` and `line-height` styles for the icon element to render it properly.
 
 Also, since the CSS API uses the icon font, Blueprint styles cannot adjust the icon visual design to have a muted
-appearance like it does with the React component API. This means __NonIdealState__ elements rendered with this API will
+appearance like it does with the React component API. This means **NonIdealState** elements rendered with this API will
 stand out visually (in a bad way) within the design system.
 
 </div>

--- a/packages/core/src/components/overflow-list/overflow-list.md
+++ b/packages/core/src/components/overflow-list/overflow-list.md
@@ -1,6 +1,6 @@
 @# Overflow list
 
-__OverflowList__ takes a generic list of items and renders as many items as can fit inside its container. Overflowed
+**OverflowList** takes a generic list of items and renders as many items as can fit inside its container. Overflowed
 items that do not fit are collapsed into a single element. The visible items will be recomputed when a resize is
 detected.
 

--- a/packages/core/src/components/panel-stack2/panel-stack2.md
+++ b/packages/core/src/components/panel-stack2/panel-stack2.md
@@ -7,17 +7,17 @@ Migrating from [PanelStack](#core/components/panel-stack)?
 
 </h5>
 
-__PanelStack2__ is a replacement for __PanelStack__. It will become the standard API in a future major version of
+**PanelStack2** is a replacement for **PanelStack**. It will become the standard API in a future major version of
 Blueprint. You are encouraged to use this new API now for forwards-compatibility. See the full
 [migration guide](https://github.com/palantir/blueprint/wiki/PanelStack2-migration) on the wiki.
 
 </div>
 
-__PanelStack2__ manages a stack of panels and displays only the topmost panel.
+**PanelStack2** manages a stack of panels and displays only the topmost panel.
 
 Each panel appears with a header containing a "back" button to return to the previous panel. The bottom-most
 `initialPanel` cannot be closed or removed from the stack. Panels use
-[__CSSTransition__](http://reactcommunity.org/react-transition-group/css-transition) for seamless transitions.
+[**CSSTransition**](http://reactcommunity.org/react-transition-group/css-transition) for seamless transitions.
 
 By default, only the currently active panel is rendered to the DOM. This means that other panels are unmounted and can
 lose their component state as a user transitions between the panels. You can notice this in the example below as the
@@ -41,9 +41,15 @@ new one on top of it during the panel's lifecycle. For example:
 ```tsx
 import { Button, PanelProps } from "@blueprintjs/core";
 
-type SettingsPanelInfo = { /* ...  */ };
-type AccountSettingsPanelInfo = { /* ...  */ };
-type NotificationSettingsPanelInfo = { /* ...  */ };
+type SettingsPanelInfo = {
+    /* ...  */
+};
+type AccountSettingsPanelInfo = {
+    /* ...  */
+};
+type NotificationSettingsPanelInfo = {
+    /* ...  */
+};
 
 const AccountSettingsPanel: React.FC<PanelProps<AccountSettingsPanelInfo>> = props => {
     // implementation
@@ -79,7 +85,7 @@ const SettingsPanel: React.FC<PanelProps<SettingsPanelInfo>> = props => {
             <Button onClick={openNotificationSettings} text="Notification settings" />
         </>
     );
-}
+};
 ```
 
 @interface Panel
@@ -88,7 +94,7 @@ const SettingsPanel: React.FC<PanelProps<SettingsPanelInfo>> = props => {
 
 @## Props interface
 
-__PanelStack2__ can be operated as a controlled or uncontrolled component.
+**PanelStack2** can be operated as a controlled or uncontrolled component.
 
 If controlled, panels should be added to and removed from the _end_ of the `stack` array.
 

--- a/packages/core/src/components/popover/menu-item.md
+++ b/packages/core/src/components/popover/menu-item.md
@@ -13,15 +13,10 @@ To make the menu item interactive, provide the `href`, `target`, and `onClick` p
 MenuItem supports multiple "role structures" which allow it to be used in different contexts
 depending on the `role` attribute of its parent `<ul>` list:
 
-- `roleStructure="menuitem"` is the default. This is appropriate for a `<ul role="menu">` parent.
-    The item will render with `<li role="none">` and `<a role="menuitem">`.
-- `roleStructure="listoption"` is appropriate for a `<ul role="listbox">` parent, such as
-    those found in Select2, Suggest2, and MultiSelect2 components. The item will render with
-    `<li role="option">` and `<a>` (anchor role undefined).
-- `roleStructure="listitem"` is appropriate for a `<ul>` (no role defined) or a `<ul role="list">` parent. The
-    item will render with `<li>` and `<a>` (roles undefined).
-- `roleStructure="none"` is useful when wrapping in a custom `<li>`. The
-    item will render with `<li role="none">` and `<a>` (roles undefined).
+-   `roleStructure="menuitem"` is the default. This is appropriate for a `<ul role="menu">` parent. The item will render with `<li role="none">` and `<a role="menuitem">`.
+-   `roleStructure="listoption"` is appropriate for a `<ul role="listbox">` parent, such as those found in Select2, Suggest2, and MultiSelect2 components. The item will render with `<li role="option">` and `<a>` (anchor role undefined).
+-   `roleStructure="listitem"` is appropriate for a `<ul>` (no role defined) or a `<ul role="list">` parent. The item will render with `<li>` and `<a>` (roles undefined).
+-   `roleStructure="none"` is useful when wrapping in a custom `<li>`. The item will render with `<li role="none">` and `<a>` (roles undefined).
 
 @## Selection state
 
@@ -53,7 +48,7 @@ function Example() {
                 <MenuItem text="Second submenu item" />
             </MenuItem>
         </Menu>
-    )
+    );
 }
 ```
 

--- a/packages/core/src/components/progress-bar/progress-bar.md
+++ b/packages/core/src/components/progress-bar/progress-bar.md
@@ -1,12 +1,12 @@
 @# Progress bar
 
-__ProgressBar__ indicates progress towards the completion of a task or an indeterminate loading state.
+**ProgressBar** indicates progress towards the completion of a task or an indeterminate loading state.
 
 @reactExample ProgressExample
 
 @## Props interface
 
-__ProgressBar__ is a simple stateless component that renders the appropriate HTML markup. It supports a `value` prop
+**ProgressBar** is a simple stateless component that renders the appropriate HTML markup. It supports a `value` prop
 between 0 and 1 that determines the width of the progress meter. Omitting `value` will result in an "indeterminate"
 progress meter that fills the entire bar.
 

--- a/packages/core/src/components/resize-sensor/resize-sensor.md
+++ b/packages/core/src/components/resize-sensor/resize-sensor.md
@@ -1,6 +1,6 @@
 @# Resize sensor
 
-__ResizeSensor__ observes the DOM and provides a callback for `"resize"` events on a single child element.
+**ResizeSensor** observes the DOM and provides a callback for `"resize"` events on a single child element.
 It is a thin wrapper around [`ResizeObserver`][resizeobserver] to provide React bindings.
 
 [resizeobserver]: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
@@ -26,7 +26,7 @@ function handleResize(entries: ResizeEntry[]) {
 
 <ResizeSensor onResize={handleResize}>
     <div style={{ width: this.props.width }} />
-</ResizeSensor>
+</ResizeSensor>;
 ```
 
 If you attach a `ref` to the child yourself, you must pass the same value to `ResizeSensor`
@@ -37,7 +37,7 @@ const myRef = React.createRef();
 
 <ResizeSensor targetRef={myRef} onResize={handleResize}>
     <div ref={myRef} style={{ width: this.props.width }} />
-</ResizeSensor>
+</ResizeSensor>;
 ```
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">

--- a/packages/core/src/components/section/section.md
+++ b/packages/core/src/components/section/section.md
@@ -4,10 +4,10 @@ tag: new
 
 @# Section
 
-The __Section__ component can be used to contain, structure, and create hierarchy for information in your UI. It makes use of some concepts from other more atomic Blueprint components:
+The **Section** component can be used to contain, structure, and create hierarchy for information in your UI. It makes use of some concepts from other more atomic Blueprint components:
 
-- The overall appearance looks like a [__Card__](#core/components/card) (with limited `elevation` options)
-- Contents may be collapsible like the [__Collapse__](#core/components/collapse) component
+-   The overall appearance looks like a [**Card**](#core/components/card) (with limited `elevation` options)
+-   Contents may be collapsible like the [**Collapse**](#core/components/collapse) component
 
 @reactExample SectionExample
 
@@ -17,7 +17,7 @@ The __Section__ component can be used to contain, structure, and create hierarch
 
 @## Section card
 
-Multiple __SectionCard__ child components can be added under one __Section__, they will be stacked vertically. This layout can be used to further group information.
+Multiple **SectionCard** child components can be added under one **Section**, they will be stacked vertically. This layout can be used to further group information.
 
 ```tsx
 <Section>

--- a/packages/core/src/components/spinner/spinner.md
+++ b/packages/core/src/components/spinner/spinner.md
@@ -1,13 +1,13 @@
 @# Spinner
 
-__Spinners__ indicate progress in a circular fashion. They're great for ongoing operations of indeterminate length and
+**Spinners** indicate progress in a circular fashion. They're great for ongoing operations of indeterminate length and
 can also represent known progress.
 
 @reactExample SpinnerExample
 
 @## Usage
 
-__Spinner__ is a simple stateless component that renders SVG markup. It can be used safely in DOM and SVG containers as
+**Spinner** is a simple stateless component that renders SVG markup. It can be used safely in DOM and SVG containers as
 it only renders SVG elements.
 
 The `value` prop determines how much of the track is filled by the head. When this prop is defined, the spinner head

--- a/packages/core/src/components/tabs/tabs.md
+++ b/packages/core/src/components/tabs/tabs.md
@@ -1,6 +1,6 @@
 @# Tabs
 
-The __Tabs__ component allows you to switch between displaying multiple panels of content.
+The **Tabs** component allows you to switch between displaying multiple panels of content.
 
 @reactExample TabsExample
 
@@ -23,7 +23,7 @@ import { Tab, Tabs } from "@blueprintjs/core";
     <Tab id="bb" disabled title="Backbone" panel={<BackbonePanel />} />
     <TabsExpander />
     <input className="@ns-input" type="text" placeholder="Search..." />
-</Tabs>
+</Tabs>;
 ```
 
 @### Tabs
@@ -43,8 +43,8 @@ Insert a `<TabsExpander />` between any two children to right-align all subseque
 
 @### Tab
 
-The __Tab__ component is a minimal wrapper with no functionality of its own&mdash;it is managed entirely by its
-parent __Tabs__ component. Tab title text can be set either via `title` prop or via React children
+The **Tab** component is a minimal wrapper with no functionality of its own&mdash;it is managed entirely by its
+parent **Tabs** component. Tab title text can be set either via `title` prop or via React children
 (for more complex content).
 
 The associated tab `panel` will be visible when the _Tab_ is active. Omitting the `panel` prop is supported; this can
@@ -54,7 +54,7 @@ be useful when you want the associated panel to appear elsewhere in the DOM (by 
 
 @### TabPanel
 
-__TabPanel__ wraps a passed `panel` in proper aria attributes, `id`, and `role`, for proper accessibility. A __TabPanel__ gets automatically rendered by a _Tab_ when `panel` is supplied and the _Tab_ is active, but __TabPanel__ is also exported for cases where you want to render the panel yourself elsewhere in the DOM, while using _Tabs_ in controlled mode:
+**TabPanel** wraps a passed `panel` in proper aria attributes, `id`, and `role`, for proper accessibility. A **TabPanel** gets automatically rendered by a _Tab_ when `panel` is supplied and the _Tab_ is active, but **TabPanel** is also exported for cases where you want to render the panel yourself elsewhere in the DOM, while using _Tabs_ in controlled mode:
 
 ```tsx
 import * as React from "react";
@@ -79,7 +79,6 @@ function TabsControlledExample() {
         </>
     );
 }
-
 ```
 
 @interface TabPanelProps

--- a/packages/core/src/components/text/text.md
+++ b/packages/core/src/components/text/text.md
@@ -1,12 +1,12 @@
 @# Text
 
-The __Text__ component adds accessible overflow behavior to a line of text by conditionally adding the title attribute
+The **Text** component adds accessible overflow behavior to a line of text by conditionally adding the title attribute
 and truncating with an ellipsis when content overflows its container.
 
 @reactExample TextExample
 
 @## Props interface
 
-__Text__ accepts and renders arbitrary children. It is intended that these children render as text.
+**Text** accepts and renders arbitrary children. It is intended that these children render as text.
 
 @interface TextProps

--- a/packages/core/src/components/tooltip/tooltip.md
+++ b/packages/core/src/components/tooltip/tooltip.md
@@ -1,12 +1,12 @@
 @# Tooltip
 
-__Tooltip__ is a lightweight popover for showing additional information during hover interactions.
+**Tooltip** is a lightweight popover for showing additional information during hover interactions.
 
 @reactExample TooltipExample
 
 @## Usage
 
-__Tooltip__ passes most of its props to [__Popover__](#core/components/popover), with some exceptions.
+**Tooltip** passes most of its props to [**Popover**](#core/components/popover), with some exceptions.
 Notably, it only supports hover interactions.
 
 When creating a tooltip, you must specify both its **content** (via the `content` prop) and
@@ -21,8 +21,8 @@ which side of the target).
     <h5 class="@ns-heading">Button targets</h5>
 
 Buttons make great tooltip targets, but the `disabled` attribute will prevent all
-events so the enclosing __Tooltip__ will not know when to respond.
-Use [__AnchorButton__](#core/components/button.anchor-button) instead;
+events so the enclosing **Tooltip** will not know when to respond.
+Use [**AnchorButton**](#core/components/button.anchor-button) instead;
 see the [callout here](#core/components/button.props) for more details.
 
 </div>

--- a/packages/core/src/components/tree/tree.md
+++ b/packages/core/src/components/tree/tree.md
@@ -1,12 +1,12 @@
 @# Tree
 
-__Trees__ display hierarchical data.
+**Trees** display hierarchical data.
 
 @reactExample TreeExample
 
 @## Props interface
 
-__Tree__ is a stateless component. Its contents are dictated by the `contents` prop, which is an array of `<TreeNode>`
+**Tree** is a stateless component. Its contents are dictated by the `contents` prop, which is an array of `<TreeNode>`
 elements (see [below](#components/tree.tree-node)). The tree is multi-rooted if `contents` contains more than one
 top-level object.
 
@@ -18,14 +18,14 @@ child (`0`) of the third top-level node (`2`).
 
 @### Instance methods
 
-*   `Tree.getNodeContentElement(nodeId: string | number): HTMLElement | undefined` &ndash;
+-   `Tree.getNodeContentElement(nodeId: string | number): HTMLElement | undefined` &ndash;
     Returns the underlying HTML element of the `Tree` node with an id of `nodeId`.
     This element does not contain the children of the node, only its label and controls.
     If the node is not currently mounted, `undefined` is returned.
 
 @### Tree node
 
-__TreeNode__ elements determine the contents, appearance, and state of each node in the tree.
+**TreeNode** elements determine the contents, appearance, and state of each node in the tree.
 
 For example, `icon` controls the icon displayed for the node, and `isExpanded` determines whether the node's children
 are shown.

--- a/packages/core/src/docs/accessibility.md
+++ b/packages/core/src/docs/accessibility.md
@@ -31,11 +31,11 @@ utility because it is always useful to know where you're typing.
 @### JavaScript API
 
 This behavior is controlled by a singleton instance called `FocusStyleManager` that lives in the
-__@blueprintjs/core__ package. It supports the following public methods:
+**@blueprintjs/core** package. It supports the following public methods:
 
-- `FocusStyleManager.isActive(): boolean`: Returns whether the `FocusStyleManager` is currently running.
-- `FocusStyleManager.onlyShowFocusOnTabs(): void`: Enable behavior which hides focus styles during mouse interaction.
-- `FocusStyleManager.alwaysShowFocus(): void`: Stop this behavior (focus styles are always visible).
+-   `FocusStyleManager.isActive(): boolean`: Returns whether the `FocusStyleManager` is currently running.
+-   `FocusStyleManager.onlyShowFocusOnTabs(): void`: Enable behavior which hides focus styles during mouse interaction.
+-   `FocusStyleManager.alwaysShowFocus(): void`: Stop this behavior (focus styles are always visible).
 
 @### Selectively ignoring the focus style manager
 
@@ -53,7 +53,6 @@ const MyComponent = () => ({
     </div>
 })
 ```
-
 
 @## Color contrast
 

--- a/packages/core/src/docs/classes.md
+++ b/packages/core/src/docs/classes.md
@@ -83,12 +83,10 @@ With this approach, you will import Blueprint's Sass sources from `/lib/scss/` i
 You must use [Dart Sass](https://sass-lang.com/dart-sass) and set up a few important bits of build configuration:
 
 1. Sass `loadPaths` must include the `node_modules` folder where `@blueprintjs` packages are installed
-1. A custom function implementation for `svg-icon()` must be defined
-1. You must copy the [resources/icons folder](https://github.com/palantir/blueprint/tree/develop/resources/icons) from
-    the Blueprint repo into your project (in the future, this may not be required once Blueprint starts publishing
-    these SVG files in a public NPM package).
+2. A custom function implementation for `svg-icon()` must be defined
+3. You must copy the [resources/icons folder](https://github.com/palantir/blueprint/tree/develop/resources/icons) from the Blueprint repo into your project (in the future, this may not be required once Blueprint starts publishing these SVG files in a public NPM package).
 
-The __@blueprintjs/node-build-scripts__ package provides some utility functions to help with this. Here's a code example
+The **@blueprintjs/node-build-scripts** package provides some utility functions to help with this. Here's a code example
 for a custom Sass compiler that can import Blueprint `.scss` sources:
 
 ```js
@@ -156,7 +154,7 @@ export default {
 Once you have this build configuration set up, you can proceed to customize Sass and JS variables:
 
 1. Define the `$ns` Sass variable in your app styles _before_ importing `blueprint.scss`.
-1. When bundling your JS JS code, define the `BLUEPRINT_NAMESPACE` variable to the same value; this will update the generated `Classes` constants. The easiest way to do is with webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
+2. When bundling your JS JS code, define the `BLUEPRINT_NAMESPACE` variable to the same value; this will update the generated `Classes` constants. The easiest way to do is with webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
 
 ```js
 plugins: [

--- a/packages/core/src/docs/colors.md
+++ b/packages/core/src/docs/colors.md
@@ -17,19 +17,18 @@ use one of the [core colors](#core/colors.core-colors) instead.
 Core colors are used to support user interface design by calling
 attention to specific elements, such as buttons, callouts, icons, etc.
 
-Each core color is mapped to what we call a __visual intent__. Intents
+Each core color is mapped to what we call a **visual intent**. Intents
 are used to convey the status and tone of UI elements:
 
-- _Blue_ (intent: primary) elevates elements from the typical gray scale UI frame.
-- _Green_ (intent: success) indicates successful operations.
-- _Orange_ (intent: warning) indicates warnings and intermediate states.
-- _Red_ (intent: danger) indicates errors and potentially destructive operations.
+-   _Blue_ (intent: primary) elevates elements from the typical gray scale UI frame.
+-   _Green_ (intent: success) indicates successful operations.
+-   _Orange_ (intent: warning) indicates warnings and intermediate states.
+-   _Red_ (intent: danger) indicates errors and potentially destructive operations.
 
 Blueprint's core colors are designed to:
 
-- go well together and be used alongside each other in any application.
-- adhere to [WCAG 2.0](https://www.w3.org/TR/WCAG20/) standards, and therefore are
-highly accessible to visually impaired and color blind users.
+-   go well together and be used alongside each other in any application.
+-   adhere to [WCAG 2.0](https://www.w3.org/TR/WCAG20/) standards, and therefore are highly accessible to visually impaired and color blind users.
 
 Many Blueprint components support the `intent` prop, which may be set to a string
 literal constant such as `intent="primary"`.
@@ -79,7 +78,7 @@ Note that aliases are not currently available in JavaScript.
 ```tsx
 import { Colors } from "@blueprintjs/core";
 
-<div style={{ color: Colors.BLUE3, background: Colors.BLACK }} />
+<div style={{ color: Colors.BLUE3, background: Colors.BLACK }} />;
 ```
 
 @## Color schemes
@@ -111,4 +110,3 @@ Qualitative color schemes use a series of unrelated colors to create a
 scheme that does not imply order, merely difference in kind.
 
 @reactDocs QualitativeSchemePalette
-

--- a/packages/core/src/docs/index.md
+++ b/packages/core/src/docs/index.md
@@ -4,14 +4,14 @@ reference: core
 
 @# Core
 
-The __@blueprintjs/core__ NPM package is the basis of any Blueprint app. It includes many (30+)
+The **@blueprintjs/core** NPM package is the basis of any Blueprint app. It includes many (30+)
 React components covering all the basic bases, from buttons to form controls to tooltips and trees.
 It also includes CSS styles for every component and the tools to style your own components and apps
 with Sass and Less variables and an elegant color palette.
 
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
 
-Note that the core package depends on __@blueprintjs/icons__ which provides 500+ UI icons.
+Note that the core package depends on **@blueprintjs/icons** which provides 500+ UI icons.
 You must include the icons CSS file in your app alongside the core CSS file.
 
 @page accessibility

--- a/packages/core/src/docs/typography.md
+++ b/packages/core/src/docs/typography.md
@@ -4,13 +4,9 @@
 
 Keep in mind these general web typography guidelines when building your applications.
 
-- The default text color in all components is compliant with the recommended
-[WCAG 2.0](https://www.w3.org/TR/WCAG20/) minimum contrast ratio.
-- If you choose to go with a custom text color, make sure the background behind it provides
-proper contrast.
-- Try not to explicitly write pixel values for your font-size or line-height CSS rules.
-Instead, reference the classes and variables we provide in Blueprint (`.@ns-ui-text`,
-`$@ns-font-size-large`, etc.).
+-   The default text color in all components is compliant with the recommended [WCAG 2.0](https://www.w3.org/TR/WCAG20/) minimum contrast ratio.
+-   If you choose to go with a custom text color, make sure the background behind it provides proper contrast.
+-   Try not to explicitly write pixel values for your font-size or line-height CSS rules. Instead, reference the classes and variables we provide in Blueprint (`.@ns-ui-text`, `$@ns-font-size-large`, etc.).
 
 @## UI text
 
@@ -30,9 +26,9 @@ For longer blocks of running text, such as articles or documents, see [running t
 Longform text, such as rendered Markdown documents, benefit from increased spacing and support for unclassed textual elements.
 Apply `.@ns-running-text` to the parent element to apply the following styles to all children:
 
-- `<h*>`, `<ul>`, `<ol>`, `<blockquote>`, `<code>`, `<pre>`, `<kbd>` tags do not require additional CSS classes for styles. This is great for rendered Markdown documents.
-- `<h*>` tag margins are adjusted to provide clear separation between sections in a document.
-- `<ul>` and `<ol>` tags receive [`.@ns-list`](#core/typography.lists) styles for legibility.
+-   `<h*>`, `<ul>`, `<ol>`, `<blockquote>`, `<code>`, `<pre>`, `<kbd>` tags do not require additional CSS classes for styles. This is great for rendered Markdown documents.
+-   `<h*>` tag margins are adjusted to provide clear separation between sections in a document.
+-   `<ul>` and `<ol>` tags receive [`.@ns-list`](#core/typography.lists) styles for legibility.
 
 @css running-text
 
@@ -108,10 +104,9 @@ setting a dark background color.
 The following elements and components support the `.@ns-dark` class directly (i.e, `.@ns-card.@ns-dark`)
 and can be used as a container for nested dark children:
 
-- `Card`
-- Overlays: `Dialog`, `Popover`, `Tooltip`, `Toast`
-- `Popover` and `Tooltip` will automatically detect when their trigger is inside a `.@ns-dark`
-container and add the same class to themselves.
+-   `Card`
+-   Overlays: `Dialog`, `Popover`, `Tooltip`, `Toast`
+-   `Popover` and `Tooltip` will automatically detect when their trigger is inside a `.@ns-dark` container and add the same class to themselves.
 
 Rather than illustrating dark components inline, this documentation site provides a site-wide switch
 in the sidebar to enable the dark theme. Try it out as you read the docs.

--- a/packages/core/src/docs/variables.md
+++ b/packages/core/src/docs/variables.md
@@ -21,12 +21,12 @@ Typically, correct typography styles should be achieved by using the proper HTML
 text, `<h*>` for headings, `<code>` for code, etc.). The following variables are provided for the
 rare cases where custom styling is necessary and should be used sparingly:
 
-- `$pt-font-family`
-- `$pt-font-family-monospace`
-- `$pt-font-size`
-- `$pt-font-size-small`
-- `$pt-font-size-large`
-- `$pt-line-height`
+-   `$pt-font-family`
+-   `$pt-font-family-monospace`
+-   `$pt-font-size`
+-   `$pt-font-size-small`
+-   `$pt-font-size-large`
+-   `$pt-line-height`
 
 @## Icon variables
 
@@ -57,34 +57,35 @@ document.querySelector(".my-custom-icon").style.content = getIconContentString("
 
 Sass variables are also provided for the two icon font families and their pixel sizes:
 
-- `$blueprint-icons-16`
-- `$blueprint-icons-20`
-- `$pt-icon-size-standard`
-- `$pt-icon-size-large`
+-   `$blueprint-icons-16`
+-   `$blueprint-icons-20`
+-   `$pt-icon-size-standard`
+-   `$pt-icon-size-large`
 
 @## Grids & dimensions
 
 Sizes of common components. Most sizing variables are based on `$pt-grid-size`, which has
 a value of `10px`. Custom components should adhere to the relevant `height` variable.
 
-- `$pt-grid-size`
-- `$pt-border-radius`
-- `$pt-button-height`
-- `$pt-button-height-large`
-- `$pt-input-height`
-- `$pt-input-height-large`
-- `$pt-navbar-height`
+-   `$pt-grid-size`
+-   `$pt-border-radius`
+-   `$pt-button-height`
+-   `$pt-button-height-large`
+-   `$pt-input-height`
+-   `$pt-input-height-large`
+-   `$pt-navbar-height`
 
 @### Grid system
 
 Blueprint doesn't provide a grid system. In general, you should try to use the `$pt-grid-size`
 variable to generate layout & sizing style rules in your CSS codebase.
 
-In lieu of a full grid system, you should try to use the __CSS flexible box layout model__ (a.k.a.
+In lieu of a full grid system, you should try to use the **CSS flexible box layout model** (a.k.a.
 "flexbox"). It's quite powerful on its own and allows you to build robust, responsive layouts
 without writing much CSS. Here are some resources for learning flexbox:
-- [MDN guide](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes)
-- [CSS Tricks guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+
+-   [MDN guide](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes)
+-   [CSS Tricks guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 
 @## Layering
 
@@ -93,9 +94,9 @@ especially if you make correct use of [stacking context][MDN]. [Overlay2](#core/
 components such as dialogs and popovers use these z-index values to configure their stacking
 contexts.
 
-- `$pt-z-index-base`
-- `$pt-z-index-content`
-- `$pt-z-index-overlay`
+-   `$pt-z-index-base`
+-   `$pt-z-index-content`
+-   `$pt-z-index-overlay`
 
 [MDN]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
 
@@ -104,39 +105,39 @@ contexts.
 Use these when you need to build custom UI components that look similar to Blueprint's
 light theme components.
 
-- `$pt-dialog-box-shadow`
-- `$pt-input-box-shadow`
-- `$pt-popover-box-shadow`
-- `$pt-tooltip-box-shadow`
+-   `$pt-dialog-box-shadow`
+-   `$pt-input-box-shadow`
+-   `$pt-popover-box-shadow`
+-   `$pt-tooltip-box-shadow`
 
 @## Dark theme styles
 
 Use these when you need to build custom UI components that look similar to Blueprint's
 dark theme components.
 
-- `$pt-dark-dialog-box-shadow`
-- `$pt-dark-input-box-shadow`
-- `$pt-dark-popover-box-shadow`
-- `$pt-dark-tooltip-box-shadow`
+-   `$pt-dark-dialog-box-shadow`
+-   `$pt-dark-input-box-shadow`
+-   `$pt-dark-popover-box-shadow`
+-   `$pt-dark-tooltip-box-shadow`
 
 @## Elevation drop shadows
 
 Use these when you need to apply a drop shadow to custom UI components to simulate height.
 These elevations correspond to those of the [Card](#core/components/card.elevation) component.
 
-- `$pt-elevation-shadow-0`
-- `$pt-elevation-shadow-1`
-- `$pt-elevation-shadow-2`
-- `$pt-elevation-shadow-3`
-- `$pt-elevation-shadow-4`
+-   `$pt-elevation-shadow-0`
+-   `$pt-elevation-shadow-1`
+-   `$pt-elevation-shadow-2`
+-   `$pt-elevation-shadow-3`
+-   `$pt-elevation-shadow-4`
 
 Use these for drop shadows in dark theme.
 
-- `$pt-dark-elevation-shadow-0`
-- `$pt-dark-elevation-shadow-1`
-- `$pt-dark-elevation-shadow-2`
-- `$pt-dark-elevation-shadow-3`
-- `$pt-dark-elevation-shadow-4`
+-   `$pt-dark-elevation-shadow-0`
+-   `$pt-dark-elevation-shadow-1`
+-   `$pt-dark-elevation-shadow-2`
+-   `$pt-dark-elevation-shadow-3`
+-   `$pt-dark-elevation-shadow-4`
 
 @## Color aliases
 
@@ -379,4 +380,3 @@ and are available in the Sass or Less variables files.
         </tr>
     </tbody>
 </table>
-

--- a/packages/datetime/src/components/time-picker/timepicker.md
+++ b/packages/datetime/src/components/time-picker/timepicker.md
@@ -1,6 +1,6 @@
 @# Time picker
 
-__TimePicker__ renders a UI to select a time.
+**TimePicker** renders a UI to select a time.
 
 This component has no direct localization support. You should handle localization in your application if needed.
 
@@ -11,6 +11,6 @@ This component has no direct localization support. You should handle localizatio
 Use the `onChange` prop to listen for changes to the set time. You can control the selected time by setting the
 `value` prop, or use the component in uncontrolled mode and specify an initial time by setting `defaultValue`.
 
-__TimePicker__ uses `Date` objects across its API but ignores their year, month, and day fields.
+**TimePicker** uses `Date` objects across its API but ignores their year, month, and day fields.
 
 @interface TimePickerProps

--- a/packages/datetime/src/components/timezone-select/timezone-select.md
+++ b/packages/datetime/src/components/timezone-select/timezone-select.md
@@ -1,6 +1,6 @@
 @# Timezone select
 
-__TimezoneSelect__ allows the user to select from a list of timezones. The list is built into the library itself, so it
+**TimezoneSelect** allows the user to select from a list of timezones. The list is built into the library itself, so it
 does not depend on any external packages for the list of timezones. It uses
 [date-fns-tz](https://github.com/marnusw/date-fns-tz) for display formatting.
 
@@ -8,7 +8,7 @@ does not depend on any external packages for the list of timezones. It uses
 
 @## Usage
 
-This component only supports __controlled__ usage.
+This component only supports **controlled** usage.
 
 Control the selected timezone with the `value` prop and use the `onChange` prop callback to listen for changes to the
 selected timezone.
@@ -19,9 +19,7 @@ import React, { useState } from "react";
 
 function TimezoneExample() {
     const [timezone, setTimezone] = useState("");
-    return (
-        <TimezoneSelect value={timezone} onChange={setTimezone} />
-    );
+    return <TimezoneSelect value={timezone} onChange={setTimezone} />;
 }
 ```
 
@@ -44,7 +42,7 @@ in this case, all button-specific props will be ignored:
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Local timezone detection</h5>
 
-__TimezoneSelect__ detects the local timezone using the
+**TimezoneSelect** detects the local timezone using the
 [i18n API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions)
 when the `showLocalTimezone` prop is enabled and cannot guarantee correctness in all browsers.
 

--- a/packages/docs-app/README.md
+++ b/packages/docs-app/README.md
@@ -11,4 +11,4 @@ From the root of the repo:
 1. Run `yarn dev`
 1. Open your browser to http://localhost:9000/
 
-*Note: if you want to run the development server on a different port, set the `PORT` environment variable.*
+_Note: if you want to run the development server on a different port, set the `PORT` environment variable._

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -16,7 +16,7 @@ The JavaScript components are stable and their APIs adhere to [semantic versioni
     yarn add @blueprintjs/core react react-dom
     ```
 
-1.  After installation, you'll be able to import the React components in your application:
+2.  After installation, you'll be able to import the React components in your application:
 
     ```tsx
     import { Button, Spinner } from "@blueprintjs/core";
@@ -28,7 +28,7 @@ The JavaScript components are stable and their APIs adhere to [semantic versioni
     const myButton = React.createElement(Button, { intent: "success" }, "button text");
     ```
 
-1.  **Don't forget to include the main CSS file from each Blueprint package!** Additionally, the `resources/` directory
+3.  **Don't forget to include the main CSS file from each Blueprint package!** Additionally, the `resources/` directory
     contains supporting media such as fonts and images.
 
     ```scss

--- a/packages/docs-app/src/principles.md
+++ b/packages/docs-app/src/principles.md
@@ -10,6 +10,6 @@ Internet Explorer (IE) is no longer supported as of Blueprint v5.0 (its support 
 
 Blueprint strictly adheres to [semver](https://semver.org/) in its public APIs:
 
-- JS APIs exported from the root/main module of a Blueprint package
-- HTML structure of components
-- CSS styles for rendered components
+-   JS APIs exported from the root/main module of a Blueprint package
+-   HTML structure of components
+-   CSS styles for rendered components

--- a/packages/landing-app/README.md
+++ b/packages/landing-app/README.md
@@ -5,5 +5,5 @@ This is the landing page for http://blueprintjs.com.
 ## Quick start
 
 1. From the root of the repo, run `npm run bootstrap`
-1. Then, in this package directory, run `npm start`
-1. Open your browser to http://localhost:8080
+2. Then, in this package directory, run `npm start`
+3. Open your browser to http://localhost:8080

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -6,11 +6,11 @@ Blueprint is a React UI toolkit for the web.
 
 This package provides React components related to selecting items from a list:
 
-* `Select` for selecting items in a list.
-* `Suggest` for selecting items in a list, from a text input.
-* `MultiSelect` for selecting multiple items in a list.
-* `Omnibar`, a macOS spotlight-style typeahead component.
-* `QueryList`, a higher-order component that provides interactions between a query string and a list of items.
+-   `Select` for selecting items in a list.
+-   `Suggest` for selecting items in a list, from a text input.
+-   `MultiSelect` for selecting multiple items in a list.
+-   `Omnibar`, a macOS spotlight-style typeahead component.
+-   `QueryList`, a higher-order component that provides interactions between a query string and a list of items.
 
 ## Installation
 

--- a/packages/select/src/components/multi-select/multi-select.md
+++ b/packages/select/src/components/multi-select/multi-select.md
@@ -1,10 +1,10 @@
 @# MultiSelect
 
-__MultiSelect__ renders a UI to choose multiple items from a list. It renders a
-[__TagInput__](#core/components/tag-input), or `customTarget` if defined, wrapped in a [__Popover__](#core/components/popover).
-Just like with [__Select__](#select/select), you can pass in a predicate to customize the filtering algorithm.
+**MultiSelect** renders a UI to choose multiple items from a list. It renders a
+[**TagInput**](#core/components/tag-input), or `customTarget` if defined, wrapped in a [**Popover**](#core/components/popover).
+Just like with [**Select**](#select/select), you can pass in a predicate to customize the filtering algorithm.
 
-The selection state of a __MultiSelect__ is controlled with the `selectedItems` prop.
+The selection state of a **MultiSelect** is controlled with the `selectedItems` prop.
 You may react to user interactions with the `onItemSelect` and `onRemove` callback props.
 
 @reactExample MultiSelectExample
@@ -13,7 +13,7 @@ You may react to user interactions with the `onItemSelect` and `onRemove` callba
     <h5 class="@ns-heading">Generic components and custom filtering</h5>
 
 For more information on controlled usage, generic components, creating new items, and custom filtering,
-please visit the documentation for [__Select__](#select/select-component).
+please visit the documentation for [**Select**](#select/select-component).
 
 </div>
 

--- a/packages/select/src/components/query-list/query-list.md
+++ b/packages/select/src/components/query-list/query-list.md
@@ -1,15 +1,15 @@
 @# QueryList
 
-__QueryList__ is a higher-order component that provides interactions between a query string and a list of items.
+**QueryList** is a higher-order component that provides interactions between a query string and a list of items.
 Specifically, it implements the two predicate props described above and provides keyboard selection. It does not render
 anything on its own, instead deferring to a `renderer` prop to perform the actual composition of components.
 
 `QueryList<T>` is a _generic component_ where `<T>` represents the type of one item in the array of `items`.
 
-You may consider using __QueryList__ if the built-in behaviors of [__Select__](#select/select-component) are
+You may consider using **QueryList** if the built-in behaviors of [**Select**](#select/select-component) are
 insufficient for your use case. This allows you to render your own item and item list components while leveraging basic
-interactions for keyboard selection and filtering. The __Select__ component source code is a great place to start when
-implementing a custom __QueryList__ `renderer`.
+interactions for keyboard selection and filtering. The **Select** component source code is a great place to start when
+implementing a custom **QueryList** `renderer`.
 
 @## Props interface
 
@@ -17,7 +17,7 @@ implementing a custom __QueryList__ `renderer`.
 
 @## Renderer API
 
-An object with the following properties will be passed to an `QueryList` `renderer`. Required properties will always be defined;  optional ones will only be defined if they are passed as props to the `QueryList`.
+An object with the following properties will be passed to an `QueryList` `renderer`. Required properties will always be defined; optional ones will only be defined if they are passed as props to the `QueryList`.
 
 This interface is generic, accepting a type parameter `<T>` for an item in the list.
 

--- a/packages/select/src/components/suggest/suggest.md
+++ b/packages/select/src/components/suggest/suggest.md
@@ -1,7 +1,7 @@
 @# Suggest
 
-__Suggest__ behaves similarly to [__Select__](#select/select-component), except it renders a text input group as the
-__Popover__ target instead of arbitrary children. This [__InputGroup__](#core/components/input-group) can
+**Suggest** behaves similarly to [**Select**](#select/select-component), except it renders a text input group as the
+**Popover** target instead of arbitrary children. This [**InputGroup**](#core/components/input-group) can
 be customized using `inputProps`.
 
 @reactExample SuggestExample

--- a/packages/select/src/index.md
+++ b/packages/select/src/index.md
@@ -4,18 +4,14 @@ reference: select
 
 @# Select
 
-The [__@blueprintjs/select__ package](https://www.npmjs.com/package/@blueprintjs/select)
+The [**@blueprintjs/select** package](https://www.npmjs.com/package/@blueprintjs/select)
 provides React components for to selecting items from a list:
 
-- [Select](#select/select-component) for selecting items in a list.
-
-- [Suggest](#select/suggest) for selecting items in a list, from a text input.
-
-- [MultiSelect](#select/multi-select) for selecting multiple items in a list.
-
-- [Omnibar](#select/omnibar), a macOS spotlight-style typeahead component.
-
-- [QueryList](#select/query-list), a higher-order component that provides interactions between a query string and a list of items.
+-   [Select](#select/select-component) for selecting items in a list.
+-   [Suggest](#select/suggest) for selecting items in a list, from a text input.
+-   [MultiSelect](#select/multi-select) for selecting multiple items in a list.
+-   [Omnibar](#select/omnibar), a macOS spotlight-style typeahead component.
+-   [QueryList](#select/query-list), a higher-order component that provides interactions between a query string and a list of items.
 
 Make sure to review the [getting started docs for installation info](#blueprint/getting-started).
 

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -24,9 +24,7 @@ Simply add this plugin in your `.stylelintrc` file and then pick the rules that 
 
 ```json
 {
-    "plugins": [
-        "@blueprintjs/stylelint-plugin"
-    ],
+    "plugins": ["@blueprintjs/stylelint-plugin"],
     "rules": {
         "@blueprintjs/no-color-literal": true,
         "@blueprintjs/no-prefix-literal": true
@@ -61,9 +59,8 @@ Enforce usage of the color variables instead of color literals.
 
 Optional secondary options:
 
-- `disableFix: boolean` - if true, autofix will be disabled
-- `variablesImportPath: { less?: string, sass?: string }` - can be used to configure a custom path for importing Blueprint variables when autofixing.
-
+-   `disableFix: boolean` - if true, autofix will be disabled
+-   `variablesImportPath: { less?: string, sass?: string }` - can be used to configure a custom path for importing Blueprint variables when autofixing.
 
 ### `@blueprintjs/no-prefix-literal` (autofixable)
 
@@ -93,8 +90,7 @@ Using the variable instead of hardcoding the prefix means that your code will st
 
 Optional secondary options:
 
-- `disableFix: boolean` - if true, autofix will be disabled
-- `variablesImportPath: { less?: string, sass?: string }` - can be used to configure a custom path for importing Blueprint variables when autofixing.
-
+-   `disableFix: boolean` - if true, autofix will be disabled
+-   `variablesImportPath: { less?: string, sass?: string }` - can be used to configure a custom path for importing Blueprint variables when autofixing.
 
 ### [Full Documentation](http://blueprintjs.com/docs) | [Source Code](https://github.com/palantir/blueprint)

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -9,13 +9,13 @@ or spreadsheet.
 
 ## Features
 
-- Fixed column headers and row indices columns
-- Resizable columns and rows
-  - Double-click column resize handles for auto-sizing
-- Viewport-only rendering for scale (also known as _lazy_ rendering)
-- Robust selections (columns, rows, or multiple cell regions)
-- Right-click to copy cell region contents
-- Inline editable column headers & cells
+-   Fixed column headers and row indices columns
+-   Resizable columns and rows
+    -   Double-click column resize handles for auto-sizing
+-   Viewport-only rendering for scale (also known as _lazy_ rendering)
+-   Robust selections (columns, rows, or multiple cell regions)
+-   Right-click to copy cell region contents
+-   Inline editable column headers & cells
 
 ## Installation
 

--- a/packages/table/src/docs/table-api.md
+++ b/packages/table/src/docs/table-api.md
@@ -4,13 +4,13 @@ reference: api
 
 @# JavaScript API
 
-The __Table__, __Column__, __Cell__, __ColumnHeaderCell__, __EditableName__, and __EditableCell2__
-components are available in the __@blueprintjs/table__ package.
+The **Table**, **Column**, **Cell**, **ColumnHeaderCell**, **EditableName**, and **EditableCell2**
+components are available in the **@blueprintjs/table** package.
 
 @## Table
 
-The top-level component of the table is __Table2__. You must at least define the number of rows (`numRows` prop)
-as well as a set of __Column__ children.
+The top-level component of the table is **Table2**. You must at least define the number of rows (`numRows` prop)
+as well as a set of **Column** children.
 
 @interface Table2Props
 
@@ -19,7 +19,6 @@ as well as a set of __Column__ children.
 @method Table.resizeRowsByTallestCell
 
 @method Table.resizeRowsByApproximateHeight
-
 
 `CellMapper` is a function that takes a cell-coordinate and returns a generic type:
 
@@ -33,20 +32,20 @@ type CellMapper<T> = (rowIndex: number, columnIndex: number) => T;
 
 @## Column
 
-__Column__ contains props for defining how the header and cells of that column are rendered.
+**Column** contains props for defining how the header and cells of that column are rendered.
 
 The table is designed to best support columnar data, meaning data where each column has only one type of value
-(for example, strings, dates, currency amounts). Because of this, the table's children are a list of __Column__
+(for example, strings, dates, currency amounts). Because of this, the table's children are a list of **Column**
 components.
 
-Use the `rowHeaderCellRenderer` prop of __Table__ to define row headers.
+Use the `rowHeaderCellRenderer` prop of **Table** to define row headers.
 
 @interface ColumnProps
 
 @## Cell
 
-The __Cell__ component renders content in the table body. `<Cell>` elements should be returned from the
-`cellRenderer` method of each __Column__.
+The **Cell** component renders content in the table body. `<Cell>` elements should be returned from the
+`cellRenderer` method of each **Column**.
 
 @interface CellProps
 
@@ -54,22 +53,22 @@ The __Cell__ component renders content in the table body. `<Cell>` elements shou
 
 Optionally customize how each column header is displayed.
 
-The `columnHeaderCellRenderer` method on each __Column__ should return a `<ColumnHeaderCell>`. Children of a
-__ColumnHeaderCell__ are rendered below the name of the column. If you want to override the render behavior of the
-name, you can supply a `nameRenderer` prop to the __ColumnHeaderCell__.
+The `columnHeaderCellRenderer` method on each **Column** should return a `<ColumnHeaderCell>`. Children of a
+**ColumnHeaderCell** are rendered below the name of the column. If you want to override the render behavior of the
+name, you can supply a `nameRenderer` prop to the **ColumnHeaderCell**.
 
 @interface ColumnHeaderCellProps
 
 @## EditableName
 
-Return a `<EditableName>` from the `nameRenderer` prop on a __ColumnHeaderCell__ to enable click-to-edit functionality
+Return a `<EditableName>` from the `nameRenderer` prop on a **ColumnHeaderCell** to enable click-to-edit functionality
 in the column header.
 
 @interface EditableNameProps
 
 @## EditableCell2
 
-Return an `<EditableCell2>` component from the `cellRenderer` prop on a __Column__ to enable double-click-to-edit
+Return an `<EditableCell2>` component from the `cellRenderer` prop on a **Column** to enable double-click-to-edit
 functionality in the table body.
 
 @interface EditableCell2Props
@@ -79,7 +78,7 @@ functionality in the table body.
 Optionally customize how each row header is displayed.
 
 In order to use this API, supply a custom renderer function which returns a `<RowHeaderCell>` from the
-`rowHeaderCellRenderer` prop on the overall __Table2__.
+`rowHeaderCellRenderer` prop on the overall **Table2**.
 
 @interface RowHeaderCellProps
 
@@ -93,28 +92,28 @@ Regions are typically used to describe boundaries for selections (via the `selec
 
 There are four different types of regions:
 
--   __Cell region:__ contains a finite, rectangular group of table cells
--   __Row region:__ represents all cells within one or more consecutive rows
--   __Column region:__ represents all cells within one or more consecutive columns
--   __Table region:__ represents all cells in the table
+-   **Cell region:** contains a finite, rectangular group of table cells
+-   **Row region:** represents all cells within one or more consecutive rows
+-   **Column region:** represents all cells within one or more consecutive columns
+-   **Table region:** represents all cells in the table
 
 Regions are defined in code according to the `Region` interface:
 
 @interface Region
 
 You can construct region objects manually according to this interface, but we recommend using our exported
-__factory methods__ to help you construct the appropriate schema for your desired region type:
+**factory methods** to help you construct the appropriate schema for your desired region type:
 
 ```ts
 import { Regions } from "@blueprintjs/table";
 
-const singleCellRegion   = Regions.cell(0, 0); // { rows: [0, 0], cols: [0, 0] }
-const singleColumnRegion = Regions.column(0);  // { rows: null, cols: [0, 0] }
-const singleRowRegion    = Regions.row(0);     // { rows: [0, 0], cols: null }
+const singleCellRegion = Regions.cell(0, 0); // { rows: [0, 0], cols: [0, 0] }
+const singleColumnRegion = Regions.column(0); // { rows: null, cols: [0, 0] }
+const singleRowRegion = Regions.row(0); // { rows: [0, 0], cols: null }
 
-const multiCellRegion   = Regions.cell(0, 0, 2, 2); // { rows: [0, 2], cols: [0, 2] }
-const multiColumnRegion = Regions.column(0, 2);     // { rows: null, cols: [0, 2] }
-const multiRowRegion    = Regions.row(0, 2);        // { rows: [0, 2], cols: null }
+const multiCellRegion = Regions.cell(0, 0, 2, 2); // { rows: [0, 2], cols: [0, 2] }
+const multiColumnRegion = Regions.column(0, 2); // { rows: null, cols: [0, 2] }
+const multiRowRegion = Regions.row(0, 2); // { rows: [0, 2], cols: null }
 
 const tableRegion = Regions.table(); // { rows: null, cols: null }
 ```
@@ -126,7 +125,7 @@ The table package also exports a `RegionCardinality` enumeration to describe the
 -   `RegionCardinality.FULL_COLUMNS`: describes a column region
 -   `RegionCardinality.FULL_TABLE`: describes a table region
 
-This enumeration is primarily used with the `selectionModes` prop to inform the __Table__ about which kinds of regions
+This enumeration is primarily used with the `selectionModes` prop to inform the **Table** about which kinds of regions
 are selectable:
 
 ```tsx
@@ -166,9 +165,9 @@ import { Regions } from "@blueprintjs/table";
 
 const cardinalities = [
     Regions.getRegionCardinality(Regions.cell(0, 0)), // RegionCardinality.CELLS
-    Regions.getRegionCardinality(Regions.row(0)),     // RegionCardinality.FULL_ROWS
-    Regions.getRegionCardinality(Regions.column(0)),  // RegionCardinality.FULL_COLUMNS
-    Regions.getRegionCardinality(Regions.table()),    // RegionCardinality.FULL_TABLE
+    Regions.getRegionCardinality(Regions.row(0)), // RegionCardinality.FULL_ROWS
+    Regions.getRegionCardinality(Regions.column(0)), // RegionCardinality.FULL_COLUMNS
+    Regions.getRegionCardinality(Regions.table()), // RegionCardinality.FULL_TABLE
 ];
 ```
 
@@ -176,22 +175,30 @@ const cardinalities = [
 
 @## TruncatedFormat
 
-Wrap your cell contents with a __TruncatedFormat__ component like so:
+Wrap your cell contents with a **TruncatedFormat** component like so:
 
 ```tsx
 const content = "A very long string...";
-return <Cell><TruncatedFormat>{content}</TruncatedFormat></Cell>
+return (
+    <Cell>
+        <TruncatedFormat>{content}</TruncatedFormat>
+    </Cell>
+);
 ```
 
 @interface TruncatedFormatProps
 
 @## JSONFormat
 
-Wrap your JavaScript object cell contents with a __JSONFormat__ component like so:
+Wrap your JavaScript object cell contents with a **JSONFormat** component like so:
 
 ```tsx
 const content = { any: "javascript variable", even: [null, "is", "okay", "too"] };
-return <Cell><JSONFormat>{content}</JSONFormat></Cell>
+return (
+    <Cell>
+        <JSONFormat>{content}</JSONFormat>
+    </Cell>
+);
 ```
 
 @interface JSONFormatProps

--- a/packages/table/src/docs/table-features.md
+++ b/packages/table/src/docs/table-features.md
@@ -14,8 +14,8 @@ rikishi (wrestler). For each column type, we define a different set of sort oper
 
 In the table below, try:
 
-*   Sorting with the menu in each column header
-*   Selecting cells and copying with the right-click context menu or with <kbd>Cmd/Ctrl</kbd> + <kbd>C</kbd> hotkeys
+-   Sorting with the menu in each column header
+-   Selecting cells and copying with the right-click context menu or with <kbd>Cmd/Ctrl</kbd> + <kbd>C</kbd> hotkeys
 
 <div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
 
@@ -32,7 +32,7 @@ demonstrated in the above example. In these cases, the typical table props which
 (like `children`, `numRows`, `selectedRegions`, etc) may not change, so the table will not re-run its `<Cell>` children
 render methods.
 
-To work around this problem, __Table2__ supports a dependency list in its `cellRendererDependencies` prop. Dependency
+To work around this problem, **Table2** supports a dependency list in its `cellRendererDependencies` prop. Dependency
 changes in this list (compared using shallow equality checks) trigger a re-render of all cells in the table.
 
 In the above sortable table example, we keep a `sortedIndexMap` value in state which is updated in the column sort
@@ -50,11 +50,11 @@ hotkeys dialog after you have clicked into the table once.
 
 @## Editing
 
-To make your table editable, use the [__EditableCell2__](#table/table2.editablecell2) and __EditableName__ components
+To make your table editable, use the [**EditableCell2**](#table/table2.editablecell2) and **EditableName** components
 to create editable table cells and column names.
 
-To further extend the interactivity of the column headers, you can add children components to each __ColumnHeaderCell__
-defined in the `columnHeaderCellRenderer` prop of __Column__.
+To further extend the interactivity of the column headers, you can add children components to each **ColumnHeaderCell**
+defined in the `columnHeaderCellRenderer` prop of **Column**.
 
 The following example renders a table with editable column names (single click), editable table cells (double click),
 and selectable column types. In this example, the editable values are validated against an alpha character-only
@@ -81,8 +81,8 @@ This will work whether or not column selection is enabled.
 
 To allow reordering of multiple contiguous columns at once, first set the following additional props:
 
-- `enableMultipleSelection={true}`
-- `selectionModes={[RegionCardinality.FULL_COLUMNS, ...]}`
+-   `enableMultipleSelection={true}`
+-   `selectionModes={[RegionCardinality.FULL_COLUMNS, ...]}`
 
 Then drag-select the desired columns into a single selection, and grab any selected column's drag handle to reorder the
 entire selected block.
@@ -100,10 +100,10 @@ Rows do not have a drag handle, so they must be selected before reordering. To r
 click and drag anywhere in a selected row header, then release. Note that the following props must be set for row
 reordering to work:
 
-- `enableRowHeader={true}`
-- `enableRowReordering={true}`
-- `selectionModes={[RegionCardinality.FULL_ROWS, ...]}`
-- `enableMultipleSelection={true}` (to optionally enable multi-row reordering)
+-   `enableRowHeader={true}`
+-   `enableRowReordering={true}`
+-   `selectionModes={[RegionCardinality.FULL_ROWS, ...]}`
+-   `enableMultipleSelection={true}` (to optionally enable multi-row reordering)
 
 ### Example
 
@@ -115,27 +115,27 @@ When fetching or updating data, it may be desirable to show a loading state. The
 loading control of loading row headers, column headers, or individual cells. Several table components expose a
 `loading` or `loadingOptions` prop, but loading-related rendering is computed with components lower in the hierarchy
 taking priority. For example, a cell with `loading` set to `false` will never render its loading state even if the
-__Column__ component to which it belongs has a `loadingOptions` value of `[ ColumnLoadingOption.CELLS ]`. The following
+**Column** component to which it belongs has a `loadingOptions` value of `[ ColumnLoadingOption.CELLS ]`. The following
 examples display a table of the largest potentially hazardous asteroid (based on absolute magnitude) discovered in a
 given year.
 
 @### Table loading states
 
-__Table2__ exposes a `loadingOptions` prop that allows you to control the loading state behavior of all column header,
+**Table2** exposes a `loadingOptions` prop that allows you to control the loading state behavior of all column header,
 row header, and body cells. Try toggling the different options.
 
 @reactExample TableLoadingExample
 
 @### Column loading states
 
-__Column__ exposes a `loadingOptions` prop that allows you to control the loading state behavior of an individual
+**Column** exposes a `loadingOptions` prop that allows you to control the loading state behavior of an individual
 column's header and body cells. Try selecting a different column in the dropdown below.
 
 @reactExample ColumnLoadingExample
 
 @### Cells
 
-__Cell__, __EditableCell2__, __ColumnHeaderCell__, and __RowHeaderCell__ expose a `loading` prop for granular
+**Cell**, **EditableCell2**, **ColumnHeaderCell**, and **RowHeaderCell** expose a `loading` prop for granular
 control of which cells should show a loading state. Try selecting a different preset loading
 configuration.
 
@@ -143,9 +143,9 @@ configuration.
 
 @## Formatting
 
-To display long strings or native JavaScript objects, the table package provides __TruncatedFormat__ and __JSONFormat__
-components. These are designed to be used within a __Cell__, where they will render a
-[__Popover__](#core/components/popover) to show the full cell contents on click.
+To display long strings or native JavaScript objects, the table package provides **TruncatedFormat** and **JSONFormat**
+components. These are designed to be used within a **Cell**, where they will render a
+[**Popover**](#core/components/popover) to show the full cell contents on click.
 
 Below is a table of timezones including the local time when this page was rendered. It uses a
 `<TruncatedFormat detectTruncation={true}>` component to show the long date string and a

--- a/packages/table/src/docs/table.md
+++ b/packages/table/src/docs/table.md
@@ -1,12 +1,12 @@
 @# Table
 
-The [__@blueprintjs/table__ package](https://www.npmjs.com/package/@blueprintjs/table) provides components
+The [**@blueprintjs/table** package](https://www.npmjs.com/package/@blueprintjs/table) provides components
 to build a highly interactive table or spreadsheet UI.
 
 <div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
 
 If you are looking for the simpler Blueprint-styled HTML `<table>` instead, see
-[__HTMLTable__](#core/components/html-table).
+[**HTMLTable**](#core/components/html-table).
 
 </div>
 
@@ -24,20 +24,20 @@ Do not forget to include `table.css` on your page:
 
 ### Features
 
-* High-scale, data-agnostic
-* Customizable cell and header rendering
-* Virtualized viewport rendering
-* Selectable rows, columns and cells
-* Resizable rows and columns
-* Editable headers and cells
-* Integrated header and context menus
+-   High-scale, data-agnostic
+-   Customizable cell and header rendering
+-   Virtualized viewport rendering
+-   Selectable rows, columns and cells
+-   Resizable rows and columns
+-   Editable headers and cells
+-   Integrated header and context menus
 
 @## Basic usage
 
 <div class="@ns-callout @ns-large @ns-intent-success @ns-icon-star">
 
 There is an updated version of the table component with some new features and compatibility with the
-[new hotkeys API](#core/components/hotkeys-target2): see [__Table2__](#table/table2).
+[new hotkeys API](#core/components/hotkeys-target2): see [**Table2**](#table/table2).
 
 </div>
 
@@ -53,7 +53,7 @@ import { Column, Table } from "@blueprintjs/table";
     <Column />
     <Column />
     <Column />
-</Table>
+</Table>;
 ```
 
 The table is **data-agnostic**. It doesn't store any data internally, so it is up to you to bind the table to your data.
@@ -66,17 +66,13 @@ For example, this creates a table that renders dollar and euro values:
 ```tsx
 import { Cell, Column, Table } from "@blueprintjs/table";
 
-const dollarCellRenderer = (rowIndex: number) => (
-    <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>
-);
-const euroCellRenderer = (rowIndex: number) => (
-    <Cell>{`€${(rowIndex * 10 * 0.85).toFixed(2)}`}</Cell>
-);
+const dollarCellRenderer = (rowIndex: number) => <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>;
+const euroCellRenderer = (rowIndex: number) => <Cell>{`€${(rowIndex * 10 * 0.85).toFixed(2)}`}</Cell>;
 
 <Table numRows={10}>
-    <Column name="Dollars" cellRenderer={dollarCellRenderer}/>
+    <Column name="Dollars" cellRenderer={dollarCellRenderer} />
     <Column name="Euros" cellRenderer={euroCellRenderer} />
-</Table>
+</Table>;
 ```
 
 @reactExample TableDollarExample


### PR DESCRIPTION
#### Proposed changes:

Run Prettier over Markdown files and manually adjust lists for correct numbering and consistent line endings.

#### Reviewers should focus on:

There should be no visible changes to generated docs as a result of this change.
