### PR TITLE
Add `size` prop to more components

### DIFF
--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -18,7 +18,10 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
+import type { Size } from "../../common/size";
+import { useValidateProps } from "../../hooks/useValidateProps";
 
 export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, Props {
     /**
@@ -50,6 +53,9 @@ export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelEleme
 
     /**
      * Whether the file input should appear with large styling.
+     *
+     * @deprecated use `size="large"` instead.
+     * @default false
      */
     large?: boolean;
 
@@ -65,8 +71,16 @@ export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelEleme
 
     /**
      * Whether the file input should appear with small styling.
+     *
+     * @deprecated use `size="small"` instead.
+     * @default false
      */
     small?: boolean;
+
+    /**
+     * The size of the file input.
+     */
+    size?: Size;
 
     /**
      * The text to display inside the input.
@@ -100,20 +114,30 @@ export const FileInput = (props: FileInputProps) => {
         fill,
         hasSelection = false,
         inputProps = {},
-        large,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        large = false,
         onInputChange,
-        small,
+        size = "medium",
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        small = false,
         text = "Choose file...",
         ...htmlProps
     } = props;
 
-    const rootClasses = classNames(className, Classes.FILE_INPUT, {
-        [Classes.FILE_INPUT_HAS_SELECTION]: hasSelection,
-        [Classes.DISABLED]: disabled,
-        [Classes.FILL]: fill,
-        [Classes.LARGE]: large,
-        [Classes.SMALL]: small,
-    });
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("FileInput", { large, small });
+    }, [large, small]);
+
+    const rootClasses = classNames(
+        className,
+        Classes.FILE_INPUT,
+        {
+            [Classes.DISABLED]: disabled,
+            [Classes.FILL]: fill,
+            [Classes.FILE_INPUT_HAS_SELECTION]: hasSelection,
+        },
+        Classes.sizeClass(size, { large, small }),
+    );
 
     const uploadProps = {
         [`${NS}-button-text`]: buttonText,
@@ -134,4 +158,5 @@ export const FileInput = (props: FileInputProps) => {
         </label>
     );
 };
+
 FileInput.displayName = `${DISPLAYNAME_PREFIX}.FileInput`;

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -18,13 +18,14 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
-import * as Errors from "../../common/errors";
+import { INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX, logDeprecatedSizeWarning } from "../../common/errors";
 import {
     type ControlledValueProps,
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
     removeNonHTMLProps,
 } from "../../common/props";
+import type { Size } from "../../common/size";
 import { Icon } from "../icon/icon";
 
 import { AsyncControllableInput } from "./asyncControllableInput";
@@ -33,7 +34,7 @@ import type { InputSharedProps } from "./inputSharedProps";
 type ControlledInputValueProps = ControlledValueProps<string, HTMLInputElement>;
 
 export interface InputGroupProps
-    extends Omit<HTMLInputProps, keyof ControlledInputValueProps>,
+    extends Omit<HTMLInputProps, keyof ControlledInputValueProps | "size">,
         ControlledInputValueProps,
         InputSharedProps {
     /**
@@ -45,11 +46,34 @@ export interface InputGroupProps
      */
     asyncControl?: boolean;
 
-    /** Whether this input should use large styles. */
+    /**
+     * Whether this input should use large styles.
+     *
+     * @deprecated use `size="large"` instead.
+     * @default false
+     */
     large?: boolean;
 
-    /** Whether this input should use small styles. */
+    /**
+     * Whether this input should use small styles.
+     *
+     * @deprecated use `size="small"` instead.
+     * @default false
+     */
     small?: boolean;
+
+    /**
+     * Size of the input.
+     *
+     * @default "medium"
+     */
+    size?: Size;
+
+    /**
+     * Alias for the native HTML input `size` attribute.
+     * see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/size
+     */
+    inputSize?: HTMLInputProps["size"];
 
     /** Whether the input (and any buttons) should appear with rounded caps. */
     round?: boolean;
@@ -103,10 +127,14 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
             fill,
             inputClassName,
             inputRef,
+            inputSize,
             intent,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             large,
             readOnly,
             round,
+            size = "medium",
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             small,
             tagName = "div",
         } = this.props;
@@ -117,10 +145,9 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
                 [Classes.DISABLED]: disabled,
                 [Classes.READ_ONLY]: readOnly,
                 [Classes.FILL]: fill,
-                [Classes.LARGE]: large,
-                [Classes.SMALL]: small,
                 [Classes.ROUND]: round,
             },
