### PR TITLE
Use stylelint's `report` instead of `output`

### DIFF
--- a/packages/node-build-scripts/sass-lint.mjs
+++ b/packages/node-build-scripts/sass-lint.mjs
@@ -33,9 +33,9 @@ stylelint
     .then(resultObject => {
         if (reportPath !== undefined) {
             console.info(`[node-build-scripts/sass-lint] Stylelint report will appear in ${reportPath}`);
-            writeFileSync(reportPath, resultObject.output);
+            writeFileSync(reportPath, resultObject.report);
         } else {
-            console.info(resultObject.output);
+            console.info(resultObject.report);
         }
         if (resultObject.errored) {
             exit(2);


### PR DESCRIPTION
Stylelint 16 deprecated the `output` property from the result object: https://stylelint.io/migration-guide/to-16/#changed-nodejs-api-returned-resolved-object

This change cleans up these deprecations from CI: https://app.circleci.com/pipelines/github/palantir/blueprint/7588/workflows/318eaca9-28d9-4ae8-8e02-62f963f3431d/jobs/100615?invite=true#step-106-893_70