### PR TITLE
docs: Fix missing hotkeys legacy reference

### DIFF
--- a/packages/core/src/components/control-card/controlCard.tsx
+++ b/packages/core/src/components/control-card/controlCard.tsx
@@ -50,7 +50,7 @@ export interface ControlCardProps extends SupportedCardProps, SupportedControlPr
      */
     controlKind: ControlKind;
 
-    // N.B. this is split out of the root properties in the inerface because it would conflict with CardProps' HTMLDivProps
+    // N.B. this is split out of the root properties in the interface because it would conflict with CardProps' HTMLDivProps
     /**
      * HTML input attributes to forward to the control `<input>` element.
      */

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.md
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.md
@@ -1,8 +1,8 @@
 @# useHotkeys
 
 The `useHotkeys()` hook adds hotkey / keyboard shortcut interactions to your application using a custom React hook.
-Compared to the deprecated [Hotkeys API](#core/legacy/hotkeys-legacy), it works with function components and its
-corresponding [context provider](#core/context/hotkeys-provider) allows more customization of the hotkeys dialog.
+This works with function components and a corresponding [context provider](#core/context/hotkeys-provider) to allow
+customization of the hotkeys dialog.
 
 Focus on the piano below to try its hotkeys. The global hotkeys dialog can be shown using the <kbd>?</kbd> key.
 


### PR DESCRIPTION
#### Changes proposed in this pull request:
Tiny docs fix left over from removing the legacy hotkeys interface. Also noticed a small typo I fixed.