### PR TITLE
deprecation: Deprecate MultiSlider.Handle component

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -96,7 +96,7 @@ export { Portal, type PortalProps, type PortalLegacyContext } from "./portal/por
 export { ProgressBar, type ProgressBarProps } from "./progress-bar/progressBar";
 export { type ResizeEntry, ResizeSensor, type ResizeSensorProps } from "./resize-sensor/resizeSensor";
 export { type HandleHtmlProps, HandleInteractionKind, type HandleProps, HandleType } from "./slider/handleProps";
-export { MultiSlider, type MultiSliderProps, type SliderBaseProps } from "./slider/multiSlider";
+export { MultiSlider, MultiSliderHandle, type MultiSliderProps, type SliderBaseProps } from "./slider/multiSlider";
 export { type NumberRange, RangeSlider, type RangeSliderProps } from "./slider/rangeSlider";
 export { Section, type SectionElevation, type SectionProps } from "./section/section";
 export { SectionCard, type SectionCardProps } from "./section/sectionCard";

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -33,10 +33,11 @@ import { HandleInteractionKind, type HandleProps, HandleType } from "./handlePro
 import { argMin, fillValues, formatPercentage } from "./sliderUtils";
 
 /**
- * SFC used to pass slider handle props to a `MultiSlider`.
- * This element is not rendered directly.
+ * Multi slider handle component, used as a child of MultiSlider. This component is not rendered directly.
+ *
+ * @see https://blueprintjs.com/docs/#core/components/sliders.handle
  */
