### PR TITLE
Update `@blueprintjs/datetime` peerDependencies to match other packages

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -51,9 +51,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17",
-        "react": "^16.8 || 17",
-        "react-dom": "^16.8 || 17"
+        "@types/react": "^16.14.41 || 17 || 18",
+        "react": "^16.8 || 17 || 18",
+        "react-dom": "^16.8 || 17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,9 +546,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17
-    react: ^16.8 || 17
-    react-dom: ^16.8 || 17
+    "@types/react": ^16.14.41 || 17 || 18
+    react: ^16.8 || 17 || 18
+    react-dom: ^16.8 || 17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
#### Proposed changes

FLUP to #7360. Add React 18 to peer dependencies of `@blueprintjs/datetime` to match other packages.