### PR TITLE
[Datetime] Add `react-day-picker` v8 alias and port over common utils from `@blueprintjs/datetime2`

### DIFF
--- a/packages/datetime/karma.conf.js
+++ b/packages/datetime/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = async function (config) {
                 "src/**/index.ts",
                 // not worth coverage, fairly simple implementation
                 "src/common/timezoneDisplayFormat.ts",
+                "src/common/classes.ts",
             ],
             coverageOverrides: {
                 "src/components/timezone-select/timezoneSelect.tsx": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -47,6 +47,7 @@
         "date-fns": "^2.28.0",
         "date-fns-tz": "^2.0.0",
         "react-day-picker": "7.4.9",
+        "react-day-picker-8": "npm:react-day-picker@^8.10.0",
         "tslib": "~2.6.2"
     },
     "peerDependencies": {

--- a/packages/datetime/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime/src/common/_react-day-picker-overrides.scss
@@ -1,0 +1,27 @@
+// Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "@blueprintjs/colors/lib/scss/colors";
+@import "@blueprintjs/core/src/common/variables";
+
+// omit file extension, otherwise this will emit a `@import url()` rule
+@import "react-day-picker-8/dist/style";
+
+.#{$ns}-datepicker-content .rdp {
+  --rdp-cell-size: #{$pt-grid-size * 3};
+  --rdp-accent-color: #{$blue3};
+  --rdp-background-color: #{$white};
+
+  /* Switch to dark colors for dark themes */
+  --rdp-accent-color-dark: #{$blue2};
+  --rdp-background-color-dark: #{$dark-gray3};
+
+  /* Outline border for focused elements */
+  --rdp-outline: 2px solid var(--rdp-accent-color);
+
+  /* Outline border for focused and selected elements */
+  --rdp-outline-selected: 2px solid rgba(0, 0, 0, 75%);
+
+  margin: 0;
+  min-width: auto;
+}

--- a/packages/datetime/src/common/classes.ts
+++ b/packages/datetime/src/common/classes.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import classNames from "classnames";
+import type { StyledElement } from "react-day-picker-8";
+
 import { Classes } from "@blueprintjs/core";
 
 const NS = Classes.getClassNamespace();
@@ -67,3 +70,108 @@ export const TIMEPICKER_AMPM_SELECT = `${TIMEPICKER}-ampm-select`;
 
 export const TIMEZONE_SELECT = `${NS}-timezone-select`;
 export const TIMEZONE_SELECT_POPOVER = `${TIMEZONE_SELECT}-popover`;
