### PR TITLE
Fix type errors hidden by disabled `strictNullChecks` in `@blueprintjs/datetime` package

### DIFF
--- a/packages/datetime/src/common/dateRangeSelectionStrategy.ts
+++ b/packages/datetime/src/common/dateRangeSelectionStrategy.ts
@@ -74,7 +74,7 @@ export class DateRangeSelectionStrategy {
             nextDateRange = this.createRangeForBoundary(boundary, nextBoundaryDate, null);
         } else if (boundaryDate == null && otherBoundaryDate != null) {
             if (isSameDay(day, otherBoundaryDate)) {
-                let nextDate: Date;
+                let nextDate: Date | null;
                 if (allowSingleDayRange) {
                     nextBoundary = boundary;
                     nextDate = otherBoundaryDate;
@@ -92,18 +92,19 @@ export class DateRangeSelectionStrategy {
             }
         } else {
             // both boundaryDate and otherBoundaryDate are already defined
-            if (isSameDay(boundaryDate, day)) {
-                const isSingleDayRangeSelected = isSameDay(boundaryDate, otherBoundaryDate);
+            if (boundaryDate != null && isSameDay(boundaryDate, day)) {
+                const isSingleDayRangeSelected =
+                    otherBoundaryDate != null && isSameDay(boundaryDate, otherBoundaryDate);
                 const nextOtherBoundaryDate = isSingleDayRangeSelected ? null : otherBoundaryDate;
                 nextBoundary = boundary;
                 nextDateRange = this.createRangeForBoundary(boundary, null, nextOtherBoundaryDate);
-            } else if (isSameDay(day, otherBoundaryDate)) {
+            } else if (otherBoundaryDate != null && isSameDay(day, otherBoundaryDate)) {
                 const [nextBoundaryDate, nextOtherBoundaryDate] = allowSingleDayRange
                     ? [otherBoundaryDate, otherBoundaryDate]
                     : [boundaryDate, null];
                 nextBoundary = allowSingleDayRange ? boundary : otherBoundary;
                 nextDateRange = this.createRangeForBoundary(boundary, nextBoundaryDate, nextOtherBoundaryDate);
-            } else if (this.isOverlappingOtherBoundary(boundary, day, otherBoundaryDate)) {
+            } else if (otherBoundaryDate != null && this.isOverlappingOtherBoundary(boundary, day, otherBoundaryDate)) {
                 nextBoundary = boundary;
                 nextDateRange = this.createRangeForBoundary(boundary, day, null);
             } else {
@@ -134,8 +135,8 @@ export class DateRangeSelectionStrategy {
         } else if (start == null && end != null) {
             nextDateRange = this.createRange(day, end, allowSingleDayRange);
         } else {
-            const isStart = isSameDay(start, day);
-            const isEnd = isSameDay(end, day);
+            const isStart = start != null && isSameDay(start, day);
+            const isEnd = end != null && isSameDay(end, day);
             if (isStart && isEnd) {
                 nextDateRange = [null, null];
             } else if (isStart) {
@@ -163,7 +164,11 @@ export class DateRangeSelectionStrategy {
         return boundary === Boundary.START ? boundaryDate > otherBoundaryDate : boundaryDate < otherBoundaryDate;
     }
 
-    private static createRangeForBoundary(boundary: Boundary, boundaryDate: Date, otherBoundaryDate: Date) {
+    private static createRangeForBoundary(
+        boundary: Boundary,
+        boundaryDate: Date | null,
+        otherBoundaryDate: Date | null,
+    ): DateRange {
         return boundary === Boundary.START
             ? ([boundaryDate, otherBoundaryDate] as DateRange)
             : ([otherBoundaryDate, boundaryDate] as DateRange);

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -39,7 +39,7 @@ export function isEqual(date1: Date, date2: Date) {
     }
 }
 
-export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange) {
+export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange): boolean {
     if (dateRange1 == null && dateRange2 == null) {
         return true;
     } else if (dateRange1 == null || dateRange2 == null) {
@@ -47,8 +47,9 @@ export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange) {
     } else {
         const [start1, end1] = dateRange1;
         const [start2, end2] = dateRange2;
-        const areStartsEqual = (start1 == null && start2 == null) || isSameDay(start1, start2);
-        const areEndsEqual = (end1 == null && end2 == null) || isSameDay(end1, end2);
+        const areStartsEqual =
+            (start1 == null && start2 == null) || (start1 != null && start2 != null && isSameDay(start1, start2));
+        const areEndsEqual = (end1 == null && end2 == null) || (end1 != null && end2 != null && isSameDay(end1, end2));
         return areStartsEqual && areEndsEqual;
     }
 }
@@ -97,8 +98,11 @@ export function isDayRangeInRange(innerRange: DateRange, outerRange: DateRange) 
     );
 }
 
-export function isMonthInRange(date: Date, dateRange: DateRange) {
+export function isMonthInRange(date: Date, dateRange: DateRange): boolean {
     if (date == null) {
+        return false;
+    }
+    if (!isNonNullRange(dateRange)) {
         return false;
     }
 
@@ -160,9 +164,9 @@ export function isTimeSameOrAfter(date: Date, dateToCompare: Date): boolean {
 /**
  * @returns a Date at the exact time-wise midpoint between startDate and endDate
  */
-export function getDateBetween(dateRange: DateRange) {
-    const start = dateRange[0].getTime();
-    const end = dateRange[1].getTime();
+export function getDateBetween(dateRange: DateRange): Date {
+    const start = dateRange[0]!.getTime();
+    const end = dateRange[1]!.getTime();
     const middle = start + (end - start) * 0.5;
     return new Date(middle);
 }

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -18,6 +18,7 @@ import { isSameDay } from "date-fns";
 
 import { type DateRange, isNonNullRange } from "./dateRange";
 import { Months } from "./months";
+import { getDefaultMaxTime, getDefaultMinTime } from "./timeUnit";
 
 export { isSameDay };
 
@@ -123,10 +124,10 @@ export function isMonthInRange(date: Date, dateRange: DateRange): boolean {
 export const isTimeEqualOrGreaterThan = (time: Date, timeToCompare: Date) => time.getTime() >= timeToCompare.getTime();
 export const isTimeEqualOrSmallerThan = (time: Date, timeToCompare: Date) => time.getTime() <= timeToCompare.getTime();
 
-export function isTimeInRange(date: Date, minDate: Date, maxDate: Date): boolean {
+export function isTimeInRange(date: Date, minDate: Date | undefined, maxDate: Date | undefined): boolean {
     const time = getDateOnlyWithTime(date);
-    const minTime = getDateOnlyWithTime(minDate);
-    const maxTime = getDateOnlyWithTime(maxDate);
+    const minTime = getDateOnlyWithTime(minDate ?? getDefaultMinTime());
+    const maxTime = getDateOnlyWithTime(maxDate ?? getDefaultMaxTime());
 
     const isTimeGreaterThanMinTime = isTimeEqualOrGreaterThan(time, minTime);
     const isTimeSmallerThanMaxTime = isTimeEqualOrSmallerThan(time, maxTime);
@@ -138,7 +139,10 @@ export function isTimeInRange(date: Date, minDate: Date, maxDate: Date): boolean
     return isTimeGreaterThanMinTime && isTimeSmallerThanMaxTime;
 }
 
-export function getTimeInRange(time: Date, minTime: Date, maxTime: Date) {
+export function getTimeInRange(time: Date, minTime: Date | undefined, maxTime: Date | undefined) {
+    minTime = minTime ?? getDefaultMinTime();
+    maxTime = maxTime ?? getDefaultMaxTime();
+
     if (isSameTime(minTime, maxTime)) {
         return maxTime;
     } else if (isTimeInRange(time, minTime, maxTime)) {

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -163,6 +163,9 @@ export function isTimeSameOrAfter(date: Date, dateToCompare: Date): boolean {
 
 /**
  * @returns a Date at the exact time-wise midpoint between startDate and endDate
+ *
+ *  TODO: Convert `dateRange` argument to a NonNullDateRange to avoid non-null assertions
+ *  see: https://github.com/palantir/blueprint/pull/7337#discussion_r1990189512
  */
 export function getDateBetween(dateRange: DateRange): Date {
     const start = dateRange[0]!.getTime();

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -18,7 +18,6 @@ import { isSameDay } from "date-fns";
 
 import { type DateRange, isNonNullRange } from "./dateRange";
 import { Months } from "./months";
-import { getDefaultMaxTime, getDefaultMinTime } from "./timeUnit";
 
 export { isSameDay };
 
@@ -124,10 +123,10 @@ export function isMonthInRange(date: Date, dateRange: DateRange): boolean {
 export const isTimeEqualOrGreaterThan = (time: Date, timeToCompare: Date) => time.getTime() >= timeToCompare.getTime();
 export const isTimeEqualOrSmallerThan = (time: Date, timeToCompare: Date) => time.getTime() <= timeToCompare.getTime();
 
-export function isTimeInRange(date: Date, minDate: Date | undefined, maxDate: Date | undefined): boolean {
+export function isTimeInRange(date: Date, minDate: Date, maxDate: Date): boolean {
     const time = getDateOnlyWithTime(date);
-    const minTime = getDateOnlyWithTime(minDate ?? getDefaultMinTime());
-    const maxTime = getDateOnlyWithTime(maxDate ?? getDefaultMaxTime());
+    const minTime = getDateOnlyWithTime(minDate);
+    const maxTime = getDateOnlyWithTime(maxDate);
 
     const isTimeGreaterThanMinTime = isTimeEqualOrGreaterThan(time, minTime);
     const isTimeSmallerThanMaxTime = isTimeEqualOrSmallerThan(time, maxTime);
@@ -139,10 +138,7 @@ export function isTimeInRange(date: Date, minDate: Date | undefined, maxDate: Da
     return isTimeGreaterThanMinTime && isTimeSmallerThanMaxTime;
 }
 
-export function getTimeInRange(time: Date, minTime: Date | undefined, maxTime: Date | undefined) {
-    minTime = minTime ?? getDefaultMinTime();
-    maxTime = maxTime ?? getDefaultMaxTime();
-
+export function getTimeInRange(time: Date, minTime: Date, maxTime: Date) {
     if (isSameTime(minTime, maxTime)) {
         return maxTime;
     } else if (isTimeInRange(time, minTime, maxTime)) {

--- a/packages/datetime/src/common/monthAndYear.ts
+++ b/packages/datetime/src/common/monthAndYear.ts
@@ -24,7 +24,7 @@ export class MonthAndYear {
     private date: Date;
 
     constructor(month?: number, year?: number) {
-        if (month !== null && year !== null) {
+        if (month != null && year != null) {
             this.date = new Date(year, month);
         } else {
             this.date = new Date();

--- a/packages/datetime/src/common/timeUnit.ts
+++ b/packages/datetime/src/common/timeUnit.ts
@@ -58,7 +58,7 @@ export function getTimeUnit(unit: TimeUnit, date: Date) {
 }
 
 /** Sets the given time unit to the given time in date object. Modifies given `date` object and returns it. */
-export function setTimeUnit(unit: TimeUnit, time: number, date: Date, isPm: boolean) {
+export function setTimeUnit(unit: TimeUnit, time: number, date: Date, isPm: boolean = false) {
     switch (unit) {
         case TimeUnit.HOUR_24:
             date.setHours(time);

--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -139,11 +139,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
                 this.props.maxTime ?? getDefaultMaxTime(),
             );
         }
-        if (
-            this.props.value != null &&
-            prevProps.value != null &&
-            !DateUtils.isSameTime(this.props.value, prevProps.value)
-        ) {
+        if (this.props.value != null && !DateUtils.isSameTime(this.props.value, prevProps.value ?? null)) {
             value = this.props.value;
         }
 

--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -69,7 +69,7 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
 
     public static displayName = `${DISPLAYNAME_PREFIX}.TimePicker`;
 
-    public constructor(props?: TimePickerProps) {
+    public constructor(props: TimePickerProps) {
         super(props);
 
         this.state = this.getFullStateFromValue(this.getInitialValue(), props.useAmPm);
@@ -133,9 +133,17 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
             value = this.getInitialValue();
         }
         if (didBoundsChange) {
-            value = DateUtils.getTimeInRange(this.state.value, this.props.minTime, this.props.maxTime);
+            value = DateUtils.getTimeInRange(
+                this.state.value ?? this.getInitialValue(),
+                this.props.minTime,
+                this.props.maxTime,
+            );
         }
-        if (this.props.value != null && !DateUtils.isSameTime(this.props.value, prevProps.value)) {
+        if (
+            this.props.value != null &&
+            prevProps.value != null &&
+            !DateUtils.isSameTime(this.props.value, prevProps.value)
+        ) {
             value = this.props.value;
         }
 
@@ -172,9 +180,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
         return <span className={Classes.TIMEPICKER_DIVIDER_TEXT}>{text}</span>;
     }
 
-    private renderInput(className: string, unit: TimeUnit, value: string) {
-        const valueNumber = parseInt(value, 10);
-        const isValid = isTimeUnitValid(unit, valueNumber);
+    private renderInput(className: string, unit: TimeUnit, value: string | undefined) {
+        const isValid = value != null ? isTimeUnitValid(unit, parseInt(value, 10)) : false;
         const isHour = unit === TimeUnit.HOUR_12 || unit === TimeUnit.HOUR_24;
 
         return (
@@ -271,7 +278,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     private handleAmPmChange = (e: React.SyntheticEvent<HTMLSelectElement>) => {
         const isNextPm = e.currentTarget.value === "pm";
         if (isNextPm !== this.state.isPm) {
-            const hour = DateUtils.convert24HourMeridiem(this.state.value.getHours(), isNextPm);
+            const value = this.state.value ?? this.getInitialValue();
+            const hour = DateUtils.convert24HourMeridiem(value.getHours(), isNextPm);
             this.setState({ isPm: isNextPm }, () => this.updateTime(hour, TimeUnit.HOUR_24));
         }
     };
@@ -281,7 +289,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
     /**
      * Generates a full TimePickerState object with all text fields set to formatted strings based on value
      */
-    private getFullStateFromValue(value: Date, useAmPm: boolean): TimePickerState {
+    private getFullStateFromValue(value: Date | undefined, useAmPm: boolean = false): TimePickerState {
+        value = value ?? this.getInitialValue();
         const timeInRange = DateUtils.getTimeInRange(value, this.props.minTime, this.props.maxTime);
         const hourUnit = useAmPm ? TimeUnit.HOUR_12 : TimeUnit.HOUR_24;
         /* eslint-disable sort-keys */
@@ -304,28 +313,29 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
         if (this.props.disabled) {
             return;
         }
-        const newTime = getTimeUnit(unit, this.state.value) + amount;
+        const newTime = getTimeUnit(unit, this.state.value ?? this.getInitialValue()) + amount;
         this.updateTime(wrapTimeAtUnit(unit, newTime), unit);
     }
 
     private updateTime(time: number, unit: TimeUnit) {
-        const newValue = DateUtils.clone(this.state.value);
+        const value = this.state.value ?? this.getInitialValue();
+        const newValue = DateUtils.clone(value);
 
         if (isTimeUnitValid(unit, time)) {
             setTimeUnit(unit, time, newValue, this.state.isPm);
             if (DateUtils.isTimeInRange(newValue, this.props.minTime, this.props.maxTime)) {
                 this.updateState({ value: newValue });
             } else {
-                this.updateState(this.getFullStateFromValue(this.state.value, this.props.useAmPm));
+                this.updateState(this.getFullStateFromValue(value, this.props.useAmPm));
             }
         } else {
-            this.updateState(this.getFullStateFromValue(this.state.value, this.props.useAmPm));
+            this.updateState(this.getFullStateFromValue(value, this.props.useAmPm));
         }
     }
 
     private updateState(state: TimePickerState) {
         let newState = state;
-        const hasNewValue = newState.value != null && !DateUtils.isSameTime(newState.value, this.state.value);
+        const hasNewValue = newState.value != null && !DateUtils.isSameTime(newState.value, this.state.value ?? null);
 
         if (this.props.value == null) {
             // component is uncontrolled
@@ -342,17 +352,21 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
                 // no new value, this means only text has changed (from user typing)
                 // we want inputs to change, so update state with new text for the inputs
                 // but don't change actual value
-                this.setState({ ...newState, value: DateUtils.clone(this.state.value) });
+                this.setState({
+                    ...newState,
+                    value: this.state.value != null ? DateUtils.clone(this.state.value) : undefined,
+                });
             }
         }
 
-        if (hasNewValue) {
+        if (hasNewValue && newState.value != null) {
             this.props.onChange?.(newState.value);
         }
     }
 
     private getInitialValue(): Date {
-        let value = this.props.minTime;
+        const minTime = this.props.minTime ?? getDefaultMinTime();
+        let value = minTime;
         if (this.props.value != null) {
             value = this.props.value;
         } else if (this.props.defaultValue != null) {

--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -135,8 +135,8 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
         if (didBoundsChange) {
             value = DateUtils.getTimeInRange(
                 this.state.value ?? this.getInitialValue(),
-                this.props.minTime,
-                this.props.maxTime,
+                this.props.minTime ?? getDefaultMinTime(),
+                this.props.maxTime ?? getDefaultMaxTime(),
             );
         }
         if (
@@ -291,7 +291,11 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
      */
     private getFullStateFromValue(value: Date | undefined, useAmPm: boolean = false): TimePickerState {
         value = value ?? this.getInitialValue();
-        const timeInRange = DateUtils.getTimeInRange(value, this.props.minTime, this.props.maxTime);
+        const timeInRange = DateUtils.getTimeInRange(
+            value,
+            this.props.minTime ?? getDefaultMinTime(),
+            this.props.maxTime ?? getDefaultMaxTime(),
+        );
         const hourUnit = useAmPm ? TimeUnit.HOUR_12 : TimeUnit.HOUR_24;
         /* eslint-disable sort-keys */
         return {
@@ -323,7 +327,13 @@ export class TimePicker extends React.Component<TimePickerProps, TimePickerState
 
         if (isTimeUnitValid(unit, time)) {
             setTimeUnit(unit, time, newValue, this.state.isPm);
-            if (DateUtils.isTimeInRange(newValue, this.props.minTime, this.props.maxTime)) {
+            if (
+                DateUtils.isTimeInRange(
+                    newValue,
+                    this.props.minTime ?? getDefaultMinTime(),
+                    this.props.maxTime ?? getDefaultMaxTime(),
+                )
+            ) {
                 this.updateState({ value: newValue });
             } else {
                 this.updateState(this.getFullStateFromValue(value, this.props.useAmPm));

--- a/packages/datetime2/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime2/src/components/date-picker3/datePicker3.tsx
@@ -322,7 +322,7 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
         }
     };
 
-    private computeValidDateInSpecifiedMonthYear(displayYear: number, displayMonth: number): Date {
+    private computeValidDateInSpecifiedMonthYear(displayYear: number, displayMonth: number): Date | null {
         const { minDate, maxDate } = this.props;
         const { selectedDay } = this.state;
         // month is 0-based, date is 1-based. date 0 is last day of previous month.
@@ -332,9 +332,9 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
         // 12:00 matches the underlying react-day-picker timestamp behavior
         const value = DateUtils.getDateTime(new Date(displayYear, displayMonth, displayDate, 12), this.state.value);
         // clamp between min and max dates
-        if (value < minDate!) {
+        if (value != null && value < minDate!) {
             return minDate!;
-        } else if (value > maxDate!) {
+        } else if (value != null && value > maxDate!) {
             return maxDate!;
         }
         return value;
@@ -344,7 +344,10 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
 
     private handleMonthChange = (newDate: Date) => {
         const date = this.computeValidDateInSpecifiedMonthYear(newDate.getFullYear(), newDate.getMonth());
-        this.setState({ displayMonth: date.getMonth(), displayYear: date.getFullYear() });
+        if (date != null) {
+            this.setState({ displayMonth: date.getMonth(), displayYear: date.getFullYear() });
+            this.props.dayPickerProps?.onMonthChange?.(date);
+        }
         if (this.state.value !== null) {
             // if handleDayClick just got run (so this flag is set), then the
             // user selected a date in a new month, so don't invoke onChange a
@@ -352,7 +355,6 @@ export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, Dat
             this.updateValue(date, false, this.ignoreNextMonthChange);
             this.ignoreNextMonthChange = false;
         }
-        this.props.dayPickerProps?.onMonthChange?.(date);
     };
 
     private handleTodayClick = () => {

--- a/packages/datetime2/src/components/date-range-picker3/contiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/contiguousDayRangePicker.tsx
@@ -195,7 +195,10 @@ function useContiguousCalendarViews(
 
     const handleMonthChange = React.useCallback<MonthChangeEventHandler>(
         newMonth => {
-            setDisplayMonth(MonthAndYear.fromDate(newMonth));
+            const newDisplayMonth = MonthAndYear.fromDate(newMonth);
+            if (newDisplayMonth) {
+                setDisplayMonth(newDisplayMonth);
+            }
             userOnMonthChange?.(newMonth);
         },
         [userOnMonthChange, setDisplayMonth],
@@ -216,6 +219,10 @@ function isDateDisplayed(date: Date | null, displayMonth: MonthAndYear, singleMo
     }
 
     const month = MonthAndYear.fromDate(date);
+
+    if (month == null) {
+        return false;
+    }
 
     return singleMonthOnly
         ? displayMonth.isSameMonth(month)

--- a/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -105,13 +105,15 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         [`${HOVERED_RANGE_MODIFIER}-end`]: Classes.DATERANGEPICKER3_HOVERED_RANGE_END,
     };
 
-    private initialMonthAndYear: MonthAndYear = MonthAndYear.fromDate(new Date());
+    private initialMonthAndYear: MonthAndYear =
+        MonthAndYear.fromDate(new Date()) ?? new MonthAndYear(new Date().getMonth(), new Date().getFullYear());
 
     public constructor(props: DateRangePicker3Props) {
         super(props);
         const value = getInitialValue(props);
         const time: DateRange = value;
-        this.initialMonthAndYear = MonthAndYear.fromDate(getInitialMonth(props, value));
+        const initialMonth = getInitialMonth(props, value);
+        this.initialMonthAndYear = new MonthAndYear(initialMonth.getMonth(), initialMonth.getFullYear());
         this.state = {
             hoverValue: NULL_RANGE,
             locale: undefined,
@@ -160,7 +162,8 @@ export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3
         const isControlled = prevProps.value !== undefined && this.props.value !== undefined;
 
         if (prevProps.contiguousCalendarMonths !== this.props.contiguousCalendarMonths) {
-            this.initialMonthAndYear = MonthAndYear.fromDate(getInitialMonth(this.props, getInitialValue(this.props)));
+            const initialMonth = getInitialMonth(this.props, getInitialValue(this.props));
+            this.initialMonthAndYear = new MonthAndYear(initialMonth.getMonth(), initialMonth.getFullYear());
         }
 
         if (

--- a/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime2/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
@@ -210,16 +210,19 @@ function useNonContiguousCalendarViews(
 
     const handleLeftMonthChange = React.useCallback(
         (newDate: Date) => {
-            let newLeftView = MonthAndYear.fromDate(newDate);
+            const newLeftView = MonthAndYear.fromDate(newDate);
+            if (newLeftView == null) {
+                return;
+            }
             setViews(({ right }) => {
                 let newRightView = right.clone();
                 if (!newLeftView.isBefore(newRightView)) {
                     newRightView = newLeftView.getNextMonth();
                 }
 
-                [newLeftView, newRightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
+                const [leftView, rightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
                 userOnMonthChange?.(newLeftView.getFullDate());
-                return { left: newLeftView, right: newRightView };
+                return { left: leftView, right: rightView };
             });
         },
         [minDate, maxDate, setViews, userOnMonthChange],
@@ -227,16 +230,19 @@ function useNonContiguousCalendarViews(
 
     const handleRightMonthChange = React.useCallback(
         (newDate: Date) => {
-            let newRightView = MonthAndYear.fromDate(newDate);
+            const newRightView = MonthAndYear.fromDate(newDate);
+            if (newRightView == null) {
+                return;
+            }
             setViews(({ left }) => {
                 let newLeftView = left.clone();
                 if (!newRightView.isAfter(newLeftView)) {
                     newLeftView = newRightView.getPreviousMonth();
                 }
 
-                [newLeftView, newRightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
+                const [leftView, rightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
                 userOnMonthChange?.(newRightView.getFullDate());
-                return { left: newLeftView, right: newRightView };
+                return { left: leftView, right: rightView };
             });
         },
         [minDate, maxDate, setViews, userOnMonthChange],


### PR DESCRIPTION
Part of #7293

### Proposed Changes

The datetime package has [`strictNullChecks`](https://www.typescriptlang.org/tsconfig/#strictNullChecks) set to `false`, which hides some type errors in the package.

https://github.com/palantir/blueprint/blob/37c3c66a445c91ca214f9e89b15140fd5c1751b3/packages/datetime/src/tsconfig.json#L3-L6

This seems to have been introduced to datetime's tsconfig in #4351

This config value is slightly problematic because `@blueprintjs/datetime2` does _**not**_ have `strictNullChecks` disabled:
https://github.com/palantir/blueprint/blob/37c3c66a445c91ca214f9e89b15140fd5c1751b3/packages/datetime2/src/tsconfig.json#L3-L6

This leads to type compilation errors when attempting to pull components/utilities from datetime into datetime2. It seems that we can either:

1. Keep `strictNullChecks` set to false when porting datetime2 components into datetime
2. Temporarily set `strictNullChecks` to true and fix type compilation errors for files relevant to datetime2 components (this PR)

This PR was created by temporarily setting `strictNullChecks` to `true` in `@blueprintjs/datetime`, showing the compilation errors and fixing ones relevant to components in `@blueprintjs/datetime2`.

### Reviewers should focus on:

Existing Datetime components should pass tests and should not have any regressions in functionality.
