### PR TITLE
[datetime2] Add back `date-fns` dependency required by `react-day-picker`

### DIFF
--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -35,6 +35,7 @@
     "dependencies": {
         "@blueprintjs/core": "workspace:^",
         "@blueprintjs/datetime": "workspace:^",
+        "date-fns": "^2.28.0",
         "react-day-picker": "^8.10.0",
         "tslib": "~2.6.2"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,6 +495,7 @@ __metadata:
     "@blueprintjs/core": "workspace:^"
     "@blueprintjs/datetime": "workspace:^"
     "@blueprintjs/node-build-scripts": "workspace:^"
+    date-fns: "npm:^2.28.0"
     npm-run-all: "npm:^4.1.5"
     react: "npm:^18.3.1"
     react-day-picker: "npm:^8.10.0"


### PR DESCRIPTION
#### Proposed changes

Fixes the following warnings on install

![Screenshot 2025-03-26 at 12 15 41@2x](https://github.com/user-attachments/assets/45577459-a957-49b9-b8d4-3bdf13ee71ca)

We removed `date-fns` from the `@blueprintjs/datetime` package in #7388. However, `date-fns` is technically required as a peer dependency in v8 ([see docs](https://daypicker.dev/v8)).

**Note:** We're only using styles from `react-day-picker` in datetime2 at this point: https://github.com/palantir/blueprint/blob/e53132439d270e20a9e953145385b46d7e8999fa/packages/datetime2/src/common/_react-day-picker-overrides.scss#L8
