### PR TITLE
Add "inputSize" to InputGroup's filtered non-HTML props

### DIFF
--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -98,7 +98,7 @@ export interface InputGroupState {
     rightElementWidth?: number;
 }
 
-const NON_HTML_PROPS: Array<keyof InputGroupProps> = ["onValueChange"];
+const NON_HTML_PROPS: Array<keyof InputGroupProps> = ["inputSize", "onValueChange"];
 
 /**
  * Input group component.


### PR DESCRIPTION
#### Proposed changes:

Issue raised in https://github.com/palantir/blueprint/issues/7232#issuecomment-2687691254, related to #7232

Fixes the following React warning coming from `InputGroup`:
```
Warning: React does not recognize the `inputSize` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `inputsize` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

This occurs when either using `inputSize` on `InputGroup`, e.g. 
```tsx
<InputGroup inputSize={10} />
```
or when using a component that wraps `InputGroup` and sets `inputSize`, like `NumericInput`.

---

Adds `inputSize` to `NON_HTML_PROPS` so that it is filtered out when it is passed to `removeNonHTMLProps`.

https://github.com/palantir/blueprint/blob/78b9f6bf3e49c5292aeaea1ef073b31d1a63ba83/packages/core/src/components/forms/inputGroup.tsx#L101

https://github.com/palantir/blueprint/blob/78b9f6bf3e49c5292aeaea1ef073b31d1a63ba83/packages/core/src/components/forms/inputGroup.tsx#L160