### PR TITLE
chore: Rename CI test build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       - store_test_results: { path: ./reports }
       - store_artifacts: { path: ./reports }
 
-  test-react-16: &test-react
+  test-react-18: &test-react
     docker: *docker-node-browsers-image
     resource_class: xlarge
     environment:
@@ -228,14 +228,14 @@ workflows:
           requires: [compile]
       - test-node-libs:
           requires: [compile]
-      - test-react-16:
+      - test-react-18:
           requires: [compile]
       - test-iso-react-16:
           requires: [compile]
       - deploy-preview:
           requires: [dist]
       - deploy-npm:
-          requires: [dist, lint, test-node-libs, test-react-16, test-iso-react-16]
+          requires: [dist, lint, test-node-libs, test-react-18, test-iso-react-16]
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       - store_test_results: { path: ./reports }
       - store_artifacts: { path: ./reports }
 
-  test-iso-react-16: &test-iso
+  test-iso-react-18: &test-iso
     docker: *docker-node-image
     environment:
       JUNIT_REPORT_PATH: reports
@@ -230,12 +230,12 @@ workflows:
           requires: [compile]
       - test-react-18:
           requires: [compile]
-      - test-iso-react-16:
+      - test-iso-react-18:
           requires: [compile]
       - deploy-preview:
           requires: [dist]
       - deploy-npm:
-          requires: [dist, lint, test-node-libs, test-react-18, test-iso-react-16]
+          requires: [dist, lint, test-node-libs, test-react-18, test-iso-react-18]
           filters:
             branches:
               only:


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Resulting from #7142, we can now rename these CI test steps since they now execute with React 18.
