### PR TITLE
fix(Table): Fix not being able to use focus mode as a value

### DIFF
--- a/packages/table/src/common/index.ts
+++ b/packages/table/src/common/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export type { CellCoordinates, FocusedCellCoordinates, FocusMode } from "./cellTypes";
+export { type CellCoordinates, type FocusedCellCoordinates, FocusMode } from "./cellTypes";
 export { Clipboard } from "./clipboard";
 export { Grid } from "./grid";
 export { Rect, type AnyRect } from "./rect";

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -30,7 +30,7 @@ export {
     type AnyRect,
     type CellCoordinates,
     Clipboard,
-    type FocusMode,
+    FocusMode,
     type FocusedCellCoordinates,
     Grid,
     Rect,


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7265

#### Changes proposed in this pull request:

We were just exporting the types of `FocusMode` which means that trying to use it as a value (e.g. `FocusMode.ROW`) would fail at compile time.
