### PR TITLE
Improve typings of `blueprintPlugin` export

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -13,12 +13,14 @@
  * limitations under the License.
  */
 
+import type { TSESLint } from "@typescript-eslint/utils";
+
 import rules from "./rules";
 
-const blueprintPlugin = { configs: {}, rules };
+const blueprintPlugin = { configs: { recommended: {} }, rules };
 
 // Assign the config here so that we can reference blueprintPlugin.
-Object.assign(blueprintPlugin.configs, {
+const configs: { [c in keyof (typeof blueprintPlugin)["configs"]]: TSESLint.FlatConfig.Config } = {
     /**
      * Enables all Blueprint-specific lint rules defined in this package.
      */
@@ -31,6 +33,7 @@ Object.assign(blueprintPlugin.configs, {
             "@blueprintjs/no-deprecated-type-references": "error",
         },
     },
-});
+};
+Object.assign(blueprintPlugin.configs, configs);
 
 export = blueprintPlugin;

--- a/packages/eslint-plugin/src/rules/classes-constants.ts
+++ b/packages/eslint-plugin/src/rules/classes-constants.ts
@@ -33,7 +33,7 @@ export const classesConstantsRule = createRule<[], MessageIds>({
     meta: {
         docs: {
             description: "Enforce usage of Classes constants over namespaced string literals.",
-            recommended: "recommended",
+            recommended: true,
             requiresTypeChecking: false,
         },
         fixable: "code",

--- a/packages/eslint-plugin/src/rules/html-components.ts
+++ b/packages/eslint-plugin/src/rules/html-components.ts
@@ -31,7 +31,7 @@ export const htmlComponentsRule = createRule<[], MessageIds>({
     meta: {
         docs: {
             description: "Enforce usage of Blueprint components over JSX intrinsic elements.",
-            recommended: "recommended",
+            recommended: true,
             requiresTypeChecking: false,
         },
         fixable: "code",

--- a/packages/eslint-plugin/src/rules/icon-components.ts
+++ b/packages/eslint-plugin/src/rules/icon-components.ts
@@ -30,7 +30,7 @@ export const iconComponentsRule = createRule<Options, MessageIds>({
     meta: {
         docs: {
             description: "Enforce usage of JSX Icon components over IconName string literals (or vice-versa)",
-            recommended: "recommended",
+            recommended: true,
             requiresTypeChecking: false,
         },
         fixable: "code",

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts
@@ -52,7 +52,7 @@ export function createNoDeprecatedComponentsRule(
             docs: {
                 description: `Reports on usage of deprecated Blueprint components${descriptionFromClause} and recommends migrating to their corresponding non-deprecated API alternatives.`,
                 requiresTypeChecking: false,
-                recommended: "recommended",
+                recommended: true,
             },
             messages: {
                 migration:

--- a/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-type-references.ts
@@ -194,7 +194,7 @@ export const noDeprecatedTypeReferencesRule = createRule<[], MessageIds>({
             description:
                 "Reports on usage of deprecated Blueprint types and recommends migrating to their corresponding replacements.",
             requiresTypeChecking: false,
-            recommended: "recommended",
+            recommended: true,
         },
         fixable: "code",
         messages: {

--- a/packages/eslint-plugin/src/rules/utils/createRule.ts
+++ b/packages/eslint-plugin/src/rules/utils/createRule.ts
@@ -15,10 +15,9 @@
  */
 
 import { ESLintUtils } from "@typescript-eslint/utils";
-import { type RuleRecommendation } from "@typescript-eslint/utils/ts-eslint";
 
 export interface PluginDocs {
-    recommended: RuleRecommendation;
+    recommended: boolean;
     requiresTypeChecking: boolean;
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

Better define the `blueprintPlugin` that's exported by the ESLint plugin. By initially setting `configs` to an empty object, the following error appears when consuming the `recommended` configuration:

![image](https://github.com/user-attachments/assets/4d02bcfc-0c8f-4575-ab90-e24478115b68)

This PR 

The other change involves making the `recommended` property in the rule docs a boolean instead of a string. I had used the wrong type before because I was using the [`typescript-eslint` plugin](https://github.com/typescript-eslint/typescript-eslint/blob/662e62baca4ed8910d09b24db64ec3535e53863d/packages/eslint-plugin/rules.d.ts#L41) as a misguided reference.