+
+// BEGIN DATETIME2 CLASS NAMES
+
+const RDP = "rdp";
+const RDP_DAY = `${RDP}-day`;
+
+/** Class names applied by react-day-picker v8.x */
+export const ReactDayPickerClasses = {
+    RDP,
+    RDP_CAPTION: `${RDP}-caption`,
+    RDP_CAPTION_DROPDOWNS: `${RDP}-caption_dropdowns`,
+    RDP_CAPTION_LABEL: `${RDP}-caption_label`,
+    RDP_DAY,
+    RDP_DAY_DISABLED: `${RDP_DAY}_disabled`,
+    RDP_DAY_HOVERED_RANGE: `${RDP_DAY}_hovered`,
+    RDP_DAY_HOVERED_RANGE_END: `${RDP_DAY}_hovered_end`,
+    RDP_DAY_HOVERED_RANGE_START: `${RDP_DAY}_hovered_start`,
+    RDP_DAY_OUTSIDE: `${RDP_DAY}_outside`,
+    RDP_DAY_RANGE_END: `${RDP_DAY}_range_end`,
+    RDP_DAY_RANGE_MIDDLE: `${RDP_DAY}_range_middle`,
+    RDP_DAY_RANGE_START: `${RDP_DAY}_range_start`,
+    RDP_DAY_SELECTED: `${RDP_DAY}_selected`,
+    RDP_DAY_TODAY: `${RDP_DAY}_today`,
+    RDP_MONTH: `${RDP}-month`,
+    RDP_NAV: `${RDP}-nav`,
+    RDP_TABLE: `${RDP}-table`,
+    RDP_VHIDDEN: `${RDP}-vhidden`,
+};
+
+export const DatePicker3CaptionClasses = {
+    DATEPICKER3_CAPTION: DATEPICKER_CAPTION,
+    DATEPICKER3_DROPDOWN_MONTH: DATEPICKER_MONTH_SELECT,
+    DATEPICKER3_DROPDOWN_YEAR: DATEPICKER_YEAR_SELECT,
+    DATEPICKER3_NAV_BUTTON: `${DATEPICKER}-nav-button`,
+    DATEPICKER3_NAV_BUTTON_NEXT: `${DATEPICKER}-nav-button-next`,
+    DATEPICKER3_NAV_BUTTON_PREVIOUS: `${DATEPICKER}-nav-button-previous`,
+};
+
+export const {
+    DATEPICKER3_CAPTION,
+    DATEPICKER3_DROPDOWN_MONTH,
+    DATEPICKER3_DROPDOWN_YEAR,
+    DATEPICKER3_NAV_BUTTON,
+    DATEPICKER3_NAV_BUTTON_NEXT,
+    DATEPICKER3_NAV_BUTTON_PREVIOUS,
+} = DatePicker3CaptionClasses;
+
+export const DatePicker3Classes = {
+    DATEPICKER3_DAY: RDP_DAY,
+    DATEPICKER3_DAY_DISABLED: ReactDayPickerClasses.RDP_DAY_DISABLED,
+    DATEPICKER3_DAY_IS_TODAY: ReactDayPickerClasses.RDP_DAY_TODAY,
+    DATEPICKER3_DAY_OUTSIDE: ReactDayPickerClasses.RDP_DAY_OUTSIDE,
+    DATEPICKER3_DAY_SELECTED: ReactDayPickerClasses.RDP_DAY_SELECTED,
+    DATEPICKER3_HIGHLIGHT_CURRENT_DAY: `${DATEPICKER}-highlight-current-day`,
+    DATEPICKER3_REVERSE_MONTH_AND_YEAR: `${DATEPICKER}-reverse-month-and-year`,
+};
+
+export const {
+    DATEPICKER3_DAY,
+    DATEPICKER3_DAY_DISABLED,
+    DATEPICKER3_DAY_IS_TODAY,
+    DATEPICKER3_DAY_OUTSIDE,
+    DATEPICKER3_DAY_SELECTED,
+    DATEPICKER3_HIGHLIGHT_CURRENT_DAY,
+    DATEPICKER3_REVERSE_MONTH_AND_YEAR,
+} = DatePicker3Classes;
+
+export const DateRangePicker3Classes = {
+    DATERANGEPICKER3_HOVERED_RANGE: ReactDayPickerClasses.RDP_DAY_HOVERED_RANGE,
+    DATERANGEPICKER3_HOVERED_RANGE_END: ReactDayPickerClasses.RDP_DAY_HOVERED_RANGE_END,
+    DATERANGEPICKER3_HOVERED_RANGE_START: ReactDayPickerClasses.RDP_DAY_HOVERED_RANGE_START,
+    DATERANGEPICKER3_REVERSE_MONTH_AND_YEAR: `${DATERANGEPICKER}-reverse-month-and-year`,
+    DATERANGEPICKER3_SELECTED_RANGE_END: ReactDayPickerClasses.RDP_DAY_RANGE_END,
+    DATERANGEPICKER3_SELECTED_RANGE_MIDDLE: ReactDayPickerClasses.RDP_DAY_RANGE_MIDDLE,
+    DATERANGEPICKER3_SELECTED_RANGE_START: ReactDayPickerClasses.RDP_DAY_RANGE_START,
+    DATERANGEPICKER3_TIMEPICKERS_STACKED: `${DATERANGEPICKER_TIMEPICKERS}-stacked`,
+};
+
+export const {
+    DATERANGEPICKER3_HOVERED_RANGE,
+    DATERANGEPICKER3_HOVERED_RANGE_END,
+    DATERANGEPICKER3_HOVERED_RANGE_START,
+    DATERANGEPICKER3_REVERSE_MONTH_AND_YEAR,
+    DATERANGEPICKER3_SELECTED_RANGE_END,
+    DATERANGEPICKER3_SELECTED_RANGE_MIDDLE,
+    DATERANGEPICKER3_SELECTED_RANGE_START,
+    DATERANGEPICKER3_TIMEPICKERS_STACKED,
+} = DateRangePicker3Classes;
+
+/**
+ * Class name overrides for components rendered by react-day-picker. These are helpful so that @blueprintjs/datetime2
+ * can have more predictable and standard DOM selectors in custom styles & tests.
+ */
+export const dayPickerClassNameOverrides: Partial<StyledElement<string>> = {
+    /* eslint-disable camelcase */
+    button: classNames(Classes.BUTTON, Classes.MINIMAL),
+    // no need for button "reset" styles since the core Button styles handle that for us
+    button_reset: undefined,
+    dropdown_month: DatePicker3CaptionClasses.DATEPICKER3_DROPDOWN_MONTH,
+    dropdown_year: DatePicker3CaptionClasses.DATEPICKER3_DROPDOWN_YEAR,
+    nav_button: DatePicker3CaptionClasses.DATEPICKER3_NAV_BUTTON,
+    nav_button_next: DatePicker3CaptionClasses.DATEPICKER3_NAV_BUTTON_NEXT,
+    nav_button_previous: DatePicker3CaptionClasses.DATEPICKER3_NAV_BUTTON_PREVIOUS,
+    /* eslint-enable camelcase */
+};

