### PR TITLE
Fix more errors hidden by disabled `strictNullChecks` in `@blueprintjs/datetime`

### DIFF
--- a/packages/datetime/src/common/dateFormatProps.tsx
+++ b/packages/datetime/src/common/dateFormatProps.tsx
@@ -68,7 +68,7 @@ export function getFormattedDateString(
         return "";
     } else if (!isDateValid(date)) {
         return props.invalidDateMessage;
-    } else if (ignoreRange || isDayInRange(date, [props.minDate, props.maxDate])) {
+    } else if (ignoreRange || isDayInRange(date, [props.minDate ?? null, props.maxDate ?? null])) {
         return props.formatDate(date, props.locale);
     } else {
         return props.outOfRangeMessage;

--- a/packages/datetime/src/common/dateUtils.ts
+++ b/packages/datetime/src/common/dateUtils.ts
@@ -39,7 +39,7 @@ export function isEqual(date1: Date, date2: Date) {
     }
 }
 
-export function areRangesEqual(dateRange1: DateRange, dateRange2: DateRange): boolean {
+export function areRangesEqual(dateRange1: DateRange | null, dateRange2: DateRange | null): boolean {
     if (dateRange1 == null && dateRange2 == null) {
         return true;
     } else if (dateRange1 == null || dateRange2 == null) {

--- a/packages/datetime/test/common/dateUtilsTests.tsx
+++ b/packages/datetime/test/common/dateUtilsTests.tsx
@@ -59,7 +59,12 @@ describe("DateUtils", () => {
             runTest("[DATE_1, DATE_2] and [DATE_3, DATE_4]", [DATE_1, DATE_2], [DATE_3, DATE_4], false);
         });
 
-        function runTest(description: string, dateRange1: DateRange, dateRange2: DateRange, expectedResult: boolean) {
+        function runTest(
+            description: string,
+            dateRange1: DateRange | null,
+            dateRange2: DateRange | null,
+            expectedResult: boolean,
+        ) {
             it(description, () => {
                 expect(DateUtils.areRangesEqual(dateRange1, dateRange2)).to.equal(expectedResult);
             });
@@ -369,9 +374,10 @@ describe("DateUtils", () => {
             assertDateTime(DateUtils.getDateTime(DATE, time), time);
         });
 
-        function assertDateTime(date: Date, time: Date = createTimeObject(0)) {
-            expect(date.toDateString()).to.equal(DATE.toDateString(), "date not preserved");
-            expect(date.toTimeString()).to.equal(time.toTimeString());
+        function assertDateTime(date: Date | null, time: Date = createTimeObject(0)) {
+            expect(date).to.not.be.null;
+            expect(date!.toDateString()).to.equal(DATE.toDateString(), "date not preserved");
+            expect(date!.toTimeString()).to.equal(time.toTimeString());
         }
     });
 });

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -141,7 +141,7 @@ describe("<TimePicker>", () => {
     it("allows valid text entry", () => {
         renderTimePicker();
         const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
-        assert.strictEqual(hourInput.value, "0");
+        assert.strictEqual(hourInput?.value, "0");
 
         hourInput.value = "2";
         TestUtils.Simulate.change(hourInput);
@@ -195,10 +195,10 @@ describe("<TimePicker>", () => {
         renderTimePicker({ selectAllOnFocus: true });
 
         focusOnInput(Classes.TIMEPICKER_HOUR);
-        assert.equal(window.getSelection().toString(), "0");
+        assert.equal(window.getSelection()?.toString(), "0");
 
         focusOnInput(Classes.TIMEPICKER_MINUTE);
-        assert.equal(window.getSelection().toString(), "00");
+        assert.equal(window.getSelection()?.toString(), "00");
     });
 
     it("value doesn't change when disabled", () => {
@@ -537,10 +537,10 @@ describe("<TimePicker>", () => {
                 precision: TimePrecision.MILLISECOND,
             });
             const { value } = timePicker.state;
-            assert.strictEqual(value.getHours(), 10);
-            assert.strictEqual(value.getMinutes(), 11);
-            assert.strictEqual(value.getSeconds(), 12);
-            assert.strictEqual(value.getMilliseconds(), 13);
+            assert.strictEqual(value?.getHours(), 10);
+            assert.strictEqual(value?.getMinutes(), 11);
+            assert.strictEqual(value?.getSeconds(), 12);
+            assert.strictEqual(value?.getMilliseconds(), 13);
         });
 
         it("should fire onChange events on up-arrow key down", () => {
@@ -557,11 +557,11 @@ describe("<TimePicker>", () => {
             renderTimePicker();
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
             assert.strictEqual(hourInput.value, "0");
-            assert.strictEqual(timePicker.state.value.getHours(), 0);
+            assert.strictEqual(timePicker.state.value?.getHours(), 0);
 
             TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" });
             assert.strictEqual(hourInput.value, "1");
-            assert.strictEqual(timePicker.state.value.getHours(), 1);
+            assert.strictEqual(timePicker.state.value?.getHours(), 1);
         });
 
         it("should fire onChange events when new value is typed in", () => {
@@ -580,13 +580,13 @@ describe("<TimePicker>", () => {
             renderTimePicker();
             const minuteInput = findInputElement(Classes.TIMEPICKER_MINUTE);
             assert.strictEqual(minuteInput.value, "00");
-            assert.strictEqual(timePicker.state.value.getMinutes(), 0);
+            assert.strictEqual(timePicker.state.value?.getMinutes(), 0);
 
             minuteInput.value = "8";
             TestUtils.Simulate.change(minuteInput);
             TestUtils.Simulate.blur(minuteInput);
             assert.strictEqual(minuteInput.value, "08");
-            assert.strictEqual(timePicker.state.value.getMinutes(), 8);
+            assert.strictEqual(timePicker.state.value?.getMinutes(), 8);
         });
 
         it("should fire onChange events when arrow button is pressed", () => {
@@ -602,11 +602,11 @@ describe("<TimePicker>", () => {
             renderTimePicker({ showArrowButtons: true });
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
             assert.strictEqual(hourInput.value, "0");
-            assert.strictEqual(timePicker.state.value.getHours(), 0);
+            assert.strictEqual(timePicker.state.value?.getHours(), 0);
 
             clickIncrementBtn(Classes.TIMEPICKER_HOUR);
             assert.strictEqual(hourInput.value, "1");
-            assert.strictEqual(timePicker.state.value.getHours(), 1);
+            assert.strictEqual(timePicker.state.value?.getHours(), 1);
         });
     });
 
@@ -614,43 +614,43 @@ describe("<TimePicker>", () => {
         it("changing value changes state", () => {
             renderTimePicker({ value: zeroDate });
             let { value } = timePicker.state;
-            assert.strictEqual(value.getHours(), 0);
-            assert.strictEqual(value.getMinutes(), 0);
-            assert.strictEqual(value.getSeconds(), 0);
-            assert.strictEqual(value.getMilliseconds(), 0);
+            assert.strictEqual(value?.getHours(), 0);
+            assert.strictEqual(value?.getMinutes(), 0);
+            assert.strictEqual(value?.getSeconds(), 0);
+            assert.strictEqual(value?.getMilliseconds(), 0);
 
             renderTimePicker({ value: new Date(2015, 1, 1, 1, 2, 3, 4) });
             value = timePicker.state.value;
-            assert.strictEqual(value.getHours(), 1);
-            assert.strictEqual(value.getMinutes(), 2);
-            assert.strictEqual(value.getSeconds(), 3);
-            assert.strictEqual(value.getMilliseconds(), 4);
+            assert.strictEqual(value?.getHours(), 1);
+            assert.strictEqual(value?.getMinutes(), 2);
+            assert.strictEqual(value?.getSeconds(), 3);
+            assert.strictEqual(value?.getMilliseconds(), 4);
         });
 
         it("changing value to null resets state", () => {
             const root = mount<TimePicker>(<TimePicker defaultValue={new Date(2015, 1, 1, 1, 2, 3, 4)} />);
 
             const initialValue = root.state("value");
-            assert.strictEqual(initialValue.getHours(), 1);
-            assert.strictEqual(initialValue.getMinutes(), 2);
-            assert.strictEqual(initialValue.getSeconds(), 3);
-            assert.strictEqual(initialValue.getMilliseconds(), 4);
+            assert.strictEqual(initialValue?.getHours(), 1);
+            assert.strictEqual(initialValue?.getMinutes(), 2);
+            assert.strictEqual(initialValue?.getSeconds(), 3);
+            assert.strictEqual(initialValue?.getMilliseconds(), 4);
 
             root.setProps({ value: new Date(2015, 1, 1, 5, 6, 7, 8) });
 
             const updatedValue = root.state("value");
-            assert.strictEqual(updatedValue.getHours(), 5);
-            assert.strictEqual(updatedValue.getMinutes(), 6);
-            assert.strictEqual(updatedValue.getSeconds(), 7);
-            assert.strictEqual(updatedValue.getMilliseconds(), 8);
+            assert.strictEqual(updatedValue?.getHours(), 5);
+            assert.strictEqual(updatedValue?.getMinutes(), 6);
+            assert.strictEqual(updatedValue?.getSeconds(), 7);
+            assert.strictEqual(updatedValue?.getMilliseconds(), 8);
 
             root.setProps({ value: null });
 
             const resetValue = root.state("value");
-            assert.strictEqual(resetValue.getHours(), 1);
-            assert.strictEqual(resetValue.getMinutes(), 2);
-            assert.strictEqual(resetValue.getSeconds(), 3);
-            assert.strictEqual(resetValue.getMilliseconds(), 4);
+            assert.strictEqual(resetValue?.getHours(), 1);
+            assert.strictEqual(resetValue?.getMinutes(), 2);
+            assert.strictEqual(resetValue?.getSeconds(), 3);
+            assert.strictEqual(resetValue?.getMilliseconds(), 4);
         });
 
         it("should fire onChange events on up-arrow key down", () => {
@@ -667,11 +667,11 @@ describe("<TimePicker>", () => {
             renderTimePicker({ value: zeroDate });
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
             assert.strictEqual(hourInput.value, "0");
-            assert.strictEqual(timePicker.state.value.getHours(), 0);
+            assert.strictEqual(timePicker.state.value?.getHours(), 0);
 
             TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" });
             assert.strictEqual(hourInput.value, "0");
-            assert.strictEqual(timePicker.state.value.getHours(), 0);
+            assert.strictEqual(timePicker.state.value?.getHours(), 0);
         });
 
         it("should fire onChange events when new value is typed in", () => {
@@ -690,13 +690,13 @@ describe("<TimePicker>", () => {
             renderTimePicker({ value: zeroDate });
             const minuteInput = findInputElement(Classes.TIMEPICKER_MINUTE);
             assert.strictEqual(minuteInput.value, "00");
-            assert.strictEqual(timePicker.state.value.getMinutes(), 0);
+            assert.strictEqual(timePicker.state.value?.getMinutes(), 0);
 
             minuteInput.value = "8";
             TestUtils.Simulate.change(minuteInput);
             TestUtils.Simulate.blur(minuteInput);
             assert.strictEqual(minuteInput.value, "00");
-            assert.strictEqual(timePicker.state.value.getMinutes(), 0);
+            assert.strictEqual(timePicker.state.value?.getMinutes(), 0);
         });
 
         it("should fire onChange events when arrow button is pressed", () => {
@@ -712,11 +712,11 @@ describe("<TimePicker>", () => {
             renderTimePicker({ showArrowButtons: true, value: zeroDate });
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
             assert.strictEqual(hourInput.value, "0");
-            assert.strictEqual(timePicker.state.value.getHours(), 0);
+            assert.strictEqual(timePicker.state.value?.getHours(), 0);
 
             clickIncrementBtn(Classes.TIMEPICKER_HOUR);
             assert.strictEqual(hourInput.value, "0");
-            assert.strictEqual(timePicker.state.value.getHours(), 0);
+            assert.strictEqual(timePicker.state.value?.getHours(), 0);
         });
     });
 
@@ -738,8 +738,11 @@ describe("<TimePicker>", () => {
         TestUtils.Simulate.keyDown(findInputElement(className), { key });
     }
 
-    function findInputElement(className: string) {
-        return document.querySelector<HTMLInputElement>(`.${Classes.TIMEPICKER_INPUT}.${className}`);
+    function findInputElement(className: string): HTMLInputElement {
+        return (
+            document.querySelector<HTMLInputElement>(`.${Classes.TIMEPICKER_INPUT}.${className}`) ??
+            document.createElement("input")
+        );
     }
 
     function changeInputThenBlur(input: HTMLInputElement, value: string) {

--- a/packages/test-commons/src/datetimeUtils.ts
+++ b/packages/test-commons/src/datetimeUtils.ts
@@ -44,14 +44,21 @@ export function createTimeObject(hour: number, minute: number = 0, second: numbe
     return new Date(IGNORED_YEAR, IGNORED_MONTH, IGNORED_DAY, hour, minute, second, millisecond);
 }
 
-export function assertTimeIs(time: Date, hours: number, minutes: number, seconds?: number, milliseconds?: number) {
-    assert.strictEqual(time.getHours(), hours);
-    assert.strictEqual(time.getMinutes(), minutes);
+export function assertTimeIs(
+    time: Date | undefined,
+    hours: number,
+    minutes: number,
+    seconds?: number,
+    milliseconds?: number,
+) {
+    assert.isDefined(time, "time is undefined");
+    assert.strictEqual(time!.getHours(), hours);
+    assert.strictEqual(time!.getMinutes(), minutes);
     if (seconds != null) {
-        assert.strictEqual(time.getSeconds(), seconds);
+        assert.strictEqual(time!.getSeconds(), seconds);
     }
     if (milliseconds != null) {
-        assert.strictEqual(time.getMilliseconds(), milliseconds);
+        assert.strictEqual(time!.getMilliseconds(), milliseconds);
     }
 }
 


### PR DESCRIPTION
#### Proposed changes

FLUP to #7337

Fixes more TypeScript compilation errors in `@blueprintjs/datetime` hidden by `strictNullChecks` being set to `false`.
