### PR TITLE
Add `size` prop to `large` variant components

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -447,7 +447,7 @@ export function positionClass(position: Position | undefined) {
 }
 
 export function sizeClass(
-    size: Size,
+    size: Size | Omit<Size, "small">,
     legacyProps: Partial<Record<"large" | "small", boolean>>,
 ): string | Record<string, boolean> {
     if (size === "small") {

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -19,7 +19,7 @@ import type { ButtonVariant } from "./buttonVariant";
 import { Elevation } from "./elevation";
 import { Intent } from "./intent";
 import { Position } from "./position";
-import type { Size } from "./size";
+import type { NonSmallSize, Size } from "./size";
 
 // injected by webpack.DefinePlugin
 declare let BLUEPRINT_NAMESPACE: string | undefined;
@@ -447,7 +447,7 @@ export function positionClass(position: Position | undefined) {
 }
 
 export function sizeClass(
-    size: Size | Omit<Size, "small">,
+    size: Size | NonSmallSize,
     legacyProps: Partial<Record<"large" | "small", boolean>>,
 ): string | Record<string, boolean> {
     if (size === "small") {

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -19,7 +19,7 @@ import type { ButtonVariant } from "./buttonVariant";
 import { Elevation } from "./elevation";
 import { Intent } from "./intent";
 import { Position } from "./position";
-import type { NonSmallSize, Size } from "./size";
+import type { Size } from "./size";
 
 // injected by webpack.DefinePlugin
 declare let BLUEPRINT_NAMESPACE: string | undefined;
@@ -447,7 +447,7 @@ export function positionClass(position: Position | undefined) {
 }
 
 export function sizeClass(
-    size: Size | NonSmallSize,
+    size: Size,
     legacyProps: Partial<Record<"large" | "small", boolean>>,
 ): string | Record<string, boolean> {
     if (size === "small") {

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -40,7 +40,7 @@ export {
     type MaybeElement,
 } from "./props";
 export { getRef, isRefCallback, isRefObject, mergeRefs, refHandler, setRef } from "./refs";
-export type { Size } from "./size";
+export type { Size, NonSmallSize } from "./size";
 
 import * as Classes from "./classes";
 import * as Utils from "./utils";

--- a/packages/core/src/common/size.ts
+++ b/packages/core/src/common/size.ts
@@ -4,4 +4,4 @@
 
 export type Size = "small" | "medium" | "large";
 
-export type NonSmallSize = Omit<Size, "small">;
+export type NonSmallSize = Exclude<Size, "small">;

--- a/packages/core/src/common/size.ts
+++ b/packages/core/src/common/size.ts
@@ -3,3 +3,5 @@
  */
 
 export type Size = "small" | "medium" | "large";
+
+export type NonSmallSize = Omit<Size, "small">;

--- a/packages/core/src/components/control-card/controlCard.tsx
+++ b/packages/core/src/components/control-card/controlCard.tsx
@@ -54,7 +54,7 @@ export interface ControlCardProps extends SupportedCardProps, SupportedControlPr
     /**
      * HTML input attributes to forward to the control `<input>` element.
      */
-    inputProps?: HTMLInputProps;
+    inputProps?: Omit<HTMLInputProps, "size">;
 
     /**
      * Whether the component should use "selected" Card styling when checked.
@@ -91,7 +91,7 @@ export const ControlCard: React.FC<ControlCardProps> = React.forwardRef((props, 
 
     // use a container element to achieve a good flex layout
     const labelElement = <div className={Classes.CONTROL_CARD_LABEL}>{children ?? label}</div>;
-    const controlProps: Omit<ControlProps, "size"> = {
+    const controlProps: ControlProps = {
         alignIndicator,
         checked,
         disabled,

--- a/packages/core/src/components/control-card/controlCard.tsx
+++ b/packages/core/src/components/control-card/controlCard.tsx
@@ -91,7 +91,7 @@ export const ControlCard: React.FC<ControlCardProps> = React.forwardRef((props, 
 
     // use a container element to achieve a good flex layout
     const labelElement = <div className={Classes.CONTROL_CARD_LABEL}>{children ?? label}</div>;
-    const controlProps: ControlProps = {
+    const controlProps: Omit<ControlProps, "size"> = {
         alignIndicator,
         checked,
         disabled,

--- a/packages/core/src/components/forms/controlProps.ts
+++ b/packages/core/src/components/forms/controlProps.ts
@@ -16,7 +16,7 @@
 
 import type * as React from "react";
 
-import type { Alignment, Size } from "../../common";
+import type { Alignment, NonSmallSize } from "../../common";
 import type { HTMLInputProps, Props } from "../../common/props";
 
 export interface CheckedControlProps {
@@ -88,7 +88,7 @@ export interface ControlProps
      *
      * @default "medium"
      */
-    size?: Omit<Size, "small">;
+    size?: NonSmallSize;
 
     /**
      * Name of the HTML tag that wraps the checkbox.

--- a/packages/core/src/components/forms/controlProps.ts
+++ b/packages/core/src/components/forms/controlProps.ts
@@ -16,7 +16,7 @@
 
 import type * as React from "react";
 
-import type { Alignment } from "../../common";
+import type { Alignment, Size } from "../../common";
 import type { HTMLInputProps, Props } from "../../common/props";
 
 export interface CheckedControlProps {
@@ -36,7 +36,7 @@ export interface CheckedControlProps {
 export interface ControlProps
     extends CheckedControlProps,
         Props,
-        HTMLInputProps,
+        Omit<HTMLInputProps, "size">,
         React.RefAttributes<HTMLLabelElement> {
     // NOTE: Some HTML props are duplicated here to provide control-specific documentation
 
@@ -75,8 +75,20 @@ export interface ControlProps
      */
     labelElement?: React.ReactNode;
 
-    /** Whether this control should use large styles. */
+    /**
+     * Whether this control should use large styles.
+     *
+     * @deprecated use `size="large"` instead
+     * @default false
+     */
     large?: boolean;
+
+    /**
+     * Size of the control.
+     *
+     * @default "medium"
+     */
+    size?: Omit<Size, "small">;
 
     /**
      * Name of the HTML tag that wraps the checkbox.

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -18,7 +18,12 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Alignment, Classes, mergeRefs } from "../../common";
-import { ALIGN_INDICATOR_CENTER, ALIGN_INDICATOR_LEFT, ALIGN_INDICATOR_RIGHT } from "../../common/errors";
+import {
+    ALIGN_INDICATOR_CENTER,
+    ALIGN_INDICATOR_LEFT,
+    ALIGN_INDICATOR_RIGHT,
+    logDeprecatedSizeWarning,
+} from "../../common/errors";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 import { useValidateProps } from "../../hooks/useValidateProps";
 
@@ -46,7 +51,9 @@ const ControlInternal: React.FC<ControlInternalProps> = React.forwardRef<HTMLLab
             inputRef,
             label,
             labelElement,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             large,
+            size = "medium",
             style,
             type,
             typeClassName,
@@ -74,9 +81,9 @@ const ControlInternal: React.FC<ControlInternalProps> = React.forwardRef<HTMLLab
             {
                 [Classes.DISABLED]: htmlProps.disabled,
                 [Classes.INLINE]: inline,
-                [Classes.LARGE]: large,
             },
             Classes.alignmentClass(alignIndicator),
+            Classes.sizeClass(size, { large }),
             className,
         );
 
@@ -121,32 +128,38 @@ export interface SwitchProps extends ControlProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/switch
  */
-export const Switch: React.FC<SwitchProps> = React.forwardRef(
-    ({ innerLabelChecked, innerLabel, ...controlProps }, ref) => {
-        const switchLabels =
-            innerLabel || innerLabelChecked
-                ? [
-                      <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
-                          <div className={Classes.SWITCH_INNER_TEXT}>
-                              {innerLabelChecked ? innerLabelChecked : innerLabel}
-                          </div>
-                      </div>,
-                      <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>
-                          <div className={Classes.SWITCH_INNER_TEXT}>{innerLabel}</div>
-                      </div>,
-                  ]
-                : null;
-        return (
-            <ControlInternal
-                {...controlProps}
-                indicatorChildren={switchLabels}
-                ref={ref}
-                type="checkbox"
-                typeClassName={Classes.SWITCH}
-            />
-        );
-    },
-);
+export const Switch: React.FC<SwitchProps> = React.forwardRef((props, ref) => {
+    const { innerLabelChecked, innerLabel, ...controlProps } = props;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { large } = controlProps;
+
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("Switch", { large });
+    }, [large]);
+
+    const switchLabels =
+        innerLabel || innerLabelChecked
+            ? [
+                  <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
+                      <div className={Classes.SWITCH_INNER_TEXT}>
+                          {innerLabelChecked ? innerLabelChecked : innerLabel}
+                      </div>
+                  </div>,
+                  <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>
+                      <div className={Classes.SWITCH_INNER_TEXT}>{innerLabel}</div>
+                  </div>,
+              ]
+            : null;
+    return (
+        <ControlInternal
+            {...controlProps}
+            indicatorChildren={switchLabels}
+            ref={ref}
+            type="checkbox"
+            typeClassName={Classes.SWITCH}
+        />
+    );
+});
 Switch.displayName = `${DISPLAYNAME_PREFIX}.Switch`;
 
 //
@@ -163,9 +176,16 @@ export type RadioProps = ControlProps;
  *
  * @see https://blueprintjs.com/docs/#core/components/radio
  */
-export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) => (
-    <ControlInternal {...props} ref={ref} type="radio" typeClassName={Classes.RADIO} />
-));
+export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { large } = props;
+
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("Radio", { large });
+    }, [large]);
+
+    return <ControlInternal {...props} ref={ref} type="radio" typeClassName={Classes.RADIO} />;
+});
 Radio.displayName = `${DISPLAYNAME_PREFIX}.Radio`;
 
 //
