### PR TITLE
fix: enum export

### DIFF
--- a/packages/core/karma.conf.js
+++ b/packages/core/karma.conf.js
@@ -20,7 +20,9 @@ module.exports = async function (config) {
                 "src/accessibility/*",
                 "src/common/abstractComponent*",
                 "src/common/abstractPureComponent*",
-                "src/common/alignment.ts",
+                "src/common/alignment.ts",      
+                "src/common/buttonVariant.ts",     
+                "src/common/size.ts",
                 "src/common/errors.ts",
                 "src/components/html/html.tsx",
                 // focus mangement is difficult to test, and this function may no longer be required

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -20,7 +20,7 @@ export { AbstractComponent } from "./abstractComponent";
 export { AbstractPureComponent } from "./abstractPureComponent";
 export { Alignment, TextAlignment } from "./alignment";
 export { Boundary } from "./boundary";
-export type { ButtonVariant } from "./buttonVariant";
+export { ButtonVariant } from "./buttonVariant";
 export { Elevation } from "./elevation";
 export { Intent } from "./intent";
 export { KeyCodes as Keys } from "./keyCodes";
@@ -40,7 +40,7 @@ export {
     type MaybeElement,
 } from "./props";
 export { getRef, isRefCallback, isRefObject, mergeRefs, refHandler, setRef } from "./refs";
-export type { Size, NonSmallSize } from "./size";
+export { Size, type NonSmallSize } from "./size";
 
 import * as Classes from "./classes";
 import * as Utils from "./utils";

--- a/packages/core/test/buttons/abstractButtonTests.tsx
+++ b/packages/core/test/buttons/abstractButtonTests.tsx
@@ -17,7 +17,7 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { Alignment, AnchorButton, Button, ButtonVariant, Size, type ButtonProps } from "../../src";
+import { Alignment, AnchorButton, Button } from "../../src";
 
 describe("ButtonProps", () => {
     describe("(omitting 'ref' prop) should be assignable to", () => {
@@ -29,9 +29,7 @@ describe("ButtonProps", () => {
                 /* no-op */
             },
             outlined: true,
-            size: Size.MEDIUM,
-            variant: ButtonVariant.SOLID,
-        } satisfies ButtonProps;
+        };
 
         it("<Button> component", () => {
             shallow(<Button {...buttonProps} />);

--- a/packages/core/test/buttons/abstractButtonTests.tsx
+++ b/packages/core/test/buttons/abstractButtonTests.tsx
@@ -17,7 +17,7 @@
 import { shallow } from "enzyme";
 import * as React from "react";
 
-import { Alignment, AnchorButton, Button } from "../../src";
+import { Alignment, AnchorButton, Button, ButtonVariant, Size, type ButtonProps } from "../../src";
 
 describe("ButtonProps", () => {
     describe("(omitting 'ref' prop) should be assignable to", () => {
@@ -29,7 +29,9 @@ describe("ButtonProps", () => {
                 /* no-op */
             },
             outlined: true,
-        };
+            size: Size.MEDIUM,
+            variant: ButtonVariant.SOLID,
+        } satisfies ButtonProps;
 
         it("<Button> component", () => {
             shallow(<Button {...buttonProps} />);


### PR DESCRIPTION
Since these were recently changed to be enums and types, we need to do `export` instead of `export type` so that we can use it as a constant.

Currently, when we try to do.

```tsx
import { Size } from '@blueprintjs/core'

...

<Button>
   size={Size.LARGE}
```

We get the error `"'Size' cannot be used as a value because it was exported using 'export type'." `