--- a/packages/datetime/src/common/dateFnsFormatUtils.ts
+++ b/packages/datetime/src/common/dateFnsFormatUtils.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { format, type Locale, parse } from "date-fns";
+
+import type { DatePickerBaseProps } from "./datePickerBaseProps";
+import { TimePrecision } from "./timePrecision";
+
+export const DefaultDateFnsFormats = {
+    DATE_ONLY: "yyyy-MM-dd",
+    DATE_TIME_MILLISECONDS: "yyyy-MM-dd HH:mm:ss.SSS",
+    DATE_TIME_MINUTES: "yyyy-MM-dd HH:mm",
+    DATE_TIME_SECONDS: "yyyy-MM-dd HH:mm:ss",
+};
+
+export function getDefaultDateFnsFormat(props: Pick<DatePickerBaseProps, "timePickerProps" | "timePrecision">): string {
+    const hasTimePickerProps = props.timePickerProps !== undefined && Object.keys(props.timePickerProps).length > 0;
+    const precision =
+        props.timePrecision ??
+        props.timePickerProps?.precision ??
+        // if timePickerProps is non-empty but has no precision defined, use the default value of "minute"
+        (hasTimePickerProps ? TimePrecision.MINUTE : undefined);
+
+    switch (precision) {
+        case TimePrecision.MILLISECOND:
+            return DefaultDateFnsFormats.DATE_TIME_MILLISECONDS;
+        case TimePrecision.MINUTE:
+            return DefaultDateFnsFormats.DATE_TIME_MINUTES;
+        case TimePrecision.SECOND:
+            return DefaultDateFnsFormats.DATE_TIME_SECONDS;
+        default:
+            return DefaultDateFnsFormats.DATE_ONLY;
+    }
+}
+
+export function getDateFnsFormatter(formatStr: string, locale: Locale | undefined) {
+    return (date: Date) => format(date, formatStr, { locale });
+}
+
+export function getDateFnsParser(formatStr: string, locale: Locale | undefined) {
+    return (str: string) => parse(str, formatStr, new Date(), { locale });
+}

