### PR TITLE
fix(DayRangePicker3): Fixed being able to get out of bounds in non contiguous mode

### DIFF
--- a/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
@@ -50,6 +50,8 @@ export const NonContiguousDayRangePicker: React.FC<DayRangePickerProps> = ({
         initialMonthAndYear,
         value,
         dayPickerProps?.onMonthChange,
+        minDate,
+        maxDate,
     );
 
     const handleDaySelect = React.useCallback<SelectRangeEventHandler>(
@@ -133,6 +135,8 @@ function useNonContiguousCalendarViews(
     initialMonthAndYear: MonthAndYear,
     selectedRange: DateRange,
     userOnMonthChange: MonthChangeEventHandler | undefined,
+    minDate: Date | undefined,
+    maxDate: Date | undefined,
 ): NonContiguousCalendarViews {
     // show the selected end date's encompassing month in the right view if
     // the calendars don't have to be contiguous.
@@ -204,48 +208,49 @@ function useNonContiguousCalendarViews(
         });
     }, [setViews, selectedRange]);
 
-    const updateLeftView = React.useCallback(
-        (newLeftView: MonthAndYear) => {
+    const handleLeftMonthChange = React.useCallback(
+        (newDate: Date) => {
+            let newLeftView = MonthAndYear.fromDate(newDate);
             setViews(({ right }) => {
                 let newRightView = right.clone();
                 if (!newLeftView.isBefore(newRightView)) {
                     newRightView = newLeftView.getNextMonth();
                 }
+
+                let maxView = MonthAndYear.fromDate(maxDate ?? null);
+                if (maxView != null && newRightView.isAfter(maxView)) {
+                    newRightView = maxView;
+                    newLeftView = newRightView.getPreviousMonth();
+                }
+
+                console.log("New left view", newLeftView);
+                userOnMonthChange?.(newLeftView.getFullDate());
                 return { left: newLeftView, right: newRightView };
             });
         },
-        [setViews],
+        [setViews, userOnMonthChange],
     );
 
-    const updateRightView = React.useCallback(
-        (newRightView: MonthAndYear) => {
+    const handleRightMonthChange = React.useCallback(
+        (newDate: Date) => {
+            let newRightView = MonthAndYear.fromDate(newDate);
             setViews(({ left }) => {
                 let newLeftView = left.clone();
                 if (!newRightView.isAfter(newLeftView)) {
                     newLeftView = newRightView.getPreviousMonth();
                 }
+
+                let minView = MonthAndYear.fromDate(minDate ?? null);
+                if (minView != null && newLeftView.isBefore(minView)) {
+                    newLeftView = minView;
+                    newRightView = newLeftView.getNextMonth();
+                }
+
+                userOnMonthChange?.(newRightView.getFullDate());
                 return { left: newLeftView, right: newRightView };
             });
         },
-        [setViews],
-    );
-
-    const handleLeftMonthChange = React.useCallback<MonthChangeEventHandler>(
-        newDate => {
-            const newLeftView = MonthAndYear.fromDate(newDate);
-            updateLeftView(newLeftView);
-            userOnMonthChange?.(newDate);
-        },
-        [userOnMonthChange, updateLeftView],
-    );
-
-    const handleRightMonthChange = React.useCallback<MonthChangeEventHandler>(
-        newDate => {
-            const newRightView = MonthAndYear.fromDate(newDate);
-            updateRightView(newRightView);
-            userOnMonthChange?.(newDate);
-        },
-        [userOnMonthChange, updateRightView],
+        [setViews, userOnMonthChange],
     );
 
     return {

--- a/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
@@ -249,7 +249,12 @@ function useNonContiguousCalendarViews(
     };
 }
 
-function getBoundedViews(leftView: MonthAndYear, rightView: MonthAndYear, minDate: Date | undefined, maxDate: Date | undefined): [left: MonthAndYear, right: MonthAndYear] {
+function getBoundedViews(
+    leftView: MonthAndYear,
+    rightView: MonthAndYear,
+    minDate: Date | undefined,
+    maxDate: Date | undefined,
+): [left: MonthAndYear, right: MonthAndYear] {
     let minView = MonthAndYear.fromDate(minDate ?? null);
     if (minView != null && leftView.isBefore(minView)) {
         return [minView, minView.getNextMonth()];
@@ -260,7 +265,7 @@ function getBoundedViews(leftView: MonthAndYear, rightView: MonthAndYear, minDat
         return [maxView.getPreviousMonth(), maxView];
     }
 
-    return [leftView, rightView]
+    return [leftView, rightView];
 }
 
 function getInitialRightView(selectedRangeEnd: Date | null, leftView: MonthAndYear) {

--- a/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
@@ -255,12 +255,12 @@ function getBoundedViews(
     minDate: Date | undefined,
     maxDate: Date | undefined,
 ): [left: MonthAndYear, right: MonthAndYear] {
-    let minView = MonthAndYear.fromDate(minDate ?? null);
+    const minView = MonthAndYear.fromDate(minDate ?? null);
     if (minView != null && leftView.isBefore(minView)) {
         return [minView, minView.getNextMonth()];
     }
 
-    let maxView = MonthAndYear.fromDate(maxDate ?? null);
+    const maxView = MonthAndYear.fromDate(maxDate ?? null);
     if (maxView != null && rightView.isAfter(maxView)) {
         return [maxView.getPreviousMonth(), maxView];
     }

--- a/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
@@ -217,18 +217,12 @@ function useNonContiguousCalendarViews(
                     newRightView = newLeftView.getNextMonth();
                 }
 
-                let maxView = MonthAndYear.fromDate(maxDate ?? null);
-                if (maxView != null && newRightView.isAfter(maxView)) {
-                    newRightView = maxView;
-                    newLeftView = newRightView.getPreviousMonth();
-                }
-
-                console.log("New left view", newLeftView);
+                [newLeftView, newRightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
                 userOnMonthChange?.(newLeftView.getFullDate());
                 return { left: newLeftView, right: newRightView };
             });
         },
-        [setViews, userOnMonthChange],
+        [minDate, maxDate, setViews, userOnMonthChange],
     );
 
     const handleRightMonthChange = React.useCallback(
@@ -240,17 +234,12 @@ function useNonContiguousCalendarViews(
                     newLeftView = newRightView.getPreviousMonth();
                 }
 
-                let minView = MonthAndYear.fromDate(minDate ?? null);
-                if (minView != null && newLeftView.isBefore(minView)) {
-                    newLeftView = minView;
-                    newRightView = newLeftView.getNextMonth();
-                }
-
+                [newLeftView, newRightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
                 userOnMonthChange?.(newRightView.getFullDate());
                 return { left: newLeftView, right: newRightView };
             });
         },
-        [setViews, userOnMonthChange],
+        [minDate, maxDate, setViews, userOnMonthChange],
     );
 
     return {
@@ -258,6 +247,20 @@ function useNonContiguousCalendarViews(
         handleLeftMonthChange,
         handleRightMonthChange,
     };
+}
+
+function getBoundedViews(leftView: MonthAndYear, rightView: MonthAndYear, minDate: Date | undefined, maxDate: Date | undefined): [left: MonthAndYear, right: MonthAndYear] {
+    let minView = MonthAndYear.fromDate(minDate ?? null);
+    if (minView != null && leftView.isBefore(minView)) {
+        return [minView, minView.getNextMonth()];
+    }
+
+    let maxView = MonthAndYear.fromDate(maxDate ?? null);
+    if (maxView != null && rightView.isAfter(maxView)) {
+        return [maxView.getPreviousMonth(), maxView];
+    }
+
+    return [leftView, rightView]
 }
 
 function getInitialRightView(selectedRangeEnd: Date | null, leftView: MonthAndYear) {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7267


#### Changes proposed in this pull request:

Fixed an issue that would allow users to get out of bounds by moving to an invalid month in a different year and then changing to that year. For example, if the max date is March 2024, you can switch to May 2023 and then change the year to 2024 and result in a broken state. This works in both directions for min and max dates.

Some minimal repros include:

```tsx
<DateRangeInput3
    contiguousCalendarMonths={false}
    minDate={new Date(2024, 3, 1)}
/>
```

```tsx
<DateRangeInput3
    contiguousCalendarMonths={false}
    maxDate={new Date()}
/>
```
