### PR TITLE
Cherry pick #7336: test: use testing-library waitFor instead of arbitrary wait times

### DIFF
--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount } from "enzyme";
 import * as React from "react";
@@ -185,14 +186,13 @@ describe("<Dialog>", () => {
             assert.notExists(dialog.find(".no-default-if-no-title").hostNodes().prop("aria-labelledby"));
         });
 
-        it("supports ref objects attached to container", done => {
+        it("supports ref objects attached to container", async () => {
             const containerRef = React.createRef<HTMLDivElement>();
             mountDialog({ containerRef });
 
             // wait for the whole lifecycle to run
-            setTimeout(() => {
+            await waitFor(() => {
                 assert.isTrue(containerRef.current?.classList.contains(Classes.DIALOG_CONTAINER));
-                done();
             });
         });
     });

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -124,7 +124,7 @@ describe("asyncControllable tests", () => {
                     input.simulate("compositionstart", { data: "" });
 
                     // Wait for the composition ending delay to pass
-                    await new Promise(resolve => setTimeout(() => resolve(null), COMPOSITION_END_DELAY + 5));
+                    await sleep(COMPOSITION_END_DELAY + 5);
 
                     assert.strictEqual(wrapper.find(element).prop("value"), "hi ");
                 });
@@ -139,7 +139,7 @@ describe("asyncControllable tests", () => {
                     input.simulate("compositionend", { data: " " });
 
                     // Wait for the composition ending delay to pass
-                    await new Promise(resolve => setTimeout(() => resolve(null), COMPOSITION_END_DELAY + 5));
+                    await sleep(COMPOSITION_END_DELAY + 5);
 
                     // we are "rejecting" the composition here by supplying a different controlled value
                     wrapper.setProps({ value: "bye" }).update();
@@ -155,9 +155,10 @@ describe("asyncControllable tests", () => {
                             return <Component value={this.state.value} onChange={this.handleChange} type={type} />;
                         }
 
-                        private handleChange = (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
+                        private handleChange = async (e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
                             const newValue = e.target.value;
-                            window.setTimeout(() => this.setState({ value: newValue }), 10);
+                            await sleep(10);
+                            this.setState({ value: newValue });
                         };
                     }
 

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -20,6 +20,7 @@ import * as React from "react";
 import { spy } from "sinon";
 
 import { ResizeSensor, type ResizeSensorProps } from "../../src/components/resize-sensor/resizeSensor";
+import { sleep } from "../utils";
 
 describe("<ResizeSensor>", () => {
     // this scope variable is assigned in mountResizeSensor() and used in resize()
@@ -97,10 +98,10 @@ describe("<ResizeSensor>", () => {
         ));
     }
 
-    function resize(size: SizeProps) {
+    async function resize(size: SizeProps) {
         wrapper!.setProps(size);
         wrapper!.update();
-        return new Promise(resolve => setTimeout(resolve, 30));
+        await sleep(30);
     }
 
     function assertResizeArgs(onResize: sinon.SinonSpy, sizes: string[]) {

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -401,7 +402,7 @@ describe("<Tabs>", () => {
             assert.deepEqual(tabs.state("selectedTabId"), TAB_ID_TO_SELECT);
         });
 
-        it("indicator moves correctly if tabs switch externally via the selectedTabId prop", done => {
+        it("indicator moves correctly if tabs switch externally via the selectedTabId prop", async () => {
             const wrapper = mount(
                 <Tabs id={ID} selectedTabId={SELECTED_TAB_ID}>
                     {getTabsContents()}
@@ -411,9 +412,8 @@ describe("<Tabs>", () => {
             wrapper.setProps({ selectedTabId: TAB_ID_TO_SELECT });
             wrapper.update();
             // indicator moves via componentDidUpdate
-            setTimeout(() => {
+            await waitFor(() => {
                 assertIndicatorPosition(wrapper, TAB_ID_TO_SELECT);
-                done();
             });
         });
     });

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom";
 import { assert, expect } from "chai";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";
 import * as React from "react";
@@ -132,7 +133,7 @@ describe("<TagInput>", () => {
             assert.deepEqual(onAdd.args[0][1], "default");
         });
 
-        it("is invoked on blur when addOnBlur=true", done => {
+        it("is invoked on blur when addOnBlur=true", async () => {
             const onAdd = sinon.stub();
             const wrapper = mount(<TagInput values={VALUES} addOnBlur={true} onAdd={onAdd} />);
             // simulate typing input text
@@ -140,34 +141,31 @@ describe("<TagInput>", () => {
             wrapper.find("input").simulate("change", { currentTarget: { value: NEW_VALUE } });
             wrapper.simulate("blur");
 
-            // Need setTimeout here to wait for focus to change after blur event
-            setTimeout(() => {
+            // Wait for focus to change after blur event
+            await waitFor(() => {
                 assert.isTrue(onAdd.calledOnce);
                 assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
                 assert.equal(onAdd.args[0][1], "blur");
-                done();
-            }, 50);
-        });
-
-        it("is not invoked on blur when addOnBlur=true but inputValue is empty", done => {
-            const onAdd = sinon.stub();
-            const wrapper = mount(<TagInput values={VALUES} addOnBlur={true} onAdd={onAdd} />);
-            wrapper.simulate("blur");
-            // Need setTimeout here to wait for focus to change after blur event
-            setTimeout(() => {
-                assert.isTrue(onAdd.notCalled);
-                done();
             });
         });
 
-        it("is not invoked on blur when addOnBlur=false", done => {
+        it("is not invoked on blur when addOnBlur=true but inputValue is empty", async () => {
+            const onAdd = sinon.stub();
+            const wrapper = mount(<TagInput values={VALUES} addOnBlur={true} onAdd={onAdd} />);
+            wrapper.simulate("blur");
+            // Wait for focus to change after blur event
+            await waitFor(() => {
+                assert.isTrue(onAdd.notCalled);
+            });
+        });
+
+        it("is not invoked on blur when addOnBlur=false", async () => {
             const onAdd = sinon.stub();
             const wrapper = mount(<TagInput values={VALUES} inputProps={{ value: NEW_VALUE }} onAdd={onAdd} />);
             wrapper.simulate("blur");
-            // Need setTimeout here to wait for focus to change after blur event
-            setTimeout(() => {
+            // Wait for focus to change after blur event
+            await waitFor(() => {
                 assert.isTrue(onAdd.notCalled);
-                done();
             });
         });
 

--- a/packages/core/test/tag/compoundTagTests.tsx
+++ b/packages/core/test/tag/compoundTagTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { assert, expect } from "chai";
 import { mount, shallow } from "enzyme";
 import * as React from "react";
@@ -106,7 +106,7 @@ describe("<CompoundTag>", () => {
         assert.deepEqual(handleRemove.args[0][1][DATA_ATTR_FOO], tagProps[DATA_ATTR_FOO]);
     });
 
-    it("supports ref objects", done => {
+    it("supports ref objects", async () => {
         const elementRef = React.createRef<HTMLSpanElement>();
         const wrapper = mount(
             <CompoundTag ref={elementRef} leftContent="Hello">
@@ -115,9 +115,8 @@ describe("<CompoundTag>", () => {
         );
 
         // wait for the whole lifecycle to run
-        setTimeout(() => {
+        await waitFor(() => {
             assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
-            done();
-        }, 0);
+        });
     });
 });

--- a/packages/core/test/tag/tagTests.tsx
+++ b/packages/core/test/tag/tagTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { assert, expect } from "chai";
 import { mount, shallow } from "enzyme";
 import * as React from "react";
@@ -106,14 +106,13 @@ describe("<Tag>", () => {
         assert.deepEqual(handleRemove.args[0][1][DATA_ATTR_FOO], tagProps[DATA_ATTR_FOO]);
     });
 
-    it("supports ref objects", done => {
+    it("supports ref objects", async () => {
         const elementRef = React.createRef<HTMLSpanElement>();
         const wrapper = mount(<Tag ref={elementRef}>Hello</Tag>);
 
         // wait for the whole lifecycle to run
-        setTimeout(() => {
+        await waitFor(() => {
             assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
-            done();
-        }, 0);
+        });
     });
 });

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -112,14 +112,13 @@ describe("OverlayToaster", () => {
                 toaster.show({
                     message: "Hello world",
                 });
-                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-                // setState needs a tick to flush DOM updates
                 await waitFor(() => {
-                    assert.isNotNull(
-                        document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`),
-                        "expected toast container element to have 'overlay open' class name",
-                    );
+                    assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
                 });
+                assert.isNotNull(
+                    document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`),
+                    "expected toast container element to have 'overlay open' class name",
+                );
             });
 
             it("multiple show()s renders them all", async () => {

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -112,13 +112,14 @@ describe("OverlayToaster", () => {
                 toaster.show({
                     message: "Hello world",
                 });
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                // setState needs a tick to flush DOM updates
                 await waitFor(() => {
-                    assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                    assert.isNotNull(
+                        document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`),
+                        "expected toast container element to have 'overlay open' class name",
+                    );
                 });
-                assert.isNotNull(
-                    document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`),
-                    "expected toast container element to have 'overlay open' class name",
-                );
             });
 
             it("multiple show()s renders them all", async () => {
@@ -331,14 +332,12 @@ describe("OverlayToaster", () => {
                 document.documentElement.removeChild(testsContainerElement);
             });
 
-            it("focuses inside toast container", done => {
+            it("focuses inside toast container", async () => {
                 toaster.show({ message: "focus near me" });
-                // small explicit timeout reduces flakiness of these tests
-                setTimeout(() => {
+                await waitFor(() => {
                     const toastElement = testsContainerElement.querySelector(`.${Classes.TOAST_CONTAINER}`);
                     assert.isTrue(toastElement?.contains(document.activeElement));
-                    done();
-                }, 100);
+                });
             });
         });
 

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -20,6 +20,7 @@ import * as React from "react";
 import { type SinonSpy, spy } from "sinon";
 
 import { AnchorButton, Button, Toast } from "../../src";
+import { sleep } from "../utils";
 
 describe("<Toast>", () => {
     it("renders only dismiss button by default", () => {
@@ -68,35 +69,31 @@ describe("<Toast>", () => {
         let handleDismiss: SinonSpy;
         beforeEach(() => (handleDismiss = spy()));
 
-        it("calls onDismiss automatically after timeout expires with `true`", done => {
+        it("calls onDismiss automatically after timeout expires with `true`", async () => {
             // mounting for lifecycle methods to start timeout
             mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />);
-            setTimeout(() => {
-                assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
-                assert.isTrue(handleDismiss.firstCall.args[0], "onDismiss not called with `true`");
-                done();
-            }, 20);
+            await sleep(20);
+
+            assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
+            assert.isTrue(handleDismiss.firstCall.args[0], "onDismiss not called with `true`");
         });
 
-        it("updating with timeout={0} cancels timeout", done => {
+        it("updating with timeout={0} cancels timeout", async () => {
             mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />).setProps({
                 timeout: 0,
             });
-            setTimeout(() => {
-                assert.isTrue(handleDismiss.notCalled, "onDismiss was called");
-                done();
-            }, 20);
+            await sleep(20);
+            assert.isTrue(handleDismiss.notCalled, "onDismiss was called");
         });
 
-        it("updating timeout={0} with timeout={X} starts timeout", done => {
+        it("updating timeout={0} with timeout={X} starts timeout", async () => {
             mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={0} />).setProps({
                 timeout: 20,
             });
-            setTimeout(() => {
-                assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
-                assert.isTrue(handleDismiss.firstCall.args[0], "onDismiss not called with `true`");
-                done();
-            }, 20);
+            await sleep(20);
+
+            assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
+            assert.isTrue(handleDismiss.firstCall.args[0], "onDismiss not called with `true`");
         });
     });
 });

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
 import * as React from "react";
@@ -263,7 +264,7 @@ describe("<Tree>", () => {
         assert.strictEqual(findNodeClass(tree, "c2", Classes.TREE_NODE_SECONDARY_LABEL).text(), "Paragraph");
     });
 
-    it("getNodeContentElement returns references to underlying node elements", done => {
+    it("getNodeContentElement returns references to underlying node elements", async () => {
         const contents = createDefaultContents();
         contents[1].isExpanded = true;
 
@@ -279,10 +280,9 @@ describe("<Tree>", () => {
         contents[1].isExpanded = false;
         wrapper.setProps({ contents });
         // wait for animation to finish
-        setTimeout(() => {
+        await waitFor(() => {
             assert.isUndefined(tree.getNodeContentElement(5));
-            done();
-        }, 300);
+        });
     });
 
     it("allows nodes to be removed without throwing", () => {


### PR DESCRIPTION
#### Changes proposed in this pull request:
Cherry picks https://github.com/palantir/blueprint/pull/7336 onto `bp6`. Had to revert one of the updated tests since that was already updated on this branch but otherwise was a pretty smooth merge.