### PR TITLE
deprecation: Deprecate nested navbar components

### DIFF
--- a/packages/core/src/components/navbar/navbar.md
+++ b/packages/core/src/components/navbar/navbar.md
@@ -13,17 +13,28 @@ The **Navbar** API includes four stateless React components:
 -   **NavbarHeading** (aliased as `Navbar.Heading`)
 -   **NavbarDivider** (aliased as `Navbar.Divider`)
 
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+    <h5 class="@ns-heading">
+    Nested components are deprecated
+
+</h5>
+
+Use of the nested components such as `<Navbar.Group>` is deprecated. Use the top-level components (e.g. `<NavbarGroup>`)
+instead.
+
+</div>
+
 These components are simple containers for their children. Each of them supports the full range of HTML `<div>`
 DOM attributes.
 
 ```tsx
 <Navbar>
-    <Navbar.Group align={Alignment.START}>
-        <Navbar.Heading>Blueprint</Navbar.Heading>
-        <Navbar.Divider />
+    <NavbarGroup align={Alignment.START}>
+        <NavbarHeading>Blueprint</NavbarHeading>
+        <NavbarDivider />
         <Button className="@ns-minimal" icon="home" text="Home" />
         <Button className="@ns-minimal" icon="document" text="Files" />
-    </Navbar.Group>
+    </NavbarGroup>
 </Navbar>
 ```
 

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -57,6 +57,9 @@ export const Navbar: React.FC<NavbarProps> & {
 Navbar.displayName = `${DISPLAYNAME_PREFIX}.Navbar`;
 
 // compound components of Navbar
+/** @deprecated Use `NavbarDivider` instead */
 Navbar.Divider = NavbarDivider;
+/** @deprecated Use `NavbarGroup` instead */
 Navbar.Group = NavbarGroup;
+/** @deprecated Use `NavbarHeading` instead */
 Navbar.Heading = NavbarHeading;

--- a/packages/table-dev-app/src/nav.tsx
+++ b/packages/table-dev-app/src/nav.tsx
@@ -15,7 +15,16 @@
 
 import * as React from "react";
 
-import { Alignment, AnchorButton, Classes, Navbar, NavbarDivider, NavbarGroup, NavbarHeading, Switch } from "@blueprintjs/core";
+import {
+    Alignment,
+    AnchorButton,
+    Classes,
+    Navbar,
+    NavbarDivider,
+    NavbarGroup,
+    NavbarHeading,
+    Switch,
+} from "@blueprintjs/core";
 
 export interface NavProps {
     selected: "index" | "features";

--- a/packages/table-dev-app/src/nav.tsx
+++ b/packages/table-dev-app/src/nav.tsx
@@ -15,7 +15,7 @@
 
 import * as React from "react";
 
-import { Alignment, AnchorButton, Classes, Navbar, Switch } from "@blueprintjs/core";
+import { Alignment, AnchorButton, Classes, Navbar, NavbarDivider, NavbarGroup, NavbarHeading, Switch } from "@blueprintjs/core";
 
 export interface NavProps {
     selected: "index" | "features";
@@ -28,16 +28,16 @@ export class Nav extends React.PureComponent<NavProps> {
 
         return (
             <Navbar className={Classes.DARK} fixedToTop={true}>
-                <Navbar.Group align={Alignment.START}>
-                    <Navbar.Heading>Blueprint Table</Navbar.Heading>
-                </Navbar.Group>
-                <Navbar.Group align={Alignment.END}>
+                <NavbarGroup align={Alignment.START}>
+                    <NavbarHeading>Blueprint Table</NavbarHeading>
+                </NavbarGroup>
+                <NavbarGroup align={Alignment.END}>
                     <AnchorButton active={isIndex} href="index.html" text="Home" variant="minimal" />
-                    <Navbar.Divider />
+                    <NavbarDivider />
                     <AnchorButton active={!isIndex} href="features.html" text="Features (Legacy)" variant="minimal" />
-                    <Navbar.Divider />
+                    <NavbarDivider />
                     <Switch style={darkThemeToggleStyles} label="Dark theme" onChange={this.handleToggleDarkTheme} />
-                </Navbar.Group>
+                </NavbarGroup>
             </Navbar>
         );
     }


### PR DESCRIPTION
#### Part of https://github.com/palantir/blueprint/issues/7365

#### Changes proposed in this pull request:
This PR deprecates the `Navbar.*` components in favor of the `Navbar*` components.