### PR TITLE
break(InputGroup, NumericInput): Remove numeric types for size prop

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -19,7 +19,6 @@ import type { ButtonVariant } from "./buttonVariant";
 import { Elevation } from "./elevation";
 import { Intent } from "./intent";
 import { Position } from "./position";
-import type { HTMLInputProps } from "./props";
 import type { Size } from "./size";
 
 // injected by webpack.DefinePlugin
@@ -449,7 +448,7 @@ export function positionClass(position: Position | undefined) {
 }
 
 export function sizeClass(
-    size: Size | HTMLInputProps["size"],
+    size: Size,
     legacyProps: Partial<Record<"large" | "small", boolean>>,
 ): string | Record<string, boolean> {
     if (size === "small") {

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -63,13 +63,11 @@ export interface InputGroupProps
     small?: boolean;
 
     /**
-     * Size of the input. If given a numeric value, and `inputSize` is not defined, then this will be provided as the
-     * `size` attribute for the underyling native HTML input element. Passing a numeric value this way is deprecated,
-     * use the `inputSize` prop instead.
+     * Size of the input.
      *
      * @default "medium"
      */
-    size?: Size | HTMLInputProps["size"];
+    size?: Size;
 
     /**
      * Alias for the native HTML input `size` attribute.
@@ -163,7 +161,7 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
             "aria-disabled": disabled,
             className: classNames(Classes.INPUT, inputClassName),
             onChange: this.handleInputChange,
-            size: inputSize ?? (typeof size === "number" ? size : undefined),
+            size: inputSize,
             style,
         } satisfies React.HTMLProps<HTMLInputElement>;
         const inputElement = asyncControl ? (

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -155,13 +155,11 @@ export interface NumericInputProps extends InputSharedProps {
     small?: boolean;
 
     /**
-     * Size of the input. If given a numeric value, and `inputSize` is not defined, then this will be provided as the
-     * `size` attribute for the underyling native HTML input element. Passing a numeric value this way is deprecated,
-     * use the `inputSize` prop instead.
+     * Size of the input.
      *
      * @default "medium"
      */
-    size?: Size | HTMLInputProps["size"];
+    size?: Size;
 
     /**
      * Alias for the native HTML input `size` attribute.


### PR DESCRIPTION

#### Changes proposed in this pull request:

In this PR, we remove the deprecated types from the `size` prop for the `InputGroup` and `NumericInput` components. This previously would pass the numeric value to the underlying native HTML `size` attribute. For this functionality, users should now use the `inputSize` prop instead.