### PR TITLE
[chore] Remove underscore prefix from memo/forwardRef components

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -40,7 +40,7 @@ export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
  *
  * @see https://blueprintjs.com/docs/#core/components/context-menu-popover
  */
-export const ContextMenuPopover = React.memo(function _ContextMenuPopover(props: ContextMenuPopoverProps) {
+export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: ContextMenuPopoverProps) {
     const {
         content,
         popoverClassName,

--- a/packages/core/src/components/forms/asyncControllableTextArea.tsx
+++ b/packages/core/src/components/forms/asyncControllableTextArea.tsx
@@ -14,7 +14,7 @@ export type AsyncControllableTextAreaProps = React.TextareaHTMLAttributes<HTMLTe
  * the same way <AsyncControllableInput> does.
  */
 export const AsyncControllableTextArea = React.forwardRef<HTMLTextAreaElement, AsyncControllableTextAreaProps>(
-    function _AsyncControllableTextArea(props, ref) {
+    function AsyncControllableTextArea(props, ref) {
         const {
             value: parentValue,
             onChange: parentOnChange,

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -231,7 +231,7 @@ export const DATEINPUT_DEFAULT_PROPS = {
  * @see https://blueprintjs.com/docs/#datetime/date-input
  * @deprecated use `{ DateInput3 } from "@blueprintjs/datetime2"` instead
  */
-export const DateInput: React.FC<DateInputProps> = React.memo(function _DateInput(props) {
+export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput(props) {
     const {
         defaultTimezone,
         defaultValue,

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -73,7 +73,7 @@ export const DATEINPUT3_DEFAULT_PROPS: DateInput3DefaultProps = {
  *
  * @see https://blueprintjs.com/docs/#datetime2/date-input3
  */
-export const DateInput3: React.FC<DateInput3Props> = React.memo(function _DateInput(props) {
+export const DateInput3: React.FC<DateInput3Props> = React.memo(function DateInput3(props) {
     const {
         closeOnSelection,
         dateFnsFormat,


### PR DESCRIPTION
#### Proposed changes:

Removes `_` prefix from the inner functions of certain components. The purpose of this is to more easily comply the with `react-hooks/rules-of-hooks` check  (see [this comment](https://github.com/palantir/blueprint/pull/7252/files#r1953639347)).

#### Reviewers should focus on:

- Are the naming collisions relevant/important here? Are the prefixes necessary?
