### PR TITLE
Replace ESLint deprecation plugin by @typescript-eslint rule

### DIFF
--- a/packages/colors/src/index.ts
+++ b/packages/colors/src/index.ts
@@ -15,5 +15,4 @@
  */
 
 export { Colors } from "./colors";
-// eslint-disable-next-line deprecation/deprecation
 export { LegacyColors } from "./legacyColors";

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -22,12 +22,10 @@ export { Alignment } from "./alignment";
 export { Boundary } from "./boundary";
 export { Elevation } from "./elevation";
 export { Intent } from "./intent";
-// eslint-disable-next-line deprecation/deprecation
 export { KeyCodes as Keys } from "./keyCodes";
 export { Position } from "./position";
 export {
     type ActionProps,
-    // eslint-disable-next-line deprecation/deprecation
     type ControlledProps,
     type ControlledValueProps,
     type IntentProps,

--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -51,10 +51,10 @@ export function showContextMenu(
     const {
         container = document.body,
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         domRenderer = ReactDOM.render,
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         domUnmounter = ReactDOM.unmountComponentAtNode,
     } = options;
 
@@ -70,7 +70,7 @@ export function showContextMenu(
     }
 
     // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     domRenderer(
         <OverlaysProvider>
             <UncontrolledContextMenuPopover {...props} />
@@ -88,7 +88,7 @@ export function showContextMenu(
  */
 export function hideContextMenu(options: DOMMountOptions<ContextMenuPopoverProps> = {}) {
     // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { domUnmounter = ReactDOM.unmountComponentAtNode } = options;
 
     if (contextMenuElement !== undefined) {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -460,6 +460,7 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
                 onCompositionEnd={this.handleCompositionEnd}
                 onCompositionUpdate={this.handleCompositionUpdate}
                 onKeyDown={this.handleInputKeyDown}
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 onKeyPress={this.handleInputKeyPress}
                 onPaste={this.handleInputPaste}
                 onValueChange={this.handleInputChange}
@@ -601,7 +602,7 @@ export class NumericInput extends AbstractPureComponent<HTMLInputProps & Numeric
             e.preventDefault();
         }
 
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         this.props.onKeyPress?.(e);
     };
 

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -107,7 +107,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     );
 
     private maybeSyncHeightToScrollHeight = () => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { autoResize, growVertically } = this.props;
 
         if (this.textareaElement != null) {
@@ -158,7 +158,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
             autoResize,
             className,
             fill,
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             growVertically,
             inputRef,
             intent,

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -242,7 +242,7 @@ export const normalizeKeyCombo = (combo: string, platformOverride: string | unde
 
 export function isMac(platformOverride: string | undefined) {
     // HACKHACK: see https://github.com/palantir/blueprint/issues/5174
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const platform = platformOverride ?? (typeof navigator !== "undefined" ? navigator.platform : undefined);
     return platform === undefined ? false : /Mac|iPod|iPhone|iPad/.test(platform);
 }

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -133,7 +133,7 @@ export const Icon: IconComponent = React.forwardRef(function <T extends Element>
     } = props;
 
     // Preserve Blueprint v4.x behavior: iconSize prop takes predecence, then size prop, then fall back to default value
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const size = props.iconSize ?? props.size ?? IconSize.STANDARD;
 
     const [iconPaths, setIconPaths] = React.useState<IconPaths | undefined>(() =>

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -70,15 +70,12 @@ export { NavbarGroup, type NavbarGroupProps } from "./navbar/navbarGroup";
 export { NavbarHeading, type NavbarHeadingProps } from "./navbar/navbarHeading";
 export { NonIdealState, type NonIdealStateProps, NonIdealStateIconSize } from "./non-ideal-state/nonIdealState";
 export { OverflowList, type OverflowListProps } from "./overflow-list/overflowList";
-// eslint-disable-next-line deprecation/deprecation
 export { Overlay } from "./overlay/overlay";
 export type { OverlayLifecycleProps, OverlayProps, OverlayableProps } from "./overlay/overlayProps";
 export { Overlay2, type Overlay2Props } from "./overlay2/overlay2";
 export type { OverlayInstance } from "./overlay2/overlayInstance";
 export { Text, type TextProps } from "./text/text";
-// eslint-disable-next-line deprecation/deprecation
 export { PanelStack, type PanelStackProps } from "./panel-stack/panelStack";
-// eslint-disable-next-line deprecation/deprecation
 export type { IPanel, IPanelProps } from "./panel-stack/panelProps";
 export { PanelStack2, type PanelStack2Props } from "./panel-stack2/panelStack2";
 export type { Panel, PanelProps } from "./panel-stack2/panelTypes";
@@ -119,14 +116,12 @@ export { RadioCard, type RadioCardProps } from "./control-card/radioCard";
 export { SwitchCard, type SwitchCardProps } from "./control-card/switchCard";
 export { Tab, type TabId, type TabProps } from "./tabs/tab";
 export { TabPanel, type TabPanelProps } from "./tabs/tabPanel";
-// eslint-disable-next-line deprecation/deprecation
 export { Tabs, type TabsProps, TabsExpander, Expander } from "./tabs/tabs";
 export { CompoundTag, type CompoundTagProps } from "./tag/compoundTag";
 export { Tag, type TagProps } from "./tag/tag";
 export { TagInput, type TagInputProps, type TagInputAddMethod } from "./tag-input/tagInput";
 export { OverlayToaster, type OverlayToasterCreateOptions } from "./toast/overlayToaster";
 export type { OverlayToasterProps, ToasterPosition } from "./toast/overlayToasterProps";
-// eslint-disable-next-line deprecation/deprecation
 export { Toast } from "./toast/toast";
 export { Toast2 } from "./toast/toast2";
 export type { ToastProps } from "./toast/toastProps";

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to Overlay2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";
@@ -152,7 +152,6 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
                 <Portal
                     className={this.props.portalClassName}
                     container={this.props.portalContainer}
-                    // eslint-disable-next-line deprecation/deprecation
                     stopPropagationEvents={this.props.portalStopPropagationEvents}
                 >
                     {transitionGroup}

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -655,7 +655,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         return transitionGroup;
     }
 });
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 Overlay2.defaultProps = OVERLAY2_DEFAULT_PROPS;
 Overlay2.displayName = `${DISPLAYNAME_PREFIX}.Overlay2`;
 

--- a/packages/core/src/components/panel-stack/panelProps.ts
+++ b/packages/core/src/components/panel-stack/panelProps.ts
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to PanelStack2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import type * as React from "react";
 

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -25,7 +25,7 @@ import type { Props } from "../../common/props";
 import type { IPanel } from "./panelProps";
 import { PanelView } from "./panelView";
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 export interface PanelStackProps extends Props {
     /**

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to PanelStack2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import * as React from "react";
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -517,7 +517,7 @@ export class Popover<
                 usePortal={usePortal}
                 portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
-                // eslint-disable-next-line deprecation/deprecation
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 portalStopPropagationEvents={this.props.portalStopPropagationEvents}
                 shouldReturnFocusOnClose={shouldReturnFocusOnClose}
             >

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -78,7 +78,7 @@ const PORTAL_LEGACY_CONTEXT_TYPES: ValidationMap<PortalLegacyContext> = {
  * @see https://blueprintjs.com/docs/#core/components/portal
  */
 export function Portal(
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     { className, stopPropagationEvents, container, onChildrenMount, children }: PortalProps,
     legacyContext: PortalLegacyContext = {},
 ) {
@@ -158,7 +158,7 @@ export function Portal(
 Portal.displayName = `${DISPLAYNAME_PREFIX}.Portal`;
 // only use legacy context in React 16 or 17
 if (!isReact18OrHigher()) {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     Portal.contextTypes = PORTAL_LEGACY_CONTEXT_TYPES;
 }
 

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -188,6 +188,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
                 <div
                     className={tabListClasses}
                     onKeyDown={this.handleKeyDown}
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     onKeyPress={this.handleKeyPress}
                     ref={this.refHandlers.tablist}
                     role="tablist"

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -77,7 +77,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         const containerElement = document.createElement("div");
         container.appendChild(containerElement);
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const toaster = ReactDOM.render<OverlayToasterProps>(
             <OverlayToaster {...props} usePortal={false} />,
             containerElement,
@@ -103,7 +103,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
 
         const container = options?.container ?? document.body;
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const domRenderer = options?.domRenderer ?? ReactDOM.render;
 
         const toasterComponentRoot = document.createElement("div");
@@ -112,7 +112,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
         return new Promise<Toaster>((resolve, reject) => {
             try {
                 // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
-                // eslint-disable-next-line deprecation/deprecation
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 domRenderer(<OverlayToaster {...props} ref={handleRef} usePortal={false} />, toasterComponentRoot);
             } catch (error) {
                 // Note that we're catching errors from the domRenderer function
@@ -307,7 +307,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
     private renderChildren() {
         return React.Children.map(this.props.children, child => {
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             if (isElementOfType(child, Toast)) {
                 return <Toast2 {...child.props} />;
             } else {

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to Toast2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/core/src/components/toast/toaster.ts
+++ b/packages/core/src/components/toast/toaster.ts
@@ -42,7 +42,7 @@ export type ToasterInstance = Toaster;
 // merges with declaration of `Toaster` type in `toasterTypes.ts`
 // kept for backwards-compatibility with v4.x
 export const Toaster = {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     create: deprecatedToasterCreate,
 };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,8 +19,6 @@ export * from "./common";
 export * from "./components";
 export * from "./context";
 export * from "./hooks";
-
-/* eslint-disable deprecation/deprecation */
 export * from "./deprecatedTypeAliases";
 
 export {

--- a/packages/core/src/legacy/contextMenuLegacy.tsx
+++ b/packages/core/src/legacy/contextMenuLegacy.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to ContextMenu2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/core/src/legacy/contextMenuTargetLegacy.tsx
+++ b/packages/core/src/legacy/contextMenuTargetLegacy.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to ContextMenu2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import * as React from "react";
 import * as ReactDOM from "react-dom";

--- a/packages/core/src/legacy/hotkeysDialogLegacy.tsx
+++ b/packages/core/src/legacy/hotkeysDialogLegacy.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to HotkeysDialog2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/core/src/legacy/hotkeysEvents.ts
+++ b/packages/core/src/legacy/hotkeysEvents.ts
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to HotkeysDialog2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import { Children, type ReactNode } from "react";
 

--- a/packages/core/src/legacy/hotkeysTargetLegacy.tsx
+++ b/packages/core/src/legacy/hotkeysTargetLegacy.tsx
@@ -19,8 +19,6 @@
  * All changes & bugfixes should be made to HotkeysTarget2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
-
 import * as React from "react";
 
 import { isFunction } from "../common/utils";

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -62,7 +62,7 @@ describe("ContextMenu", () => {
     });
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(containerElement!);
         containerElement!.remove();
     });

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -1387,6 +1387,7 @@ describe("<NumericInput>", () => {
     ) {
         const onKeyPressSpy = spy();
         const component = mount(
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             <NumericInput allowNumericCharactersOnly={allowNumericCharactersOnly} onKeyPress={onKeyPressSpy} />,
         );
         const inputField = component.find("input");

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -32,7 +32,7 @@ describe("<TextArea>", () => {
 
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(containerElement!);
         containerElement!.remove();
     });
@@ -86,6 +86,7 @@ describe("<TextArea>", () => {
     // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
     // Note that growVertically is deprecated as of 28/07/2023
     it.skip("can resize automatically", () => {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const wrapper = mount(<TextArea growVertically={true} />, { attachTo: containerElement });
         const textarea = wrapper.find("textarea");
 
@@ -129,6 +130,7 @@ describe("<TextArea>", () => {
         Sed eros sapien, semper sed imperdiet sed,
         dictum eget purus. Donec porta accumsan pretium.
         Fusce at felis mattis, tincidunt erat non, varius erat.`;
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const wrapper = mount(<TextArea growVertically={true} value={initialValue} style={{ marginTop: 10 }} />, {
             attachTo: containerElement,
         });
@@ -180,6 +182,7 @@ describe("<TextArea>", () => {
     it.skip("resizes when props change if growVertically is true", () => {
         const initialText = "A";
         const longText = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const wrapper = mount(<TextArea growVertically={true} value={initialText} />, { attachTo: containerElement });
         const initialHeight = wrapper.find("textarea").getDOMNode<HTMLElement>().style.height;
         wrapper.setProps({ value: longText }).update();

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to Overlay2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to PanelStack2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -48,7 +48,7 @@ describe("<MultiSlider>", () => {
 
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(testsContainerElement);
         testsContainerElement.remove();
     });

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -62,7 +62,7 @@ function unmountReact16Toaster(containerElement: HTMLElement) {
         throw new Error("No elements were found under Toaster container.");
     }
     // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     ReactDOM.unmountComponentAtNode(toasterRenderRoot);
 }
 

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to Toast2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";

--- a/packages/core/test/toast/toasterTests.tsx
+++ b/packages/core/test/toast/toasterTests.tsx
@@ -28,13 +28,13 @@ describe("Toaster", () => {
 
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
 
     describe("(v4.x backwards-compatibility)", () => {
         it("supports Toaster.create() method", () => {
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             const toaster = Toaster.create({}, testsContainerElement);
             toaster.clear();
         });

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -33,7 +33,7 @@ describe("<Tree>", () => {
 
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
 

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components, react-hooks/exhaustive-deps */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components, react-hooks/exhaustive-deps */
 
 import classNames from "classnames";
 import * as React from "react";
@@ -700,7 +700,6 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function _DateInpu
     );
 });
 DateInput.displayName = `${DISPLAYNAME_PREFIX}.DateInput`;
-// eslint-disable-next-line deprecation/deprecation
 DateInput.defaultProps = DATEINPUT_DEFAULT_PROPS;
 
 function getInitialTimezoneValue({ defaultTimezone, timezone }: DateInputProps) {

--- a/packages/datetime/src/components/date-picker/datePicker.tsx
+++ b/packages/datetime/src/components/date-picker/datePicker.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import { isSameDay, isValid } from "date-fns";

--- a/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -38,9 +38,6 @@ export {
     type DateRangeShortcut,
 } from "./components/shortcuts/shortcuts";
 export { TimezoneSelect, type TimezoneSelectProps } from "./components/timezone-select/timezoneSelect";
-
-/* eslint-disable deprecation/deprecation */
-
 export { DateInput, type DateInputProps } from "./components/date-input/dateInput";
 export { DatePicker, type DatePickerProps } from "./components/date-picker/datePicker";
 export { DateRangeInput, type DateRangeInputProps } from "./components/date-range-input/dateRangeInput";

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import { assert } from "chai";
 import { intlFormat, isEqual, parseISO } from "date-fns";

--- a/packages/datetime/test/components/datePickerTests.tsx
+++ b/packages/datetime/test/components/datePickerTests.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import { assert } from "chai";
 import { mount } from "enzyme";

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import { expect } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
@@ -76,7 +76,6 @@ describe("<DateRangeInput>", () => {
     afterEach(() => {
         if (containerElement !== undefined) {
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-            // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
         }

--- a/packages/datetime/test/components/dateRangePickerTests.tsx
+++ b/packages/datetime/test/components/dateRangePickerTests.tsx
@@ -20,7 +20,7 @@
  * package instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components, sort-keys */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components, sort-keys */
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -44,7 +44,7 @@ describe("<TimePicker>", () => {
 
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(testsContainerElement);
     });
 
@@ -750,7 +750,7 @@ describe("<TimePicker>", () => {
 
     function renderTimePicker(props?: Partial<TimePickerProps>) {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         timePicker = ReactDOM.render<TimePickerProps>(
             <TimePicker onChange={onTimePickerChange} {...props} />,
             testsContainerElement,

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -571,7 +571,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateIn
 DateInput3.displayName = `${DISPLAYNAME_PREFIX}.DateInput3`;
 
 // TODO: Removing `defaultProps` here breaks tests. Investigate why.
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 DateInput3.defaultProps = DATEINPUT3_DEFAULT_PROPS;
 
 /** Gets the input `placeholder` value from props, using default values if undefined */

--- a/packages/datetime2/src/index.ts
+++ b/packages/datetime2/src/index.ts
@@ -24,8 +24,6 @@ import * as DateInput2MigrationUtils from "./dateInput2MigrationUtils";
 export { DateInput2MigrationUtils };
 export { Classes as Datetime2Classes, ReactDayPickerClasses } from "./classes";
 
-/* eslint-disable deprecation/deprecation */
-
 export {
     /** @deprecated import from `@blueprintjs/datetime` instead, or use `Datetime2Classes` */
     Classes,

--- a/packages/datetime2/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime2/test/components/dateRangeInput3Tests.tsx
@@ -89,7 +89,7 @@ describe("<DateRangeInput3>", () => {
     afterEach(() => {
         if (containerElement !== undefined) {
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
         }

--- a/packages/datetime2/test/dateInput2MigrationUtilsTests.tsx
+++ b/packages/datetime2/test/dateInput2MigrationUtilsTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import { assert } from "chai";
 import { mount } from "enzyme";

--- a/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyPiano.tsx
@@ -26,7 +26,7 @@ export interface HotkeyPianoState {
     keys: boolean[];
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 @HotkeysTarget
 export class HotkeyPiano extends React.PureComponent<ExampleProps, HotkeyPianoState> {
     public state: HotkeyPianoState = {

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -18,7 +18,7 @@
  * All changes & bugfixes should be made to Overlay2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to PanelStack2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, max-classes-per-file, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, max-classes-per-file, @blueprintjs/no-deprecated-components */
 
 import * as React from "react";
 

--- a/packages/docs-app/src/examples/core-examples/toastCreateAsyncExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastCreateAsyncExample.tsx
@@ -94,7 +94,7 @@ function unmountReact16Toaster(containerElement: HTMLElement) {
         throw new Error("No elements were found under Toaster container.");
     }
     // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7166
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     ReactDOM.unmountComponentAtNode(toasterRenderRoot);
 }
 

--- a/packages/docs-app/src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx
@@ -19,7 +19,7 @@
  * Newer datetime2 components support date-fns format strings directly.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import { format, type Locale, parse } from "date-fns";
 import * as React from "react";

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to DateInput3 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to DatePicker3 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import * as React from "react";
 

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to DateRangeInput3 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import * as React from "react";
 
@@ -135,7 +135,6 @@ export class DateRangeInputExample extends React.PureComponent<ExampleProps, Dat
                             : undefined
                     }
                 />
-                {/* eslint-disable-next-line deprecation/deprecation */}
                 <DateFnsDateRange range={range} />
             </Example>
         );

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to DateRangePicker3 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import moment from "moment";
 import * as React from "react";

--- a/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/dateInput3Example.tsx
@@ -42,6 +42,7 @@ interface DateInput3ExampleState {
     showRightElement: boolean;
     showTimePickerArrows: boolean;
     showTimezoneSelect: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     timePrecision: TimePrecision | undefined;
     useAmPm: boolean;
 }
@@ -61,6 +62,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
         showRightElement: false,
         showTimePickerArrows: false,
         showTimezoneSelect: true,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         timePrecision: TimePrecision.MINUTE,
         useAmPm: false,
     };
@@ -97,6 +99,7 @@ export class DateInput3Example extends React.PureComponent<ExampleProps, DateInp
 
     private handleLocaleCodeChange = (localeCode: CommonDateFnsLocale) => this.setState({ localeCode });
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     private handleTimePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
         this.setState({ timePrecision: timePrecision === "none" ? undefined : timePrecision }),
     );

--- a/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/datePicker3Example.tsx
@@ -40,6 +40,7 @@ interface DatePicker3ExampleState {
     showOutsideDays: boolean;
     showTimeArrowButtons: boolean;
     showWeekNumber: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     timePrecision: TimePrecision | undefined;
     useAmPm?: boolean;
 }
@@ -79,6 +80,7 @@ export class DatePicker3Example extends React.PureComponent<ExampleProps, DatePi
 
     private handleMinDateChange = (minDate: Date) => this.setState({ minDate });
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     private handlePrecisionChange = handleValueChange((p: TimePrecision | "none") =>
         this.setState({ timePrecision: p === "none" ? undefined : p }),
     );

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -31,6 +31,7 @@ export class TableDollarExample extends React.PureComponent<ExampleProps> {
         );
         return (
             <Example options={false} showOptionsBelowExample={true} {...this.props}>
+                {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
                 <Table2 numRows={20} enableGhostCells={true} enableFocusedCell={true}>
                     <Column cellRenderer={dollarCellRenderer} columnHeaderCellRenderer={renderColumnHeader} />
                     <Column cellRenderer={euroCellRenderer} columnHeaderCellRenderer={renderColumnHeader} />

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -216,6 +216,7 @@ export class TableSortableExample extends React.PureComponent<ExampleProps> {
                     selectionModes={SelectionModes.COLUMNS_AND_CELLS}
                     getCellClipboardData={this.getCellData}
                     cellRendererDependencies={[this.state.sortedIndexMap]}
+                    // eslint-disable-next-line @typescript-eslint/no-deprecated
                     enableFocusedCell={true}
                 >
                     {columns}

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -56,7 +56,7 @@ module.exports = {
             env: {
                 browser: true,
             },
-            plugins: ["@typescript-eslint", "deprecation"],
+            plugins: ["@typescript-eslint"],
             parser: "@typescript-eslint/parser",
             parserOptions: {
                 projectService: true,
@@ -64,7 +64,6 @@ module.exports = {
             },
             rules: {
                 ...tsEslintRules,
-                "deprecation/deprecation": "error",
             },
         },
         {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -7,7 +7,6 @@
         "@typescript-eslint/eslint-plugin": "^8.23.0",
         "@typescript-eslint/parser": "^8.23.0",
         "eslint": "^8.57.0",
-        "eslint-plugin-deprecation": "^2.0.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "~2.29.1",
         "eslint-plugin-jsdoc": "^48.0.2",

--- a/packages/eslint-config/typescript-eslint-rules.json
+++ b/packages/eslint-config/typescript-eslint-rules.json
@@ -49,6 +49,7 @@
         }
     ],
     "@typescript-eslint/no-confusing-non-null-assertion": "error",
+    "@typescript-eslint/no-deprecated": "error",
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-empty-interface": "error",
     "@typescript-eslint/no-empty-object-type": "error",

--- a/packages/popover2/src/index.ts
+++ b/packages/popover2/src/index.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable deprecation/deprecation */
-
 export {
     /** @deprecated import from `@blueprintjs/core` instead */
     type BreadcrumbProps,

--- a/packages/popover2/src/popover2.tsx
+++ b/packages/popover2/src/popover2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -201,6 +201,7 @@ class EditableTable extends React.Component<{}, EditableTableState> {
             <Table2
                 numRows={7}
                 selectionModes={SelectionModes.COLUMNS_AND_CELLS}
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 enableFocusedCell={true}
                 enableColumnInteractionBar={true}
             >

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -476,6 +476,7 @@ export class MutableTable extends React.Component<{}, MutableTableState> {
                 onColumnWidthChanged={this.onColumnWidthChanged}
                 onCompleteRender={this.onCompleteRender}
                 onCopy={this.onCopy}
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 onFocusedCell={this.onFocus}
                 onFocusedRegion={this.onFocusRegion}
                 onRowHeightChanged={this.onRowHeightChanged}

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -81,7 +81,7 @@ export interface EditableCellState {
 }
 
 // HACKHACK(adahiya): fix for Blueprint 6.0
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 @HotkeysTarget
 export class EditableCell extends React.Component<EditableCellProps, EditableCellState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.EditableCell`;

--- a/packages/table/src/common/contextMenuTargetWrapper.tsx
+++ b/packages/table/src/common/contextMenuTargetWrapper.tsx
@@ -19,7 +19,7 @@
  * Table components should use ContextMenu2 instead.
  */
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import * as React from "react";
 

--- a/packages/table/src/common/internal/focusedCellUtils.ts
+++ b/packages/table/src/common/internal/focusedCellUtils.ts
@@ -31,7 +31,7 @@ import * as Errors from "../errors";
  * deprecated enableFocusedCell API if that is not provided.
  */
 export function getFocusModeFromProps(props: TableProps): FocusMode | undefined {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { enableFocusedCell, focusMode } = props;
     return focusMode ?? getFocusModeFromEnabled(enableFocusedCell);
 }
@@ -45,7 +45,7 @@ function getFocusModeFromEnabled(enableFocusedCell = false): FocusMode | undefin
  * deprecated API if a focused region is not provided.
  */
 export function getFocusedRegionFromProps(props: TableProps): FocusedRegion | undefined {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { focusedRegion, focusedCell } = props;
     return focusedRegion ?? getFocusedCellFromCoordinates(focusedCell);
 }

--- a/packages/table/src/common/internal/platformUtils.ts
+++ b/packages/table/src/common/internal/platformUtils.ts
@@ -20,7 +20,7 @@
  */
 export function isMac(platformOverride?: string) {
     // HACKHACK: see https://github.com/palantir/blueprint/issues/5174
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     const platform = platformOverride ?? (typeof navigator !== "undefined" ? navigator.platform : undefined);
     return platform === undefined ? false : /Mac|iPod|iPhone|iPad/.test(platform);
 }

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -73,7 +73,6 @@ export {
     TableLoadingOption,
 } from "./regions";
 
-// eslint-disable-next-line deprecation/deprecation
 export { Table } from "./table";
 
 export type { TableProps } from "./tableProps";

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -370,7 +370,7 @@ export class DragSelectable extends React.PureComponent<DragSelectableProps> {
     }
 
     private invokeOnFocusCallbackForRegion = (focusRegion: Region, focusSelectionIndex = 0) => {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { focusMode, onFocusedCell, onFocusedRegion } = this.props;
         const focusedCellCoords = Regions.getFocusCellCoordinatesFromRegion(focusRegion);
         const newFocusedRegion = this.focusedCellUtils.toFocusedRegion(
@@ -414,7 +414,7 @@ export class DragSelectable extends React.PureComponent<DragSelectableProps> {
     }
 
     private getFocusedRegion(): FocusedRegion | undefined {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const { focusedCell, focusedRegion } = this.props;
         if (focusedRegion != null) {
             return focusedRegion;

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to Table2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/table/src/table2.tsx
+++ b/packages/table/src/table2.tsx
@@ -1510,7 +1510,7 @@ export class Table2 extends AbstractComponent<Table2Props, TableState, TableSnap
 
         if (focusedRegion.type === FocusMode.CELL) {
             const { type, ...focusedCell } = focusedRegion;
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             this.props.onFocusedCell?.(focusedCell);
         }
 

--- a/packages/table/test/common/internal/scrollUtilsTests.tsx
+++ b/packages/table/test/common/internal/scrollUtilsTests.tsx
@@ -340,7 +340,7 @@ describe("scrollUtils", () => {
         function mountElementsWithContentSize(contentWidth: number, contentHeight: number) {
             // HACKHACK: `as unknown as HTMLElement` cast is sketchy
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             return ReactDOM.render<React.HTMLProps<HTMLDivElement>>(
                 <div style={parentStyle}>
                     <div style={{ ...baseStyles, height: contentHeight, width: contentWidth }} />

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -26,8 +26,6 @@ import sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";
 
-/* eslint-disable deprecation/deprecation */
-
 import { Cell, EditableCell } from "../src";
 import * as TableClasses from "../src/common/classes";
 

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -55,7 +55,7 @@ function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: 
     let metaKey = false;
 
     if (modKey) {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         if (typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform)) {
             metaKey = true;
         } else {
@@ -64,7 +64,7 @@ function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: 
     }
 
     // HACKHACK: need to move away from custom test harness infrastructure in @blueprintjs/table package
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     event.initKeyboardEvent(eventType, true, true, window, key, 0, ctrlKey, false, false, metaKey);
     Object.defineProperty(event, "key", { get: () => key });
     Object.defineProperty(event, "which", { get: () => keyCode });
@@ -184,7 +184,7 @@ export class ElementHarness {
             // Apparently onChange listeners are listening for "input" events.
             const event = document.createEvent("HTMLEvents");
             // HACKHACK: need to move away from custom test harness infrastructure in @blueprintjs/table package
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             event.initEvent("input", true, true);
             this.element!.dispatchEvent(event);
         }
@@ -216,14 +216,14 @@ export class ReactHarness {
     public mount(component: React.ReactElement<any>) {
         // wrap in a root provider to avoid console warnings
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.render(React.createElement(BlueprintProvider, { children: component }), this.container);
         return new ElementHarness(this.container);
     }
 
     public unmount() {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(this.container);
     }
 

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -56,7 +56,7 @@ describe("Locator", () => {
         containerElement = document.createElement("div");
         document.body.appendChild(containerElement);
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.render(
             <div className="table-wrapper" style={style}>
                 <div className="body" style={style}>
@@ -78,7 +78,7 @@ describe("Locator", () => {
 
     afterEach(() => {
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         ReactDOM.unmountComponentAtNode(containerElement);
     });
 

--- a/packages/table/test/mocks/table.tsx
+++ b/packages/table/test/mocks/table.tsx
@@ -51,6 +51,6 @@ export function createTableWithData(columnNames: string[], data: string[][], col
     });
 
     // HACKHACK: see https://github.com/palantir/blueprint/issues/6126
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     return <Table {...tablePropsWithDefaults}>{SampleColumns}</Table>;
 }

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -560,7 +560,7 @@ describe("TableQuadrantStack", () => {
 
         afterEach(() => {
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             ReactDOM.unmountComponentAtNode(container);
             onScroll.resetHistory();
         });
@@ -718,7 +718,7 @@ describe("TableQuadrantStack", () => {
         const containerElement = document.createElement("div");
         document.body.appendChild(containerElement);
         // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         const component = ReactDOM.render<any>(element, containerElement);
         return {
             component: component as TableQuadrantStack,

--- a/packages/table/test/table2Tests.tsx
+++ b/packages/table/test/table2Tests.tsx
@@ -39,6 +39,8 @@ import { CellType, expectCellLoading } from "./cellTestUtils";
 import { type ElementHarness, ReactHarness } from "./harness";
 import { createStringOfLength, createTableOfSize } from "./mocks/table";
 
+/* eslint-disable @typescript-eslint/no-deprecated */
+
 /**
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26979#issuecomment-465304376
  */
@@ -62,7 +64,6 @@ describe("<Table2>", function (this) {
         harness.unmount();
         if (containerElement !== undefined) {
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-            // eslint-disable-next-line deprecation/deprecation
             ReactDOM.unmountComponentAtNode(containerElement);
             containerElement.remove();
         }
@@ -1501,7 +1502,6 @@ describe("<Table2>", function (this) {
             const tableNode = table.getDOMNode();
             const tableBodySelector = `.${Classes.TABLE_BODY_VIRTUAL_CLIENT}`;
             // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-            // eslint-disable-next-line deprecation/deprecation
             const tableBodyNode = ReactDOM.findDOMNode(tableNode.querySelector(tableBodySelector));
 
             // trigger a drag-selection starting at the center of the activation cell

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to TableBody2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components */
+/* eslint-disable @blueprintjs/no-deprecated-components */
 
 import { expect } from "chai";
 import { mount, type ReactWrapper } from "enzyme";

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to Table2 instead.
  */
 
-/* eslint-disable deprecation/deprecation, @blueprintjs/no-deprecated-components, sort-keys */
+/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components, sort-keys */
 
 import { expect } from "chai";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,7 +674,6 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.23.0"
     "@typescript-eslint/parser": "npm:^8.23.0"
     eslint: "npm:^8.57.0"
-    eslint-plugin-deprecation: "npm:^2.0.0"
     eslint-plugin-header: "npm:^3.1.1"
     eslint-plugin-import: "npm:~2.29.1"
     eslint-plugin-jsdoc: "npm:^48.0.2"
@@ -3139,7 +3138,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.14
   resolution: "@types/json-schema@npm:7.0.14"
   checksum: da68689ccd44cb93ca4c9a4af3b25c6091ecf45fb370d1ed0d0ac5b780e235bf0b9bdc1f7e28f19e6713b22567c3db11fefcbcc6d48ac6b356d035a8f9f4ea30
@@ -3315,13 +3314,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.5.0":
-  version: 7.5.4
-  resolution: "@types/semver@npm:7.5.4"
-  checksum: dee66a71d9f089c118be74b5937d4fef42864d68d9472a3f4f5399b9e3ad74d56a8e155020c846667b9ecf9de78fdb9ea55a53fff5067af28e06779b282b6c40
-  languageName: node
-  linkType: hard
-
 "@types/send@npm:*":
   version: 0.17.3
   resolution: "@types/send@npm:0.17.3"
@@ -3476,16 +3468,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/scope-manager@npm:6.19.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:6.19.1"
-    "@typescript-eslint/visitor-keys": "npm:6.19.1"
-  checksum: a81315b4a2888343d3be781fe8d6b4c229c656d7bf1bd74bc44a89bba96bb6a10a0319d301f24ca91adb898374eaadbd38979e6567ac9085b5d7076163794281
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.23.0":
   version: 8.23.0
   resolution: "@typescript-eslint/scope-manager@npm:8.23.0"
@@ -3511,36 +3493,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/types@npm:6.19.1"
-  checksum: b8f75df157ca383e5bd6c07276fbeed6ff775e1354260a1653777749c0d71626fb29be5d36c9570e2c5cfaa5db62deaae20aa4be8a2d7d753782ab66d88e007f
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.23.0":
   version: 8.23.0
   resolution: "@typescript-eslint/types@npm:8.23.0"
   checksum: 78737a14e8469e33212d9bbc26d6880bca3f8e47764273eb4c662f5ed38d0b35c626d646d4a8e9a6ee64a0e352b18dd36422e59ce217362b5af473b79d058b35
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/typescript-estree@npm:6.19.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:6.19.1"
-    "@typescript-eslint/visitor-keys": "npm:6.19.1"
-    debug: "npm:^4.3.4"
-    globby: "npm:^11.1.0"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:9.0.3"
-    semver: "npm:^7.5.4"
-    ts-api-utils: "npm:^1.0.1"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: dec16f873084e9eeb1a696dff82c42164e75908221f7868d900ad7b7fcec6fc62a9a7dddb8bc17c78c19bf35f07acee81b3778b20b9735ffdaeee732ecb643d3
   languageName: node
   linkType: hard
 
@@ -3574,33 +3530,6 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.8.0"
   checksum: 8967cf6543b1df2fb8d29086a0d35f5f7623e935706ad7c5bfcc6123e6fb08a767be1770601d481d815022bec43422730c6c8035892f23cd11cdadb16176b418
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/utils@npm:^6.0.0":
-  version: 6.19.1
-  resolution: "@typescript-eslint/utils@npm:6.19.1"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@types/json-schema": "npm:^7.0.12"
-    "@types/semver": "npm:^7.5.0"
-    "@typescript-eslint/scope-manager": "npm:6.19.1"
-    "@typescript-eslint/types": "npm:6.19.1"
-    "@typescript-eslint/typescript-estree": "npm:6.19.1"
-    semver: "npm:^7.5.4"
-  peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
-  checksum: 5fa58a32722e9915bfe8433fda2f46be894352549e8406acc4e29a04a8ddb0ea5988fddda2a3145f8952129a267cb51b666206b30489d2ff36b7911f540f1d57
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:6.19.1":
-  version: 6.19.1
-  resolution: "@typescript-eslint/visitor-keys@npm:6.19.1"
-  dependencies:
-    "@typescript-eslint/types": "npm:6.19.1"
-    eslint-visitor-keys: "npm:^3.4.1"
-  checksum: b0370a9bc6fd8d243aa8b7ccd1657ec2fbd25ceb7b067aac64322f03aa0f64b97444b13b0946f52a53d6bc5edd43e0b447f72160be4a5b72e073c1d3679b6b4c
   languageName: node
   linkType: hard
 
@@ -7148,20 +7077,6 @@ __metadata:
     eslint:
       optional: true
   checksum: c7a8d1a58d76ec8217a8fea49271ec8132d1b9390965a75f6a4ecbc9e5983d742195b46d2e4378231d2186801439fe1aa5700714b0bfd4eb17aac6e1b65309df
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-deprecation@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "eslint-plugin-deprecation@npm:2.0.0"
-  dependencies:
-    "@typescript-eslint/utils": "npm:^6.0.0"
-    tslib: "npm:^2.3.1"
-    tsutils: "npm:^3.21.0"
-  peerDependencies:
-    eslint: ^7.0.0 || ^8.0.0
-    typescript: ^4.2.4 || ^5.0.0
-  checksum: 6b9cb65ecd3e98d29683bb9b7e5af01e8ac8acadacc313e18757b8120c3850a5a11bfea67f3203975a82e018ea1c07d79dabe20ade921658e8bc03c736469079
   languageName: node
   linkType: hard
 
@@ -11378,15 +11293,6 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: baa60fc5839205f13d6c266d8ad4d160ae37c33f66b130b5640acac66deff84b934ac6307f5dc5e4b30362c51284817c12df7c9746ffb600b9009c581e0b1634
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 85f407dcd38ac3e180f425e86553911d101455ca3ad5544d6a7cec16286657e4f8a9aa6695803025c55e31e35a91a2252b5dc8e7d527211278b8b65b4dbd5eac
   languageName: node
   linkType: hard
 
@@ -15818,15 +15724,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^1.0.1":
-  version: 1.0.3
-  resolution: "ts-api-utils@npm:1.0.3"
-  peerDependencies:
-    typescript: ">=4.2.0"
-  checksum: 9408338819c3aca2a709f0bc54e3f874227901506cacb1163612a6c8a43df224174feb965a5eafdae16f66fc68fd7bfee8d3275d0fa73fbb8699e03ed26520c9
-  languageName: node
-  linkType: hard
-
 "ts-api-utils@npm:^2.0.1":
   version: 2.0.1
   resolution: "ts-api-utils@npm:2.0.1"
@@ -15880,7 +15777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.3.1, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:~2.6.2":
+"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:~2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb


### PR DESCRIPTION
#### Changes proposed in this pull request:

Now that the `@typescript-eslint` packages have been updated in https://github.com/palantir/blueprint/pull/7229, we can get rid of https://github.com/gund/eslint-plugin-deprecation, which is no longer maintained as the rule has been incorporated to `@typescript-eslint`.

Note that the rule has some slight differences (e.g. there's no warning when exporting a deprecated object) and so besides updating the `eslint-disable` comments, I've also removed them where they're no longer needed.