--- a/packages/datetime/src/common/dateFnsLocaleProps.ts
+++ b/packages/datetime/src/common/dateFnsLocaleProps.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+
+/**
+ * @param localeCode - ISO 639-1 + optional country code
+ * @returns date-fns `Locale` object
+ */
+export type DateFnsLocaleLoader = (localeCode: string) => Promise<Locale | undefined>;
+
+export interface DateFnsLocaleProps {
+    /**
+     * Optional custom loader function for the date-fns `Locale` which will be used to localize the date picker.
+     * This is useful in test environments or in build systems where you wish to customize module loading behavior.
+     * If not provided, a default loader will be used which uses dynamic imports to load `date-fns/locale/${localeCode}`
+     * modules.
+     */
+    dateFnsLocaleLoader?: DateFnsLocaleLoader;
+
+    /**
+     * date-fns `Locale` object or locale code string ((ISO 639-1 + optional country code) which will be used
+     * to localize the date picker.
+     *
+     * If you provide a locale code string and receive a loading error, please make sure it is included in the list of
+     * date-fns' [supported locales](https://github.com/date-fns/date-fns/tree/main/src/locale).
+     * See date-fns [Locale](https://date-fns.org/v2.28.0/docs/Locale).
+     *
+     * @default "en-US"
+     */
+    locale?: Locale | string;
+}
+
+export function getLocaleCodeFromProps(localeOrCode: DateFnsLocaleProps["locale"]): string | undefined {
+    return typeof localeOrCode === "string" ? localeOrCode : localeOrCode?.code;
+}

--- a/packages/datetime/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime/src/common/dateFnsLocaleUtils.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+import * as React from "react";
+
+import { Utils } from "@blueprintjs/core";
+
+import type { DateFnsLocaleLoader } from "./dateFnsLocaleProps";
+
+/**
+ * Lazy-loads a date-fns locale for use in a datetime class component.
+ */
+export async function loadDateFnsLocale(localeCode: string): Promise<Locale | undefined> {
+    try {
+        const localeModule = await import(
+            /* webpackChunkName: "date-fns-locale-[request]" */
+            `date-fns/locale/${localeCode}/index.js`
+        );
+        return localeModule.default;
+    } catch {
+        if (!Utils.isNodeEnv("production")) {
+            console.error(
+                `[Blueprint] Could not load "${localeCode}" date-fns locale, please check that this locale code is supported: https://github.com/date-fns/date-fns/tree/main/src/locale`,
+            );
+        }
+        return undefined;
+    }
+}
+
+/**
+ * Lazy-loads a date-fns locale for use in a datetime function component.
+ */
+export function useDateFnsLocale(
+    localeOrCode: Locale | string | undefined,
+    dateFnsLocaleLoader: DateFnsLocaleLoader = loadDateFnsLocale,
+) {
+    // make sure to set the locale correctly on first render if it is available
+    const [locale, setLocale] = React.useState<Locale | undefined>(
+        typeof localeOrCode === "object" ? localeOrCode : undefined,
+    );
+
+    React.useEffect(() => {
+        setLocale(prevLocale => {
+            if (typeof localeOrCode === "string") {
+                dateFnsLocaleLoader(localeOrCode).then(setLocale);
+                // keep the current locale for now, it will be updated async
+                return prevLocale;
+            } else {
+                return localeOrCode;
+            }
+        });
+    }, [dateFnsLocaleLoader, localeOrCode]);
+    return locale;
+}

