### PR TITLE
deprecation: Deprecate Tabs.Tab alias

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7369.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7369.v2.yml
@@ -1,0 +1,5 @@
+type: deprecation
+deprecation:
+  description: Deprecate Tabs.Tab alias
+  links:
+  - https://github.com/palantir/blueprint/pull/7369

--- a/packages/core/changelog/@unreleased/pr-7369.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7369.v2.yml
@@ -1,5 +1,0 @@
-type: deprecation
-deprecation:
-  description: Deprecate Tabs.Tab alias
-  links:
-  - https://github.com/palantir/blueprint/pull/7369

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -126,6 +126,7 @@ export interface TabsState {
  * @see https://blueprintjs.com/docs/#core/components/tabs
  */
 export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
+    /** @deprecated Use `Tab` instead */
     public static Tab = Tab;
 
     public static defaultProps: Partial<TabsProps> = {

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -126,7 +126,11 @@ export interface TabsState {
  * @see https://blueprintjs.com/docs/#core/components/tabs
  */
 export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
-    /** @deprecated Use `Tab` instead */
+    /**
+     * @deprecated Use the `Tab` component directly instead
+     *
+     * @see https://blueprintjs.com/docs/#core/components/tabs.tab
+     */
     public static Tab = Tab;
 
     public static defaultProps: Partial<TabsProps> = {


### PR DESCRIPTION
#### Part of https://github.com/palantir/blueprint/issues/7365

#### Changes proposed in this pull request:
This PR deprecates the `Tabs.Tab` component in favor of just `Tab`. I think this is rarely used as is.