### PR TITLE
break(Tabs): Delete deprecated TabsExpander aliases

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -113,7 +113,7 @@ export { RadioCard, type RadioCardProps } from "./control-card/radioCard";
 export { SwitchCard, type SwitchCardProps } from "./control-card/switchCard";
 export { Tab, type TabId, type TabProps } from "./tabs/tab";
 export { TabPanel, type TabPanelProps } from "./tabs/tabPanel";
-export { Tabs, type TabsProps, TabsExpander, Expander } from "./tabs/tabs";
+export { Tabs, type TabsProps, TabsExpander } from "./tabs/tabs";
 export { CompoundTag, type CompoundTagProps } from "./tag/compoundTag";
 export { Tag, type TagProps } from "./tag/tag";
 export { TagInput, type TagInputProps, type TagInputAddMethod } from "./tag-input/tagInput";

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -28,9 +28,6 @@ import { TabTitle } from "./tabTitle";
  */
 export const TabsExpander: React.FC = () => <div className={Classes.FLEX_EXPANDER} />;
 
-/** @deprecated use `TabsExpander` instead */
-export const Expander = TabsExpander;
-
 type TabElement = React.ReactElement<TabProps & { children: React.ReactNode }>;
 
 const TAB_SELECTOR = `.${Classes.TAB}`;
@@ -129,13 +126,6 @@ export interface TabsState {
  * @see https://blueprintjs.com/docs/#core/components/tabs
  */
 export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
-    /**
-     * Insert a `TabsExpander` between any two children to right-align all subsequent children.
-     *
-     * @deprecated use `TabsExpander`
-     */
-    public static Expander = TabsExpander;
-
     public static Tab = Tab;
 
     public static defaultProps: Partial<TabsProps> = {


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7363


#### Changes proposed in this pull request:
Deletes `<Tabs.Expander />` and `<Expander />` components since they are deprecated. `<TabsExpander />` is the canonical way to introduce and expander into a tabs list.