### PR TITLE
[docs] Fix horizontal overflow scrolling sidebar nav

### DIFF
--- a/packages/core/src/docs/accessibility.md
+++ b/packages/core/src/docs/accessibility.md
@@ -37,9 +37,9 @@ This behavior is controlled by a singleton instance called `FocusStyleManager` t
 -   `FocusStyleManager.onlyShowFocusOnTabs(): void`: Enable behavior which hides focus styles during mouse interaction.
 -   `FocusStyleManager.alwaysShowFocus(): void`: Stop this behavior (focus styles are always visible).
 
-@### Selectively ignoring the focus style manager
+@### Ignoring focus style manager
 
-There is an escape hatch to allow components to ignore the focus style manager. This
+There is an escape hatch to allow components to selectively ignore the focus style manager. This
 can be useful when you do want to always show the focus outline, but only for certain
 components, like a tree. This is done by applying `Classes.FOCUS_STYLE_MANAGER_IGNORE`
 to a container element.

--- a/packages/core/src/docs/typography.md
+++ b/packages/core/src/docs/typography.md
@@ -86,7 +86,7 @@ use the library of your choice for managing internationalized strings.
 
 Blueprint supports layout and text alignment adjustments for right-to-left (RTL) languages to ensure proper rendering in different writing systems.
 
-@#### Logical Properties: Start and End
+@#### Logical Properties
 
 To provide better RTL support, many Blueprint components adopt [logical property names](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values) for alignment. Logical properties are direction-relative, meaning their behavior depends on the text direction (LTR or RTL) of the document:
 

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -63,8 +63,7 @@ Page layout elements
   // these rules allow the nav background-color to cover all area to the left
   /* stylelint-disable-next-line order/properties-order */
   margin-left: -$background-shift;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden auto;
   padding-bottom: $sidebar-padding * 2;
   padding-left: $background-shift + $container-padding;
 

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -63,6 +63,7 @@ Page layout elements
   // these rules allow the nav background-color to cover all area to the left
   /* stylelint-disable-next-line order/properties-order */
   margin-left: -$background-shift;
+  overflow-x: hidden;
   overflow-y: auto;
   padding-bottom: $sidebar-padding * 2;
   padding-left: $background-shift + $container-padding;

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -8,7 +8,7 @@
 $container-width: $pt-grid-size * 110;
 $container-padding: $pt-grid-size * 0.5;
 
-$sidebar-width: $pt-grid-size * 27;
+$sidebar-width: $pt-grid-size * 30;
 $sidebar-padding: $pt-grid-size * 1.5;
 $sidebar-background-color: $white;
 $dark-sidebar-background-color: $dark-gray3;


### PR DESCRIPTION
#### Proposed changes

Fixes a small issue where the left sidebar navigation scrolls horizontally in the Blueprint docs (looks bad)

![Screenshot 2025-02-21 at 16 31 50](https://github.com/user-attachments/assets/f50a1170-aedb-4ce8-b530-bc90e1a313d9)

#### Screenshots

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/6c6f943e-ead9-4c51-a3c9-d8c181d5f5fd) | ![after](https://github.com/user-attachments/assets/4adaa8d9-7252-4280-a8ed-a020a0a34364) |



