### PR TITLE
Fix Table row reordering example

### DIFF
--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -74,6 +74,7 @@ export class TableReorderableExample extends React.PureComponent<ExampleProps, T
         return (
             <Example options={options} showOptionsBelowExample={true} {...this.props}>
                 <Table2
+                    cellRendererDependencies={[this.state]}
                     enableColumnReordering={true}
                     enableColumnResizing={false}
                     enableRowReordering={true}

--- a/packages/table/src/docs/table-features.md
+++ b/packages/table/src/docs/table-features.md
@@ -65,7 +65,8 @@ regular expression (`[a-zA-Z]`). If the content is invalid, a `Intent.DANGER` st
 @## Reordering
 
 The table supports drag-reordering of columns and rows via the `enableColumnReordering` and `enableRowReordering`
-props, respectively.
+
+props, respectively. Use `cellRendererDependencies` to ensure the latest state updates are reflected.
 
 ### Reordering columns
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7128

#### Checklist

-   [x] Includes tests
  - None needed, before and after video included
-   [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Table2 row reordering didn't work because the cells weren't rerendering after the React state updated.

#### Reviewers should focus on:

Column reordering worked without `cellRendererDependencies` because the children depended on columns directly. Maybe there's a smarter way so that Table2 knows when rows have been reordered, but in the meantime, update the docs to help consumers avoid this footgun.

#### Screenshot

After:

https://github.com/user-attachments/assets/79a87138-2188-40d6-927e-741f96ae4ded

Multirow reordering works too:

https://github.com/user-attachments/assets/316bf62e-1fc6-4fc8-a991-517c52e727b8