-const MultiSliderHandle: React.FC<HandleProps> = () => null;
+export const MultiSliderHandle: React.FC<HandleProps> = () => null;
 MultiSliderHandle.displayName = `${DISPLAYNAME_PREFIX}.MultiSliderHandle`;
 
 export interface SliderBaseProps extends Props, IntentProps {
@@ -161,6 +162,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
 
     public static displayName = `${DISPLAYNAME_PREFIX}.MultiSlider`;
 
+    /** @deprecated Use `MultiSliderHandle` instead */
     public static Handle = MultiSliderHandle;
 
     public static getDerivedStateFromProps(props: MultiSliderProps) {
@@ -242,7 +244,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
         let anyInvalidChildren = false;
         React.Children.forEach(props.children, child => {
             // allow boolean coercion to omit nulls and false values
-            if (child && !Utils.isElementOfType(child, MultiSlider.Handle)) {
+            if (child && !Utils.isElementOfType(child, MultiSliderHandle)) {
                 anyInvalidChildren = true;
             }
         });
@@ -507,7 +509,7 @@ function getSortedInteractiveHandleProps(props: React.PropsWithChildren<MultiSli
 
 function getSortedHandleProps({ children }: MultiSliderProps, predicate: (props: HandleProps) => boolean = () => true) {
     const maybeHandles = React.Children.map(children, child =>
-        Utils.isElementOfType(child, MultiSlider.Handle) && predicate(child.props) ? child.props : null,
+        Utils.isElementOfType(child, MultiSliderHandle) && predicate(child.props) ? child.props : null,
     );
     let handles = maybeHandles != null ? maybeHandles : [];
     handles = handles.filter(handle => handle !== null);

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -20,7 +20,7 @@ import { AbstractPureComponent, DISPLAYNAME_PREFIX, Intent } from "../../common"
 import * as Errors from "../../common/errors";
 
 import type { HandleHtmlProps } from "./handleProps";
-import { MultiSlider, type SliderBaseProps } from "./multiSlider";
+import { MultiSlider, MultiSliderHandle, type SliderBaseProps } from "./multiSlider";
 
 export type NumberRange = [number, number];
 
@@ -65,13 +65,13 @@ export class RangeSlider extends AbstractPureComponent<RangeSliderProps> {
         const { value, handleHtmlProps, ...props } = this.props;
         return (
             <MultiSlider {...props}>
-                <MultiSlider.Handle
+                <MultiSliderHandle
                     value={value![RangeIndex.START]}
                     type="start"
                     intentAfter={props.intent}
                     htmlProps={handleHtmlProps?.start}
                 />
-                <MultiSlider.Handle value={value![RangeIndex.END]} type="end" htmlProps={handleHtmlProps?.end} />
+                <MultiSliderHandle value={value![RangeIndex.END]} type="end" htmlProps={handleHtmlProps?.end} />
             </MultiSlider>
         );
     }

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -20,7 +20,7 @@ import { AbstractPureComponent, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 
 import type { HandleHtmlProps } from "./handleProps";
-import { MultiSlider, type SliderBaseProps } from "./multiSlider";
+import { MultiSlider, MultiSliderHandle, type SliderBaseProps } from "./multiSlider";
 
 export interface SliderProps extends SliderBaseProps {
     /**
@@ -67,7 +67,7 @@ export class Slider extends AbstractPureComponent<SliderProps> {
         const { initialValue, intent, value, onChange, onRelease, handleHtmlProps, ...props } = this.props;
         return (
             <MultiSlider {...props}>
-                <MultiSlider.Handle
+                <MultiSliderHandle
                     value={value!}
                     intentAfter={value! < initialValue! ? intent : undefined}
                     intentBefore={value! > initialValue! ? intent : undefined}
@@ -75,7 +75,7 @@ export class Slider extends AbstractPureComponent<SliderProps> {
                     onRelease={onRelease}
                     htmlProps={handleHtmlProps}
                 />
-                <MultiSlider.Handle value={initialValue!} interactionKind="none" />
+                <MultiSliderHandle value={initialValue!} interactionKind="none" />
             </MultiSlider>
         );
     }

--- a/packages/core/src/components/slider/sliders.md
+++ b/packages/core/src/components/slider/sliders.md
@@ -49,19 +49,19 @@ implementing more advanced use cases than one or two numbers.
 
 @### Handle
 
-Handles for a `MultiSlider` are configured as `MultiSlider.Handle` children
+Handles for a `MultiSlider` are configured as `MultiSliderHandle` children
 elements, each with their own `value` and other properties.
 
 ```tsx
 // RangeSlider looks roughly like this:
 <MultiSlider onChange={...}>
-    <MultiSlider.Handle
+    <MultiSliderHandle
         value={startValue}
         type="start"
         intentAfter={Intent.PRIMARY}
         htmlProps={handleHtmlProps.start}
     />
-    <MultiSlider.Handle
+    <MultiSliderHandle
         value={endValue}
         type="end"
         htmlProps={handleHtmlProps.end}

--- a/packages/core/test/isotest.mjs
+++ b/packages/core/test/isotest.mjs
@@ -77,6 +77,9 @@ describe("@blueprintjs/core isomorphic rendering", () => {
             Icon: {
                 props: { icon: "build" },
             },
+            MultiSliderHandle: {
+                skip: true,
+            },
             MultistepDialog: {
                 props: { isOpen: true, lazy: false, usePortal: false },
                 children: React.createElement(Core.DialogStep, {

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -24,6 +24,7 @@ import { expectPropValidationError } from "@blueprintjs/test-commons";
 
 import { Classes, MultiSlider, type MultiSliderProps } from "../../src";
 import { Handle } from "../../src/components/slider/handle";
+import { MultiSliderHandle } from "../../src/components/slider/multiSlider";
 
 import { mouseUpHorizontal, simulateMovement } from "./sliderTestUtils";
 
@@ -65,8 +66,8 @@ describe("<MultiSlider>", () => {
         it("propagates className to the handles", () => {
             const slider = mount(
                 <MultiSlider>
-                    <MultiSlider.Handle value={3} className="testClass" />
-                    <MultiSlider.Handle value={5} />
+                    <MultiSliderHandle value={3} className="testClass" />
+                    <MultiSliderHandle value={5} />
                 </MultiSlider>,
                 { attachTo: testsContainerElement },
             );
@@ -247,9 +248,9 @@ describe("<MultiSlider>", () => {
         beforeEach(() => {
             slider = mount(
                 <MultiSlider defaultTrackIntent="warning">
-                    <MultiSlider.Handle value={3} intentBefore="primary" intentAfter="danger" />
-                    <MultiSlider.Handle value={5} intentBefore="primary" intentAfter="danger" />
-                    <MultiSlider.Handle value={7} intentBefore="primary" />
+                    <MultiSliderHandle value={3} intentBefore="primary" intentAfter="danger" />
+                    <MultiSliderHandle value={5} intentBefore="primary" intentAfter="danger" />
+                    <MultiSliderHandle value={7} intentBefore="primary" />
                 </MultiSlider>,
                 { attachTo: testsContainerElement },
             );
@@ -280,8 +281,8 @@ describe("<MultiSlider>", () => {
         it("track section positioning is correct", () => {
             slider = mount(
                 <MultiSlider max={1}>
-                    <MultiSlider.Handle value={1.2e-7} intentBefore="warning" intentAfter="warning" />
-                    <MultiSlider.Handle value={0.2} intentBefore="danger" intentAfter="success" />
+                    <MultiSliderHandle value={1.2e-7} intentBefore="warning" intentAfter="warning" />
+                    <MultiSliderHandle value={0.2} intentBefore="danger" intentAfter="success" />
                 </MultiSlider>,
             );
             const locations = slider.find(`.${Classes.SLIDER_PROGRESS}`).map(segment => {
@@ -298,12 +299,12 @@ describe("<MultiSlider>", () => {
         it("trackStyleBefore and trackStyleAfter work as intended", () => {
             slider = mount(
                 <MultiSlider>
-                    <MultiSlider.Handle
+                    <MultiSliderHandle
                         value={1}
                         trackStyleBefore={{ background: "red" }}
                         trackStyleAfter={{ background: "yellow" }}
                     />
-                    <MultiSlider.Handle
+                    <MultiSliderHandle
                         value={2}
                         trackStyleBefore={{ background: "blue" }}
                         trackStyleAfter={{ background: "purple" }}
@@ -359,9 +360,9 @@ describe("<MultiSlider>", () => {
         const { values = [0, 5, 10], ...props } = joinedProps;
         return mount(
             <MultiSlider {...props}>
-                <MultiSlider.Handle value={values[0]} />
-                <MultiSlider.Handle value={values[1]} />
-                <MultiSlider.Handle value={values[2]} />
+                <MultiSliderHandle value={values[0]} />
+                <MultiSliderHandle value={values[1]} />
+                <MultiSliderHandle value={values[2]} />
             </MultiSlider>,
             { attachTo: testsContainerElement },
         );

--- a/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
@@ -16,7 +16,16 @@
 
 import * as React from "react";
 
-import { H5, HandleInteractionKind, Intent, MultiSlider, Radio, RadioGroup, Switch } from "@blueprintjs/core";
+import {
+    H5,
+    HandleInteractionKind,
+    Intent,
+    MultiSlider,
+    MultiSliderHandle,
+    Radio,
+    RadioGroup,
+    Switch,
+} from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 interface SliderValues {
@@ -82,7 +91,7 @@ export class MultiSliderExample extends React.PureComponent<ExampleProps, MultiS
                 >
                     {/* up to four handles, toggle-able in pairs */}
                     {showDanger && (
-                        <MultiSlider.Handle
+                        <MultiSliderHandle
                             type="start"
                             value={values.dangerStart}
                             intentBefore="danger"
@@ -91,7 +100,7 @@ export class MultiSliderExample extends React.PureComponent<ExampleProps, MultiS
                         />
                     )}
                     {showWarning && (
-                        <MultiSlider.Handle
+                        <MultiSliderHandle
                             type="start"
                             value={values.warningStart}
                             intentBefore="warning"
@@ -100,7 +109,7 @@ export class MultiSliderExample extends React.PureComponent<ExampleProps, MultiS
                         />
                     )}
                     {showWarning && (
-                        <MultiSlider.Handle
+                        <MultiSliderHandle
                             type="end"
                             value={values.warningEnd}
                             intentAfter="warning"
@@ -109,7 +118,7 @@ export class MultiSliderExample extends React.PureComponent<ExampleProps, MultiS
                         />
                     )}
                     {showDanger && (
-                        <MultiSlider.Handle
+                        <MultiSliderHandle
                             type="end"
                             value={values.dangerEnd}
                             intentAfter="danger"


### PR DESCRIPTION
#### Part of https://github.com/palantir/blueprint/issues/7365

#### Changes proposed in this pull request:
This PR deprecates the `MultiSlider.Handle` component and exports `MultiSliderHandle` as the conventional replacement.