### PR TITLE
Custom attributes for <EditableText /> underlying textarea

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -106,6 +106,5 @@
         "default": ["{projectRoot}/src/**/*", "sharedGlobals"],
         "sharedGlobals": [],
         "production": ["default"]
-    },
-    "nxCloudAccessToken": "YmI1NzE4NGItZDg5Zi00MDEyLWIxOWItYzkwYzQ4OWYwZTdlfHJlYWQtd3JpdGU="
+    }
 }

--- a/nx.json
+++ b/nx.json
@@ -106,5 +106,6 @@
         "default": ["{projectRoot}/src/**/*", "sharedGlobals"],
         "sharedGlobals": [],
         "production": ["default"]
-    }
+    },
+    "nxCloudAccessToken": "YmI1NzE4NGItZDg5Zi00MDEyLWIxOWItYzkwYzQ4OWYwZTdlfHJlYWQtd3JpdGU="
 }

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -35,6 +35,12 @@ export type HTMLDivProps = React.HTMLAttributes<HTMLDivElement>;
 export type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 /**
+ * Alias for all valid HTML props for `<textarea>` element.
+ * Does not include React's `ref` or `key`.
+ */
+export type HTMLTextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+/**
  * Alias for a `React.JSX.Element` or a value that renders nothing.
  *
  * In React, `boolean`, `null`, and `undefined` do not produce any output.

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -23,6 +23,12 @@ import { clamp } from "../../common/utils";
 
 export interface EditableTextProps extends IntentProps, Props {
     /**
+     * Custom attributes to pass to the textarea element.
+     */
+    customTextareaAttributes?: {
+        [key: string]: string;
+    };
+    /**
      * EXPERIMENTAL FEATURE.
      *
      * When true, this forces the component to _always_ render an editable input (or textarea)
@@ -383,7 +389,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
     };
 
     private renderInput(value: string | undefined) {
-        const { disabled, maxLength, multiline, type, placeholder } = this.props;
+        const { disabled, maxLength, multiline, type, placeholder, customTextareaAttributes } = this.props;
         const props: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> = {
             className: Classes.EDITABLE_TEXT_INPUT,
             disabled,
@@ -405,7 +411,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
         }
 
         return multiline ? (
-            <textarea ref={this.refHandlers.input} {...props} />
+            <textarea ref={this.refHandlers.input} {...props} {...customTextareaAttributes} />
         ) : (
             <input ref={this.refHandlers.input} type={type} {...props} />
         );

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -23,7 +23,9 @@ import { clamp } from "../../common/utils";
 
 export interface EditableTextProps extends IntentProps, Props {
     /**
-     * Custom attributes to pass to the textarea element.
+     * Custom attributes that will be passed to the underlying textarea element when
+     * `multiline={true}`. This allows you to specify additional attributes like
+     * `aria-` attributes, `data-` attributes, etc.
      */
     customTextareaAttributes?: {
         [key: string]: string;

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -21,15 +21,16 @@ import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
 import { clamp } from "../../common/utils";
 
+type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
+type HTMLTextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
 export interface EditableTextProps extends IntentProps, Props {
     /**
-     * Custom attributes that will be passed to the underlying textarea element when
-     * `multiline={true}`. This allows you to specify additional attributes like
+     * Custom attributes that will be passed to the underlying input (or textarea) element.
+     * This allows you to specify additional attributes like
      * `aria-` attributes, `data-` attributes, etc.
      */
-    customTextareaAttributes?: {
-        [key: string]: string;
-    };
+    customInputAttributes?: HTMLInputProps & HTMLTextAreaProps;
     /**
      * EXPERIMENTAL FEATURE.
      *
@@ -391,7 +392,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
     };
 
     private renderInput(value: string | undefined) {
-        const { disabled, maxLength, multiline, type, placeholder, customTextareaAttributes } = this.props;
+        const { disabled, maxLength, multiline, type, placeholder, customInputAttributes } = this.props;
         const props: React.InputHTMLAttributes<HTMLInputElement | HTMLTextAreaElement> = {
             className: Classes.EDITABLE_TEXT_INPUT,
             disabled,
@@ -413,9 +414,9 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
         }
 
         return multiline ? (
-            <textarea ref={this.refHandlers.input} {...props} {...customTextareaAttributes} />
+            <textarea ref={this.refHandlers.input} {...props} {...customInputAttributes} />
         ) : (
-            <input ref={this.refHandlers.input} type={type} {...props} />
+            <input ref={this.refHandlers.input} type={type} {...props} {...customInputAttributes} />
         );
     }
 

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -18,11 +18,14 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
-import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";
+import {
+    DISPLAYNAME_PREFIX,
+    type HTMLInputProps,
+    type HTMLTextAreaProps,
+    type IntentProps,
+    type Props,
+} from "../../common/props";
 import { clamp } from "../../common/utils";
-
-type HTMLInputProps = React.InputHTMLAttributes<HTMLInputElement>;
-type HTMLTextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 export interface EditableTextProps extends IntentProps, Props {
     /**

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -215,6 +215,22 @@ describe("<EditableText>", () => {
             assert.lengthOf(mount(<EditableText isEditing={true} multiline={true} />).find("textarea"), 1);
         });
 
+        it("passes custom attributes to the textarea element", () => {
+            const customProps = {
+                "data-gramm": "false",
+                spellcheck: "false",
+                "aria-label": "Edit description",
+            };
+
+            const wrapper = mount(
+                <EditableText isEditing={true} multiline={true} customTextareaAttributes={customProps} />,
+            );
+            const textarea = wrapper.getDOMNode().querySelector<HTMLTextAreaElement>("textarea")!;
+            assert.strictEqual(textarea.getAttribute("data-gramm"), "false");
+            assert.strictEqual(textarea.getAttribute("spellcheck"), "false");
+            assert.strictEqual(textarea.getAttribute("aria-label"), "Edit description");
+        });
+
         it("does not call onConfirm when enter key is pressed", () => {
             const confirmSpy = spy();
             mount(<EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} />)

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -224,11 +224,10 @@ describe("<EditableText>", () => {
 
             const wrapper = mount(
                 <EditableText isEditing={true} multiline={true} customTextareaAttributes={customProps} />,
-            );
-            const textarea = wrapper.getDOMNode().querySelector<HTMLTextAreaElement>("textarea")!;
-            assert.strictEqual(textarea.getAttribute("data-gramm"), "false");
-            assert.strictEqual(textarea.getAttribute("spellcheck"), "false");
-            assert.strictEqual(textarea.getAttribute("aria-label"), "Edit description");
+            ).find("textarea");
+            assert.strictEqual(wrapper.prop("data-gramm"), "false");
+            assert.strictEqual(wrapper.prop("spellcheck"), "false");
+            assert.strictEqual(wrapper.prop("aria-label"), "Edit description");
         });
 
         it("does not call onConfirm when enter key is pressed", () => {

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -217,9 +217,9 @@ describe("<EditableText>", () => {
 
         it("passes custom attributes to the textarea element", () => {
             const customProps = {
+                "aria-label": "Edit description",
                 "data-gramm": "false",
                 spellcheck: "false",
-                "aria-label": "Edit description",
             };
 
             const wrapper = mount(

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -215,21 +215,6 @@ describe("<EditableText>", () => {
             assert.lengthOf(mount(<EditableText isEditing={true} multiline={true} />).find("textarea"), 1);
         });
 
-        it("passes custom attributes to the textarea element", () => {
-            const customProps = {
-                "aria-label": "Edit description",
-                "data-gramm": "false",
-                spellcheck: "false",
-            };
-
-            const wrapper = mount(
-                <EditableText isEditing={true} multiline={true} customTextareaAttributes={customProps} />,
-            ).find("textarea");
-            assert.strictEqual(wrapper.prop("data-gramm"), "false");
-            assert.strictEqual(wrapper.prop("spellcheck"), "false");
-            assert.strictEqual(wrapper.prop("aria-label"), "Edit description");
-        });
-
         it("does not call onConfirm when enter key is pressed", () => {
             const confirmSpy = spy();
             mount(<EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} />)
@@ -324,5 +309,31 @@ describe("<EditableText>", () => {
         function simulateHelper(wrapper: ReactWrapper<any>, value: string, e: FakeKeyboardEvent) {
             wrapper.find("textarea").simulate("change", { target: { value } }).simulate("keydown", e);
         }
+    });
+
+    describe("custom attributes", () => {
+        const customProps = {
+            "aria-label": "Edit description",
+            "data-gramm": "false",
+            spellcheck: "false",
+        };
+
+        it("passes custom attributes to textarea when multiline is true", () => {
+            const wrapper = mount(
+                <EditableText isEditing={true} multiline={true} customInputAttributes={customProps} />,
+            ).find("textarea");
+            assert.strictEqual(wrapper.prop("data-gramm"), "false");
+            assert.strictEqual(wrapper.prop("spellcheck"), "false");
+            assert.strictEqual(wrapper.prop("aria-label"), "Edit description");
+        });
+
+        it("passes custom attributes to input when multiline is false", () => {
+            const wrapper = mount(
+                <EditableText isEditing={true} multiline={false} customInputAttributes={customProps} />,
+            ).find("input");
+            assert.strictEqual(wrapper.prop("data-gramm"), "false");
+            assert.strictEqual(wrapper.prop("spellcheck"), "false");
+            assert.strictEqual(wrapper.prop("aria-label"), "Edit description");
+        });
     });
 });


### PR DESCRIPTION
#### Fixes #6916

#### Checklist

-   [x] Includes tests
-   [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:
I added the ability to pass custom attributes to the underlying text area element. It was not clear to me if this should also be added for the underlying input and if so should that have a seperate prop? Or would we just use the same prop for the two.

Furthermore, this is the first time i try contributing to an open source project, would love feedback if any!

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
