### PR TITLE
feat(ContextMenu): Introduce new API for imperative rendering

### DIFF
--- a/packages/core/src/common/utils/mountOptions.ts
+++ b/packages/core/src/common/utils/mountOptions.ts
@@ -23,6 +23,8 @@ import type * as React from "react";
  * The `domRenderer` currently defaults to React 16's `ReactDOM.render()`; a future version of Blueprint
  * will default to using React 18's `createRoot()` instead, but it's possible to configure this
  * function to use the newer API by overriding the default.
+ *
+ * @deprecated Use more API specific options instead.
  */
 export interface DOMMountOptions<P> {
     /**

--- a/packages/core/src/components/context-menu/context-menu-popover.md
+++ b/packages/core/src/components/context-menu/context-menu-popover.md
@@ -32,10 +32,7 @@ Two functions are provided as an imperative API for showing and hiding a singlet
 the page:
 
 ```ts
-export function showContextMenu(
-    props: ContextMenuPopoverProps,
-    options?: DOMMountOptions<ContextMenuPopoverProps>,
-): void;
+export function showContextMenu(props: ContextMenuPopoverProps, options?: ShowContextMenuOptions): void;
 export function hideContextMenu(options?: DOMMountOptions<ContextMenuPopoverProps>): void;
 ```
 

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -36,7 +36,7 @@ export {
     type ContextMenuContentProps,
 } from "./context-menu/contextMenu";
 export { ContextMenuPopover, type ContextMenuPopoverProps } from "./context-menu/contextMenuPopover";
-export { showContextMenu, hideContextMenu } from "./context-menu/contextMenuSingleton";
+export { showContextMenu, hideContextMenu, type ShowContextMenuOptions } from "./context-menu/contextMenuSingleton";
 export { Dialog, type DialogProps } from "./dialog/dialog";
 export { DialogBody, type DialogBodyProps } from "./dialog/dialogBody";
 export { DialogFooter, type DialogFooterProps } from "./dialog/dialogFooter";


### PR DESCRIPTION

#### Changes proposed in this pull request:
This PR introduces a new rendering API for the `showContextMenu` and `hideContextMenu` options and deprecates the old API. The old API will be dropped in Blueprint 6.

Previously these functions would allow users to pass in an object with `domRenderer` and `domUnmounter` options which were implemented via `ReactDOM.render` and `ReactDOM.unmountComponentAtNode` respectively. This API does not work for React 18 which requires tracking a root node between the render and unmount stages. To allow for this, the new API instead allows passing a single `render` function which should return a function that unmounts the rendered node.

The default implementation still uses React 16 compatible defaults as before. In Blueprint 6 we will be making a few breaks here:
1. Remove the `DOMMountOptions<T>` type from the `options` prop of `showContextMenu`
2. Remove the options parameter of `hideContextMenu`
3. Change the default implementation of the `render` method to use React 18 compatible methods. It will look something like:

```tsx
const defaultRenderer: ShowContextMenuDOMRenderer = (element, container) => {
    const root = ReactDOMClient.createRoot(container);
    root.render(element);
    return () => root.unmount();
}