### PR TITLE
[DialogBody] Set missing `useOverflowScrollContainer` default prop

### DIFF
--- a/packages/core/src/components/dialog/dialogBody.tsx
+++ b/packages/core/src/components/dialog/dialogBody.tsx
@@ -38,7 +38,7 @@ export interface DialogBodyProps extends Props, HTMLDivProps {
  * @see https://blueprintjs.com/docs/#core/components/dialog.dialog-body-props
  */
 export const DialogBody: React.FC<DialogBodyProps> = props => {
-    const { children, className, useOverflowScrollContainer, ...htmlProps } = props;
+    const { children, className, useOverflowScrollContainer = true, ...htmlProps } = props;
     return (
         <div
             {...htmlProps}


### PR DESCRIPTION
#### Fixes #0000

#### Proposed changes:

Fixes an issue caused by a component refactor in #7180 where the `defaultProps` value of `useOverflowScrollContainer` was mistakingly omitted. 