--- a/packages/datetime/src/common/dayPickerModifiers.ts
+++ b/packages/datetime/src/common/dayPickerModifiers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DayModifiers } from "react-day-picker-8";
+
+export const DISABLED_MODIFIER = "disabled";
+export const HOVERED_RANGE_MODIFIER = "hovered-range";
+export const OUTSIDE_MODIFIER = "outside";
+export const SELECTED_MODIFIER = "selected";
+export const SELECTED_RANGE_MODIFIER = "selected-range";
+// modifiers the user can't set because they are used by Blueprint or react-day-picker
+export const DISALLOWED_MODIFIERS = [
+    DISABLED_MODIFIER,
+    HOVERED_RANGE_MODIFIER,
+    OUTSIDE_MODIFIER,
+    SELECTED_MODIFIER,
+    SELECTED_RANGE_MODIFIER,
+];
+
+export function combineModifiers(baseModifiers: DayModifiers, userModifiers: DayModifiers | undefined): DayModifiers {
+    let modifiers = baseModifiers;
+    if (userModifiers !== undefined) {
+        modifiers = {};
+        for (const key of Object.keys(userModifiers)) {
+            if (DISALLOWED_MODIFIERS.indexOf(key) === -1) {
+                modifiers[key] = userModifiers[key];
+            }
+        }
+        for (const key of Object.keys(baseModifiers)) {
+            modifiers[key] = baseModifiers[key];
+        }
+    }
+    return modifiers;
+}

--- a/packages/datetime/src/common/reactDayPickerProps.ts
+++ b/packages/datetime/src/common/reactDayPickerProps.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DayPickerBase, DayPickerRangeProps, DayPickerSingleProps } from "react-day-picker-8";
+
+type ReactDayPickerOmittedProps =
+    | "captionLayout"
+    | "disableNavigation"
+    | "fromDate"
+    | "fromMonth"
+    | "fromYear"
+    | "locale"
+    | "mode"
+    | "month"
+    | "numberOfMonths"
+    | "required"
+    | "selected"
+    | "toDate"
+    | "toMonth"
+    | "toYear";
+
+/**
+ * react-day-picker v8.x options which may be customized / overriden on
+ * `DatePicker3`, `DateInput3`, `DateRangePicker3`, and `DateRangeInput3` via the `dayPickerProps` prop.
+ */
+export type DayPickerProps = Omit<DayPickerBase, ReactDayPickerOmittedProps>;
+
+export interface ReactDayPickerRangeProps {
+    /**
+     * Props to pass to react-day-picker's day range picker. See API documentation
+     * [here](https://daypicker.dev/v8/api/interfaces/DayPickerRangeProps).
+     *
+     * Some properties are unavailable since they are set by the component design and cannot be changed:
+     *  - "captionLayout"
+     *  - "disableNavigation"
+     *  - "mode"
+     *
+     * Other properties have alternative names as top-level props:
+     *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
+     *  - "locale"
+     *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
+     *  - "numberOfMonths": use "singleMonthOnly" prop instead
+     *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
+     *  - "selected": use "value" instead
+     */
+    dayPickerProps?: Omit<DayPickerRangeProps, ReactDayPickerOmittedProps>;
+}
+
+export interface ReactDayPickerSingleProps {
+    /**
+     * Props to pass to react-day-picker's single day picker. See API documentation
+     * [here](https://daypicker.dev/v8/api/interfaces/DayPickerSingleProps).
+     *
+     * Some properties are unavailable since they are set by the component design and cannot be changed:
+     *  - "captionLayout"
+     *  - "disableNavigation"
+     *  - "mode"
+     *  - "numberOfMonths": fixed to 1 month
+     *
+     * Other properties have alternative names as top-level props:
+     *  - "fromDate", "fromMonth", "fromYear", "toDate", "toMonth", "toYear": use "minDate" and "maxDate" instead (legacy names from @blueprintjs/datetime v4)
+     *  - "locale"
+     *  - "month": navigation is controlled by the component; use "defaultMonth" to set the initially displayed month
+     *  - "required": use "canClearSelection" instead (legacy name from @blueprintjs/datetime v4)
+     *  - "selected": use "value" instead
+     */
+    dayPickerProps?: Omit<DayPickerSingleProps, ReactDayPickerOmittedProps>;
+}

--- a/packages/datetime/src/common/reactDayPickerUtils.ts
+++ b/packages/datetime/src/common/reactDayPickerUtils.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DateRange as RDPRange } from "react-day-picker-8";
+
+import type { DateRange } from "./dateRange";
+
+/**
+ * Converts a Blueprint `DateRange` to a react-day-picker `DateRange`.
+ */
+export function dateRangeToDayPickerRange(range: DateRange): RDPRange {
+    return { from: range[0] ?? undefined, to: range[1] ?? undefined };
+}