+            Classes.sizeClass(size, { large, small }),
             className,
         );
         const style: React.CSSProperties = {
@@ -134,6 +161,7 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
             "aria-disabled": disabled,
             className: classNames(Classes.INPUT, inputClassName),
             onChange: this.handleInputChange,
+            size: inputSize,
             style,
         } satisfies React.HTMLProps<HTMLInputElement>;
         const inputElement = asyncControl ? (
@@ -164,8 +192,11 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
 
     protected validateProps(props: InputGroupProps) {
         if (props.leftElement != null && props.leftIcon != null) {
-            console.warn(Errors.INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX);
+            console.warn(INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX);
         }
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const { large, small } = props;
+        logDeprecatedSizeWarning("InputGroup", { large, small });
     }
 
     private handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -32,6 +32,7 @@ import {
     Utils,
 } from "../../common";
 import * as Errors from "../../common/errors";
+import type { Size } from "../../common/size";
 import { ButtonGroup } from "../button/buttonGroup";
 import { Button } from "../button/buttons";
 
@@ -94,6 +95,7 @@ export interface NumericInputProps extends InputSharedProps {
      * This is equivalent to setting `Classes.LARGE` via className on the
      * parent control group and on the child input group.
      *
+     * @deprecated use size="large" instead
      * @default false
      */
     large?: boolean;
@@ -147,9 +149,23 @@ export interface NumericInputProps extends InputSharedProps {
      * This is equivalent to setting `Classes.SMALL` via className on the
      * parent control group and on the child input group.
      *
+     * @deprecated use size="small" instead
      * @default false
      */
     small?: boolean;
+
+    /**
+     * The size of the input.
+     *
+     * @default "medium"
+     */
+    size?: Size;
+
+    /**
+     * Alias for the native HTML input `size` attribute.
+     * see: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/size
+     */
+    inputSize?: HTMLInputProps["size"];
 
     /**
      * The increment between successive values when no modifier keys are held.
@@ -206,7 +222,10 @@ type ButtonEventHandlers = Required<Pick<React.HTMLAttributes<HTMLElement>, "onK
  *
  * @see https://blueprintjs.com/docs/#core/components/numeric-input
  */
-export class NumericInput extends AbstractPureComponent<HTMLInputProps & NumericInputProps, NumericInputState> {
+export class NumericInput extends AbstractPureComponent<
+    Omit<HTMLInputProps, "size"> & NumericInputProps,
+    NumericInputState
+> {
     public static displayName = `${DISPLAYNAME_PREFIX}.NumericInput`;
 
     public static VALUE_EMPTY = "";
@@ -225,6 +244,7 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
         minorStepSize: 0.1,
         selectAllOnFocus: false,
         selectAllOnIncrement: false,
+        size: "medium",
         small: false,
         stepSize: 1,
     };
@@ -263,7 +283,7 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
 
     // Value Helpers
     // =============
-    private static getStepMaxPrecision(props: HTMLInputProps & NumericInputProps) {
+    private static getStepMaxPrecision(props: Omit<HTMLInputProps, "size"> & NumericInputProps) {
         if (props.minorStepSize != null) {
             return Utils.countDecimalPlaces(props.minorStepSize);
         } else {
@@ -313,10 +333,11 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
     private getCurrentValueAsNumber = () => Number(parseStringToStringNumber(this.state.value, this.props.locale));
 
     public render() {
-        const { buttonPosition, className, fill, large, small } = this.props;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const { buttonPosition, className, fill, large, size = "medium", small } = this.props;
         const containerClasses = classNames(
             Classes.NUMERIC_INPUT,
-            { [Classes.LARGE]: large, [Classes.SMALL]: small },
+            Classes.sizeClass(size, { large, small }),
             className,
         );
         const buttons = this.renderButtons();
@@ -359,7 +380,8 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
     }
 
     protected validateProps(nextProps: HTMLInputProps & NumericInputProps) {
-        const { majorStepSize, max, min, minorStepSize, stepSize, value } = nextProps;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const { large, majorStepSize, max, min, minorStepSize, small, stepSize, value } = nextProps;
         if (min != null && max != null && min > max) {
             console.error(Errors.NUMERIC_INPUT_MIN_MAX);
         }
@@ -378,6 +400,7 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
         if (majorStepSize && majorStepSize < stepSize!) {
             console.error(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_BOUND);
         }
+        Errors.logDeprecatedSizeWarning("NumericInput", { large, small });
 
         // controlled mode
         if (value != null) {
@@ -452,6 +475,8 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
                 intent={this.state.currentImeInputInvalid ? Intent.DANGER : this.props.intent}
                 inputClassName={this.props.inputClassName}
                 inputRef={this.inputRef}
+                inputSize={this.props.inputSize}
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 large={this.props.large}
                 leftElement={this.props.leftElement}
                 leftIcon={this.props.leftIcon}
@@ -465,6 +490,8 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
                 onPaste={this.handleInputPaste}
                 onValueChange={this.handleInputChange}
                 rightElement={this.props.rightElement}
+                size={this.props.size}
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 small={this.props.small}
                 value={this.state.value}
             />

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -18,7 +18,9 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes, refHandler, setRef } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
+import type { Size } from "../../common/size";
 
 import { AsyncControllableTextArea } from "./asyncControllableTextArea";
 
@@ -62,6 +64,7 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
     /**
      * Whether the text area should appear with large styling.
      *
+     * @deprecated use `size="large"` instead.
      * @default false
      */
     large?: boolean;
@@ -69,9 +72,17 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
     /**
      * Whether the text area should appear with small styling.
      *
+     * @deprecated use `size="small"` instead.
      * @default false
      */
     small?: boolean;
+
+    /**
+     * The size styling of the text area.
+     *
+     * @default "medium"
+     */
+    size: Size;
 }
 
 export interface TextAreaState {
@@ -90,6 +101,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
         autoResize: false,
         fill: false,
         large: false,
+        size: "medium",
         small: false,
     };
 
@@ -162,7 +174,10 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
             growVertically,
             inputRef,
             intent,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             large,
+            size,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             small,
             ...htmlProps
         } = this.props;
@@ -171,10 +186,9 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
             Classes.INPUT,
             Classes.TEXT_AREA,
             Classes.intentClass(intent),
+            Classes.sizeClass(size, { large, small }),
             {
                 [Classes.FILL]: fill,
-                [Classes.LARGE]: large,
-                [Classes.SMALL]: small,
                 [Classes.TEXT_AREA_AUTO_RESIZE]: autoResize,
             },
             className,
@@ -202,6 +216,12 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
                 ref={this.handleRef}
             />
         );
+    }
+
+    protected validateProps(nextProps: TextAreaProps) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const { small, large } = nextProps;
+        logDeprecatedSizeWarning("TextArea", { large, small });
     }
 
     private handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -18,17 +18,37 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
+import type { Size } from "../../common/size";
+import { useValidateProps } from "../../hooks/useValidateProps";
 
 export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement> {
     /** Menu items. */
     children?: React.ReactNode;
 
-    /** Whether the menu items in this menu should use a large appearance. */
+    /**
+     * Whether the menu items in this menu should use a large appearance.
+     *
+     * @deprecated use `size="large"` instead.
+     * @default false
+     */
     large?: boolean;
 
-    /** Whether the menu items in this menu should use a small appearance. */
+    /**
+     * Whether the menu items in this menu should use a small appearance.
+     *
+     * @deprecated use `size="small"` instead.
+     * @default false
+     */
     small?: boolean;
+
+    /**
+     * The size of the items in this menu.
+     *
+     * @default "medium"
+     */
+    size?: Size;
 
     /** Ref handler that receives the HTML `<ul>` element backing this component. */
     ulRef?: React.Ref<HTMLUListElement>;
@@ -39,13 +59,21 @@ export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement>
  *
  * @see https://blueprintjs.com/docs/#core/components/menu
  */
-export const Menu: React.FC<MenuProps> = ({ className, children, large, small, ulRef, ...htmlProps }) => {
-    const classes = classNames(className, Classes.MENU, {
-        [Classes.LARGE]: large,
-        [Classes.SMALL]: small,
-    });
+export const Menu: React.FC<MenuProps> = props => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { className, children, large, size = "medium", small, ulRef, ...htmlProps } = props;
+
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("Menu", { large, small });
+    }, [large, small]);
+
     return (
-        <ul role="menu" {...htmlProps} className={classes} ref={ulRef}>
+        <ul
+            role="menu"
+            {...htmlProps}
+            className={classNames(className, Classes.MENU, Classes.sizeClass(size, { large, small }))}
+            ref={ulRef}
+        >
             {children}
         </ul>
     );

--- a/packages/core/src/components/segmented-control/segmentedControl.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Intent, mergeRefs, Utils } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import {
     type ControlledValueProps,
     DISPLAYNAME_PREFIX,
@@ -25,6 +26,8 @@ import {
     type Props,
     removeNonHTMLProps,
 } from "../../common/props";
+import type { Size } from "../../common/size";
+import { useValidateProps } from "../../hooks/useValidateProps";
 import type { ButtonProps } from "../button/buttonProps";
 import { Button } from "../button/buttons";
 
@@ -52,6 +55,7 @@ export interface SegmentedControlProps
     /**
      * Whether this control should use large buttons.
      *
+     * @deprecated use `size="large"` instead.
      * @default false
      */
     large?: boolean;
@@ -76,8 +80,16 @@ export interface SegmentedControlProps
     role?: Extract<React.AriaRole, "radiogroup" | "group" | "toolbar">;
 
     /**
+     * The size of the control.
+     *
+     * @default "medium"
+     */
+    size?: Size;
+
+    /**
      * Whether this control should use small buttons.
      *
+     * @deprecated use `size="small"` instead.
      * @default false
      */
     small?: boolean;
@@ -95,10 +107,13 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRe
         fill,
         inline,
         intent = Intent.NONE,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         large,
         onValueChange,
         options,
         role = "radiogroup",
+        size = "medium",
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         small,
         value: controlledValue,
         ...htmlProps
@@ -108,6 +123,10 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRe
     const selectedValue = controlledValue ?? localValue;
 
     const outerRef = React.useRef<HTMLDivElement>(null);
+
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("SegmentedControl", { large, small });
+    }, [large, small]);
 
     const handleOptionClick = React.useCallback(
         (newSelectedValue: string, targetElement: HTMLElement) => {
@@ -170,8 +189,11 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRe
                         intent={intent}
                         isSelected={isSelected}
                         key={option.value}
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         large={large}
                         onClick={handleOptionClick}
+                        size={size}
+                        // eslint-disable-next-line @typescript-eslint/no-deprecated
                         small={small}
                         {...(role === "radiogroup"
                             ? {
@@ -196,7 +218,7 @@ SegmentedControl.displayName = `${DISPLAYNAME_PREFIX}.SegmentedControl`;
 
 interface SegmentedControlOptionProps
     extends OptionProps<string>,
-        Pick<SegmentedControlProps, "intent" | "small" | "large">,
+        Pick<SegmentedControlProps, "intent" | "small" | "large" | "size">,
         Pick<ButtonProps, "role" | "tabIndex">,
         React.AriaAttributes {
     isSelected: boolean;

--- a/packages/core/test/forms/fileInputTests.tsx
+++ b/packages/core/test/forms/fileInputTests.tsx
@@ -22,9 +22,9 @@ import sinon from "sinon";
 import { Classes, FileInput } from "../../src";
 
 describe("<FileInput>", () => {
-    it("supports className, fill, & large", () => {
+    it(`supports className, fill, & size="large"`, () => {
         const CUSTOM_CLASS = "foo";
-        const wrapper = shallow(<FileInput className={CUSTOM_CLASS} fill={true} large={true} />);
+        const wrapper = shallow(<FileInput className={CUSTOM_CLASS} fill={true} size="large" />);
         assert.isTrue(wrapper.hasClass(Classes.FILE_INPUT), "Classes.FILE_INPUT");
         assert.isTrue(wrapper.hasClass(CUSTOM_CLASS), CUSTOM_CLASS);
         assert.isTrue(wrapper.hasClass(Classes.FILL), "Classes.FILL");

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -56,10 +56,10 @@ export class Icons extends React.PureComponent<IconsProps, IconsState> {
                 <InputGroup
                     autoFocus={true}
                     className={Classes.FILL}
-                    large={true}
                     leftIcon="search"
                     onValueChange={this.handleFilterChange}
                     placeholder="Search for icons..."
+                    size="large"
                     type="search"
                     value={this.state.filter}
                 />

--- a/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
@@ -33,7 +33,7 @@ export const AlignmentSelect: React.FC<AlignmentSelectProps> = ({ align, label =
     const handleChange = React.useCallback((value: string) => onChange(value as Alignment), [onChange]);
     return (
         <FormGroup label={label}>
-            <SegmentedControl small={true} fill={true} options={options} onValueChange={handleChange} value={align} />
+            <SegmentedControl fill={true} options={options} onValueChange={handleChange} size="small" value={align} />
         </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
@@ -48,7 +48,7 @@ export const BooleanOrUndefinedSelect: React.FC<BooleanOrUndefinedSelectProps> =
                     { disabled, value: "false" },
                 ]}
                 onValueChange={handleChange}
-                small={true}
+                size="small"
                 value={value === undefined ? "undefined" : value === true ? "true" : "false"}
             />
         </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
@@ -38,7 +38,7 @@ export const LayoutSelect: React.FC<LayoutSelectProps> = ({ layout, onChange }) 
                     { label: "Horizontal", value: "horizontal" },
                     { label: "Vertical", value: "vertical" },
                 ]}
-                small={true}
+                size="small"
                 value={layout}
             />
         </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/common/legacySizeSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/legacySizeSelect.tsx
@@ -41,13 +41,13 @@ export const LegacySizeSelect: React.FC<LegacySizeSelectProps> = ({
         <FormGroup label={label}>
             <SegmentedControl
                 fill={true}
-                small={true}
                 options={[
                     { label: optionLabels[0], value: "small" },
                     { label: optionLabels[1], value: "regular" },
                     { label: optionLabels[2], value: "large" },
                 ]}
                 onValueChange={handleChange}
+                size="small"
                 value={size}
             />
         </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
@@ -27,7 +27,7 @@ export const SizeSelect: React.FC<SizeSelectProps> = ({ label = "Size", onChange
     const handleChange = React.useCallback((value: string) => onChange(value as Size), [onChange]);
     return (
         <FormGroup label={label}>
-            <SegmentedControl fill={true} onValueChange={handleChange} options={options} small={true} value={size} />
+            <SegmentedControl fill={true} onValueChange={handleChange} options={options} size="small" value={size} />
         </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/common/textAlignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/textAlignmentSelect.tsx
@@ -22,7 +22,7 @@ export const TextAlignmentSelect: React.FC<AlignmentSelectProps> = ({ align, lab
     const handleChange = React.useCallback((value: string) => onChange(value as TextAlignment), [onChange]);
     return (
         <FormGroup label={label}>
-            <SegmentedControl small={true} fill={true} options={options} onValueChange={handleChange} value={align} />
+            <SegmentedControl fill={true} options={options} onValueChange={handleChange} size="small" value={align} />
         </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -156,7 +156,7 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
                             { value: Position.LEFT },
                         ]}
                         onValueChange={this.handlePositionChange}
-                        small={true}
+                        size="small"
                         value={position}
                     />
                 </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
@@ -15,13 +15,14 @@
 
 import * as React from "react";
 
-import { FileInput, FormGroup, H5, InputGroup, Switch } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { FileInput, FormGroup, H5, InputGroup, type Size } from "@blueprintjs/core";
+import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
+
+import { SizeSelect } from "./common/sizeSelect";
 
 export const FileInputExample: React.FC<ExampleProps> = props => {
     const [buttonText, setButtonText] = React.useState("");
-    const [large, setLarge] = React.useState(false);
-    const [small, setSmall] = React.useState(false);
+    const [size, setSize] = React.useState<Size>("medium");
     const [text, setText] = React.useState(undefined);
 
     const options = (
@@ -33,14 +34,13 @@ export const FileInputExample: React.FC<ExampleProps> = props => {
             <FormGroup label="Button text">
                 <InputGroup onValueChange={setButtonText} placeholder="Browse" value={buttonText} />
             </FormGroup>
-            <Switch checked={large} label="Large" onChange={handleBooleanChange(setLarge)} />
-            <Switch checked={small} label="Small" onChange={handleBooleanChange(setSmall)} />
+            <SizeSelect onChange={setSize} size={size} />
         </>
     );
 
     return (
         <Example options={options} {...props}>
-            <FileInput buttonText={buttonText} large={large} small={small} text={text} />
+            <FileInput buttonText={buttonText} size={size} text={text} />
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -27,6 +27,7 @@ import {
     Menu,
     MenuItem,
     Popover,
+    type Size,
     Spinner,
     Switch,
     Tag,
@@ -36,41 +37,26 @@ import { Example, type ExampleProps, handleBooleanChange, handleStringChange } f
 import { IconNames, IconSize } from "@blueprintjs/icons";
 
 import { IntentSelect } from "./common/intentSelect";
+import { SizeSelect } from "./common/sizeSelect";
 
 export const InputGroupExample: React.FC<ExampleProps> = props => {
     const [disabled, setDisabled] = React.useState(false);
     const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [large, setLarge] = React.useState(false);
     const [readOnly, setReadOnly] = React.useState(false);
-    const [small, setSmall] = React.useState(false);
-
-    const handleLargeChange = handleBooleanChange(newLarge => {
-        setLarge(newLarge);
-        if (newLarge) {
-            setSmall(false);
-        }
-    });
-
-    const handleSmallChange = handleBooleanChange(newSmall => {
-        setSmall(newSmall);
-        if (newSmall) {
-            setLarge(false);
-        }
-    });
+    const [size, setSize] = React.useState<Size>("medium");
 
     const options = (
         <>
             <H5>Props</H5>
             <Switch checked={disabled} label="Disabled" onChange={handleBooleanChange(setDisabled)} />
             <Switch checked={readOnly} label="Read-only" onChange={handleBooleanChange(setReadOnly)} />
-            <Switch checked={large} label="Large" onChange={handleLargeChange} />
-            <Switch checked={small} label="Small" onChange={handleSmallChange} />
             <Divider />
+            <SizeSelect onChange={setSize} size={size} />
             <IntentSelect intent={intent} onChange={setIntent} />
         </>
     );
 
-    const inputGroupProps: InputGroupProps = { disabled, intent, large, readOnly, small };
+    const inputGroupProps: InputGroupProps = { disabled, intent, readOnly, size };
 
     return (
         <Example options={options} {...props}>

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -16,24 +16,25 @@
 
 import * as React from "react";
 
-import { Classes, H5, Icon, InputGroup, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+import { Classes, H5, Icon, InputGroup, Menu, MenuDivider, MenuItem, type Size } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
-import { getSizeProp, LegacySizeSelect, type Size } from "./common/legacySizeSelect";
+import { SizeSelect } from "./common/sizeSelect";
 
 export function MenuExample(props: ExampleProps) {
-    const [size, setSize] = React.useState<Size>("regular");
-    const [count, setCount] = React.useState<number>(0);
+    const [count, setCount] = React.useState(0);
+    const [size, setSize] = React.useState<Size>("medium");
 
     const options = (
         <>
             <H5>Props</H5>
-            <LegacySizeSelect size={size} onChange={setSize} />
+            <SizeSelect size={size} onChange={setSize} />
         </>
     );
+
     return (
         <Example className="docs-menu-example" options={options} {...props}>
-            <Menu className={Classes.ELEVATION_1} {...getSizeProp(size)}>
+            <Menu className={Classes.ELEVATION_1} size={size}>
                 <MenuItem icon={<PalantirLogo />} text="Custom SVG icon" />
                 <MenuDivider />
                 <MenuItem icon="new-text-box" text="New text box" />
@@ -48,7 +49,7 @@ export function MenuExample(props: ExampleProps) {
                 />
                 <MenuItem icon="cog" labelElement={<Icon icon="share" />} text="Settings..." intent="primary" />
             </Menu>
-            <Menu className={Classes.ELEVATION_1} {...getSizeProp(size)}>
+            <Menu className={Classes.ELEVATION_1} size={size}>
                 <MenuDivider title="Edit" />
                 <MenuItem icon="cut" text="Cut" label="⌘X" />
                 <MenuItem icon="duplicate" text="Copy" label="⌘C" />

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -71,7 +71,7 @@ export function MenuExample(props: ExampleProps) {
                     <MenuItem
                         icon="edit"
                         text="Set name"
-                        labelElement={<InputGroup small={true} placeholder="Item name..." />}
+                        labelElement={<InputGroup placeholder="Item name..." size="small" />}
                         shouldDismissPopover={false}
                     />
                     <MenuItem icon="more" text="Look in here for even more items">

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -81,7 +81,7 @@ export function MenuItemExample(props: ExampleProps) {
                 <SegmentedControl
                     options={[{ value: "menuitem" }, { value: "listoption" }]}
                     onValueChange={handleRoleStructureChange}
-                    small={true}
+                    size="small"
                     value={roleStructure}
                 />
             </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -102,7 +102,7 @@ export const MultistepDialogExample: React.FC<ExampleProps<BlueprintExampleData>
                     fill={true}
                     onValueChange={handleNavPositionChange}
                     options={NAV_POSITIONS.map(position => ({ value: position }))}
-                    small={true}
+                    size="small"
                     value={navPosition}
                 />
             </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -150,7 +150,7 @@ const NonIdealStateVisualSelect: React.FC<{
                     { label: "Icon", value: "icon" },
                     { label: "Spinner", value: "spinner" },
                 ]}
-                small={true}
+                size="small"
                 value={visual}
             />
         </FormGroup>

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -29,6 +29,7 @@ import {
     type OptionProps,
     Popover,
     Position,
+    type Size,
     Switch,
 } from "@blueprintjs/core";
 import {
@@ -43,6 +44,7 @@ import { IconNames } from "@blueprintjs/icons";
 
 import { IntentSelect } from "./common/intentSelect";
 import { LOCALES } from "./common/locales";
+import { SizeSelect } from "./common/sizeSelect";
 
 const MIN_VALUES = [
     { label: "None", value: -Infinity },
@@ -71,14 +73,13 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
         disabled: false,
         fill: false,
         intent: Intent.NONE,
-        large: false,
         majorStepSize: 10,
         max: 100,
         min: 0,
         minorStepSize: 0.1,
         selectAllOnFocus: false,
         selectAllOnIncrement: false,
-        small: false,
+        size: "medium",
         stepSize: 1,
         value: "",
     };
@@ -103,9 +104,7 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
         this.setState({ leftIcon: leftIcon ? "dollar" : undefined }),
     );
 
-    private handleSmallChange = handleBooleanChange(small => this.setState({ small, ...(small && { large: false }) }));
-
-    private handleLargeChange = handleBooleanChange(large => this.setState({ large, ...(large && { small: false }) }));
+    private handleSizeChange = (size: Size) => this.setState({ size });
 
     private toggleLeftElement = handleBooleanChange(leftElement =>
         this.setState({
@@ -157,11 +156,10 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
             selectAllOnIncrement,
             disabled,
             fill,
-            large,
             leftIcon,
             leftElement,
             locale,
-            small,
+            size,
         } = this.state;
 
         return (
@@ -169,8 +167,6 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
                 <H5>Props</H5>
                 {this.renderSwitch("Disabled", disabled, this.toggleDisabled)}
                 {this.renderSwitch("Fill", fill, this.toggleFullWidth)}
-                {this.renderSwitch("Large", large, this.handleLargeChange)}
-                {this.renderSwitch("Small", small, this.handleSmallChange)}
                 {this.renderSwitch("Left icon", leftIcon != null, this.toggleLeftIcon)}
                 {this.renderSwitch("Left element", leftElement != null, this.toggleLeftElement)}
                 {this.renderSwitch("Numeric characters only", allowNumericCharactersOnly, this.toggleNumericCharsOnly)}
@@ -192,6 +188,7 @@ export class NumericInputBasicExample extends React.PureComponent<ExampleProps, 
                     [{ label: "Default", value: "default" }, ...LOCALES],
                     this.handleLocaleChange,
                 )}
+                <SizeSelect onChange={this.handleSizeChange} size={size} />
             </>
         );
     }

--- a/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
@@ -16,35 +16,28 @@
 
 import * as React from "react";
 
-import { H5, InputGroup, Switch } from "@blueprintjs/core";
+import { H5, InputGroup, type Size, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+
+import { SizeSelect } from "./common/sizeSelect";
 
 export const SearchInputExample: React.FC<ExampleProps> = props => {
     const [disabled, setDisabled] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
     const [readOnly, setReadOnly] = React.useState(false);
-    const [small, setSmall] = React.useState(false);
+    const [size, setSize] = React.useState<Size>("medium");
 
     const options = (
         <>
             <H5>Props</H5>
             <Switch checked={disabled} label="Disabled" onChange={handleBooleanChange(setDisabled)} />
             <Switch checked={readOnly} label="Read-only" onChange={handleBooleanChange(setReadOnly)} />
-            <Switch checked={large} label="Large" onChange={handleBooleanChange(setLarge)} />
-            <Switch checked={small} label="Small" onChange={handleBooleanChange(setSmall)} />
+            <SizeSelect onChange={setSize} size={size} />
         </>
     );
 
     return (
         <Example options={options} {...props}>
-            <InputGroup
-                disabled={disabled}
-                large={large}
-                placeholder="Search..."
-                readOnly={readOnly}
-                small={small}
-                type="search"
-            />
+            <InputGroup disabled={disabled} placeholder="Search..." readOnly={readOnly} size={size} type="search" />
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
@@ -16,21 +16,29 @@
 
 import * as React from "react";
 
-import { Divider, FormGroup, H5, SegmentedControl, type SegmentedControlIntent, Switch } from "@blueprintjs/core";
+import {
+    Divider,
+    FormGroup,
+    H5,
+    SegmentedControl,
+    type SegmentedControlIntent,
+    type Size,
+    Switch,
+} from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
-import { LegacySizeSelect, type Size } from "./common/legacySizeSelect";
+import { SizeSelect } from "./common/sizeSelect";
 
 export const SegmentedControlExample: React.FC<ExampleProps> = props => {
+    const [fill, setFill] = React.useState(false);
+    const [inline, setInline] = React.useState(false);
     const [intent, setIntent] = React.useState<SegmentedControlIntent>("none");
+    const [size, setSize] = React.useState<Size>("medium");
+
     const handleIntentChange = React.useCallback(
         (newIntent: string) => setIntent(newIntent as SegmentedControlIntent),
         [],
     );
-
-    const [fill, setFill] = React.useState<boolean>(false);
-    const [inline, setInline] = React.useState<boolean>(false);
-    const [size, setSize] = React.useState<Size>("small");
 
     const options = (
         <>
@@ -47,10 +55,10 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
                         { label: "Primary", value: "primary" },
                     ]}
                     onValueChange={handleIntentChange}
-                    small={true}
+                    size="small"
                 />
             </FormGroup>
-            <LegacySizeSelect size={size} onChange={setSize} />
+            <SizeSelect size={size} onChange={setSize} />
         </>
     );
 
@@ -67,8 +75,7 @@ export const SegmentedControlExample: React.FC<ExampleProps> = props => {
                     { disabled: true, label: "Disabled", value: "disabled" },
                     { label: "Gallery", value: "gallery" },
                 ]}
-                large={size === "large"}
-                small={size === "small"}
+                size={size}
             />
         </Example>
     );

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -22,6 +22,7 @@ import {
     ControlGroup,
     H5,
     Intent,
+    type Size,
     Switch,
     TextArea,
     type TextAreaProps,
@@ -32,6 +33,7 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
 import { IntentSelect } from "./common/intentSelect";
+import { SizeSelect } from "./common/sizeSelect";
 
 const INTITIAL_CONTROLLED_TEXT = "In a galaxy far, far away...";
 const CONTROLLED_TEXT_TO_APPEND =
@@ -43,20 +45,9 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
     const [disabled, setDisabled] = React.useState(false);
     const [growVertically, setGrowVertically] = React.useState(false);
     const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [large, setLarge] = React.useState(false);
     const [readOnly, setReadOnly] = React.useState(false);
-    const [small, setSmall] = React.useState(false);
+    const [size, setSize] = React.useState<Size>("medium");
     const [value, setValue] = React.useState(INTITIAL_CONTROLLED_TEXT);
-
-    const handleLargeChange = handleBooleanChange(isLarge => {
-        setLarge(isLarge);
-        if (isLarge) setSmall(false);
-    });
-
-    const handleSmallChange = handleBooleanChange(isSmall => {
-        setSmall(isSmall);
-        if (isSmall) setLarge(false);
-    });
 
     const appendControlledText = React.useCallback(() => setValue(prev => prev + " " + CONTROLLED_TEXT_TO_APPEND), []);
 
@@ -65,9 +56,8 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
     const options = (
         <>
             <H5>Appearance props</H5>
-            <Switch checked={large} label="Large" disabled={small} onChange={handleLargeChange} />
-            <Switch checked={small} label="Small" disabled={large} onChange={handleSmallChange} />
             <IntentSelect intent={intent} onChange={setIntent} />
+            <SizeSelect onChange={setSize} size={size} />
             <H5>Behavior props</H5>
             <Switch checked={disabled} label="Disabled" onChange={handleBooleanChange(setDisabled)} />
             <Switch checked={readOnly} label="Read-only" onChange={handleBooleanChange(setReadOnly)} />
@@ -110,9 +100,8 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
         disabled,
         growVertically,
         intent,
-        large,
         readOnly,
-        small,
+        size,
     };
 
     return (

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -99,9 +99,9 @@ export class Omnibar<T> extends React.PureComponent<OmnibarProps<T>> {
                 <div className={classNames(Classes.OMNIBAR, listProps.className)} {...handlers}>
                     <InputGroup
                         autoFocus={true}
-                        large={true}
                         leftIcon={<Search />}
                         placeholder="Search..."
+                        size="large"
                         {...inputProps}
                         onChange={listProps.handleQueryChange}
                         value={listProps.query}


### PR DESCRIPTION
#### Part of #7232

#### Proposed changes:

FLUP to #7226 that adds the `size` prop to the following components:
- `<FileInput>`
- `<InputGroup>`
- `<NumericInput>`
- `<TextArea>`
- `<Menu>`
- `<SegmentedControl>`
