### PR TITLE
[Proposal] break(ContextMenu): Use React 18 rendering

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -15,16 +15,44 @@
  */
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
 
 import { Classes } from "../../common";
-import type { DOMMountOptions } from "../../common/utils/mountOptions";
 import { OverlaysProvider } from "../../context/overlays/overlaysProvider";
 
 import { ContextMenuPopover, type ContextMenuPopoverProps } from "./contextMenuPopover";
 
-/** DOM element which contains the context menu singleton instance for the imperative ContextMenu APIs. */
-let contextMenuElement: HTMLElement | undefined;
+/**
+ * Options for specifying how an imperatively created context menu should be rendered to the DOM.
+ */
+export interface ShowContextMenuOptions {
+    /**
+     * A new DOM element will be created and appended to this container.
+     *
+     * @default document.body
+     */
+    container?: HTMLElement;
+    /**
+     * A function render the React component onto a newly created DOM element. This should return a function which
+     * unmounts the rendered element from the DOM.
+     */
+    render?: ShowContextMenuDOMRenderer;
+}
+
+type ShowContextMenuDOMRenderer = (
+    element: React.ReactElement<ContextMenuPopoverProps>,
+    container: Element | DocumentFragment,
+) => ShowContextMenuDOMUnmounter;
+
+type ShowContextMenuDOMUnmounter = () => void;
+
+interface ContextMenuState {
+    element: HTMLElement;
+    unmount: () => void;
+}
+
+/** State which contains the context menu singleton instance for the imperative ContextMenu APIs. */
+let contextMenuState: ContextMenuState | undefined;
 
 /**
  * Show a context menu at a particular offset from the top-left corner of the document.
@@ -44,40 +72,34 @@ let contextMenuElement: HTMLElement | undefined;
  *
  * @see https://blueprintjs.com/docs/#core/components/context-menu-popover.imperative-api
  */
-export function showContextMenu(
-    props: Omit<ContextMenuPopoverProps, "isOpen">,
-    options: DOMMountOptions<ContextMenuPopoverProps> = {},
-) {
-    const {
-        container = document.body,
-        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        domRenderer = ReactDOM.render,
-        // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        domUnmounter = ReactDOM.unmountComponentAtNode,
-    } = options;
+export function showContextMenu(props: Omit<ContextMenuPopoverProps, "isOpen">, options: ShowContextMenuOptions = {}) {
+    const { container = document.body, render = defaultDomRenderer } = options;
 
-    if (contextMenuElement === undefined) {
-        contextMenuElement = document.createElement("div");
-        contextMenuElement.classList.add(Classes.CONTEXT_MENU);
-        container.appendChild(contextMenuElement);
+    if (contextMenuState == null) {
+        const element = document.createElement("div");
+        element.classList.add(Classes.CONTEXT_MENU);
+        container.appendChild(element);
+        contextMenuState = { element, unmount: undefined! };
     } else {
         // N.B. It's important to unmount previous instances of the ContextMenuPopover rendered by this function.
         // Otherwise, React will detect no change in props sent to the already-mounted component, and therefore
         // do nothing after the first call to this function, leading to bugs like https://github.com/palantir/blueprint/issues/5949
-        domUnmounter(contextMenuElement);
+        contextMenuState.unmount();
     }
 
-    // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    domRenderer(
+    contextMenuState.unmount = render(
         <OverlaysProvider>
             <UncontrolledContextMenuPopover {...props} />
         </OverlaysProvider>,
-        contextMenuElement,
+        contextMenuState.element,
     );
 }
+
+const defaultDomRenderer: ShowContextMenuDOMRenderer = (element, container) => {
+    const root = ReactDOMClient.createRoot(container);
+    root.render(element);
+    return () => root.unmount();
+};
 
 /**
  * Hide a context menu that was created using `showContextMenu()`.
@@ -86,14 +108,10 @@ export function showContextMenu(
  *
  * @see https://blueprintjs.com/docs/#core/components/context-menu-popover.imperative-api
  */
-export function hideContextMenu(options: DOMMountOptions<ContextMenuPopoverProps> = {}) {
-    // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7165
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const { domUnmounter = ReactDOM.unmountComponentAtNode } = options;
-
-    if (contextMenuElement !== undefined) {
-        domUnmounter(contextMenuElement);
-        contextMenuElement = undefined;
+export function hideContextMenu() {
+    if (contextMenuState != null) {
+        contextMenuState.unmount();
+        contextMenuState = undefined;
     }
 }
 


### PR DESCRIPTION
#### Part of https://github.com/palantir/blueprint/issues/7165

#### Changes proposed in this pull request:
This PR proposes a changed API  for the context menu imperative API to support React 18 rendering. In this API instead of having two different render and unmount functions we have a single function which renders the element and returns an unmount function. This allows a root node to be maintained between these functions so that we can use the React 18 rendering API.

If we're happy with this API then I've introduced a change here https://github.com/palantir/blueprint/pull/7391 which implements this API in a non-breaking way, maintaining the old types and React 16 compatible rendering. Once that's in, I'll cherry pick onto `bp6` and then update this PR and make it ready for review.