### PR TITLE
Remove component API console deprecation warnings

### DIFF
--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -17,16 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Alignment, type ButtonVariant, Classes, type Size } from "../../common";
-import {
-    ALIGN_TEXT_LEFT,
-    ALIGN_TEXT_RIGHT,
-    BUTTON_GROUP_WARN_MINIMAL,
-    BUTTON_GROUP_WARN_OUTLINED,
-    logDeprecatedSizeWarning,
-} from "../../common/errors";
+import { type Alignment, type ButtonVariant, Classes, type Size } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
-import { useValidateProps } from "../../hooks/useValidateProps";
 
 export interface ButtonGroupProps extends Props, HTMLDivProps, React.RefAttributes<HTMLDivElement> {
     /**
@@ -117,24 +109,6 @@ export const ButtonGroup: React.FC<ButtonGroupProps> = React.forwardRef<HTMLDivE
             vertical,
             ...htmlProps
         } = props;
-
-        useValidateProps(() => {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            if (alignText === Alignment.LEFT) {
-                console.warn(ALIGN_TEXT_LEFT);
-            }
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            if (alignText === Alignment.RIGHT) {
-                console.warn(ALIGN_TEXT_RIGHT);
-            }
-            if (minimal != null) {
-                console.warn(BUTTON_GROUP_WARN_MINIMAL);
-            }
-            if (outlined != null) {
-                console.warn(BUTTON_GROUP_WARN_OUTLINED);
-            }
-            logDeprecatedSizeWarning("ButtonGroup", { large });
-        }, [alignText, large, minimal, outlined]);
 
         const buttonGroupClasses = classNames(
             Classes.BUTTON_GROUP,

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -21,16 +21,8 @@ import {
     useInteractiveAttributes,
     type UseInteractiveAttributesOptions,
 } from "../../accessibility/useInteractiveAttributes";
-import { Alignment, Classes, Utils } from "../../common";
-import {
-    ALIGN_TEXT_LEFT,
-    ALIGN_TEXT_RIGHT,
-    BUTTON_WARN_MINIMAL,
-    BUTTON_WARN_OUTLINED,
-    logDeprecatedSizeWarning,
-} from "../../common/errors";
+import { Classes, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
-import { useValidateProps } from "../../hooks/useValidateProps";
 import { Icon } from "../icon/icon";
 import { Spinner, SpinnerSize } from "../spinner/spinner";
 import { Text } from "../text/text";
@@ -107,24 +99,6 @@ function useSharedButtonAttributes<E extends HTMLAnchorElement | HTMLButtonEleme
     const disabled = props.disabled || loading;
 
     const [active, interactiveProps] = useInteractiveAttributes(!disabled, props, ref, options);
-
-    useValidateProps(() => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        if (alignText === Alignment.LEFT) {
-            console.warn(ALIGN_TEXT_LEFT);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        if (alignText === Alignment.RIGHT) {
-            console.warn(ALIGN_TEXT_RIGHT);
-        }
-        if (minimal != null) {
-            console.warn(BUTTON_WARN_MINIMAL);
-        }
-        if (outlined != null) {
-            console.warn(BUTTON_WARN_OUTLINED);
-        }
-        logDeprecatedSizeWarning("Button", { large, small });
-    }, [alignText, large, minimal, outlined, small]);
 
     const className = classNames(
         Classes.BUTTON,

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -109,9 +109,6 @@ export interface SwitchProps extends ControlProps {
  */
 export const Switch: React.FC<SwitchProps> = React.forwardRef((props, ref) => {
     const { innerLabelChecked, innerLabel, ...controlProps } = props;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const { large } = controlProps;
-
     const switchLabels =
         innerLabel || innerLabelChecked
             ? [

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -17,15 +17,8 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { Alignment, Classes, mergeRefs } from "../../common";
-import {
-    ALIGN_INDICATOR_CENTER,
-    ALIGN_INDICATOR_LEFT,
-    ALIGN_INDICATOR_RIGHT,
-    logDeprecatedSizeWarning,
-} from "../../common/errors";
+import { Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { useValidateProps } from "../../hooks/useValidateProps";
 
 import type { ControlProps } from "./controlProps";
 
@@ -60,20 +53,6 @@ const ControlInternal: React.FC<ControlInternalProps> = React.forwardRef<HTMLLab
             tagName = "label",
             ...htmlProps
         } = props;
-
-        useValidateProps(() => {
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            if (alignIndicator === Alignment.LEFT) {
-                console.warn(ALIGN_INDICATOR_LEFT);
-            }
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            if (alignIndicator === Alignment.RIGHT) {
-                console.warn(ALIGN_INDICATOR_RIGHT);
-            }
-            if (alignIndicator === Alignment.CENTER) {
-                console.warn(ALIGN_INDICATOR_CENTER);
-            }
-        }, [alignIndicator]);
 
         const classes = classNames(
             Classes.CONTROL,
@@ -133,10 +112,6 @@ export const Switch: React.FC<SwitchProps> = React.forwardRef((props, ref) => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { large } = controlProps;
 
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("Switch", { large });
-    }, [large]);
-
     const switchLabels =
         innerLabel || innerLabelChecked
             ? [
@@ -177,13 +152,6 @@ export type RadioProps = ControlProps;
  * @see https://blueprintjs.com/docs/#core/components/radio
  */
 export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const { large } = props;
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("Radio", { large });
-    }, [large]);
-
     return <ControlInternal {...props} ref={ref} type="radio" typeClassName={Classes.RADIO} />;
 });
 Radio.displayName = `${DISPLAYNAME_PREFIX}.Radio`;
@@ -217,8 +185,6 @@ export interface CheckboxProps extends ControlProps {
  */
 export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) => {
     const { defaultIndeterminate, indeterminate, onChange, ...controlProps } = props;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const { large } = controlProps;
 
     const [isIndeterminate, setIsIndeterminate] = React.useState<boolean>(
         indeterminate || defaultIndeterminate || false,
@@ -238,10 +204,6 @@ export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) =
         },
         [indeterminate, onChange],
     );
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("Checkbox", { large });
-    }, [large]);
 
     React.useEffect(() => {
         if (indeterminate !== undefined) {

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -18,10 +18,8 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
 import type { Size } from "../../common/size";
-import { useValidateProps } from "../../hooks/useValidateProps";
 
 export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelElement>, Props {
     /**
@@ -123,10 +121,6 @@ export const FileInput = (props: FileInputProps) => {
         text = "Choose file...",
         ...htmlProps
     } = props;
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("FileInput", { large, small });
-    }, [large, small]);
 
     const rootClasses = classNames(
         className,

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
-import { INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX, logDeprecatedSizeWarning } from "../../common/errors";
+import { INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX } from "../../common/errors";
 import {
     type ControlledValueProps,
     DISPLAYNAME_PREFIX,
@@ -196,9 +196,6 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
         if (props.leftElement != null && props.leftIcon != null) {
             console.warn(INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX);
         }
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const { large, small } = props;
-        logDeprecatedSizeWarning("InputGroup", { large, small });
     }
 
     private handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -382,8 +382,7 @@ export class NumericInput extends AbstractPureComponent<
     }
 
     protected validateProps(nextProps: HTMLInputProps & NumericInputProps) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const { large, majorStepSize, max, min, minorStepSize, small, stepSize, value } = nextProps;
+        const { majorStepSize, max, min, minorStepSize, stepSize, value } = nextProps;
         if (min != null && max != null && min > max) {
             console.error(Errors.NUMERIC_INPUT_MIN_MAX);
         }
@@ -402,7 +401,6 @@ export class NumericInput extends AbstractPureComponent<
         if (majorStepSize && majorStepSize < stepSize!) {
             console.error(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_BOUND);
         }
-        Errors.logDeprecatedSizeWarning("NumericInput", { large, small });
 
         // controlled mode
         if (value != null) {

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -18,7 +18,6 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes, refHandler, setRef } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
 import type { Size } from "../../common/size";
 
@@ -216,12 +215,6 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
                 ref={this.handleRef}
             />
         );
-    }
-
-    protected validateProps(nextProps: TextAreaProps) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const { small, large } = nextProps;
-        logDeprecatedSizeWarning("TextArea", { large, small });
     }
 
     private handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -18,10 +18,8 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
 import type { Size } from "../../common/size";
-import { useValidateProps } from "../../hooks/useValidateProps";
 
 export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement> {
     /** Menu items. */
@@ -62,11 +60,6 @@ export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement>
 export const Menu: React.FC<MenuProps> = props => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { className, children, large, size = "medium", small, ulRef, ...htmlProps } = props;
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("Menu", { large, small });
-    }, [large, small]);
-
     return (
         <ul
             role="menu"

--- a/packages/core/src/components/segmented-control/segmentedControl.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.tsx
@@ -18,7 +18,6 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, Intent, mergeRefs, Utils } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import {
     type ControlledValueProps,
     DISPLAYNAME_PREFIX,
@@ -27,7 +26,6 @@ import {
     removeNonHTMLProps,
 } from "../../common/props";
 import type { Size } from "../../common/size";
-import { useValidateProps } from "../../hooks/useValidateProps";
 import type { ButtonProps } from "../button/buttonProps";
 import { Button } from "../button/buttons";
 
@@ -123,10 +121,6 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRe
     const selectedValue = controlledValue ?? localValue;
 
     const outerRef = React.useRef<HTMLDivElement>(null);
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("SegmentedControl", { large, small });
-    }, [large, small]);
 
     const handleOptionClick = React.useCallback(
         (newSelectedValue: string, targetElement: HTMLElement) => {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -18,7 +18,6 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type NonSmallSize, type Props, Utils } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 
 import { Tab, type TabId, type TabProps } from "./tab";
 import { TabPanel } from "./tabPanel";
@@ -218,11 +217,6 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
                 {tabPanels}
             </div>
         );
-    }
-
-    protected validateProps(props: TabsProps) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        logDeprecatedSizeWarning("Tabs", { large: props.large });
     }
 
     public componentDidMount() {

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -20,7 +20,6 @@ import * as React from "react";
 import { type IconName, IconSize } from "@blueprintjs/icons";
 
 import { AbstractPureComponent, Classes, type NonSmallSize, refHandler, setRef, Utils } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import {
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
@@ -331,12 +330,6 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
                 {this.props.rightElement}
             </div>
         );
-    }
-
-    protected validateProps(nextProps: TagInputProps) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const { large } = nextProps;
-        logDeprecatedSizeWarning("TagInput", { large });
     }
 
     public componentDidUpdate(prevProps: TagInputProps) {

--- a/packages/core/src/components/tag/compoundTag.tsx
+++ b/packages/core/src/components/tag/compoundTag.tsx
@@ -18,9 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import { isReactNodeEmpty } from "../../common/utils";
-import { useValidateProps } from "../../hooks/useValidateProps";
 import { Icon } from "../icon/icon";
 import { Text } from "../text/text";
 
@@ -78,10 +76,6 @@ export const CompoundTag: React.FC<CompoundTagProps> = React.forwardRef((props, 
     } = props;
 
     const isRemovable = Utils.isFunction(onRemove);
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("CompoundTag", { large });
-    }, [large]);
 
     const tagClasses = classNames(
         Classes.TAG,

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -29,9 +29,7 @@ import {
     removeNonHTMLProps,
     Utils,
 } from "../../common";
-import { logDeprecatedSizeWarning } from "../../common/errors";
 import { isReactNodeEmpty } from "../../common/utils";
-import { useValidateProps } from "../../hooks/useValidateProps";
 import { Icon } from "../icon/icon";
 import { Text } from "../text/text";
 
@@ -121,10 +119,6 @@ export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
         defaultTabIndex: 0,
         disabledTabIndex: undefined,
     });
-
-    useValidateProps(() => {
-        logDeprecatedSizeWarning("Tag", { large });
-    }, [large]);
 
     const tagClasses = classNames(
         Classes.TAG,


### PR DESCRIPTION
## Proposed changes

Removes warnings for component API deprecations released in `5.17.0`. The intention here is to temporarily disable and cut a release without the warnings. We will then follow up by re-enabling the deprecation warnings in a separate `5.x` patch release. That way, consumers will be able to incrementally opt-in to these warnings by pinning to the release that does not include the console warnings.