### PR TITLE
Make ESLint plugin backwards compatible with v8

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -26,7 +26,7 @@ const eslintPluginRules = require("./eslint-plugin-rules.js");
 const tsEslintRules = require("./typescript-eslint-rules.js");
 
 module.exports = tseslint.config(
-    blueprintPlugin.configs.recommended,
+    blueprintPlugin.flatConfigs.recommended,
     importPlugin.flatConfigs.typescript,
     {
         plugins: {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,8 +11,10 @@
         "test": "SWC_NODE_PROJECT=./tsconfig.test.json mocha --require @swc-node/register,test/setup.ts --watch-extensions ts,tsx 'test/**/*.{ts,tsx}'"
     },
     "dependencies": {
-        "@typescript-eslint/utils": "^8.23.0",
-        "eslint": "^9.20.0"
+        "@typescript-eslint/utils": "^8.23.0"
+    },
+    "peerDependencies": {
+        "eslint": "^8.57 || ^9.0.0"
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "workspace:^",

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -17,23 +17,31 @@ import type { TSESLint } from "@typescript-eslint/utils";
 
 import rules from "./rules";
 
-const blueprintPlugin = { configs: { recommended: {} }, rules };
+type ConfigName = "recommended";
 
-// Assign the config here so that we can reference blueprintPlugin.
-const configs: { [c in keyof (typeof blueprintPlugin)["configs"]]: TSESLint.FlatConfig.Config } = {
-    /**
-     * Enables all Blueprint-specific lint rules defined in this package.
-     */
-    recommended: {
-        plugins: { "@blueprintjs": blueprintPlugin },
-        rules: {
-            "@blueprintjs/classes-constants": "error",
-            "@blueprintjs/html-components": "error",
-            "@blueprintjs/no-deprecated-components": "error",
-            "@blueprintjs/no-deprecated-type-references": "error",
-        },
+const blueprintPlugin = {
+    configs: { recommended: {} } as Record<ConfigName, TSESLint.ClassicConfig.Config>,
+    flatConfigs: { recommended: {} } as Record<ConfigName, TSESLint.FlatConfig.Config>,
+    rules,
+};
+
+// The recommended config enables all Blueprint-specific lint rules defined in this package.
+const config: TSESLint.ClassicConfig.Config = {
+    plugins: ["@blueprintjs"],
+    rules: {
+        "@blueprintjs/classes-constants": "error",
+        "@blueprintjs/html-components": "error",
+        "@blueprintjs/no-deprecated-components": "error",
+        "@blueprintjs/no-deprecated-type-references": "error",
     },
 };
-Object.assign(blueprintPlugin.configs, configs);
+const flatConfig: TSESLint.FlatConfig.Config = {
+    ...config,
+    plugins: { "@blueprintjs": blueprintPlugin },
+};
+
+// Assign the config here so that we can reference blueprintPlugin.
+Object.assign(blueprintPlugin.configs.recommended, config);
+Object.assign(blueprintPlugin.flatConfigs.recommended, flatConfig);
 
 export = blueprintPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -701,9 +701,10 @@ __metadata:
     "@typescript-eslint/rule-tester": "npm:^8.23.0"
     "@typescript-eslint/utils": "npm:^8.23.0"
     dedent: "npm:^1.5.1"
-    eslint: "npm:^9.20.0"
     mocha: "npm:^10.2.0"
     typescript: "npm:~5.3.3"
+  peerDependencies:
+    eslint: ^8.57 || ^9.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Follow-up of https://github.com/palantir/blueprint/pull/7252.

To make the transition easier for consumers of the ESLint plugin, I'm making it backwards compatible with ESLint by adding both a "flat" configuration and a legacy one.
