### PR TITLE
Remove `skipLibCheck` from eslint-plugin

### DIFF
--- a/packages/eslint-plugin/src/tsconfig.json
+++ b/packages/eslint-plugin/src/tsconfig.json
@@ -3,8 +3,5 @@
     "compilerOptions": {
         "lib": ["ES2015", "dom"],
         "outDir": "../lib",
-        // HACKHACK: `skipLibCheck` required due to type incompatibility between typescript-eslint
-        // 6.17.0 and typescript 5.3.3, see https://github.com/typescript-eslint/typescript-eslint/issues/8047
-        "skipLibCheck": true,
     },
 }

--- a/packages/eslint-plugin/test/tsconfig.json
+++ b/packages/eslint-plugin/test/tsconfig.json
@@ -4,9 +4,6 @@
         "lib": ["es2021"],
         "module": "commonjs",
         "noEmit": true,
-        // HACKHACK: `skipLibCheck` required due to type incompatibility between typescript-eslint
-        // 6.17.0 and typescript 5.3.3, see https://github.com/typescript-eslint/typescript-eslint/issues/8047
-        "skipLibCheck": true,
         "target": "es2021",
     },
 }


### PR DESCRIPTION
#### Proposed changes

Removes `skipLibCheck` set in `eslint-plugin`. This was originally added in #6620. Looking through the linked issues, it appears that it was since fixed in a v6 release of `typescript-eslint`.

We are now on `8.23.0` of `typescript-eslint` as of #7229