### PR TITLE
Remove unwarranted size deprecation console warnings

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -141,14 +141,14 @@ export const OVERLAY_CHILD_REQUIRES_KEY =
 
 export function logDeprecatedSizeWarning(component: string, props: Partial<Record<"large" | "small", boolean>>) {
     const { large, small } = props;
-    if (large != null && small != null) {
+    if (large && small) {
         console.warn(
             ns +
                 ` <${component}> large and small props are mutually exclusive. Please use size="large" or size="small" instead.`,
         );
-    } else if (large != null) {
+    } else if (large) {
         console.warn(ns + ` <${component}> large is deprecated. Please use size="large" instead.`);
-    } else if (small != null) {
+    } else if (small) {
         console.warn(ns + ` <${component}> small is deprecated. Please use size="small" instead.`);
     }
 }


### PR DESCRIPTION
#### Proposed changes:

Issue raised in https://github.com/palantir/blueprint/issues/7232#issuecomment-2687691254, related to #7232

Fixes deprecation warnings for newly deprecated `small` and `large` props firing where they shouldn't for components that provide `defaultProps` to these props (like NumericInput).

Setting these to explicitly check for `true` values makes the warning less effective against warning against mixed use, e.g.
```tsx
<InputGroup small={true} large={false} />
```
but it also makes it more resilient against triggering false-positives, which seems more important.