### PR TITLE
break(TextArea): Delete growVertically prop

### DIFF
--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -49,13 +49,6 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
     fill?: boolean;
 
     /**
-     * Whether the text area should automatically grow vertically to accomodate content.
-     *
-     * @deprecated use the `autoResize` prop instead.
-     */
-    growVertically?: boolean;
-
-    /**
      * Ref handler that receives HTML `<textarea>` element backing this component.
      */
     inputRef?: React.Ref<HTMLTextAreaElement>;
@@ -118,8 +111,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
     );
 
     private maybeSyncHeightToScrollHeight = () => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const { autoResize, growVertically } = this.props;
+        const { autoResize } = this.props;
 
         if (this.textareaElement != null) {
             const { scrollHeight } = this.textareaElement;
@@ -129,9 +121,6 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
                 // the content of the textarea
                 this.textareaElement.style.height = "0px";
                 this.textareaElement.style.height = scrollHeight.toString() + "px";
-                this.setState({ height: scrollHeight });
-            } else if (growVertically && scrollHeight > 0) {
-                // N.B. this code path will be deleted in Blueprint v6.0 when `growVertically` is removed
                 this.setState({ height: scrollHeight });
             }
         }
@@ -169,8 +158,6 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
             autoResize,
             className,
             fill,
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            growVertically,
             inputRef,
             intent,
             // eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -195,7 +182,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
 
         // add explicit height style while preserving user-supplied styles if they exist
         let { style = {} } = htmlProps;
-        if ((autoResize || growVertically) && this.state.height != null) {
+        if (autoResize && this.state.height != null) {
             // this style object becomes non-extensible when mounted (at least in the enzyme renderer),
             // so we make a new one to add a property
             style = {

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -83,18 +83,6 @@ describe("<TextArea>", () => {
         assert.notEqual(scrollHeightInPixelsBefore, scrollHeightInPixelsAfter);
     });
 
-    // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
-    // Note that growVertically is deprecated as of 28/07/2023
-    it.skip("can resize automatically", () => {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const wrapper = mount(<TextArea growVertically={true} />, { attachTo: containerElement });
-        const textarea = wrapper.find("textarea");
-
-        textarea.simulate("change", { target: { scrollHeight: 500 } });
-
-        assert.equal(textarea.getDOMNode<HTMLElement>().style.height, "500px");
-    });
-
     it("doesn't resize by default", () => {
         const wrapper = mount(<TextArea />, { attachTo: containerElement });
         const textarea = wrapper.find("textarea");
@@ -117,26 +105,6 @@ describe("<TextArea>", () => {
         textarea.simulate("change", { target: { scrollHeight: 500 } });
 
         assert.equal(textarea.getDOMNode<HTMLElement>().style.marginTop, "10px");
-    });
-
-    // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
-    // Note that growVertically is deprecated as of 28/07/2023
-    it.skip("can fit large initial content", () => {
-        const initialValue = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        Aenean finibus eget enim non accumsan.
-        Nunc lobortis luctus magna eleifend consectetur.
-        Suspendisse ut semper sem, quis efficitur felis.
-        Praesent suscipit nunc non semper tempor.
-        Sed eros sapien, semper sed imperdiet sed,
-        dictum eget purus. Donec porta accumsan pretium.
-        Fusce at felis mattis, tincidunt erat non, varius erat.`;
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const wrapper = mount(<TextArea growVertically={true} value={initialValue} style={{ marginTop: 10 }} />, {
-            attachTo: containerElement,
-        });
-        const textarea = wrapper.find("textarea");
-        const scrollHeightInPixels = `${textarea.getDOMNode<HTMLElement>().scrollHeight}px`;
-        assert.equal(textarea.getDOMNode<HTMLElement>().style.height, scrollHeightInPixels);
     });
 
     it("updates on ref change", () => {
@@ -175,18 +143,5 @@ describe("<TextArea>", () => {
         textAreawrapper.setProps({ inputRef: textAreaNewRef });
         assert.isNull(textAreaRef.current);
         assert.instanceOf(textAreaNewRef.current, HTMLTextAreaElement);
-    });
-
-    // HACKHACK: skipped test, see https://github.com/palantir/blueprint/issues/5976
-    // Note that growVertically is deprecated as of 28/07/2023
-    it.skip("resizes when props change if growVertically is true", () => {
-        const initialText = "A";
-        const longText = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        const wrapper = mount(<TextArea growVertically={true} value={initialText} />, { attachTo: containerElement });
-        const initialHeight = wrapper.find("textarea").getDOMNode<HTMLElement>().style.height;
-        wrapper.setProps({ value: longText }).update();
-        const newHeight = wrapper.find("textarea").getDOMNode<HTMLElement>().style.height;
-        assert.notEqual(newHeight, initialHeight);
     });
 });

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -43,7 +43,6 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
     const [autoResize, setAutoResize] = React.useState(false);
     const [controlled, setControlled] = React.useState(false);
     const [disabled, setDisabled] = React.useState(false);
-    const [growVertically, setGrowVertically] = React.useState(false);
     const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
     const [readOnly, setReadOnly] = React.useState(false);
     const [size, setSize] = React.useState<Size>("medium");
@@ -76,29 +75,12 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
                     <AnchorButton disabled={!controlled} icon="reset" onClick={resetControlledText} />
                 </Tooltip>
             </ControlGroup>
-            <H5>Deprecated props</H5>
-            <PropCodeTooltip
-                content={
-                    <span>
-                        This behavior is enabled by the new <Code>autoResize</Code> prop
-                    </span>
-                }
-                disabled={!autoResize}
-            >
-                <Switch
-                    checked={autoResize || growVertically}
-                    disabled={autoResize}
-                    label="Grow vertically"
-                    onChange={handleBooleanChange(setGrowVertically)}
-                />
-            </PropCodeTooltip>
         </>
     );
 
     const textAreaProps: TextAreaProps = {
         autoResize,
         disabled,
-        growVertically,
         intent,
         readOnly,
         size,

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -18,7 +18,6 @@ import * as React from "react";
 
 import {
     AnchorButton,
-    Code,
     ControlGroup,
     H5,
     Intent,


### PR DESCRIPTION
#### Part 2 of https://github.com/palantir/blueprint/issues/7294
Fixes https://github.com/palantir/blueprint/issues/5976

#### Changes proposed in this pull request:

Removed the deprecated `growVertically` prop from the `TextArea` component. The `autoResize` prop should be used instead.
