### PR TITLE
[chore] Remove unused eslint-disable directives

### DIFF
--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -18,7 +18,7 @@
  * All changes & bugfixes should be made to Overlay2 instead.
  */
 
-/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import classNames from "classnames";
 import * as React from "react";

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -19,7 +19,7 @@
  * All changes & bugfixes should be made to PanelStack2 instead.
  */
 
-/* eslint-disable @typescript-eslint/no-deprecated, max-classes-per-file, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated, max-classes-per-file */
 
 import * as React from "react";
 

--- a/packages/docs-app/src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx
@@ -19,7 +19,7 @@
  * Newer datetime2 components support date-fns format strings directly.
  */
 
-/* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
+/* eslint-disable @typescript-eslint/no-deprecated */
 
 import { format, type Locale, parse } from "date-fns";
 import * as React from "react";


### PR DESCRIPTION
#### Proposed changes:

Follow up to #7252

Removes some unused eslint-disable directives in `docs-app` causing the following warnings to appear during lint:

```
> nx run @blueprintjs/docs-app:lint

[node-build-scripts/es-lint] Running ESLint on /Volumes/git/blueprint/packages/docs-app/{src,test}/**/*.{ts,tsx}
warning: Unused eslint-disable directive (no problems were reported from '@blueprintjs/no-deprecated-components') (null) at src/examples/core-examples/overlayExample.tsx:21:1:
  19 |  */
  20 |
> 21 | /* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
     | ^
  22 |
  23 | import classNames from "classnames";
  24 | import * as React from "react";
warning: Unused eslint-disable directive (no problems were reported from '@blueprintjs/no-deprecated-components') (null) at src/examples/core-examples/panelStackExample.tsx:22:1:
  20 |  */
  21 |
> 22 | /* eslint-disable @typescript-eslint/no-deprecated, max-classes-per-file, @blueprintjs/no-deprecated-components */
     | ^
  23 |
  24 | import * as React from "react";
  25 |
warning: Unused eslint-disable directive (no problems were reported from '@blueprintjs/no-deprecated-components') (null) at src/examples/datetime-examples/common/dateFnsDateFormatPropsSelect.tsx:22:1:
  20 |  */
  21 |
> 22 | /* eslint-disable @typescript-eslint/no-deprecated, @blueprintjs/no-deprecated-components */
     | ^
  23 |
  24 | import { format, type Locale, parse } from "date-fns";
  25 | import * as React from "react";
```
