### PR TITLE
fix(DateRangeInput3): Reset shortcut selection on selection

### DIFF
--- a/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime2/src/components/date-range-input3/dateRangeInput3.tsx
@@ -371,13 +371,14 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
             boundaryToModify = Boundary.END;
         }
 
-        const baseStateChange = {
+        const baseStateChange: Partial<DateRangeInput3State> = {
             boundaryToModify,
             endHoverString,
             endInputString: this.formatDate(selectedEnd),
             isEndInputFocused,
             isOpen,
             isStartInputFocused,
+            selectedShortcutIndex: -1,
             startHoverString,
             startInputString: this.formatDate(selectedStart),
             wasLastFocusChangeDueToHover: false,
@@ -583,6 +584,7 @@ export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Pr
         const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
         const nextState: Partial<DateRangeInput3State> = {
             [keys.inputString]: this.formatDate(clampedDate),
+            selectedShortcutIndex: -1,
             shouldSelectAfterUpdate: true,
         };
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7204


#### Reviewers should focus on:

When selecting a date either via keyboard input or via mouse click we reset the selected shortcut index.