### PR TITLE
fix(CompoundTag): Right icon alignment

### DIFF
--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -75,7 +75,7 @@ $compound-tag-left-intent-colors: (
       margin-left: 4px;
     }
 
-    .#{$ns}-compound-tag-right-text {
+    .#{$ns}-compound-tag-right-content {
       flex-grow: 1;
     }
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7203

#### Changes proposed in this pull request:

Looks like at some point the `$ns-compound-tag-right-text` class name was renamed to `$ns-compound-tag-right-content` but the CSS was never properly updated.


#### Screenshot

<img width="622" alt="Screenshot 2025-02-05 at 10 14 36 AM" src="https://github.com/user-attachments/assets/5bb09b90-3264-46fe-9237-1552e89cb4c6" />
