### PR TITLE
[core] fix: Switch literal unions to enums

### DIFF
--- a/packages/core/src/common/buttonVariant.ts
+++ b/packages/core/src/common/buttonVariant.ts
@@ -2,4 +2,10 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-export type ButtonVariant = "solid" | "minimal" | "outlined";
+/** The visual style variant for buttons. */
+export const ButtonVariant = {
+    MINIMAL: "minimal",
+    OUTLINED: "outlined",
+    SOLID: "solid",
+} as const;
+export type ButtonVariant = (typeof ButtonVariant)[keyof typeof ButtonVariant];

--- a/packages/core/src/common/size.ts
+++ b/packages/core/src/common/size.ts
@@ -2,6 +2,15 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-export type Size = "small" | "medium" | "large";
+/* eslint-disable sort-keys */
 
+/** The rendering size of a component. */
+export const Size = {
+    SMALL: "small",
+    MEDIUM: "medium",
+    LARGE: "large",
+} as const;
+export type Size = (typeof Size)[keyof typeof Size];
+
+/** A subset of `Size` which excludes `"small"` */
 export type NonSmallSize = Exclude<Size, "small">;


### PR DESCRIPTION
From feedback received, want to be able to express these as both values and types through enum interfaces. Also added docs comments for completeness sake.