--- a/packages/datetime/src/common/useMonthSelectRightOffset.ts
+++ b/packages/datetime/src/common/useMonthSelectRightOffset.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+
+import { IconSize } from "@blueprintjs/icons";
+
+import { DatePickerUtils } from "../components/date-picker/datePickerUtils";
+
+import { Classes } from ".";
+
+export function useMonthSelectRightOffset(
+    monthSelectElement: React.RefObject<HTMLSelectElement>,
+    containerElement: React.RefObject<HTMLElement>,
+    displayedMonthText: string,
+): number {
+    const [monthRightOffset, setMonthRightOffset] = React.useState<number>(0);
+
+    React.useLayoutEffect(() => {
+        if (containerElement.current == null) {
+            return;
+        }
+
+        // measure width of text as rendered inside our container element.
+        const monthTextWidth = DatePickerUtils.measureTextWidth(
+            displayedMonthText,
+            Classes.DATEPICKER_CAPTION_MEASURE,
+            containerElement.current,
+        );
+        const monthSelectWidth = monthSelectElement.current?.clientWidth ?? 0;
+        const rightOffset = Math.max(2, monthSelectWidth - monthTextWidth - IconSize.STANDARD - 2);
+        setMonthRightOffset(rightOffset);
+    }, [containerElement, displayedMonthText, monthSelectElement]);
+
+    return monthRightOffset;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,6 +541,7 @@ __metadata:
     npm-run-all: "npm:^4.1.5"
     react: "npm:^18.3.1"
     react-day-picker: "patch:react-day-picker@npm%3A7.4.9#~/.yarn/patches/react-day-picker-npm-7.4.9-8853eff118.patch"
+    react-day-picker-8: "npm:react-day-picker@^8.10.0"
     react-dom: "npm:^18.3.1"
     react-test-renderer: "npm:^18.3.1"
     tslib: "npm:~2.6.2"
@@ -13864,6 +13865,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-day-picker-8@npm:react-day-picker@^8.10.0, react-day-picker@npm:^8.10.0":
+  version: 8.10.0
+  resolution: "react-day-picker@npm:8.10.0"
+  peerDependencies:
+    date-fns: ^2.28.0 || ^3.0.0
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: e9868aced1e40b4cb7d6cf8d50e250226b38ec7ebea944b65aa9db20a0f36d0581b8a501297d09dcbf2d812de852168952b3fb27990915381629d6e314c2a4d8
+  languageName: node
+  linkType: hard
+
 "react-day-picker@npm:7.4.9":
   version: 7.4.9
   resolution: "react-day-picker@npm:7.4.9"
@@ -13872,16 +13883,6 @@ __metadata:
   peerDependencies:
     react: ~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
   checksum: 9f503fbfbda61f1e1b7aeae5587a79fe3fe0a606ef6fe4637e2d27999c84ac785d6e976f275f8b215bb8a7298257a7063d917ac86522d69e8be9033e03815b8f
-  languageName: node
-  linkType: hard
-
-"react-day-picker@npm:^8.10.0":
-  version: 8.10.0
-  resolution: "react-day-picker@npm:8.10.0"
-  peerDependencies:
-    date-fns: ^2.28.0 || ^3.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: e9868aced1e40b4cb7d6cf8d50e250226b38ec7ebea944b65aa9db20a0f36d0581b8a501297d09dcbf2d812de852168952b3fb27990915381629d6e314c2a4d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Part of #7342

#### Proposed changes

Performs steps 1 and 2 from `datetime2`/`datetime` merge (#7342)

- Creates a v8 alias for `react-day-picker`  to be used with components/utils ported over from `datetime2`
- Ports over class constants and common utils from `datetime2` (direct copies of components with imports changed)
