### PR TITLE
[Datetime] Port v3 components from `datetime2` to `datetime`

### DIFF
--- a/packages/datetime/src/components/date-input3/date-input3.md
+++ b/packages/datetime/src/components/date-input3/date-input3.md
@@ -1,0 +1,95 @@
+---
+tag: new
+---
+
+@# DateInput3
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Migrating from [DateInput](#datetime/date-input)?
+
+</h5>
+
+**DateInput3** is a replacement for DateInput and will replace it in Blueprint v6.
+You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
+See the [react-day-picker v8 migration guide](https://github.com/palantir/blueprint/wiki/react-day-picker-8-migration)
+on the wiki.
+
+</div>
+
+**DateInput3** has the same functionality as [DateInput](#datetime/date-input) but uses
+[react-day-picker v8](https://daypicker.dev/v8) instead of [v7](https://react-day-picker-v7.netlify.app/)
+to render its calendar. It renders an interactive [**InputGroup**](#core/components/input-group)
+which, when focussed, displays a [**DatePicker3**](#datetime2/date-picker3) inside a
+[**Popover**](#core/components/popover). It optionally renders a [**TimezoneSelect**](#datetime/timezone-select)
+on the right side of the InputGroup which allows users to change the timezone of the selected date.
+
+@reactExample DateInput3Example
+
+@## Usage
+
+**DateInput3** supports both controlled and uncontrolled usage. You can control
+the selected date by setting the `value` prop, or use the component in
+uncontrolled mode and specify an initial date by setting `defaultValue`.
+Use the `onChange` prop callback to listen for changes to the selected day and
+the `onError` prop to react to invalid dates entered in the text input.
+
+This component uses ISO strings to represent timestamp values in the `value` & `defaultValue` props
+and the `onChange` callback.
+
+@## Props interface
+
+In addition to top-level **DateInput3** props, you may forward some props to `<DayPicker mode="single">` to customize
+react-day-picker's behavior via `dayPickerProps` (the full list is
+[documented here](https://daypicker.dev/v8/api/interfaces/DayPickerSingleProps)).
+
+Shortcuts and modifiers are also configurable via the same API as [**DatePicker3**](#datetime2/date-picker3); see those
+docs for more info.
+
+@interface DateInput3Props
+
+@## Date formatting
+
+By default, **DateInput3** utilizes [date-fns](https://date-fns.org/docs/) to format & parse date strings. You may
+specify which [date-fns format](https://date-fns.org/docs/format) to use with the `dateFnsFormat` prop.
+
+If you do not specify this prop, the component will use one of its default formats corresponding to the time precision
+specified by the `timePrecision` and `timePickerProps` props.
+
+Finally, you have the option to specify a custom formatter & parser with the `formatDate` and `parseDate` props:
+
+-   `formatDate(date: Date, localeCode?: string)` receives the current `Date` and returns a string representation of it.
+    The result of this function becomes the input value when it is not being edited.
+-   `parseDate(str: string, localeCode?: string)` receives text inputted by the user and converts it to a `Date` object.
+    The returned `Date` becomes the next value of the component.
+
+The optional `localeCode` argument to these functions is the value of the `locale` prop set on the component.
+
+A simple implementation of a custom formatter & parser using built-in browser methods could look like this:
+
+```tsx
+import { DateInput3 } from "@blueprintjs/datetime2";
+import { useCallback, useState } from "react";
+
+function Example() {
+    const [dateValue, setDateValue] = useState<string>(null);
+    const handleChange = useCallback(setDateValue, []);
+    const formatDate = useCallback((date: Date) => date.toLocaleString(), []);
+    const parseDate = useCallback((str: string) => new Date(str), []);
+
+    return (
+        <DateInput3
+            formatDate={formatDate}
+            onChange={handleChange}
+            parseDate={parseDate}
+            placeholder="M/D/YYYY"
+            value={dateValue}
+        />
+    );
+}
+```
+
+@## Localization
+
+See the [**DatePicker3** localization docs](#datetime2/date-picker3.localization).

--- a/packages/datetime/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime/src/components/date-input3/dateInput3.tsx
@@ -1,0 +1,617 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+
+import {
+    type ButtonProps,
+    DISPLAYNAME_PREFIX,
+    InputGroup,
+    Intent,
+    mergeRefs,
+    Popover,
+    type PopoverClickTargetHandlers,
+    type PopoverTargetProps,
+    Tag,
+    Utils,
+} from "@blueprintjs/core";
+
+import { Classes, DateUtils, Errors, TimezoneNameUtils, TimezoneUtils } from "../../common";
+import { getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
+import { useDateFnsLocale } from "../../common/dateFnsLocaleUtils";
+import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
+import { DatePickerUtils } from "../date-picker/datePickerUtils";
+import { DatePicker3 } from "../date-picker3/datePicker3";
+import type { DatePickerShortcut } from "../shortcuts/shortcuts";
+import { TimezoneSelect } from "../timezone-select/timezoneSelect";
+
+import type { DateInput3DefaultProps, DateInput3Props, DateInput3PropsWithDefaults } from "./dateInput3Props";
+import { useDateFormatter } from "./useDateFormatter";
+import { useDateParser } from "./useDateParser";
+
+export type { DateInput3Props };
+
+const timezoneSelectButtonProps: Partial<ButtonProps> = {
+    fill: false,
+    minimal: true,
+    outlined: true,
+};
+
+export const DATEINPUT3_DEFAULT_PROPS: DateInput3DefaultProps = {
+    closeOnSelection: true,
+    disabled: false,
+    invalidDateMessage: "Invalid date",
+    locale: "en-US",
+    maxDate: DatePickerUtils.getDefaultMaxDate(),
+    minDate: DatePickerUtils.getDefaultMinDate(),
+    outOfRangeMessage: "Out of range",
+    reverseMonthAndYearMenus: false,
+};
+
+/**
+ * Date input (v3) component.
+ *
+ * @see https://blueprintjs.com/docs/#datetime2/date-input3
+ */
+export const DateInput3: React.FC<DateInput3Props> = React.memo(function DateInput3(props) {
+    const {
+        closeOnSelection,
+        dateFnsFormat,
+        dateFnsLocaleLoader,
+        defaultTimezone,
+        defaultValue,
+        disabled,
+        disableTimezoneSelect,
+        fill,
+        inputProps = {},
+        invalidDateMessage,
+        locale: localeOrCode,
+        maxDate,
+        minDate,
+        onChange,
+        onError,
+        onTimezoneChange,
+        outOfRangeMessage,
+        popoverProps = {},
+        popoverRef,
+        rightElement,
+        showTimezoneSelect,
+        timePrecision,
+        timezone: controlledTimezone,
+        value,
+        ...datePickerProps
+    } = props as DateInput3PropsWithDefaults;
+
+    const locale = useDateFnsLocale(localeOrCode, dateFnsLocaleLoader);
+    const placeholder = getPlaceholder(props);
+    const formatDateString = useDateFormatter(props, locale);
+    const parseDateString = useDateParser(props, locale);
+
+    // Refs
+    // ------------------------------------------------------------------------
+
+    const inputRef = React.useRef<HTMLInputElement | null>(null);
+    const popoverContentRef = React.useRef<HTMLDivElement | null>(null);
+    const popoverId = Utils.uniqueId("date-picker");
+
+    // State
+    // ------------------------------------------------------------------------
+
+    const [isOpen, setIsOpen] = React.useState(false);
+    const [timezoneValue, setTimezoneValue] = React.useState(getInitialTimezoneValue(props));
+    const valueFromProps = React.useMemo(
+        () => TimezoneUtils.getDateObjectFromIsoString(value, timezoneValue),
+        [timezoneValue, value],
+    );
+    const isControlled = valueFromProps !== undefined;
+    const defaultValueFromProps = React.useMemo(
+        () => TimezoneUtils.getDateObjectFromIsoString(defaultValue, timezoneValue),
+        [defaultValue, timezoneValue],
+    );
+    const [valueAsDate, setValue] = React.useState<Date | null | undefined>(
+        isControlled ? valueFromProps : defaultValueFromProps,
+    );
+
+    const [selectedShortcutIndex, setSelectedShortcutIndex] = React.useState<number | undefined>(undefined);
+    const [isInputFocused, setIsInputFocused] = React.useState(false);
+
+    // rendered as the text input's value
+    const formattedDateString = React.useMemo(
+        () => (valueAsDate === null ? undefined : formatDateString(valueAsDate)),
+        [valueAsDate, formatDateString],
+    );
+    const [inputValue, setInputValue] = React.useState(formattedDateString ?? undefined);
+
+    const isErrorState =
+        valueAsDate != null &&
+        (!DateUtils.isDateValid(valueAsDate) || !DateUtils.isDayInRange(valueAsDate, [minDate, maxDate]));
+
+    // Effects
+    // ------------------------------------------------------------------------
+
+    React.useEffect(() => {
+        if (isControlled) {
+            setValue(valueFromProps);
+        }
+    }, [isControlled, valueFromProps]);
+
+    React.useEffect(() => {
+        // uncontrolled mode, updating initial timezone value
+        if (defaultTimezone !== undefined && TimezoneNameUtils.isValidTimezone(defaultTimezone)) {
+            setTimezoneValue(defaultTimezone);
+        }
+    }, [defaultTimezone]);
+
+    React.useEffect(() => {
+        // controlled mode, updating timezone value
+        if (controlledTimezone !== undefined && TimezoneNameUtils.isValidTimezone(controlledTimezone)) {
+            setTimezoneValue(controlledTimezone);
+        }
+    }, [controlledTimezone]);
+
+    React.useEffect(() => {
+        if (isControlled && !isInputFocused) {
+            setInputValue(formattedDateString);
+        }
+    }, [isControlled, isInputFocused, formattedDateString]);
+
+    // Popover contents (date picker)
+    // ------------------------------------------------------------------------
+
+    const handlePopoverClose = React.useCallback(
+        (e: React.SyntheticEvent<HTMLElement>) => {
+            popoverProps.onClose?.(e);
+            setIsOpen(false);
+        },
+        [popoverProps],
+    );
+
+    const handleDateChange = React.useCallback(
+        (newDate: Date | null, isUserChange: boolean, didSubmitWithEnter = false) => {
+            const prevDate = valueAsDate;
+
+            if (newDate === null) {
+                if (!isControlled && !didSubmitWithEnter) {
+                    // user clicked on current day in the calendar, so we should clear the input when uncontrolled
+                    setInputValue("");
+                }
+                onChange?.(null, isUserChange);
+                return;
+            }
+
+            // this change handler was triggered by a change in month, day, or (if
+            // enabled) time. for UX purposes, we want to close the popover only if
+            // the user explicitly clicked a day within the current month.
+            const newIsOpen =
+                !isUserChange ||
+                !closeOnSelection ||
+                (prevDate != null &&
+                    (DateUtils.hasMonthChanged(prevDate, newDate) ||
+                        (timePrecision !== undefined && DateUtils.hasTimeChanged(prevDate, newDate))));
+
+            // if selecting a date via click or Tab, the input will already be
+            // blurred by now, so sync isInputFocused to false. if selecting via
+            // Enter, setting isInputFocused to false won't do anything by itself,
+            // plus we want the field to retain focus anyway.
+            // (note: spelling out the ternary explicitly reads more clearly.)
+            const newIsInputFocused = didSubmitWithEnter ? true : false;
+
+            if (isControlled) {
+                setIsInputFocused(newIsInputFocused);
+                setIsOpen(newIsOpen);
+            } else {
+                const newFormattedDateString = formatDateString(newDate);
+                setIsInputFocused(newIsInputFocused);
+                setIsOpen(newIsOpen);
+                setValue(newDate);
+                setInputValue(newFormattedDateString);
+            }
+
+            const newIsoDateString = TimezoneUtils.getIsoEquivalentWithUpdatedTimezone(
+                newDate,
+                timezoneValue,
+                timePrecision,
+            );
+            onChange?.(newIsoDateString, isUserChange);
+        },
+        [closeOnSelection, isControlled, formatDateString, onChange, timezoneValue, timePrecision, valueAsDate],
+    );
+
+    const dayPickerProps: ReactDayPickerSingleProps["dayPickerProps"] = {
+        ...props.dayPickerProps,
+        onDayKeyDown: (day, modifiers, e) => {
+            props.dayPickerProps?.onDayKeyDown?.(day, modifiers, e);
+        },
+        onMonthChange: (month: Date) => {
+            props.dayPickerProps?.onMonthChange?.(month);
+        },
+    };
+
+    const handleShortcutChange = React.useCallback((_: DatePickerShortcut, index: number) => {
+        setSelectedShortcutIndex(index);
+    }, []);
+
+    const handleStartFocusBoundaryFocusIn = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+        if (popoverContentRef.current?.contains(getRelatedTargetWithFallback(e))) {
+            // Not closing Popover to allow user to freely switch between manually entering a date
+            // string in the input and selecting one via the Popover
+            inputRef.current?.focus();
+        } else {
+            getKeyboardFocusableElements(popoverContentRef).shift()?.focus();
+        }
+    }, []);
+
+    const handleEndFocusBoundaryFocusIn = React.useCallback(
+        (e: React.FocusEvent<HTMLDivElement>) => {
+            if (popoverContentRef.current?.contains(getRelatedTargetWithFallback(e))) {
+                inputRef.current?.focus();
+                handlePopoverClose(e);
+            } else {
+                getKeyboardFocusableElements(popoverContentRef).pop()?.focus();
+            }
+        },
+        [handlePopoverClose],
+    );
+
+    // React's onFocus prop listens to the focusin browser event under the hood, so it's safe to
+    // provide it the focusIn event handlers instead of using a ref and manually adding the
+    // event listeners ourselves.
+    const popoverContent = (
+        <div ref={popoverContentRef} role="dialog" aria-label="date picker" id={popoverId}>
+            <div onFocus={handleStartFocusBoundaryFocusIn} tabIndex={0} />
+            <DatePicker3
+                {...datePickerProps}
+                dateFnsLocaleLoader={dateFnsLocaleLoader}
+                dayPickerProps={dayPickerProps}
+                locale={locale}
+                maxDate={maxDate}
+                minDate={minDate}
+                onChange={handleDateChange}
+                onShortcutChange={handleShortcutChange}
+                selectedShortcutIndex={selectedShortcutIndex}
+                timePrecision={timePrecision}
+                timezone={timezoneValue}
+                // the rest of this component handles invalid dates gracefully (to show error messages),
+                // but DatePicker does not, so we must take care to filter those out
+                value={isErrorState ? null : valueAsDate}
+            />
+            <div onFocus={handleEndFocusBoundaryFocusIn} tabIndex={0} />
+        </div>
+    );
+
+    // Timezone select
+    // ------------------------------------------------------------------------
+
+    // we need a date which is guaranteed to be non-null here; if necessary,
+    // we use today's date and shift it to the desired/current timezone
+    const tzSelectDate = React.useMemo(
+        () =>
+            valueAsDate != null && DateUtils.isDateValid(valueAsDate)
+                ? valueAsDate
+                : TimezoneUtils.convertLocalDateToTimezoneTime(new Date(), timezoneValue),
+        [timezoneValue, valueAsDate],
+    );
+
+    const isTimezoneSelectHidden = timePrecision === undefined || showTimezoneSelect === false;
+    const isTimezoneSelectDisabled = disabled || disableTimezoneSelect;
+
+    const handleTimezoneChange = React.useCallback(
+        (newTimezone: string) => {
+            if (controlledTimezone === undefined) {
+                // uncontrolled timezone
+                setTimezoneValue(newTimezone);
+            }
+            onTimezoneChange?.(newTimezone);
+
+            if (valueAsDate != null) {
+                const newDateString = TimezoneUtils.getIsoEquivalentWithUpdatedTimezone(
+                    valueAsDate,
+                    newTimezone,
+                    timePrecision,
+                );
+                onChange?.(newDateString, true);
+            }
+        },
+        [onChange, onTimezoneChange, valueAsDate, timePrecision, controlledTimezone],
+    );
+
+    const maybeTimezonePicker = React.useMemo(
+        () =>
+            isTimezoneSelectHidden ? undefined : (
+                <TimezoneSelect
+                    buttonProps={timezoneSelectButtonProps}
+                    className={Classes.DATE_INPUT_TIMEZONE_SELECT}
+                    date={tzSelectDate}
+                    disabled={isTimezoneSelectDisabled}
+                    onChange={handleTimezoneChange}
+                    value={timezoneValue}
+                >
+                    <Tag
+                        endIcon={isTimezoneSelectDisabled ? undefined : "caret-down"}
+                        interactive={!isTimezoneSelectDisabled}
+                        minimal={true}
+                    >
+                        {TimezoneNameUtils.getTimezoneShortName(timezoneValue, tzSelectDate)}
+                    </Tag>
+                </TimezoneSelect>
+            ),
+        [handleTimezoneChange, isTimezoneSelectDisabled, isTimezoneSelectHidden, timezoneValue, tzSelectDate],
+    );
+
+    // Text input
+    // ------------------------------------------------------------------------
+
+    const handleInputFocus = React.useCallback(
+        (e: React.FocusEvent<HTMLInputElement>) => {
+            setIsInputFocused(true);
+            setIsOpen(true);
+            setInputValue(formattedDateString);
+            inputProps?.onFocus?.(e);
+        },
+        [formattedDateString, inputProps],
+    );
+
+    const handleInputBlur = React.useCallback(
+        (e: React.FocusEvent<HTMLInputElement>) => {
+            if (inputValue == null || valueAsDate == null) {
+                setIsInputFocused(false);
+                return;
+            }
+
+            const date = parseDateString(inputValue);
+
+            if (
+                inputValue.length > 0 &&
+                inputValue !== formattedDateString &&
+                (!DateUtils.isDateValid(date) || !DateUtils.isDayInRange(date, [minDate, maxDate]))
+            ) {
+                if (isControlled) {
+                    setIsInputFocused(false);
+                } else {
+                    setIsInputFocused(false);
+                    setValue(date);
+                    setInputValue(undefined);
+                }
+
+                if (date === null) {
+                    onChange?.(null, true);
+                } else {
+                    onError?.(date);
+                }
+            } else {
+                if (inputValue.length === 0) {
+                    setIsInputFocused(false);
+                    setValue(null);
+                    setInputValue(undefined);
+                } else {
+                    setIsInputFocused(false);
+                }
+            }
+            inputProps?.onBlur?.(e);
+        },
+        [
+            formattedDateString,
+            inputProps,
+            inputValue,
+            isControlled,
+            maxDate,
+            minDate,
+            onChange,
+            onError,
+            parseDateString,
+            valueAsDate,
+        ],
+    );
+
+    const handleInputChange = React.useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const valueString = e.target.value;
+            const inputValueAsDate = parseDateString(valueString);
+
+            if (
+                DateUtils.isDateValid(inputValueAsDate) &&
+                DateUtils.isDayInRange(inputValueAsDate, [minDate, maxDate])
+            ) {
+                if (isControlled) {
+                    setInputValue(valueString);
+                } else {
+                    setValue(inputValueAsDate);
+                    setInputValue(valueString);
+                }
+                const newIsoDateString = TimezoneUtils.getIsoEquivalentWithUpdatedTimezone(
+                    inputValueAsDate,
+                    timezoneValue,
+                    timePrecision,
+                );
+                onChange?.(newIsoDateString, true);
+            } else {
+                if (valueString.length === 0) {
+                    onChange?.(null, true);
+                }
+                setValue(inputValueAsDate);
+                setInputValue(valueString);
+            }
+            inputProps?.onChange?.(e);
+        },
+        [isControlled, minDate, maxDate, timezoneValue, timePrecision, parseDateString, onChange, inputProps],
+    );
+
+    const handleInputClick = React.useCallback(
+        (e: React.MouseEvent<HTMLInputElement>) => {
+            // stop propagation to the Popover's internal handleTargetClick handler;
+            // otherwise, the popover will flicker closed as soon as it opens.
+            e.stopPropagation();
+            inputProps?.onClick?.(e);
+        },
+        [inputProps],
+    );
+
+    const handleInputKeyDown = React.useCallback(
+        (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === "Tab" && e.shiftKey) {
+                // close popover on SHIFT+TAB key press
+                handlePopoverClose(e);
+            } else if (e.key === "Tab" && isOpen) {
+                getKeyboardFocusableElements(popoverContentRef).shift()?.focus();
+                // necessary to prevent focusing the second focusable element
+                e.preventDefault();
+            } else if (e.key === "Escape") {
+                setIsOpen(false);
+                inputRef.current?.blur();
+            } else if (e.key === "Enter" && inputValue != null) {
+                const nextDate = parseDateString(inputValue);
+                if (DateUtils.isDateValid(nextDate)) {
+                    handleDateChange(nextDate, true, true);
+                }
+            }
+
+            inputProps?.onKeyDown?.(e);
+        },
+        [handleDateChange, handlePopoverClose, inputProps, inputValue, isOpen, parseDateString],
+    );
+
+    // Main render
+    // ------------------------------------------------------------------------
+
+    const shouldShowErrorStyling =
+        !isInputFocused || inputValue === outOfRangeMessage || inputValue === invalidDateMessage;
+
+    // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like the "fill" prop.
+    const renderTarget = React.useCallback(
+        ({ isOpen: targetIsOpen, ref, ...targetProps }: PopoverTargetProps & PopoverClickTargetHandlers) => {
+            return (
+                <InputGroup
+                    autoComplete="off"
+                    className={classNames(targetProps.className, inputProps.className)}
+                    intent={shouldShowErrorStyling && isErrorState ? Intent.DANGER : Intent.NONE}
+                    placeholder={placeholder}
+                    rightElement={
+                        <>
+                            {rightElement}
+                            {maybeTimezonePicker}
+                        </>
+                    }
+                    tagName={popoverProps.targetTagName}
+                    type="text"
+                    role="combobox"
+                    {...targetProps}
+                    {...inputProps}
+                    aria-controls={popoverId}
+                    aria-expanded={targetIsOpen}
+                    disabled={disabled}
+                    fill={fill}
+                    inputRef={mergeRefs(ref, inputRef, inputProps?.inputRef)}
+                    onBlur={handleInputBlur}
+                    onChange={handleInputChange}
+                    onClick={handleInputClick}
+                    onFocus={handleInputFocus}
+                    onKeyDown={handleInputKeyDown}
+                    value={(isInputFocused ? inputValue : formattedDateString) ?? ""}
+                />
+            );
+        },
+        [
+            disabled,
+            fill,
+            formattedDateString,
+            handleInputBlur,
+            handleInputChange,
+            handleInputClick,
+            handleInputFocus,
+            handleInputKeyDown,
+            inputProps,
+            inputValue,
+            isErrorState,
+            isInputFocused,
+            maybeTimezonePicker,
+            placeholder,
+            popoverId,
+            popoverProps.targetTagName,
+            rightElement,
+            shouldShowErrorStyling,
+        ],
+    );
+
+    // N.B. no need to set `fill` since that is unused with the `renderTarget` API
+    return (
+        <Popover
+            isOpen={isOpen && !disabled}
+            {...popoverProps}
+            autoFocus={false}
+            className={classNames(Classes.DATE_INPUT, popoverProps.className, props.className)}
+            content={popoverContent}
+            enforceFocus={false}
+            onClose={handlePopoverClose}
+            popoverClassName={classNames(Classes.DATE_INPUT_POPOVER, popoverProps.popoverClassName)}
+            ref={popoverRef}
+            renderTarget={renderTarget}
+        />
+    );
+});
+DateInput3.displayName = `${DISPLAYNAME_PREFIX}.DateInput3`;
+
+// TODO: Removing `defaultProps` here breaks tests. Investigate why.
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+DateInput3.defaultProps = DATEINPUT3_DEFAULT_PROPS;
+
+/** Gets the input `placeholder` value from props, using default values if undefined */
+function getPlaceholder(props: DateInput3Props): string | undefined {
+    if (props.placeholder !== undefined || (props.formatDate !== undefined && props.parseDate !== undefined)) {
+        return props.placeholder;
+    } else {
+        return props.dateFnsFormat ?? getDefaultDateFnsFormat(props);
+    }
+}
+
+function getInitialTimezoneValue({ defaultTimezone, timezone }: DateInput3Props) {
+    if (timezone !== undefined) {
+        // controlled mode
+        if (TimezoneNameUtils.isValidTimezone(timezone)) {
+            return timezone;
+        } else {
+            console.error(Errors.DATEINPUT_INVALID_TIMEZONE);
+            return TimezoneUtils.UTC_TIME.ianaCode;
+        }
+    } else if (defaultTimezone !== undefined) {
+        // uncontrolled mode with initial value
+        if (TimezoneNameUtils.isValidTimezone(defaultTimezone)) {
+            return defaultTimezone;
+        } else {
+            console.error(Errors.DATEINPUT_INVALID_DEFAULT_TIMEZONE);
+            return TimezoneUtils.UTC_TIME.ianaCode;
+        }
+    } else {
+        // uncontrolled mode
+        return TimezoneUtils.getCurrentTimezone();
+    }
+}
+
+function getRelatedTargetWithFallback(e: React.FocusEvent<HTMLElement>) {
+    return e.relatedTarget ?? Utils.getActiveElement(e.currentTarget);
+}
+
+function getKeyboardFocusableElements(popoverContentRef: React.MutableRefObject<HTMLDivElement | null>) {
+    if (popoverContentRef.current === null) {
+        return [];
+    }
+
+    const elements = Utils.getFocusableElements(popoverContentRef.current);
+    // Remove focus boundary div elements
+    elements.pop();
+    elements.shift();
+    return elements;
+}

--- a/packages/datetime/src/components/date-input3/dateInput3Props.ts
+++ b/packages/datetime/src/components/date-input3/dateInput3Props.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DateFormatProps } from "../../common";
+import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
+
+import type { DateInputProps } from "./dateInputProps";
+
+/**
+ * Props shared between DateInput v1 and v3.
+ *
+ * Note that we exclude formatDate and parseDate so that we can make those optional in DateInput3 and provide a default
+ * implementation for those functions using date-fns.
+ */
+type DateInputSharedProps = Omit<
+    DateInputProps,
+    "dayPickerProps" | "formatDate" | "locale" | "localeUtils" | "modifiers" | "parseDate"
+>;
+
+export interface DateInput3Props
+    extends DateInputSharedProps,
+        ReactDayPickerSingleProps,
+        DateFnsLocaleProps,
+        Partial<Omit<DateFormatProps, "locale">> {
+    /**
+     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
+     *
+     * Mutually exclusive with the `formatDate` and `parseDate` props.
+     *
+     * See date-fns [format](https://date-fns.org/docs/format).
+     */
+    dateFnsFormat?: string;
+}
+
+export type DateInput3DefaultProps = Required<
+    Pick<
+        DateInput3Props,
+        | "closeOnSelection"
+        | "disabled"
+        | "invalidDateMessage"
+        | "locale"
+        | "maxDate"
+        | "minDate"
+        | "outOfRangeMessage"
+        | "reverseMonthAndYearMenus"
+    >
+>;
+
+export type DateInput3PropsWithDefaults = Omit<DateInput3Props, keyof DateInput3DefaultProps> & DateInput3DefaultProps;

--- a/packages/datetime/src/components/date-input3/dateInputProps.ts
+++ b/packages/datetime/src/components/date-input3/dateInputProps.ts
@@ -1,0 +1,155 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { InputGroupProps, Props } from "@blueprintjs/core";
+
+import type { DateFormatProps, DatePickerBaseProps } from "../../common";
+import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
+import type { DatePickerShortcut } from "../shortcuts/shortcuts";
+
+export interface DateInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
+    /**
+     * Allows the user to clear the selection by clicking the currently selected day.
+     * Passed to `DatePicker` component.
+     *
+     * @default true
+     */
+    canClearSelection?: boolean;
+
+    /**
+     * Text for the reset button in the date picker action bar.
+     * Passed to `DatePicker` component.
+     *
+     * @default "Clear"
+     */
+    clearButtonText?: string;
+
+    /**
+     * Whether the calendar popover should close when a date is selected.
+     *
+     * @default true
+     */
+    closeOnSelection?: boolean;
+
+    /**
+     * The default timezone selected. Defaults to the user's local timezone.
+     *
+     * Mutually exclusive with `timezone` prop.
+     *
+     * @see https://www.iana.org/time-zones
+     */
+    defaultTimezone?: string;
+
+    /**
+     * Whether to disable the timezone select.
+     *
+     * @default false
+     */
+    disableTimezoneSelect?: boolean;
+
+    /**
+     * The default date to be used in the component when uncontrolled, represented as an ISO string.
+     */
+    defaultValue?: string;
+
+    /**
+     * Whether the date input is non-interactive.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether the component should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * Props to pass to the [InputGroup component](#core/components/input-group).
+     *
+     * Some properties are unavailable:
+     * - `inputProps.value`: use `value` instead
+     * - `inputProps.disabled`: use `disabled` instead
+     * - `inputProps.type`: cannot be customized, always set to "text"
+     *
+     * Note that `inputProps.tagName` will override `popoverProps.targetTagName`.
+     */
+    inputProps?: Partial<Omit<InputGroupProps, "disabled" | "type" | "value">>;
+
+    /**
+     * Callback invoked whenever the date or timezone has changed.
+     *
+     * @param newDate ISO string or `null` (if the date is invalid or text input has been cleared)
+     * @param isUserChange `true` if the user clicked on a date in the calendar, changed the input value,
+     *     or cleared the selection; `false` if the date was changed by changing the month or year.
+     */
+    onChange?: (newDate: string | null, isUserChange: boolean) => void;
+
+    /**
+     * Called when the user finishes typing in a new date and the date causes an error state.
+     * If the date is invalid, `new Date(undefined)` will be returned. If the date is out of range,
+     * the out of range date will be returned (`onChange` is not called in this case).
+     */
+    onError?: (errorDate: Date) => void;
+
+    /**
+     * Callback invoked when the user selects a timezone.
+     *
+     * @param timezone the new timezone's IANA code
+     */
+    onTimezoneChange?: (timezone: string) => void;
+
+    /**
+     * Element to render on right side of input.
+     */
+    rightElement?: React.JSX.Element;
+
+    /**
+     * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown below the calendar.
+     *
+     * @default false
+     */
+    showActionsBar?: boolean;
+
+    /**
+     * Whether to show the timezone select dropdown on the right side of the input.
+     * If `timePrecision` is undefined, this will always be false.
+     *
+     * @default false
+     */
+    showTimezoneSelect?: boolean;
+
+    /**
+     * Whether shortcuts to quickly select a date are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     *
+     * @default false
+     */
+    shortcuts?: boolean | DatePickerShortcut[];
+
+    /**
+     * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".
+     *
+     * If you set this prop, the TimezoneSelect will behave in a controlled manner and you are responsible
+     * for updating this value using the `onTimezoneChange` callback.
+     *
+     * Mutually exclusive with `defaultTimezone` prop.
+     *
+     * See [IANA Time Zones](https://www.iana.org/time-zones).
+     */
+    timezone?: string;
+
+    /**
+     * Text for the today button in the date picker action bar.
+     * Passed to `DatePicker` component.
+     *
+     * @default "Today"
+     */
+    todayButtonText?: string;
+
+    /** An ISO string representing the selected time. */
+    value?: string | null;
+}

--- a/packages/datetime/src/components/date-input3/useDateFormatter.ts
+++ b/packages/datetime/src/components/date-input3/useDateFormatter.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+import * as React from "react";
+
+import { DateUtils } from "../../common";
+import { getDateFnsFormatter, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
+import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
+
+import type { DateInput3Props, DateInput3PropsWithDefaults } from "./dateInput3Props";
+
+/**
+ * Create a date string parser function based on a given locale.
+ *
+ * Prefer using user-provided `props.formatDate` and `props.dateFnsFormat` if available, otherwise fall back to
+ * default formats inferred from time picker props.
+ */
+export function useDateFormatter(props: DateInput3Props, locale: Locale | undefined) {
+    const {
+        dateFnsFormat,
+        locale: localeFromProps,
+        formatDate,
+        invalidDateMessage,
+        maxDate,
+        minDate,
+        outOfRangeMessage,
+        timePickerProps,
+        timePrecision,
+    } = props as DateInput3PropsWithDefaults;
+
+    return React.useCallback(
+        (date: Date | undefined) => {
+            if (date === undefined) {
+                return "";
+            }
+            if (!DateUtils.isDateValid(date)) {
+                return invalidDateMessage;
+            } else if (DateUtils.isDayInRange(date, [minDate, maxDate])) {
+                if (formatDate !== undefined) {
+                    // user-provided date formatter
+                    return formatDate(date, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
+                } else {
+                    // use user-provided date-fns format or one of the default formats inferred from time picker props
+                    const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
+                    return getDateFnsFormatter(format, locale)(date);
+                }
+            } else {
+                return outOfRangeMessage;
+            }
+        },
+        [
+            dateFnsFormat,
+            formatDate,
+            invalidDateMessage,
+            locale,
+            localeFromProps,
+            maxDate,
+            minDate,
+            outOfRangeMessage,
+            timePickerProps,
+            timePrecision,
+        ],
+    );
+}

--- a/packages/datetime/src/components/date-input3/useDateParser.ts
+++ b/packages/datetime/src/components/date-input3/useDateParser.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+import * as React from "react";
+
+import { getDateFnsParser, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
+import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
+
+import type { DateInput3Props, DateInput3PropsWithDefaults } from "./dateInput3Props";
+
+const INVALID_DATE = new Date(undefined!);
+
+/**
+ * Create a date string parser function based on a given locale.
+ *
+ * Prefer using user-provided `props.parseDate` and `props.dateFnsFormat` if available, otherwise fall back to
+ * default formats inferred from time picker props.
+ */
+export function useDateParser(props: DateInput3Props, locale: Locale | undefined) {
+    const {
+        dateFnsFormat,
+        invalidDateMessage,
+        locale: localeFromProps,
+        outOfRangeMessage,
+        parseDate,
+        timePickerProps,
+        timePrecision,
+    } = props as DateInput3PropsWithDefaults;
+
+    return React.useCallback(
+        (dateString: string): Date | null => {
+            if (dateString === outOfRangeMessage || dateString === invalidDateMessage) {
+                return null;
+            }
+            let newDate: false | Date | null = null;
+
+            if (parseDate !== undefined) {
+                // user-provided date parser
+                newDate = parseDate(dateString, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
+            } else {
+                // use user-provided date-fns format or one of the default formats inferred from time picker props
+                const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
+                newDate = getDateFnsParser(format, locale)(dateString);
+            }
+
+            return newDate === false ? INVALID_DATE : newDate;
+        },
+        [
+            dateFnsFormat,
+            invalidDateMessage,
+            locale,
+            localeFromProps,
+            outOfRangeMessage,
+            parseDate,
+            timePickerProps,
+            timePrecision,
+        ],
+    );
+}

--- a/packages/datetime/src/components/date-picker3/_date-picker3-caption.scss
+++ b/packages/datetime/src/components/date-picker3/_date-picker3-caption.scss
@@ -1,0 +1,49 @@
+// Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "@blueprintjs/colors/lib/scss/colors";
+@import "@blueprintjs/datetime/src/common";
+
+// react-day-picker does not conform to our naming scheme
+/* stylelint-disable selector-class-pattern */
+
+// use extra specificity to override DatePicker v1 styles
+.#{$ns}-datepicker-caption.rdp-caption {
+  @include pt-flex-container(row);
+  justify-content: space-between;
+  margin: 0;
+
+  // override HTMLSelect styles for a narrower appearance
+  // N.B. these styles are important to achieve accurate measurements to position the dropdown arrows in <DatePickerCaption>
+  .#{$ns}-html-select select {
+    font-weight: 600;
+    padding-left: $datepicker-padding;
+    padding-right: $pt-icon-size-standard;
+
+    + .#{$ns}-icon {
+      right: 2px;
+    }
+  }
+
+  + .#{$ns}-divider {
+    margin: 0;
+  }
+
+  .#{$ns}-datepicker-nav-button-hidden {
+    visibility: hidden;
+  }
+}
+
+.#{$ns}-datepicker-month-select {
+  flex-shrink: 1;
+}
+
+.#{$ns}-datepicker-year-select {
+  flex-shrink: 1;
+  min-width: 60px;
+}
+
+.#{$ns}-datepicker-caption-measure {
+  font-weight: 600;
+  padding-left: $datepicker-padding;
+}

--- a/packages/datetime/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime/src/components/date-picker3/_date-picker3.scss
@@ -1,0 +1,208 @@
+// Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "@blueprintjs/colors/lib/scss/colors";
+@import "@blueprintjs/core/src/components/popover/common";
+@import "@blueprintjs/datetime/src/common";
+
+// react-day-picker does not conform to our naming scheme
+/* stylelint-disable selector-class-pattern */
+
+.#{$ns}-datepicker {
+  .rdp {
+    display: inline-block;
+    min-width: $datepicker-min-width;
+    position: relative;
+    vertical-align: top;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .rdp-month {
+    display: flex;
+    flex-direction: column;
+    margin: 0 $datepicker-padding;
+    user-select: none;
+
+    // create space between months (selector matches all but first month)
+    & + & {
+      margin-left: $pt-grid-size;
+    }
+  }
+
+  .rdp-caption {
+    border-bottom: solid 1px $pt-divider-black;
+    padding-bottom: $datepicker-padding;
+  }
+
+  .rdp-table {
+    // table is typically slightly narrower than the header, so this ensure that it is horizontally centered
+    align-self: center;
+  }
+
+  .rdp-head_cell {
+    font-size: inherit;
+    font-weight: 600;
+    padding-top: $datepicker-padding;
+    text-decoration: none;
+    text-transform: none;
+  }
+
+  .rdp-weeknumber {
+    color: $pt-text-color-muted;
+  }
+
+  .rdp-day {
+    border-radius: $pt-border-radius;
+
+    // spelling out full name so these are equal specificity to pseudo-classes (.DayPicker-Day:hover)
+    &.rdp-day_outside {
+      color: $pt-text-color-disabled;
+    }
+
+    &.rdp-day_today {
+      // override rdp's default of making today's date bold
+      font-weight: 400;
+    }
+
+    // need some extra specificity here to override rdp default styles
+    &:not([disabled], .rdp-day_selected) {
+      &:hover,
+      &:focus {
+        background: $datepicker-day-background-color-hover;
+        color: $pt-text-color;
+      }
+
+      &:active {
+        background: $datepicker-day-background-color-active;
+      }
+    }
+
+    &.rdp-day_disabled {
+      background: none;
+      color: $pt-text-color-disabled;
+      cursor: not-allowed;
+    }
+
+    // selected styles should override disabled styles (this can happen when single day ranges are not allowed,
+    // rdp applies "disabled" to the first selection in the range)
+    &.rdp-day_selected {
+      background-color: $blue3;
+      border-radius: $pt-border-radius;
+      color: $white;
+
+      &:hover {
+        background-color: $blue2;
+        color: $white;
+      }
+
+      &:active {
+        background-color: $blue1;
+      }
+    }
+  }
+
+  &.#{$ns}-datepicker-highlight-current-day .rdp-day.rdp-day_today {
+    border: 1px solid $pt-divider-black;
+  }
+
+  &.#{$ns}-datepicker-reverse-month-and-year .rdp-caption_dropdowns {
+    flex-direction: row-reverse;
+  }
+}
+
+.#{$ns}-datepicker-content {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  > .#{$ns}-divider {
+    margin: 0; // margin is already applied via flex gap
+    width: calc(100% - #{$datepicker-padding * 2});
+  }
+}
+
+.#{$ns}-datepicker-month-select,
+.#{$ns}-datepicker-year-select {
+  select {
+    font-weight: 600;
+    padding-left: $datepicker-padding;
+    padding-right: $pt-icon-size-standard;
+
+    + .#{$ns}-icon {
+      right: 2px;
+    }
+  }
+}
+
+.#{$ns}-datepicker-footer {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.#{$ns}-dark .#{$ns}-datepicker {
+  background: $dark-datepicker-background-color;
+
+  .rdp-week-number {
+    color: $pt-dark-text-color-muted;
+  }
+
+  .rdp-day {
+    &.rdp-day_outside {
+      color: $pt-dark-text-color-disabled;
+    }
+
+    // need some extra specificity here to override rdp default styles
+    &:not([disabled], .rdp-day_selected) {
+      &:hover,
+      &:focus {
+        background: $dark-datepicker-day-background-color-hover;
+        color: $white;
+      }
+
+      &:active {
+        background: $dark-datepicker-day-background-color-active;
+      }
+    }
+
+    &.rdp-day_selected {
+      background-color: $blue3;
+
+      &:hover {
+        background-color: $blue2;
+      }
+
+      &:active {
+        background-color: $blue1;
+      }
+    }
+
+    &.rdp-day_disabled {
+      background: none;
+      color: $pt-dark-text-color-disabled;
+    }
+  }
+
+  &.#{$ns}-datepicker-highlight-current-day .rdp-day.rdp-day_today {
+    border: 1px solid $pt-dark-divider-white;
+  }
+
+  .#{$ns}-datepicker-footer {
+    border-top-color: $pt-dark-divider-black;
+  }
+}
+
+.#{$ns}-datepicker-timepicker-wrapper {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  .#{$ns}-timepicker-arrow-row:empty + .#{$ns}-timepicker-input-row {
+    // when timepicker arrows are not displayed in the datepicker, we need a bit of extra margin
+    margin: $datepicker-padding 0;
+  }
+}

--- a/packages/datetime/src/components/date-picker3/date-picker3.md
+++ b/packages/datetime/src/components/date-picker3/date-picker3.md
@@ -1,0 +1,150 @@
+---
+tag: new
+---
+
+@# DatePicker3
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Migrating from [DatePicker](#datetime/datepicker)?
+
+</h5>
+
+**DatePicker3** is a replacement for DatePicker and will replace it in Blueprint v6.
+You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
+See the [react-day-picker v8 migration guide](https://github.com/palantir/blueprint/wiki/react-day-picker-8-migration)
+on the wiki.
+
+</div>
+
+**DatePicker3** has the same functionality as [DatePicker](#datetime/datepicker) but uses
+[react-day-picker v8](https://daypicker.dev/v8) instead of [v7](https://react-day-picker-v7.netlify.app/)
+to render its calendar. It renders a UI to choose a single date and (optionally) a time of day. Time selection
+is enabled by the [TimePicker](#datetime/timepicker) component.
+
+@reactExample DatePicker3Example
+
+@## Usage
+
+**DatePicker3** supports both controlled and uncontrolled usage. You can control the selected day by setting the `value`
+prop, or use the component in uncontrolled mode and specify an initial day by setting `defaultValue`. Use the `onChange`
+prop to listen for changes to the selected day.
+
+@## Props interface
+
+In addition to top-level **DatePicker3** props, you may forward some props to `<DayPicker mode="single">` to customize
+react-day-picker's behavior via `dayPickerProps` (the full list is
+[documented here](https://daypicker.dev/v8/api/interfaces/DayPickerSingleProps)).
+
+@interface DatePicker3Props
+
+@## Shortcuts
+
+The menu on the left of the calendars provides "shortcuts" which allow users to quickly select common dates.
+The items in this menu are controlled through the `shortcuts` prop:
+
+-   `false` (default) will hide the shortcuts menu,
+-   `true` will show the built-in shortcuts, and
+-   custom shortcuts can be shown by defining an array of `DatePickerShortcut` objects.
+
+The built-in **preset shortcuts** can be seen in the example above. They are as follows:
+
+-   Today
+-   Yesterday
+-   1 week ago
+-   1 month ago
+-   3 months ago
+-   1 year ago
+
+**Custom shortcuts** use the following interface:
+
+@interface DatePickerShortcut
+
+@## Modifiers
+
+**DatePicker3** utilizes react-day-picker's built-in [modifiers](https://daypicker.dev/guides/custom-modifiers#built-in-modifiers) for
+various functionality (highlighting the current day, showing selected days, etc.).
+
+You may extend and customize the default modifiers by specifying various properties in the `dayPickerProps` prop object.
+In the example below, we add a custom class name to every odd-numbered day in the calendar using a simple
+[Matcher](https://daypicker.dev/api/type-aliases/Matcher).
+
+@reactExample DatePicker3ModifierExample
+
+See [react-day-picker's "Custom modifiers" documentation](https://daypicker.dev/guides/custom-modifiers)
+for more info.
+
+@## Localization
+
+**DatePicker3**, **DateInput3**, **DateRangePicker3**, and **DateRangeInput3** support calendar
+localization using date-fns's [Locale](https://date-fns.org/v2.28.0/docs/Locale) features. The `locale` prop on each
+of these components accepts two types of values, either a `Locale` object or a locale code `string`.
+
+### Using a locale code
+
+Use the `locale: string` type to interpret the prop as a locale code (ISO 639-1 + optional country code).
+The component will attempt to dynamically import the corresponding date-fns locale module.
+
+```ts
+import { DatePicker3 } from "@blueprintjs/datetime2";
+
+function Example() {
+    return <DatePicker3 locale="en-US" />;
+}
+```
+
+At runtime, this will trigger a dynamic import like the following statement:
+
+```ts
+await import(/* webpackChunkName: "date-fns-en-US" */ "date-fns/locale/en-US");
+```
+
+#### Loading `date-fns` locales
+
+By default, `date-fns` locales are loaded using an async `import("date-fns/*")` of the corresponding locale submodule.
+If you need to customize this loader function, you may do so with the `dateFnsLocaleLoader` prop; this is sometimes
+necessary for bundlers like Vite. For example:
+
+```tsx
+import { Locale } from "date-fns";
+import React from "react";
+import { DatePicker3 } from "@blueprintjs/datetime2";
+
+const loadDateFnsLocale: (localeCode: string) => Promise<Locale> = async localeCode => {
+    const localeModule = await import(`../node_modules/date-fns/esm/locale/${localeCode}/index.js`);
+    return localeModule.default;
+};
+
+export const Example: React.FC = () => {
+    return <DatePicker3 dateFnsLocaleLoader={loadDateFnsLocale} />;
+};
+```
+
+### Using a `Locale` object
+
+Use the `locale: Locale` type if you wish to statically load date-fns locale modules:
+
+```ts
+import { DatePicker3 } from "@blueprintjs/datetime2";
+import enUS from "date-fns/locale/en-US";
+
+function Example() {
+    return <DatePicker3 locale={enUS} />;
+}
+```
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Localizing shortcuts
+
+</h5>
+
+Built-in preset shortcut labels are not automatically localized by setting the `locale` prop. If you need these
+strings to appear in different languages, you will need to specify custom shortcuts and update their `label`
+properties accordingly.
+
+</div>
+
+@reactExample DatePicker3LocalizedExample

--- a/packages/datetime/src/components/date-picker3/datePicker3.tsx
+++ b/packages/datetime/src/components/date-picker3/datePicker3.tsx
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import { format } from "date-fns";
+import * as React from "react";
+import { type ActiveModifiers, type DateFormatter, DayPicker } from "react-day-picker-8";
+
+import { Button, DISPLAYNAME_PREFIX, Divider } from "@blueprintjs/core";
+
+import { Classes, type DateRange, DateUtils, Errors, TimezoneUtils } from "../../common";
+import { dayPickerClassNameOverrides } from "../../common/classes";
+import { DatePickerUtils } from "../date-picker/datePickerUtils";
+import { DateFnsLocalizedComponent } from "../dateFnsLocalizedComponent";
+import { DatePicker3Dropdown } from "../react-day-picker/datePicker3Dropdown";
+import { IconLeft, IconRight } from "../react-day-picker/datePickerNavIcons";
+import { DatePickerShortcutMenu, type DateRangeShortcut } from "../shortcuts/shortcuts";
+import { TimePicker } from "../time-picker/timePicker";
+
+import { DatePicker3Provider } from "./datePicker3Context";
+import type { DatePicker3Props } from "./datePicker3Props";
+import type { DatePicker3State } from "./datePicker3State";
+
+export type { DatePicker3Props };
+
+/**
+ * Date picker (v3) component.
+ *
+ * @see https://blueprintjs.com/docs/#datetime2/date-picker3
+ */
+export class DatePicker3 extends DateFnsLocalizedComponent<DatePicker3Props, DatePicker3State> {
+    public static defaultProps: DatePicker3Props = {
+        canClearSelection: true,
+        clearButtonText: "Clear",
+        dayPickerProps: {},
+        highlightCurrentDay: false,
+        locale: "en-US",
+        maxDate: DatePickerUtils.getDefaultMaxDate(),
+        minDate: DatePickerUtils.getDefaultMinDate(),
+        reverseMonthAndYearMenus: false,
+        shortcuts: false,
+        showActionsBar: false,
+        todayButtonText: "Today",
+    };
+
+    public static displayName = `${DISPLAYNAME_PREFIX}.DatePicker3`;
+
+    private ignoreNextMonthChange = false;
+
+    public constructor(props: DatePicker3Props) {
+        super(props);
+        const value = getInitialValue(props);
+        const initialMonth = getInitialMonth(props, value);
+        this.state = {
+            displayMonth: initialMonth.getMonth(),
+            displayYear: initialMonth.getFullYear(),
+            locale: undefined,
+            selectedDay: value == null ? null : value.getDate(),
+            selectedShortcutIndex:
+                this.props.selectedShortcutIndex !== undefined ? this.props.selectedShortcutIndex : -1,
+            value,
+        };
+    }
+
+    public render() {
+        const { className, dayPickerProps, footerElement, maxDate, minDate, showActionsBar } = this.props;
+        const { displayMonth, displayYear, locale } = this.state;
+
+        return (
+            <div
+                className={classNames(Classes.DATEPICKER, className, {
+                    [Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
+                    [Classes.DATEPICKER3_REVERSE_MONTH_AND_YEAR]: this.props.reverseMonthAndYearMenus,
+                })}
+            >
+                {this.maybeRenderShortcuts()}
+                <div className={Classes.DATEPICKER_CONTENT}>
+                    <DatePicker3Provider {...this.props} {...this.state}>
+                        <DayPicker
+                            locale={locale}
+                            showOutsideDays={true}
+                            {...dayPickerProps}
+                            captionLayout="dropdown-buttons"
+                            classNames={{
+                                ...dayPickerClassNameOverrides,
+                                ...dayPickerProps?.classNames,
+                            }}
+                            components={{
+                                Dropdown: DatePicker3Dropdown,
+                                IconLeft,
+                                IconRight,
+                                ...dayPickerProps?.components,
+                            }}
+                            formatters={{
+                                formatWeekdayName: this.renderWeekdayName,
+                                ...dayPickerProps?.formatters,
+                            }}
+                            fromDate={minDate}
+                            mode="single"
+                            month={new Date(displayYear, displayMonth)}
+                            onMonthChange={this.handleMonthChange}
+                            onSelect={this.handleDaySelect}
+                            required={!this.props.canClearSelection}
+                            selected={this.state.value ?? undefined}
+                            toDate={maxDate}
+                        />
+                        {this.maybeRenderTimePicker()}
+                        {showActionsBar && this.renderOptionsBar()}
+                        {footerElement}
+                    </DatePicker3Provider>
+                </div>
+            </div>
+        );
+    }
+
+    public async componentDidMount() {
+        await super.componentDidMount();
+    }
+
+    public async componentDidUpdate(prevProps: DatePicker3Props) {
+        super.componentDidUpdate(prevProps);
+
+        if (this.props.value !== prevProps.value) {
+            if (this.props.value == null) {
+                // clear the value
+                this.setState({ value: null });
+            } else {
+                this.setState({
+                    displayMonth: this.props.value.getMonth(),
+                    displayYear: this.props.value.getFullYear(),
+                    selectedDay: this.props.value.getDate(),
+                    value: this.props.value,
+                });
+            }
+        }
+
+        if (this.props.selectedShortcutIndex !== prevProps.selectedShortcutIndex) {
+            this.setState({ selectedShortcutIndex: this.props.selectedShortcutIndex });
+        }
+    }
+
+    protected validateProps(props: DatePicker3Props) {
+        const { defaultValue, initialMonth, maxDate, minDate, value } = props;
+        if (defaultValue != null && !DateUtils.isDayInRange(defaultValue, [minDate!, maxDate!])) {
+            console.error(Errors.DATEPICKER_DEFAULT_VALUE_INVALID);
+        }
+
+        if (initialMonth != null && !DateUtils.isMonthInRange(initialMonth, [minDate!, maxDate!])) {
+            console.error(Errors.DATEPICKER_INITIAL_MONTH_INVALID);
+        }
+
+        if (maxDate != null && minDate != null && maxDate < minDate && !DateUtils.isSameDay(maxDate, minDate)) {
+            console.error(Errors.DATEPICKER_MAX_DATE_INVALID);
+        }
+
+        if (value != null && !DateUtils.isDayInRange(value, [minDate!, maxDate!])) {
+            console.error(Errors.DATEPICKER_VALUE_INVALID);
+        }
+    }
+
+    /**
+     * Custom formatter to render weekday names in the calendar header. The default formatter generally works fine,
+     * but it was returning CAPITALIZED strings for some reason, while we prefer Title Case.
+     */
+    private renderWeekdayName: DateFormatter = date => {
+        return format(date, "EEEEEE", { locale: this.state.locale });
+    };
+
+    private renderOptionsBar() {
+        const { clearButtonText, todayButtonText, minDate, maxDate, canClearSelection } = this.props;
+        const todayEnabled = isTodayEnabled(minDate!, maxDate!);
+        return [
+            <Divider key="div" />,
+            <div className={Classes.DATEPICKER_FOOTER} key="footer">
+                <Button
+                    disabled={!todayEnabled}
+                    onClick={this.handleTodayClick}
+                    text={todayButtonText}
+                    variant="minimal"
+                />
+                <Button
+                    disabled={!canClearSelection}
+                    onClick={this.handleClearClick}
+                    text={clearButtonText}
+                    variant="minimal"
+                />
+            </div>,
+        ];
+    }
+
+    private maybeRenderTimePicker() {
+        const { timePrecision, timePickerProps, minDate, maxDate } = this.props;
+        if (timePrecision == null && timePickerProps === undefined) {
+            return null;
+        }
+        const applyMin = this.state.value != null && DateUtils.isSameDay(this.state.value, minDate!);
+        const applyMax = this.state.value != null && DateUtils.isSameDay(this.state.value, maxDate!);
+        return (
+            <div className={Classes.DATEPICKER_TIMEPICKER_WRAPPER}>
+                <TimePicker
+                    precision={timePrecision}
+                    minTime={applyMin ? minDate : undefined}
+                    maxTime={applyMax ? maxDate : undefined}
+                    {...timePickerProps}
+                    onChange={this.handleTimeChange}
+                    value={this.state.value}
+                />
+            </div>
+        );
+    }
+
+    private maybeRenderShortcuts() {
+        const { shortcuts } = this.props;
+        if (shortcuts == null || shortcuts === false) {
+            return null;
+        }
+
+        const { selectedShortcutIndex } = this.state;
+        const { maxDate, minDate, timePrecision } = this.props;
+        // Reuse the existing date range shortcuts and only care about start date
+        const dateRangeShortcuts: DateRangeShortcut[] | true =
+            shortcuts === true
+                ? true
+                : shortcuts.map(shortcut => ({
+                      ...shortcut,
+                      // TODO: Remove cast after setting "strictNullChecks: true"
+                      dateRange: [shortcut.date, null] as [Date, null],
+                  }));
+        return [
+            <DatePickerShortcutMenu
+                key="shortcuts"
+                {...{
+                    allowSingleDayRange: true,
+                    maxDate,
+                    minDate,
+                    selectedShortcutIndex,
+                    shortcuts: dateRangeShortcuts,
+                    timePrecision,
+                }}
+                onShortcutClick={this.handleShortcutClick}
+                useSingleDateShortcuts={true}
+            />,
+            <Divider key="div" />,
+        ];
+    }
+
+    private handleDaySelect = (
+        day: Date | undefined,
+        selectedDay: Date,
+        activeModifiers: ActiveModifiers,
+        e: React.MouseEvent,
+    ) => {
+        if (activeModifiers.disabled) {
+            return;
+        } else if (day === undefined) {
+            this.handleClearClick();
+            return;
+        }
+
+        this.updateDay(day);
+        this.props.dayPickerProps?.onSelect?.(day, selectedDay, activeModifiers, e);
+
+        // allow toggling selected date by clicking it again (if prop enabled)
+        const newValue =
+            this.props.canClearSelection && activeModifiers.selected
+                ? null
+                : DateUtils.getDateTime(day, this.state.value);
+        this.updateValue(newValue, true);
+    };
+
+    private handleShortcutClick = (shortcut: DateRangeShortcut, selectedShortcutIndex: number) => {
+        const { onShortcutChange, selectedShortcutIndex: currentShortcutIndex } = this.props;
+        const { dateRange, includeTime } = shortcut;
+
+        const newDate = dateRange[0];
+        const newValue = includeTime ? newDate : DateUtils.getDateTime(newDate, this.state.value);
+
+        if (newDate == null) {
+            return;
+        }
+
+        this.updateDay(newDate);
+        this.updateValue(newValue, true);
+
+        if (currentShortcutIndex === undefined) {
+            this.setState({ selectedShortcutIndex });
+        }
+
+        const datePickerShortcut = { ...shortcut, date: newDate };
+        onShortcutChange?.(datePickerShortcut, selectedShortcutIndex);
+    };
+
+    private updateDay = (day: Date) => {
+        if (this.props.value === undefined) {
+            // set now if uncontrolled, otherwise they'll be updated in `componentDidUpdate`
+            this.setState({
+                displayMonth: day.getMonth(),
+                displayYear: day.getFullYear(),
+                selectedDay: day.getDate(),
+            });
+        }
+        if (this.state.value != null && this.state.value.getMonth() !== day.getMonth()) {
+            this.ignoreNextMonthChange = true;
+        }
+    };
+
+    private computeValidDateInSpecifiedMonthYear(displayYear: number, displayMonth: number): Date | null {
+        const { minDate, maxDate } = this.props;
+        const { selectedDay } = this.state;
+        // month is 0-based, date is 1-based. date 0 is last day of previous month.
+        const maxDaysInMonth = new Date(displayYear, displayMonth + 1, 0).getDate();
+        const displayDate = selectedDay == null ? 1 : Math.min(selectedDay, maxDaysInMonth);
+
+        // 12:00 matches the underlying react-day-picker timestamp behavior
+        const value = DateUtils.getDateTime(new Date(displayYear, displayMonth, displayDate, 12), this.state.value);
+        // clamp between min and max dates
+        if (value != null && value < minDate!) {
+            return minDate!;
+        } else if (value != null && value > maxDate!) {
+            return maxDate!;
+        }
+        return value;
+    }
+
+    private handleClearClick = () => this.updateValue(null, true);
+
+    private handleMonthChange = (newDate: Date) => {
+        const date = this.computeValidDateInSpecifiedMonthYear(newDate.getFullYear(), newDate.getMonth());
+        if (date != null) {
+            this.setState({ displayMonth: date.getMonth(), displayYear: date.getFullYear() });
+            this.props.dayPickerProps?.onMonthChange?.(date);
+        }
+        if (this.state.value !== null) {
+            // if handleDayClick just got run (so this flag is set), then the
+            // user selected a date in a new month, so don't invoke onChange a
+            // second time
+            this.updateValue(date, false, this.ignoreNextMonthChange);
+            this.ignoreNextMonthChange = false;
+        }
+    };
+
+    private handleTodayClick = () => {
+        const { timezone } = this.props;
+        const today = new Date();
+        const value = timezone != null ? TimezoneUtils.convertLocalDateToTimezoneTime(today, timezone) : today;
+        const displayMonth = value.getMonth();
+        const displayYear = value.getFullYear();
+        const selectedDay = value.getDate();
+        this.setState({ displayMonth, displayYear, selectedDay });
+        this.updateValue(value, true);
+    };
+
+    private handleTimeChange = (time: Date) => {
+        this.props.timePickerProps?.onChange?.(time);
+        const { value } = this.state;
+        const newValue = DateUtils.getDateTime(value != null ? value : new Date(), time);
+        this.updateValue(newValue, true);
+    };
+
+    /**
+     * Update `value` by invoking `onChange` (always) and setting state (if uncontrolled).
+     */
+    private updateValue(value: Date | null, isUserChange: boolean, skipOnChange = false) {
+        if (!skipOnChange) {
+            this.props.onChange?.(value, isUserChange);
+        }
+        if (this.props.value === undefined) {
+            this.setState({ value });
+        }
+    }
+}
+
+function getInitialValue(props: DatePicker3Props): Date | null {
+    // !== because `null` is a valid value (no date)
+    if (props.value !== undefined) {
+        return props.value;
+    }
+    if (props.defaultValue !== undefined) {
+        return props.defaultValue;
+    }
+    return null;
+}
+
+function getInitialMonth(props: DatePicker3Props, value: Date | null): Date {
+    const rangeFromProps: DateRange = [props.minDate ?? null, props.maxDate ?? null];
+    const today = new Date();
+    // != because we must have a real `Date` to begin the calendar on.
+    if (props.initialMonth != null) {
+        return props.initialMonth;
+    } else if (value != null) {
+        return value;
+    } else if (DateUtils.isDayInRange(today, rangeFromProps)) {
+        return today;
+    } else {
+        return DateUtils.getDateBetween(rangeFromProps);
+    }
+}
+
+function isTodayEnabled(minDate: Date, maxDate: Date): boolean {
+    const today = new Date();
+    return DateUtils.isDayInRange(today, [minDate, maxDate]);
+}

--- a/packages/datetime/src/components/date-picker3/datePicker3Props.ts
+++ b/packages/datetime/src/components/date-picker3/datePicker3Props.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
+
+import type { DatePickerProps } from "./datePickerProps";
+
+/** Props shared between DatePicker v1 and v3 */
+type DatePickerSharedProps = Omit<
+    DatePickerProps,
+    "dayPickerProps" | "defaultValue" | "locale" | "localeUtils" | "modifiers" | "onChange" | "value"
+>;
+
+export interface DatePicker3Props extends DatePickerSharedProps, DateFnsLocaleProps, ReactDayPickerSingleProps {
+    /**
+     * Initial day the calendar will display as selected.
+     * This should not be set if `value` is set.
+     */
+    defaultValue?: Date;
+
+    /**
+     * Called when the user selects a day.
+     * If being used in an uncontrolled manner, `selectedDate` will be `null` if the user clicks the currently selected
+     * day. If being used in a controlled manner, `selectedDate` will contain the day clicked no matter what.
+     * `isUserChange` is true if the user selected a day, and false if the date was automatically changed
+     * by the user navigating to a new month or year rather than explicitly clicking on a date in the calendar.
+     */
+    onChange?: (selectedDate: Date | null, isUserChange: boolean) => void;
+
+    /**
+     * The currently selected day. If this prop is provided, the component acts in a controlled manner.
+     */
+    value?: Date | null;
+
+    /**
+     * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".
+     *
+     * This prop is only used to determine what date should be selected when clicking the "Today" button in the actions
+     * bar. If this value is omitted, the current date will be set using the user's local timezone.
+     *
+     * See [IANA Time Zones](https://www.iana.org/time-zones).
+     */
+    timezone?: string;
+}

--- a/packages/datetime/src/components/date-picker3/datePickerProps.ts
+++ b/packages/datetime/src/components/date-picker3/datePickerProps.ts
@@ -1,0 +1,78 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Props } from "@blueprintjs/core";
+
+import type { DatePickerBaseProps } from "../../common";
+import type { DatePickerShortcut } from "../shortcuts/shortcuts";
+
+export interface DatePickerProps extends DatePickerBaseProps, Props {
+    /**
+     * Allows the user to clear the selection by clicking the currently selected day.
+     * If disabled, the "Clear" Button in the Actions Bar will also be disabled.
+     *
+     * @default true
+     */
+    canClearSelection?: boolean;
+
+    /**
+     * Initial day the calendar will display as selected.
+     * This should not be set if `value` is set.
+     */
+    defaultValue?: Date;
+
+    /**
+     * Called when the user selects a day.
+     * If being used in an uncontrolled manner, `selectedDate` will be `null` if the user clicks the currently selected
+     * day. If being used in a controlled manner, `selectedDate` will contain the day clicked no matter what.
+     * `isUserChange` is true if the user selected a day, and false if the date was automatically changed
+     * by the user navigating to a new month or year rather than explicitly clicking on a date in the calendar.
+     */
+    onChange?: (selectedDate: Date, isUserChange: boolean) => void;
+
+    /**
+     * Called when the `shortcuts` props is enabled and the user changes the shortcut.
+     */
+    onShortcutChange?: (shortcut: DatePickerShortcut, index: number) => void;
+
+    /**
+     * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
+     *
+     * @default false
+     */
+    showActionsBar?: boolean;
+
+    /**
+     * Whether shortcuts to quickly select a date are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     */
+    shortcuts?: boolean | DatePickerShortcut[];
+
+    /**
+     * The currently selected shortcut.
+     * If this prop is provided, the component acts in a controlled manner.
+     */
+    selectedShortcutIndex?: number;
+
+    /**
+     * Text for the today button in the action bar.
+     *
+     * @default "Today"
+     */
+    todayButtonText?: string;
+
+    /**
+     * Text for the reset button in the action bar.
+     *
+     * @default "Clear"
+     */
+    clearButtonText?: string;
+
+    /**
+     * The currently selected day. If this prop is provided, the component acts in a controlled manner.
+     */
+    value?: Date | null;
+}

--- a/packages/datetime/src/components/date-range-input3/date-range-input3.md
+++ b/packages/datetime/src/components/date-range-input3/date-range-input3.md
@@ -1,0 +1,53 @@
+---
+tag: new
+---
+
+@# DateRangeInput3
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Migrating from [DateRangeInput](#datetime/date-range-input)?
+
+</h5>
+
+**DateRangeInput3** is a replacement for DateRangeInput and will replace it in Blueprint v6.
+You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
+See the [react-day-picker v8 migration guide](https://github.com/palantir/blueprint/wiki/react-day-picker-8-migration)
+on the wiki.
+
+</div>
+
+**DateRangeInput3** has the same functionality as [DateRangeInput](#datetime/date-range-input) but uses
+[react-day-picker v8](https://daypicker.dev/v8) instead of [v7](https://react-day-picker-v7.netlify.app/)
+to render its calendar(s). It renders a [**ControlGroup**](#core/components/control-group) composed
+of two [**InputGroups**](#core/components/input-group) and shows a [**DateRangePicker3**](#datetime2/date-range-picker3)
+inside a [**Popover**](#core/components/popover) upon focus.
+
+Unlike [**DateInput3**](#datetime2/date-input3), this component does _not_ yet have support for
+a built-in [**TimezoneSelect**](#datetime/timezone-select).
+
+<!-- It optionally shows a [TimezoneSelect](#datetime/timezone-select) as the third
+element in the ControlGroup, allowing the user to change the timezone of the selected date range. -->
+
+@reactExample DateRangeInput3Example
+
+@## Usage
+
+**DateRangeInput3** supports both controlled and uncontrolled usage. You can control the selected date by setting the
+`value` prop, or use the component in uncontrolled mode and specify an initial date by setting `defaultValue`.
+Use the `onChange` prop callback to listen for changes to the selected day and the `onError` prop to react to invalid
+dates entered in the text inputs.
+
+@## Date formatting
+
+You may customize the date display format with the required `formatDate` and `parseDate` props.
+See [DateInput3's date formatting docs](#datetime3/date-input3.date-formatting) for more details.
+
+@## Props interface
+
+@interface DateRangeInput3Props
+
+@## Localization
+
+See the [**DatePicker3** localization docs](#datetime2/date-picker3.localization).

--- a/packages/datetime/src/components/date-range-input3/dateRangeInput3.tsx
+++ b/packages/datetime/src/components/date-range-input3/dateRangeInput3.tsx
@@ -1,0 +1,1067 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import { isSameDay, isValid } from "date-fns";
+import * as React from "react";
+
+import {
+    Boundary,
+    Classes as CoreClasses,
+    DISPLAYNAME_PREFIX,
+    InputGroup,
+    Intent,
+    Popover,
+    type PopoverClickTargetHandlers,
+    type PopoverTargetProps,
+    refHandler,
+    setRef,
+    Utils,
+} from "@blueprintjs/core";
+
+import { Classes, type DateRange, DateUtils, Errors, type NonNullDateRange } from "../../common";
+import { getDateFnsFormatter, getDateFnsParser, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
+import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
+import { DatePickerUtils } from "../date-picker/datePickerUtils";
+import { DateRangePicker3 } from "../date-range-picker3/dateRangePicker3";
+import { DateFnsLocalizedComponent } from "../dateFnsLocalizedComponent";
+import type { DateRangeShortcut } from "../shortcuts/shortcuts";
+
+import type {
+    DateRangeInput3DefaultProps,
+    DateRangeInput3Props,
+    DateRangeInput3PropsWithDefaults,
+} from "./dateRangeInput3Props";
+import type { DateRangeInput3State } from "./dateRangeInput3State";
+import {
+    clampDate,
+    getTodayAtMidnight,
+    isEntireInputSelected,
+    shiftDateByArrowKey,
+    shiftDateByDays,
+} from "./dateRangeInputUilts";
+
+export type { DateRangeInput3Props };
+
+// We handle events in a kind of generic way in this component, so here
+// we enumerate all the different kinds of events for which we have handlers.
+type InputEvent =
+    | React.MouseEvent<HTMLInputElement>
+    | React.KeyboardEvent<HTMLInputElement>
+    | React.FocusEvent<HTMLInputElement>
+    | React.ChangeEvent<HTMLInputElement>;
+
+interface StateKeysAndValuesObject {
+    keys: {
+        hoverString: "startHoverString" | "endHoverString";
+        inputString: "startInputString" | "endInputString";
+        isInputFocused: "isStartInputFocused" | "isEndInputFocused";
+        selectedValue: "selectedStart" | "selectedEnd";
+    };
+    values: {
+        controlledValue?: Date | null;
+        hoverString?: string | null;
+        inputString?: string;
+        isInputFocused: boolean;
+        selectedValue: Date | null;
+    };
+}
+
+/**
+ * Date range input (v3) component.
+ *
+ * @see https://blueprintjs.com/docs/#datetime2/date-range-input3
+ */
+export class DateRangeInput3 extends DateFnsLocalizedComponent<DateRangeInput3Props, DateRangeInput3State> {
+    public static defaultProps: DateRangeInput3DefaultProps = {
+        allowSingleDayRange: false,
+        closeOnSelection: true,
+        contiguousCalendarMonths: true,
+        dayPickerProps: {},
+        disabled: false,
+        endInputProps: {},
+        invalidDateMessage: "Invalid date",
+        locale: "en-US",
+        maxDate: DatePickerUtils.getDefaultMaxDate(),
+        minDate: DatePickerUtils.getDefaultMinDate(),
+        outOfRangeMessage: "Out of range",
+        overlappingDatesMessage: "Overlapping dates",
+        popoverProps: {},
+        selectAllOnFocus: false,
+        shortcuts: true,
+        singleMonthOnly: false,
+        startInputProps: {},
+    };
+
+    public static displayName = `${DISPLAYNAME_PREFIX}.DateRangeInput3`;
+
+    public startInputElement: HTMLInputElement | null = null;
+
+    public endInputElement: HTMLInputElement | null = null;
+
+    private handleStartInputRef = refHandler<HTMLInputElement, "startInputElement">(
+        this,
+        "startInputElement",
+        this.props.startInputProps?.inputRef,
+    );
+
+    private handleEndInputRef = refHandler<HTMLInputElement, "endInputElement">(
+        this,
+        "endInputElement",
+        this.props.endInputProps?.inputRef,
+    );
+
+    public constructor(props: DateRangeInput3Props) {
+        super(props);
+        const [selectedStart, selectedEnd] = this.getInitialRange();
+        this.state = {
+            formattedMaxDateString: this.formatMinMaxDateString(props, "maxDate"),
+            formattedMinDateString: this.formatMinMaxDateString(props, "minDate"),
+            isEndInputFocused: false,
+            isOpen: false,
+            isStartInputFocused: false,
+            locale: undefined,
+            selectedEnd,
+            selectedShortcutIndex: -1,
+            selectedStart,
+        };
+    }
+
+    public async componentDidMount() {
+        await super.componentDidMount();
+    }
+
+    public async componentDidUpdate(prevProps: DateRangeInput3Props) {
+        super.componentDidUpdate(prevProps);
+
+        const { isStartInputFocused, isEndInputFocused, shouldSelectAfterUpdate } = this.state;
+
+        if (prevProps.startInputProps?.inputRef !== this.props.startInputProps?.inputRef) {
+            setRef(prevProps.startInputProps?.inputRef, null);
+            this.handleStartInputRef = refHandler(this, "startInputElement", this.props.startInputProps?.inputRef);
+            setRef(this.props.startInputProps?.inputRef, this.startInputElement);
+        }
+        if (prevProps.endInputProps?.inputRef !== this.props.endInputProps?.inputRef) {
+            setRef(prevProps.endInputProps?.inputRef, null);
+            this.handleEndInputRef = refHandler(this, "endInputElement", this.props.endInputProps?.inputRef);
+            setRef(this.props.endInputProps?.inputRef, this.endInputElement);
+        }
+
+        const shouldFocusStartInput = this.shouldFocusInputRef(isStartInputFocused, this.startInputElement);
+        const shouldFocusEndInput = this.shouldFocusInputRef(isEndInputFocused, this.endInputElement);
+
+        if (shouldFocusStartInput) {
+            this.startInputElement?.focus();
+        } else if (shouldFocusEndInput) {
+            this.endInputElement?.focus();
+        }
+
+        if (isStartInputFocused && shouldSelectAfterUpdate) {
+            this.startInputElement?.select();
+        } else if (isEndInputFocused && shouldSelectAfterUpdate) {
+            this.endInputElement?.select();
+        }
+
+        let nextState: Partial<DateRangeInput3State> = {};
+
+        if (this.props.value !== prevProps.value) {
+            const [selectedStart, selectedEnd] = this.getInitialRange(this.props);
+            nextState = {
+                ...nextState,
+                selectedEnd,
+                selectedStart,
+            };
+        }
+
+        // cache the formatted date strings to avoid computing on each render.
+        if (this.props.minDate !== prevProps.minDate) {
+            const formattedMinDateString = this.formatMinMaxDateString(this.props, "minDate");
+            nextState = { ...nextState, formattedMinDateString };
+        }
+        if (this.props.maxDate !== prevProps.maxDate) {
+            const formattedMaxDateString = this.formatMinMaxDateString(this.props, "maxDate");
+            nextState = { ...nextState, formattedMaxDateString };
+        }
+
+        this.setState(nextState);
+    }
+
+    public render() {
+        const { locale, selectedShortcutIndex } = this.state;
+        const { popoverProps = {}, popoverRef } = this.props;
+
+        const popoverContent = (
+            <DateRangePicker3
+                {...this.props}
+                boundaryToModify={this.state.boundaryToModify}
+                locale={locale ?? this.props.locale}
+                onChange={this.handleDateRangePickerChange}
+                onHoverChange={this.handleDateRangePickerHoverChange}
+                onShortcutChange={this.handleShortcutChange}
+                selectedShortcutIndex={selectedShortcutIndex}
+                value={this.getSelectedRange()}
+            />
+        );
+
+        // allow custom props for the popover and each input group, but pass them in an order that
+        // guarantees only some props are overridable.
+        return (
+            <Popover
+                isOpen={this.state.isOpen}
+                placement="bottom-start"
+                {...popoverProps}
+                autoFocus={false}
+                className={classNames(Classes.DATE_RANGE_INPUT, popoverProps.className, this.props.className)}
+                content={popoverContent}
+                enforceFocus={false}
+                onClose={this.handlePopoverClose}
+                popoverClassName={classNames(Classes.DATE_RANGE_INPUT_POPOVER, popoverProps.popoverClassName)}
+                ref={popoverRef}
+                renderTarget={this.renderTarget}
+            />
+        );
+    }
+
+    protected validateProps(props: DateRangeInput3Props) {
+        if (props.value === null) {
+            // throw a blocking error here because we don't handle a null value gracefully across this component
+            // (it's not allowed by TS under strict null checks anyway)
+            throw new Error(Errors.DATERANGEINPUT_NULL_VALUE);
+        }
+    }
+
+    // We use the renderTarget API to flatten the rendered DOM.
+    private renderTarget =
+        // N.B. pull out `isOpen` so that it's not forwarded to the DOM.
+        ({ isOpen, ...targetProps }: PopoverTargetProps & PopoverClickTargetHandlers) => {
+            const { fill, popoverProps = {} } = this.props;
+            const { targetTagName = "div" } = popoverProps;
+            return React.createElement(
+                targetTagName,
+                {
+                    ...targetProps,
+                    className: classNames(CoreClasses.CONTROL_GROUP, targetProps.className, {
+                        [CoreClasses.FILL]: fill,
+                    }),
+                },
+                this.renderInputGroup(Boundary.START),
+                this.renderInputGroup(Boundary.END),
+            );
+        };
+
+    private renderInputGroup = (boundary: Boundary) => {
+        const inputProps = this.getInputProps(boundary);
+        const handleInputEvent = boundary === Boundary.START ? this.handleStartInputEvent : this.handleEndInputEvent;
+
+        return (
+            <InputGroup
+                autoComplete="off"
+                disabled={inputProps?.disabled ?? this.props.disabled}
+                fill={this.props.fill}
+                {...inputProps}
+                intent={this.isInputInErrorState(boundary) ? Intent.DANGER : inputProps?.intent}
+                inputRef={this.getInputRef(boundary)}
+                onBlur={handleInputEvent}
+                onChange={handleInputEvent}
+                onClick={handleInputEvent}
+                onFocus={handleInputEvent}
+                onKeyDown={handleInputEvent}
+                onMouseDown={handleInputEvent}
+                placeholder={this.getInputPlaceholderString(boundary)}
+                value={this.getInputDisplayString(boundary)}
+            />
+        );
+    };
+
+    // Callbacks - DateRangePicker3
+    // ===========================
+
+    private handleDateRangePickerChange = (selectedRange: DateRange, didSubmitWithEnter = false) => {
+        // ignore mouse events in the date-range picker if the popover is animating closed.
+        if (!this.state.isOpen) {
+            return;
+        }
+
+        const [selectedStart, selectedEnd] = selectedRange;
+
+        let isOpen = true;
+
+        let isStartInputFocused: boolean | undefined;
+        let isEndInputFocused: boolean | undefined;
+
+        let startHoverString: string | null | undefined;
+        let endHoverString: string | null | undefined;
+
+        let boundaryToModify: Boundary | undefined;
+
+        if (selectedStart == null) {
+            // focus the start field by default or if only an end date is specified
+            if (this.props.timePrecision == null) {
+                isStartInputFocused = true;
+                isEndInputFocused = false;
+            } else {
+                isStartInputFocused = false;
+                isEndInputFocused = false;
+                boundaryToModify = Boundary.START;
+            }
+
+            // for clarity, hide the hover string until the mouse moves over a different date
+            startHoverString = null;
+        } else if (selectedEnd == null) {
+            // focus the end field if a start date is specified
+            if (this.props.timePrecision == null) {
+                isStartInputFocused = false;
+                isEndInputFocused = true;
+            } else {
+                isStartInputFocused = false;
+                isEndInputFocused = false;
+                boundaryToModify = Boundary.END;
+            }
+
+            endHoverString = null;
+        } else if (this.props.closeOnSelection) {
+            isOpen = this.getIsOpenValueWhenDateChanges(selectedStart, selectedEnd);
+            isStartInputFocused = false;
+
+            if (this.props.timePrecision == null && didSubmitWithEnter) {
+                // if we submit via click or Tab, the focus will have moved already.
+                // it we submit with Enter, the focus won't have moved, and setting
+                // the flag to false won't have an effect anyway, so leave it true.
+                isEndInputFocused = true;
+            } else {
+                isEndInputFocused = false;
+                boundaryToModify = Boundary.END;
+            }
+        } else if (this.state.lastFocusedField === Boundary.START) {
+            // keep the start field focused
+            if (this.props.timePrecision == null) {
+                isStartInputFocused = true;
+                isEndInputFocused = false;
+            } else {
+                isStartInputFocused = false;
+                isEndInputFocused = false;
+                boundaryToModify = Boundary.START;
+            }
+        } else if (this.props.timePrecision == null) {
+            // keep the end field focused
+            isStartInputFocused = false;
+            isEndInputFocused = true;
+        } else {
+            isStartInputFocused = false;
+            isEndInputFocused = false;
+            boundaryToModify = Boundary.END;
+        }
+
+        const baseStateChange: Partial<DateRangeInput3State> = {
+            boundaryToModify,
+            endHoverString,
+            endInputString: this.formatDate(selectedEnd),
+            isEndInputFocused,
+            isOpen,
+            isStartInputFocused,
+            selectedShortcutIndex: -1,
+            startHoverString,
+            startInputString: this.formatDate(selectedStart),
+            wasLastFocusChangeDueToHover: false,
+        };
+
+        if (this.isControlled()) {
+            this.setState(baseStateChange);
+        } else {
+            this.setState({ ...baseStateChange, selectedEnd, selectedStart });
+        }
+
+        this.props.onChange?.(selectedRange);
+    };
+
+    private handleShortcutChange = (_: DateRangeShortcut, selectedShortcutIndex: number) => {
+        this.setState({ selectedShortcutIndex });
+    };
+
+    private handleDateRangePickerHoverChange = (
+        hoveredRange: DateRange | undefined,
+        _hoveredDay: Date,
+        hoveredBoundary: Boundary | undefined,
+    ) => {
+        // ignore mouse events in the date-range picker if the popover is animating closed.
+        if (!this.state.isOpen) {
+            return;
+        }
+
+        if (hoveredRange == null) {
+            // undo whatever focus changes we made while hovering over various calendar dates
+            const isEndInputFocused = this.state.boundaryToModify === Boundary.END;
+
+            this.setState({
+                endHoverString: null,
+                isEndInputFocused,
+                isStartInputFocused: !isEndInputFocused,
+                lastFocusedField: this.state.boundaryToModify,
+                startHoverString: null,
+            });
+        } else {
+            const [hoveredStart, hoveredEnd] = hoveredRange;
+            const isStartInputFocused =
+                hoveredBoundary != null ? hoveredBoundary === Boundary.START : this.state.isStartInputFocused;
+            const isEndInputFocused =
+                hoveredBoundary != null ? hoveredBoundary === Boundary.END : this.state.isEndInputFocused;
+
+            this.setState({
+                endHoverString: this.formatDate(hoveredEnd),
+                isEndInputFocused,
+                isStartInputFocused,
+                lastFocusedField: isStartInputFocused ? Boundary.START : Boundary.END,
+                shouldSelectAfterUpdate: this.props.selectAllOnFocus,
+                startHoverString: this.formatDate(hoveredStart),
+                wasLastFocusChangeDueToHover: true,
+            });
+        }
+    };
+
+    // Callbacks - Input
+    // =================
+
+    // instantiate these two functions once so we don't have to for each callback on each render.
+
+    private handleStartInputEvent = (e: InputEvent) => {
+        this.handleInputEvent(e, Boundary.START);
+    };
+
+    private handleEndInputEvent = (e: InputEvent) => {
+        this.handleInputEvent(e, Boundary.END);
+    };
+
+    private handleInputEvent = (e: InputEvent, boundary: Boundary) => {
+        const inputProps = this.getInputProps(boundary);
+
+        switch (e.type) {
+            case "blur":
+                this.handleInputBlur(e, boundary);
+                inputProps?.onBlur?.(e as React.FocusEvent<HTMLInputElement>);
+                break;
+            case "change":
+                this.handleInputChange(e, boundary);
+                inputProps?.onChange?.(e as React.ChangeEvent<HTMLInputElement>);
+                break;
+            case "click":
+                e = e as React.MouseEvent<HTMLInputElement>;
+                this.handleInputClick(e);
+                inputProps?.onClick?.(e);
+                break;
+            case "focus":
+                this.handleInputFocus(e, boundary);
+                inputProps?.onFocus?.(e as React.FocusEvent<HTMLInputElement>);
+                break;
+            case "keydown":
+                e = e as React.KeyboardEvent<HTMLInputElement>;
+                this.handleInputKeyDown(e, boundary);
+                inputProps?.onKeyDown?.(e);
+                break;
+            case "mousedown":
+                e = e as React.MouseEvent<HTMLInputElement>;
+                this.handleInputMouseDown();
+                inputProps?.onMouseDown?.(e);
+                break;
+            default:
+                break;
+        }
+    };
+
+    // add a keydown listener to persistently change focus when tabbing:
+    // - if focused in start field, Tab moves focus to end field
+    // - if focused in end field, Shift+Tab moves focus to start field
+    private handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, boundary: Boundary) => {
+        const isArrowKeyPresssed =
+            e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "ArrowLeft" || e.key === "ArrowRight";
+        const isTabPressed = e.key === "Tab";
+        const isEnterPressed = e.key === "Enter";
+        const isEscapeKeyPressed = e.key === "Escape";
+        const isShiftPressed = e.shiftKey;
+
+        const { selectedStart, selectedEnd } = this.state;
+
+        if (isArrowKeyPresssed) {
+            this.handleInputArrowKeyDown(e, boundary);
+            return;
+        }
+
+        if (isEscapeKeyPressed) {
+            this.startInputElement?.blur();
+            this.endInputElement?.blur();
+            this.setState({ isEndInputFocused: false, isOpen: false, isStartInputFocused: false });
+            return;
+        }
+
+        // order of JS events is our enemy here. when tabbing between fields,
+        // this handler will fire in the middle of a focus exchange when no
+        // field is currently focused. we work around this by referring to the
+        // most recently focused field, rather than the currently focused field.
+        const wasStartFieldFocused = this.state.lastFocusedField === Boundary.START;
+        const wasEndFieldFocused = this.state.lastFocusedField === Boundary.END;
+
+        // move focus to the other field
+        if (isTabPressed) {
+            let isEndInputFocused: boolean;
+            let isStartInputFocused: boolean;
+            let isOpen = true;
+
+            if (wasStartFieldFocused && !isShiftPressed) {
+                isStartInputFocused = false;
+                isEndInputFocused = true;
+
+                // prevent the default focus-change behavior to avoid race conditions;
+                // we'll handle the focus change ourselves in componentDidUpdate.
+                e.preventDefault();
+            } else if (wasEndFieldFocused && isShiftPressed) {
+                isStartInputFocused = true;
+                isEndInputFocused = false;
+                e.preventDefault();
+            } else {
+                // don't prevent default here, otherwise Tab won't do anything.
+                isStartInputFocused = false;
+                isEndInputFocused = false;
+                isOpen = false;
+            }
+
+            this.setState({
+                isEndInputFocused,
+                isOpen,
+                isStartInputFocused,
+                wasLastFocusChangeDueToHover: false,
+            });
+        } else if (wasStartFieldFocused && isEnterPressed) {
+            const nextStartDate = this.parseDate(this.state.startInputString);
+            this.handleDateRangePickerChange([nextStartDate, selectedEnd], true);
+        } else if (wasEndFieldFocused && isEnterPressed) {
+            const nextEndDate = this.parseDate(this.state.endInputString);
+            this.handleDateRangePickerChange([selectedStart, nextEndDate] as DateRange, true);
+        } else {
+            // let the default keystroke happen without side effects
+            return;
+        }
+    };
+
+    private handleInputArrowKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, boundary: Boundary) => {
+        const { minDate, maxDate } = this.props;
+        const { isOpen } = this.state;
+        const inputElement = boundary === Boundary.START ? this.startInputElement : this.endInputElement;
+
+        if (!isOpen || !isEntireInputSelected(inputElement)) {
+            return;
+        }
+
+        const shiftedDate =
+            this.getNextDateForArrowKeyNavigation(e.key, boundary) ??
+            this.getDefaultDateForArrowKeyNavigation(e.key, boundary);
+
+        if (shiftedDate == null) {
+            return;
+        }
+
+        // We've commited to moving the selection, prevent the default arrow key interactions
+        e.preventDefault();
+
+        const clampedDate = clampDate(shiftedDate, minDate, maxDate);
+        const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
+        const nextState: Partial<DateRangeInput3State> = {
+            [keys.inputString]: this.formatDate(clampedDate),
+            selectedShortcutIndex: -1,
+            shouldSelectAfterUpdate: true,
+        };
+
+        if (!this.isControlled()) {
+            nextState[keys.selectedValue] = clampedDate;
+        }
+
+        this.props.onChange?.(this.getDateRangeForCallback(clampedDate, boundary));
+        this.setState(nextState);
+    };
+
+    private getNextDateForArrowKeyNavigation(arrowKey: string, boundary: Boundary) {
+        const { allowSingleDayRange } = this.props;
+        const [selectedStart, selectedEnd] = this.getSelectedRange();
+        const initialDate = boundary === Boundary.START ? selectedStart : selectedEnd;
+        if (initialDate == null) {
+            return undefined;
+        }
+
+        const relativeDate = shiftDateByArrowKey(initialDate, arrowKey);
+
+        // Ensure that we don't move onto a single day range selection if that is disallowed
+        const adjustedStart =
+            selectedStart == null || allowSingleDayRange ? selectedStart : shiftDateByDays(selectedStart, 1);
+        const adjustedEnd = selectedEnd == null || allowSingleDayRange ? selectedEnd : shiftDateByDays(selectedEnd, -1);
+
+        return boundary === Boundary.START
+            ? clampDate(relativeDate, undefined, adjustedEnd)
+            : clampDate(relativeDate, adjustedStart, undefined);
+    }
+
+    private getDefaultDateForArrowKeyNavigation(arrowKey: string, boundary: Boundary) {
+        const [selectedStart, selectedEnd] = this.getSelectedRange();
+        const otherBoundary = boundary === Boundary.START ? selectedEnd : selectedStart;
+
+        if (otherBoundary == null) {
+            return getTodayAtMidnight();
+        }
+
+        const isForwardArrowKey = arrowKey === "ArrowRight" || arrowKey === "ArrowDown";
+        // If the arrow key direction is in the same direction as the boundary, then moving that way will not create an
+        // overlapping date range
+        if (isForwardArrowKey === (boundary === Boundary.END)) {
+            return shiftDateByArrowKey(otherBoundary, arrowKey);
+        }
+
+        return undefined;
+    }
+
+    private handleInputMouseDown = () => {
+        // clicking in the field constitutes an explicit focus change. we update
+        // the flag on "mousedown" instead of on "click", because it needs to be
+        // set before onFocus is called ("click" triggers after "focus").
+        this.setState({ wasLastFocusChangeDueToHover: false });
+    };
+
+    private handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+        // unless we stop propagation on this event, a click within an input
+        // will close the popover almost as soon as it opens.
+        e.stopPropagation();
+    };
+
+    private handleInputFocus = (_e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
+        const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
+        const isValueControlled = this.isControlled();
+        // We may be reacting to a programmatic focus triggered by componentDidUpdate() at a point when
+        // values.selectedValue may not have been updated yet in controlled mode, so we must use values.controlledValue
+        // in that case.
+        const inputString = formatDateString(
+            isValueControlled ? values.controlledValue : values.selectedValue,
+            this.props,
+            this.state.locale,
+            true,
+        );
+
+        // change the boundary only if the user explicitly focused in the field.
+        // focus changes from hovering don't count; they're just temporary.
+        const boundaryToModify = this.state.wasLastFocusChangeDueToHover ? this.state.boundaryToModify : boundary;
+
+        this.setState({
+            [keys.inputString]: inputString,
+            [keys.isInputFocused]: true,
+            boundaryToModify,
+            isOpen: true,
+            lastFocusedField: boundary,
+            shouldSelectAfterUpdate: this.props.selectAllOnFocus,
+            wasLastFocusChangeDueToHover: false,
+        });
+    };
+
+    private handleInputBlur = (_e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
+        const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
+
+        const maybeNextDate = this.parseDate(values.inputString);
+        const isValueControlled = this.isControlled();
+
+        let nextState: Partial<DateRangeInput3State> = {
+            [keys.isInputFocused]: false,
+            shouldSelectAfterUpdate: false,
+        };
+
+        if (this.isInputEmpty(values.inputString)) {
+            if (isValueControlled) {
+                nextState = {
+                    ...nextState,
+                    [keys.inputString]: formatDateString(values.controlledValue, this.props, this.state.locale),
+                };
+            } else {
+                nextState = {
+                    ...nextState,
+                    [keys.inputString]: null,
+                    [keys.selectedValue]: null,
+                };
+            }
+        } else if (!this.isNextDateRangeValid(maybeNextDate, boundary)) {
+            if (!isValueControlled) {
+                nextState = {
+                    ...nextState,
+                    [keys.inputString]: null,
+                    [keys.selectedValue]: maybeNextDate,
+                };
+            }
+            this.props.onError?.(this.getDateRangeForCallback(maybeNextDate, boundary));
+        }
+
+        this.setState(nextState);
+    };
+
+    private handleInputChange = (e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
+        const inputString = (e.target as HTMLInputElement).value;
+
+        const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
+        const maybeNextDate = this.parseDate(inputString);
+        const isValueControlled = this.isControlled();
+
+        let nextState: Partial<DateRangeInput3State> = { shouldSelectAfterUpdate: false };
+
+        if (inputString.length === 0) {
+            // this case will be relevant when we start showing the hovered range in the input
+            // fields. goal is to show an empty field for clarity until the mouse moves over a
+            // different date.
+            const baseState = { ...nextState, [keys.inputString]: "" };
+            if (isValueControlled) {
+                nextState = baseState;
+            } else {
+                nextState = { ...baseState, [keys.selectedValue]: null };
+            }
+            this.props.onChange?.(this.getDateRangeForCallback(null, boundary));
+        } else if (this.isDateValidAndInRange(maybeNextDate)) {
+            // note that error cases that depend on both fields (e.g. overlapping dates) should fall
+            // through into this block so that the UI can update immediately, possibly with an error
+            // message on the other field.
+            // also, clear the hover string to ensure the most recent keystroke appears.
+            const baseState: Partial<DateRangeInput3State> = {
+                ...nextState,
+                [keys.hoverString]: null,
+                [keys.inputString]: inputString,
+            };
+            if (isValueControlled) {
+                nextState = baseState;
+            } else {
+                nextState = { ...baseState, [keys.selectedValue]: maybeNextDate };
+            }
+            if (this.isNextDateRangeValid(maybeNextDate, boundary)) {
+                this.props.onChange?.(this.getDateRangeForCallback(maybeNextDate, boundary));
+            }
+        } else {
+            // again, clear the hover string to ensure the most recent keystroke appears
+            nextState = { ...nextState, [keys.inputString]: inputString, [keys.hoverString]: null };
+        }
+
+        this.setState(nextState);
+    };
+
+    // Callbacks - Popover
+    // ===================
+
+    private handlePopoverClose = (event: React.SyntheticEvent<HTMLElement>) => {
+        this.setState({ isOpen: false });
+        this.props.popoverProps?.onClose?.(event);
+    };
+
+    // Helpers
+    // =======
+
+    private shouldFocusInputRef(isFocused: boolean, inputRef: HTMLInputElement | null) {
+        return isFocused && inputRef != null && Utils.getActiveElement(this.startInputElement) !== inputRef;
+    }
+
+    private getIsOpenValueWhenDateChanges = (nextSelectedStart: Date, nextSelectedEnd: Date): boolean => {
+        if (this.props.closeOnSelection) {
+            // trivial case when TimePicker is not shown
+            if (this.props.timePrecision == null) {
+                return false;
+            }
+
+            const fallbackDate = getTodayAtMidnight();
+            const [selectedStart, selectedEnd] = this.getSelectedRange([fallbackDate, fallbackDate]);
+
+            // case to check if the user has changed TimePicker values
+            if (
+                DateUtils.isSameTime(selectedStart, nextSelectedStart) &&
+                DateUtils.isSameTime(selectedEnd, nextSelectedEnd)
+            ) {
+                return false;
+            }
+            return true;
+        }
+
+        return true;
+    };
+
+    private getInitialRange = (props = this.props): DateRange => {
+        const { defaultValue, value } = props;
+        if (value != null) {
+            return value;
+        } else if (defaultValue != null) {
+            return defaultValue;
+        } else {
+            return [null, null];
+        }
+    };
+
+    private getSelectedRange = (fallbackRange?: NonNullDateRange) => {
+        let selectedStart: Date | null;
+        let selectedEnd: Date | null;
+
+        if (this.isControlled()) {
+            [selectedStart, selectedEnd] = this.props.value!;
+        } else {
+            selectedStart = this.state.selectedStart;
+            selectedEnd = this.state.selectedEnd;
+        }
+
+        // this helper function checks if the provided boundary date *would* overlap the selected
+        // other boundary date. providing the already-selected start date simply tells us if we're
+        // currently in an overlapping state.
+        const doBoundaryDatesOverlap = this.doBoundaryDatesOverlap(selectedStart, Boundary.START);
+        const dateRange = [selectedStart, doBoundaryDatesOverlap ? undefined : selectedEnd];
+
+        return dateRange.map((selectedBound: Date | null | undefined, index: number) => {
+            const fallbackDate = fallbackRange != null ? fallbackRange[index] : undefined;
+            return this.isDateValidAndInRange(selectedBound ?? null) ? selectedBound : fallbackDate;
+        }) as DateRange;
+    };
+
+    private getInputDisplayString = (boundary: Boundary) => {
+        const { values } = this.getStateKeysAndValuesForBoundary(boundary);
+        const { isInputFocused, inputString, selectedValue, hoverString } = values;
+
+        if (hoverString != null) {
+            return hoverString;
+        } else if (isInputFocused) {
+            return inputString == null ? "" : inputString;
+        } else if (selectedValue == null) {
+            return "";
+        } else if (this.doesEndBoundaryOverlapStartBoundary(selectedValue, boundary)) {
+            return this.props.overlappingDatesMessage;
+        } else {
+            return formatDateString(selectedValue, this.props, this.state.locale);
+        }
+    };
+
+    private getInputPlaceholderString = (boundary: Boundary) => {
+        const isStartBoundary = boundary === Boundary.START;
+        const isEndBoundary = boundary === Boundary.END;
+
+        const inputProps = this.getInputProps(boundary);
+        const { isInputFocused } = this.getStateKeysAndValuesForBoundary(boundary).values;
+
+        // use the custom placeholder text for the input, if providied
+        if (inputProps?.placeholder != null) {
+            return inputProps.placeholder;
+        } else if (isStartBoundary) {
+            return isInputFocused ? this.state.formattedMinDateString : "Start date";
+        } else if (isEndBoundary) {
+            return isInputFocused ? this.state.formattedMaxDateString : "End date";
+        } else {
+            return "";
+        }
+    };
+
+    private getInputProps = (boundary: Boundary) => {
+        return boundary === Boundary.START ? this.props.startInputProps : this.props.endInputProps;
+    };
+
+    private getInputRef = (boundary: Boundary) => {
+        return boundary === Boundary.START ? this.handleStartInputRef : this.handleEndInputRef;
+    };
+
+    private getStateKeysAndValuesForBoundary = (boundary: Boundary): StateKeysAndValuesObject => {
+        const controlledRange = this.props.value;
+        if (boundary === Boundary.START) {
+            return {
+                keys: {
+                    hoverString: "startHoverString",
+                    inputString: "startInputString",
+                    isInputFocused: "isStartInputFocused",
+                    selectedValue: "selectedStart",
+                },
+                values: {
+                    controlledValue: controlledRange != null ? controlledRange[0] : undefined,
+                    hoverString: this.state.startHoverString,
+                    inputString: this.state.startInputString,
+                    isInputFocused: this.state.isStartInputFocused,
+                    selectedValue: this.state.selectedStart,
+                },
+            };
+        } else {
+            return {
+                keys: {
+                    hoverString: "endHoverString",
+                    inputString: "endInputString",
+                    isInputFocused: "isEndInputFocused",
+                    selectedValue: "selectedEnd",
+                },
+                values: {
+                    controlledValue: controlledRange != null ? controlledRange[1] : undefined,
+                    hoverString: this.state.endHoverString,
+                    inputString: this.state.endInputString,
+                    isInputFocused: this.state.isEndInputFocused,
+                    selectedValue: this.state.selectedEnd,
+                },
+            };
+        }
+    };
+
+    private getDateRangeForCallback = (currDate: Date | null, currBoundary?: Boundary): DateRange => {
+        const otherBoundary = this.getOtherBoundary(currBoundary);
+        const otherDate = this.getStateKeysAndValuesForBoundary(otherBoundary).values.selectedValue;
+
+        return currBoundary === Boundary.START ? [currDate, otherDate] : [otherDate, currDate];
+    };
+
+    private getOtherBoundary = (boundary?: Boundary) => {
+        return boundary === Boundary.START ? Boundary.END : Boundary.START;
+    };
+
+    private doBoundaryDatesOverlap = (date: Date | null, boundary: Boundary) => {
+        const { allowSingleDayRange } = this.props;
+        const otherBoundary = this.getOtherBoundary(boundary);
+        const otherBoundaryDate = this.getStateKeysAndValuesForBoundary(otherBoundary).values.selectedValue;
+        if (date == null || otherBoundaryDate == null) {
+            return false;
+        }
+
+        if (boundary === Boundary.START) {
+            const isAfter = date > otherBoundaryDate;
+            return isAfter || (!allowSingleDayRange && isSameDay(date, otherBoundaryDate));
+        } else {
+            const isBefore = date < otherBoundaryDate;
+            return isBefore || (!allowSingleDayRange && isSameDay(date, otherBoundaryDate));
+        }
+    };
+
+    /**
+     * Returns true if the provided boundary is an END boundary overlapping the
+     * selected start date. (If the boundaries overlap, we consider the END
+     * boundary to be erroneous.)
+     */
+    private doesEndBoundaryOverlapStartBoundary = (boundaryDate: Date, boundary: Boundary) => {
+        return boundary === Boundary.START ? false : this.doBoundaryDatesOverlap(boundaryDate, boundary);
+    };
+
+    private isControlled = () => this.props.value !== undefined;
+
+    private isInputEmpty = (inputString: string | undefined) => inputString == null || inputString.length === 0;
+
+    private isInputInErrorState = (boundary: Boundary) => {
+        const values = this.getStateKeysAndValuesForBoundary(boundary).values;
+        const { isInputFocused, hoverString, inputString, selectedValue } = values;
+        if (hoverString != null || this.isInputEmpty(inputString)) {
+            // don't show an error state while we're hovering over a valid date.
+            return false;
+        }
+
+        const boundaryValue = isInputFocused ? this.parseDate(inputString) : selectedValue;
+        return (
+            boundaryValue != null &&
+            (!this.isDateValidAndInRange(boundaryValue) ||
+                this.doesEndBoundaryOverlapStartBoundary(boundaryValue, boundary))
+        );
+    };
+
+    private isDateValidAndInRange = (date: Date | null): date is Date => {
+        // min/max dates defined in defaultProps
+        return isValid(date) && DateUtils.isDayInRange(date, [this.props.minDate!, this.props.maxDate!]);
+    };
+
+    private isNextDateRangeValid(nextDate: Date | null, boundary: Boundary): nextDate is Date {
+        return this.isDateValidAndInRange(nextDate) && !this.doBoundaryDatesOverlap(nextDate, boundary);
+    }
+
+    // this is a slightly kludgy function, but it saves us a good amount of repeated code between
+    // the constructor and componentDidUpdate.
+    private formatMinMaxDateString = (props: DateRangeInput3Props, propName: "minDate" | "maxDate") => {
+        const date = props[propName];
+
+        // N.B. default values are applied only if a prop is strictly `undefined`
+        // See: https://facebook.github.io/react/docs/react-component.html#defaultprops
+        const defaultDate = DateRangeInput3.defaultProps[propName];
+
+        // N.B. this.state will be undefined in the constructor, so we need a fallback in that case
+        const maybeLocale = this.state?.locale ?? typeof props.locale === "string" ? undefined : props.locale;
+
+        return formatDateString(date ?? defaultDate, this.props, maybeLocale);
+    };
+
+    private parseDate = (dateString: string | undefined): Date | null => {
+        if (
+            dateString === undefined ||
+            dateString === this.props.outOfRangeMessage ||
+            dateString === this.props.invalidDateMessage
+        ) {
+            return null;
+        }
+
+        // HACKHACK: this code below is largely copied from the `useDateParser()` hook, which is the preferred
+        // implementation that we can migrate to once DateRangeInput3 is a function component.
+        const { dateFnsFormat, locale: localeFromProps, parseDate, timePickerProps, timePrecision } = this.props;
+        const { locale } = this.state;
+        let newDate: false | Date | null = null;
+
+        if (parseDate !== undefined) {
+            // user-provided date parser
+            newDate = parseDate(dateString, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
+        } else {
+            // use user-provided date-fns format or one of the default formats inferred from time picker props
+            const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
+            newDate = getDateFnsParser(format, locale)(dateString);
+        }
+
+        return newDate === false ? getTodayAtMidnight() : newDate;
+    };
+
+    // called on date hover & selection
+    private formatDate = (date: Date | null): string => {
+        if (!this.isDateValidAndInRange(date)) {
+            return "";
+        }
+
+        // HACKHACK: the code below is largely copied from the `useDateFormatter()` hook, which is the preferred
+        // implementation that we can migrate to once DateRangeInput3 is a function component.
+        const { dateFnsFormat, formatDate, locale: localeFromProps, timePickerProps, timePrecision } = this.props;
+        const { locale } = this.state;
+
+        if (formatDate !== undefined) {
+            // user-provided date formatter
+            return formatDate(date, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
+        } else {
+            // use user-provided date-fns format or one of the default formats inferred from time picker props
+            const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
+            return getDateFnsFormatter(format, locale)(date);
+        }
+    };
+}
+
+// called on initial construction, input focus & blur, and the standard input render path
+function formatDateString(
+    date: Date | false | null | undefined,
+    props: DateRangeInput3Props,
+    locale: Locale | undefined,
+    ignoreRange = false,
+) {
+    const { invalidDateMessage, maxDate, minDate, outOfRangeMessage } = props as DateRangeInput3PropsWithDefaults;
+
+    if (date == null) {
+        return "";
+    } else if (!DateUtils.isDateValid(date)) {
+        return invalidDateMessage;
+    } else if (ignoreRange || DateUtils.isDayInRange(date, [minDate, maxDate])) {
+        // HACKHACK: the code below is largely copied from the `useDateFormatter()` hook, which is the preferred
+        // implementation that we can migrate to once DateRangeInput3 is a function component.
+        const { dateFnsFormat, formatDate, locale: localeFromProps, timePickerProps, timePrecision } = props;
+        if (formatDate !== undefined) {
+            // user-provided date formatter
+            return formatDate(date, locale?.code ?? getLocaleCodeFromProps(localeFromProps));
+        } else {
+            // use user-provided date-fns format or one of the default formats inferred from time picker props
+            const format = dateFnsFormat ?? getDefaultDateFnsFormat({ timePickerProps, timePrecision });
+            return getDateFnsFormatter(format, locale)(date);
+        }
+    } else {
+        return outOfRangeMessage;
+    }
+}

--- a/packages/datetime/src/components/date-range-input3/dateRangeInput3Props.ts
+++ b/packages/datetime/src/components/date-range-input3/dateRangeInput3Props.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DateFormatProps } from "../../common";
+import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
+
+import type { DateRangeInputProps } from "./dateRangeInputProps";
+
+/**
+ * Props shared between DateRangeInput v1 and v
+ *
+ * Note that we exclude formatDate and parseDate so that we can make those optional in DateInput3 and provide a default
+ * implementation for those functions using date-fns.
+ */
+type DateRangeInputSharedProps = Omit<
+    DateRangeInputProps,
+    "dayPickerProps" | "formatDate" | "locale" | "localeUtils" | "modifiers" | "parseDate"
+>;
+
+export interface DateRangeInput3Props
+    extends DateRangeInputSharedProps,
+        ReactDayPickerRangeProps,
+        DateFnsLocaleProps,
+        Partial<Omit<DateFormatProps, "locale">> {
+    /**
+     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
+     *
+     * Mutually exclusive with the `formatDate` and `parseDate` props.
+     *
+     * See date-fns [format](https://date-fns.org/docs/format).
+     */
+    dateFnsFormat?: string;
+}
+
+export type DateRangeInput3DefaultProps = Required<
+    Pick<
+        DateRangeInput3Props,
+        | "allowSingleDayRange"
+        | "closeOnSelection"
+        | "contiguousCalendarMonths"
+        | "dayPickerProps"
+        | "disabled"
+        | "endInputProps"
+        | "invalidDateMessage"
+        | "locale"
+        | "maxDate"
+        | "minDate"
+        | "outOfRangeMessage"
+        | "overlappingDatesMessage"
+        | "popoverProps"
+        | "selectAllOnFocus"
+        | "shortcuts"
+        | "singleMonthOnly"
+        | "startInputProps"
+    >
+>;
+
+export type DateRangeInput3PropsWithDefaults = Omit<DateRangeInput3Props, keyof DateRangeInput3DefaultProps> &
+    DateRangeInput3DefaultProps;

--- a/packages/datetime/src/components/date-range-input3/dateRangeInput3State.ts
+++ b/packages/datetime/src/components/date-range-input3/dateRangeInput3State.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+
+import type { Boundary } from "@blueprintjs/core";
+
+export interface DateRangeInput3State {
+    isOpen?: boolean;
+    boundaryToModify?: Boundary;
+    lastFocusedField?: Boundary;
+    locale?: Locale | undefined;
+
+    formattedMinDateString?: string;
+    formattedMaxDateString?: string;
+
+    isStartInputFocused: boolean;
+    isEndInputFocused: boolean;
+
+    startInputString?: string;
+    endInputString?: string;
+
+    startHoverString?: string | null;
+    endHoverString?: string | null;
+
+    selectedEnd: Date | null;
+    selectedStart: Date | null;
+
+    shouldSelectAfterUpdate?: boolean;
+    wasLastFocusChangeDueToHover?: boolean;
+
+    selectedShortcutIndex?: number;
+}

--- a/packages/datetime/src/components/date-range-input3/dateRangeInputProps.ts
+++ b/packages/datetime/src/components/date-range-input3/dateRangeInputProps.ts
@@ -1,0 +1,126 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { InputGroupProps, Props } from "@blueprintjs/core";
+
+import type { DateFormatProps, DatePickerBaseProps, DateRange } from "../../common";
+import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
+import type { DateRangeShortcut } from "../shortcuts/shortcuts";
+
+export interface DateRangeInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
+    /**
+     * Whether the start and end dates of the range can be the same day.
+     * If `true`, clicking a selected date will create a one-day range.
+     * If `false`, clicking a selected date will clear the selection.
+     *
+     * @default false
+     */
+    allowSingleDayRange?: boolean;
+
+    /**
+     * Whether the calendar popover should close when a date range is fully selected.
+     *
+     * @default true
+     */
+    closeOnSelection?: boolean;
+
+    /**
+     * Whether displayed months in the calendar are contiguous.
+     * If false, each side of the calendar can move independently to non-contiguous months.
+     *
+     * @default true
+     */
+    contiguousCalendarMonths?: boolean;
+
+    /**
+     * The default date range to be used in the component when uncontrolled.
+     * This will be ignored if `value` is set.
+     */
+    defaultValue?: DateRange;
+
+    /**
+     * Whether the text inputs are non-interactive.
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * Whether the component should take up the full width of its container.
+     */
+    fill?: boolean;
+
+    /**
+     * Props to pass to the end-date [input group](#core/components/input-group).
+     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
+     * `ref` is not supported; use `inputRef` instead.
+     */
+    endInputProps?: InputGroupProps;
+
+    /**
+     * Called when the user selects a day.
+     * If no days are selected, it will pass `[null, null]`.
+     * If a start date is selected but not an end date, it will pass `[selectedDate, null]`.
+     * If both a start and end date are selected, it will pass `[startDate, endDate]`.
+     */
+    onChange?: (selectedRange: DateRange) => void;
+
+    /**
+     * Called when the user finishes typing in a new date and the date causes an error state.
+     * If the date is invalid, `new Date(undefined)` will be returned for the corresponding
+     * boundary of the date range.
+     * If the date is out of range, the out-of-range date will be returned for the corresponding
+     * boundary of the date range (`onChange` is not called in this case).
+     */
+    onError?: (errorRange: DateRange) => void;
+
+    /**
+     * The error message to display when the selected dates overlap.
+     * This can only happen when typing dates in the input field.
+     *
+     * @default "Overlapping dates"
+     */
+    overlappingDatesMessage?: string;
+
+    /**
+     * Whether the entire text field should be selected on focus.
+     *
+     * @default false
+     */
+    selectAllOnFocus?: boolean;
+
+    /**
+     * Whether shortcuts to quickly select a range of dates are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     *
+     * @default true
+     */
+    shortcuts?: boolean | DateRangeShortcut[];
+
+    /**
+     * Whether to show only a single month calendar.
+     *
+     * @default false
+     */
+    singleMonthOnly?: boolean;
+
+    /**
+     * Props to pass to the start-date [input group](#core/components/input-group).
+     * `disabled` and `value` will be ignored in favor of the top-level props on this component.
+     * `ref` is not supported; use `inputRef` instead.
+     */
+    startInputProps?: InputGroupProps;
+
+    /**
+     * The currently selected date range.
+     * If the prop is strictly `undefined`, the component acts in an uncontrolled manner.
+     * If this prop is anything else, the component acts in a controlled manner.
+     * To display an empty value in the input fields in a controlled manner, pass `[null, null]`.
+     * To display an invalid date error in either input field, pass `new Date(undefined)`
+     * for the appropriate date in the value prop.
+     */
+    value?: DateRange;
+}

--- a/packages/datetime/src/components/date-range-input3/dateRangeInputUilts.ts
+++ b/packages/datetime/src/components/date-range-input3/dateRangeInputUilts.ts
@@ -1,0 +1,52 @@
+/* !
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ */
+
+const DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
+const WEEK_IN_MILLIS = 7 * DAY_IN_MILLIS;
+
+export function getTodayAtMidnight() {
+    return new Date(new Date().setHours(0, 0, 0, 0));
+}
+
+export function shiftDateByDays(date: Date, days: number): Date {
+    return new Date(date.valueOf() + days * DAY_IN_MILLIS);
+}
+
+export function shiftDateByWeeks(date: Date, weeks: number): Date {
+    return new Date(date.valueOf() + weeks * WEEK_IN_MILLIS);
+}
+
+export function shiftDateByArrowKey(date: Date, key: string): Date {
+    switch (key) {
+        case "ArrowUp":
+            return shiftDateByWeeks(date, -1);
+        case "ArrowDown":
+            return shiftDateByWeeks(date, 1);
+        case "ArrowLeft":
+            return shiftDateByDays(date, -1);
+        case "ArrowRight":
+            return shiftDateByDays(date, 1);
+        default:
+            return date;
+    }
+}
+
+export function clampDate(date: Date, minDate: Date | null | undefined, maxDate: Date | null | undefined) {
+    let result = date;
+    if (minDate != null && date < minDate) {
+        result = minDate;
+    }
+    if (maxDate != null && date > maxDate) {
+        result = maxDate;
+    }
+    return result;
+}
+
+export function isEntireInputSelected(element: HTMLInputElement | null) {
+    if (element == null) {
+        return false;
+    }
+
+    return element.selectionStart === 0 && element.selectionEnd === element.value.length;
+}

--- a/packages/datetime/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime/src/components/date-range-picker3/_date-range-picker3.scss
@@ -1,0 +1,154 @@
+// Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "@blueprintjs/colors/lib/scss/colors";
+@import "@blueprintjs/core/src/common/variables";
+@import "@blueprintjs/core/src/common/flex";
+@import "@blueprintjs/core/src/components/button/common";
+@import "@blueprintjs/datetime/src/common";
+
+// react-day-picker does not conform to our naming scheme
+/* stylelint-disable selector-class-pattern */
+
+.#{$ns}-daterangepicker {
+  // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
+  &.#{$ns}-daterangepicker-contiguous .rdp {
+    min-width: $datepicker-min-width + $pt-grid-size;
+  }
+
+  &.#{$ns}-daterangepicker-single-month .rdp {
+    min-width: $datepicker-min-width;
+  }
+
+  .rdp.rdp-multiple_months {
+    .rdp-caption {
+      // the default "caption" block + "nav" absolute position styles place the nav buttons slightly off,
+      // so we use flex instead
+      @include pt-flex-container(row);
+      justify-content: space-between;
+    }
+
+    .rdp-caption_start .rdp-caption {
+      flex-direction: row-reverse;
+
+      &::before {
+        // use a dummy pseudo element to achieve our desired flex box layout where we want the dropdowns to
+        // be centered over the calendar (even when there is an extra-wide footer element) while the nav buttons
+        // are justified on the corresponding start or end edge
+        content: "";
+        height: $pt-button-height;
+        width: $pt-button-height;
+      }
+    }
+
+    .rdp-caption_end .rdp-caption {
+      flex-direction: row;
+
+      &::before {
+        content: "";
+        height: $pt-button-height;
+        width: $pt-button-height;
+      }
+    }
+
+    .rdp-nav {
+      left: initial;
+      position: initial;
+      top: initial;
+      transform: none;
+    }
+  }
+
+  // need some extra specificity to override DatePicker styles
+  &.#{$ns}-datepicker .rdp-day {
+    // we only want outside days to be shown when displaying one month at a time
+    // https://github.com/palantir/blueprint/pull/586/files#r98813760
+    &_outside {
+      visibility: hidden;
+    }
+
+    &_hovered:not(.rdp-day_selected) {
+      border-radius: 0;
+      color: $blue2;
+
+      // need to disable hover styles for all variants of selected dates
+      &:not(.rdp-day_range_start, .rdp-day_range_middle, .rdp-day_range_end) {
+        background-color: $daterangepicker-range-background-color;
+      }
+    }
+
+    &_range_middle {
+      background-color: $daterangepicker-range-background-color-selected;
+      border-radius: 0;
+      color: $blue2;
+
+      &:hover {
+        background-color: $daterangepicker-range-background-color-selected-hover;
+        color: $blue2;
+      }
+    }
+
+    &_range_start:not(.rdp-day_range_end, .rdp-day_hovered_end) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    &_range_end:not(.rdp-day_range_start, .rdp_day_hovered_start) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+
+    &_hovered_start:not(.rdp-day_hovered_end) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    &_hovered_end:not(.rdp-day_hovered_start) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+  }
+
+  &.#{$ns}-datepicker-highlight-current-day .rdp-day.rdp-day_today {
+    border: 1px solid $pt-divider-black;
+  }
+
+  /* prettier-ignore */
+  &.#{$ns}-daterangepicker-reverse-month-and-year.#{$ns}-daterangepicker-contiguous.rdp-caption_dropdowns {
+    // only apply this for contiguous pickers where we delegate to rdp to render the dropdowns
+    flex-direction: row-reverse;
+  }
+}
+
+.#{$ns}-daterangepicker-timepickers {
+  &.#{$ns}-daterangepicker-timepickers-stacked {
+    align-items: center;
+    flex-direction: column;
+  }
+}
+
+.#{$ns}-dark .#{$ns}-daterangepicker {
+  &.#{$ns}-datepicker .rdp-day {
+    &_hovered {
+      color: $light-gray5;
+
+      /* prettier-ignore */
+      &:not(.rdp-day_selected, .rdp-day_range_start, .rdp-day_range_middle, .rdp-day_range_end) {
+        background-color: $dark-daterangepicker-range-background-color;
+      }
+    }
+
+    &_range_middle {
+      background-color: $dark-daterangepicker-range-background-color-selected;
+      color: $light-gray5;
+
+      &:hover {
+        background-color: $dark-daterangepicker-range-background-color-selected-hover;
+      }
+    }
+  }
+
+  &.#{$ns}-datepicker-highlight-current-day .rdp-day.rdp-day_today {
+    border: 1px solid $pt-dark-divider-white;
+  }
+}

--- a/packages/datetime/src/components/date-range-picker3/contiguousDayRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker3/contiguousDayRangePicker.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import { DayPicker, type MonthChangeEventHandler, type SelectRangeEventHandler } from "react-day-picker-8";
+
+import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
+
+import type { DateRange } from "../../common";
+import { DateRangeSelectionStrategy } from "../../common/dateRangeSelectionStrategy";
+import { MonthAndYear } from "../../common/monthAndYear";
+import { dateRangeToDayPickerRange } from "../../common/reactDayPickerUtils";
+import { DatePicker3Dropdown } from "../react-day-picker/datePicker3Dropdown";
+import { IconLeft, IconRight } from "../react-day-picker/datePickerNavIcons";
+
+import type { DayRangePickerProps } from "./dayRangePickerProps";
+
+/**
+ * Render a standard day range picker where props.contiguousCalendarMonths is expected to be `true`.
+ */
+export const ContiguousDayRangePicker: React.FC<DayRangePickerProps> = ({
+    allowSingleDayRange,
+    boundaryToModify,
+    dayPickerEventHandlers,
+    dayPickerProps,
+    initialMonthAndYear,
+    locale,
+    maxDate,
+    minDate,
+    onRangeSelect,
+    singleMonthOnly = false,
+    value,
+}) => {
+    const { displayMonth, handleMonthChange } = useContiguousCalendarViews(
+        initialMonthAndYear,
+        singleMonthOnly,
+        value,
+        dayPickerProps?.onMonthChange,
+    );
+
+    const handleRangeSelect = React.useCallback<SelectRangeEventHandler>(
+        (range, selectedDay, activeModifiers, e) => {
+            dayPickerProps?.onSelect?.(range, selectedDay, activeModifiers, e);
+
+            if (activeModifiers.disabled) {
+                return;
+            }
+
+            const { dateRange: nextValue, boundary } = DateRangeSelectionStrategy.getNextState(
+                value,
+                selectedDay,
+                allowSingleDayRange!,
+                boundaryToModify,
+            );
+            onRangeSelect(nextValue, selectedDay, boundary);
+        },
+        [allowSingleDayRange, boundaryToModify, dayPickerProps, onRangeSelect, value],
+    );
+
+    return (
+        <DayPicker
+            showOutsideDays={true}
+            {...dayPickerEventHandlers}
+            {...dayPickerProps}
+            captionLayout="dropdown-buttons"
+            components={{
+                Dropdown: DatePicker3Dropdown,
+                IconLeft,
+                IconRight,
+                ...dayPickerProps?.components,
+            }}
+            fromDate={minDate}
+            locale={locale}
+            mode="range"
+            month={displayMonth.getFullDate()}
+            numberOfMonths={singleMonthOnly ? 1 : 2}
+            onMonthChange={handleMonthChange}
+            onSelect={handleRangeSelect}
+            selected={dateRangeToDayPickerRange(value)}
+            toDate={maxDate}
+        />
+    );
+};
+ContiguousDayRangePicker.displayName = `${DISPLAYNAME_PREFIX}.ContiguousDayRangePicker`;
+
+interface ContiguousCalendarViews {
+    displayMonth: MonthAndYear;
+    handleMonthChange: MonthChangeEventHandler;
+}
+
+/**
+ * State management and navigation event handlers for a single calendar or two contiguous calendar views.
+ *
+ * @param initialMonthAndYear initial month and year to display in the left calendar
+ * @param singleMonthOnly whether we are only displaying a single month instead of two
+ * @param selectedRange currently selected date range
+ * @param userOnMonthChange custom `dayPickerProps.onMonthChange` handler supplied by users of `DateRangePicker3`
+ */
+function useContiguousCalendarViews(
+    initialMonthAndYear: MonthAndYear,
+    singleMonthOnly: boolean,
+    selectedRange: DateRange,
+    userOnMonthChange: MonthChangeEventHandler | undefined,
+): ContiguousCalendarViews {
+    const [displayMonth, setDisplayMonth] = React.useState(initialMonthAndYear);
+    const prevSelectedRange = React.useRef<DateRange>(selectedRange);
+    const isInitialRender = React.useRef<boolean>(true);
+
+    // use an effect to react to external value updates (such as shortcut item selections)
+    React.useEffect(() => {
+        // upon first render, we shouldn't update the display month; instead just use the initially computed value.
+        // this is important in cases where the user sets `initialMonth` and a controlled `value`.
+        if (isInitialRender.current) {
+            isInitialRender.current = false;
+            return;
+        }
+
+        if (selectedRange == null) {
+            return;
+        }
+
+        setDisplayMonth(prevDisplayMonth => {
+            let newDisplayMonth = prevDisplayMonth.clone();
+
+            if (selectedRange[0] == null || selectedRange[1] == null) {
+                // special case: if only one boundary of the range is selected and it is already displayed in one of the
+                // months, don't update the display month. this prevents the picker from shifting around when a user is in
+                // the middle of a selection.
+                if (
+                    isDateDisplayed(selectedRange[0], prevDisplayMonth, singleMonthOnly) ||
+                    isDateDisplayed(selectedRange[1], prevDisplayMonth, singleMonthOnly)
+                ) {
+                    return newDisplayMonth;
+                }
+            }
+
+            const nextRangeStart = MonthAndYear.fromDate(selectedRange[0]);
+            const nextRangeEnd = MonthAndYear.fromDate(selectedRange[1]);
+            const hasSelectionEndChanged = prevSelectedRange.current[0]?.valueOf() === selectedRange[0]?.valueOf();
+
+            if (nextRangeStart == null && nextRangeEnd != null) {
+                // Only end date selected.
+                // If the newly selected end date isn't in either of the displayed months, then
+                //   - set the right DayPicker to the month of the selected end date
+                //   - ensure the left DayPicker is before the right, changing if needed
+                if (!nextRangeEnd.isSame(newDisplayMonth.getNextMonth())) {
+                    newDisplayMonth = nextRangeEnd.getPreviousMonth();
+                }
+            } else if (nextRangeStart != null && nextRangeEnd == null) {
+                // Only start date selected.
+                // If the newly selected start date isn't in either of the displayed months, then
+                //   - set the left DayPicker to the month of the selected start date
+                //   - ensure the right DayPicker is before the left, changing if needed
+                if (!nextRangeStart.isSame(newDisplayMonth)) {
+                    newDisplayMonth = nextRangeStart;
+                }
+            } else if (nextRangeStart != null && nextRangeEnd != null) {
+                if (nextRangeStart.isSame(nextRangeEnd)) {
+                    // Both start and end date months are identical
+                    if (
+                        newDisplayMonth.isSame(nextRangeStart) ||
+                        (!singleMonthOnly && newDisplayMonth.getNextMonth().isSame(nextRangeEnd))
+                    ) {
+                        // do nothing
+                    } else {
+                        newDisplayMonth = nextRangeStart;
+                    }
+                } else if (hasSelectionEndChanged) {
+                    // If the selection end has changed, adjust the view to show the new end date
+                    newDisplayMonth = singleMonthOnly ? nextRangeEnd : nextRangeEnd.getPreviousMonth();
+                } else {
+                    // Otherwise, the selection start must have changed, show that
+                    newDisplayMonth = nextRangeStart;
+                }
+            }
+
+            return newDisplayMonth;
+        });
+    }, [setDisplayMonth, selectedRange, singleMonthOnly]);
+
+    React.useEffect(() => {
+        prevSelectedRange.current = selectedRange;
+    }, [selectedRange]);
+
+    const handleMonthChange = React.useCallback<MonthChangeEventHandler>(
+        newMonth => {
+            const newDisplayMonth = MonthAndYear.fromDate(newMonth);
+            if (newDisplayMonth) {
+                setDisplayMonth(newDisplayMonth);
+            }
+            userOnMonthChange?.(newMonth);
+        },
+        [userOnMonthChange, setDisplayMonth],
+    );
+
+    return {
+        displayMonth,
+        handleMonthChange,
+    };
+}
+
+/**
+ * Determines whether a given date is displayed in a contiguous single- or double-calendar view.
+ */
+function isDateDisplayed(date: Date | null, displayMonth: MonthAndYear, singleMonthOnly: boolean): boolean {
+    if (date == null) {
+        return false;
+    }
+
+    const month = MonthAndYear.fromDate(date);
+
+    if (month == null) {
+        return false;
+    }
+
+    return singleMonthOnly
+        ? displayMonth.isSameMonth(month)
+        : displayMonth.isSameMonth(month) || displayMonth.getNextMonth().isSameMonth(month);
+}

--- a/packages/datetime/src/components/date-range-picker3/date-range-picker3.md
+++ b/packages/datetime/src/components/date-range-picker3/date-range-picker3.md
@@ -1,0 +1,71 @@
+---
+tag: new
+---
+
+@# DateRangePicker3
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+
+Migrating from [DateRangePicker](#datetime/daterangepicker)?
+
+</h5>
+
+**DateRangePicker3** is a replacement for DateRangePicker and will replace it in Blueprint v6.
+You are encouraged to use this new API now to ease the transition to the next major version of Blueprint.
+See the [react-day-picker v8 migration guide](https://github.com/palantir/blueprint/wiki/react-day-picker-8-migration)
+on the wiki.
+
+</div>
+
+**DateRangePicker3** shows two sequential month calendars and allows the user to select a _range_ of days.
+
+@reactExample DateRangePicker3Example
+
+@## Usage
+
+**DateRangePicker3** supports both controlled and uncontrolled usage. You can control the selected date range by setting
+the `value` prop, or use the component in uncontrolled mode and specify an initial date range by setting `defaultValue`.
+Use the `onChange` prop to listen for changes to the selected range.
+
+@## Date ranges
+
+**DateRangePicker3** uses the `DateRange` type across its API. This is an alias for the tuple type `[Date, Date]`.
+
+Semantically:
+
+-   `[null, null]` represents an empty selection.
+-   `[someDate, null]` represents a date range where a single endpoint is known.
+-   `[someDate, someOtherDate]` represents a full date range where both endpoints are known.
+
+@## Shortcuts
+
+The menu on the left of the calendars provides "shortcuts" which allow users to quickly select common date ranges. The
+items in this menu are controlled through the `shortcuts` prop:
+
+-   `true` (default) will show the built-in shortcuts,
+-   `false` will hide the shortcuts menu, and
+-   custom shortcuts can be shown by defining an array of `DateRangeShortcut` objects.
+
+The **preset shortcuts** can be seen in the example above. They are as follows:
+
+-   Today (only appears if `allowSingleDayRange={true}`)
+-   Yesterday (only appears if `allowSingleDayRange={true}`)
+-   Past week
+-   Past month
+-   Past 3 months
+-   Past 6 months
+-   Past year
+-   Past 2 years
+
+**Custom shortcuts** use the following interface:
+
+@interface DateRangeShortcut
+
+@## Props interface
+
+@interface DateRangePicker3Props
+
+@## Localization
+
+See the [**DatePicker3** localization docs](#datetime2/date-picker3.localization).

--- a/packages/datetime/src/components/date-range-picker3/dateRangePicker3.tsx
+++ b/packages/datetime/src/components/date-range-picker3/dateRangePicker3.tsx
@@ -1,0 +1,487 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import { addDays, format } from "date-fns";
+import * as React from "react";
+import type { DateFormatter, DayModifiers, DayMouseEventHandler, ModifiersClassNames } from "react-day-picker-8";
+
+import { Boundary, DISPLAYNAME_PREFIX, Divider } from "@blueprintjs/core";
+
+import { Classes, type DateRange, DateUtils, Errors, TimePrecision } from "../../common";
+import { dayPickerClassNameOverrides } from "../../common/classes";
+import { DateRangeSelectionStrategy } from "../../common/dateRangeSelectionStrategy";
+import { combineModifiers, HOVERED_RANGE_MODIFIER } from "../../common/dayPickerModifiers";
+import { MonthAndYear } from "../../common/monthAndYear";
+import { DatePickerUtils } from "../date-picker/datePickerUtils";
+import { DatePicker3Provider } from "../date-picker3/datePicker3Context";
+import { DateFnsLocalizedComponent } from "../dateFnsLocalizedComponent";
+import { DatePickerShortcutMenu, type DateRangeShortcut } from "../shortcuts/shortcuts";
+import { TimePicker } from "../time-picker/timePicker";
+
+import { ContiguousDayRangePicker } from "./contiguousDayRangePicker";
+import type { DateRangePicker3DefaultProps, DateRangePicker3Props } from "./dateRangePicker3Props";
+import type { DateRangePicker3State } from "./dateRangePicker3State";
+import { NonContiguousDayRangePicker } from "./nonContiguousDayRangePicker";
+
+export type { DateRangePicker3Props };
+
+const NULL_RANGE: DateRange = [null, null];
+
+/**
+ * Date range picker (v3) component.
+ *
+ * @see https://blueprintjs.com/docs/#datetime2/date-range-picker3
+ */
+export class DateRangePicker3 extends DateFnsLocalizedComponent<DateRangePicker3Props, DateRangePicker3State> {
+    public static defaultProps: DateRangePicker3DefaultProps = {
+        allowSingleDayRange: false,
+        contiguousCalendarMonths: true,
+        dayPickerProps: {},
+        locale: "en-US",
+        maxDate: DatePickerUtils.getDefaultMaxDate(),
+        minDate: DatePickerUtils.getDefaultMinDate(),
+        reverseMonthAndYearMenus: false,
+        shortcuts: true,
+        singleMonthOnly: false,
+        timePickerProps: {},
+    };
+
+    public static displayName = `${DISPLAYNAME_PREFIX}.DateRangePicker3`;
+
+    // these will get merged with the user's own
+    private modifiers: DayModifiers = {
+        [HOVERED_RANGE_MODIFIER]: day => {
+            const {
+                hoverValue,
+                value: [selectedStart, selectedEnd],
+            } = this.state;
+            if (selectedStart == null && selectedEnd == null) {
+                return false;
+            }
+            if (hoverValue == null || hoverValue[0] == null || hoverValue[1] == null) {
+                return false;
+            }
+            return DateUtils.isDayInRange(day, hoverValue, true);
+        },
+        [`${HOVERED_RANGE_MODIFIER}-start`]: day => {
+            const { hoverValue } = this.state;
+            if (hoverValue == null || hoverValue[0] == null) {
+                return false;
+            }
+            return DateUtils.isSameDay(hoverValue[0], day);
+        },
+        [`${HOVERED_RANGE_MODIFIER}-end`]: day => {
+            const { hoverValue } = this.state;
+            if (hoverValue == null || hoverValue[1] == null) {
+                return false;
+            }
+            return DateUtils.isSameDay(hoverValue[1], day);
+        },
+    };
+
+    private modifiersClassNames: ModifiersClassNames = {
+        [HOVERED_RANGE_MODIFIER]: Classes.DATERANGEPICKER3_HOVERED_RANGE,
+        [`${HOVERED_RANGE_MODIFIER}-start`]: Classes.DATERANGEPICKER3_HOVERED_RANGE_START,
+        [`${HOVERED_RANGE_MODIFIER}-end`]: Classes.DATERANGEPICKER3_HOVERED_RANGE_END,
+    };
+
+    private initialMonthAndYear: MonthAndYear =
+        MonthAndYear.fromDate(new Date()) ?? new MonthAndYear(new Date().getMonth(), new Date().getFullYear());
+
+    public constructor(props: DateRangePicker3Props) {
+        super(props);
+        const value = getInitialValue(props);
+        const time: DateRange = value;
+        const initialMonth = getInitialMonth(props, value);
+        this.initialMonthAndYear = new MonthAndYear(initialMonth.getMonth(), initialMonth.getFullYear());
+        this.state = {
+            hoverValue: NULL_RANGE,
+            locale: undefined,
+            selectedShortcutIndex:
+                this.props.selectedShortcutIndex !== undefined ? this.props.selectedShortcutIndex : -1,
+            time,
+            value,
+        };
+    }
+
+    public render() {
+        const { className, contiguousCalendarMonths, footerElement } = this.props;
+        const isSingleMonthOnly = getIsSingleMonthOnly(this.props);
+
+        const classes = classNames(Classes.DATEPICKER, Classes.DATERANGEPICKER, className, {
+            [Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY]: this.props.highlightCurrentDay,
+            [Classes.DATERANGEPICKER_CONTIGUOUS]: contiguousCalendarMonths,
+            [Classes.DATERANGEPICKER_SINGLE_MONTH]: isSingleMonthOnly,
+            [Classes.DATERANGEPICKER3_REVERSE_MONTH_AND_YEAR]: this.props.reverseMonthAndYearMenus,
+        });
+
+        // use the left DayPicker when we only need one
+        return (
+            <div className={classes}>
+                {this.maybeRenderShortcuts()}
+                <div className={Classes.DATEPICKER_CONTENT}>
+                    <DatePicker3Provider {...this.props} {...this.state}>
+                        {contiguousCalendarMonths || isSingleMonthOnly
+                            ? this.renderContiguousDayRangePicker(isSingleMonthOnly)
+                            : this.renderNonContiguousDayRangePicker()}
+                        {this.maybeRenderTimePickers(isSingleMonthOnly)}
+                        {footerElement}
+                    </DatePicker3Provider>
+                </div>
+            </div>
+        );
+    }
+
+    public async componentDidMount() {
+        await super.componentDidMount();
+    }
+
+    public async componentDidUpdate(prevProps: DateRangePicker3Props) {
+        super.componentDidUpdate(prevProps);
+
+        const isControlled = prevProps.value !== undefined && this.props.value !== undefined;
+
+        if (prevProps.contiguousCalendarMonths !== this.props.contiguousCalendarMonths) {
+            const initialMonth = getInitialMonth(this.props, getInitialValue(this.props));
+            this.initialMonthAndYear = new MonthAndYear(initialMonth.getMonth(), initialMonth.getFullYear());
+        }
+
+        if (
+            isControlled &&
+            (!DateUtils.areRangesEqual(prevProps.value!, this.props.value!) ||
+                prevProps.contiguousCalendarMonths !== this.props.contiguousCalendarMonths)
+        ) {
+            this.setState({ value: this.props.value ?? NULL_RANGE });
+        }
+
+        if (this.props.selectedShortcutIndex !== prevProps.selectedShortcutIndex) {
+            this.setState({ selectedShortcutIndex: this.props.selectedShortcutIndex });
+        }
+    }
+
+    protected validateProps(props: DateRangePicker3Props) {
+        const { defaultValue, initialMonth, maxDate, minDate, boundaryToModify, value } = props;
+        const dateRange: DateRange = [minDate!, maxDate!];
+
+        if (defaultValue != null && !DateUtils.isDayRangeInRange(defaultValue, dateRange)) {
+            console.error(Errors.DATERANGEPICKER_DEFAULT_VALUE_INVALID);
+        }
+
+        if (initialMonth != null && !DateUtils.isMonthInRange(initialMonth, dateRange)) {
+            console.error(Errors.DATERANGEPICKER_INITIAL_MONTH_INVALID);
+        }
+
+        if (maxDate != null && minDate != null && maxDate < minDate && !DateUtils.isSameDay(maxDate, minDate)) {
+            console.error(Errors.DATERANGEPICKER_MAX_DATE_INVALID);
+        }
+
+        if (value != null && !DateUtils.isDayRangeInRange(value, dateRange)) {
+            console.error(Errors.DATERANGEPICKER_VALUE_INVALID);
+        }
+
+        if (boundaryToModify != null && boundaryToModify !== Boundary.START && boundaryToModify !== Boundary.END) {
+            console.error(Errors.DATERANGEPICKER_PREFERRED_BOUNDARY_TO_MODIFY_INVALID);
+        }
+    }
+
+    private maybeRenderShortcuts() {
+        const { shortcuts } = this.props;
+        if (shortcuts == null || shortcuts === false) {
+            return null;
+        }
+
+        const { selectedShortcutIndex } = this.state;
+        const { allowSingleDayRange, maxDate, minDate, timePrecision } = this.props;
+        return [
+            <DatePickerShortcutMenu
+                key="shortcuts"
+                {...{
+                    allowSingleDayRange,
+                    maxDate,
+                    minDate,
+                    selectedShortcutIndex,
+                    shortcuts,
+                    timePrecision,
+                }}
+                onShortcutClick={this.handleShortcutClick}
+            />,
+            <Divider key="div" />,
+        ];
+    }
+
+    private maybeRenderTimePickers(isShowingOneMonth: boolean) {
+        // timePrecision may be set as a root prop or as a property inside timePickerProps, so we need to check both
+        const { timePickerProps, timePrecision = timePickerProps?.precision } = this.props;
+        if (timePrecision == null && timePickerProps === DateRangePicker3.defaultProps.timePickerProps) {
+            return null;
+        }
+
+        const isLongTimePicker =
+            timePickerProps?.useAmPm ||
+            timePrecision === TimePrecision.SECOND ||
+            timePrecision === TimePrecision.MILLISECOND;
+
+        return (
+            <div
+                className={classNames(Classes.DATERANGEPICKER_TIMEPICKERS, {
+                    [Classes.DATERANGEPICKER3_TIMEPICKERS_STACKED]: isShowingOneMonth && isLongTimePicker,
+                })}
+            >
+                <TimePicker
+                    precision={timePrecision}
+                    {...timePickerProps}
+                    onChange={this.handleTimeChangeLeftCalendar}
+                    value={this.state.time[0]}
+                />
+                <TimePicker
+                    precision={timePrecision}
+                    {...timePickerProps}
+                    onChange={this.handleTimeChangeRightCalendar}
+                    value={this.state.time[1]}
+                />
+            </div>
+        );
+    }
+
+    private handleTimeChange = (newTime: Date, dateIndex: number) => {
+        this.props.timePickerProps?.onChange?.(newTime);
+
+        const { value, time } = this.state;
+        const newValue = DateUtils.getDateTime(
+            value[dateIndex] != null ? DateUtils.clone(value[dateIndex]!) : this.getDefaultDate(dateIndex),
+            newTime,
+        );
+        const newDateRange: DateRange = [value[0], value[1]];
+        newDateRange[dateIndex] = newValue;
+        const newTimeRange: DateRange = [time[0], time[1]];
+        newTimeRange[dateIndex] = newTime;
+
+        this.props.onChange?.(newDateRange);
+        this.setState({ time: newTimeRange, value: newDateRange });
+    };
+
+    // When a user sets the time value before choosing a date, we need to pick a date for them
+    // The default depends on the value of the other date since there's an invariant
+    // that the left/0 date is always less than the right/1 date
+    private getDefaultDate = (dateIndex: number) => {
+        const { value } = this.state;
+        const otherIndex = dateIndex === 0 ? 1 : 0;
+        const otherDate = value[otherIndex];
+        if (otherDate == null) {
+            return new Date();
+        }
+
+        const { allowSingleDayRange } = this.props;
+        if (!allowSingleDayRange) {
+            const dateDiff = dateIndex === 0 ? -1 : 1;
+            return addDays(otherDate, dateDiff);
+        }
+
+        return otherDate;
+    };
+
+    private handleTimeChangeLeftCalendar = (time: Date) => {
+        this.handleTimeChange(time, 0);
+    };
+
+    private handleTimeChangeRightCalendar = (time: Date) => {
+        this.handleTimeChange(time, 1);
+    };
+
+    /**
+     * Render a standard day range picker where props.contiguousCalendarMonths is expected to be `true`.
+     */
+    private renderContiguousDayRangePicker(singleMonthOnly: boolean) {
+        const { dayPickerProps, ...props } = this.props;
+        return (
+            <ContiguousDayRangePicker
+                {...props}
+                contiguousCalendarMonths={true}
+                dayPickerEventHandlers={{
+                    onDayMouseEnter: this.handleDayMouseEnter,
+                    onDayMouseLeave: this.handleDayMouseLeave,
+                }}
+                dayPickerProps={this.resolvedDayPickerProps}
+                initialMonthAndYear={this.initialMonthAndYear}
+                locale={this.state.locale}
+                onRangeSelect={this.handleDayRangeSelect}
+                singleMonthOnly={singleMonthOnly}
+                value={this.state.value}
+            />
+        );
+    }
+
+    /**
+     * react-day-picker doesn't have built-in support for non-contiguous calendar months in its range picker,
+     * so we have to implement this ourselves.
+     */
+    private renderNonContiguousDayRangePicker() {
+        const { dayPickerProps, ...props } = this.props;
+        return (
+            <NonContiguousDayRangePicker
+                {...props}
+                dayPickerProps={this.resolvedDayPickerProps}
+                dayPickerEventHandlers={{
+                    onDayMouseEnter: this.handleDayMouseEnter,
+                    onDayMouseLeave: this.handleDayMouseLeave,
+                }}
+                initialMonthAndYear={this.initialMonthAndYear}
+                locale={this.state.locale}
+                onRangeSelect={this.handleDayRangeSelect}
+                value={this.state.value}
+            />
+        );
+    }
+
+    private get resolvedDayPickerProps(): DateRangePicker3Props["dayPickerProps"] {
+        const { dayPickerProps = {} } = this.props;
+        return {
+            ...dayPickerProps,
+            classNames: {
+                ...dayPickerClassNameOverrides,
+                ...dayPickerProps.classNames,
+            },
+            formatters: {
+                formatWeekdayName: this.formatWeekdayName,
+                ...dayPickerProps.formatters,
+            },
+            modifiers: combineModifiers(this.modifiers, dayPickerProps.modifiers),
+            modifiersClassNames: {
+                ...this.modifiersClassNames,
+                ...dayPickerProps.modifiersClassNames,
+            },
+        };
+    }
+
+    /**
+     * Custom formatter to render weekday names in the calendar header. The default formatter generally works fine,
+     * but it was returning CAPITALIZED strings for some reason, while we prefer Title Case.
+     */
+    private formatWeekdayName: DateFormatter = date => format(date, "EEEEEE", { locale: this.state.locale });
+
+    private handleDayMouseEnter: DayMouseEventHandler = (day, activeModifiers, e) => {
+        this.props.dayPickerProps?.onDayMouseEnter?.(day, activeModifiers, e);
+        if (activeModifiers.disabled) {
+            return;
+        }
+        const { dateRange, boundary } = DateRangeSelectionStrategy.getNextState(
+            this.state.value,
+            day,
+            this.props.allowSingleDayRange!,
+            this.props.boundaryToModify,
+        );
+        this.setState({ hoverValue: dateRange });
+        this.props.onHoverChange?.(dateRange, day, boundary);
+    };
+
+    private handleDayMouseLeave: DayMouseEventHandler = (day, activeModifiers, e) => {
+        this.props.dayPickerProps?.onDayMouseLeave?.(day, activeModifiers, e);
+        if (activeModifiers.disabled) {
+            return;
+        }
+        this.setState({ hoverValue: undefined });
+        this.props.onHoverChange?.(undefined, day, undefined);
+    };
+
+    private handleDayRangeSelect = (nextValue: DateRange, selectedDay: Date, boundary: Boundary) => {
+        // update the hovered date range after click to show the newly selected
+        // state, at leasts until the mouse moves again
+        this.setState({ hoverValue: nextValue });
+        this.props.onHoverChange?.(nextValue, selectedDay, boundary);
+        this.updateSelectedRange(nextValue);
+    };
+
+    private handleShortcutClick = (shortcut: DateRangeShortcut, selectedShortcutIndex: number) => {
+        const { dateRange, includeTime } = shortcut;
+
+        if (includeTime) {
+            this.updateSelectedRange(dateRange, [dateRange[0], dateRange[1]]);
+        } else {
+            this.updateSelectedRange(dateRange);
+        }
+
+        if (this.props.selectedShortcutIndex === undefined) {
+            // uncontrolled shorcut selection
+            this.setState({ selectedShortcutIndex });
+        }
+
+        this.props.onShortcutChange?.(shortcut, selectedShortcutIndex);
+    };
+
+    private updateSelectedRange = (selectedRange: DateRange, selectedTimeRange: DateRange = this.state.time) => {
+        selectedRange[0] = DateUtils.getDateTime(selectedRange[0], selectedTimeRange[0]);
+        selectedRange[1] = DateUtils.getDateTime(selectedRange[1], selectedTimeRange[1]);
+
+        if (this.props.value == null) {
+            // uncontrolled range selection
+            this.setState({ time: selectedTimeRange, value: selectedRange });
+        }
+        this.props.onChange?.(selectedRange);
+    };
+}
+
+function getIsSingleMonthOnly(props: DateRangePicker3Props): boolean {
+    return props.singleMonthOnly || DateUtils.isSameMonth(props.minDate!, props.maxDate!);
+}
+
+function getInitialValue(props: DateRangePicker3Props): DateRange {
+    if (props.value != null) {
+        return props.value;
+    }
+    if (props.defaultValue != null) {
+        return props.defaultValue;
+    }
+    return NULL_RANGE;
+}
+
+function getInitialMonth(props: DateRangePicker3Props, value: DateRange): Date {
+    const today = new Date();
+    const isSingleMonthOnly = getIsSingleMonthOnly(props);
+
+    if (props.initialMonth != null) {
+        if (!isSingleMonthOnly && DateUtils.isSameMonth(props.initialMonth, props.maxDate!)) {
+            // special case: if initial month is same as maxDate month, display it on the right calendar
+            return DateUtils.getDatePreviousMonth(props.initialMonth);
+        }
+        return props.initialMonth;
+    } else if (value[0] != null) {
+        if (!isSingleMonthOnly && DateUtils.isSameMonth(value[0], props.maxDate!)) {
+            // special case: if start of range is selected and that date is in the maxDate month, display it on the right calendar
+            return DateUtils.getDatePreviousMonth(value[0]);
+        }
+        return DateUtils.clone(value[0]);
+    } else if (value[1] != null) {
+        const month = DateUtils.clone(value[1]);
+        if (!DateUtils.isSameMonth(month, props.minDate!)) {
+            month.setMonth(month.getMonth() - 1);
+        }
+        return month;
+    } else if (DateUtils.isDayInRange(today, [props.minDate!, props.maxDate!])) {
+        if (!isSingleMonthOnly && DateUtils.isSameMonth(today, props.maxDate!)) {
+            // special case: if today is in the maxDate month, display it on the right calendar
+            today.setMonth(today.getMonth() - 1);
+        }
+        return today;
+    } else {
+        const betweenDate = DateUtils.getDateBetween([props.minDate!, props.maxDate!]);
+        if (!isSingleMonthOnly && DateUtils.isSameMonth(betweenDate, props.maxDate!)) {
+            // special case: if betweenDate is in the maxDate month, display it on the right calendar
+            betweenDate.setMonth(betweenDate.getMonth() - 1);
+        }
+        return betweenDate;
+    }
+}

--- a/packages/datetime/src/components/date-range-picker3/dateRangePicker3Props.ts
+++ b/packages/datetime/src/components/date-range-picker3/dateRangePicker3Props.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
+
+import type { DateRangePickerProps } from "./dateRangePickerProps";
+
+/** Props shared between DateRangePicker v1 and v3 */
+type DateRangePickerSharedProps = Omit<DateRangePickerProps, "dayPickerProps" | "locale" | "localeUtils" | "modifiers">;
+
+export type DateRangePicker3Props = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;
+
+export type DateRangePicker3DefaultProps = Required<
+    Pick<
+        DateRangePicker3Props,
+        | "allowSingleDayRange"
+        | "contiguousCalendarMonths"
+        | "dayPickerProps"
+        | "locale"
+        | "maxDate"
+        | "minDate"
+        | "reverseMonthAndYearMenus"
+        | "shortcuts"
+        | "singleMonthOnly"
+        | "timePickerProps"
+    >
+>;
+
+export type DateRangePicker3PropsWithDefaults = Omit<DateRangePicker3Props, keyof DateRangePicker3DefaultProps> &
+    DateRangePicker3DefaultProps;

--- a/packages/datetime/src/components/date-range-picker3/dateRangePicker3State.ts
+++ b/packages/datetime/src/components/date-range-picker3/dateRangePicker3State.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Locale } from "date-fns";
+
+import type { DateRange } from "../../common";
+
+export interface DateRangePicker3State {
+    hoverValue?: DateRange;
+    locale: Locale | undefined;
+    value: DateRange;
+    time: DateRange;
+    selectedShortcutIndex?: number;
+}

--- a/packages/datetime/src/components/date-range-picker3/dateRangePickerProps.ts
+++ b/packages/datetime/src/components/date-range-picker3/dateRangePickerProps.ts
@@ -1,0 +1,94 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Boundary, Props } from "@blueprintjs/core";
+
+import type { DatePickerBaseProps, DateRange } from "../../common";
+import type { DateRangeShortcut } from "../shortcuts/shortcuts";
+
+export interface DateRangePickerProps extends DatePickerBaseProps, Props {
+    /**
+     * Whether the start and end dates of the range can be the same day.
+     * If `true`, clicking a selected date will create a one-day range.
+     * If `false`, clicking a selected date will clear the selection.
+     *
+     * @default false
+     */
+    allowSingleDayRange?: boolean;
+
+    /**
+     * The date-range boundary that the next click should modify.
+     * This will be honored unless the next click would overlap the other boundary date.
+     * In that case, the two boundary dates will be auto-swapped to keep them in chronological order.
+     * If `undefined`, the picker will revert to its default selection behavior.
+     */
+    boundaryToModify?: Boundary;
+
+    /**
+     * Whether displayed months in the calendar are contiguous.
+     * If false, each side of the calendar can move independently to non-contiguous months.
+     *
+     * @default true
+     */
+    contiguousCalendarMonths?: boolean;
+
+    /**
+     * Initial `DateRange` the calendar will display as selected.
+     * This should not be set if `value` is set.
+     */
+    defaultValue?: DateRange;
+
+    /**
+     * Called when the user selects a day.
+     * If no days are selected, it will pass `[null, null]`.
+     * If a start date is selected but not an end date, it will pass `[selectedDate, null]`.
+     * If both a start and end date are selected, it will pass `[startDate, endDate]`.
+     */
+    onChange?: (selectedDates: DateRange) => void;
+
+    /**
+     * Called when the user changes the hovered date range, either from mouseenter or mouseleave.
+     * When triggered from mouseenter, it will pass the date range that would result from next click.
+     * When triggered from mouseleave, it will pass `undefined`.
+     */
+    onHoverChange?: (
+        hoveredDates: DateRange | undefined,
+        hoveredDay: Date,
+        hoveredBoundary: Boundary | undefined,
+    ) => void;
+
+    /**
+     * Called when the `shortcuts` props is enabled and the user changes the shortcut.
+     */
+    onShortcutChange?: (shortcut: DateRangeShortcut, index: number) => void;
+
+    /**
+     * Whether shortcuts to quickly select a range of dates are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     *
+     * @default true
+     */
+    shortcuts?: boolean | DateRangeShortcut[];
+
+    /**
+     * The currently selected shortcut.
+     * If this prop is provided, the component acts in a controlled manner.
+     */
+    selectedShortcutIndex?: number;
+
+    /**
+     * Whether to show only a single month calendar.
+     *
+     * @default false
+     */
+    singleMonthOnly?: boolean;
+
+    /**
+     * The currently selected `DateRange`.
+     * If this prop is provided, the component acts in a controlled manner.
+     */
+    value?: DateRange;
+}

--- a/packages/datetime/src/components/date-range-picker3/dayRangePickerProps.ts
+++ b/packages/datetime/src/components/date-range-picker3/dayRangePickerProps.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DayPickerRangeProps } from "react-day-picker-8";
+
+import type { Boundary } from "@blueprintjs/core";
+
+import type { DateRange } from "../../common";
+import type { MonthAndYear } from "../../common/monthAndYear";
+
+import type { DateRangePicker3Props } from "./dateRangePicker3Props";
+import type { DateRangePicker3State } from "./dateRangePicker3State";
+
+/**
+ * Props used to render an interactive single- or double-calendar day range picker.
+ * This is the core UI of DateRangePicker3 (exclusive of time pickers, shortcuts, and the actions bar).
+ */
+export interface DayRangePickerProps
+    extends Omit<DateRangePicker3Props, "initialMonth" | "locale" | "value">,
+        Pick<DateRangePicker3State, "locale" | "value"> {
+    /**
+     * react-day-picker event handlers. These are used to update hover state in DateRangePicker3.
+     */
+    dayPickerEventHandlers: Required<Pick<DayPickerRangeProps, "onDayMouseEnter" | "onDayMouseLeave">>;
+
+    /**
+     * Initial month and year to display. If there are multiple calendars, this applies to the left calendar.
+     */
+    initialMonthAndYear: MonthAndYear;
+
+    /**
+     * Date range selection handler triggered when clicking a day in one of the calendars.
+     *
+     * @param selectedRange the new selected date range
+     * @param selectedDay the date that was clicked to trigger this selection
+     * @param boundary the boundary (start or end) which has just been modified by this click
+     */
+    onRangeSelect: (selectedRange: DateRange, selectedDay: Date, boundary: Boundary) => void;
+}

--- a/packages/datetime/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker3/nonContiguousDayRangePicker.tsx
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from "react";
+import {
+    DayPicker,
+    type DayPickerRangeProps,
+    type MonthChangeEventHandler,
+    type SelectRangeEventHandler,
+} from "react-day-picker-8";
+
+import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
+
+import { Classes, type DateRange, DateUtils } from "../../common";
+import { DateRangeSelectionStrategy } from "../../common/dateRangeSelectionStrategy";
+import { MonthAndYear } from "../../common/monthAndYear";
+import { dateRangeToDayPickerRange } from "../../common/reactDayPickerUtils";
+import { DatePicker3Caption } from "../react-day-picker/datePicker3Caption";
+
+import type { DayRangePickerProps } from "./dayRangePickerProps";
+
+/**
+ * Date range picker with two calendars which can move independently of each other.
+ */
+export const NonContiguousDayRangePicker: React.FC<DayRangePickerProps> = ({
+    allowSingleDayRange,
+    boundaryToModify,
+    dayPickerEventHandlers,
+    dayPickerProps,
+    initialMonthAndYear,
+    locale,
+    maxDate,
+    minDate,
+    onRangeSelect,
+    value,
+}) => {
+    const { displayMonths, handleLeftMonthChange, handleRightMonthChange } = useNonContiguousCalendarViews(
+        initialMonthAndYear,
+        value,
+        dayPickerProps?.onMonthChange,
+        minDate,
+        maxDate,
+    );
+
+    const handleDaySelect = React.useCallback<SelectRangeEventHandler>(
+        (range, selectedDay, activeModifiers, e) => {
+            dayPickerProps?.onSelect?.(range, selectedDay, activeModifiers, e);
+
+            if (activeModifiers.disabled) {
+                return;
+            }
+
+            const { dateRange: nextValue, boundary } = DateRangeSelectionStrategy.getNextState(
+                value,
+                selectedDay,
+                allowSingleDayRange!,
+                boundaryToModify,
+            );
+            onRangeSelect(nextValue, selectedDay, boundary);
+        },
+        [allowSingleDayRange, boundaryToModify, dayPickerProps, onRangeSelect, value],
+    );
+
+    // props applied to both the left and right calendars
+    const commonDayPickerProps: DayPickerRangeProps = {
+        locale,
+        mode: "range",
+        showOutsideDays: true,
+        ...dayPickerProps,
+        ...dayPickerEventHandlers,
+        components: {
+            Caption: DatePicker3Caption,
+            ...dayPickerProps?.components,
+        },
+        onSelect: handleDaySelect,
+        selected: dateRangeToDayPickerRange(value),
+    };
+
+    return (
+        <div className={Classes.DATERANGEPICKER_CALENDARS}>
+            <DayPicker
+                key="left"
+                {...commonDayPickerProps}
+                fromDate={minDate}
+                month={displayMonths.left.getFullDate()}
+                numberOfMonths={1}
+                onMonthChange={handleLeftMonthChange}
+                toMonth={DateUtils.getDatePreviousMonth(maxDate!)}
+            />
+            <DayPicker
+                key="right"
+                {...commonDayPickerProps}
+                fromMonth={DateUtils.getDateNextMonth(minDate!)}
+                month={displayMonths.right.getFullDate()}
+                numberOfMonths={1}
+                onMonthChange={handleRightMonthChange}
+                toDate={maxDate}
+            />
+        </div>
+    );
+};
+NonContiguousDayRangePicker.displayName = `${DISPLAYNAME_PREFIX}.NonContiguousDayRangePicker`;
+
+interface LeftAndRightDisplayMonths {
+    left: MonthAndYear;
+    right: MonthAndYear;
+}
+
+interface NonContiguousCalendarViews {
+    handleLeftMonthChange: MonthChangeEventHandler;
+    handleRightMonthChange: MonthChangeEventHandler;
+    displayMonths: LeftAndRightDisplayMonths;
+}
+
+/**
+ * State management and navigation event handlers for two (left and right) non-contiguous calendar views.
+ *
+ * @param initialMonthAndYear initial month and year to display in the left calendar
+ * @param selectedRange currently selected date range
+ * @param userOnMonthChange custom `dayPickerProps.onMonthChange` handler supplied by users of `DateRangePicker3`
+ */
+function useNonContiguousCalendarViews(
+    initialMonthAndYear: MonthAndYear,
+    selectedRange: DateRange,
+    userOnMonthChange: MonthChangeEventHandler | undefined,
+    minDate: Date | undefined,
+    maxDate: Date | undefined,
+): NonContiguousCalendarViews {
+    // show the selected end date's encompassing month in the right view if
+    // the calendars don't have to be contiguous.
+    // if left view and right view months are the same, show next month in the right view.
+    const [views, setViews] = React.useState<LeftAndRightDisplayMonths>({
+        left: initialMonthAndYear,
+        right: getInitialRightView(selectedRange[1], initialMonthAndYear),
+    });
+
+    React.useEffect(() => {
+        if (selectedRange == null) {
+            return;
+        }
+
+        setViews(({ left, right }) => {
+            let newLeftView = left.clone();
+            let newRightView = right.clone();
+
+            const nextValueStartView = MonthAndYear.fromDate(selectedRange[0]);
+            const nextValueEndView = MonthAndYear.fromDate(selectedRange[1]);
+
+            if (nextValueStartView == null && nextValueEndView != null) {
+                // Only end date selected.
+                // If the newly selected end date isn't in either of the displayed months, then
+                //   - set the right DayPicker to the month of the selected end date
+                //   - ensure the left DayPicker is before the right, changing if needed
+                if (!nextValueEndView.isSame(newLeftView) && !nextValueEndView.isSame(newRightView)) {
+                    newRightView = nextValueEndView;
+                    if (!newLeftView.isBefore(newRightView)) {
+                        newLeftView = newRightView.getPreviousMonth();
+                    }
+                }
+            } else if (nextValueStartView != null && nextValueEndView == null) {
+                // Only start date selected.
+                // If the newly selected start date isn't in either of the displayed months, then
+                //   - set the left DayPicker to the month of the selected start date
+                //   - ensure the right DayPicker is before the left, changing if needed
+                if (!nextValueStartView.isSame(newLeftView) && !nextValueStartView.isSame(newRightView)) {
+                    newLeftView = nextValueStartView;
+                    if (!newRightView.isAfter(newLeftView)) {
+                        newRightView = newLeftView.getNextMonth();
+                    }
+                }
+            } else if (nextValueStartView != null && nextValueEndView != null) {
+                // Both start and end date months are identical
+                // If the selected month isn't in either of the displayed months, then
+                //   - set the left DayPicker to be the selected month
+                //   - set the right DayPicker to +1
+                if (nextValueStartView.isSame(nextValueEndView)) {
+                    if (newLeftView.isSame(nextValueStartView) || newRightView.isSame(nextValueStartView)) {
+                        // do nothing
+                    } else {
+                        newLeftView = nextValueStartView;
+                        newRightView = nextValueStartView.getNextMonth();
+                    }
+                } else {
+                    // Different start and end date months, adjust display months.
+                    if (!newLeftView.isSame(nextValueStartView)) {
+                        newLeftView = nextValueStartView;
+                        newRightView = nextValueStartView.getNextMonth();
+                    }
+                    if (!newRightView.isSame(nextValueEndView)) {
+                        newRightView = nextValueEndView;
+                    }
+                }
+            }
+
+            return { left: newLeftView, right: newRightView };
+        });
+    }, [setViews, selectedRange]);
+
+    const handleLeftMonthChange = React.useCallback(
+        (newDate: Date) => {
+            const newLeftView = MonthAndYear.fromDate(newDate);
+            if (newLeftView == null) {
+                return;
+            }
+            setViews(({ right }) => {
+                let newRightView = right.clone();
+                if (!newLeftView.isBefore(newRightView)) {
+                    newRightView = newLeftView.getNextMonth();
+                }
+
+                const [leftView, rightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
+                userOnMonthChange?.(newLeftView.getFullDate());
+                return { left: leftView, right: rightView };
+            });
+        },
+        [minDate, maxDate, setViews, userOnMonthChange],
+    );
+
+    const handleRightMonthChange = React.useCallback(
+        (newDate: Date) => {
+            const newRightView = MonthAndYear.fromDate(newDate);
+            if (newRightView == null) {
+                return;
+            }
+            setViews(({ left }) => {
+                let newLeftView = left.clone();
+                if (!newRightView.isAfter(newLeftView)) {
+                    newLeftView = newRightView.getPreviousMonth();
+                }
+
+                const [leftView, rightView] = getBoundedViews(newLeftView, newRightView, minDate, maxDate);
+                userOnMonthChange?.(newRightView.getFullDate());
+                return { left: leftView, right: rightView };
+            });
+        },
+        [minDate, maxDate, setViews, userOnMonthChange],
+    );
+
+    return {
+        displayMonths: views,
+        handleLeftMonthChange,
+        handleRightMonthChange,
+    };
+}
+
+function getBoundedViews(
+    leftView: MonthAndYear,
+    rightView: MonthAndYear,
+    minDate: Date | undefined,
+    maxDate: Date | undefined,
+): [left: MonthAndYear, right: MonthAndYear] {
+    const minView = MonthAndYear.fromDate(minDate ?? null);
+    if (minView != null && leftView.isBefore(minView)) {
+        return [minView, minView.getNextMonth()];
+    }
+
+    const maxView = MonthAndYear.fromDate(maxDate ?? null);
+    if (maxView != null && rightView.isAfter(maxView)) {
+        return [maxView.getPreviousMonth(), maxView];
+    }
+
+    return [leftView, rightView];
+}
+
+function getInitialRightView(selectedRangeEnd: Date | null, leftView: MonthAndYear) {
+    const rightView = MonthAndYear.fromDate(selectedRangeEnd);
+
+    if (rightView === undefined || rightView.isSameMonth(leftView)) {
+        return leftView.getNextMonth();
+    }
+
+    return rightView;
+}

--- a/packages/datetime/test/common/dayPicker8TestUtils.ts
+++ b/packages/datetime/test/common/dayPicker8TestUtils.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @fileoverview test utils for react-day-picker v8 */
+
+import { assert } from "chai";
+import type { ReactWrapper } from "enzyme";
+
+import { Classes } from "../../src";
+
+const isDayHidden = (day: ReactWrapper<any, any>): boolean => !day.find(`.${Classes.DATEPICKER3_DAY}`).exists();
+
+export function assertDayDisabled(day: ReactWrapper<any, any>, expectDisabled: boolean = true) {
+    assert.equal(day.hasClass(Classes.DATEPICKER3_DAY_DISABLED), expectDisabled);
+}
+
+export function assertDayHidden(day: ReactWrapper<any, any>, expectHidden: boolean = true) {
+    assert.equal(isDayHidden(day), expectHidden);
+}

--- a/packages/datetime/test/common/loadDateFnsLocaleFake.ts
+++ b/packages/datetime/test/common/loadDateFnsLocaleFake.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Locales from "date-fns/locale";
+
+export async function loadDateFnsLocaleFake(localeOrCode: Locale | string | undefined) {
+    if (localeOrCode === undefined) {
+        return undefined;
+    } else if (typeof localeOrCode === "string") {
+        const localeKey = localeCodeToKey(localeOrCode);
+        return Locales[localeKey];
+    } else {
+        return localeOrCode;
+    }
+}
+
+/**
+ * Converts "en-US" to "enUS" which can be used to index into locales export object
+ */
+function localeCodeToKey(localeCode: string): keyof typeof Locales {
+    let localeKey = localeCode as keyof typeof Locales;
+    // convert "en-US" to "enUS" which can be used to index into locales export object
+    if (localeKey.includes("-")) {
+        const splits = localeKey.split("-");
+        localeKey = `${splits[0]}${splits[1].toUpperCase()}` as keyof typeof Locales;
+    }
+    return localeKey;
+}

--- a/packages/datetime/test/components/dateInput3Tests.tsx
+++ b/packages/datetime/test/components/dateInput3Tests.tsx
@@ -1,0 +1,987 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { intlFormat, isEqual, parseISO } from "date-fns";
+import enUSLocale from "date-fns/locale/en-US";
+import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
+import { mount, type ReactWrapper } from "enzyme";
+import * as React from "react";
+import * as sinon from "sinon";
+
+import { Classes as CoreClasses, InputGroup, Popover, Tag } from "@blueprintjs/core";
+
+import {
+    Classes,
+    type DateFormatProps,
+    Months,
+    TimePrecision,
+    TimeUnit,
+    TimezoneNameUtils,
+    TimezoneSelect,
+    TimezoneUtils,
+} from "../../src";
+import { DefaultDateFnsFormats, getDateFnsFormatter } from "../../src/common/dateFnsFormatUtils";
+import { TIMEZONE_ITEMS } from "../../src/common/timezoneItems";
+import {
+    DateInput3,
+    DATEINPUT3_DEFAULT_PROPS,
+    type DateInput3Props,
+} from "../../src/components/date-input3/dateInput3";
+import { DatePicker3 } from "../../src/components/date-picker3/datePicker3";
+import { loadDateFnsLocaleFake } from "../common/loadDateFnsLocaleFake";
+
+const NEW_YORK_TIMEZONE = TIMEZONE_ITEMS.find(item => item.label === "New York")!;
+const PARIS_TIMEZONE = TIMEZONE_ITEMS.find(item => item.label === "Paris")!;
+const TOKYO_TIMEZONE = TIMEZONE_ITEMS.find(item => item.label === "Tokyo")!;
+
+const VALUE = "2021-11-29T10:30:00z";
+
+const LOCALE_LOADER = {
+    dateFnsLocaleLoader: loadDateFnsLocaleFake,
+};
+
+const DEFAULT_PROPS: DateInput3Props & DateFormatProps = {
+    ...LOCALE_LOADER,
+    defaultTimezone: TimezoneUtils.UTC_TIME.ianaCode,
+    formatDate: (date: Date | null | undefined, localeCode?: string) => {
+        if (date == null) {
+            return "";
+        } else if (localeCode === "de") {
+            return intlFormat(
+                date,
+                {
+                    day: "2-digit",
+                    month: "2-digit",
+                    year: "numeric",
+                },
+                { locale: "de-DE" },
+            );
+        } else {
+            return [date.getMonth() + 1, date.getDate(), date.getFullYear()].join("/");
+        }
+    },
+    parseDate: (str: string) => new Date(str),
+    popoverProps: {
+        usePortal: false,
+    },
+    showTimezoneSelect: true,
+    timePrecision: TimePrecision.SECOND,
+};
+
+describe("<DateInput3>", () => {
+    const onChange = sinon.spy();
+    let testsContainerElement: HTMLElement | undefined;
+
+    beforeEach(() => {
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        testsContainerElement?.remove();
+        onChange.resetHistory();
+    });
+
+    describe("basic rendering", () => {
+        it("passes custom classNames to popover target", () => {
+            const CLASS_1 = "foo";
+            const CLASS_2 = "bar";
+
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS}
+                    className={CLASS_1}
+                    popoverProps={{ ...DEFAULT_PROPS.popoverProps, className: CLASS_2 }}
+                />,
+            );
+
+            const popoverTarget = wrapper.find(`.${Classes.DATE_INPUT}.${CoreClasses.POPOVER_TARGET}`).hostNodes();
+            assert.isTrue(popoverTarget.hasClass(CLASS_1));
+            assert.isTrue(popoverTarget.hasClass(CLASS_2));
+        });
+
+        it("supports custom input props", () => {
+            const wrapper = mount(
+                <DateInput3 {...DEFAULT_PROPS} inputProps={{ style: { background: "yellow" }, tabIndex: 4 }} />,
+            );
+            const inputElement = wrapper.find("input").getDOMNode<HTMLInputElement>();
+            assert.equal(inputElement.style.background, "yellow");
+            assert.equal(inputElement.tabIndex, 4);
+        });
+
+        it("supports inputProps.inputRef", () => {
+            const inputRef = React.createRef<HTMLInputElement>();
+            mount(<DateInput3 {...DEFAULT_PROPS} inputProps={{ inputRef }} />);
+            assert.instanceOf(inputRef.current, HTMLInputElement);
+        });
+
+        it("does not render a TimezoneSelect if timePrecision is undefined", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} timePrecision={undefined} />);
+            assert.isFalse(wrapper.find(TimezoneSelect).exists());
+        });
+
+        it("correctly passes on defaultTimezone to TimezoneSelect", () => {
+            const defaultTimezone = "Europe/Paris";
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} defaultTimezone={defaultTimezone} />);
+            const timezoneSelect = wrapper.find(TimezoneSelect);
+            assert.strictEqual(timezoneSelect.prop("value"), defaultTimezone);
+        });
+
+        it("passes datePickerProps to DatePicker correctly", () => {
+            const datePickerProps = {
+                clearButtonText: "clear",
+                todayButtonText: "today",
+            };
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} {...datePickerProps} />);
+            focusInput(wrapper);
+            const datePicker = wrapper.find(DatePicker3);
+            assert.equal(datePicker.prop("clearButtonText"), "clear");
+            assert.equal(datePicker.prop("todayButtonText"), "today");
+        });
+
+        it("passes fill and inputProps to InputGroup", () => {
+            const inputRef = sinon.spy();
+            const onFocus = sinon.spy();
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS}
+                    fill={true}
+                    inputProps={{
+                        inputRef,
+                        leftIcon: "star",
+                        onFocus,
+                        required: true,
+                    }}
+                />,
+            );
+            focusInput(wrapper);
+
+            const input = wrapper.find(InputGroup);
+            assert.isTrue(input.prop("fill"));
+            assert.strictEqual(input.prop("leftIcon"), "star");
+            assert.isTrue(input.prop("required"));
+            assert.isTrue(inputRef.called, "inputRef not invoked");
+            assert.isTrue(onFocus.called, "onFocus not invoked");
+        });
+
+        it("passes popoverProps to Popover", () => {
+            const onOpening = sinon.spy();
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS}
+                    popoverProps={{
+                        onOpening,
+                        placement: "top",
+                        usePortal: false,
+                    }}
+                />,
+            );
+            focusInput(wrapper);
+
+            const popover = wrapper.find(Popover).first();
+            assert.strictEqual(popover.prop("placement"), "top");
+            assert.isFalse(popover.prop("usePortal"));
+            assert.isTrue(onOpening.calledOnce);
+        });
+
+        it("gracefully handles invalid defaultTimezone prop value", () => {
+            mount(<DateInput3 {...DEFAULT_PROPS} defaultTimezone="Foo/Bar" />);
+        });
+    });
+
+    describe("popover interaction", () => {
+        it("opens the popover when focusing input", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("doesn't open the popover when disabled", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} disabled={true} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            assertPopoverIsOpen(wrapper, false);
+        });
+
+        it("popover closes when ESC key pressed", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            wrapper.find(InputGroup).find("input").simulate("keydown", { key: "Escape" });
+            assertPopoverIsOpen(wrapper, false);
+        });
+    });
+
+    describe("uncontrolled usage", () => {
+        const DEFAULT_PROPS_UNCONTROLLED = {
+            ...DEFAULT_PROPS,
+            defaultValue: VALUE,
+            onChange,
+        };
+
+        it("calls onChange on date changes", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            wrapper
+                .find(`.${Classes.DATEPICKER3_DAY}:not(.${Classes.DATEPICKER3_DAY_OUTSIDE})`)
+                .first()
+                .simulate("click")
+                .update();
+            assert.isTrue(onChange.calledOnce);
+            // first non-outside day should be the November 1st
+            assert.strictEqual(onChange.firstCall.args[0], "2021-11-01T10:30:00+00:00");
+        });
+
+        it("calls onChange on timezone changes", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            clickTimezoneItem(wrapper, NEW_YORK_TIMEZONE.label);
+            assert.isTrue(onChange.calledOnce);
+            // New York is UTC-5
+            assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30:00-05:00");
+        });
+
+        // HACKHACK: this test ported from Blueprint v4.x doesn't seem to match any real UX, since pressing Shift+Tab
+        // on the first focussable day in a calendar month doesn't move you to the previous month; instead it moves focus
+        // to the year dropdown. It might be worth testing behavior when pressing the left arrow key, since that _does_
+        // move focus to the last day of the previous month.
+        it.skip("popover should not close if focus moves to previous day (last day of prev month)", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            blurInput(wrapper);
+            const firstTabbable = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 }).first();
+            const lastDayOfPrevMonth = wrapper
+                .find(Popover)
+                .find(".DayPicker-Body > .DayPicker-Week .DayPicker-Day--outside")
+                .last();
+
+            firstTabbable.simulate("focus");
+            firstTabbable.simulate("blur", {
+                relatedTarget: lastDayOfPrevMonth.getDOMNode(),
+                target: firstTabbable.getDOMNode(),
+            });
+            wrapper.update();
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover should not close if focus moves to month select", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            blurInput(wrapper);
+            changeSelectDropdown(wrapper, Classes.DATEPICKER_MONTH_SELECT, Months.NOVEMBER);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover should not close if focus moves to year select", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            blurInput(wrapper);
+            changeSelectDropdown(wrapper, Classes.DATEPICKER_YEAR_SELECT, 2020);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover should not close when time picker arrows are clicked after selecting a month", () => {
+            const wrapper = mount(
+                <DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} timePickerProps={{ showArrowButtons: true }} />,
+                { attachTo: testsContainerElement },
+            );
+            focusInput(wrapper);
+            changeSelectDropdown(wrapper, Classes.DATEPICKER_MONTH_SELECT, Months.OCTOBER);
+            wrapper.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("pressing Enter saves the inputted date and closes the popover", () => {
+            const IMPROPERLY_FORMATTED_DATE_STRING = "002/0015/2015";
+            const PROPERLY_FORMATTED_DATE_STRING = "2/15/2015";
+            const onKeyDown = sinon.spy();
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} inputProps={{ onKeyDown }} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            const input = wrapper.find(InputGroup).find("input");
+            input.simulate("change", { target: { value: IMPROPERLY_FORMATTED_DATE_STRING } });
+            input.simulate("keydown", { key: "Enter" });
+            assertPopoverIsOpen(wrapper, false);
+            assert.notStrictEqual(document.activeElement, input.getDOMNode(), "input should not be focused");
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), PROPERLY_FORMATTED_DATE_STRING);
+            assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
+        });
+
+        it("clicking a date puts it in the input box and closes the popover", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "");
+            const dayToClick = 12;
+            clickCalendarDay(wrapper, dayToClick);
+            const today = new Date();
+            assert.equal(
+                wrapper.find(InputGroup).prop("value"),
+                `${today.getMonth() + 1}/${dayToClick}/${today.getFullYear()}`,
+            );
+            assertPopoverIsOpen(wrapper, false);
+        });
+
+        it("clicking a date in the same month closes the popover when there is already a default value", () => {
+            const DAY = 15;
+            const PREV_DAY = DAY - 1;
+            const defaultValue = `2022-07-${DAY}T15:00:00z`; // include an arbitrary non-zero hour
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} defaultValue={defaultValue} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            clickCalendarDay(wrapper, PREV_DAY);
+            assertPopoverIsOpen(wrapper, false);
+        });
+
+        it("clearing the date in the DatePicker clears the input, and calls onChange with null", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "11/29/2021");
+            // default value is 29th day of November
+            clickCalendarDay(wrapper, 29);
+            wrapper.update();
+            assert.equal(wrapper.find(InputGroup).prop("value"), "");
+            assert.isTrue(onChange.calledWith(null));
+        });
+
+        it("clearing the date in the input clears the selection and invokes onChange with null", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            wrapper
+                .find(InputGroup)
+                .find("input")
+                .simulate("change", { target: { value: "" } });
+
+            assert.lengthOf(wrapper.find(`.${Classes.DATEPICKER3_DAY_SELECTED}`), 0);
+            assert.isTrue(onChange.calledWith(null));
+        });
+
+        it("popover stays open on date click if closeOnSelection=false", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} closeOnSelection={false} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            wrapper.find(`.${Classes.DATEPICKER3_DAY}`).first().simulate("click").update();
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover stays open when month changes", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            changeSelectDropdown(wrapper, Classes.DATEPICKER_MONTH_SELECT, Months.DECEMBER);
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("popover stays open when time changes", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+
+            // try typing a new time
+            setTimeUnit(wrapper, TimeUnit.SECOND, 1);
+            assertPopoverIsOpen(wrapper);
+
+            // try keyboard-incrementing to a new time
+            wrapper.find(`.${Classes.TIMEPICKER_SECOND}`).first().simulate("keydown", { key: "ArrowUp" });
+            assertPopoverIsOpen(wrapper);
+        });
+
+        it("clicking a day in a different month sets input value but keeps popover open", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} defaultValue="2016-04-03T00:00:00z" />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "4/3/2016");
+
+            wrapper
+                .find(`.${Classes.DATEPICKER3_DAY}`)
+                .filterWhere(day => day.text() === "27")
+                .first()
+                .simulate("click");
+
+            assertPopoverIsOpen(wrapper);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "3/27/2016");
+        });
+
+        it("typing in a valid date invokes onChange and inputProps.onChange", () => {
+            const DATE_VALUE = "2015-02-10T00:00:00+00:00";
+            const DATE_STR = "2/10/2015";
+            const onInputChange = sinon.spy();
+            const wrapper = mount(
+                <DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} inputProps={{ onChange: onInputChange }} />,
+                { attachTo: testsContainerElement },
+            );
+            changeInput(wrapper, DATE_STR);
+
+            assert.isTrue(onChange.calledOnce);
+            assert.strictEqual(onChange.args[0][0], DATE_VALUE);
+            assert.isTrue(onInputChange.calledOnce);
+            assert.strictEqual(onInputChange.args[0][0].type, "change", "inputProps.onChange expects change event");
+        });
+
+        it("typing in a date out of range displays the error message and calls onError with invalid date", () => {
+            const rangeMessage = "RANGE ERROR";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS_UNCONTROLLED}
+                    defaultValue={new Date(2015, Months.MAY, 1).toISOString()}
+                    minDate={new Date(2015, Months.MARCH, 1)}
+                    onError={onError}
+                    outOfRangeMessage={rangeMessage}
+                />,
+            );
+            const value = "2/1/2030";
+            wrapper.find("input").simulate("change", { target: { value } }).simulate("blur");
+
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), "danger");
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), rangeMessage);
+
+            assert.isTrue(onError.calledOnce);
+            assert.strictEqual(
+                DEFAULT_PROPS.formatDate!(onError.args[0][0]),
+                DEFAULT_PROPS.formatDate!(new Date(value)),
+            );
+        });
+
+        it("typing in an invalid date displays the error message and calls onError with Date(undefined)", () => {
+            const invalidDateMessage = "INVALID DATE";
+            const onError = sinon.spy();
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS_UNCONTROLLED}
+                    defaultValue={new Date(2015, Months.MAY, 1).toISOString()}
+                    onError={onError}
+                    invalidDateMessage={invalidDateMessage}
+                />,
+            );
+            wrapper
+                .find("input")
+                .simulate("change", { target: { value: "not a date" } })
+                .simulate("blur");
+
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), "danger");
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), invalidDateMessage);
+
+            assert.isTrue(onError.calledOnce);
+            assert.isNaN((onError.args[0][0] as Date).valueOf());
+        });
+
+        it("clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
+            const DATE = new Date(2016, Months.APRIL, 4);
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS_UNCONTROLLED}
+                    canClearSelection={false}
+                    defaultValue={dateToIsoString(DATE)}
+                    timePrecision={TimePrecision.SECOND}
+                />,
+                { attachTo: testsContainerElement },
+            );
+            focusInput(wrapper);
+            clickCalendarDay(wrapper, DATE.getDate());
+            assert.isTrue(onChange.calledOnce);
+            assert.isTrue(isEqual(parseISO(onChange.firstCall.args[0]), DATE));
+        });
+
+        describe("allows changing timezone via user interaction (uncontrolled timezone value)", () => {
+            it("before selecting a date", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} />, { attachTo: testsContainerElement });
+                focusInput(wrapper);
+                // Japan is one of the few countries that does not have any kind of daylight savings, so this unit test
+                // keeps working all year round
+                clickTimezoneItem(wrapper, TOKYO_TIMEZONE.label);
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+
+            it("after selecting a date", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} />, { attachTo: testsContainerElement });
+                focusInput(wrapper);
+                clickCalendarDay(wrapper, 1);
+                clickTimezoneItem(wrapper, TOKYO_TIMEZONE.label);
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+        });
+
+        describe("allows changing timezone programmatically (controlled timezone value)", () => {
+            it("before selecting a date", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} timezone={TimezoneUtils.UTC_TIME.ianaCode} />, {
+                    attachTo: testsContainerElement,
+                });
+                wrapper.setProps({ timezone: TOKYO_TIMEZONE.ianaCode }).update();
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+
+            it("after selecting a date", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} timezone={TimezoneUtils.UTC_TIME.ianaCode} />, {
+                    attachTo: testsContainerElement,
+                });
+                focusInput(wrapper);
+                clickCalendarDay(wrapper, 1);
+                wrapper.setProps({ timezone: TOKYO_TIMEZONE.ianaCode }).update();
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+        });
+
+        it("allows changing defaultTimezone", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: testsContainerElement });
+            assert.strictEqual(
+                wrapper.find(TimezoneSelect).text(),
+                TimezoneNameUtils.getTimezoneShortName(TimezoneUtils.UTC_TIME.ianaCode, undefined),
+            );
+            wrapper.setProps({ defaultTimezone: TOKYO_TIMEZONE.ianaCode }).update();
+            assert.strictEqual(
+                wrapper.find(TimezoneSelect).text(),
+                TimezoneNameUtils.getTimezoneShortName(TOKYO_TIMEZONE.ianaCode, undefined),
+            );
+        });
+    });
+
+    describe("controlled usage", () => {
+        const DEFAULT_PROPS_CONTROLLED = {
+            ...DEFAULT_PROPS,
+            onChange,
+            value: VALUE,
+        };
+
+        it("handles null inputs without crashing", () => {
+            assert.doesNotThrow(() => mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={null} />));
+        });
+
+        it("changing the time calls onChange with the updated ISO string", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} />, { attachTo: testsContainerElement });
+            focusInput(wrapper);
+            setTimeUnit(wrapper, TimeUnit.HOUR_24, 11);
+            assert.isTrue(onChange.calledOnce);
+            assert.deepEqual(onChange.firstCall.args, ["2021-11-29T11:30:00+00:00", true]);
+        });
+
+        it("clearing the input invokes onChange with null", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} />);
+            wrapper
+                .find(InputGroup)
+                .find("input")
+                .simulate("change", { target: { value: "" } });
+            assert.isTrue(onChange.calledOnceWithExactly(null, true));
+        });
+
+        // tests ported from DateInput3
+        const DATE1_VALUE = "2016-04-04T00:00:00+00:00";
+        const DATE1_UI_STR = "4/4/2016";
+        const DATE2_VALUE = "2015-02-01T00:00:00+00:00";
+        const DATE2_UI_STR = "2/1/2015";
+        const DATE2_UI_STR_DE = "01.02.2015";
+
+        // HACKHACK: DATE2 gets interpreted in the local timezone when typed into the input, even though
+        // we've set defaultTimezone to UTC and specified the initial controlled value with a UTC offset.
+        // This results in the onChange callback getting the previous day (Jan 31), since the local timezone
+        // for most Blueprint development is before UTC time (negative offset). This is buggy and needs to be
+        // fixed.
+        it.skip("pressing Enter saves the inputted date and closes the popover", () => {
+            const onKeyDown = sinon.spy();
+            const wrapper = mount(
+                <DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} inputProps={{ onKeyDown }} />,
+                { attachTo: testsContainerElement },
+            );
+            focusInput(wrapper);
+            changeInput(wrapper, DATE2_UI_STR);
+            submitInput(wrapper);
+
+            // onChange is called once on change, once on Enter
+            assert.isTrue(onChange.calledTwice, "onChange called twice");
+            assert.strictEqual(
+                onChange.args[1][0],
+                formatInTimeZone(parseISO(DATE2_VALUE), TimezoneUtils.UTC_TIME.ianaCode, "yyyy-MM-dd'T'HH:mm:ssxxx"),
+            );
+            assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
+            assert.strictEqual(
+                document.activeElement,
+                wrapper.find(InputGroup).find("input").getDOMNode(),
+                "input should remain focused",
+            );
+            assertPopoverIsOpen(wrapper, false);
+        });
+
+        it("clicking a date invokes onChange callback with that date", () => {
+            const wrapper = mount(
+                <DateInput3 {...DEFAULT_PROPS_CONTROLLED} onChange={onChange} value={DATE1_VALUE} />,
+                {
+                    attachTo: testsContainerElement,
+                },
+            );
+            focusInput(wrapper);
+            clickCalendarDay(wrapper, 27);
+
+            assert.isTrue(onChange.calledOnce);
+            assert.strictEqual(onChange.args[0][0], "2016-04-27T00:00:00+00:00");
+            assert.isTrue(onChange.args[0][1], "expected isUserChange to be true");
+        });
+
+        it("clearing the date in the DatePicker invokes onChange with null but doesn't change UI", () => {
+            const wrapper = mount(
+                <DateInput3 {...DEFAULT_PROPS_CONTROLLED} onChange={onChange} value={DATE1_VALUE} />,
+                {
+                    attachTo: testsContainerElement,
+                },
+            );
+            focusInput(wrapper);
+            clickCalendarDay(wrapper, 4);
+            assert.equal(wrapper.find(InputGroup).prop("value"), "4/4/2016");
+            assert.isTrue(onChange.calledWith(null, true));
+        });
+
+        it("updating controlled value updates the text input", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: testsContainerElement,
+            });
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE1_UI_STR);
+            wrapper.setProps({ value: DATE2_VALUE });
+            wrapper.update();
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_UI_STR);
+        });
+
+        it("typing in a date invokes onChange and inputProps.onChange", () => {
+            const onInputChange = sinon.spy();
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS_CONTROLLED}
+                    inputProps={{ onChange: onInputChange }}
+                    onChange={onChange}
+                    value={DATE1_VALUE}
+                />,
+                { attachTo: testsContainerElement },
+            );
+            changeInput(wrapper, DATE2_UI_STR);
+            assert.isTrue(onChange.calledOnce);
+            assert.strictEqual(onChange.args[0][0], DATE2_VALUE);
+            assert.isTrue(onInputChange.calledOnce);
+            assert.strictEqual(onInputChange.args[0][0].type, "change", "inputProps.onChange expects change event");
+        });
+
+        it("typing an invalid date updates the text input with the 'invalid date' message", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            changeInput(wrapper, "4/77/2016");
+            blurInput(wrapper);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATEINPUT3_DEFAULT_PROPS.invalidDateMessage);
+        });
+
+        it("text input does not show error styling until user is done typing and blurs the input", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            changeInput(wrapper, "4/77/201");
+            assert.notEqual(wrapper.find(InputGroup).prop("intent"), "danger");
+            blurInput(wrapper);
+            assert.strictEqual(wrapper.find(InputGroup).prop("intent"), "danger");
+        });
+
+        it("clearing the date in the input invokes onChange with null", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: testsContainerElement,
+            });
+            changeInput(wrapper, "");
+            assert.isTrue(onChange.calledWith(null, true));
+        });
+
+        it("clearing a date should not be possible with canClearSelection=false and timePrecision enabled", () => {
+            const wrapper = mount(
+                <DateInput3
+                    {...DEFAULT_PROPS_CONTROLLED}
+                    canClearSelection={false}
+                    timePrecision="second"
+                    value={DATE1_VALUE}
+                />,
+                { attachTo: testsContainerElement },
+            );
+            focusInput(wrapper);
+            clickCalendarDay(wrapper, 4);
+            assert.isTrue(onChange.calledOnce);
+            assert.deepEqual(onChange.firstCall.args, [DATE1_VALUE, true]);
+        });
+
+        it("isUserChange is false when month changes", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} value={DATE1_VALUE} />, {
+                attachTo: testsContainerElement,
+            });
+            focusInput(wrapper);
+            changeSelectDropdown(wrapper, Classes.DATEPICKER_MONTH_SELECT, Months.FEBRUARY);
+            assert.isTrue(onChange.calledOnce);
+            assert.isFalse(onChange.args[0][1], "expected isUserChange to be false");
+        });
+
+        it("formats locale-specific format strings properly", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} locale="de" value={DATE2_VALUE} />);
+            assert.strictEqual(wrapper.find(InputGroup).prop("value"), DATE2_UI_STR_DE);
+        });
+
+        describe("when changing timezone", () => {
+            it("calls onChange with the updated ISO string", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} />, {
+                    attachTo: testsContainerElement,
+                });
+                clickTimezoneItem(wrapper, PARIS_TIMEZONE.label);
+                assert.isTrue(onChange.calledOnce);
+                assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30:00+01:00");
+            });
+
+            it("formats the returned ISO string according to timePrecision", () => {
+                const wrapper = mount(
+                    <DateInput3 {...DEFAULT_PROPS_CONTROLLED} timePrecision={TimePrecision.MINUTE} />,
+                    { attachTo: testsContainerElement },
+                );
+                clickTimezoneItem(wrapper, PARIS_TIMEZONE.label);
+                assert.isTrue(onChange.calledOnce);
+                assert.strictEqual(onChange.firstCall.args[0], "2021-11-29T10:30+01:00");
+            });
+
+            it("updates the displayed timezone", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} />, {
+                    attachTo: testsContainerElement,
+                });
+                clickTimezoneItem(wrapper, TOKYO_TIMEZONE.label);
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+
+            it("before selecting a date (initial value={null})", () => {
+                const wrapper = mount(<DateInput3 {...DEFAULT_PROPS} value={null} />, {
+                    attachTo: testsContainerElement,
+                });
+                clickTimezoneItem(wrapper, TOKYO_TIMEZONE.label);
+                assertTimezoneIsSelected(wrapper, "GMT+9");
+            });
+        });
+
+        describe("allows changing defaultTimezone", () => {
+            const wrapper = mount(<DateInput3 {...DEFAULT_PROPS_CONTROLLED} />, { attachTo: testsContainerElement });
+            assert.strictEqual(
+                wrapper.find(TimezoneSelect).text(),
+                TimezoneNameUtils.getTimezoneShortName(TimezoneUtils.UTC_TIME.ianaCode, undefined),
+            );
+            wrapper.setProps({ defaultTimezone: TOKYO_TIMEZONE.ianaCode });
+            assert.strictEqual(
+                wrapper.find(TimezoneSelect).text(),
+                TimezoneNameUtils.getTimezoneShortName(TOKYO_TIMEZONE.ianaCode, undefined),
+            );
+        });
+    });
+
+    describe("date formatting", () => {
+        const today = new Date();
+        const todayIsoString = dateToIsoString(today);
+
+        describe("with formatDate & parseDate defined", () => {
+            const formatDate = sinon.stub().returns("custom date");
+            const parseDate = sinon.stub().returns(today);
+            const localeCode = "en-US";
+            const FORMATTING_PROPS: DateInput3Props = {
+                dateFnsLocaleLoader: DEFAULT_PROPS.dateFnsLocaleLoader,
+                formatDate,
+                locale: localeCode,
+                parseDate,
+            };
+
+            beforeEach(() => {
+                formatDate.resetHistory();
+                parseDate.resetHistory();
+            });
+
+            it("formatDate called on render with locale prop", () => {
+                mount(<DateInput3 {...FORMATTING_PROPS} value={todayIsoString} />, { attachTo: testsContainerElement });
+                assert.isTrue(formatDate.calledWith(today, localeCode));
+            });
+
+            it("formatDate result becomes input value", () => {
+                const wrapper = mount(<DateInput3 {...FORMATTING_PROPS} value={todayIsoString} />, {
+                    attachTo: testsContainerElement,
+                });
+                assert.strictEqual(wrapper.find("input").prop("value"), "custom date");
+            });
+
+            it("parseDate called on change with locale prop", () => {
+                const value = "new date";
+                const wrapper = mount(<DateInput3 {...FORMATTING_PROPS} />, { attachTo: testsContainerElement });
+                changeInput(wrapper, value);
+                assert.isTrue(parseDate.calledWith(value, localeCode));
+            });
+
+            it("parseDate returns false renders invalid date", () => {
+                const invalidParse = sinon.stub().returns(false);
+                const wrapper = mount(<DateInput3 {...FORMATTING_PROPS} parseDate={invalidParse} />, {
+                    attachTo: testsContainerElement,
+                });
+                changeInput(wrapper, "invalid");
+                blurInput(wrapper);
+                assert.strictEqual(wrapper.find("input").prop("value"), DATEINPUT3_DEFAULT_PROPS.invalidDateMessage);
+            });
+        });
+
+        describe("with formatDate & parseDate undefined", () => {
+            describe("with dateFnsFormat defined", () => {
+                it("uses the specified format", () => {
+                    const format = "Pp";
+                    const wrapper = mount(
+                        <DateInput3 {...LOCALE_LOADER} dateFnsFormat={format} value={todayIsoString} />,
+                        {
+                            attachTo: testsContainerElement,
+                        },
+                    );
+                    const formatter = getDateFnsFormatter(format, enUSLocale);
+                    assert.strictEqual(wrapper.find("input").prop("value"), formatter(today));
+                });
+            });
+
+            describe("with dateFnsFormat undefined", () => {
+                it(`uses default date-only format "${DefaultDateFnsFormats.DATE_ONLY}" when timepicker disabled`, () => {
+                    const wrapper = mount(<DateInput3 {...LOCALE_LOADER} value={todayIsoString} />, {
+                        attachTo: testsContainerElement,
+                    });
+                    const defaultFormatter = getDateFnsFormatter(DefaultDateFnsFormats.DATE_ONLY, enUSLocale);
+                    assert.strictEqual(wrapper.find("input").prop("value"), defaultFormatter(today));
+                });
+
+                it(`uses default date + time minute format "${DefaultDateFnsFormats.DATE_TIME_MINUTES}" when timepicker enabled`, () => {
+                    const wrapper = mount(
+                        <DateInput3 {...LOCALE_LOADER} value={todayIsoString} timePrecision="minute" />,
+                        {
+                            attachTo: testsContainerElement,
+                        },
+                    );
+                    const defaultFormatter = getDateFnsFormatter(DefaultDateFnsFormats.DATE_TIME_MINUTES, enUSLocale);
+                    assert.strictEqual(wrapper.find("input").prop("value"), defaultFormatter(today));
+                });
+
+                it(`uses default date + time seconds format "${DefaultDateFnsFormats.DATE_TIME_SECONDS}" when timePrecision="second"`, () => {
+                    const wrapper = mount(
+                        <DateInput3 {...LOCALE_LOADER} value={todayIsoString} timePrecision="second" />,
+                        {
+                            attachTo: testsContainerElement,
+                        },
+                    );
+                    const defaultFormatter = getDateFnsFormatter(DefaultDateFnsFormats.DATE_TIME_SECONDS, enUSLocale);
+                    assert.strictEqual(wrapper.find("input").prop("value"), defaultFormatter(today));
+                });
+            });
+        });
+    });
+
+    function focusInput(wrapper: ReactWrapper<DateInput3Props>) {
+        wrapper.find(InputGroup).find("input").simulate("focus");
+    }
+
+    function changeInput(wrapper: ReactWrapper<DateInput3Props>, value: string) {
+        wrapper.find(InputGroup).find("input").simulate("change", { target: { value } });
+    }
+
+    function blurInput(wrapper: ReactWrapper<DateInput3Props>) {
+        wrapper.find(InputGroup).find("input").simulate("blur");
+    }
+
+    function submitInput(wrapper: ReactWrapper<DateInput3Props>) {
+        wrapper.find(InputGroup).find("input").simulate("keydown", { key: "Enter" });
+    }
+
+    function clickTimezoneItem(wrapper: ReactWrapper<DateInput3Props>, searchQuery: string) {
+        wrapper.find(`.${Classes.TIMEZONE_SELECT}`).hostNodes().simulate("click");
+        const tzItem = wrapper
+            .find(`.${Classes.TIMEZONE_SELECT_POPOVER}`)
+            .find(`.${CoreClasses.MENU_ITEM}`)
+            .hostNodes()
+            .findWhere(item => item.text().includes(searchQuery))
+            .first();
+
+        if (tzItem.exists()) {
+            tzItem.simulate("click");
+        } else {
+            assert.fail(`Could not find timezone option with query '${searchQuery}'`);
+        }
+    }
+
+    function clickCalendarDay(wrapper: ReactWrapper<DateInput3Props>, dayNumber: number) {
+        wrapper
+            .find(`.${Classes.DATEPICKER3_DAY}`)
+            .filterWhere(day => day.text() === `${dayNumber}` && !day.hasClass(Classes.DATEPICKER3_DAY_OUTSIDE))
+            .hostNodes()
+            .simulate("click");
+    }
+
+    function setTimeUnit(wrapper: ReactWrapper<DateInput3Props>, unit: TimeUnit, value: number) {
+        focusInput(wrapper);
+        let inputClass: string;
+        switch (unit) {
+            case TimeUnit.HOUR_12:
+            case TimeUnit.HOUR_24:
+                inputClass = Classes.TIMEPICKER_HOUR;
+                break;
+            case TimeUnit.MINUTE:
+                inputClass = Classes.TIMEPICKER_MINUTE;
+                break;
+            case TimeUnit.SECOND:
+                inputClass = Classes.TIMEPICKER_SECOND;
+                break;
+            case TimeUnit.MS:
+                inputClass = Classes.TIMEPICKER_MILLISECOND;
+                break;
+        }
+        const input = wrapper.find(`.${inputClass}`).first();
+        input.simulate("focus");
+        input.simulate("change", { target: { value } });
+        input.simulate("blur");
+    }
+
+    function changeSelectDropdown(wrapper: ReactWrapper<DateInput3Props>, className: string, value: string | number) {
+        wrapper
+            .find(`.${className}`)
+            .find("select")
+            .simulate("change", { target: { value: value.toString() } });
+    }
+
+    function assertPopoverIsOpen(wrapper: ReactWrapper<DateInput3Props>, expectedIsOpen: boolean = true) {
+        const openPopoverTarget = wrapper.find(`.${CoreClasses.POPOVER_OPEN}`);
+        if (expectedIsOpen) {
+            assert.isTrue(
+                openPopoverTarget.exists(),
+                `Expected .${CoreClasses.POPOVER_OPEN} to exist, indicating the popover is open`,
+            );
+        } else {
+            assert.isFalse(
+                openPopoverTarget.exists(),
+                `Expected .${CoreClasses.POPOVER_OPEN} NOT to exist, indicating the popover is closed`,
+            );
+        }
+    }
+
+    function assertTimezoneIsSelected(wrapper: ReactWrapper<DateInput3Props>, tzCode: string) {
+        const tzTag = wrapper.find(Tag);
+        assert.strictEqual(tzTag.text(), tzCode);
+    }
+});
+
+/**
+ * When we construct a Date() object in this test file, it sets it to the local timezone.
+ * Use this helper function to reset the date's timezone to UTC instead.
+ */
+function localDateToUtcDate(date: Date) {
+    return zonedTimeToUtc(date, TimezoneUtils.getCurrentTimezone());
+}
+
+function dateToIsoString(date: Date) {
+    return localDateToUtcDate(date).toISOString();
+}

--- a/packages/datetime/test/components/datePicker3Tests.tsx
+++ b/packages/datetime/test/components/datePicker3Tests.tsx
@@ -1,0 +1,921 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import enUSLocale from "date-fns/locale/en-US";
+import { mount, type ReactWrapper } from "enzyme";
+import * as React from "react";
+import { Day } from "react-day-picker-8";
+import sinon from "sinon";
+
+import { Button, Classes as CoreClasses, HTMLSelect, Menu, MenuItem } from "@blueprintjs/core";
+import { assertDatesEqual } from "@blueprintjs/test-commons";
+
+import {
+    Classes,
+    type DatePickerShortcut,
+    DatePickerShortcutMenu,
+    DateUtils,
+    Errors,
+    Months,
+    TimePicker,
+    TimePrecision,
+} from "../../src";
+import { DatePicker3, type DatePicker3Props } from "../../src/components/date-picker3/datePicker3";
+import type { DatePicker3State } from "../../src/components/date-picker3/datePicker3State";
+import { assertDayDisabled, assertDayHidden } from "../common/dayPicker8TestUtils";
+import { loadDateFnsLocaleFake } from "../common/loadDateFnsLocaleFake";
+
+const LOCALE_LOADER: DatePicker3Props = {
+    dateFnsLocaleLoader: loadDateFnsLocaleFake,
+};
+
+describe("<DatePicker3>", () => {
+    let testsContainerElement: HTMLElement;
+    let datePicker3Wrapper: ReactWrapper<DatePicker3Props, DatePicker3State>;
+
+    beforeEach(() => {
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        datePicker3Wrapper?.unmount();
+        datePicker3Wrapper?.detach();
+        testsContainerElement.remove();
+    });
+
+    it(`renders .${Classes.DATEPICKER}`, () => {
+        assert.lengthOf(wrap(<DatePicker3 {...LOCALE_LOADER} />).root.find(`.${Classes.DATEPICKER}`), 1);
+    });
+
+    it("no day is selected by default", () => {
+        const { assertSelectedDays, root } = wrap(<DatePicker3 {...LOCALE_LOADER} />);
+        assertSelectedDays();
+        assert.isNull(root.state("selectedDay"));
+    });
+
+    it("current day is not highlighted by default", () => {
+        const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} />);
+        assert.lengthOf(root.find(`.${Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY}`), 0);
+    });
+
+    it("current day should be highlighted when highlightCurrentDay={true}", () => {
+        const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} highlightCurrentDay={true} />);
+        assert.lengthOf(root.find(`.${Classes.DATEPICKER3_HIGHLIGHT_CURRENT_DAY}`), 1);
+    });
+
+    describe("reconciliates dayPickerProps", () => {
+        it("shows outside days by default", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const firstDayInView = new Date(2017, Months.AUGUST, 27, 12, 0);
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} />);
+            // TODO: refactor this to avoid knowing about react-day-picker's internal component names
+            const firstDay = root.find(Day).first();
+            assertDatesEqual(new Date(firstDay.prop("date")), firstDayInView);
+        });
+
+        it("doesn't show outside days if enableOutsideDays=false", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1, 12);
+            const { root } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    dayPickerProps={{ showOutsideDays: false }}
+                />,
+            );
+            const days = root.find(Day);
+
+            assertDayHidden(days.at(0));
+            assertDayHidden(days.at(1));
+            assertDayHidden(days.at(2));
+            assertDayHidden(days.at(3));
+            assertDayHidden(days.at(4));
+            assertDayHidden(days.at(5), false);
+        });
+
+        it("disables days according to custom modifiers in addition to default modifiers", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const disableFridays = { dayOfWeek: [5] };
+            const { getDay } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    maxDate={new Date(2017, Months.SEPTEMBER, 20)}
+                    dayPickerProps={{ disabled: disableFridays }}
+                />,
+            );
+            assertDayDisabled(getDay(15));
+            assertDayDisabled(getDay(21));
+            assertDayDisabled(getDay(10), false);
+        });
+
+        it("disables out-of-range max dates", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const { getDay } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    maxDate={new Date(2017, Months.SEPTEMBER, 20)}
+                />,
+            );
+            assertDayDisabled(getDay(21));
+            assertDayDisabled(getDay(10), false);
+        });
+
+        it("disables out-of-range min dates", () => {
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+            const { getDay, clickPreviousMonth } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    minDate={new Date(2017, Months.AUGUST, 20)}
+                />,
+            );
+            clickPreviousMonth();
+            assertDayDisabled(getDay(10));
+            assertDayDisabled(getDay(21), false);
+        });
+
+        describe("event handlers", () => {
+            // use a date that lets us navigate forward and backward in the same year
+            const defaultValue = new Date(2017, Months.SEPTEMBER, 1);
+
+            it("calls onMonthChange on button next click", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(
+                    <DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                );
+                root.find(`.${Classes.DATEPICKER3_NAV_BUTTON_NEXT}`).first().simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(
+                    <DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                );
+                root.find(`.${Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS}`).first().simulate("click");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on month select change", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(
+                    <DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                );
+                root.find(`.${Classes.DATEPICKER_MONTH_SELECT}`).first().find("select").simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on year select change", () => {
+                const onMonthChange = sinon.spy();
+                const { root } = wrap(
+                    <DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                );
+                root.find(`.${Classes.DATEPICKER_YEAR_SELECT}`).first().find("select").simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onDayClick", () => {
+                const onDayClick = sinon.spy();
+                const { getDay } = wrap(
+                    <DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} dayPickerProps={{ onDayClick }} />,
+                );
+                getDay().simulate("click");
+                assert.isTrue(onDayClick.called);
+            });
+        });
+    });
+
+    it("user-provided modifiers are applied", () => {
+        const ODD_CLASS = "test-odd";
+        const oddifier = (d: Date) => d.getDate() % 2 === 1;
+        const { getDay } = wrap(
+            <DatePicker3
+                {...LOCALE_LOADER}
+                dayPickerProps={{ modifiers: { odd: oddifier }, modifiersClassNames: { odd: ODD_CLASS } }}
+            />,
+        );
+
+        assert.isFalse(getDay(4).hasClass(ODD_CLASS));
+        assert.isTrue(getDay(5).hasClass(ODD_CLASS));
+    });
+
+    it("renders the actions bar when showActionsBar=true", () => {
+        const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} showActionsBar={true} />);
+        assert.lengthOf(root.find({ className: Classes.DATEPICKER_FOOTER }), 1);
+    });
+
+    describe("initially displayed month", () => {
+        it("is defaultValue", () => {
+            const defaultValue = new Date(2007, Months.APRIL, 4);
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} />);
+            assert.equal(root.state("displayYear"), 2007);
+            assert.equal(root.state("displayMonth"), Months.APRIL);
+        });
+
+        it("is initialMonth if set (overrides defaultValue)", () => {
+            const defaultValue = new Date(2007, Months.APRIL, 4);
+            const initialMonth = new Date(2002, Months.MARCH, 1);
+            const { root } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} initialMonth={initialMonth} />,
+            );
+            assert.equal(root.state("displayYear"), 2002);
+            assert.equal(root.state("displayMonth"), Months.MARCH);
+        });
+
+        it("is value if set and initialMonth not set", () => {
+            const value = new Date(2007, Months.APRIL, 4);
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} value={value} />);
+            assert.equal(root.state("displayYear"), 2007);
+            assert.equal(root.state("displayMonth"), Months.APRIL);
+        });
+
+        it("is today if today is within date range", () => {
+            const today = new Date();
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} />);
+            assert.equal(root.state("displayYear"), today.getFullYear());
+            assert.equal(root.state("displayMonth"), today.getMonth());
+        });
+
+        it("is a day between minDate and maxDate if today is not in range", () => {
+            const maxDate = new Date(2005, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} maxDate={maxDate} minDate={minDate} />);
+            assert.isTrue(
+                DateUtils.isDayInRange(new Date(root.state("displayYear"), root.state("displayMonth")), [
+                    minDate,
+                    maxDate,
+                ]),
+            );
+        });
+
+        it("selectedDay is set to the day of the value", () => {
+            const value = new Date(2007, Months.APRIL, 4);
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} value={value} />);
+            assert.strictEqual(root.state("selectedDay"), value.getDate());
+        });
+
+        it("selectedDay is set to the day of the defaultValue", () => {
+            const defaultValue = new Date(2007, Months.APRIL, 4);
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} defaultValue={defaultValue} />);
+            assert.strictEqual(root.state("selectedDay"), defaultValue.getDate());
+        });
+    });
+
+    describe("minDate/maxDate bounds", () => {
+        const MIN_DATE = new Date(2015, Months.JANUARY, 7);
+        const MAX_DATE = new Date(2015, Months.JANUARY, 12);
+
+        describe("validation", () => {
+            let consoleError: sinon.SinonStub;
+
+            before(() => (consoleError = sinon.stub(console, "error")));
+            afterEach(() => consoleError.resetHistory());
+            after(() => consoleError.restore());
+
+            it("maxDate must be later than minDate", () => {
+                wrap(<DatePicker3 {...LOCALE_LOADER} maxDate={MIN_DATE} minDate={MAX_DATE} />);
+                assert.isTrue(consoleError.calledWith(Errors.DATEPICKER_MAX_DATE_INVALID));
+            });
+
+            it("an error is logged if defaultValue is outside bounds", () => {
+                wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        defaultValue={new Date(2015, Months.JANUARY, 5)}
+                        maxDate={MAX_DATE}
+                        minDate={MIN_DATE}
+                    />,
+                );
+                assert.isTrue(consoleError.calledWith(Errors.DATEPICKER_DEFAULT_VALUE_INVALID));
+            });
+
+            it("an error is logged if value is outside bounds", () => {
+                wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        value={new Date(2015, Months.JANUARY, 20)}
+                        maxDate={MAX_DATE}
+                        minDate={MIN_DATE}
+                    />,
+                );
+                assert.isTrue(consoleError.calledWith(Errors.DATEPICKER_VALUE_INVALID));
+            });
+
+            it("an error is logged if initialMonth is outside month bounds", () => {
+                wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        initialMonth={new Date(2015, Months.FEBRUARY, 12)}
+                        maxDate={MAX_DATE}
+                        minDate={MIN_DATE}
+                    />,
+                );
+                assert.isTrue(consoleError.calledWith(Errors.DATEPICKER_INITIAL_MONTH_INVALID));
+            });
+
+            it("an error is not logged if initialMonth is outside day bounds but inside month bounds", () => {
+                wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        initialMonth={new Date(2015, Months.JANUARY, 12)}
+                        minDate={MIN_DATE}
+                        maxDate={MAX_DATE}
+                    />,
+                );
+                assert.isTrue(consoleError.notCalled);
+            });
+        });
+
+        describe("today button validation", () => {
+            const today = new Date();
+            const MIN_DATE_BEFORE_TODAY = MIN_DATE;
+            const MAX_DATE_BEFORE_TODAY = MAX_DATE;
+
+            const MIN_DATE_AFTER_TODAY = new Date(today.getFullYear() + 1, today.getMonth(), today.getDate());
+            const MAX_DATE_AFTER_TODAY = new Date(today.getFullYear() + 2, today.getMonth(), today.getDate());
+
+            it("min/max before today has disabled button", () => {
+                const { getTodayButton } = wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        minDate={MIN_DATE_BEFORE_TODAY}
+                        maxDate={MAX_DATE_BEFORE_TODAY}
+                        showActionsBar={true}
+                    />,
+                );
+
+                assert.isTrue(getTodayButton().props().disabled);
+            });
+
+            it("min/max after today has disabled button", () => {
+                const { getTodayButton } = wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        minDate={MIN_DATE_AFTER_TODAY}
+                        maxDate={MAX_DATE_AFTER_TODAY}
+                        showActionsBar={true}
+                    />,
+                );
+
+                assert.isTrue(getTodayButton().props().disabled);
+            });
+
+            it("valid min/max today has enabled button", () => {
+                const { getTodayButton } = wrap(
+                    <DatePicker3
+                        {...LOCALE_LOADER}
+                        minDate={MIN_DATE_BEFORE_TODAY}
+                        maxDate={MAX_DATE_AFTER_TODAY}
+                        showActionsBar={true}
+                    />,
+                );
+
+                assert.isFalse(getTodayButton().props().disabled);
+            });
+        });
+
+        it("only days outside bounds have disabled class", () => {
+            const minDate = new Date(2000, Months.JANUARY, 10);
+            const { getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} initialMonth={minDate} minDate={minDate} />);
+            // 8 is before min date, 12 is after
+            assert.isTrue(getDay(8).hasClass(Classes.DATEPICKER3_DAY_DISABLED));
+            assert.isFalse(getDay(12).hasClass(Classes.DATEPICKER3_DAY_DISABLED));
+        });
+
+        it("onChange not fired when a day outside of bounds is clicked", () => {
+            const onChange = sinon.spy();
+            const { getDay } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} maxDate={MAX_DATE} minDate={MIN_DATE} onChange={onChange} />,
+            );
+            assert.isTrue(onChange.notCalled);
+            getDay(4).simulate("click");
+            getDay(16).simulate("click");
+            assert.isTrue(onChange.notCalled);
+            getDay(8).simulate("click");
+            assert.isTrue(onChange.calledOnce);
+        });
+
+        it("constrains time picker when minDate is selected", () => {
+            const { root } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    maxDate={MAX_DATE}
+                    minDate={MIN_DATE}
+                    timePrecision={TimePrecision.MINUTE}
+                    value={MIN_DATE}
+                />,
+            );
+            const timePicker = root.find(TimePicker).first();
+            assert.strictEqual(timePicker.props().minTime, MIN_DATE);
+        });
+
+        it("constrains time picker when max date is selected", () => {
+            const { root } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    maxDate={MAX_DATE}
+                    minDate={MIN_DATE}
+                    timePrecision={TimePrecision.MINUTE}
+                    value={MAX_DATE}
+                />,
+            );
+            const timePicker = root.find(TimePicker).first();
+            assert.strictEqual(timePicker.props().maxTime, MAX_DATE);
+        });
+    });
+
+    describe("when controlled", () => {
+        it("value initially selects a day", () => {
+            const value = new Date(2010, Months.JANUARY, 1);
+            const { assertSelectedDays } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} defaultValue={new Date(2010, Months.FEBRUARY, 2)} value={value} />,
+            );
+            assertSelectedDays(value.getDate());
+        });
+
+        it("selection does not update automatically", () => {
+            const { getDay, assertSelectedDays } = wrap(<DatePicker3 {...LOCALE_LOADER} value={null} />);
+            assertSelectedDays();
+            getDay().simulate("click");
+            assertSelectedDays();
+        });
+
+        it("selected day doesn't update on current month view change", () => {
+            const value = new Date(2010, Months.JANUARY, 2);
+            const { assertSelectedDays, clickPreviousMonth, months, years } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} value={value} />,
+            );
+            clickPreviousMonth();
+
+            assertSelectedDays(2);
+
+            months.simulate("change", { target: { value: Months.JUNE } });
+            assertSelectedDays();
+
+            years.simulate("change", { target: { value: 2014 } });
+            assertSelectedDays();
+        });
+
+        it("onChange fired when a day is clicked", () => {
+            const onChange = sinon.spy();
+            const { getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} onChange={onChange} value={null} />);
+            getDay().simulate("click");
+            assert.isTrue(onChange.calledOnce);
+            assert.isTrue(onChange.args[0][1]);
+        });
+
+        it("onChange fired when month is changed", () => {
+            const value = new Date(2010, Months.JANUARY, 2);
+            const onChange = sinon.spy();
+            const { months, clickPreviousMonth } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} onChange={onChange} value={value} />,
+            );
+
+            clickPreviousMonth();
+            assert.isTrue(onChange.calledOnce, "expected onChange called");
+            assert.isFalse(onChange.firstCall.args[1], "expected isUserChange to be false");
+
+            months.simulate("change", { target: { value: Months.JUNE } });
+            assert.isTrue(onChange.calledTwice, "expected onChange called again");
+            assert.isFalse(onChange.secondCall.args[1], "expected isUserChange to be false again");
+        });
+
+        it("can change displayed date with the dropdowns in the caption", () => {
+            const { months, root, years } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} initialMonth={new Date(2015, Months.MARCH, 2)} value={null} />,
+            );
+            assert.equal(root.state("displayMonth"), Months.MARCH);
+            assert.equal(root.state("displayYear"), 2015);
+
+            months.simulate("change", { target: { value: Months.JANUARY } });
+            years.simulate("change", { target: { value: 2014 } });
+            assert.equal(root.state("displayMonth"), Months.JANUARY);
+            assert.equal(root.state("displayYear"), 2014);
+        });
+
+        it("shortcuts fire onChange with correct values", () => {
+            const today = new Date();
+            const aWeekAgo = DateUtils.clone(today);
+            aWeekAgo.setDate(today.getDate() - 6);
+            const onChange = sinon.spy();
+            const { clickShortcut } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} onChange={onChange} value={today} shortcuts={true} />,
+            );
+            clickShortcut(2);
+
+            assert.isTrue(onChange.calledOnce, "called");
+            const value = onChange.args[0][0];
+            assert.isTrue(DateUtils.isSameDay(aWeekAgo, value));
+        });
+
+        it("all shortcuts are displayed as inactive when none are selected", () => {
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} shortcuts={true} />);
+
+            assert.isFalse(
+                root.find(DatePickerShortcutMenu).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`).exists(),
+            );
+        });
+
+        it("corresponding shortcut is displayed as active when selected", () => {
+            const selectedShortcut = 0;
+            const { root } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} shortcuts={true} selectedShortcutIndex={selectedShortcut} />,
+            );
+
+            assert.isTrue(
+                root.find(DatePickerShortcutMenu).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`).exists(),
+            );
+
+            assert.lengthOf(
+                root.find(DatePickerShortcutMenu).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`),
+                1,
+            );
+
+            assert.isTrue(root.state("selectedShortcutIndex") === selectedShortcut);
+        });
+
+        it("should call onShortcutChangeSpy on selecting a shortcut ", () => {
+            const selectedShortcut = 0;
+            const onShortcutChangeSpy = sinon.spy();
+            const onChangeSpy = sinon.spy();
+            const { clickShortcut } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    onChange={onChangeSpy}
+                    shortcuts={true}
+                    onShortcutChange={onShortcutChangeSpy}
+                />,
+            );
+
+            clickShortcut(selectedShortcut);
+
+            assert.isTrue(onChangeSpy.calledOnce);
+            assert.isTrue(onShortcutChangeSpy.calledOnce);
+            assert.isTrue(onShortcutChangeSpy.lastCall.args[0].label === "Today");
+            assert.isTrue(onShortcutChangeSpy.lastCall.args[1] === selectedShortcut);
+        });
+
+        it("custom shortcuts select the correct values", () => {
+            const date = new Date(2015, Months.JANUARY, 1);
+            const onChangeSpy = sinon.spy();
+            const { clickShortcut, assertSelectedDays } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    onChange={onChangeSpy}
+                    shortcuts={[{ date, label: "custom shortcut" }]}
+                />,
+            );
+            clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            const value = onChangeSpy.args[0][0];
+            assert.isTrue(DateUtils.isSameDay(date, value));
+            assertSelectedDays(date.getDate());
+        });
+    });
+
+    describe("when uncontrolled", () => {
+        it("defaultValue initially selects a day", () => {
+            const today = new Date();
+            const { assertSelectedDays } = wrap(<DatePicker3 {...LOCALE_LOADER} defaultValue={today} />);
+            assertSelectedDays(today.getDate());
+        });
+
+        it("onChange fired when a day is clicked", () => {
+            const onChange = sinon.spy();
+            const { getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} onChange={onChange} />);
+            assert.isTrue(onChange.notCalled);
+            getDay().simulate("click");
+            assert.isTrue(onChange.calledOnce);
+        });
+
+        it("onChange fired when month is changed", () => {
+            const onChange = sinon.spy();
+            // must use an initial month otherwise clicking next month in december will fail
+            const { getDay, clickNextMonth } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    initialMonth={new Date(2015, Months.JANUARY, 12)}
+                    onChange={onChange}
+                />,
+            );
+            assert.isTrue(onChange.notCalled);
+            getDay().simulate("click");
+            assert.isTrue(onChange.calledOnce, "expected onChange called");
+            clickNextMonth();
+            assert.isTrue(onChange.calledTwice, "expected onChange called again");
+        });
+
+        it("selected day updates are automatic", () => {
+            const { assertSelectedDays, getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} />);
+            assertSelectedDays();
+            getDay(3).simulate("click");
+            assertSelectedDays(3);
+        });
+
+        it("selected day is preserved when selections are changed", () => {
+            const initialMonth = new Date(2015, Months.JULY, 1);
+            const { assertSelectedDays, getDay, months } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} initialMonth={initialMonth} />,
+            );
+            getDay(31).simulate("click");
+            months.simulate("change", { target: { value: Months.AUGUST } });
+            assertSelectedDays(31);
+        });
+
+        it("selected day is changed if necessary when selections are changed", () => {
+            const initialMonth = new Date(2015, Months.JULY, 1);
+            const { assertSelectedDays, getDay, clickPreviousMonth } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} initialMonth={initialMonth} />,
+            );
+            getDay(31).simulate("click");
+            clickPreviousMonth();
+            assertSelectedDays(30);
+            // remembers actual date that was clicked and restores if possible
+            clickPreviousMonth();
+            assertSelectedDays(31);
+        });
+
+        it("selected day is changed to minDate or maxDate if selections are changed outside bounds", () => {
+            const initialMonth = new Date(2015, Months.JULY, 1);
+            const minDate = new Date(2015, Months.MARCH, 13);
+            const maxDate = new Date(2015, Months.NOVEMBER, 21);
+            const { assertSelectedDays, getDay, months } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} initialMonth={initialMonth} minDate={minDate} maxDate={maxDate} />,
+            );
+
+            getDay(1).simulate("click");
+            months.simulate("change", { target: { value: Months.MARCH } });
+            assertSelectedDays(minDate.getDate());
+
+            getDay(25).simulate("click");
+            months.simulate("change", { target: { value: Months.NOVEMBER } });
+            assertSelectedDays(maxDate.getDate());
+        });
+
+        it("can change displayed date with the dropdowns in the caption", () => {
+            const { months, root, years } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} initialMonth={new Date(2015, Months.MARCH, 2)} />,
+            );
+            assert.equal(root.state("displayMonth"), Months.MARCH);
+            assert.equal(root.state("displayYear"), 2015);
+
+            months.simulate("change", { target: { value: Months.JANUARY } });
+            years.simulate("change", { target: { value: 2014 } });
+            assert.equal(root.state("displayMonth"), Months.JANUARY);
+            assert.equal(root.state("displayYear"), 2014);
+        });
+
+        it("shortcuts select values", () => {
+            const { root, clickShortcut } = wrap(<DatePicker3 {...LOCALE_LOADER} shortcuts={true} />);
+            clickShortcut(2);
+
+            const today = new Date();
+            const aWeekAgo = DateUtils.clone(today);
+            aWeekAgo.setDate(today.getDate() - 6);
+
+            const value = root.state("value");
+            assert.isTrue(DateUtils.isSameDay(aWeekAgo, value!));
+        });
+
+        it("custom shortcuts select the correct values", () => {
+            const date = new Date(2010, Months.JANUARY, 10);
+            const { clickShortcut, assertSelectedDays } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} shortcuts={[{ date, label: "custom shortcut" }]} />,
+            );
+            clickShortcut();
+            assertSelectedDays(date.getDate());
+        });
+    });
+
+    describe("time selection", () => {
+        const defaultValue = new Date(2012, 2, 5, 6, 5, 40);
+
+        it("setting timePrecision shows a TimePicker", () => {
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} />);
+            assert.isFalse(root.find(TimePicker).exists());
+            root.setProps({ timePrecision: "minute" });
+            assert.isTrue(root.find(TimePicker).exists());
+        });
+
+        it("setting timePickerProps shows a TimePicker", () => {
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} timePickerProps={{}} />);
+            assert.isTrue(root.find(TimePicker).exists());
+        });
+
+        it("onChange fired when the time is changed", () => {
+            const onChangeSpy = sinon.spy();
+            const { root } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    onChange={onChangeSpy}
+                    timePickerProps={{ showArrowButtons: true }}
+                />,
+            );
+            assert.isTrue(onChangeSpy.notCalled);
+            root.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
+            assert.isTrue(onChangeSpy.calledOnce);
+            const cbHour = onChangeSpy.firstCall.args[0].getHours();
+            assert.strictEqual(cbHour, defaultValue.getHours() + 1);
+        });
+
+        it("changing date does not change time", () => {
+            const onChangeSpy = sinon.spy();
+            wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    onChange={onChangeSpy}
+                    timePrecision="minute"
+                />,
+            )
+                .getDay(16)
+                .simulate("click");
+            assert.isTrue(DateUtils.isSameTime(onChangeSpy.firstCall.args[0] as Date, defaultValue));
+        });
+
+        it("changing time does not change date", () => {
+            const onChangeSpy = sinon.spy();
+            const { setTimeInput } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    onChange={onChangeSpy}
+                    timePrecision="minute"
+                />,
+            );
+            setTimeInput("minute", 45);
+            assert.isTrue(DateUtils.isSameDay(onChangeSpy.firstCall.args[0] as Date, defaultValue));
+        });
+
+        it("changing time without date uses today", () => {
+            const onChangeSpy = sinon.spy();
+            // no date set via props
+            const { setTimeInput } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} onChange={onChangeSpy} timePrecision="minute" />,
+            );
+            setTimeInput("minute", 45);
+            assert.isTrue(DateUtils.isSameDay(onChangeSpy.firstCall.args[0] as Date, new Date()));
+        });
+
+        it("clicking a shortcut with includeTime=true changes time", () => {
+            const onChangeSpy = sinon.spy();
+            const date = DateUtils.clone(defaultValue);
+            date.setHours(date.getHours() - 2);
+
+            const shortcuts: DatePickerShortcut[] = [
+                {
+                    date,
+                    includeTime: true,
+                    label: "shortcut with time",
+                },
+            ];
+            const { clickShortcut } = wrap(
+                <DatePicker3
+                    {...LOCALE_LOADER}
+                    defaultValue={defaultValue}
+                    onChange={onChangeSpy}
+                    timePrecision="minute"
+                    shortcuts={shortcuts}
+                />,
+            );
+            clickShortcut();
+            assert.equal(onChangeSpy.firstCall.args[0] as Date, date);
+        });
+    });
+
+    describe("clearing a selection", () => {
+        const MOCK_TODAY = new Date(2024, 11, 24, 16, 30);
+        let clock: sinon.SinonFakeTimers;
+        beforeEach(() => {
+            clock = sinon.useFakeTimers(MOCK_TODAY);
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
+        it("onChange correctly passes a Date and never null when canClearSelection is false", () => {
+            const onChange = sinon.spy();
+            const { getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} canClearSelection={false} onChange={onChange} />);
+            getDay().simulate("click");
+            assert.isNotNull(onChange.firstCall.args[0]);
+            getDay().simulate("click");
+            assert.isNotNull(onChange.secondCall.args[0]);
+        });
+
+        it("onChange correctly passes a Date or null when canClearSelection is true", () => {
+            const onChange = sinon.spy();
+            const { getDay } = wrap(<DatePicker3 {...LOCALE_LOADER} canClearSelection={true} onChange={onChange} />);
+            getDay().simulate("click");
+            assert.isNotNull(onChange.firstCall.args[0]);
+            getDay().simulate("click");
+            assert.isNull(onChange.secondCall.args[0]);
+        });
+
+        it("Clear button disabled when canClearSelection is false", () => {
+            const { getClearButton } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} canClearSelection={false} showActionsBar={true} />,
+            );
+            assert.isTrue(getClearButton().props().disabled);
+        });
+
+        it("Clear button enabled when canClearSelection is true", () => {
+            const { getClearButton } = wrap(
+                <DatePicker3 {...LOCALE_LOADER} canClearSelection={true} showActionsBar={true} />,
+            );
+            assert.isFalse(getClearButton().props().disabled);
+        });
+
+        it("selects the current day when Today is clicked", () => {
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} showActionsBar={true} />);
+            root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).first().simulate("click");
+
+            const today = new Date();
+            const value = root.state("value");
+            assert.isNotNull(value);
+            assert.equal(value!.getDate(), today.getDate());
+            assert.equal(value!.getMonth(), today.getMonth());
+            assert.equal(value!.getFullYear(), today.getFullYear());
+        });
+
+        it("selects the current day in the given timezone when Today is clicked", () => {
+            const { root } = wrap(<DatePicker3 {...LOCALE_LOADER} showActionsBar={true} timezone="Asia/Tokyo" />);
+            root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).first().simulate("click");
+
+            const value = root.state("value")!;
+            assert.isNotNull(value);
+            assert.equal(value.getDate(), MOCK_TODAY.getDate() + 1);
+            assert.equal(value.getMonth(), MOCK_TODAY.getMonth());
+            assert.equal(value.getFullYear(), MOCK_TODAY.getFullYear());
+            assert.equal(value.getHours(), 1);
+            assert.equal(value.getMinutes(), 30);
+        });
+
+        it("clears the value when Clear is clicked", () => {
+            const { getDay, root } = wrap(<DatePicker3 {...LOCALE_LOADER} showActionsBar={true} />);
+            getDay().simulate("click");
+            root.find({ className: Classes.DATEPICKER_FOOTER }).find(Button).last().simulate("click");
+            assert.isNull(root.state("value"));
+        });
+    });
+
+    describe("localization", () => {
+        it("accept a statically-loaded date-fns locale and doesn't try to load it again", () => {
+            const stub = sinon.stub();
+            stub.callsFake(loadDateFnsLocaleFake);
+            wrap(<DatePicker3 dateFnsLocaleLoader={stub} locale={enUSLocale} />);
+            assert.isTrue(stub.notCalled, "Expected locale loader not to be called");
+        });
+    });
+
+    function wrap(datepicker: React.JSX.Element) {
+        const wrapper = mount<DatePicker3Props, DatePicker3State>(datepicker, { attachTo: testsContainerElement });
+        datePicker3Wrapper = wrapper;
+        return {
+            /** Asserts that the given days are selected. No arguments asserts that selection is empty. */
+            assertSelectedDays: (...days: number[]) =>
+                assert.sameMembers(
+                    wrapper
+                        .find(`.${Classes.DATEPICKER3_DAY_SELECTED}`)
+                        .hostNodes()
+                        .map(d => +d.text()),
+                    days,
+                ),
+            clickNextMonth: () => wrapper.find(`.${Classes.DATEPICKER3_NAV_BUTTON_NEXT}`).hostNodes().simulate("click"),
+            clickPreviousMonth: () =>
+                wrapper.find(`.${Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS}`).hostNodes().simulate("click"),
+            clickShortcut: (index = 0) => {
+                wrapper.find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`).hostNodes().find("a").at(index).simulate("click");
+            },
+            getClearButton: () => wrapper.find(`.${Classes.DATEPICKER_FOOTER}`).find(Button).last(),
+            getDay: (dayNumber = 1) =>
+                wrapper
+                    .find(`.${Classes.DATEPICKER3_DAY}`)
+                    .filterWhere(day => day.text() === "" + dayNumber && !day.hasClass(Classes.DATEPICKER3_DAY_OUTSIDE))
+                    .hostNodes(),
+            getTodayButton: () => wrapper.find(`.${Classes.DATEPICKER_FOOTER}`).find(Button).first(),
+            months: wrapper.find(HTMLSelect).filter(`.${Classes.DATEPICKER_MONTH_SELECT}`).find("select"),
+            root: wrapper,
+            setTimeInput: (precision: TimePrecision | "hour", value: number) =>
+                wrapper.find(`.${Classes.TIMEPICKER}-${precision}`).simulate("blur", { target: { value } }),
+            years: wrapper.find(HTMLSelect).filter(`.${Classes.DATEPICKER_YEAR_SELECT}`).find("select"),
+        };
+    }
+});

--- a/packages/datetime/test/components/dateRangeInput3Tests.tsx
+++ b/packages/datetime/test/components/dateRangeInput3Tests.tsx
@@ -1,0 +1,3191 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai";
+import { format, parse } from "date-fns";
+import * as Locales from "date-fns/locale";
+import esLocale from "date-fns/locale/es";
+import { mount, type ReactWrapper } from "enzyme";
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as TestUtils from "react-dom/test-utils";
+import * as sinon from "sinon";
+
+import {
+    Boundary,
+    Classes as CoreClasses,
+    type HTMLDivProps,
+    type HTMLInputProps,
+    InputGroup,
+    type InputGroupProps,
+    Popover,
+    type PopoverProps,
+} from "@blueprintjs/core";
+import { expectPropValidationError } from "@blueprintjs/test-commons";
+
+import { Classes, type DateFormatProps, type DateRange, Months, TimePrecision } from "../../src";
+import { ReactDayPickerClasses } from "../../src/common/classes";
+import { DateRangeInput3, type DateRangeInput3Props } from "../../src/components/date-range-input3/dateRangeInput3";
+import { DateRangePicker3 } from "../../src/components/date-range-picker3/dateRangePicker3";
+import { loadDateFnsLocaleFake } from "../common/loadDateFnsLocaleFake";
+
+type NullableRange<T> = [T | null, T | null];
+type DateStringRange = NullableRange<string>;
+
+type WrappedComponentRoot = ReactWrapper<any>;
+type WrappedComponentInput = ReactWrapper<HTMLInputProps, any>;
+type WrappedComponentDayElement = ReactWrapper<HTMLDivProps, any>;
+
+type OutOfRangeTestFunction = (
+    inputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
+    inputString: string,
+    boundary?: Boundary,
+) => void;
+
+type InvalidDateTestFunction = (
+    inputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
+    boundary: Boundary,
+    otherInputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
+) => void;
+
+// Change the default for testability
+DateRangeInput3.defaultProps.popoverProps = { usePortal: false };
+(DateRangeInput3.defaultProps as DateRangeInput3Props).dateFnsLocaleLoader = loadDateFnsLocaleFake;
+
+const DATE_FORMAT = getDateFnsFormatter("M/d/yyyy");
+const DATETIME_FORMAT = getDateFnsFormatter("M/d/yyyy HH:mm:ss");
+
+describe("<DateRangeInput3>", () => {
+    let containerElement: HTMLElement | undefined;
+
+    beforeEach(() => {
+        containerElement = document.createElement("div");
+        document.body.appendChild(containerElement);
+    });
+
+    afterEach(() => {
+        if (containerElement !== undefined) {
+            // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            ReactDOM.unmountComponentAtNode(containerElement);
+            containerElement.remove();
+        }
+    });
+
+    const YEAR = 2022;
+    const START_DAY = 22;
+    const START_DATE = new Date(YEAR, Months.JANUARY, START_DAY);
+    const START_STR = DATE_FORMAT.formatDate(START_DATE);
+    const END_DAY = 24;
+    const END_DATE = new Date(YEAR, Months.JANUARY, END_DAY);
+    const END_STR = DATE_FORMAT.formatDate(END_DATE);
+    const DATE_RANGE = [START_DATE, END_DATE] as DateRange;
+
+    const START_DATE_2 = new Date(YEAR, Months.JANUARY, 1);
+    const START_STR_2 = DATE_FORMAT.formatDate(START_DATE_2);
+    const START_STR_2_ES_LOCALE = "1 de enero de 2022";
+    const END_DATE_2 = new Date(YEAR, Months.JANUARY, 31);
+    const END_STR_2 = DATE_FORMAT.formatDate(END_DATE_2);
+    const END_STR_2_ES_LOCALE = "31 de enero de 2022";
+    const DATE_RANGE_2 = [START_DATE_2, END_DATE_2] as DateRange;
+
+    const INVALID_STR = "<this is an invalid date string>";
+    const INVALID_MESSAGE = "Custom invalid-date message";
+
+    const OUT_OF_RANGE_TEST_MIN = new Date(2000, 1, 1);
+    const OUT_OF_RANGE_TEST_MAX = new Date(2030, 1, 1);
+    const OUT_OF_RANGE_START_DATE = new Date(1000, 1, 1);
+    const OUT_OF_RANGE_START_STR = DATE_FORMAT.formatDate(OUT_OF_RANGE_START_DATE);
+    const OUT_OF_RANGE_END_DATE = new Date(3000, 1, 1);
+    const OUT_OF_RANGE_END_STR = DATE_FORMAT.formatDate(OUT_OF_RANGE_END_DATE);
+    const OUT_OF_RANGE_MESSAGE = "Custom out-of-range message";
+
+    const OVERLAPPING_DATES_MESSAGE = "Custom overlapping-dates message";
+    const OVERLAPPING_START_DATE = END_DATE_2; // should be later then END_DATE
+    const OVERLAPPING_END_DATE = START_DATE_2; // should be earlier then START_DATE
+    const OVERLAPPING_START_STR = DATE_FORMAT.formatDate(OVERLAPPING_START_DATE);
+    const OVERLAPPING_END_STR = DATE_FORMAT.formatDate(OVERLAPPING_END_DATE);
+
+    const OVERLAPPING_START_DATETIME = new Date(2022, Months.JANUARY, 1, 9); // should be same date but later time
+    const OVERLAPPING_END_DATETIME = new Date(2022, Months.JANUARY, 1, 1); // should be same date but earlier time
+    const OVERLAPPING_START_DT_STR = DATETIME_FORMAT.formatDate(OVERLAPPING_START_DATETIME);
+    const OVERLAPPING_END_DT_STR = DATETIME_FORMAT.formatDate(OVERLAPPING_END_DATETIME);
+    const DATE_RANGE_3 = [OVERLAPPING_END_DATETIME, OVERLAPPING_START_DATETIME] as DateRange; // initial state should be correct
+
+    // a custom string representation for `new Date(undefined)` that we use in
+    // date-range equality checks just in this file
+    const UNDEFINED_DATE_STR = "<UNDEFINED DATE>";
+
+    it("renders with two InputGroup children", () => {
+        const component = mount(<DateRangeInput3 {...DATE_FORMAT} />);
+        expect(component.find(InputGroup)).to.have.lengthOf(2);
+    });
+
+    it("passes custom classNames to popover wrapper", () => {
+        const CLASS_1 = "foo";
+        const CLASS_2 = "bar";
+
+        const wrapper = mount(
+            <DateRangeInput3
+                {...DATE_FORMAT}
+                className={CLASS_1}
+                popoverProps={{ className: CLASS_2, usePortal: false }}
+            />,
+        );
+        React.act(() => {
+            wrapper.setState({ isOpen: true });
+        });
+
+        const popoverTarget = wrapper.find(`.${CoreClasses.POPOVER_TARGET}`).hostNodes();
+        expect(popoverTarget.hasClass(CLASS_1)).to.be.true;
+        expect(popoverTarget.hasClass(CLASS_2)).to.be.true;
+    });
+
+    it("inner DateRangePicker3 receives all supported props", () => {
+        const component = mount(<DateRangeInput3 {...DATE_FORMAT} locale="uk" contiguousCalendarMonths={false} />);
+        React.act(() => {
+            component.setState({ isOpen: true });
+        });
+        component.update();
+        const picker = component.find(DateRangePicker3);
+        expect(picker.prop("locale")).to.equal("uk");
+        expect(picker.prop("contiguousCalendarMonths")).to.be.false;
+    });
+
+    it("shows empty fields when no date range is selected", () => {
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} />);
+        assertInputValuesEqual(root, "", "");
+    });
+
+    it("throws error if value === null", () => {
+        expectPropValidationError(DateRangeInput3, { ...DATE_FORMAT, value: null! });
+    });
+
+    describe("timePrecision prop", () => {
+        it("<TimePicker /> should not lose focus on increment/decrement with up/down arrows", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
+
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+            expect(root.find(Popover).prop("isOpen"), "Popover isOpen").to.be.true;
+
+            keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
+            expect(isStartInputFocused(root), "start input is focused").to.be.false;
+            expect(isEndInputFocused(root), "end input is focused").to.be.false;
+        });
+
+        it("when timePrecision != null && closeOnSelection=true && <TimePicker /> values is changed popover should not close", () => {
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
+                true,
+            );
+
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+
+            getDayElement(1).simulate("click");
+            getDayElement(10).simulate("click");
+
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+
+            keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
+            root.update();
+            expect(root.find(Popover).prop("isOpen")).to.be.true;
+        });
+
+        it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
+
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
+            root.update();
+            keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp", 1);
+            root.update();
+            expect(root.find(Popover).prop("isOpen")).to.be.true;
+        });
+
+        function keyDownOnInput(className: string, key: string, inputElementIndex: number = 0) {
+            TestUtils.Simulate.keyDown(findTimePickerInputElement(className, inputElementIndex), { key });
+        }
+
+        function findTimePickerInputElement(className: string, inputElementIndex: number = 0) {
+            return document.querySelectorAll<HTMLInputElement>(`.${Classes.TIMEPICKER_INPUT}.${className}`)[
+                inputElementIndex
+            ];
+        }
+    });
+
+    describe("startInputProps and endInputProps", () => {
+        it("startInput is disabled when startInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} startInputProps={{ disabled: true }} />);
+            const startInput = getStartInput(root);
+
+            startInput.simulate("click");
+            expect(root.find(Popover).prop("isOpen")).to.be.false;
+            expect(startInput.prop("disabled")).to.be.true;
+        });
+
+        it("endInput is not disabled when startInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} startInputProps={{ disabled: true }} />);
+            const endInput = getEndInput(root);
+            expect(endInput.prop("disabled")).to.be.false;
+        });
+
+        it("endInput is disabled when endInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} endInputProps={{ disabled: true }} />);
+            const endInput = getEndInput(root);
+
+            endInput.simulate("click");
+            expect(root.find(Popover).prop("isOpen")).to.be.false;
+            expect(endInput.prop("disabled")).to.be.true;
+        });
+
+        it("startInput is not disabled when endInputProps={ disabled: true }", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} endInputProps={{ disabled: true }} />);
+            const startInput = getStartInput(root);
+            expect(startInput.prop("disabled")).to.be.false;
+        });
+
+        describe("startInputProps", () => {
+            runTestSuite(getStartInput, inputGroupProps => {
+                return mount(<DateRangeInput3 {...DATE_FORMAT} startInputProps={inputGroupProps} />);
+            });
+        });
+
+        describe("endInputProps", () => {
+            runTestSuite(getEndInput, inputGroupProps => {
+                return mount(<DateRangeInput3 {...DATE_FORMAT} endInputProps={inputGroupProps} />);
+            });
+        });
+
+        function runTestSuite(
+            inputGetterFn: (root: WrappedComponentRoot) => WrappedComponentInput,
+            mountFn: (inputGroupProps: InputGroupProps) => any,
+        ) {
+            it("allows custom placeholder text", () => {
+                const root = mountFn({ placeholder: "Hello" });
+                expect(getInputPlaceholderText(inputGetterFn(root))).to.equal("Hello");
+            });
+
+            it("supports custom style", () => {
+                const root = mountFn({ style: { background: "yellow" } });
+                const inputElement = inputGetterFn(root).getDOMNode<HTMLElement>();
+                expect(inputElement.style.background).to.equal("yellow");
+            });
+
+            // verify custom callbacks are called for each event that we listen for internally.
+            // (note: we could be more clever and accept just one string param here, but this
+            // approach keeps both string params grep-able in the codebase.)
+            runCallbackTest("onChange", "change");
+            runCallbackTest("onFocus", "focus");
+            runCallbackTest("onBlur", "blur");
+            runCallbackTest("onClick", "click");
+            runCallbackTest("onKeyDown", "keydown");
+            runCallbackTest("onMouseDown", "mousedown");
+
+            function runCallbackTest(callbackName: string, eventName: string) {
+                it(`fires custom ${callbackName} callback`, () => {
+                    const spy = sinon.spy();
+                    const component = mountFn({ [callbackName]: spy });
+                    const input = inputGetterFn(component);
+                    input.simulate(eventName);
+                    expect(spy.calledOnce).to.be.true;
+                });
+            }
+        }
+    });
+
+    it("placeholder text", () => {
+        it("shows proper placeholder text when empty inputs are focused and unfocused", () => {
+            // arbitrarily choose the out-of-range tests' min/max dates for this test
+            const MIN_DATE = new Date(2022, Months.JANUARY, 1);
+            const MAX_DATE = new Date(2022, Months.JANUARY, 31);
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} minDate={MIN_DATE} maxDate={MAX_DATE} />);
+
+            const startInput = getStartInput(root);
+            const endInput = getEndInput(root);
+
+            expect(getInputPlaceholderText(startInput)).to.equal("Start date");
+            expect(getInputPlaceholderText(endInput)).to.equal("End date");
+
+            startInput.simulate("focus");
+            expect(getInputPlaceholderText(startInput)).to.equal(DATE_FORMAT.formatDate(MIN_DATE));
+            startInput.simulate("blur");
+            endInput.simulate("focus");
+            expect(getInputPlaceholderText(endInput)).to.equal(DATE_FORMAT.formatDate(MAX_DATE));
+        });
+
+        // need to check this case, because formatted min/max date strings are cached internally
+        // until props change again
+        it("updates placeholder text properly when min/max dates change", () => {
+            const MIN_DATE_1 = new Date(2022, Months.JANUARY, 1);
+            const MAX_DATE_1 = new Date(2022, Months.JANUARY, 31);
+            const MIN_DATE_2 = new Date(2022, Months.JANUARY, 2);
+            const MAX_DATE_2 = new Date(2022, Months.FEBRUARY, 1);
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} minDate={MIN_DATE_1} maxDate={MAX_DATE_1} />);
+
+            const startInput = getStartInput(root);
+            const endInput = getEndInput(root);
+
+            // change while end input is still focused to make sure things change properly in spite of that
+            endInput.simulate("focus");
+            root.setProps({ maxDate: MAX_DATE_2, minDate: MIN_DATE_2 });
+
+            endInput.simulate("blur");
+            startInput.simulate("focus");
+            expect(getInputPlaceholderText(startInput)).to.equal(DATE_FORMAT.formatDate(MIN_DATE_2));
+            startInput.simulate("blur");
+            endInput.simulate("focus");
+            expect(getInputPlaceholderText(endInput)).to.equal(DATE_FORMAT.formatDate(MAX_DATE_2));
+        });
+
+        it("updates placeholder text properly when format changes", () => {
+            const MIN_DATE = new Date(2022, Months.JANUARY, 1);
+            const MAX_DATE = new Date(2022, Months.JANUARY, 31);
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} minDate={MIN_DATE} maxDate={MAX_DATE} />);
+
+            const startInput = getStartInput(root);
+            const endInput = getEndInput(root);
+
+            root.setProps({ format: "MM/DD/YYYY" });
+
+            startInput.simulate("focus");
+            expect(getInputPlaceholderText(startInput)).to.equal("01/01/2022");
+            startInput.simulate("blur");
+            endInput.simulate("focus");
+            expect(getInputPlaceholderText(endInput)).to.equal("01/31/2022");
+        });
+    });
+
+    it("inputs disable and popover doesn't open if disabled=true", () => {
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} disabled={true} />);
+        const startInput = getStartInput(root);
+        startInput.simulate("click");
+        expect(root.find(Popover).prop("isOpen")).to.be.false;
+        expect(startInput.prop("disabled")).to.be.true;
+        expect(getEndInput(root).prop("disabled")).to.be.true;
+    });
+
+    describe("closeOnSelection", () => {
+        it("if closeOnSelection=false, popover stays open when full date range is selected", () => {
+            const { root, getDayElement } = wrap(<DateRangeInput3 {...DATE_FORMAT} closeOnSelection={false} />, true);
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+            getDayElement(1).simulate("click");
+            getDayElement(10).simulate("click");
+            expect(root.state("isOpen")).to.be.true;
+            root.unmount();
+        });
+
+        it("if closeOnSelection=true, popover closes when full date range is selected", () => {
+            const { root, getDayElement } = wrap(<DateRangeInput3 {...DATE_FORMAT} />, true);
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+            getDayElement(1).simulate("click");
+            getDayElement(10).simulate("click");
+            expect(root.state("isOpen")).to.be.false;
+            root.unmount();
+        });
+
+        it("if closeOnSelection=true && timePrecision != null, popover closes when full date range is selected", () => {
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
+                true,
+            );
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+            getDayElement(1).simulate("click");
+            getDayElement(10).simulate("click");
+            root.update();
+            expect(root.state("isOpen")).to.be.false;
+            root.unmount();
+        });
+    });
+
+    it("accepts contiguousCalendarMonths prop and passes it to the date range picker", () => {
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} contiguousCalendarMonths={false} />);
+        React.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
+        expect(root.find(DateRangePicker3).prop("contiguousCalendarMonths")).to.be.false;
+    });
+
+    it("accepts singleMonthOnly prop and passes it to the date range picker", () => {
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} singleMonthOnly={false} />);
+        React.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
+        expect(root.find(DateRangePicker3).prop("singleMonthOnly")).to.be.false;
+    });
+
+    it("accepts shortcuts prop and passes it to the date range picker", () => {
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} shortcuts={false} />);
+        React.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
+        expect(root.find(DateRangePicker3).prop("shortcuts")).to.be.false;
+    });
+
+    it("should update the selectedShortcutIndex state when clicking on a shortcut", () => {
+        const selectedShortcut = 1;
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} />);
+
+        React.act(() => {
+            root.setState({ isOpen: true });
+        });
+        root.update();
+        root.find(DateRangePicker3)
+            .find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`)
+            .find("a")
+            .at(selectedShortcut)
+            .simulate("click");
+        expect(root.state("selectedShortcutIndex")).equals(selectedShortcut);
+    });
+
+    it("pressing Shift+Tab in the start field blurs the start field and closes the popover", () => {
+        const startInputProps = { onKeyDown: sinon.spy() };
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...{ startInputProps }} />);
+        const startInput = getStartInput(root);
+        startInput.simulate("keydown", { key: "Tab", shiftKey: true });
+        expect(root.state("isStartInputFocused"), "start input blurred").to.be.false;
+        expect(startInputProps.onKeyDown.calledOnce, "onKeyDown called once").to.be.true;
+        expect(root.state("isOpen"), "popover closed").to.be.false;
+    });
+
+    it("pressing Tab in the end field blurs the end field and closes the popover", () => {
+        const endInputProps = { onKeyDown: sinon.spy() };
+        const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...{ endInputProps }} />);
+        const endInput = getEndInput(root);
+        endInput.simulate("keydown", { key: "Tab" });
+        expect(root.state("isEndInputFocused"), "end input blurred").to.be.false;
+        expect(endInputProps.onKeyDown.calledOnce, "onKeyDown called once").to.be.true;
+        expect(root.state("isOpen"), "popover closed").to.be.false;
+    });
+
+    describe("selectAllOnFocus", () => {
+        it("if false (the default), does not select any text on focus", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} defaultValue={[START_DATE, null]} />, true);
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            const startInputNode = containerElement!.querySelectorAll("input")[0];
+            expect(startInputNode.selectionStart).to.equal(startInputNode.selectionEnd);
+        });
+
+        it("if true, selects all text on focus", () => {
+            const { root } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} defaultValue={[START_DATE, null]} selectAllOnFocus={true} />,
+                true,
+            );
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            const startInputNode = containerElement!.querySelectorAll("input")[0];
+            expect(startInputNode.selectionStart).to.equal(0);
+            expect(startInputNode.selectionEnd).to.equal(START_STR.length);
+        });
+
+        it.skip("if true, selects all text on day mouseenter in calendar", () => {
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} defaultValue={[START_DATE, null]} selectAllOnFocus={true} />,
+                true,
+            );
+
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            // getDay is 0-indexed, but getDayElement is 1-indexed
+            getDayElement(START_DATE_2.getDay() + 1).simulate("mouseenter");
+
+            const startInputNode = containerElement!.querySelectorAll("input")[0];
+            expect(startInputNode.selectionStart).to.equal(0);
+            expect(startInputNode.selectionEnd).to.equal(START_STR.length);
+        });
+    });
+
+    describe("allowSingleDayRange", () => {
+        it("allows start and end to be the same day when clicking", () => {
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} allowSingleDayRange={true} defaultValue={[START_DATE, END_DATE]} />,
+            );
+            getEndInput(root).simulate("focus");
+            getDayElement(END_DAY).simulate("click");
+            getDayElement(START_DAY).simulate("click");
+            assertInputValuesEqual(root, START_STR, START_STR);
+        });
+
+        it("allows start and end to be the same day when typing", () => {
+            const { root } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} allowSingleDayRange={true} defaultValue={[START_DATE, END_DATE]} />,
+            );
+            changeEndInputText(root, "");
+            changeEndInputText(root, START_STR);
+            assertInputValuesEqual(root, START_STR, START_STR);
+        });
+    });
+
+    describe("popoverProps", () => {
+        it("accepts custom popoverProps", () => {
+            const popoverProps: Partial<PopoverProps> = {
+                backdropProps: {},
+                placement: "top-start",
+                usePortal: false,
+            };
+            const popover = wrap(<DateRangeInput3 {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            expect(popover.prop("backdropProps")).to.equal(popoverProps.backdropProps);
+            expect(popover.prop("placement")).to.equal(popoverProps.placement);
+        });
+
+        it("ignores autoFocus, enforceFocus, and content in custom popoverProps", () => {
+            const CUSTOM_CONTENT = "Here is some custom content";
+            const popoverProps = {
+                autoFocus: true,
+                content: CUSTOM_CONTENT,
+                enforceFocus: true,
+                usePortal: false,
+            };
+            const popover = wrap(<DateRangeInput3 {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            // this test assumes the following values will be the defaults internally
+            expect(popover.prop("autoFocus")).to.be.false;
+            expect(popover.prop("enforceFocus")).to.be.false;
+            expect(popover.prop("content")).to.not.equal(CUSTOM_CONTENT);
+        });
+    });
+
+    describe("when uncontrolled", () => {
+        it("Shows empty fields when defaultValue is [null, null]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} defaultValue={[null, null]} />);
+            assertInputValuesEqual(root, "", "");
+        });
+
+        it("Shows empty start field and formatted date in end field when defaultValue is [null, <date>]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} defaultValue={[null, END_DATE]} />);
+            assertInputValuesEqual(root, "", END_STR);
+        });
+
+        it("Shows empty end field and formatted date in start field when defaultValue is [<date>, null]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} defaultValue={[START_DATE, null]} />);
+            assertInputValuesEqual(root, START_STR, "");
+        });
+
+        it("Shows formatted dates in both fields when defaultValue is [<date1>, <date2>]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} defaultValue={[START_DATE, END_DATE]} />);
+            assertInputValuesEqual(root, START_STR, END_STR);
+        });
+
+        // HACKHACK: https://github.com/palantir/blueprint/issues/6109
+        // N.B. this test passes locally
+        it.skip("Pressing Enter saves the inputted date and closes the popover", () => {
+            const startInputProps = { onKeyDown: sinon.spy() };
+            const endInputProps = { onKeyDown: sinon.spy() };
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} {...{ endInputProps, startInputProps }} />);
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+
+            // Don't save the input elements into variables; they can become
+            // stale across React updates.
+
+            getStartInput(root).simulate("focus");
+            getStartInput(root).simulate("change", { target: { value: START_STR } });
+            getStartInput(root).simulate("keydown", { key: "Enter" });
+            expect(startInputProps.onKeyDown.calledOnce, "startInputProps.onKeyDown called once");
+            expect(isStartInputFocused(root), "start input still focused").to.be.false;
+
+            expect(root.state("isOpen"), "popover still open").to.be.true;
+
+            getEndInput(root).simulate("focus");
+            getEndInput(root).simulate("change", { target: { value: END_STR } });
+            getEndInput(root).simulate("keydown", { key: "Enter" });
+            expect(endInputProps.onKeyDown.calledOnce, "endInputProps.onKeyDown called once");
+            expect(isEndInputFocused(root), "end input still focused").to.be.true;
+
+            expect(getStartInput(root).prop("value"), "startInput value is correct").to.equal(START_STR);
+            expect(getEndInput(root).prop("value"), "endInput value is correct").to.equal(END_STR);
+
+            expect(root.state("isOpen"), "popover closed at end").to.be.false;
+        });
+
+        it("Clicking a date invokes onChange with the new date range and updates the input fields", () => {
+            const defaultValue = [START_DATE, null] as DateRange;
+
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3
+                    {...DATE_FORMAT}
+                    closeOnSelection={false}
+                    defaultValue={defaultValue}
+                    onChange={onChange}
+                />,
+            );
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+
+            getDayElement(END_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, END_STR]);
+            assertInputValuesEqual(root, START_STR, END_STR);
+
+            getDayElement(START_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(1).args[0], [null, END_STR]);
+            assertInputValuesEqual(root, "", END_STR);
+
+            getDayElement(END_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(2).args[0], [null, null]);
+            assertInputValuesEqual(root, "", "");
+
+            getDayElement(START_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(3).args[0], [START_STR, null]);
+            assertInputValuesEqual(root, START_STR, "");
+
+            expect(onChange.callCount).to.equal(4);
+        });
+
+        it(`Typing a valid start or end date invokes onChange with the new date range and updates the
+            input fields`, () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={DATE_RANGE} />);
+
+            changeStartInputText(root, START_STR_2);
+            expect(onChange.callCount).to.equal(1);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR_2, END_STR]);
+            assertInputValuesEqual(root, START_STR_2, END_STR);
+
+            changeEndInputText(root, END_STR_2);
+            expect(onChange.callCount).to.equal(2);
+            assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR_2, END_STR_2]);
+            assertInputValuesEqual(root, START_STR_2, END_STR_2);
+        });
+
+        it(`Typing in a field while hovering over a date shows the typed date, not the hovered date`, () => {
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={DATE_RANGE} />,
+            );
+
+            getStartInput(root).simulate("focus");
+            getDayElement(1).simulate("mouseenter");
+            changeStartInputText(root, START_STR_2);
+            assertInputValuesEqual(root, START_STR_2, END_STR);
+        });
+
+        // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+        describe.skip("Typing an out-of-range date", () => {
+            // we run the same four tests for each of several cases. putting
+            // setup logic in beforeEach lets us express our it(...) tests as
+            // nice one-liners further down this block, and it also gives
+            // certain tests easy access to onError/onChange if they need it.
+
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                // use defaultValue to specify the calendar months in view
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        defaultValue={DATE_RANGE}
+                        minDate={OUT_OF_RANGE_TEST_MIN}
+                        maxDate={OUT_OF_RANGE_TEST_MAX}
+                        onError={onError}
+                        outOfRangeMessage={OUT_OF_RANGE_MESSAGE}
+                    />,
+                );
+                root = result.root;
+
+                // clear the fields *before* setting up an onChange callback to
+                // keep onChange.callCount at 0 before tests run
+                changeStartInputText(root, "");
+                changeEndInputText(root, "");
+                root.setProps({ onChange });
+            });
+
+            describe("shows the error message on blur", () => {
+                runTestForEachScenario((inputGetterFn, inputString) => {
+                    changeInputText(inputGetterFn(root), inputString);
+                    inputGetterFn(root).simulate("blur");
+                    assertInputValueEquals(inputGetterFn(root), OUT_OF_RANGE_MESSAGE);
+                });
+            });
+
+            describe("shows the offending date in the field on focus", () => {
+                runTestForEachScenario((inputGetterFn, inputString) => {
+                    changeInputText(inputGetterFn(root), inputString);
+                    inputGetterFn(root).simulate("blur");
+                    inputGetterFn(root).simulate("focus");
+                    assertInputValueEquals(inputGetterFn(root), inputString);
+                });
+            });
+
+            describe("calls onError with invalid date on blur", () => {
+                runTestForEachScenario((inputGetterFn, inputString, boundary) => {
+                    const expectedRange: DateStringRange =
+                        boundary === Boundary.START ? [inputString, null] : [null, inputString];
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), inputString);
+                    expect(onError.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], expectedRange);
+                });
+            });
+
+            describe("does NOT call onChange before OR after blur", () => {
+                runTestForEachScenario((inputGetterFn, inputString) => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), inputString);
+                    expect(onChange.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+            });
+
+            describe("removes error message if input is changed to an in-range date again", () => {
+                runTestForEachScenario((inputGetterFn, inputString) => {
+                    changeInputText(inputGetterFn(root), inputString);
+                    inputGetterFn(root).simulate("blur");
+
+                    const IN_RANGE_DATE_STR = START_STR;
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), IN_RANGE_DATE_STR);
+                    inputGetterFn(root).simulate("blur");
+                    assertInputValueEquals(inputGetterFn(root), IN_RANGE_DATE_STR);
+                });
+            });
+
+            function runTestForEachScenario(runTestFn: OutOfRangeTestFunction) {
+                const { START, END } = Boundary; // deconstruct to keep line lengths under threshold
+                it("if start < minDate", () => runTestFn(getStartInput, OUT_OF_RANGE_START_STR, START));
+                it("if start > maxDate", () => runTestFn(getStartInput, OUT_OF_RANGE_END_STR, START));
+                it("if end < minDate", () => runTestFn(getEndInput, OUT_OF_RANGE_START_STR, END));
+                it("if end > maxDate", () => runTestFn(getEndInput, OUT_OF_RANGE_END_STR, END));
+            }
+        });
+
+        // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+        describe.skip("Typing an invalid date", () => {
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        defaultValue={DATE_RANGE}
+                        invalidDateMessage={INVALID_MESSAGE}
+                        onError={onError}
+                    />,
+                );
+                root = result.root;
+
+                // clear the fields *before* setting up an onChange callback to
+                // keep onChange.callCount at 0 before tests run
+                changeStartInputText(root, "");
+                changeEndInputText(root, "");
+                root.setProps({ onChange });
+            });
+
+            describe("shows the error message on blur", () => {
+                runTestForEachScenario(inputGetterFn => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    inputGetterFn(root).simulate("blur");
+                    assertInputValueEquals(inputGetterFn(root), INVALID_MESSAGE);
+                });
+            });
+
+            describe("keeps showing the error message on next focus", () => {
+                runTestForEachScenario(inputGetterFn => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    inputGetterFn(root).simulate("blur");
+                    inputGetterFn(root).simulate("focus");
+                    assertInputValueEquals(inputGetterFn(root), INVALID_MESSAGE);
+                });
+            });
+
+            describe.skip("calls onError on blur with Date(undefined) in place of the invalid date", () => {
+                runTestForEachScenario((inputGetterFn, boundary) => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    expect(onError.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+
+                    const dateRange = onError.getCall(0).args[0];
+                    const dateIndex = boundary === Boundary.START ? 0 : 1;
+                    expect((dateRange[dateIndex] as Date).valueOf()).to.be.NaN;
+                });
+            });
+
+            describe("does NOT call onChange before OR after blur", () => {
+                runTestForEachScenario(inputGetterFn => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    expect(onChange.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+            });
+
+            describe("removes error message if input is changed to an in-range date again", () => {
+                runTestForEachScenario(inputGetterFn => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    inputGetterFn(root).simulate("blur");
+
+                    // just use START_STR for this test, because it will be
+                    // valid in either field.
+                    const VALID_STR = START_STR;
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), VALID_STR);
+                    inputGetterFn(root).simulate("blur");
+                    assertInputValueEquals(inputGetterFn(root), VALID_STR);
+                });
+            });
+
+            describe("calls onChange if last-edited boundary is in range and the other boundary is out of range", () => {
+                runTestForEachScenario((inputGetterFn, boundary, otherInputGetterFn) => {
+                    otherInputGetterFn(root).simulate("focus");
+                    changeInputText(otherInputGetterFn(root), INVALID_STR);
+                    otherInputGetterFn(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+
+                    const VALID_STR = START_STR;
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), VALID_STR);
+                    expect(onChange.calledOnce).to.be.true; // because latest date is valid
+
+                    const actualRange = onChange.getCall(0).args[0];
+                    const expectedRange: DateStringRange =
+                        boundary === Boundary.START ? [VALID_STR, UNDEFINED_DATE_STR] : [UNDEFINED_DATE_STR, VALID_STR];
+
+                    assertDateRangesEqual(actualRange, expectedRange);
+                });
+            });
+
+            function runTestForEachScenario(runTestFn: InvalidDateTestFunction) {
+                it("in start field", () => runTestFn(getStartInput, Boundary.START, getEndInput));
+                it("in end field", () => runTestFn(getEndInput, Boundary.END, getStartInput));
+            }
+        });
+
+        describe("Typing an overlapping date time", () => {
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATETIME_FORMAT}
+                        allowSingleDayRange={true}
+                        defaultValue={DATE_RANGE_3}
+                        overlappingDatesMessage={OVERLAPPING_DATES_MESSAGE}
+                        onChange={onChange}
+                        onError={onError}
+                        timePrecision={TimePrecision.MINUTE}
+                    />,
+                );
+                root = result.root;
+            });
+
+            describe("in the end field", () => {
+                it("shows an error message when the start time is later than the end time", () => {
+                    getStartInput(root).simulate("focus");
+                    changeInputText(getStartInput(root), OVERLAPPING_START_DT_STR);
+                    getStartInput(root).simulate("blur");
+                    assertInputValueEquals(getStartInput(root), OVERLAPPING_START_DT_STR);
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), OVERLAPPING_END_DT_STR);
+                    getEndInput(root).simulate("blur");
+                    assertInputValueEquals(getEndInput(root), OVERLAPPING_DATES_MESSAGE);
+                });
+            });
+        });
+
+        // this test sub-suite is structured a little differently because of the
+        // different semantics of this error case in each field
+        // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+        describe.skip("Typing an overlapping date", () => {
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        defaultValue={DATE_RANGE}
+                        overlappingDatesMessage={OVERLAPPING_DATES_MESSAGE}
+                        onChange={onChange}
+                        onError={onError}
+                    />,
+                );
+                root = result.root;
+            });
+
+            describe("in the start field", () => {
+                it("shows an error message in the end field right away", () => {
+                    getStartInput(root).simulate("focus");
+                    changeInputText(getStartInput(root), OVERLAPPING_START_STR);
+                    assertInputValueEquals(getEndInput(root), OVERLAPPING_DATES_MESSAGE);
+                });
+
+                it("shows the offending date in the end field on focus in the end field", () => {
+                    getStartInput(root).simulate("focus");
+                    changeInputText(getStartInput(root), OVERLAPPING_START_STR);
+                    getStartInput(root).simulate("blur");
+                    getEndInput(root).simulate("focus");
+                    assertInputValueEquals(getEndInput(root), END_STR);
+                });
+
+                it("calls onError with [<overlappingDate>, <endDate] on blur", () => {
+                    getStartInput(root).simulate("focus");
+                    changeInputText(getStartInput(root), OVERLAPPING_START_STR);
+                    expect(onError.called).to.be.false;
+                    getStartInput(root).simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], [OVERLAPPING_START_STR, END_STR]);
+                });
+
+                it("does NOT call onChange before OR after blur", () => {
+                    getStartInput(root).simulate("focus");
+                    changeInputText(getStartInput(root), OVERLAPPING_START_STR);
+                    expect(onChange.called).to.be.false;
+                    getStartInput(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+
+                it("removes error message if input is changed to an in-range date again", () => {
+                    getStartInput(root).simulate("focus");
+                    changeInputText(getStartInput(root), OVERLAPPING_START_STR);
+                    changeInputText(getStartInput(root), START_STR);
+                    assertInputValueEquals(getEndInput(root), END_STR);
+                });
+            });
+
+            describe("in the end field", () => {
+                // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+                it.skip("shows an error message in the end field on blur", () => {
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), OVERLAPPING_END_STR);
+                    assertInputValueEquals(getEndInput(root), OVERLAPPING_END_STR);
+                    getEndInput(root).simulate("blur");
+                    assertInputValueEquals(getEndInput(root), OVERLAPPING_DATES_MESSAGE);
+                });
+
+                // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+                it.skip("shows the offending date in the end field on re-focus", () => {
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), OVERLAPPING_END_STR);
+                    getEndInput(root).simulate("blur");
+                    getEndInput(root).simulate("focus");
+                    assertInputValueEquals(getEndInput(root), OVERLAPPING_END_STR);
+                });
+
+                it("calls onError with [<startDate>, <overlappingDate>] on blur", () => {
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), OVERLAPPING_END_STR);
+                    expect(onError.called).to.be.false;
+                    getEndInput(root).simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], [START_STR, OVERLAPPING_END_STR]);
+                });
+
+                it("does NOT call onChange before OR after blur", () => {
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), OVERLAPPING_END_STR);
+                    expect(onChange.called).to.be.false;
+                    getEndInput(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+
+                it("removes error message if input is changed to an in-range date again", () => {
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), OVERLAPPING_END_STR);
+                    getEndInput(root).simulate("blur");
+                    getEndInput(root).simulate("focus");
+                    changeInputText(getEndInput(root), END_STR);
+                    getEndInput(root).simulate("blur");
+                    assertInputValueEquals(getEndInput(root), END_STR);
+                });
+            });
+        });
+
+        describe("Arrow key navigation", () => {
+            it("Pressing an arrow key has no effect when the input is not fully selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={DATE_RANGE} />,
+                );
+
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                expect(onChange.called).to.be.false;
+            });
+
+            it("Pressing the left arrow key moves the date back by a day", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedStartDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 1));
+                const expectedStartDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 2));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowLeft" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate1, END_STR]);
+
+                getStartInput(root).simulate("keydown", { key: "ArrowLeft" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [expectedStartDate2, END_STR]);
+            });
+
+            it("Pressing the right arrow key moves the date forward by a day", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedEndDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY + 1));
+                const expectedEndDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY + 2));
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowRight" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, expectedEndDate1]);
+
+                getEndInput(root).simulate("keydown", { key: "ArrowRight" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, expectedEndDate2]);
+            });
+
+            it("Pressing the up arrow key moves the date back by a week", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedStartDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 7));
+                const expectedStartDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 14));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate1, END_STR]);
+
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [expectedStartDate2, END_STR]);
+            });
+
+            it("Pressing the down arrow key moves the date forward by a week", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedEndDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY + 7));
+                const expectedEndDate2 = DATE_FORMAT.formatDate(new Date(YEAR, Months.FEBRUARY, 7));
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, expectedEndDate1]);
+
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate2);
+                assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, expectedEndDate2]);
+            });
+
+            it("Will not move past the end boundary", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedStartDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY - 1));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate, END_STR]);
+            });
+
+            it("Will not move past the end boundary when allowSingleDayRange={true}", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        allowSingleDayRange={true}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), END_STR);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [END_STR, END_STR]);
+            });
+
+            it("Will not move past the start boundary", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                const expectedEndDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY + 1));
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, expectedEndDate]);
+            });
+
+            it("Will not move past the start boundary when allowSingleDayRange={true}", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        allowSingleDayRange={true}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getEndInput(root), START_STR);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, START_STR]);
+            });
+
+            it("Will not move past the min date", () => {
+                const minDate = new Date(YEAR, Months.JANUARY, START_DAY - 3);
+                const minDateStr = DATE_FORMAT.formatDate(minDate);
+
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        minDate={minDate}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), minDateStr);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [minDateStr, END_STR]);
+            });
+
+            it("Will not move past the max date", () => {
+                const maxDate = new Date(YEAR, Months.JANUARY, END_DAY + 3);
+                const maxDateStr = DATE_FORMAT.formatDate(maxDate);
+
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        onChange={onChange}
+                        defaultValue={DATE_RANGE}
+                        maxDate={maxDate}
+                        selectAllOnFocus={true}
+                    />,
+                );
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getEndInput(root), maxDateStr);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR, maxDateStr]);
+            });
+
+            it("Will select today's date by default", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} />);
+
+                const today = DATE_FORMAT.formatDate(new Date());
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), today);
+            });
+
+            it("Will choose a reasonable end date when only the start is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[START_DATE, null]} />,
+                );
+
+                const expectedEndDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY + 1));
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowRight" });
+                assertInputValueEquals(getEndInput(root), expectedEndDate);
+            });
+
+            it("Will choose a reasonable start date when only the end is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[null, END_DATE]} />,
+                );
+
+                const expectedEndDate = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, END_DAY - 7));
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getStartInput(root), expectedEndDate);
+            });
+
+            it("Will not make a selection when trying to move backward and only the start is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[START_DATE, null]} />,
+                );
+
+                getEndInput(root).simulate("focus");
+                getEndInput(root).simulate("keydown", { key: "ArrowLeft" });
+                getEndInput(root).simulate("keydown", { key: "ArrowUp" });
+                assertInputValueEquals(getEndInput(root), "");
+                expect(onChange.called).to.be.false;
+            });
+
+            it("Will not make a selection when trying to move forward and only the end is selected", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[null, END_DATE]} />,
+                );
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowRight" });
+                getStartInput(root).simulate("keydown", { key: "ArrowDown" });
+                assertInputValueEquals(getStartInput(root), "");
+                expect(onChange.called).to.be.false;
+            });
+        });
+
+        // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+        describe.skip("Hovering over dates", () => {
+            // define new constants to clarify chronological ordering of dates
+            // TODO: rename all date constants in this file to use a similar
+            // scheme, then get rid of these extra constants
+
+            const HOVER_TEST_DAY_1 = 5;
+            const HOVER_TEST_DAY_2 = 10;
+            const HOVER_TEST_DAY_3 = 15;
+            const HOVER_TEST_DAY_4 = 20;
+            const HOVER_TEST_DAY_5 = 25;
+
+            const HOVER_TEST_DATE_1 = new Date(2022, Months.JANUARY, HOVER_TEST_DAY_1);
+            const HOVER_TEST_DATE_2 = new Date(2022, Months.JANUARY, HOVER_TEST_DAY_2);
+            const HOVER_TEST_DATE_3 = new Date(2022, Months.JANUARY, HOVER_TEST_DAY_3);
+            const HOVER_TEST_DATE_4 = new Date(2022, Months.JANUARY, HOVER_TEST_DAY_4);
+            const HOVER_TEST_DATE_5 = new Date(2022, Months.JANUARY, HOVER_TEST_DAY_5);
+
+            const HOVER_TEST_STR_1 = DATE_FORMAT.formatDate(HOVER_TEST_DATE_1);
+            const HOVER_TEST_STR_2 = DATE_FORMAT.formatDate(HOVER_TEST_DATE_2);
+            const HOVER_TEST_STR_3 = DATE_FORMAT.formatDate(HOVER_TEST_DATE_3);
+            const HOVER_TEST_STR_4 = DATE_FORMAT.formatDate(HOVER_TEST_DATE_4);
+            const HOVER_TEST_STR_5 = DATE_FORMAT.formatDate(HOVER_TEST_DATE_5);
+
+            const HOVER_TEST_DATE_CONFIG_1 = {
+                date: HOVER_TEST_DATE_1,
+                day: HOVER_TEST_DAY_1,
+                str: HOVER_TEST_STR_1,
+            };
+            const HOVER_TEST_DATE_CONFIG_2 = {
+                date: HOVER_TEST_DATE_2,
+                day: HOVER_TEST_DAY_2,
+                str: HOVER_TEST_STR_2,
+            };
+            const HOVER_TEST_DATE_CONFIG_3 = {
+                date: HOVER_TEST_DATE_3,
+                day: HOVER_TEST_DAY_3,
+                str: HOVER_TEST_STR_3,
+            };
+            const HOVER_TEST_DATE_CONFIG_4 = {
+                date: HOVER_TEST_DATE_4,
+                day: HOVER_TEST_DAY_4,
+                str: HOVER_TEST_STR_4,
+            };
+            const HOVER_TEST_DATE_CONFIG_5 = {
+                date: HOVER_TEST_DATE_5,
+                day: HOVER_TEST_DAY_5,
+                str: HOVER_TEST_STR_5,
+            };
+
+            interface HoverTextDateConfig {
+                day: number;
+                date: Date;
+                str: string;
+            }
+
+            let root: WrappedComponentRoot;
+            let getDayElement: (dayNumber?: number, fromLeftMonth?: boolean) => WrappedComponentDayElement;
+
+            before(() => {
+                // reuse the same mounted component for every test to speed
+                // things up (mounting is costly).
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        closeOnSelection={false}
+                        defaultValue={[HOVER_TEST_DATE_2, HOVER_TEST_DATE_4]}
+                    />,
+                );
+
+                root = result.root;
+                getDayElement = result.getDayElement;
+            });
+
+            beforeEach(() => {
+                // need to set wasLastFocusChangeDueToHover=false to fully reset state between tests.
+                React.act(() => {
+                    root.setState({ isOpen: true, wasLastFocusChangeDueToHover: false });
+                });
+                // clear the inputs to start from a fresh state, but do so
+                // *after* opening the popover so that the calendar doesn't
+                // move away from the view we expect for these tests.
+                changeInputText(getStartInput(root), "");
+                changeInputText(getEndInput(root), "");
+            });
+
+            function setSelectedRangeForHoverTest(selectedDateConfigs: NullableRange<HoverTextDateConfig>) {
+                const [startConfig, endConfig] = selectedDateConfigs;
+                changeInputText(getStartInput(root), startConfig == null ? "" : startConfig.str);
+                changeInputText(getEndInput(root), endConfig == null ? "" : endConfig.str);
+            }
+
+            describe("when selected date range is [null, null]", () => {
+                const SELECTED_RANGE: NullableRange<HoverTextDateConfig> = [null, null];
+                const HOVER_TEST_DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
+                describe("if start field is focused", () => {
+                    beforeEach(() => {
+                        getStartInput(root).simulate("focus");
+                        getDayElement(HOVER_TEST_DATE_CONFIG.day).simulate("mouseenter");
+                    });
+
+                    it("shows [<hoveredDate>, null] in input fields", () => {
+                        assertInputValuesEqual(root, HOVER_TEST_DATE_CONFIG.str, "");
+                    });
+
+                    it("keeps focus on start field", () => {
+                        assertStartInputFocused(root);
+                    });
+
+                    describe("on click", () => {
+                        beforeEach(() => {
+                            getDayElement(HOVER_TEST_DATE_CONFIG.day).simulate("click");
+                        });
+
+                        it("sets selection to [<hoveredDate>, null]", () => {
+                            assertInputValuesEqual(root, HOVER_TEST_DATE_CONFIG.str, "");
+                        });
+
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
+                        });
+                    });
+
+                    describe("if mouse moves to no longer be over a calendar day", () => {
+                        beforeEach(() => {
+                            getDayElement(HOVER_TEST_DATE_CONFIG.day).simulate("mouseleave");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputValuesEqual(root, "", "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+                    });
+                });
+
+                describe("if end field is focused", () => {
+                    beforeEach(() => {
+                        getEndInput(root).simulate("focus");
+                        getDayElement(HOVER_TEST_DATE_CONFIG.day).simulate("mouseenter");
+                    });
+
+                    it("shows [null, <hoveredDate>] in input fields", () => {
+                        assertInputValuesEqual(root, "", HOVER_TEST_DATE_CONFIG.str);
+                    });
+
+                    it("keeps focus on end field", () => {
+                        assertEndInputFocused(root);
+                    });
+
+                    describe("on click", () => {
+                        beforeEach(() => {
+                            getDayElement(HOVER_TEST_DATE_CONFIG.day).simulate("click");
+                        });
+
+                        it("sets selection to [null, <hoveredDate>]", () => {
+                            assertInputValuesEqual(root, "", HOVER_TEST_DATE_CONFIG.str);
+                        });
+
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
+                        });
+                    });
+
+                    describe("if mouse moves to no longer be over a calendar day", () => {
+                        beforeEach(() => {
+                            getDayElement(HOVER_TEST_DATE_CONFIG.day).simulate("mouseleave");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputValuesEqual(root, "", "");
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+                    });
+                });
+            });
+
+            describe("when selected date range is [<startDate>, null]", () => {
+                const SELECTED_RANGE: NullableRange<HoverTextDateConfig> = [HOVER_TEST_DATE_CONFIG_2, null];
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
+                describe("if start field is focused", () => {
+                    beforeEach(() => {
+                        getStartInput(root).simulate("focus");
+                    });
+
+                    describe("if <startDate> < <hoveredDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> < <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputValuesEqual(root, "", "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, null]", () => {
+                                assertInputValuesEqual(root, "", "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+                });
+
+                describe("if end field is focused", () => {
+                    beforeEach(() => {
+                        getEndInput(root).simulate("focus");
+                    });
+
+                    describe("if <startDate> < <hoveredDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, <hoveredDate>]", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> < <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <startDate>] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[0]?.str);
+                        });
+
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <startDate>]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[0]?.str);
+                            });
+
+                            it("leaves focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputValuesEqual(root, "", "");
+                        });
+
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, null] on click", () => {
+                                assertInputValuesEqual(root, "", "");
+                            });
+
+                            it("leaves focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, null] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+                });
+            });
+
+            describe("when selected date range is [null, <endDate>]", () => {
+                const SELECTED_RANGE: NullableRange<HoverTextDateConfig> = [null, HOVER_TEST_DATE_CONFIG_4];
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
+                describe("if start field is focused", () => {
+                    beforeEach(() => {
+                        getStartInput(root).simulate("focus");
+                    });
+
+                    describe("if <hoveredDate> < <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <endDate>] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1]?.str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <endDate>]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <endDate> < <hoveredDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<endDate>, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, SELECTED_RANGE[1]?.str, DATE_CONFIG.str);
+                        });
+
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<endDate>, <hoveredDate>] on click", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[1]?.str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("moves focus back to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputValuesEqual(root, "", "");
+                        });
+
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, null] on click", () => {
+                                assertInputValuesEqual(root, "", "");
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+                });
+
+                describe("if end field is focused", () => {
+                    beforeEach(() => {
+                        getEndInput(root).simulate("focus");
+                    });
+
+                    describe("if <hoveredDate> < <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>]", () => {
+                                assertInputValuesEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <endDate> < <hoveredDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>] on click", () => {
+                                assertInputValuesEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, null] in input fields", () => {
+                            assertInputValuesEqual(root, "", "");
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, null] on click", () => {
+                                assertInputValuesEqual(root, "", "");
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [null, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+                });
+            });
+
+            describe("when selected date range is [<startDate>, <endDate>]", () => {
+                const SELECTED_RANGE: NullableRange<HoverTextDateConfig> = [
+                    HOVER_TEST_DATE_CONFIG_2,
+                    HOVER_TEST_DATE_CONFIG_4,
+                ];
+
+                beforeEach(() => {
+                    setSelectedRangeForHoverTest(SELECTED_RANGE);
+                });
+
+                describe("if start field is focused", () => {
+                    beforeEach(() => {
+                        getStartInput(root).simulate("focus");
+                    });
+
+                    describe("if <hoveredDate> < <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <endDate>] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1]?.str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <endDate>]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <startDate> < <hoveredDate> < <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, <endDate>] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1]?.str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, <endDate>]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <endDate> < <hoveredDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<hoveredDate>, null] in input fields", () => {
+                            assertInputValuesEqual(root, DATE_CONFIG.str, "");
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<hoveredDate>, null]", () => {
+                                assertInputValuesEqual(root, DATE_CONFIG.str, "");
+                            });
+
+                            it("moves focus to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, <endDate>] in input fields", () => {
+                            assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                        });
+
+                        it("keeps focus on start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, <endDate>]", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keep focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, null] in input fields", () => {
+                            assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                        });
+
+                        it("moves focus to end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, null]", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("moves focus back to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+                    });
+                });
+
+                describe("if end field is focused", () => {
+                    beforeEach(() => {
+                        getEndInput(root).simulate("focus");
+                    });
+
+                    describe("if <hoveredDate> < <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_1;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, "", DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, <hoveredDate>]", () => {
+                                assertInputValuesEqual(root, "", DATE_CONFIG.str);
+                            });
+
+                            it("moves focus to start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <startDate> < <hoveredDate> < <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_3;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, <hoveredDate>]", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <endDate> < <hoveredDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_5;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, <hoveredDate>] in input fields", () => {
+                            assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, DATE_CONFIG.str);
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, <hoveredDate>]", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, DATE_CONFIG.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <startDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_2;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [null, <endDate>] in input fields", () => {
+                            assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                        });
+
+                        it("moves focus to start field", () => {
+                            assertStartInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [null, <endDate>]", () => {
+                                assertInputValuesEqual(root, "", SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on start field", () => {
+                                assertStartInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("moves focus back to end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+
+                    describe("if <hoveredDate> == <endDate>", () => {
+                        const DATE_CONFIG = HOVER_TEST_DATE_CONFIG_4;
+
+                        beforeEach(() => {
+                            getDayElement(DATE_CONFIG.day).simulate("mouseenter");
+                        });
+
+                        it("shows [<startDate>, null] in input fields", () => {
+                            assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                        });
+
+                        it("keeps focus on end field", () => {
+                            assertEndInputFocused(root);
+                        });
+
+                        describe("on click", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("click");
+                            });
+
+                            it("sets selection to [<startDate>, null]", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, "");
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+
+                        describe("if mouse moves to no longer be over a calendar day", () => {
+                            beforeEach(() => {
+                                getDayElement(DATE_CONFIG.day).simulate("mouseleave");
+                            });
+
+                            it("shows [<startDate>, <endDate>] in input fields", () => {
+                                assertInputValuesEqual(root, SELECTED_RANGE[0]?.str, SELECTED_RANGE[1]?.str);
+                            });
+
+                            it("keeps focus on end field", () => {
+                                assertEndInputFocused(root);
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it("Clearing the date range in the picker invokes onChange with [null, null] and clears the inputs", () => {
+            const onChange = sinon.spy();
+            const defaultValue = [START_DATE, null] as DateRange;
+
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} defaultValue={defaultValue} onChange={onChange} />,
+            );
+
+            getStartInput(root).simulate("focus");
+            getDayElement(START_DAY).simulate("click");
+            assertInputValuesEqual(root, "", "");
+            expect(onChange.called).to.be.true;
+            expect(onChange.calledWith([null, null])).to.be.true;
+        });
+
+        it("Clearing only the start input (e.g.) invokes onChange with [null, <endDate>]", () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={DATE_RANGE} />);
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+            changeInputText(startInput, "");
+            expect(onChange.called).to.be.true;
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
+            assertInputValuesEqual(root, "", END_STR);
+        });
+
+        it("Clearing the dates in both inputs invokes onChange with [null, null] and leaves the inputs empty", () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} defaultValue={[START_DATE, null]} />,
+            );
+            getStartInput(root).simulate("focus");
+            changeStartInputText(root, "");
+            expect(onChange.called).to.be.true;
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
+            assertInputValuesEqual(root, "", "");
+        });
+    });
+
+    describe("when controlled", () => {
+        it("Setting value causes defaultValue to be ignored", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} defaultValue={DATE_RANGE_2} value={DATE_RANGE} />);
+            assertInputValuesEqual(root, START_STR, END_STR);
+        });
+
+        it("Setting value to [undefined, undefined] shows empty fields", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[null, null]} />);
+            assertInputValuesEqual(root, "", "");
+        });
+
+        it("Setting value to [null, null] shows empty fields", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[null, null]} />);
+            assertInputValuesEqual(root, "", "");
+        });
+
+        it("Shows empty start field and formatted date in end field when value is [null, <date>]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[null, END_DATE]} />);
+            assertInputValuesEqual(root, "", END_STR);
+        });
+
+        it("Shows empty end field and formatted date in start field when value is [<date>, null]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[START_DATE, null]} />);
+            assertInputValuesEqual(root, START_STR, "");
+        });
+
+        it("Shows formatted dates in both fields when value is [<date1>, <date2>]", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[START_DATE, END_DATE]} />);
+            assertInputValuesEqual(root, START_STR, END_STR);
+        });
+
+        it("Updating value changes the text accordingly in both fields", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={DATE_RANGE} />);
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+            root.update();
+            root.setProps({ value: DATE_RANGE_2 }).update();
+            assertInputValuesEqual(root, START_STR_2, END_STR_2);
+        });
+
+        // HACKHACK: https://github.com/palantir/blueprint/issues/6109
+        // N.B. this test passes locally
+        it.skip("Pressing Enter saves the inputted date and closes the popover", () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={[null, null]} />);
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+            startInput.simulate("change", { target: { value: START_STR } });
+            startInput.simulate("keydown", { key: "Enter" });
+            expect(isStartInputFocused(root), "start input blurred next").to.be.false;
+
+            expect(root.state("isOpen"), "popover still open").to.be.true;
+
+            const endInput = getEndInput(root);
+            expect(isEndInputFocused(root), "end input focused next").to.be.true;
+            endInput.simulate("change", { target: { value: END_STR } });
+            endInput.simulate("keydown", { key: "Enter" });
+
+            expect(isStartInputFocused(root), "start input blurred at end").to.be.false;
+            expect(isEndInputFocused(root), "end input still focused at end").to.be.true;
+
+            // onChange is called once on change, once on Enter
+            expect(onChange.callCount, "onChange called four times").to.equal(4);
+            // check one of the invocations
+            assertDateRangesEqual(onChange.args[1][0], [START_STR, null]);
+        });
+
+        it("pressing Escape closes the popover", () => {
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} value={[null, null]} />);
+            React.act(() => {
+                root.setState({ isOpen: true });
+            });
+
+            const startInput = getStartInput(root);
+            startInput.simulate("focus");
+
+            expect(root.state("isOpen")).to.be.true;
+
+            startInput.simulate("keydown", { key: "Escape" });
+
+            expect(root.state("isOpen")).to.be.false;
+            expect(isStartInputFocused(root)).to.be.false;
+        });
+
+        it("Clicking a date invokes onChange with the new date range and updates the input field text", () => {
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} value={DATE_RANGE} onChange={onChange} />,
+            );
+            getStartInput(root).simulate("focus"); // to open popover
+            getDayElement(START_DAY).simulate("click");
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
+            assertInputValuesEqual(root, "", END_STR);
+            expect(onChange.callCount).to.equal(1);
+        });
+
+        it("Typing a valid start or end date invokes onChange with the new date range but doesn't change UI", () => {
+            const onChange = sinon.spy();
+            const { root } = wrap(<DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={DATE_RANGE} />);
+
+            changeStartInputText(root, START_STR_2);
+            expect(onChange.callCount).to.equal(1);
+            assertDateRangesEqual(onChange.getCall(0).args[0], [START_STR_2, END_STR]);
+            assertInputValuesEqual(root, START_STR, END_STR);
+
+            // since the component is controlled, value changes don't persist across onChanges
+            changeEndInputText(root, END_STR_2);
+            expect(onChange.callCount).to.equal(2);
+            assertDateRangesEqual(onChange.getCall(1).args[0], [START_STR, END_STR_2]);
+            assertInputValuesEqual(root, START_STR, END_STR);
+        });
+
+        it("Clicking a start date causes focus to move to end field", () => {
+            // eslint-disable-next-line prefer-const
+            let controlledRoot: WrappedComponentRoot;
+
+            const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={[null, null]} />,
+            );
+            controlledRoot = root;
+
+            getStartInput(controlledRoot).simulate("focus");
+            getDayElement(1).simulate("click"); // triggers a controlled value change
+            assertEndInputFocused(controlledRoot);
+        });
+
+        it("Typing in a field while hovering over a date shows the typed date, not the hovered date", () => {
+            // eslint-disable-next-line prefer-const
+            let controlledRoot: WrappedComponentRoot;
+
+            const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={[null, null]} />,
+            );
+            controlledRoot = root;
+
+            getStartInput(root).simulate("focus");
+            getDayElement(1).simulate("mouseenter");
+            changeStartInputText(root, START_STR_2);
+            assertInputValuesEqual(root, START_STR_2, "");
+        });
+
+        // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+        describe.skip("Typing an out-of-range date", () => {
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        minDate={OUT_OF_RANGE_TEST_MIN}
+                        maxDate={OUT_OF_RANGE_TEST_MAX}
+                        onChange={onChange}
+                        onError={onError}
+                        outOfRangeMessage={OUT_OF_RANGE_MESSAGE}
+                        value={[null, null]}
+                    />,
+                );
+                root = result.root;
+            });
+
+            describe("calls onError with invalid date on blur", () => {
+                runTestForEachScenario((inputGetterFn, inputString, boundary) => {
+                    const expectedRange: DateStringRange =
+                        boundary === Boundary.START ? [inputString, null] : [null, inputString];
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), inputString);
+                    expect(onError.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], expectedRange);
+                });
+            });
+
+            describe("does NOT call onChange before OR after blur", () => {
+                runTestForEachScenario((inputGetterFn, inputString) => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), inputString);
+                    expect(onChange.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+            });
+
+            function runTestForEachScenario(runTestFn: OutOfRangeTestFunction) {
+                const { START, END } = Boundary;
+                it("if start < minDate", () => runTestFn(getStartInput, OUT_OF_RANGE_START_STR, START));
+                it("if start > maxDate", () => runTestFn(getStartInput, OUT_OF_RANGE_END_STR, START));
+                it("if end < minDate", () => runTestFn(getEndInput, OUT_OF_RANGE_START_STR, END));
+                it("if end > maxDate", () => runTestFn(getEndInput, OUT_OF_RANGE_END_STR, END));
+            }
+        });
+
+        describe("Typing an invalid date", () => {
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        invalidDateMessage={INVALID_MESSAGE}
+                        onError={onError}
+                        value={DATE_RANGE}
+                    />,
+                );
+                root = result.root;
+
+                changeStartInputText(root, "");
+                changeEndInputText(root, "");
+                root.setProps({ onChange });
+            });
+
+            // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+            describe.skip("calls onError on blur with Date(undefined) in place of the invalid date", () => {
+                runTestForEachScenario((inputGetterFn, boundary) => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    expect(onError.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+
+                    const dateRange = onError.getCall(0).args[0];
+                    const dateIndex = boundary === Boundary.START ? 0 : 1;
+                    expect((dateRange[dateIndex] as Date).valueOf()).to.be.NaN;
+                });
+            });
+
+            describe("does NOT call onChange before OR after blur", () => {
+                runTestForEachScenario(inputGetterFn => {
+                    inputGetterFn(root).simulate("focus");
+                    changeInputText(inputGetterFn(root), INVALID_STR);
+                    expect(onChange.called).to.be.false;
+                    inputGetterFn(root).simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+            });
+
+            function runTestForEachScenario(runTestFn: InvalidDateTestFunction) {
+                it("in start field", () => runTestFn(getStartInput, Boundary.START, getEndInput));
+                it("in end field", () => runTestFn(getEndInput, Boundary.END, getStartInput));
+            }
+        });
+
+        // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+        describe.skip("Typing an overlapping date", () => {
+            let onChange: sinon.SinonSpy;
+            let onError: sinon.SinonSpy;
+            let root: WrappedComponentRoot;
+            let startInput: WrappedComponentInput;
+            let endInput: WrappedComponentInput;
+
+            beforeEach(() => {
+                onChange = sinon.spy();
+                onError = sinon.spy();
+
+                const result = wrap(
+                    <DateRangeInput3
+                        {...DATE_FORMAT}
+                        overlappingDatesMessage={OVERLAPPING_DATES_MESSAGE}
+                        onChange={onChange}
+                        onError={onError}
+                        value={DATE_RANGE}
+                    />,
+                );
+                root = result.root;
+
+                startInput = getStartInput(root);
+                endInput = getEndInput(root);
+            });
+
+            describe("in the start field", () => {
+                it("calls onError with [<overlappingDate>, <endDate] on blur", () => {
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    expect(onError.called).to.be.false;
+                    startInput.simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], [OVERLAPPING_START_STR, END_STR]);
+                });
+
+                it("does NOT call onChange before OR after blur", () => {
+                    startInput.simulate("focus");
+                    changeInputText(startInput, OVERLAPPING_START_STR);
+                    expect(onChange.called).to.be.false;
+                    startInput.simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+            });
+
+            describe("in the end field", () => {
+                it("calls onError with [<startDate>, <overlappingDate>] on blur", () => {
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    expect(onError.called).to.be.false;
+                    endInput.simulate("blur");
+                    expect(onError.calledOnce).to.be.true;
+                    assertDateRangesEqual(onError.getCall(0).args[0], [START_STR, OVERLAPPING_END_STR]);
+                });
+
+                it("does NOT call onChange before OR after blur", () => {
+                    endInput.simulate("focus");
+                    changeInputText(endInput, OVERLAPPING_END_STR);
+                    expect(onChange.called).to.be.false;
+                    endInput.simulate("blur");
+                    expect(onChange.called).to.be.false;
+                });
+            });
+        });
+
+        describe("Arrow key navigation", () => {
+            it("Pressing the left arrow key moves the date back by a day", () => {
+                const onChange = sinon.spy();
+                const { root } = wrap(
+                    <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={DATE_RANGE} selectAllOnFocus={true} />,
+                );
+
+                const expectedStartDate1 = DATE_FORMAT.formatDate(new Date(YEAR, Months.JANUARY, START_DAY - 1));
+
+                getStartInput(root).simulate("focus");
+                getStartInput(root).simulate("keydown", { key: "ArrowLeft" });
+                assertInputValueEquals(getStartInput(root), expectedStartDate1);
+                assertDateRangesEqual(onChange.getCall(0).args[0], [expectedStartDate1, END_STR]);
+            });
+        });
+
+        it("Clearing the dates in the picker invokes onChange with [null, null] and updates input fields", () => {
+            const onChange = sinon.spy();
+            const value = [START_DATE, null] as DateRange;
+
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} value={value} onChange={onChange} />,
+            );
+
+            // popover opens on focus
+            getStartInput(root).simulate("focus");
+            getDayElement(START_DAY).simulate("click");
+
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
+            assertInputValuesEqual(root, "", "");
+        });
+
+        it(`Clearing only the start input (e.g.) invokes onChange with [null, <endDate>], doesn't clear the\
+            selected dates, and repopulates the controlled values in the inputs on blur`, () => {
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={DATE_RANGE} />,
+            );
+
+            const startInput = getStartInput(root);
+
+            startInput.simulate("focus");
+            changeInputText(startInput, "");
+            expect(onChange.calledOnce).to.be.true;
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, END_STR]);
+            assertInputValuesEqual(root, "", END_STR);
+
+            // start day should still be selected in the calendar, ignoring user's typing
+            expect(getDayElement(START_DAY).hasClass(Classes.DATEPICKER3_DAY_SELECTED)).to.be.true;
+
+            // blurring should put the controlled start date back in the start input, overriding user's typing
+            startInput.simulate("blur");
+            assertInputValuesEqual(root, START_STR, END_STR);
+        });
+
+        it(`Clearing the inputs invokes onChange with [null, null], doesn't clear the selected dates, and\
+            repopulates the controlled values in the inputs on blur`, () => {
+            const onChange = sinon.spy();
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3 {...DATE_FORMAT} onChange={onChange} value={[START_DATE, null]} />,
+            );
+
+            const startInput = getStartInput(root);
+
+            startInput.simulate("focus");
+            changeInputText(startInput, "");
+            expect(onChange.calledOnce).to.be.true;
+            assertDateRangesEqual(onChange.getCall(0).args[0], [null, null]);
+            assertInputValuesEqual(root, "", "");
+
+            expect(getDayElement(START_DAY).hasClass(Classes.DATEPICKER3_DAY_SELECTED)).to.be.true;
+
+            startInput.simulate("blur");
+            assertInputValuesEqual(root, START_STR, "");
+        });
+
+        // Regression test for https://github.com/palantir/blueprint/issues/5791
+        it("Hovering and clicking on end date shows the new date in input, not a previously selected date", () => {
+            const DEC_1_DATE = new Date(2022, 11, 1);
+            const DEC_1_STR = DATE_FORMAT.formatDate(DEC_1_DATE);
+            const DEC_2_DATE = new Date(2022, 11, 2);
+            const DEC_2_STR = DATE_FORMAT.formatDate(DEC_2_DATE);
+            const DEC_6_DATE = new Date(2022, 11, 6);
+            const DEC_6_STR = DATE_FORMAT.formatDate(DEC_6_DATE);
+            const DEC_8_DATE = new Date(2022, 11, 8);
+            const DEC_8_STR = DATE_FORMAT.formatDate(DEC_8_DATE);
+
+            // eslint-disable-next-line prefer-const
+            let controlledRoot: WrappedComponentRoot;
+
+            const onChange = (nextValue: DateRange) => controlledRoot.setProps({ value: nextValue });
+            const { root, getDayElement } = wrap(
+                <DateRangeInput3
+                    {...DATE_FORMAT}
+                    closeOnSelection={false}
+                    popoverProps={{ isOpen: true }}
+                    onChange={onChange}
+                    value={[DEC_6_DATE, DEC_8_DATE]}
+                />,
+                true,
+            );
+            controlledRoot = root;
+
+            // initial state
+            getStartInput(root).simulate("focus");
+            assertInputValuesEqual(root, DEC_6_STR, DEC_8_STR);
+
+            // hover over Dec 1
+            getDayElement(1).simulate("mouseenter");
+            assertInputValuesEqual(root, DEC_1_STR, DEC_8_STR);
+
+            // click to select Dec 1
+            getDayElement(1).simulate("click");
+            getDayElement(1).simulate("mouseleave");
+            assertInputValuesEqual(root, DEC_1_STR, DEC_8_STR);
+
+            // re-focus on start input to ensure the component doesn't think we're changing the end boundary
+            // (this mimics real UX, where the component-refocuses the start input after selecting a start date)
+            getStartInput(root).simulate("focus");
+
+            // hover over Dec 2
+            getDayElement(2).simulate("mouseenter");
+            assertInputValuesEqual(root, DEC_2_STR, DEC_8_STR);
+
+            // click to select Dec 2
+            getDayElement(2).simulate("click");
+            getDayElement(2).simulate("mouseleave");
+            assertInputValuesEqual(root, DEC_2_STR, DEC_8_STR);
+        });
+
+        describe("localization", () => {
+            describe("with formatDate & parseDate undefined", () => {
+                it("formats date strings with provided Locale object", () => {
+                    const { root } = wrap(
+                        <DateRangeInput3 dateFnsFormat="PPP" locale={esLocale} value={DATE_RANGE_2} />,
+                        true,
+                    );
+                    assertInputValuesEqual(root, START_STR_2_ES_LOCALE, END_STR_2_ES_LOCALE);
+                });
+
+                // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
+                it.skip("formats date strings with async-loaded locale corresponding to provided locale code", done => {
+                    const { root } = wrap(
+                        <DateRangeInput3 dateFnsFormat="PPP" locale="es" value={DATE_RANGE_2} />,
+                        true,
+                    );
+                    // give the component one animation frame to load the locale upon mount
+                    setTimeout(() => {
+                        root.update();
+                        assertInputValuesEqual(root, START_STR_2_ES_LOCALE, END_STR_2_ES_LOCALE);
+                        done();
+                    });
+                });
+            });
+        });
+    });
+
+    function getStartInput(root: WrappedComponentRoot): WrappedComponentInput {
+        return root.find(InputGroup).first().find("input") as WrappedComponentInput;
+    }
+
+    function getEndInput(root: WrappedComponentRoot): WrappedComponentInput {
+        return root.find(InputGroup).last().find("input") as WrappedComponentInput;
+    }
+
+    function getInputPlaceholderText(input: WrappedComponentInput) {
+        return input.prop("placeholder");
+    }
+
+    function isStartInputFocused(root: WrappedComponentRoot) {
+        // TODO: find a more elegant way to do this; reaching into component state is gross.
+        return root.state("isStartInputFocused");
+    }
+
+    function isEndInputFocused(root: WrappedComponentRoot) {
+        // TODO: find a more elegant way to do this; reaching into component state is gross.
+        return root.state("isEndInputFocused");
+    }
+
+    function changeStartInputText(root: WrappedComponentRoot, value: string) {
+        changeInputText(getStartInput(root), value);
+    }
+
+    function changeEndInputText(root: WrappedComponentRoot, value: string) {
+        changeInputText(getEndInput(root), value);
+    }
+
+    function changeInputText(input: WrappedComponentInput, value: string) {
+        input.simulate("change", { target: { value } });
+    }
+
+    function assertStartInputFocused(root: WrappedComponentRoot) {
+        expect(isStartInputFocused(root)).to.be.true;
+    }
+
+    function assertEndInputFocused(root: WrappedComponentRoot) {
+        expect(isEndInputFocused(root)).to.be.true;
+    }
+
+    function assertInputValuesEqual(
+        root: WrappedComponentRoot,
+        startInputValue: string | undefined,
+        endInputValue: string | undefined,
+    ) {
+        assertInputValueEquals(getStartInput(root), startInputValue);
+        assertInputValueEquals(getEndInput(root), endInputValue);
+    }
+
+    function assertInputValueEquals(input: WrappedComponentInput, inputValue: string | undefined) {
+        expect(input.closest(InputGroup).prop("value")).to.equal(inputValue);
+    }
+
+    function assertDateRangesEqual(actual: DateRange, expected: DateStringRange) {
+        const [expectedStart, expectedEnd] = expected;
+        const [actualStart, actualEnd] = actual.map((date: Date | null) => {
+            if (date == null) {
+                return null;
+            } else if (isNaN(date.valueOf())) {
+                return UNDEFINED_DATE_STR;
+            } else {
+                return DATE_FORMAT.formatDate(date);
+            }
+        });
+        expect(actualStart).to.equal(expectedStart);
+        expect(actualEnd).to.equal(expectedEnd);
+    }
+
+    function wrap(dateRangeInput: React.JSX.Element, attachToDOM = false) {
+        const mountOptions = attachToDOM ? { attachTo: containerElement } : undefined;
+        const wrapper = mount(dateRangeInput, mountOptions);
+        return {
+            getDayElement: (dayNumber = 1, fromLeftMonth = true) => {
+                const monthElement = wrapper.find(`.${ReactDayPickerClasses.RDP_MONTH}`).at(fromLeftMonth ? 0 : 1);
+                const dayElements = monthElement.find(`.${Classes.DATEPICKER3_DAY}`);
+                return dayElements
+                    .filterWhere(d => d.text() === dayNumber.toString() && !d.hasClass(Classes.DATEPICKER3_DAY_OUTSIDE))
+                    .hostNodes();
+            },
+            root: wrapper,
+        };
+    }
+});
+
+function getDateFnsFormatter(formatStr: string): DateFormatProps {
+    return {
+        formatDate: (date, localeCode) => format(date, formatStr, maybeGetDateFnsLocaleOptions(localeCode)),
+        parseDate: (str, localeCode) => parse(str, formatStr, new Date(), maybeGetDateFnsLocaleOptions(localeCode)),
+        placeholder: `${formatStr}`,
+    };
+}
+
+const AllLocales: Record<string, Locale> = Locales;
+
+function maybeGetDateFnsLocaleOptions(localeCode: string | undefined): { locale: Locale } | undefined {
+    if (localeCode !== undefined && AllLocales[localeCode] !== undefined) {
+        return { locale: AllLocales[localeCode] };
+    }
+    return undefined;
+}

--- a/packages/datetime/test/components/dateRangePicker3Tests.tsx
+++ b/packages/datetime/test/components/dateRangePicker3Tests.tsx
@@ -1,0 +1,1505 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from "chai";
+import { addDays, format, parse } from "date-fns";
+import enUSLocale from "date-fns/locale/en-US";
+import { mount, type ReactWrapper } from "enzyme";
+import * as React from "react";
+import { type DayModifiers, DayPicker, type ModifiersClassNames } from "react-day-picker-8";
+import sinon from "sinon";
+
+import { Button, Classes as CoreClasses, Menu, MenuItem } from "@blueprintjs/core";
+
+import {
+    Classes,
+    DatePickerShortcutMenu,
+    type DateRange,
+    type DateRangeShortcut,
+    DateUtils,
+    Errors,
+    MonthAndYear,
+    Months,
+    type NonNullDateRange,
+    TimePicker,
+    type TimePrecision,
+} from "../../src";
+import { ReactDayPickerClasses } from "../../src/common/classes";
+import { DateRangePicker3, type DateRangePicker3Props } from "../../src/components/date-range-picker3/dateRangePicker3";
+import type { DateRangePicker3State } from "../../src/components/date-range-picker3/dateRangePicker3State";
+import { assertDayDisabled } from "../common/dayPicker8TestUtils";
+import { loadDateFnsLocaleFake } from "../common/loadDateFnsLocaleFake";
+
+// Change the default for testability
+(DateRangePicker3.defaultProps as DateRangePicker3Props).dateFnsLocaleLoader = loadDateFnsLocaleFake;
+
+describe("<DateRangePicker3>", () => {
+    let testsContainerElement: HTMLElement;
+    let drpWrapper: ReactWrapper<DateRangePicker3Props, DateRangePicker3State>;
+
+    let onChangeSpy: sinon.SinonSpy;
+    let onHoverChangeSpy: sinon.SinonSpy;
+
+    beforeEach(() => {
+        testsContainerElement = document.createElement("div");
+        document.body.appendChild(testsContainerElement);
+    });
+
+    afterEach(() => {
+        drpWrapper?.unmount();
+        drpWrapper?.detach();
+        testsContainerElement.remove();
+    });
+
+    it("renders its template", () => {
+        const { wrapper } = render();
+        assert.isTrue(wrapper.find(`.${Classes.DATERANGEPICKER}`).exists());
+    });
+
+    it("no days are selected by default", () => {
+        const { wrapper, assertSelectedDays } = render();
+        assert.deepEqual(wrapper.state("value"), [null, null]);
+        assertSelectedDays();
+    });
+
+    it("user-provided modifiers are applied", () => {
+        const modifiers: DayModifiers = { odd: (d: Date) => d.getDate() % 2 === 1 };
+        const modifiersClassNames: ModifiersClassNames = {
+            odd: "test-odd",
+        };
+        const { left } = render({ dayPickerProps: { modifiers, modifiersClassNames } });
+        assert.isFalse(left.findDay(4).hasClass(modifiersClassNames.odd));
+        assert.isTrue(left.findDay(5).hasClass(modifiersClassNames.odd));
+    });
+
+    describe("reconciliates dayPickerProps", () => {
+        it("hides unnecessary nav buttons in contiguous months mode", () => {
+            const defaultValue: DateRange = [new Date(2017, Months.SEPTEMBER, 1), null];
+            const { wrapper } = wrap(<DateRangePicker3 defaultValue={defaultValue} />);
+            assert.isFalse(wrapper.find(".rdp-month").at(0).find(`.${Classes.DATEPICKER3_NAV_BUTTON_NEXT}`).exists());
+            assert.isFalse(
+                wrapper.find(".rdp-month").at(1).find(`.${Classes.DATEPICKER3_NAV_BUTTON_PREVIOUS}`).exists(),
+            );
+        });
+
+        it("disables days according to custom modifiers in addition to default modifiers", () => {
+            const disableFridays = { dayOfWeek: [5] };
+            const defaultValue: DateRange = [new Date(2017, Months.SEPTEMBER, 1), null];
+            const maxDate = new Date(2017, Months.OCTOBER, 20);
+
+            const { left, right } = wrap(
+                <DateRangePicker3
+                    dayPickerProps={{ disabled: disableFridays }}
+                    defaultValue={defaultValue}
+                    maxDate={maxDate}
+                />,
+            );
+
+            assertDayDisabled(left.findDay(15));
+            assertDayDisabled(right.findDay(21));
+            assertDayDisabled(left.findDay(10), false);
+        });
+
+        it("disables out-of-range max dates", () => {
+            const { right } = wrap(
+                <DateRangePicker3
+                    initialMonth={new Date(2017, Months.AUGUST, 1)}
+                    maxDate={new Date(2017, Months.SEPTEMBER, 20)}
+                />,
+            );
+            assertDayDisabled(right.findDay(21));
+            assertDayDisabled(right.findDay(10), false);
+        });
+
+        it("disables out-of-range min dates", () => {
+            const { left } = wrap(
+                <DateRangePicker3
+                    initialMonth={new Date(2017, Months.AUGUST, 1)}
+                    minDate={new Date(2017, Months.AUGUST, 20)}
+                />,
+            );
+            assertDayDisabled(left.findDay(10));
+            assertDayDisabled(left.findDay(21), false);
+        });
+
+        describe("event handlers", () => {
+            // use a date that lets us navigate forward and backward in the same year
+            const defaultValue = [new Date(2017, Months.SEPTEMBER, 1), null] as DateRange;
+
+            it("calls onMonthChange on button next click", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                ).clickNavButton("next", 1);
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                ).clickNavButton("previous");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button next click of left calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3
+                        defaultValue={defaultValue}
+                        contiguousCalendarMonths={false}
+                        dayPickerProps={{ onMonthChange }}
+                    />,
+                ).clickNavButton("next");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click of left calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3
+                        defaultValue={defaultValue}
+                        contiguousCalendarMonths={false}
+                        dayPickerProps={{ onMonthChange }}
+                    />,
+                ).clickNavButton("previous");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button next click of right calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3
+                        defaultValue={defaultValue}
+                        contiguousCalendarMonths={false}
+                        dayPickerProps={{ onMonthChange }}
+                    />,
+                ).clickNavButton("next", 1);
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on button prev click of right calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3
+                        defaultValue={defaultValue}
+                        contiguousCalendarMonths={false}
+                        dayPickerProps={{ onMonthChange }}
+                    />,
+                ).clickNavButton("previous", 1);
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on month select change in left calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                ).left.monthSelect.simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on month select change in right calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                ).right.monthSelect.simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on year select change in left calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                ).left.monthSelect.simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onMonthChange on year select change in right calendar", () => {
+                const onMonthChange = sinon.spy();
+                wrap(
+                    <DateRangePicker3 defaultValue={defaultValue} dayPickerProps={{ onMonthChange }} />,
+                ).right.monthSelect.simulate("change");
+                assert.isTrue(onMonthChange.called);
+            });
+
+            it("calls onDayMouseEnter", () => {
+                const onDayMouseEnter = sinon.spy();
+                render({ dayPickerProps: { onDayMouseEnter }, defaultValue }).left.mouseEnterDay(14);
+                assert.isTrue(onDayMouseEnter.called);
+            });
+
+            it("calls onDayMouseLeave", () => {
+                const onDayMouseLeave = sinon.spy();
+                render({ dayPickerProps: { onDayMouseLeave }, defaultValue })
+                    .left.mouseEnterDay(14)
+                    .findDay(14)
+                    .simulate("mouseleave");
+                assert.isTrue(onDayMouseLeave.called);
+            });
+
+            it("calls onDayClick", () => {
+                const onDayClick = sinon.spy();
+                render({ dayPickerProps: { onDayClick }, defaultValue }).left.clickDay(14);
+                assert.isTrue(onDayClick.called);
+            });
+        });
+
+        describe("for i18n", () => {
+            // regression test for https://github.com/palantir/blueprint/issues/6489
+            it("DatePicker3Caption accepts custom month name formatters (contiguousCalendarMonths={false})", () => {
+                const CUSTOM_MONTH_NAMES = [
+                    "First",
+                    "Second",
+                    "Third",
+                    "Fourth",
+                    "Fifth",
+                    "Sixth",
+                    "Seventh",
+                    "Eighth",
+                    "Ninth",
+                    "Tenth",
+                    "Eleventh",
+                    "Twelfth",
+                ];
+                const formatters = {
+                    formatMonthCaption: (d: Date) => CUSTOM_MONTH_NAMES[d.getMonth()],
+                };
+                // try a month which is not January to make sure we're actually setting a value in the <select>
+                // and not just displaying the default value which is the first option
+                const initialMonthIndex = Months.AUGUST;
+                const initialMonth = new Date(2023, initialMonthIndex, 1);
+                const { left } = wrap(
+                    <DateRangePicker3
+                        initialMonth={initialMonth}
+                        contiguousCalendarMonths={false}
+                        dayPickerProps={{ formatters }}
+                    />,
+                );
+                const leftMonth = left.monthSelect.getDOMNode<HTMLSelectElement>();
+                assert.strictEqual(leftMonth.selectedIndex, initialMonthIndex);
+                for (const option of Array.from(leftMonth.options)) {
+                    assert.strictEqual(option.text, CUSTOM_MONTH_NAMES[option.index]);
+                }
+            });
+        });
+    });
+
+    describe("initially displayed month", () => {
+        it("is initialMonth if set", () => {
+            const defaultValue = [new Date(2007, Months.APRIL, 4), null] as DateRange;
+            const initialMonth = new Date(2002, Months.MARCH, 1);
+            const maxDate = new Date(2030, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const { left } = render({ defaultValue, initialMonth, maxDate, minDate });
+            left.assertDisplayMonth(Months.MARCH, 2002);
+        });
+
+        it("is defaultValue if set and initialMonth not set", () => {
+            const defaultValue = [new Date(2007, Months.APRIL, 4), null] as DateRange;
+            const maxDate = new Date(2030, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const { left } = render({ defaultValue, maxDate, minDate });
+            left.assertDisplayMonth(Months.APRIL, 2007);
+        });
+
+        it("is value if set and initialMonth not set", () => {
+            const maxDate = new Date(2030, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const value = [new Date(2007, Months.APRIL, 4), null] as DateRange;
+            const { left } = render({ maxDate, minDate, value });
+            left.assertDisplayMonth(Months.APRIL, 2007);
+        });
+
+        it("has correct initial month on singleMonthOnly and maxDate == initialMonth", () => {
+            const maxDate = new Date(2019, Months.MAY, 6);
+            const minDate = new Date(2019, Months.MARCH, 3);
+            const initialMonth = maxDate;
+            const { left } = render({ initialMonth, maxDate, minDate, singleMonthOnly: true });
+            left.assertDisplayMonth(Months.MAY, 2019);
+        });
+
+        it("is (endDate - 1 month) if only endDate is set", () => {
+            const value = [null, new Date(2007, Months.APRIL, 4)] as DateRange;
+            const { left } = render({ value });
+            left.assertDisplayMonth(Months.MARCH, 2007);
+        });
+
+        it("is endDate if only endDate is set and endDate === minDate month", () => {
+            const minDate = new Date(2007, Months.APRIL);
+            const value = [null, new Date(2007, Months.APRIL, 4)] as DateRange;
+            const { left } = render({ minDate, value });
+            left.assertDisplayMonth(Months.APRIL, 2007);
+        });
+
+        it("is today if only maxDate/minDate set and today is in date range", () => {
+            const maxDate = new Date(2030, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const today = new Date();
+            const { left } = render({ maxDate, minDate });
+            left.assertDisplayMonth(today.getMonth(), today.getFullYear());
+        });
+
+        it("is a day between minDate and maxDate if only maxDate/minDate set and today is not in range", () => {
+            const maxDate = new Date(2005, Months.JANUARY);
+            const minDate = new Date(2000, Months.JANUARY);
+            const { left } = render({ maxDate, minDate });
+            assert.isTrue(DateUtils.isDayInRange(left.displayMonthAndYear.getFullDate(), [minDate, maxDate]));
+        });
+
+        it("is initialMonth - 1 if initialMonth === maxDate month", () => {
+            const MAX_YEAR = 2016;
+
+            const initialMonth = new Date(MAX_YEAR, Months.DECEMBER, 1);
+            const maxDate = new Date(MAX_YEAR, Months.DECEMBER, 31);
+            const minDate = new Date(2000, 0);
+
+            const { left } = render({ initialMonth, maxDate, minDate });
+            left.assertDisplayMonth(Months.NOVEMBER, MAX_YEAR);
+        });
+
+        it("is value - 1 if set and initialMonth not set and value month === maxDate month", () => {
+            const value = [new Date(2017, Months.OCTOBER, 4), null] as DateRange;
+            const maxDate = new Date(2017, Months.OCTOBER, 15);
+
+            const { left } = render({ maxDate, value });
+            left.assertDisplayMonth(Months.SEPTEMBER, 2017);
+        });
+
+        it("is initialMonth if initialMonth === minDate month and initialMonth === maxDate month", () => {
+            const YEAR = 2016;
+
+            const initialMonth = new Date(YEAR, Months.DECEMBER, 11);
+            const maxDate = new Date(YEAR, Months.DECEMBER, 15);
+            const minDate = new Date(YEAR, Months.DECEMBER, 1);
+
+            const { left } = render({ initialMonth, maxDate, minDate });
+            left.assertDisplayMonth(Months.DECEMBER, YEAR);
+        });
+
+        it("right calendar shows the month immediately after the left view by default", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.JULY, 5);
+            const { right } = render({ value: [startDate, endDate] });
+            right.assertDisplayMonth(Months.JUNE, 2017);
+        });
+    });
+
+    describe("left/right calendar", () => {
+        function assertSelectOptionBounds(monthSelect: ReactWrapper, first: Months, last: Months) {
+            const options = monthSelect.find("option");
+            const expectedFirstOption = renderMonthName(first);
+            const expectedLastOption = renderMonthName(last);
+            assert.equal(options.first().text(), expectedFirstOption, "First option in dropdown");
+            assert.equal(options.last().text(), expectedLastOption, "Last option in dropdown");
+        }
+
+        it("only shows one calendar when minDate and maxDate are in the same month", () => {
+            const minDate = new Date(2015, Months.DECEMBER, 1);
+            const maxDate = new Date(2015, Months.DECEMBER, 15);
+            const { wrapper, right } = render({
+                contiguousCalendarMonths: false,
+                maxDate,
+                minDate,
+            });
+            assert.isFalse(right.wrapper.exists());
+            // nav buttons are disabled
+            assert.isTrue(wrapper.find(Button).every({ disabled: true }));
+        });
+
+        it("only shows one calendar when singleMonthOnly is set", () => {
+            const { right } = render({ singleMonthOnly: true });
+            assert.isFalse(right.wrapper.exists());
+        });
+
+        it("left calendar is bound between minDate and (maxDate - 1 month)", () => {
+            const minDate = new Date(2015, Months.JANUARY, 1);
+            const maxDate = new Date(2015, Months.DECEMBER, 15);
+            const { monthSelect } = render({
+                contiguousCalendarMonths: false,
+                maxDate,
+                minDate,
+            }).left;
+            assertSelectOptionBounds(monthSelect, Months.JANUARY, Months.NOVEMBER);
+        });
+
+        it("right calendar is bound between (minDate + 1 month) and maxDate", () => {
+            const minDate = new Date(2015, Months.JANUARY, 1);
+            const maxDate = new Date(2015, Months.DECEMBER, 15);
+            const { monthSelect } = render({
+                contiguousCalendarMonths: false,
+                maxDate,
+                minDate,
+            }).right;
+            assertSelectOptionBounds(monthSelect, Months.FEBRUARY, Months.DECEMBER);
+        });
+
+        it("right calendar shows the month containing the selected end date", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.JULY, 5);
+            const { right } = render({
+                contiguousCalendarMonths: false,
+                value: [startDate, endDate],
+            });
+            right.assertDisplayMonth(Months.JULY);
+        });
+
+        it("right calendar shows the month immediately after the left view if startDate === endDate month", () => {
+            const startDate = new Date(2017, Months.MAY, 5);
+            const endDate = new Date(2017, Months.MAY, 15);
+            const { right } = render({
+                contiguousCalendarMonths: false,
+                value: [startDate, endDate],
+            });
+            right.assertDisplayMonth(Months.JUNE);
+        });
+    });
+
+    describe("left/right calendar when contiguous", () => {
+        it("changing left calendar with month dropdown shifts left to the selected month", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right } = render({ initialMonth });
+            left.assertDisplayMonth(Months.MAY);
+            right.assertDisplayMonth(Months.JUNE);
+            left.monthSelect.simulate("change", { target: { value: Months.AUGUST } });
+            left.assertDisplayMonth(Months.AUGUST);
+            right.assertDisplayMonth(Months.SEPTEMBER);
+        });
+
+        it("changing right calendar with month dropdown shifts right to the selected month", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right } = render({ initialMonth });
+            left.assertDisplayMonth(Months.MAY);
+            right.assertDisplayMonth(Months.JUNE);
+            right.monthSelect.simulate("change", { target: { value: Months.AUGUST } });
+            left.assertDisplayMonth(Months.JULY);
+            right.assertDisplayMonth(Months.AUGUST);
+        });
+
+        it("changing left calendar with year dropdown shifts left to the selected year", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertDisplayMonth(Months.MAY);
+            right.assertDisplayMonth(Months.JUNE);
+            left.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertDisplayMonth(Months.MAY, NEW_YEAR);
+            right.assertDisplayMonth(Months.JUNE, NEW_YEAR);
+        });
+
+        it("changing right calendar with year dropdown shifts right to the selected year", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertDisplayMonth(Months.MAY);
+            right.assertDisplayMonth(Months.JUNE);
+            right.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertDisplayMonth(Months.MAY, NEW_YEAR);
+            right.assertDisplayMonth(Months.JUNE, NEW_YEAR);
+        });
+
+        it("when calendar is between December and January, changing left calendar with year dropdown shifts left to the selected year", () => {
+            const INITIAL_YEAR = 2015;
+            const initialMonth = new Date(INITIAL_YEAR, Months.DECEMBER, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertDisplayMonth(Months.DECEMBER, INITIAL_YEAR);
+            right.assertDisplayMonth(Months.JANUARY, INITIAL_YEAR + 1);
+            left.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertDisplayMonth(Months.DECEMBER, NEW_YEAR);
+            right.assertDisplayMonth(Months.JANUARY, NEW_YEAR + 1);
+        });
+
+        it("when calendar is between December and January, changing right calendar with year dropdown shifts right to the selected year", () => {
+            const INITIAL_YEAR = 2015;
+            const initialMonth = new Date(INITIAL_YEAR, Months.DECEMBER, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ initialMonth });
+            left.assertDisplayMonth(Months.DECEMBER, INITIAL_YEAR);
+            right.assertDisplayMonth(Months.JANUARY, INITIAL_YEAR + 1);
+            right.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertDisplayMonth(Months.DECEMBER, NEW_YEAR - 1);
+            right.assertDisplayMonth(Months.JANUARY, NEW_YEAR);
+        });
+    });
+
+    describe("left/right calendar when not contiguous", () => {
+        it("left calendar can be altered independently of right calendar", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+            const { left, clickNavButton } = render({
+                contiguousCalendarMonths: false,
+                initialMonth,
+            });
+            left.assertDisplayMonth(Months.MAY);
+            clickNavButton("previous");
+            left.assertDisplayMonth(Months.APRIL);
+            clickNavButton("next");
+            left.assertDisplayMonth(Months.MAY);
+        });
+
+        it("right calendar can be altered independently of left calendar", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { right, clickNavButton } = render({
+                contiguousCalendarMonths: false,
+                initialMonth,
+            });
+            right.assertDisplayMonth(Months.JUNE);
+            clickNavButton("previous", 1);
+            right.assertDisplayMonth(Months.MAY);
+            clickNavButton("next", 1);
+            right.assertDisplayMonth(Months.JUNE);
+        });
+
+        it("changing left calendar with month dropdown to be equal or after right calendar, shifts the right", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right } = render({ contiguousCalendarMonths: false, initialMonth });
+            left.assertDisplayMonth(Months.MAY);
+            right.assertDisplayMonth(Months.JUNE);
+            left.monthSelect.simulate("change", { target: { value: Months.AUGUST } });
+            left.assertDisplayMonth(Months.AUGUST);
+            right.assertDisplayMonth(Months.SEPTEMBER);
+        });
+
+        it("changing right calendar with month dropdown to be equal or before left calendar, shifts the left", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right } = render({ contiguousCalendarMonths: false, initialMonth });
+            left.assertDisplayMonth(Months.MAY);
+            right.assertDisplayMonth(Months.JUNE);
+            right.monthSelect.simulate("change", { target: { value: Months.APRIL } });
+            left.assertDisplayMonth(Months.MARCH);
+            right.assertDisplayMonth(Months.APRIL);
+        });
+
+        it("changing left calendar with year dropdown to be equal or after right calendar, shifts the right", () => {
+            const initialMonth = new Date(2013, Months.MAY, 5);
+            const NEW_YEAR = 2014;
+
+            const { left, right } = render({ contiguousCalendarMonths: false, initialMonth });
+            left.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertDisplayMonth(Months.MAY, NEW_YEAR);
+            right.assertDisplayMonth(Months.JUNE, NEW_YEAR);
+        });
+
+        it("changing right calendar with year dropdown to be equal or before left calendar, shifts the left", () => {
+            const initialMonth = new Date(2013, Months.MAY, 5);
+            const NEW_YEAR = 2012;
+
+            const { left, right } = render({ contiguousCalendarMonths: false, initialMonth });
+            right.yearSelect.simulate("change", { target: { value: NEW_YEAR } });
+            left.assertDisplayMonth(Months.MAY, NEW_YEAR);
+            right.assertDisplayMonth(Months.JUNE, NEW_YEAR);
+        });
+
+        it("changing left calendar with navButton to equal right calendar, shifts the right", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right, clickNavButton } = render({
+                contiguousCalendarMonths: false,
+                initialMonth,
+            });
+            clickNavButton("next");
+            left.assertDisplayMonth(Months.JUNE);
+            right.assertDisplayMonth(Months.JULY);
+        });
+
+        it("changing right calendar with navButton to equal left calendar, shifts the left", () => {
+            const initialMonth = new Date(2015, Months.MAY, 5);
+
+            const { left, right, clickNavButton } = render({
+                contiguousCalendarMonths: false,
+                initialMonth,
+            });
+            clickNavButton("previous", 1);
+            left.assertDisplayMonth(Months.APRIL);
+            right.assertDisplayMonth(Months.MAY);
+        });
+    });
+
+    describe("validation: minDate/maxDate bounds", () => {
+        const TODAY = new Date(2015, Months.FEBRUARY, 5);
+        const LAST_WEEK_START = new Date(2015, Months.JANUARY, 29);
+        const LAST_MONTH_START = new Date(2015, Months.JANUARY, 5);
+        const TWO_WEEKS_AGO_START = new Date(2015, Months.JANUARY, 22);
+
+        let consoleError: sinon.SinonStub;
+
+        before(() => (consoleError = sinon.stub(console, "error")));
+        afterEach(() => consoleError.resetHistory());
+        after(() => consoleError.restore());
+
+        it("maxDate must be later than minDate", () => {
+            wrap(
+                <DateRangePicker3
+                    minDate={new Date(2000, Months.JANUARY, 10)}
+                    maxDate={new Date(2000, Months.JANUARY, 8)}
+                />,
+            );
+            assert.isTrue(consoleError.calledOnceWith(Errors.DATERANGEPICKER_MAX_DATE_INVALID));
+        });
+
+        it("only days outside bounds have disabled class", () => {
+            const minDate = new Date(2000, Months.JANUARY, 10);
+            const initialMonth = minDate;
+            const { left } = render({ initialMonth, minDate });
+            assert.isTrue(left.findDay(8).hasClass(Classes.DATEPICKER3_DAY_DISABLED));
+            assert.isFalse(left.findDay(10).hasClass(Classes.DATEPICKER3_DAY_DISABLED));
+        });
+
+        it("an error is logged if defaultValue is outside bounds", () => {
+            wrap(
+                <DateRangePicker3
+                    defaultValue={[new Date(2015, Months.JANUARY, 12), null] as DateRange}
+                    minDate={new Date(2015, Months.JANUARY, 5)}
+                    maxDate={new Date(2015, Months.JANUARY, 7)}
+                />,
+            );
+            assert.isTrue(consoleError.calledOnceWith(Errors.DATERANGEPICKER_DEFAULT_VALUE_INVALID));
+        });
+
+        it("an error is logged if initialMonth is outside month bounds", () => {
+            wrap(
+                <DateRangePicker3
+                    initialMonth={new Date(2015, Months.FEBRUARY, 12)}
+                    minDate={new Date(2015, Months.JANUARY, 5)}
+                    maxDate={new Date(2015, Months.JANUARY, 7)}
+                />,
+            );
+            assert.isTrue(consoleError.calledOnceWith(Errors.DATERANGEPICKER_INITIAL_MONTH_INVALID));
+        });
+
+        it("no error if initialMonth is outside day bounds but inside month bounds", () => {
+            wrap(
+                <DateRangePicker3
+                    initialMonth={new Date(2015, Months.JANUARY, 12)}
+                    minDate={new Date(2015, Months.JANUARY, 5)}
+                    maxDate={new Date(2015, Months.JANUARY, 7)}
+                />,
+            );
+            assert.isTrue(consoleError.notCalled);
+        });
+
+        it("an error is logged if value is outside bounds", () => {
+            wrap(
+                <DateRangePicker3
+                    value={[new Date(2015, Months.JANUARY, 12), null] as DateRange}
+                    minDate={new Date(2015, Months.JANUARY, 5)}
+                    maxDate={new Date(2015, Months.JANUARY, 7)}
+                />,
+            );
+            assert.isTrue(consoleError.calledOnceWith(Errors.DATERANGEPICKER_VALUE_INVALID));
+        });
+
+        it("onChange not fired when a day outside of bounds is clicked", () => {
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
+            const { left } = render({ maxDate, minDate });
+            assert.isTrue(onChangeSpy.notCalled);
+            left.findDay(10).simulate("click");
+            assert.isTrue(onChangeSpy.notCalled);
+        });
+
+        it("caption options are only displayed for possible months and years", () => {
+            const minDate = new Date(2015, Months.JANUARY, 5);
+            const maxDate = new Date(2015, Months.JANUARY, 7);
+            const { left } = render({ maxDate, minDate });
+            const monthOptions = left.monthSelect.find("option").map(o => o.text());
+            const yearOptions = left.yearSelect.find("option").map(o => o.text());
+            assert.sameMembers(monthOptions, ["January"]);
+            assert.sameMembers(yearOptions, ["2015"]);
+        });
+
+        it("disables shortcuts that begin earlier than minDate", () => {
+            const { shortcuts } = render({
+                initialMonth: TODAY,
+                minDate: TWO_WEEKS_AGO_START,
+                shortcuts: [
+                    { dateRange: [LAST_WEEK_START, TODAY], label: "last week" },
+                    { dateRange: [LAST_MONTH_START, TODAY], label: "last month" },
+                ],
+            });
+            assert.isFalse(shortcuts.childAt(0).prop("disabled"));
+            assert.isTrue(shortcuts.childAt(1).prop("disabled"));
+        });
+
+        it("disables shortcuts that end later than maxDate", () => {
+            const { shortcuts } = render({
+                initialMonth: TWO_WEEKS_AGO_START,
+                maxDate: TWO_WEEKS_AGO_START,
+                shortcuts: [
+                    { dateRange: [LAST_WEEK_START, TODAY], label: "last week" },
+                    { dateRange: [LAST_MONTH_START, TODAY], label: "last month" },
+                ],
+            });
+            assert.isTrue(shortcuts.childAt(0).prop("disabled"));
+            assert.isTrue(shortcuts.childAt(1).prop("disabled"));
+        });
+    });
+
+    describe("hover interactions", () => {
+        describe("when neither start nor end date is defined", () => {
+            it("should show a hovered range of [day, null]", () => {
+                const { left, assertHoveredDays } = render();
+                left.mouseEnterDay(14);
+                assertHoveredDays(14, null);
+            });
+        });
+
+        describe("when only start date is defined", () => {
+            it("should show a hovered range of [start, day] if day > start", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).mouseEnterDay(18);
+                assertHoveredDays(14, 18);
+            });
+
+            it("should show a hovered range of [null, null] if day === start", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).mouseEnterDay(14);
+                assertHoveredDays(null, null);
+            });
+
+            it("should show a hovered range of [day, start] if day < start", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).mouseEnterDay(10);
+                assertHoveredDays(10, 14);
+            });
+
+            it("should not show a hovered range when mousing over a disabled date", () => {
+                const { left, right, assertHoveredDays } = render({
+                    maxDate: new Date(2017, Months.FEBRUARY, 10),
+                    minDate: new Date(2017, Months.JANUARY, 1),
+                });
+                left.clickDay(14); // Jan 14th
+                right.mouseEnterDay(14); // Feb 14th
+                assertHoveredDays(14, null);
+            });
+        });
+
+        describe("when only end date is defined", () => {
+            it("should show a hovered range of [end, day] if day > end", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14)
+                    .clickDay(18)
+                    .clickDay(14) // deselect start date
+                    .mouseEnterDay(22);
+                assertHoveredDays(18, 22);
+            });
+
+            it("should show a hovered range of [null, null] if day === end", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).clickDay(14).mouseEnterDay(18);
+                assertHoveredDays(null, null);
+            });
+
+            it("should show a hovered range of [day, end] if day < end", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).clickDay(14).mouseEnterDay(14);
+                assertHoveredDays(14, 18);
+            });
+        });
+
+        describe("when both start and end date are defined", () => {
+            it("should show a hovered range of [null, end] if day === start", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).mouseEnterDay(14);
+                assertHoveredDays(null, 18);
+            });
+
+            it("should show a hovered range of [start, null] if day === end", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).mouseEnterDay(18);
+                assertHoveredDays(14, null);
+            });
+
+            it("should show a hovered range of [day, null] if start < day < end", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).mouseEnterDay(16);
+                assertHoveredDays(16, null);
+            });
+
+            it("should show a hovered range of [day, null] if day < start", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).mouseEnterDay(10);
+                assertHoveredDays(10, null);
+            });
+
+            it("should show a hovered range of [day, null] if day > end", () => {
+                const { left, assertHoveredDays } = render();
+                left.clickDay(14).clickDay(18).mouseEnterDay(22);
+                assertHoveredDays(22, null);
+            });
+
+            it("should show a hovered range of [null, null] if start === day === end", () => {
+                const { left, assertHoveredDays } = render({ allowSingleDayRange: true });
+                left.clickDay(14).clickDay(14).mouseEnterDay(14);
+                assertHoveredDays(null, null);
+            });
+        });
+
+        it("hovering on day in month prior to selected start date's month, should not shift calendar view", () => {
+            const INITIAL_MONTH = Months.MARCH;
+            const MONTH_OUT_OF_VIEW = Months.JANUARY;
+            const { left, right } = render({ initialMonth: new Date(2017, INITIAL_MONTH, 1) });
+
+            left.clickDay(14).clickDay(18);
+            left.monthSelect.simulate("change", { target: { value: MONTH_OUT_OF_VIEW } });
+            // hover on left month
+            left.mouseEnterDay(14);
+            left.assertDisplayMonth(MONTH_OUT_OF_VIEW);
+
+            // hover on right month
+            right.mouseEnterDay(14);
+            left.assertDisplayMonth(MONTH_OUT_OF_VIEW);
+        });
+
+        // verifies the fix for https://github.com/palantir/blueprint/issues/1048
+        it("hovering when contiguousCalendarMonths=false shows a hovered range", () => {
+            const { left, right, assertHoveredDays } = render({ contiguousCalendarMonths: false });
+            left.clickDay(14);
+            right.mouseEnterDay(18);
+            assertHoveredDays(14, 18);
+        });
+    });
+
+    describe("when controlled", () => {
+        it("value initially selects a day", () => {
+            const defaultValue: DateRange = [new Date(2010, Months.FEBRUARY, 2), null];
+            const value: DateRange = [new Date(2010, Months.JANUARY, 1), null];
+            render({ defaultValue, value }).assertSelectedDays(value[0]!.getDate());
+        });
+
+        it("onChange fired when a day is clicked", () => {
+            const { left } = render({ value: [null, null] });
+            assert.isTrue(onChangeSpy.notCalled);
+            left.clickDay();
+            assert.isTrue(onChangeSpy.calledOnce);
+        });
+
+        it("onHoverChange fired on mouseenter within a day", () => {
+            const { left } = render({ value: [null, null] });
+            assert.isTrue(onHoverChangeSpy.notCalled);
+            left.mouseEnterDay();
+            assert.isTrue(onHoverChangeSpy.calledOnce);
+        });
+
+        it("onHoverChange fired on mouseleave within a day", () => {
+            const { left } = render({ value: [null, null] });
+            assert.isTrue(onHoverChangeSpy.notCalled);
+            left.findDay().simulate("mouseleave");
+            assert.isTrue(onHoverChangeSpy.calledOnce);
+        });
+
+        it("selected day updates are not automatic", () => {
+            const { left, assertSelectedDays } = render({ value: [null, null] });
+            assertSelectedDays();
+            left.clickDay();
+            assertSelectedDays();
+        });
+
+        it("can change displayed date with the dropdowns in the caption", () => {
+            const { left } = render({
+                initialMonth: new Date(2015, Months.MARCH, 2),
+                value: [null, null],
+            });
+            left.assertDisplayMonth(Months.MARCH, 2015);
+            left.monthSelect.simulate("change", { target: { value: Months.JANUARY } });
+            left.yearSelect.simulate("change", { target: { value: 2014 } });
+            left.assertDisplayMonth(Months.JANUARY, 2014);
+        });
+
+        it("shortcuts fire onChange with correct values", () => {
+            render().clickShortcut();
+
+            const today = new Date();
+            const aWeekAgo = DateUtils.clone(today);
+            aWeekAgo.setDate(today.getDate() - 6);
+
+            assert.isTrue(onChangeSpy.calledOnce, "called");
+            const value = onChangeSpy.args[0][0];
+            assert.isTrue(DateUtils.isSameDay(aWeekAgo, value[0]));
+            assert.isTrue(DateUtils.isSameDay(today, value[1]));
+        });
+
+        it("shortcuts fire onChange with correct values when single day range enabled", () => {
+            render({ allowSingleDayRange: true }).clickShortcut();
+
+            const today = new Date();
+
+            assert.isTrue(onChangeSpy.calledOnce);
+            const value = onChangeSpy.args[0][0];
+            assert.isTrue(DateUtils.isSameDay(today, value[0]));
+            assert.isTrue(DateUtils.isSameDay(today, value[1]));
+        });
+
+        it("shortcuts fire onChange with correct values when single day range and allowSingleDayRange enabled", () => {
+            render({ allowSingleDayRange: true, timePrecision: "minute" }).clickShortcut();
+
+            const today = new Date();
+            const tomorrow = DateUtils.clone(today);
+            tomorrow.setDate(today.getDate() + 1);
+
+            assert.isTrue(onChangeSpy.calledOnce);
+            const value = onChangeSpy.args[0][0];
+            assert.isTrue(DateUtils.isSameDay(today, value[0]));
+            assert.isTrue(DateUtils.isSameDay(tomorrow, value[1]));
+        });
+
+        it("all shortcuts are displayed as inactive when none are selected", () => {
+            const { wrapper } = render();
+
+            assert.isFalse(
+                wrapper.find(DatePickerShortcutMenu).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`).exists(),
+            );
+        });
+
+        it("corresponding shortcut is displayed as active when selected", () => {
+            const selectedShortcut = 0;
+            const { wrapper } = render({ selectedShortcutIndex: selectedShortcut });
+
+            assert.isTrue(
+                wrapper.find(DatePickerShortcutMenu).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`).exists(),
+            );
+
+            assert.lengthOf(
+                wrapper.find(DatePickerShortcutMenu).find(Menu).find(MenuItem).find(`.${CoreClasses.ACTIVE}`),
+                1,
+            );
+
+            assert.isTrue(wrapper.state("selectedShortcutIndex") === selectedShortcut);
+        });
+
+        it("should call onShortcutChangeSpy on selecting a shortcut ", () => {
+            const selectedShortcut = 1;
+            const onShortcutChangeSpy = sinon.spy();
+            const { clickShortcut } = render({ onShortcutChange: onShortcutChangeSpy });
+
+            clickShortcut(selectedShortcut);
+
+            assert.isTrue(onChangeSpy.calledOnce);
+            assert.isTrue(onShortcutChangeSpy.calledOnce);
+            assert.isTrue(onShortcutChangeSpy.lastCall.lastArg === selectedShortcut);
+        });
+
+        it("custom shortcuts select the correct values", () => {
+            const dateRange: NonNullDateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)];
+            render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+                shortcuts: [{ dateRange, label: "custom shortcut" }],
+            }).clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            const value = onChangeSpy.args[0][0];
+            assert.isTrue(DateUtils.isSameDay(dateRange[0], value[0]));
+            assert.isTrue(DateUtils.isSameDay(dateRange[1], value[1]));
+        });
+
+        it("custom shortcuts set the displayed months correctly when start month changes", () => {
+            const dateRange: NonNullDateRange = [
+                new Date(2016, Months.JANUARY, 1),
+                new Date(2016, Months.DECEMBER, 31),
+            ];
+            const { left, right } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+                shortcuts: [{ dateRange, label: "custom shortcut" }],
+            }).clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            left.assertDisplayMonth(Months.JANUARY, 2016);
+            right.assertDisplayMonth(Months.FEBRUARY, 2016);
+        });
+
+        it(
+            "custom shortcuts set the displayed months correctly when start month changes " +
+                "and contiguousCalendarMonths is false",
+            () => {
+                const dateRange: NonNullDateRange = [
+                    new Date(2016, Months.JANUARY, 1),
+                    new Date(2016, Months.DECEMBER, 31),
+                ];
+                const { left, right } = render({
+                    contiguousCalendarMonths: false,
+                    initialMonth: new Date(2015, Months.JANUARY, 1),
+                    shortcuts: [{ dateRange, label: "custom shortcut" }],
+                }).clickShortcut();
+                assert.isTrue(onChangeSpy.calledOnce);
+                left.assertDisplayMonth(Months.JANUARY, 2016);
+                right.assertDisplayMonth(Months.DECEMBER, 2016);
+            },
+        );
+
+        it("custom shortcuts set the displayed months correctly when start month stays the same", () => {
+            const dateRange: NonNullDateRange = [
+                new Date(2016, Months.JANUARY, 1),
+                new Date(2016, Months.DECEMBER, 31),
+            ];
+            const { clickShortcut, left, right } = render({
+                initialMonth: new Date(2016, Months.JANUARY, 1),
+                shortcuts: [{ dateRange, label: "custom shortcut" }],
+            });
+
+            clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            left.assertDisplayMonth(Months.JANUARY, 2016);
+            right.assertDisplayMonth(Months.FEBRUARY, 2016);
+
+            clickShortcut();
+            left.assertDisplayMonth(Months.JANUARY, 2016);
+            right.assertDisplayMonth(Months.FEBRUARY, 2016);
+        });
+
+        it("custom shortcuts set the displayed dates correctly when month stays the same but not years and contiguousCalendarMonths is false", () => {
+            const dateRange: NonNullDateRange = [new Date(2014, Months.JUNE, 1), new Date(2015, Months.JUNE, 1)];
+            const { clickShortcut, left, right } = render({
+                contiguousCalendarMonths: false,
+                initialMonth: new Date(2015, Months.JUNE, 1),
+                shortcuts: [{ dateRange, label: "custom shortcut" }],
+            });
+
+            clickShortcut();
+            assert.isTrue(onChangeSpy.calledOnce);
+            left.assertDisplayMonth(Months.JUNE, 2014);
+            right.assertDisplayMonth(Months.JUNE, 2015);
+
+            clickShortcut();
+            left.assertDisplayMonth(Months.JUNE, 2014);
+            right.assertDisplayMonth(Months.JUNE, 2015);
+        });
+    });
+
+    describe("when uncontrolled", () => {
+        it("defaultValue initially selects a day", () => {
+            const today = new Date();
+            render({ defaultValue: [today, null] }).assertSelectedDays(today.getDate());
+        });
+
+        it("onChange fired when a day is clicked", () => {
+            const { left } = render();
+            assert.isTrue(onChangeSpy.notCalled);
+            left.clickDay();
+            assert.isTrue(onChangeSpy.calledOnce);
+        });
+
+        it("onHoverChange fired with correct values when a day is clicked", () => {
+            const dateRange: NonNullDateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)];
+            const { left } = render({ initialMonth: new Date(2015, Months.JANUARY, 1) });
+            assert.isTrue(onHoverChangeSpy.notCalled);
+            left.clickDay(1);
+            assert.isTrue(onHoverChangeSpy.calledOnce);
+            assert.isTrue(DateUtils.isSameDay(dateRange[0], onHoverChangeSpy.args[0][0][0]));
+            assert.isNull(onHoverChangeSpy.args[0][0][1]);
+        });
+
+        it("onHoverChange fired with correct values on mouseenter within a day", () => {
+            const dateRange: NonNullDateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)];
+            const { left } = render({ initialMonth: new Date(2015, Months.JANUARY, 1) });
+            assert.isTrue(onHoverChangeSpy.notCalled);
+            left.clickDay(1).mouseEnterDay(5);
+            assert.isTrue(onHoverChangeSpy.calledTwice);
+            assert.isTrue(DateUtils.isSameDay(dateRange[0], onHoverChangeSpy.args[1][0][0]));
+            assert.isTrue(DateUtils.isSameDay(dateRange[1], onHoverChangeSpy.args[1][0][1]));
+        });
+
+        it("onHoverChange fired with `undefined` on mouseleave within a day", () => {
+            const { left } = render({ initialMonth: new Date(2015, Months.JANUARY, 1) });
+            assert.isTrue(onHoverChangeSpy.notCalled);
+            left.clickDay(1).findDay(5).simulate("mouseleave");
+            assert.isTrue(onHoverChangeSpy.calledTwice);
+            assert.isUndefined(onHoverChangeSpy.args[1][0]);
+        });
+
+        it("selected day updates are automatic", () => {
+            const { assertSelectedDays, left } = render();
+            assertSelectedDays();
+            left.clickDay(3);
+            assertSelectedDays(3);
+        });
+
+        it("selects a range of dates when two days are clicked", () => {
+            const { assertSelectedDays, left } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+            });
+            assertSelectedDays();
+            left.clickDay(10).clickDay(14);
+            assertSelectedDays(10, 14);
+        });
+
+        it("selects a range of dates when days are clicked in reverse", () => {
+            const { assertSelectedDays, left } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+            });
+            assertSelectedDays();
+            left.clickDay(14).clickDay(10);
+            assertSelectedDays(10, 14);
+        });
+
+        it("deselects everything when only selected day is clicked", () => {
+            const { assertSelectedDays, left } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+            });
+            left.clickDay(10).clickDay(10);
+            assertSelectedDays();
+        });
+
+        it("starts a new selection when a non-endpoint is clicked in the current selection", () => {
+            const { assertSelectedDays, left, right } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+            });
+            left.clickDay(10).clickDay(14);
+            right.clickDay(11);
+            assertSelectedDays(11);
+        });
+
+        it("deselects endpoint when an endpoint of the current selection is clicked", () => {
+            const { assertSelectedDays, left } = render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+            });
+            left.clickDay(10).clickDay(14).clickDay(10);
+            assertSelectedDays(14);
+
+            left.clickDay(10).clickDay(14);
+            assertSelectedDays(10);
+        });
+
+        it("allowSingleDayRange={true} allows start and end to be the same day", () => {
+            const { assertSelectedDays, left } = render({
+                allowSingleDayRange: true,
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+            });
+            left.clickDay(10).clickDay(10);
+            assertSelectedDays(10);
+        });
+
+        it("shortcuts select values", () => {
+            const { wrapper } = render().clickShortcut();
+
+            const today = new Date();
+            const aWeekAgo = DateUtils.clone(today);
+            aWeekAgo.setDate(today.getDate() - 6);
+
+            const [start, end] = wrapper.state("value");
+            assert.isTrue(DateUtils.isSameDay(aWeekAgo, start!));
+            assert.isTrue(DateUtils.isSameDay(today, end!));
+        });
+
+        it("custom shortcuts select the correct values", () => {
+            const dateRange: NonNullDateRange = [new Date(2015, Months.JANUARY, 1), new Date(2015, Months.JANUARY, 5)];
+            render({
+                initialMonth: new Date(2015, Months.JANUARY, 1),
+                shortcuts: [{ dateRange, label: "custom shortcut" }],
+            })
+                .clickShortcut()
+                .assertSelectedDays(1, 5);
+        });
+
+        it("can change displayed date with the dropdowns in the caption", () => {
+            const { left } = render({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            left.assertDisplayMonth(Months.MARCH, 2015);
+            left.monthSelect.simulate("change", { target: { value: Months.JANUARY } });
+            left.yearSelect.simulate("change", { target: { value: 2014 } });
+            left.assertDisplayMonth(Months.JANUARY, 2014);
+        });
+
+        it("does not change display month when selecting dates from left month", () => {
+            const { left } = render({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            left.clickDay(2).clickDay(15).assertDisplayMonth(Months.MARCH, 2015);
+        });
+
+        it("does not change display month when selecting dates from right month", () => {
+            const { right } = render({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            right.clickDay(2).clickDay(15).assertDisplayMonth(Months.APRIL, 2015);
+        });
+
+        it("does not change display month when selecting dates from left and right month", () => {
+            const { left, right } = render({ initialMonth: new Date(2015, Months.MARCH, 2) });
+            right.clickDay(15);
+            left.clickDay(2).assertDisplayMonth(Months.MARCH, 2015);
+        });
+
+        it("does not change display month when selecting dates across December (left) and January (right)", () => {
+            const { left, right } = render({ initialMonth: new Date(2015, Months.DECEMBER, 2) });
+            left.clickDay(15);
+            right.clickDay(2);
+            left.assertDisplayMonth(Months.DECEMBER, 2015);
+        });
+    });
+
+    describe("time selection", () => {
+        const defaultRange: NonNullDateRange = [new Date(2012, 2, 5, 6, 5, 40), new Date(2012, 4, 5, 7, 8, 20)];
+
+        it("setting timePrecision shows a TimePicker", () => {
+            const { wrapper } = render();
+            assert.isFalse(wrapper.find(TimePicker).exists());
+            wrapper.setProps({ timePrecision: "minute" });
+            assert.isTrue(wrapper.find(TimePicker).exists());
+        });
+
+        it("setting timePickerProps shows a TimePicker", () => {
+            const { wrapper } = render({ timePickerProps: {} });
+            assert.isTrue(wrapper.find(TimePicker).exists());
+        });
+
+        it("onChange fired when the time is changed", () => {
+            const { wrapper } = render({
+                defaultValue: defaultRange,
+                timePickerProps: { showArrowButtons: true },
+            });
+            assert.isTrue(onChangeSpy.notCalled);
+            wrapper.find(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${Classes.TIMEPICKER_HOUR}`).first().simulate("click");
+            assert.isTrue(onChangeSpy.calledOnce);
+            const cbHour = onChangeSpy.firstCall.args[0][0].getHours();
+            assert.strictEqual(cbHour, defaultRange[0].getHours() + 1);
+        });
+
+        it("changing date does not change time", () => {
+            render({ defaultValue: defaultRange, timePrecision: "minute" }).left.clickDay(16);
+            assert.isTrue(DateUtils.isSameTime(onChangeSpy.firstCall.args[0][0] as Date, defaultRange[0]));
+        });
+
+        it("changing time does not change date", () => {
+            render({ defaultValue: defaultRange, timePrecision: "minute" }).setTimeInput("minute", "left", 10);
+            assert.isTrue(DateUtils.isSameDay(onChangeSpy.firstCall.args[0][0] as Date, defaultRange[0]));
+        });
+
+        it("hovering over date does not change entered time", () => {
+            const harness = render({ defaultValue: defaultRange, timePrecision: "minute" });
+            const newLeftMinute = 10;
+            harness.setTimeInput("minute", "left", newLeftMinute);
+            onChangeSpy.resetHistory();
+            const { left } = harness;
+            left.mouseEnterDay(5);
+            assert.isTrue(onChangeSpy.notCalled);
+            const minuteInputText = harness.getTimeInput("minute", "left");
+            assert.equal(parseInt(minuteInputText, 10), newLeftMinute);
+        });
+
+        it("changing time without date uses today, when other date not selected", () => {
+            render({ timePrecision: "minute" }).setTimeInput("minute", "left", 45);
+            assert.isTrue(DateUtils.isSameDay(onChangeSpy.firstCall.args[0][0] as Date, new Date()));
+        });
+
+        it("changing time without date uses other date if selected and `allowSingleDayRange` is true", () => {
+            const dateRange = render({ allowSingleDayRange: true, timePrecision: "minute" });
+
+            dateRange.left.clickDay(10);
+            dateRange.setTimeInput("minute", "right", 45);
+            const [start, end] = dateRange.wrapper.state("value");
+
+            assert.isNotNull(start);
+            assert.isNotNull(end);
+            assert.isTrue(DateUtils.isSameDay(start!, end!));
+        });
+
+        it("changing time without date uses 1 day offset from other date if selected and `allowSingleDayRange` is false", () => {
+            const dateRange = render({ allowSingleDayRange: false, timePrecision: "minute" });
+
+            dateRange.left.clickDay(10);
+            dateRange.setTimeInput("minute", "right", 45);
+            const [start, end] = dateRange.wrapper.state("value");
+
+            assert.isNotNull(start);
+            assert.isNotNull(end);
+            assert.isTrue(DateUtils.isSameDay(end!, addDays(start!, 1)));
+        });
+
+        it("clicking a shortcut with includeTime=false doesn't change time", () => {
+            render({ defaultValue: defaultRange, timePrecision: "minute" }).clickShortcut();
+            assert.isTrue(DateUtils.isSameTime(onChangeSpy.firstCall.args[0][0] as Date, defaultRange[0]));
+        });
+
+        it("clicking a shortcut with includeTime=true changes time", () => {
+            const endTime = defaultRange[1];
+            const startTime = new Date(defaultRange[1].getTime());
+            startTime.setHours(startTime.getHours() - 2);
+
+            const shortcuts: DateRangeShortcut[] = [
+                {
+                    dateRange: [startTime, endTime] as NonNullDateRange,
+                    includeTime: true,
+                    label: "shortcut with time",
+                },
+            ];
+
+            render({
+                defaultValue: defaultRange,
+                shortcuts,
+                timePrecision: "minute",
+            }).clickShortcut();
+            assert.isTrue(DateUtils.isEqual(onChangeSpy.firstCall.args[0][0] as Date, startTime));
+        });
+
+        it("selecting and unselecting a day doesn't change time", () => {
+            const leftDatePicker = render({ defaultValue: defaultRange, timePrecision: "minute" }).left;
+            leftDatePicker.clickDay(5);
+            leftDatePicker.clickDay(5);
+            assert.isTrue(DateUtils.isSameTime(onChangeSpy.secondCall.args[0][0] as Date, defaultRange[0]));
+        });
+    });
+
+    function dayNotOutside(day: ReactWrapper) {
+        return !day.hasClass(Classes.DATEPICKER3_DAY_OUTSIDE);
+    }
+
+    function render(props?: DateRangePicker3Props) {
+        onChangeSpy = sinon.spy();
+        onHoverChangeSpy = sinon.spy();
+        return wrap(<DateRangePicker3 onChange={onChangeSpy} onHoverChange={onHoverChangeSpy} {...props} />);
+    }
+
+    function wrap(datepicker: React.JSX.Element) {
+        const wrapper = mount<DateRangePicker3Props, DateRangePicker3State>(datepicker, {
+            attachTo: testsContainerElement,
+        });
+        drpWrapper = wrapper;
+
+        const findTimeInput = (precision: TimePrecision | "hour", which: "left" | "right") =>
+            wrapper.find(`.${Classes.TIMEPICKER}-${precision}`).at(which === "left" ? 0 : 1);
+
+        // Don't cache the left/right day pickers into variables in this scope,
+        // because as of Enzyme 3.0 they can get stale if the views change.
+        const harness = {
+            wrapper,
+
+            left: wrapDayPicker(wrapper, "left"),
+            right: wrapDayPicker(wrapper, "right"),
+            shortcuts: wrapper.find(`.${Classes.DATERANGEPICKER_SHORTCUTS}`).hostNodes(),
+
+            assertHoveredDays: (fromDate: number | null, toDate: number | null) => {
+                const [from, to] = wrapper.state("hoverValue")!;
+
+                if (fromDate == null) {
+                    assert.isNull(from);
+                } else {
+                    assert.equal(from!.getDate(), fromDate);
+                }
+
+                if (toDate == null) {
+                    assert.isNull(to);
+                } else {
+                    assert.equal(to!.getDate(), toDate);
+                }
+
+                return harness;
+            },
+            assertSelectedDays: (from?: number, to?: number) => {
+                const rangeStart = wrapper.find(`.${Classes.DATERANGEPICKER3_SELECTED_RANGE_START}`).first();
+                const rangeEnd = wrapper.find(`.${Classes.DATERANGEPICKER3_SELECTED_RANGE_END}`).first();
+                if (from !== undefined) {
+                    assert.isTrue(rangeStart.exists());
+                    assert.equal(parseInt(rangeStart.text(), 10), from);
+                }
+                if (to !== undefined) {
+                    assert.isTrue(rangeEnd.exists());
+                    assert.equal(parseInt(rangeEnd.text(), 10), to);
+                }
+                if (from !== undefined && to !== undefined) {
+                    assert.lengthOf(
+                        harness.getDays(Classes.DATERANGEPICKER3_SELECTED_RANGE_MIDDLE),
+                        Math.max(0, to - from - 1),
+                    );
+                }
+            },
+            changeTimeInput: (precision: TimePrecision | "hour", which: "left" | "right", value: number) =>
+                findTimeInput(precision, which).simulate("change", { target: { value } }),
+            clickNavButton: (which: "next" | "previous", navIndex = 0) => {
+                const month = wrapper.find(`.rdp-month`).at(navIndex);
+                const navButton = month.find(`.${Classes.DATEPICKER3_NAV_BUTTON}-${which}`);
+                navButton.hostNodes().simulate("click");
+                return harness;
+            },
+            clickShortcut: (index = 0) => {
+                harness.shortcuts.find("a").at(index).simulate("click");
+                return harness;
+            },
+            getDays: (className: string) => {
+                return wrapper.find(`.${className}`).filterWhere(dayNotOutside).hostNodes();
+            },
+            getTimeInput: (precision: TimePrecision | "hour", which: "left" | "right") =>
+                findTimeInput(precision, which).props().value as string,
+            setTimeInput: (precision: TimePrecision | "hour", which: "left" | "right", value: number) =>
+                findTimeInput(precision, which).simulate("blur", { target: { value } }),
+        };
+        return harness;
+    }
+
+    function wrapDayPicker(
+        parent: ReactWrapper<DateRangePicker3Props, DateRangePicker3State>,
+        whichCalendar: "left" | "right",
+    ) {
+        /* eslint-disable sort-keys */
+        const harness = {
+            get wrapper() {
+                // use accessor to ensure it's always the latest reference
+                return parent
+                    .find(DayPicker)
+                    .find("Month")
+                    .at(whichCalendar === "left" ? 0 : 1);
+            },
+            get displayMonthAndYear(): MonthAndYear {
+                const captionLabel = harness.wrapper.find(`.${ReactDayPickerClasses.RDP_CAPTION_LABEL}`);
+                assert.exists(captionLabel, "Expected caption label which labels the current display month to exist");
+                const [monthText, yearText] = captionLabel.text().split(" ");
+                const month = getMonthIndex(monthText);
+                const year = parseInt(yearText, 10);
+                return new MonthAndYear(month, year);
+            },
+            get monthSelect() {
+                return harness.wrapper.find(`.${Classes.DATEPICKER_MONTH_SELECT}`).find("select");
+            },
+            get yearSelect() {
+                return harness.wrapper.find(`.${Classes.DATEPICKER_YEAR_SELECT}`).find("select");
+            },
+
+            assertDisplayMonth: (expectedMonth: number, expectedYear?: number) => {
+                const displayMonthAndYear = harness.displayMonthAndYear;
+                assert.equal(displayMonthAndYear.getMonth(), expectedMonth);
+                if (expectedYear !== undefined) {
+                    assert.equal(displayMonthAndYear.getYear(), expectedYear);
+                }
+            },
+            clickDay: (dayNumber = 1) => {
+                harness.findDay(dayNumber).simulate("click");
+                return harness;
+            },
+            findDay: (dayNumber = 1) => {
+                return harness
+                    .findDays()
+                    .filterWhere(day => day.text() === "" + dayNumber)
+                    .filterWhere(day => !day.hasClass(Classes.DATEPICKER3_DAY_OUTSIDE))
+                    .first();
+            },
+            findDays: () => harness.wrapper.find(`.${Classes.DATEPICKER3_DAY}`),
+            mouseEnterDay: (dayNumber = 1) => {
+                harness.findDay(dayNumber).simulate("mouseenter");
+                return harness;
+            },
+        };
+        /* eslint-enable sort-keys */
+        return harness;
+    }
+});
+
+function renderMonthName(monthIndex: number) {
+    return format(new Date(2023, monthIndex), "LLLL", { locale: enUSLocale });
+}
+
+function getMonthIndex(monthName: string) {
+    return parse(monthName, "LLLL", new Date(), { locale: enUSLocale }).getMonth();
+}


### PR DESCRIPTION
#### Part of #7342

#### Proposed changes:

Copies over the following v3 components (and their tests) with modified imports. These components and tests are not wired up yet (that follows in the next step).
- `<DatePicker3>`
- `<DateInput3>`
- `<DateRangePicker3>`
- `<DateRangeInput3>`