### PR TITLE
Upgrade to `typescript-eslint` 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@yarnpkg/types": "^4.0.0",
         "chai": "^5.0.0",
         "dedent": "^1.5.1",
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.0",
         "gh-pages": "^6.1.1",
         "http-server": "^14.1.1",
         "npm-run-all": "^4.1.5",

--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -22,7 +22,7 @@ import { isNodeEnv } from "./utils";
  * An abstract component that Blueprint components can extend
  * in order to add some common functionality like runtime props validation.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export abstract class AbstractComponent<P, S = {}, SS = {}> extends React.Component<P, S, SS> {
     // unsafe lifecycle methods
     public componentWillUpdate!: never;

--- a/packages/core/src/common/abstractPureComponent.ts
+++ b/packages/core/src/common/abstractPureComponent.ts
@@ -22,7 +22,7 @@ import { isNodeEnv } from "./utils";
  * An abstract component that Blueprint components can extend
  * in order to add some common functionality like runtime props validation.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export abstract class AbstractPureComponent<P, S = {}, SS = {}> extends React.PureComponent<P, S, SS> {
     // unsafe lifecycle method
     public componentWillUpdate!: never;

--- a/packages/core/src/common/alignment.ts
+++ b/packages/core/src/common/alignment.ts
@@ -20,5 +20,4 @@ export const Alignment = {
     LEFT: "left" as const,
     RIGHT: "right" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Alignment = (typeof Alignment)[keyof typeof Alignment];

--- a/packages/core/src/common/boundary.ts
+++ b/packages/core/src/common/boundary.ts
@@ -20,5 +20,4 @@ export const Boundary = {
     /* eslint-disable-next-line sort-keys */
     END: "end" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Boundary = (typeof Boundary)[keyof typeof Boundary];

--- a/packages/core/src/common/elevation.ts
+++ b/packages/core/src/common/elevation.ts
@@ -22,5 +22,4 @@ export const Elevation = {
     THREE: 3 as const,
     FOUR: 4 as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Elevation = (typeof Elevation)[keyof typeof Elevation];

--- a/packages/core/src/common/intent.ts
+++ b/packages/core/src/common/intent.ts
@@ -26,5 +26,4 @@ export const Intent = {
     WARNING: "warning" as const,
     DANGER: "danger" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Intent = (typeof Intent)[keyof typeof Intent];

--- a/packages/core/src/common/position.ts
+++ b/packages/core/src/common/position.ts
@@ -28,7 +28,6 @@ export const Position = {
     TOP_LEFT: "top-left" as const,
     TOP_RIGHT: "top-right" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type Position = (typeof Position)[keyof typeof Position];
 
 export function isPositionHorizontal(position: Position) {

--- a/packages/core/src/common/utils/compareUtils.ts
+++ b/packages/core/src/common/utils/compareUtils.ts
@@ -15,7 +15,7 @@
  */
 
 // we use the empty object {} a lot in this public API
-/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
 
 export interface KeyAllowlist<T> {
     include: Array<keyof T>;

--- a/packages/core/src/common/utils/domUtils.ts
+++ b/packages/core/src/common/utils/domUtils.ts
@@ -116,12 +116,12 @@ export function throttleReactEventCallback<E extends React.SyntheticEvent = Reac
  * the throttled function.
  */
 /* istanbul ignore next */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export function throttle<T extends Function>(method: T): T {
     return throttleImpl(method);
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 function throttleImpl<T extends Function>(
     onAnimationFrameRequested: T,
     onBeforeIsRunningCheck?: T,

--- a/packages/core/src/common/utils/functionUtils.ts
+++ b/packages/core/src/common/utils/functionUtils.ts
@@ -16,7 +16,7 @@
 
 /** Returns whether the value is a function. Acts as a type guard. */
 /* istanbul ignore next */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export function isFunction(value: any): value is Function {
     return typeof value === "function";
 }

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -111,7 +111,7 @@ function isReactNodeArray(child: React.ReactNode): child is React.ReactNode[] {
  * @param element JSX element in question
  * @param ComponentType desired component type of element
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export function isElementOfType<P = {}>(
     element: any,
     ComponentType: React.ComponentType<P>,

--- a/packages/core/src/components/panel-stack/panelProps.ts
+++ b/packages/core/src/components/panel-stack/panelProps.ts
@@ -28,7 +28,7 @@ import type * as React from "react";
  *
  * @deprecated use `Panel<T>` with PanelStack2
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface IPanel<P = {}> {
     /**
      * The component type to render for this panel. This must be a reference to

--- a/packages/core/src/components/panel-stack2/panelStack2.tsx
+++ b/packages/core/src/components/panel-stack2/panelStack2.tsx
@@ -27,7 +27,6 @@ import { PanelView2 } from "./panelView2";
 /**
  * @template T type union of all possible panels in this stack
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
 export interface PanelStack2Props<T extends Panel<object>> extends Props {
     /**
      * The initial panel to show on mount. This panel cannot be removed from the
@@ -76,7 +75,6 @@ interface PanelStack2Component {
     /**
      * @template T type union of all possible panels in this stack
      */
-    // eslint-disable-next-line @typescript-eslint/ban-types
     <T extends Panel<object>>(props: PanelStack2Props<T>): React.JSX.Element | null;
     displayName: string;
 }
@@ -87,7 +85,6 @@ interface PanelStack2Component {
  * @see https://blueprintjs.com/docs/#core/components/panel-stack2
  * @template T type union of all possible panels in this stack
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
 export const PanelStack2: PanelStack2Component = <T extends Panel<object>>(props: PanelStack2Props<T>) => {
     const {
         initialPanel,

--- a/packages/core/src/components/panel-stack2/panelView2.tsx
+++ b/packages/core/src/components/panel-stack2/panelView2.tsx
@@ -22,7 +22,6 @@ import { Text } from "../text/text";
 
 import type { Panel, PanelProps } from "./panelTypes";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export interface PanelView2Props<T extends Panel<object>> {
     /**
      * Callback invoked when the user presses the back button or a panel invokes
@@ -47,12 +46,10 @@ export interface PanelView2Props<T extends Panel<object>> {
 }
 
 interface PanelView2Component {
-    // eslint-disable-next-line @typescript-eslint/ban-types
     <T extends Panel<object>>(props: PanelView2Props<T>): React.JSX.Element | null;
     displayName: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export const PanelView2: PanelView2Component = <T extends Panel<object>>({
     panel,
     onClose,

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -59,7 +59,6 @@ export const PopoverInteractionKind = {
     HOVER: "hover" as const,
     HOVER_TARGET_ONLY: "hover-target" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PopoverInteractionKind = (typeof PopoverInteractionKind)[keyof typeof PopoverInteractionKind];
 
 export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>

--- a/packages/core/src/components/popover/popoverPosition.ts
+++ b/packages/core/src/components/popover/popoverPosition.ts
@@ -22,5 +22,4 @@ export const PopoverPosition = {
     AUTO_END: "auto-end" as const,
     AUTO_START: "auto-start" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PopoverPosition = (typeof PopoverPosition)[keyof typeof PopoverPosition];

--- a/packages/core/src/components/slider/handleProps.tsx
+++ b/packages/core/src/components/slider/handleProps.tsx
@@ -29,7 +29,6 @@ export const HandleType = {
     // eslint-disable-next-line sort-keys
     END: "end" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HandleType = (typeof HandleType)[keyof typeof HandleType];
 
 export const HandleInteractionKind = {
@@ -46,7 +45,6 @@ export const HandleInteractionKind = {
     // eslint-disable-next-line sort-keys
     NONE: "none" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HandleInteractionKind = (typeof HandleInteractionKind)[keyof typeof HandleInteractionKind];
 
 export type HandleHtmlProps = Pick<HTMLProps<HTMLSpanElement>, "aria-label" | "aria-labelledby">;

--- a/packages/core/src/components/toast/toaster.ts
+++ b/packages/core/src/components/toast/toaster.ts
@@ -41,7 +41,6 @@ export interface Toaster {
 export type ToasterInstance = Toaster;
 // merges with declaration of `Toaster` type in `toasterTypes.ts`
 // kept for backwards-compatibility with v4.x
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export const Toaster = {
     // eslint-disable-next-line deprecation/deprecation
     create: deprecatedToasterCreate,

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -22,7 +22,7 @@ import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import { TreeNode } from "./treeNode";
 import type { TreeEventHandler, TreeNodeInfo } from "./treeTypes";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TreeProps<T = {}> extends Props {
     /**
      * Whether to use a compact appearance which reduces the visual padding around node content.
@@ -77,7 +77,7 @@ export interface TreeProps<T = {}> extends Props {
  *
  * @see https://blueprintjs.com/docs/#core/components/tree
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export class Tree<T = {}> extends React.Component<TreeProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tree`;
 

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -25,7 +25,7 @@ import { Icon } from "../icon/icon";
 
 import type { TreeEventHandler, TreeNodeInfo } from "./treeTypes";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TreeNodeProps<T = {}> extends TreeNodeInfo<T> {
     children?: React.ReactNode;
     contentRef?: (node: TreeNodeInfo<T>, element: HTMLDivElement | null) => void;
@@ -46,7 +46,7 @@ export interface TreeNodeProps<T = {}> extends TreeNodeInfo<T> {
  *
  * @see https://blueprintjs.com/docs/#core/components/tree.tree-node
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export class TreeNode<T = {}> extends React.Component<TreeNodeProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TreeNode`;
 

--- a/packages/core/src/components/tree/treeTypes.ts
+++ b/packages/core/src/components/tree/treeTypes.ts
@@ -17,7 +17,7 @@
 import type { MaybeElement } from "../../common/props";
 import type { IconName } from "../icon/icon";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface TreeNodeInfo<T = {}> {
     /**
      * A space-delimited list of class names for this tree node element.
@@ -80,7 +80,7 @@ export interface TreeNodeInfo<T = {}> {
     nodeData?: T;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export type TreeEventHandler<T = {}> = (
     node: TreeNodeInfo<T>,
     nodePath: number[],

--- a/packages/core/test/panel-stack2/panelStack2Tests.tsx
+++ b/packages/core/test/panel-stack2/panelStack2Tests.tsx
@@ -21,7 +21,7 @@ import { spy } from "sinon";
 
 import { Classes, NumericInput, type Panel, type PanelProps, PanelStack2, type PanelStack2Props } from "../../src";
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type TestPanelInfo = {};
 type TestPanelType = Panel<TestPanelInfo>;
 
@@ -311,7 +311,6 @@ describe("<PanelStack2>", () => {
         });
     });
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
     interface PanelStack2Wrapper<T extends Panel<object>> extends ReactWrapper<PanelStack2Props<T>, any> {
         findClass(className: string): ReactWrapper<React.HTMLAttributes<HTMLElement>, any>;
     }

--- a/packages/datetime/src/common/timePrecision.ts
+++ b/packages/datetime/src/common/timePrecision.ts
@@ -19,5 +19,4 @@ export const TimePrecision = {
     MINUTE: "minute" as const,
     SECOND: "second" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type TimePrecision = (typeof TimePrecision)[keyof typeof TimePrecision];

--- a/packages/datetime/src/common/timezoneDisplayFormat.ts
+++ b/packages/datetime/src/common/timezoneDisplayFormat.ts
@@ -44,7 +44,6 @@ export const TimezoneDisplayFormat = {
      */
     OFFSET: "offset" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type TimezoneDisplayFormat = (typeof TimezoneDisplayFormat)[keyof typeof TimezoneDisplayFormat];
 
 /**

--- a/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStack2Example.tsx
@@ -36,7 +36,7 @@ import {
 } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
 interface Panel1Info {
     // empty
 }

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -33,7 +33,6 @@ export const CellsLoadingConfiguration = {
     NONE: "none" as const,
     RANDOM: "random" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type CellsLoadingConfiguration = (typeof CellsLoadingConfiguration)[keyof typeof CellsLoadingConfiguration];
 
 const CONFIGURATIONS = [

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -24,10 +24,10 @@ import type {
 } from "@documentalist/client";
 import * as React from "react";
 
-/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
 /** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
 export type DocsData = MarkdownPluginData & (TypescriptPluginData | {}) & (KssPluginData | {}) & (NpmPluginData | {});
-/* eslint-enable @typescript-eslint/ban-types */
+/* eslint-enable @typescript-eslint/no-empty-object-type */
 
 export function hasTypescriptData(docs: DocsData): docs is MarkdownPluginData & TypescriptPluginData {
     return docs != null && (docs as TypescriptPluginData).typescript != null;

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -59,8 +59,8 @@ module.exports = {
             plugins: ["@typescript-eslint", "deprecation"],
             parser: "@typescript-eslint/parser",
             parserOptions: {
-                sourceType: "module",
-                project: ["{src,test}/tsconfig.json"],
+                projectService: true,
+                tsConfigRootDir: __dirname,
             },
             rules: {
                 ...tsEslintRules,

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -6,7 +6,7 @@
         "@blueprintjs/eslint-plugin": "workspace:^",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
         "@typescript-eslint/parser": "^6.19.1",
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.0",
         "eslint-plugin-deprecation": "^2.0.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "~2.29.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -4,8 +4,8 @@
     "description": "ESLint configuration for @blueprintjs packages",
     "dependencies": {
         "@blueprintjs/eslint-plugin": "workspace:^",
-        "@typescript-eslint/eslint-plugin": "^6.19.1",
-        "@typescript-eslint/parser": "^6.19.1",
+        "@typescript-eslint/eslint-plugin": "^8.23.0",
+        "@typescript-eslint/parser": "^8.23.0",
         "eslint": "^8.57.0",
         "eslint-plugin-deprecation": "^2.0.0",
         "eslint-plugin-header": "^3.1.1",

--- a/packages/eslint-config/typescript-eslint-rules.json
+++ b/packages/eslint-config/typescript-eslint-rules.json
@@ -6,7 +6,6 @@
             "default": "array-simple"
         }
     ],
-    "@typescript-eslint/ban-types": "error",
     "@typescript-eslint/consistent-type-assertions": "error",
     "@typescript-eslint/consistent-type-exports": [
         "error",
@@ -53,6 +52,7 @@
     "@typescript-eslint/no-confusing-non-null-assertion": "error",
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-empty-interface": "error",
+    "@typescript-eslint/no-empty-object-type": "error",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-extraneous-class": [
         "error",
@@ -74,9 +74,11 @@
     ],
     "@typescript-eslint/no-this-alias": "error",
     "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unsafe-function-type": "error",
     "@typescript-eslint/no-unused-expressions": "error",
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-var-requires": "error",
+    "@typescript-eslint/no-wrapper-object-types": "error",
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/prefer-function-type": "error",
     "@typescript-eslint/prefer-namespace-keyword": "error",

--- a/packages/eslint-config/typescript-eslint-rules.json
+++ b/packages/eslint-config/typescript-eslint-rules.json
@@ -64,7 +64,6 @@
     "@typescript-eslint/no-misused-new": "error",
     "@typescript-eslint/no-namespace": "error",
     "@typescript-eslint/no-parameter-properties": "off",
-    "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-shadow": [
         "error",
         {

--- a/packages/eslint-config/typescript-eslint-rules.json
+++ b/packages/eslint-config/typescript-eslint-rules.json
@@ -30,7 +30,6 @@
             }
         }
     ],
-    "@typescript-eslint/lines-between-class-members": "error",
     "@typescript-eslint/naming-convention": [
         "error",
         {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,7 +11,7 @@
         "test": "SWC_NODE_PROJECT=./tsconfig.test.json mocha --require @swc-node/register,test/setup.ts --watch-extensions ts,tsx 'test/**/*.{ts,tsx}'"
     },
     "dependencies": {
-        "@typescript-eslint/utils": "^6.19.1 || ^7.0.0",
+        "@typescript-eslint/utils": "^8.23.0",
         "eslint": "^8.57.0"
     },
     "devDependencies": {
@@ -20,7 +20,7 @@
         "@swc-node/register": "^1.6.8",
         "@swc/core": "^1.3.105",
         "@types/dedent": "~0.7.2",
-        "@typescript-eslint/rule-tester": "^6.19.1",
+        "@typescript-eslint/rule-tester": "^8.23.0",
         "dedent": "^1.5.1",
         "mocha": "^10.2.0",
         "typescript": "~5.3.3"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "@typescript-eslint/utils": "^6.19.1 || ^7.0.0",
-        "eslint": "^8.56.0"
+        "eslint": "^8.57.0"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "workspace:^",

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts
@@ -7,6 +7,7 @@
 import { type TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 import { createRule } from "../utils/createRule";
+import { isIdentifierNode } from "../utils/isIdentifierNode";
 
 type MessageIds =
     | "migration"
@@ -155,8 +156,9 @@ export function createNoDeprecatedComponentsRule(
                                 break;
                             case TSESTree.AST_NODE_TYPES.ImportSpecifier:
                                 if (
-                                    deprecatedComponentConfig[importClause.imported.name] != null ||
-                                    additionalDeprecatedComponents.includes(importClause.imported.name)
+                                    isIdentifierNode(importClause.imported) &&
+                                    (deprecatedComponentConfig[importClause.imported.name] != null ||
+                                        additionalDeprecatedComponents.includes(importClause.imported.name))
                                 ) {
                                     deprecatedImports.push({
                                         functionName: importClause.imported.name,

--- a/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
@@ -10,6 +10,7 @@ import { createRule } from "./utils/createRule";
 import { FixList } from "./utils/fixList";
 import { getAllIdentifiersInFile } from "./utils/getAllIdentifiersInFile";
 import { getProgram } from "./utils/getProgram";
+import { isIdentifierNode } from "./utils/isIdentifierNode";
 import { replaceImportInFile } from "./utils/replaceImportInFile";
 
 type MessageIds = "migration";
@@ -250,7 +251,10 @@ export const noDeprecatedTypeReferencesRule = createRule<[], MessageIds>({
                             });
                             break;
                         case TSESTree.AST_NODE_TYPES.ImportSpecifier:
-                            if (deprecatedToNewType.hasOwnProperty(importClause.imported.name)) {
+                            if (
+                                isIdentifierNode(importClause.imported) &&
+                                deprecatedToNewType.hasOwnProperty(importClause.imported.name)
+                            ) {
                                 deprecatedImports.push({
                                     symbolName: importClause.imported.name,
                                     localSymbolName: importClause.local.name,

--- a/packages/eslint-plugin/src/rules/utils/createRule.ts
+++ b/packages/eslint-plugin/src/rules/utils/createRule.ts
@@ -15,8 +15,14 @@
  */
 
 import { ESLintUtils } from "@typescript-eslint/utils";
+import { type RuleRecommendation } from "@typescript-eslint/utils/ts-eslint";
+
+export interface PluginDocs {
+    recommended: RuleRecommendation;
+    requiresTypeChecking: boolean;
+}
 
 /** Create a rule and automatically fill its url based on the rule name. */
-export const createRule = ESLintUtils.RuleCreator(
+export const createRule = ESLintUtils.RuleCreator<PluginDocs>(
     name => `https://github.com/palantir/blueprint/tree/develop/packages/eslint-plugin/src/rules/${name}.ts`,
 );

--- a/packages/eslint-plugin/src/rules/utils/isIdentifierNode.ts
+++ b/packages/eslint-plugin/src/rules/utils/isIdentifierNode.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TSESTree } from "@typescript-eslint/utils";
+
+export function isIdentifierNode(node: TSESTree.Node): node is TSESTree.Identifier {
+    return node.type === TSESTree.AST_NODE_TYPES.Identifier;
+}

--- a/packages/eslint-plugin/src/rules/utils/replaceImportInFile.ts
+++ b/packages/eslint-plugin/src/rules/utils/replaceImportInFile.ts
@@ -42,16 +42,19 @@ export const replaceImportInFile =
 
         const nodeToReplace = importToModify.specifiers.find(
             specifier =>
-                specifier.type === AST_NODE_TYPES.ImportSpecifier && specifier.imported.name === options.fromName,
+                specifier.type === AST_NODE_TYPES.ImportSpecifier &&
+                specifier.imported.type === AST_NODE_TYPES.Identifier &&
+                specifier.imported.name === options.fromName,
         ) as TSESTree.ImportSpecifier;
+        const nodeToReplaceImported = nodeToReplace?.imported as unknown as TSESTree.Identifier | undefined;
 
         if (nodeToReplace === undefined) {
             throw new Error(
                 `Unable to find import { ${options.fromName} } from "${options.moduleSpecifier}" while fixing lint error`,
             );
-        } else if (options.alias !== undefined && nodeToReplace.local.name !== nodeToReplace.imported.name) {
+        } else if (options.alias !== undefined && nodeToReplace.local.name !== nodeToReplaceImported?.name) {
             throw new Error(
-                `Existing import '${nodeToReplace.imported.name}' is already aliased as '${nodeToReplace.local.name}', refusing to rename with new alias '${options.alias}'`,
+                `Existing import '${nodeToReplaceImported?.name}' is already aliased as '${nodeToReplace.local.name}', refusing to rename with new alias '${options.alias}'`,
             );
         }
 

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { classesConstantsRule } from "../src/rules/classes-constants";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/html-components.test.ts
+++ b/packages/eslint-plugin/test/html-components.test.ts
@@ -22,12 +22,12 @@ import { htmlComponentsRule } from "../src/rules/html-components";
 /* eslint-disable sort-keys */
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/icon-components.test.ts
+++ b/packages/eslint-plugin/test/icon-components.test.ts
@@ -21,10 +21,11 @@ import { iconComponentsRule, OPTION_COMPONENT, OPTION_LITERAL } from "../src/rul
 /* eslint-disable sort-keys */
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
     },
 });

--- a/packages/eslint-plugin/test/no-deprecated-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedCoreComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-datetime-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-datetime-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedDatetimeComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-datetime2-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-datetime2-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedDatetime2ComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-popover2-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-popover2-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedPopover2ComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-select-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-select-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedSelectComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-table-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-table-components.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedTableComponentsRule } from "../src/rules/no-deprecated-components";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/eslint-plugin/test/no-deprecated-type-references.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-type-references.test.ts
@@ -22,12 +22,12 @@ import dedent from "dedent";
 import { noDeprecatedTypeReferencesRule } from "../src/rules/no-deprecated-type-references";
 
 const ruleTester = new RuleTester({
-    parser: require.resolve("@typescript-eslint/parser"),
-    parserOptions: {
-        ecmaFeatures: {
-            jsx: true,
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: {
+                jsx: true,
+            },
         },
-        sourceType: "module",
     },
 });
 

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -23,7 +23,7 @@
         "cross-spawn": "^7.0.3",
         "css-select": "^5.1.0",
         "dom-serializer": "^2.0.0",
-        "eslint": "^8.56.0",
+        "eslint": "^8.57.0",
         "eslint-formatter-codeframe": "^7.32.1",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",

--- a/packages/select/src/common/index.ts
+++ b/packages/select/src/common/index.ts
@@ -18,8 +18,8 @@ import * as Classes from "./classes";
 export { Classes };
 
 export * from "./itemListRenderer";
-export * from "./itemRenderer";
+export type * from "./itemRenderer";
 export * from "./listItemsProps";
 export * from "./listItemsUtils";
-export * from "./predicate";
+export type * from "./predicate";
 export type { SelectPopoverProps } from "./selectPopoverProps";

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -180,7 +180,7 @@ interface EditableTableState {
     sparseCellIntent: { [key: string]: Intent };
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 class EditableTable extends React.Component<{}, EditableTableState> {
     public static dataKey = (rowIndex: number, columnIndex: number) => {
         return `${rowIndex}-${columnIndex}`;
@@ -631,7 +631,7 @@ const REORDERABLE_TABLE_DATA = [
     ["E", "Eggplant", "Elk", "Eritrea", "El Paso"],
 ].map(([letter, fruit, animal, country, city]) => ({ animal, city, country, fruit, letter }));
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 class ReorderableTableExample extends React.Component<{}, ReorderableTableExampleState> {
     public state: ReorderableTableExampleState = {
         data: REORDERABLE_TABLE_DATA,

--- a/packages/table-dev-app/src/localStore.ts
+++ b/packages/table-dev-app/src/localStore.ts
@@ -20,7 +20,7 @@ import defaults from "lodash/defaults";
  * Simple typed storage API for a JSON serializable object in web local storage
  * or session storage.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export class LocalStore<T extends {}> {
     private storage: Storage;
 
@@ -31,12 +31,12 @@ export class LocalStore<T extends {}> {
         this.storage = session ? sessionStorage : localStorage;
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     public getWithDefaults(defaultValue?: T): T | {} {
         return defaults(this.get(), defaultValue);
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     public get(): T | {} {
         const domString = this.storage.getItem(this.key);
         if (domString == null || domString === "") {

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -318,7 +318,7 @@ const DEFAULT_STATE: MutableTableState = {
     showZebraStriping: false,
 };
 
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export class MutableTable extends React.Component<{}, MutableTableState> {
     private store = new DenseGridMutableStore<any>();
 
@@ -339,7 +339,7 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
         tableWrapperRef: (ref: HTMLDivElement) => (this.tableWrapperRef = ref),
     };
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     public constructor(props: {}) {
         super(props);
         this.stateStore = new LocalStore<MutableTableState>("BP_TABLE_MUTABLE_TABLE_DEV_PREVIEW", true);
@@ -378,7 +378,7 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
         this.syncFocusStyle();
     }
 
-    // eslint-disable-next-line @typescript-eslint/ban-types
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     public componentWillUpdate(_nextProps: {}, nextState: MutableTableState) {
         if (
             nextState.cellContent !== this.state.cellContent ||

--- a/packages/table/test/cellTestUtils.ts
+++ b/packages/table/test/cellTestUtils.ts
@@ -27,7 +27,6 @@ export const CellType = {
     COLUMN_HEADER: TableLoadingOption.COLUMN_HEADERS as const,
     ROW_HEADER: TableLoadingOption.ROW_HEADERS as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type CellType = (typeof CellType)[keyof typeof CellType];
 
 export function expectCellLoading(cell: Element, cellType: CellType, loading = true) {

--- a/packages/test-commons/src/utils.ts
+++ b/packages/test-commons/src/utils.ts
@@ -94,7 +94,7 @@ export function dispatchTouchEvent(target: EventTarget, eventType = "touchstart"
  * We can't simply call mount() here since React 16 throws before we can even validate the errors thrown
  * in component constructors.
  */
-// eslint-disable-next-line @typescript-eslint/ban-types
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export function expectPropValidationError<P extends object>(
     Component: React.ComponentClass<P>,
     props: P & { children?: React.ReactNode },
@@ -103,7 +103,7 @@ export function expectPropValidationError<P extends object>(
 ) {
     const { defaultProps = {} } = Component;
     // HACKHACK: weird casts ahead
-    // eslint-disable-next-line @typescript-eslint/ban-types, @typescript-eslint/consistent-type-assertions
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
     expect(() => new Component({ ...(defaultProps as object), ...(props as object) } as P)).to.throw(
         errorMessage,
         assertionMessage,

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,7 +673,7 @@ __metadata:
     "@blueprintjs/eslint-plugin": "workspace:^"
     "@typescript-eslint/eslint-plugin": "npm:^6.19.1"
     "@typescript-eslint/parser": "npm:^6.19.1"
-    eslint: "npm:^8.56.0"
+    eslint: "npm:^8.57.0"
     eslint-plugin-deprecation: "npm:^2.0.0"
     eslint-plugin-header: "npm:^3.1.1"
     eslint-plugin-import: "npm:~2.29.1"
@@ -701,7 +701,7 @@ __metadata:
     "@typescript-eslint/rule-tester": "npm:^6.19.1"
     "@typescript-eslint/utils": "npm:^6.19.1 || ^7.0.0"
     dedent: "npm:^1.5.1"
-    eslint: "npm:^8.56.0"
+    eslint: "npm:^8.57.0"
     mocha: "npm:^10.2.0"
     typescript: "npm:~5.3.3"
   languageName: unknown
@@ -809,7 +809,7 @@ __metadata:
     cross-spawn: "npm:^7.0.3"
     css-select: "npm:^5.1.0"
     dom-serializer: "npm:^2.0.0"
-    eslint: "npm:^8.56.0"
+    eslint: "npm:^8.57.0"
     eslint-formatter-codeframe: "npm:^7.32.1"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^10.3.10"
@@ -882,7 +882,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.0"
     chai: "npm:^5.0.0"
     dedent: "npm:^1.5.1"
-    eslint: "npm:^8.56.0"
+    eslint: "npm:^8.57.0"
     gh-pages: "npm:^6.1.1"
     http-server: "npm:^14.1.1"
     npm-run-all: "npm:^4.1.5"
@@ -1223,10 +1223,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:8.56.0":
-  version: 8.56.0
-  resolution: "@eslint/js@npm:8.56.0"
-  checksum: 60b3a1cf240e2479cec9742424224465dc50e46d781da1b7f5ef240501b2d1202c225bd456207faac4b34a64f4765833345bc4ddffd00395e1db40fa8c426f5a
+"@eslint/js@npm:8.57.1":
+  version: 8.57.1
+  resolution: "@eslint/js@npm:8.57.1"
+  checksum: b489c474a3b5b54381c62e82b3f7f65f4b8a5eaaed126546520bf2fede5532a8ed53212919fed1e9048dcf7f37167c8561d58d0ba4492a4244004e7793805223
   languageName: node
   linkType: hard
 
@@ -1237,14 +1237,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.11.13":
-  version: 0.11.13
-  resolution: "@humanwhocodes/config-array@npm:0.11.13"
+"@humanwhocodes/config-array@npm:^0.13.0":
+  version: 0.13.0
+  resolution: "@humanwhocodes/config-array@npm:0.13.0"
   dependencies:
-    "@humanwhocodes/object-schema": "npm:^2.0.1"
-    debug: "npm:^4.1.1"
+    "@humanwhocodes/object-schema": "npm:^2.0.3"
+    debug: "npm:^4.3.1"
     minimatch: "npm:^3.0.5"
-  checksum: d76ca802d853366094d0e98ff0d0994117fc8eff96649cd357b15e469e428228f597cd2e929d54ab089051684949955f16ee905bb19f7b2f0446fb377157be7a
+  checksum: 205c99e756b759f92e1f44a3dc6292b37db199beacba8f26c2165d4051fe73a4ae52fdcfd08ffa93e7e5cb63da7c88648f0e84e197d154bbbbe137b2e0dd332e
   languageName: node
   linkType: hard
 
@@ -1255,10 +1255,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@humanwhocodes/object-schema@npm:2.0.1"
-  checksum: 9dba24e59fdb4041829d92b693aacb778add3b6f612aaa9c0774f3b650c11a378cc64f042a59da85c11dae33df456580a3c36837b953541aed6ff94294f97fac
+"@humanwhocodes/object-schema@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@humanwhocodes/object-schema@npm:2.0.3"
+  checksum: 80520eabbfc2d32fe195a93557cef50dfe8c8905de447f022675aaf66abc33ae54098f5ea78548d925aa671cd4ab7c7daa5ad704fe42358c9b5e7db60f80696c
   languageName: node
   linkType: hard
 
@@ -6154,15 +6154,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:~4.3.1, debug@npm:~4.3.2":
-  version: 4.3.7
-  resolution: "debug@npm:4.3.7"
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.7":
+  version: 4.4.0
+  resolution: "debug@npm:4.4.0"
   dependencies:
     ms: "npm:^2.1.3"
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  checksum: db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
   languageName: node
   linkType: hard
 
@@ -6184,6 +6184,18 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 37d96ae42cbc71c14844d2ae3ba55adf462ec89fd3a999459dec3833944cd999af6007ff29c780f1c61153bcaaf2c842d1e4ce1ec621e4fc4923244942e4a02a
+  languageName: node
+  linkType: hard
+
+"debug@npm:~4.3.1, debug@npm:~4.3.2":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
   languageName: node
   linkType: hard
 
@@ -7218,15 +7230,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.56.0":
-  version: 8.56.0
-  resolution: "eslint@npm:8.56.0"
+"eslint@npm:^8.57.0":
+  version: 8.57.1
+  resolution: "eslint@npm:8.57.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.6.1"
     "@eslint/eslintrc": "npm:^2.1.4"
-    "@eslint/js": "npm:8.56.0"
-    "@humanwhocodes/config-array": "npm:^0.11.13"
+    "@eslint/js": "npm:8.57.1"
+    "@humanwhocodes/config-array": "npm:^0.13.0"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@nodelib/fs.walk": "npm:^1.2.8"
     "@ungap/structured-clone": "npm:^1.2.0"
@@ -7262,7 +7274,7 @@ __metadata:
     text-table: "npm:^0.2.0"
   bin:
     eslint: bin/eslint.js
-  checksum: 2be598f7da1339d045ad933ffd3d4742bee610515cd2b0d9a2b8b729395a01d4e913552fff555b559fccaefd89d7b37632825789d1b06470608737ae69ab43fb
+  checksum: 1fd31533086c1b72f86770a4d9d7058ee8b4643fd1cfd10c7aac1ecb8725698e88352a87805cf4b2ce890aa35947df4b4da9655fb7fdfa60dbb448a43f6ebcf1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -671,8 +671,8 @@ __metadata:
   resolution: "@blueprintjs/eslint-config@workspace:packages/eslint-config"
   dependencies:
     "@blueprintjs/eslint-plugin": "workspace:^"
-    "@typescript-eslint/eslint-plugin": "npm:^6.19.1"
-    "@typescript-eslint/parser": "npm:^6.19.1"
+    "@typescript-eslint/eslint-plugin": "npm:^8.23.0"
+    "@typescript-eslint/parser": "npm:^8.23.0"
     eslint: "npm:^8.57.0"
     eslint-plugin-deprecation: "npm:^2.0.0"
     eslint-plugin-header: "npm:^3.1.1"
@@ -698,8 +698,8 @@ __metadata:
     "@swc-node/register": "npm:^1.6.8"
     "@swc/core": "npm:^1.3.105"
     "@types/dedent": "npm:~0.7.2"
-    "@typescript-eslint/rule-tester": "npm:^6.19.1"
-    "@typescript-eslint/utils": "npm:^6.19.1 || ^7.0.0"
+    "@typescript-eslint/rule-tester": "npm:^8.23.0"
+    "@typescript-eslint/utils": "npm:^8.23.0"
     dedent: "npm:^1.5.1"
     eslint: "npm:^8.57.0"
     mocha: "npm:^10.2.0"
@@ -1182,10 +1182,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.5.1, @eslint-community/regexpp@npm:^4.6.1":
-  version: 4.10.0
-  resolution: "@eslint-community/regexpp@npm:4.10.0"
-  checksum: c5f60ef1f1ea7649fa7af0e80a5a79f64b55a8a8fa5086de4727eb4c86c652aedee407a9c143b8995d2c0b2d75c1222bec9ba5d73dbfc1f314550554f0979ef4
+"@eslint-community/regexpp@npm:^4.10.0, @eslint-community/regexpp@npm:^4.6.1":
+  version: 4.12.1
+  resolution: "@eslint-community/regexpp@npm:4.12.1"
+  checksum: a03d98c246bcb9109aec2c08e4d10c8d010256538dcb3f56610191607214523d4fb1b00aa81df830b6dffb74c5fa0be03642513a289c567949d3e550ca11cdf6
   languageName: node
   linkType: hard
 
@@ -3423,62 +3423,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:6.19.1"
+"@typescript-eslint/eslint-plugin@npm:^8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.23.0"
   dependencies:
-    "@eslint-community/regexpp": "npm:^4.5.1"
-    "@typescript-eslint/scope-manager": "npm:6.19.1"
-    "@typescript-eslint/type-utils": "npm:6.19.1"
-    "@typescript-eslint/utils": "npm:6.19.1"
-    "@typescript-eslint/visitor-keys": "npm:6.19.1"
-    debug: "npm:^4.3.4"
+    "@eslint-community/regexpp": "npm:^4.10.0"
+    "@typescript-eslint/scope-manager": "npm:8.23.0"
+    "@typescript-eslint/type-utils": "npm:8.23.0"
+    "@typescript-eslint/utils": "npm:8.23.0"
+    "@typescript-eslint/visitor-keys": "npm:8.23.0"
     graphemer: "npm:^1.4.0"
-    ignore: "npm:^5.2.4"
+    ignore: "npm:^5.3.1"
     natural-compare: "npm:^1.4.0"
-    semver: "npm:^7.5.4"
-    ts-api-utils: "npm:^1.0.1"
+    ts-api-utils: "npm:^2.0.1"
   peerDependencies:
-    "@typescript-eslint/parser": ^6.0.0 || ^6.0.0-alpha
-    eslint: ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 01f1d643219b51bfad76734c6eb19a480309f0e66877ddc00bca89368e5aee3eb907e366977a8d11094c49e807773f5cfba306c861cd690d70044a7925173823
+    "@typescript-eslint/parser": ^8.0.0 || ^8.0.0-alpha.0
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 6c760a5f90748774f79a1b701f85fe6d99e89f289bc33993009987b0ffe2d13b3960ce595d452a937f3413af3918c76830659317242c05e49db40ceaca593033
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/parser@npm:6.19.1"
+"@typescript-eslint/parser@npm:^8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/parser@npm:8.23.0"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:6.19.1"
-    "@typescript-eslint/types": "npm:6.19.1"
-    "@typescript-eslint/typescript-estree": "npm:6.19.1"
-    "@typescript-eslint/visitor-keys": "npm:6.19.1"
+    "@typescript-eslint/scope-manager": "npm:8.23.0"
+    "@typescript-eslint/types": "npm:8.23.0"
+    "@typescript-eslint/typescript-estree": "npm:8.23.0"
+    "@typescript-eslint/visitor-keys": "npm:8.23.0"
     debug: "npm:^4.3.4"
   peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 442e860fbc4786fe999205528cc74b31d933008e170a707ddaec0c9e2c374f62c36c8d05d3dd446c9ceb802f2b403806d72c78ffd97867cf1672028b754b6262
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: f9e0f83a6dd97a9049d4ce23d660a1d4d5f3c57be8efc68e2258e6b2d5b823086d188b534f791a3412ef10d211fe4916b378254728150094c4f8b0ab44aae2a7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/rule-tester@npm:^6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/rule-tester@npm:6.19.1"
+"@typescript-eslint/rule-tester@npm:^8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/rule-tester@npm:8.23.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:6.19.1"
-    "@typescript-eslint/utils": "npm:6.19.1"
-    ajv: "npm:^6.10.0"
+    "@typescript-eslint/typescript-estree": "npm:8.23.0"
+    "@typescript-eslint/utils": "npm:8.23.0"
+    ajv: "npm:^6.12.6"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
     lodash.merge: "npm:4.6.2"
-    semver: "npm:^7.5.4"
+    semver: "npm:^7.6.0"
   peerDependencies:
-    "@eslint/eslintrc": ">=2"
-    eslint: ">=8"
-  checksum: 7f9ec901470400e39353b32b9ccdf44288673991cd0646ecd8815fc1a14597d2d8fef57cb22055e26efa8d01b11e5bb2cb687489bb1e3058224b34c8a1921ea4
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: d181e3b79e3e4ea002558572198ea07bd54d4f8b211476ab2b17587dbebc019599c3c3a149de5b64e7be77e119c69498088772d06a11e8364e4b4b304b225e76
   languageName: node
   linkType: hard
 
@@ -3492,20 +3486,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/type-utils@npm:6.19.1"
+"@typescript-eslint/scope-manager@npm:8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.23.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:6.19.1"
-    "@typescript-eslint/utils": "npm:6.19.1"
+    "@typescript-eslint/types": "npm:8.23.0"
+    "@typescript-eslint/visitor-keys": "npm:8.23.0"
+  checksum: 625b524a4fc25667b20f3541da84674af9c2abfac6596e30f7a40085513172bf1aac125488b32885894e3ef6596a0d06dec9a65ed4562884e0bca87a758600fa
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/type-utils@npm:8.23.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": "npm:8.23.0"
+    "@typescript-eslint/utils": "npm:8.23.0"
     debug: "npm:^4.3.4"
-    ts-api-utils: "npm:^1.0.1"
+    ts-api-utils: "npm:^2.0.1"
   peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 78c185c64a8c92d7b5f2132ef4880b974a2e07e9ae7913ad53e327972af540a8a8bf75bc319c8aaa82445615e2680f3c85736ee67aa174a5ba91798fe5068f95
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: a98dc2f2f75ec2132176428011ba620ad5b641a04e9e18471a7b9f979f6966a76aeaf6e51072c5364de68f83832a3a77b04518ec65c3092dadbd033d03fb5e35
   languageName: node
   linkType: hard
 
@@ -3513,6 +3515,13 @@ __metadata:
   version: 6.19.1
   resolution: "@typescript-eslint/types@npm:6.19.1"
   checksum: b8f75df157ca383e5bd6c07276fbeed6ff775e1354260a1653777749c0d71626fb29be5d36c9570e2c5cfaa5db62deaae20aa4be8a2d7d753782ab66d88e007f
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/types@npm:8.23.0"
+  checksum: 78737a14e8469e33212d9bbc26d6880bca3f8e47764273eb4c662f5ed38d0b35c626d646d4a8e9a6ee64a0e352b18dd36422e59ce217362b5af473b79d058b35
   languageName: node
   linkType: hard
 
@@ -3535,7 +3544,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:6.19.1, @typescript-eslint/utils@npm:^6.0.0, @typescript-eslint/utils@npm:^6.19.1 || ^7.0.0":
+"@typescript-eslint/typescript-estree@npm:8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.23.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.23.0"
+    "@typescript-eslint/visitor-keys": "npm:8.23.0"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 2cc8defb3d9b25b899a62c6b6ca26c442433bf95f626f6275935e2754d9a74abb0015c737de27038b0f378273e67e61120d9cf2941c44848e4bffbbc297fdf74
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.23.0, @typescript-eslint/utils@npm:^8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/utils@npm:8.23.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:8.23.0"
+    "@typescript-eslint/types": "npm:8.23.0"
+    "@typescript-eslint/typescript-estree": "npm:8.23.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <5.8.0"
+  checksum: 8967cf6543b1df2fb8d29086a0d35f5f7623e935706ad7c5bfcc6123e6fb08a767be1770601d481d815022bec43422730c6c8035892f23cd11cdadb16176b418
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^6.0.0":
   version: 6.19.1
   resolution: "@typescript-eslint/utils@npm:6.19.1"
   dependencies:
@@ -3559,6 +3601,16 @@ __metadata:
     "@typescript-eslint/types": "npm:6.19.1"
     eslint-visitor-keys: "npm:^3.4.1"
   checksum: b0370a9bc6fd8d243aa8b7ccd1657ec2fbd25ceb7b067aac64322f03aa0f64b97444b13b0946f52a53d6bc5edd43e0b447f72160be4a5b72e073c1d3679b6b4c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.23.0":
+  version: 8.23.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.23.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.23.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: a406f78aa18b4efb2adf26e3a6ca48c9a6f2cc9545e083b50efaaf90f0a80d2bea79ceda51da1f109706d4138756b0978a323b9176c9a6a519e87168851e7e16
   languageName: node
   linkType: hard
 
@@ -3985,7 +4037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.10.0, ajv@npm:^6.12.4, ajv@npm:^6.12.5":
+"ajv@npm:^6.12.4, ajv@npm:^6.12.5, ajv@npm:^6.12.6":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -7230,6 +7282,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-visitor-keys@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "eslint-visitor-keys@npm:4.2.0"
+  checksum: 2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
+  languageName: node
+  linkType: hard
+
 "eslint@npm:^8.57.0":
   version: 8.57.1
   resolution: "eslint@npm:8.57.1"
@@ -8901,10 +8960,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.2.4":
-  version: 5.2.4
-  resolution: "ignore@npm:5.2.4"
-  checksum: 7c7cd90edd9fea6e037f9b9da4b01bf0a86b198ce78345f9bbd983929d68ff14830be31111edc5d70c264921f4962404d75b7262b4d9cc3bc12381eccbd03096
+"ignore@npm:^5.0.4, ignore@npm:^5.2.0, ignore@npm:^5.2.4, ignore@npm:^5.3.1":
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
   languageName: node
   linkType: hard
 
@@ -11340,7 +11399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.5":
+"minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:
@@ -14357,12 +14416,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.0, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3":
-  version: 7.6.3
-  resolution: "semver@npm:7.6.3"
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.5, semver@npm:^7.5.0, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3":
+  version: 7.7.1
+  resolution: "semver@npm:7.7.1"
   bin:
     semver: bin/semver.js
-  checksum: 88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
+  checksum: fd603a6fb9c399c6054015433051bdbe7b99a940a8fb44b85c2b524c4004b023d7928d47cb22154f8d054ea7ee8597f586605e05b52047f048278e4ac56ae958
   languageName: node
   linkType: hard
 
@@ -15765,6 +15824,15 @@ __metadata:
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 9408338819c3aca2a709f0bc54e3f874227901506cacb1163612a6c8a43df224174feb965a5eafdae16f66fc68fd7bfee8d3275d0fa73fbb8699e03ed26520c9
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "ts-api-utils@npm:2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 23fd56a958b332cac00150a652e4c84730df30571bd2faa1ba6d7b511356d1a61656621492bb6c7f15dd6e18847a1408357a0e406671d358115369a17f5bfedd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

As a first step of updating to ESLint 9, this PR updates the `@typescript/eslint` dependencies to version 8.

The main changes are:
- Update `@typescript-eslint` dependencies to the latest version. Note that this required updating ESLint by a minor version to satisfy peer dependencies.
- Modify the `createRule` utility to specify the type of `meta.docs` for custom rules. Followed https://typescript-eslint.io/developers/custom-rules/#extra-rule-docs-types.
- As of [this PR](https://github.com/typescript-eslint/typescript-eslint/pull/9972) import specifiers can also be literals, and so I added an `isIdentifierNode` type guard to handle these cases.
- Replaced the `ban-types` rule (which was removed upstream) by `no-empty-object-type`, `no-unsafe-function-type` and `no-wrapper-object-types`. I chose these ones as they cover the default options from the removed rule. More info [here](https://typescript-eslint.io/rules/ban-types/).
- Removed the `lines-between-class-members` rule as this is now handled by Prettier in this repo. I missed this in https://github.com/palantir/blueprint/pull/7081.
- Updated ESLint rule tests as the rule tester now uses flat configs, so [some of the defaults changed](https://typescript-eslint.io/blog/announcing-typescript-eslint-v8#flat-configuration-ruletester).
- Removed the `no-redeclare` linting rule as [the docs warn that it shouldn't be used in new TypeScript projects as it's already checked by the compiler](https://typescript-eslint.io/rules/no-redeclare/).

#### Reviewers should focus on:

- That the dev experience in this repo (e.g. linting errors are still reported correctly in VS Code) hasn't changed.
- CI changes feel reasonable.

#### Open questions:

- Not sure of what the version changes to the public Blueprint libraries should be here.
