### PR TITLE
Enable strictNullChecks in `@blueprintjs/datetime`

### DIFF
--- a/packages/datetime/src/tsconfig.json
+++ b/packages/datetime/src/tsconfig.json
@@ -2,6 +2,5 @@
     "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm",
-        "strictNullChecks": false,
     },
 }


### PR DESCRIPTION
#### Proposed changes:

FLUP to #7337, #7340, and #7359.

Now that all code causing compilation errors with `strictNullChecks` enabled has been either fixed or removed, we can now enable it in the `@blueprintjs/datetime` package.
