### PR TITLE
Add script to pack/store packages on `develop` and `next`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,17 @@ jobs:
       - store_artifacts: { path: packages/demo-app/dist }
       - run: ./scripts/submit-preview-comment.sh
 
+  store-packages:
+    docker: *docker-node-image
+    steps:
+      - checkout
+      - restore_cache: *restore-node-modules-cache
+      - attach_workspace: { at: "." }
+      - run: sudo corepack enable
+      - run: mkdir ./artifacts
+      - run: ./scripts/pack-npm
+      - store_artifacts: { path: ./artifacts }
+
   deploy-npm:
     docker: *docker-node-image
     steps:
@@ -233,6 +244,8 @@ workflows:
       - test-iso-react-18:
           requires: [compile]
       - deploy-preview:
+          requires: [dist]
+      - store-packages:
           requires: [dist]
       - deploy-npm:
           requires: [dist, lint, test-node-libs, test-react-18, test-iso-react-18]

--- a/scripts/pack-npm
+++ b/scripts/pack-npm
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+packages=("colors" "core" "datetime" "datetime2" "icons" "select" "table")
+
+mkdir -p artifacts
+
+for package in ${packages[@]}; do
+    path="packages/$package"
+    pushd $path
+
+    version=$(jq -r '.version' package.json)
+    filename="../../artifacts/blueprintjs-$(basename "$path")-$version.tgz"
+
+    echo "Attempting to pack package at path '$path'"
+    yarn pack --filename $filename
+
+    popd
+done


### PR DESCRIPTION
#### Proposed changes

Adds an additional job, `store-packages`, to CI that packs and stores tgz artifacts of each package. This will help facilitate easier prerelease testing by making the built packages more easily accessible.