@@ -197,6 +217,9 @@ export interface CheckboxProps extends ControlProps {
  */
 export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) => {
     const { defaultIndeterminate, indeterminate, onChange, ...controlProps } = props;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { large } = controlProps;
+
     const [isIndeterminate, setIsIndeterminate] = React.useState<boolean>(
         indeterminate || defaultIndeterminate || false,
     );
@@ -215,6 +238,10 @@ export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) =
         },
         [indeterminate, onChange],
     );
+
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("Checkbox", { large });
+    }, [large]);
 
     React.useEffect(() => {
         if (indeterminate !== undefined) {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -17,7 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props, Utils } from "../../common";
+import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props, type Size, Utils } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 
 import { Tab, type TabId, type TabProps } from "./tab";
 import { TabPanel } from "./tabPanel";
@@ -65,9 +66,17 @@ export interface TabsProps extends Props {
      * If set to `true`, the tab titles will display with larger styling.
      * This will apply large styles only to the tabs at this level, not to nested tabs.
      *
+     * @deprecated use `size="large"` instead
      * @default false
      */
     large?: boolean;
+
+    /**
+     * The size of the tab titles.
+     *
+     * @default "medium"
+     */
+    size?: Omit<Size, "small">;
 
     /**
      * Whether inactive tab panels should be removed from the DOM and unmounted in React.
@@ -135,6 +144,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
         fill: false,
         large: false,
         renderActiveTabPanelOnly: false,
+        size: "medium",
         vertical: false,
     };
 
@@ -161,27 +171,36 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
     }
 
     public render() {
+        const {
+            animate,
+            children,
+            className,
+            fill,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            large,
+            renderActiveTabPanelOnly,
+            size = "medium",
+            vertical,
+        } = this.props;
         const { indicatorWrapperStyle, selectedTabId } = this.state;
 
-        const tabTitles = React.Children.map(this.props.children, this.renderTabTitle);
+        const tabTitles = React.Children.map(children, this.renderTabTitle);
 
         const tabPanels = this.getTabChildren()
-            .filter(this.props.renderActiveTabPanelOnly ? tab => tab.props.id === selectedTabId : () => true)
+            .filter(renderActiveTabPanelOnly ? tab => tab.props.id === selectedTabId : () => true)
             .map(this.renderTabPanel);
 
-        const tabIndicator = this.props.animate ? (
+        const tabIndicator = animate ? (
             <div className={Classes.TAB_INDICATOR_WRAPPER} style={indicatorWrapperStyle}>
                 <div className={Classes.TAB_INDICATOR} />
             </div>
         ) : null;
 
-        const classes = classNames(Classes.TABS, this.props.className, {
-            [Classes.VERTICAL]: this.props.vertical,
-            [Classes.FILL]: this.props.fill,
+        const classes = classNames(Classes.TABS, className, {
+            [Classes.VERTICAL]: vertical,
+            [Classes.FILL]: fill,
         });
-        const tabListClasses = classNames(Classes.TAB_LIST, {
-            [Classes.LARGE]: this.props.large,
-        });
+        const tabListClasses = classNames(Classes.TAB_LIST, Classes.sizeClass(size, { large }));
 
         return (
             <div className={classes}>
@@ -199,6 +218,11 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
                 {tabPanels}
             </div>
         );
+    }
+
+    protected validateProps(props: TabsProps) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        logDeprecatedSizeWarning("Tabs", { large: props.large });
     }
 
     public componentDidMount() {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props, type Size, Utils } from "../../common";
+import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type NonSmallSize, type Props, Utils } from "../../common";
 import { logDeprecatedSizeWarning } from "../../common/errors";
 
 import { Tab, type TabId, type TabProps } from "./tab";
@@ -76,7 +76,7 @@ export interface TabsProps extends Props {
      *
      * @default "medium"
      */
-    size?: Omit<Size, "small">;
+    size?: NonSmallSize;
 
     /**
      * Whether inactive tab panels should be removed from the DOM and unmounted in React.

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -19,7 +19,8 @@ import * as React from "react";
 
 import { type IconName, IconSize } from "@blueprintjs/icons";
 
-import { AbstractPureComponent, Classes, refHandler, setRef, Utils } from "../../common";
+import { AbstractPureComponent, Classes, refHandler, setRef, type Size, Utils } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import {
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
@@ -106,7 +107,12 @@ export interface TagInputProps extends IntentProps, Props {
     /** Controlled value of the `<input>` element. This is shorthand for `inputProps={{ value }}`. */
     inputValue?: string;
 
-    /** Whether the tag input should use a large size. */
+    /**
+     * Whether the tag input should use a large size.
+     *
+     * @deprecated use `size="large"` instead.
+     * @default false
+     */
     large?: boolean;
 
     /** Name of a Blueprint UI icon (or an icon element) to render on the left side of the input. */
@@ -188,6 +194,13 @@ export interface TagInputProps extends IntentProps, Props {
     separator?: string | RegExp | false;
 
     /**
+     * The size of the tag input.
+     *
+     * @default "medium"
+     */
+    size: Omit<Size, "small">;
+
+    /**
      * React props to pass to each `Tag`. Provide an object to pass the same props to every tag,
      * or a function to customize props per tag.
      *
@@ -255,8 +268,20 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
     private handleRef: React.Ref<HTMLInputElement> = refHandler(this, "inputElement", this.props.inputRef);
 
     public render() {
-        const { autoResize, className, disabled, fill, inputProps, intent, large, leftIcon, placeholder, values } =
-            this.props;
+        const {
+            autoResize,
+            className,
+            disabled,
+            fill,
+            inputProps,
+            intent,
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            large,
+            leftIcon,
+            placeholder,
+            size,
+            values,
+        } = this.props;
 
         const classes = classNames(
             Classes.INPUT,
@@ -265,9 +290,9 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
                 [Classes.ACTIVE]: this.state.isInputFocused,
                 [Classes.DISABLED]: disabled,
                 [Classes.FILL]: fill,
-                [Classes.LARGE]: large,
             },
             Classes.intentClass(intent),
+            Classes.sizeClass(size, { large }),
             className,
         );
         const isLarge = classes.indexOf(Classes.LARGE) > NONE;
@@ -308,6 +333,12 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
         );
     }
 
+    protected validateProps(nextProps: TagInputProps) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const { large } = nextProps;
+        logDeprecatedSizeWarning("TagInput", { large });
+    }
+
     public componentDidUpdate(prevProps: TagInputProps) {
         if (prevProps.inputRef !== this.props.inputRef) {
             setRef(prevProps.inputRef, null);
@@ -334,15 +365,18 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
         if (!tag) {
             return null;
         }
-        const { large, tagProps } = this.props;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        const { large, size, tagProps } = this.props;
         const props = Utils.isFunction(tagProps) ? tagProps(tag, index) : tagProps;
         return (
             <Tag
                 active={index === this.state.activeIndex}
                 data-tag-index={index}
                 key={tag + "__" + index}
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 large={large}
                 onRemove={this.props.disabled ? undefined : this.handleRemoveTag}
+                size={size}
                 {...props}
             >
                 {tag}

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -19,7 +19,7 @@ import * as React from "react";
 
 import { type IconName, IconSize } from "@blueprintjs/icons";
 
-import { AbstractPureComponent, Classes, refHandler, setRef, type Size, Utils } from "../../common";
+import { AbstractPureComponent, Classes, type NonSmallSize, refHandler, setRef, Utils } from "../../common";
 import { logDeprecatedSizeWarning } from "../../common/errors";
 import {
     DISPLAYNAME_PREFIX,
@@ -198,7 +198,7 @@ export interface TagInputProps extends IntentProps, Props {
      *
      * @default "medium"
      */
-    size: Omit<Size, "small">;
+    size: NonSmallSize;
 
     /**
      * React props to pass to each `Tag`. Provide an object to pass the same props to every tag,

--- a/packages/core/src/components/tag/compoundTag.tsx
+++ b/packages/core/src/components/tag/compoundTag.tsx
@@ -18,7 +18,9 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import { isReactNodeEmpty } from "../../common/utils";
+import { useValidateProps } from "../../hooks/useValidateProps";
 import { Icon } from "../icon/icon";
 import { Text } from "../text/text";
 
@@ -62,26 +64,32 @@ export const CompoundTag: React.FC<CompoundTagProps> = React.forwardRef((props, 
         intent,
         interactive = false,
         leftContent,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         large = false,
         minimal = false,
         onRemove,
         rightIcon,
         round = false,
+        size = "medium",
         tabIndex = 0,
         ...htmlProps
     } = props;
 
     const isRemovable = Utils.isFunction(onRemove);
 
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("CompoundTag", { large });
+    }, [large]);
+
     const tagClasses = classNames(
         Classes.TAG,
         Classes.COMPOUND_TAG,
         Classes.intentClass(intent),
+        Classes.sizeClass(size, { large }),
         {
             [Classes.ACTIVE]: active,
             [Classes.FILL]: fill,
             [Classes.INTERACTIVE]: interactive,
-            [Classes.LARGE]: large,
             [Classes.MINIMAL]: minimal,
             [Classes.ROUND]: round,
         },

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -29,7 +29,9 @@ import {
     removeNonHTMLProps,
     Utils,
 } from "../../common";
+import { logDeprecatedSizeWarning } from "../../common/errors";
 import { isReactNodeEmpty } from "../../common/utils";
+import { useValidateProps } from "../../hooks/useValidateProps";
 import { Icon } from "../icon/icon";
 import { Text } from "../text/text";
 
@@ -97,12 +99,14 @@ export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
         icon,
         intent,
         interactive,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         large = false,
         minimal = false,
         multiline,
         onRemove,
         rightIcon,
         round = false,
+        size = "medium",
         tabIndex = 0,
         htmlTitle,
         ...htmlProps
@@ -116,14 +120,18 @@ export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
         disabledTabIndex: undefined,
     });
 
+    useValidateProps(() => {
+        logDeprecatedSizeWarning("Tag", { large });
+    }, [large]);
+
     const tagClasses = classNames(
         Classes.TAG,
         Classes.intentClass(intent),
+        Classes.sizeClass(size, { large }),
         {
             [Classes.ACTIVE]: active,
             [Classes.FILL]: fill,
             [Classes.INTERACTIVE]: isInteractive,
-            [Classes.LARGE]: large,
             [Classes.MINIMAL]: minimal,
             [Classes.ROUND]: round,
         },

--- a/packages/core/src/components/tag/tagRemoveButton.tsx
+++ b/packages/core/src/components/tag/tagRemoveButton.tsx
@@ -26,8 +26,9 @@ import type { TagProps } from "./tag";
 export type TagRemoveButtonProps = CompoundTagProps | TagProps;
 
 export const TagRemoveButton = (props: TagRemoveButtonProps) => {
-    const { className, large, onRemove, tabIndex } = props;
-    const isLarge = large || className?.includes(Classes.LARGE);
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const { className, large, onRemove, size, tabIndex } = props;
+    const isLarge = large || size === "large" || className?.includes(Classes.LARGE);
     const handleRemoveClick = React.useCallback(
         (e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove?.(e, props as any);

--- a/packages/core/src/components/tag/tagSharedProps.ts
+++ b/packages/core/src/components/tag/tagSharedProps.ts
@@ -16,7 +16,7 @@
 
 import type { IconName } from "@blueprintjs/icons";
 
-import type { IntentProps, MaybeElement, Props } from "../../common";
+import type { IntentProps, MaybeElement, Props, Size } from "../../common";
 
 export interface TagSharedProps extends Props, IntentProps {
     /**
@@ -52,6 +52,7 @@ export interface TagSharedProps extends Props, IntentProps {
     /**
      * Whether this tag should use large styles.
      *
+     * @deprecated use size="large" instead
      * @default false
      */
     large?: boolean;
@@ -81,4 +82,11 @@ export interface TagSharedProps extends Props, IntentProps {
      * @default false
      */
     round?: boolean;
+
+    /**
+     * The size of the tag.
+     *
+     * @default "medium"
+     */
+    size?: Omit<Size, "small">;
 }

--- a/packages/core/src/components/tag/tagSharedProps.ts
+++ b/packages/core/src/components/tag/tagSharedProps.ts
@@ -16,7 +16,7 @@
 
 import type { IconName } from "@blueprintjs/icons";
 
-import type { IntentProps, MaybeElement, Props, Size } from "../../common";
+import type { IntentProps, MaybeElement, NonSmallSize, Props } from "../../common";
 
 export interface TagSharedProps extends Props, IntentProps {
     /**
@@ -88,5 +88,5 @@ export interface TagSharedProps extends Props, IntentProps {
      *
      * @default "medium"
      */
-    size?: Omit<Size, "small">;
+    size?: NonSmallSize;
 }

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -97,9 +97,9 @@ describe("<Tabs>", () => {
         assert.lengthOf(wrapper.find(`${TAB_LIST_SELECTOR}.${Classes.LARGE}`), 0);
     });
 
-    it(`renders using ${Classes.LARGE} when large={true}`, () => {
+    it(`renders using ${Classes.LARGE} when size="large"`, () => {
         const wrapper = mount(
-            <Tabs id={ID} large={true}>
+            <Tabs id={ID} size="large">
                 {getTabsContents()}
             </Tabs>,
         );

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -16,9 +16,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
-import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
-
-import { Examples } from "./examples/Examples";
+import { BlueprintProvider, Button, FocusStyleManager } from "@blueprintjs/core";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -31,7 +29,9 @@ const root = ReactDOM.createRoot(container);
     await import("./index.scss");
     root.render(
         <BlueprintProvider>
-            <Examples />
+            <Button intent="primary" small={null}>
+                Click me
+            </Button>
         </BlueprintProvider>,
     );
 })();

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -16,7 +16,9 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
-import { BlueprintProvider, Button, FocusStyleManager } from "@blueprintjs/core";
+import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
+
+import { Examples } from "./examples/Examples";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -29,9 +31,7 @@ const root = ReactDOM.createRoot(container);
     await import("./index.scss");
     root.render(
         <BlueprintProvider>
-            <Button intent="primary" small={null}>
-                Click me
-            </Button>
+            <Examples />
         </BlueprintProvider>,
     );
 })();

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -37,7 +37,7 @@ export const CheckboxExample: React.FC<ExampleProps> = props => {
         </>
     );
 
-    const checkboxProps: CheckboxProps = { alignIndicator, disabled, inline, large };
+    const checkboxProps: CheckboxProps = { alignIndicator, disabled, inline, size: large ? "large" : undefined };
 
     return (
         <Example options={options} {...props}>

--- a/packages/docs-app/src/examples/core-examples/compoundTagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/compoundTagExample.tsx
@@ -69,12 +69,12 @@ export const CompoundTagExample: React.FC<ExampleProps> = props => {
                     icon={icon ? IconNames.GLOBE : undefined}
                     intent={intent}
                     interactive={interactive}
-                    large={large}
                     leftContent="City"
                     minimal={minimal}
                     onRemove={removable && handleRemove(tag)}
                     rightIcon={rightIcon ? IconNames.MAP_MARKER : undefined}
                     round={round}
+                    size={large ? "large" : undefined}
                 >
                     {tag}
                 </CompoundTag>

--- a/packages/docs-app/src/examples/core-examples/radioExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/radioExample.tsx
@@ -38,7 +38,7 @@ export const RadioExample: React.FC<ExampleProps> = props => {
         </>
     );
 
-    const radioProps: RadioProps = { alignIndicator, disabled, inline, large };
+    const radioProps: RadioProps = { alignIndicator, disabled, inline, size: large ? "large" : undefined };
 
     return (
         <Example options={options} {...props}>

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -37,7 +37,7 @@ export const SwitchExample: React.FC<ExampleProps> = props => {
         </>
     );
 
-    const switchProps: SwitchProps = { alignIndicator, disabled, inline, large };
+    const switchProps: SwitchProps = { alignIndicator, disabled, inline, size: large ? "large" : undefined };
 
     return (
         <Example options={options} {...props}>

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -92,8 +92,8 @@ export const TabsExample: React.FC<ExampleProps> = props => {
                     key={vertical ? "vertical" : "horizontal"}
                     animate={animate}
                     id="TabsExample"
-                    large={large}
                     renderActiveTabPanelOnly={activePanelOnly}
+                    size={large ? "large" : undefined}
                     vertical={vertical}
                 >
                     <Tab id="rx" title="React" panel={<ReactPanel />} />
@@ -125,9 +125,9 @@ export const TabsExample: React.FC<ExampleProps> = props => {
                                 animate={animate}
                                 fill={fill}
                                 id={NAVBAR_PARENT_ID}
-                                large={large}
                                 onChange={setNavbarTabId}
                                 selectedTabId={navbarTabId}
+                                size={large ? "large" : undefined}
                             >
                                 <Tab icon={showIcon ? "home" : undefined} id="Home" title="Home" />
                                 <Tab icon={showIcon ? "folder-open" : undefined} id="Files" title="Files" />

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -68,11 +68,11 @@ export const TagExample: React.FC<ExampleProps> = props => {
                     icon={icon ? "home" : undefined}
                     intent={intent}
                     interactive={interactive}
-                    large={large}
                     minimal={minimal}
                     onRemove={removable ? handleRemove(tag) : undefined}
                     rightIcon={rightIcon ? "map" : undefined}
                     round={round}
+                    size={large ? "large" : undefined}
                 >
                     {tag}
                 </Tag>

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -57,8 +57,8 @@ export const TagInputExample: React.FC<ExampleProps> = props => {
     const getTagProps = React.useCallback(
         (_v: React.ReactNode, index: number): TagProps => ({
             intent: tagIntents ? INTENTS[index % INTENTS.length] : Intent.NONE,
-            large,
             minimal: tagMinimal,
+            size: large ? "large" : undefined,
         }),
         [tagIntents, large, tagMinimal],
     );
@@ -91,7 +91,6 @@ export const TagInputExample: React.FC<ExampleProps> = props => {
                 disabled={disabled}
                 fill={fill}
                 intent={intent}
-                large={large}
                 leftIcon={leftIcon ? "user" : undefined}
                 onChange={setValues}
                 placeholder="Separate values with commas..."
@@ -103,6 +102,7 @@ export const TagInputExample: React.FC<ExampleProps> = props => {
                         variant="minimal"
                     />
                 }
+                size={large ? "large" : undefined}
                 tagProps={getTagProps}
                 values={values}
             />

--- a/packages/docs-app/src/examples/select-examples/multiSelectCustomTarget.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectCustomTarget.tsx
@@ -13,12 +13,12 @@ interface IMultiSelectCustomTargetProps {
 export const MultiSelectCustomTarget: React.FC<IMultiSelectCustomTargetProps> = ({ count }) => {
     return (
         <Tag
-            large={true}
-            round={true}
-            minimal={true}
-            interactive={true}
-            intent={"primary"}
             className="docs-custom-target"
+            intent={"primary"}
+            interactive={true}
+            minimal={true}
+            round={true}
+            size="large"
         >
             <div className="docs-custom-target-content">
                 <Text className={"docs-custom-target-text"}>Custom Target</Text>


### PR DESCRIPTION
#### Part of #7232

#### Proposed changes:

FLUP to #7226 that adds the `size` prop to the following components:
- `<Checkbox>`
- `<CompoundTag>`
- `<Radio>`
- `<Switch>`
- `<Tabs>`
- `<Tag>`
- `<TagInput>`
