### PR TITLE
fix(Core) Fix variables imports

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -1,8 +1,8 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@use "@blueprintjs/colors/lib/scss/colors" as *;
-@use "color-aliases" as *;
+@import "@blueprintjs/colors/lib/scss/colors";
+@import "color-aliases";
 
 // ----------------------------------------------------------------------------
 // This file is part of the public Sass API of @blueprintjs/core.


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/pull/7157

#### Changes proposed in this pull request:

In https://github.com/palantir/blueprint/pull/7157 we switched our sass from `@import` to `@use` across the board, however this has the side effect of not re-exporting the imported variables to consumers of that sass file. For our `_variables.scss` we need our consumers to have these variables since that's the contract of this file. As a result consumers of core were failing to compile unless they took an explicit dependency on the colors package. This should hopefully fix that.