### PR TITLE
[Datetime] Swap `useLayoutEffect` for `useIsomorphicLayoutEffect` in `useMonthSelectRightOffset`

### DIFF
--- a/packages/datetime/src/common/useMonthSelectRightOffset.ts
+++ b/packages/datetime/src/common/useMonthSelectRightOffset.ts
@@ -16,6 +16,7 @@
 
 import * as React from "react";
 
+import { useIsomorphicLayoutEffect } from "@blueprintjs/core";
 import { IconSize } from "@blueprintjs/icons";
 
 import { DatePickerUtils } from "../components/date-picker/datePickerUtils";
@@ -29,7 +30,7 @@ export function useMonthSelectRightOffset(
 ): number {
     const [monthRightOffset, setMonthRightOffset] = React.useState<number>(0);
 
-    React.useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         if (containerElement.current == null) {
             return;
         }


### PR DESCRIPTION
#### Proposed changes:

Swaps an instance where we call `React.useLayoutEffect` for [`useIsomorphicLayoutEffect`](https://github.com/palantir/blueprint/blob/develop/packages/core/src/hooks/useIsomorphicLayoutEffect.ts).

This improves SSR compatability for components using the `useMonthSelectRightOffset` hook and also quiets some warnings in our isomorphic tests:

```
❯ yarn test:iso
...
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
```