### PR TITLE
break(OverlayToaster): Remove synchronous API

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -103,11 +103,6 @@ export const TOASTER_CREATE_NULL =
     ns +
     ` OverlayToaster.create() is not supported inside React lifecycle methods in React 16.` +
     ` See usage example on the docs site. https://blueprintjs.com/docs/#core/components/toast.example`;
-export const TOASTER_CREATE_ASYNC_NULL =
-    ns +
-    ` OverlayToaster.createAsync() received a null component ref. This can happen if called inside React lifecycle ` +
-    `methods in React 16. See usage example on the docs site. ` +
-    `https://blueprintjs.com/docs/#core/components/toast.example`;
 export const TOASTER_MAX_TOASTS_INVALID =
     ns + ` <OverlayToaster> maxToasts is set to an invalid number, must be greater than 0`;
 export const TOASTER_WARN_INLINE =

--- a/packages/core/src/components/toast/toast.md
+++ b/packages/core/src/components/toast/toast.md
@@ -34,23 +34,15 @@ of its container.
 
 There are three ways to use **OverlayToaster**:
 
-1. **Recommended**: use the `OverlayToaster.createAsync()` static method to create a new `Toaster` instance:
+1. **Recommended**: use the `OverlayToaster.create()` static method to create a new `Toaster` instance:
 
     ```ts
-    const myToaster: Toaster = await OverlayToaster.createAsync({ position: "bottom" });
+    const myToaster: Toaster = await OverlayToaster.create({ position: "bottom" });
     myToaster.show({ ...toastOptions });
     ```
 
-    We recommend calling `OverlayToaster.createAsync` once in your application and
+    We recommend calling `OverlayToaster.create` once in your application and
     [sharing the generated instance](#core/components/toast.example) throughout your application.
-
-    A synchronous `OverlayToaster.create()` static method is also available, but will be phased out
-    since React 18+ no longer synchronously renders components to the DOM.
-
-    ```ts
-    const myToaster: Toaster = OverlayToaster.create({ position: "bottom" });
-    myToaster.show({ ...toastOptions });
-    ```
 
 2. Render an `<OverlayToaster>` with `<Toast>` children:
     ```ts
@@ -95,12 +87,12 @@ enable `autoFocus` for an individual `OverlayToaster` via a prop, if desired.
 
 @## Static usage
 
-**OverlayToaster** provides the static `createAsync` method that returns a new `Toaster`, rendered
-into an element attached to `<body>`. A toaster instance has a collection of methods to show and
+**OverlayToaster** provides the static `create` method that returns a promise that resolves to a new `Toaster`,
+rendered into an element attached to `<body>`. A toaster instance has a collection of methods to show and
 hide toasts in its given container.
 
 ```ts
-OverlayToaster.createAsync(props?: OverlayToasterProps, options?: OverlayToasterCreateOptions): Promise<Toaster>;
+OverlayToaster.create(props?: OverlayToasterProps, options?: OverlayToasterCreateOptions): Promise<Toaster>;
 ```
 
 @interface OverlayToasterCreateOptions
@@ -109,7 +101,7 @@ The toaster will be rendered into a new element appended to the given `container
 The `container` determines which element toasts are positioned relative to; the default value of
 `<body>` allows them to use the entire viewport.
 
-The return type is `Promise<Toaster>`, which is a minimal interface that exposes only the instance
+The returned promise contains a `Toaster` which is a minimal interface that exposes only the instance
 methods detailed below. It can be thought of as `OverlayToaster` minus the `React.Component` methods,
 because the `OverlayToaster` should not be treated as a normal React component.
 
@@ -119,24 +111,26 @@ possible to attach `.then()` handlers to the returned toaster.
 
 ```ts
 function synchronousFn() {
-    const toasterPromise = OverlayToaster.createAsync({});
+    const toasterPromise = OverlayToaster.create({});
     toasterPromise.then(toaster => toaster.show({ message: "Toast!" }));
 }
 ```
 
-Note that `OverlayToaster.createAsync()` will throw an error if invoked inside a component lifecycle
+Note that `OverlayToaster.create()` will throw an error if invoked inside a component lifecycle
 method, as `ReactDOM.render()` will return `null` resulting in an inaccessible toaster instance.
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
     <h5 class="@ns-heading">Beware of memory leaks</h5>
 
-The static `createAsync` and `create` methods create a new `OverlayToaster` instance for the full lifetime of your
-application. Since there's no React parent component, these methods create a new DOM node as a container for the
-rendered `<OverlayToaster>` component. Every `createAsync` call will add a new DOM node. We do not recommend creating a
+The static `create` method creates a new `OverlayToaster` instance for the full lifetime of your
+application. Since there's no React parent component, this method creates a new DOM node as a container for the
+rendered `<OverlayToaster>` component. Every `create` call will add a new DOM node. We do not recommend creating a
 new `Toaster` every time a toast needs to be shown. To minimize leaking:
 
-1. Call `OverlayToaster.createAsync` once in an application and [share the instance](#core/components/toast.example).
-2. Consider one of the alternative APIs that mount the `<OverlayToaster>` somewhere in the application's React component tree. This provides component lifecycle management out of the box. See [_React component usage_](#core/components/toast.react-component-usage) for an example.
+1. Call `OverlayToaster.create` once in an application and [share the instance](#core/components/toast.example).
+2. Consider one of the alternative APIs that mount the `<OverlayToaster>` somewhere in the application's React component
+tree. This provides component lifecycle management out of the box. See
+[_React component usage_](#core/components/toast.react-component-usage) for an example.
 
 </div>
 
@@ -154,7 +148,7 @@ The following code samples demonstrate our preferred pattern for intergrating a 
 import { OverlayToaster, Position } from "@blueprintjs/core";
 
 /** Singleton toaster instance. Create separate instances for different options. */
-export const AppToaster = OverlayToaster.createAsync({
+export const AppToaster = OverlayToaster.create({
     className: "recipe-toaster",
     position: Position.TOP,
 });
@@ -167,43 +161,20 @@ import { Button } from "@blueprintjs/core";
 import * as React from "react";
 import { AppToaster } from "./toaster";
 
-export class App extends React.PureComponent {
-    render() {
-        return <Button onClick={this.showToast} text="Toast please" />;
-    }
-
-    showToast = async () => {
+export const App: React.FC = () => {
+    const handleClick = React.useCallback(() => {
         // create toasts in response to interactions.
         // in most cases, it's enough to simply create and forget (thanks to timeout).
         (await AppToaster).show({ message: "Toasted." });
-    };
+    }, []);
+
+    return <Button onClick={handleClick} text="Toast please" />;
 }
 ```
 
-The example below uses the `OverlayToaster.createAsync()` static method. Clicking the button will create a new toaster mounted to `<body>`, show a message, and unmount the toaster from the DOM once the message is dismissed.
+The example below uses the `OverlayToaster.create()` static method. Clicking the button will create a new toaster mounted to `<body>`, show a message, and unmount the toaster from the DOM once the message is dismissed.
 
 @reactExample ToastCreateAsyncExample
-
-#### React 18
-
-To maintain backwards compatibility with React 16 and 17, `OverlayToaster.createAsync` uses `ReactDOM.render` out of the box. This triggers a [console warning on React 18](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis).
-A future major version of Blueprint will drop support for React versions before 18 and switch the
-default rendering function from `ReactDOM.render` to `createRoot`.
-
-If you're using React 18, we recommend passing in a custom `domRenderer` function.
-
-```tsx
-import { OverlayToaster } from "@blueprintjs/core";
-import { createRoot } from "react-dom/client";
-
-const toaster = await OverlayToaster.createAsync(toasterProps, {
-    // Use createRoot() instead of ReactDOM.render(). This can be deleted after
-    // a future Blueprint version uses createRoot() for Toasters by default.
-    domRenderer: (toaster, containerElement) => createRoot(containerElement).render(toaster),
-});
-
-toaster.show({ message: "Hello React 18!" });
-```
 
 @## React component usage
 

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -16,349 +16,282 @@
 
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
-import { mount } from "enzyme";
-import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as ReactDOMClient from "react-dom/client";
 import sinon, { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 
-import { Classes, OverlayToaster, type OverlayToasterProps, type Toaster } from "../../src";
-import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
-import { OVERLAY_TOASTER_DELAY_MS } from "../../src/components/toast/overlayToaster";
+import { Classes, OverlayToaster, type Toaster } from "../../src";
+import { TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
+import { OVERLAY_TOASTER_DELAY_MS, type OverlayToasterDOMRenderer } from "../../src/components/toast/overlayToaster";
 
 let react18Root: ReactDOMClient.Root | undefined;
-
-const SPECS = [
-    {
-        cleanup: unmountReact16Toaster,
-        create: (props: OverlayToasterProps | undefined, containerElement: HTMLElement) =>
-            OverlayToaster.create(props, containerElement),
-        name: "create",
-    },
-    {
-        cleanup: () => {
-            /* noop */
-        },
-        create: (props: OverlayToasterProps | undefined, containerElement: HTMLElement) =>
-            OverlayToaster.createAsync(props, {
-                container: containerElement,
-                domRenderer: (element, container) => {
-                    react18Root?.unmount();
-                    react18Root = ReactDOMClient.createRoot(container);
-                    react18Root.render(element);
-                },
-            }),
-        name: "createAsync",
-    },
-];
-
-/**
- * Dynamically run describe blocks. The helper function here reduces indentation
- * width compared to inlining a for loop.
- *
- * https://mochajs.org/#dynamically-generating-tests
- */
-function describeEach<T extends { name: string }>(specs: readonly T[], runner: (spec: T) => void) {
-    for (const spec of specs) {
-        describe(spec.name, () => runner(spec));
-    }
-}
-
-/**
- * @param containerElement The container argument passed to OverlayToaster.create/OverlayToaster.createAsync
- */
-function unmountReact16Toaster(containerElement: HTMLElement) {
-    const toasterRenderRoot = containerElement.firstElementChild;
-    if (toasterRenderRoot == null) {
-        throw new Error("No elements were found under Toaster container.");
-    }
-    // TODO(React 18): Replace deprecated ReactDOM methods. See: https://github.com/palantir/blueprint/issues/7167
-    // eslint-disable-next-line @typescript-eslint/no-deprecated
-    ReactDOM.unmountComponentAtNode(toasterRenderRoot);
-}
 
 describe("OverlayToaster", () => {
     let testsContainerElement: HTMLElement;
     let toaster: Toaster;
 
-    describeEach(SPECS, spec => {
-        describe("with default props", () => {
-            before(async () => {
-                testsContainerElement = document.createElement("div");
-                document.documentElement.appendChild(testsContainerElement);
-                toaster = await spec.create({}, testsContainerElement);
-            });
+    const domRenderer: OverlayToasterDOMRenderer = (element, container) => {
+        react18Root?.unmount();
+        react18Root = ReactDOMClient.createRoot(container);
+        react18Root.render(element);
+    };
 
-            afterEach(() => {
-                toaster.clear();
-            });
-
-            after(() => {
-                spec.cleanup(testsContainerElement);
-                document.documentElement.removeChild(testsContainerElement);
-            });
-
-            it("does not attach toast container to body on script load", () => {
-                assert.lengthOf(
-                    document.getElementsByClassName(Classes.TOAST_CONTAINER),
-                    0,
-                    "unexpected toast container",
-                );
-            });
-
-            it("show() renders toast on next tick", async () => {
-                toaster.show({
-                    message: "Hello world",
-                });
-                await waitFor(() => {
-                    assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-                });
-                assert.isNotNull(
-                    document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`),
-                    "expected toast container element to have 'overlay open' class name",
-                );
-            });
-
-            it("multiple show()s renders them all", async () => {
-                toaster.show({ message: "one" });
-                toaster.show({ message: "two" });
-                toaster.show({ message: "six" });
-                await waitFor(() => assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts"), {
-                    timeout: 3 * OVERLAY_TOASTER_DELAY_MS,
-                });
-            });
-
-            it("multiple shows() get queued if provided too quickly", async () => {
-                toaster.show({ message: "one" });
-                toaster.show({ message: "two" });
-                toaster.show({ message: "three" });
-                await waitFor(() => assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast"));
-                await waitFor(() => assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts after delay"), {
-                    timeout: 3 * OVERLAY_TOASTER_DELAY_MS,
-                });
-                // clock.restore();
-            });
-
-            it("show() immediately displays a toast when waiting after the previous show()", async () => {
-                toaster.show({ message: "one" });
-                await waitFor(() => assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast"));
-                await waitFor(
-                    () => {
-                        toaster.show({ message: "two" });
-                        assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
-                    },
-                    { timeout: 2 * OVERLAY_TOASTER_DELAY_MS },
-                );
-            });
-
-            it("show() updates existing toast", async () => {
-                const key = toaster.show({ message: "one" });
-                await waitFor(() => {
-                    assert.deepEqual(toaster.getToasts()[0].message, "one");
-                });
-                toaster.show({ message: "two" }, key);
-                await waitFor(() => {
-                    assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
-                    assert.deepEqual(toaster.getToasts()[0].message, "two");
-                });
-            });
-
-            it("show() updates existing toast in queue", async () => {
-                toaster.show({ message: "one" });
-                const key = toaster.show({ message: "two" });
-                toaster.show({ message: "two updated" }, key);
-                await waitFor(
-                    () => {
-                        assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
-                        assert.deepEqual(toaster.getToasts()[0].message, "two updated");
-                    },
-                    { timeout: 2 * OVERLAY_TOASTER_DELAY_MS },
-                );
-            });
-
-            it("dismiss() removes just the toast in question", async () => {
-                toaster.show({ message: "one" });
-                const key = toaster.show({ message: "two" });
-                toaster.show({ message: "six" });
-                await waitFor(() => assert.lengthOf(toaster.getToasts(), 3));
-                toaster.dismiss(key);
-                await waitFor(
-                    () => {
-                        assert.deepEqual(
-                            toaster.getToasts().map(t => t.message),
-                            ["six", "one"],
-                        );
-                    },
-                    { timeout: 3 * OVERLAY_TOASTER_DELAY_MS },
-                );
-            });
-
-            it("clear() removes all toasts", async () => {
-                toaster.show({ message: "one" });
-                toaster.show({ message: "two" });
-                toaster.show({ message: "six" });
-                await waitFor(() => {
-                    assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
-                });
-                toaster.clear();
-                await waitFor(
-                    () => {
-                        // Ensure the queue is cleared
-                        assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
-                    },
-                    { timeout: 2 * OVERLAY_TOASTER_DELAY_MS },
-                );
-            });
-
-            it("action onClick callback invoked when action clicked", async () => {
-                const onClick = spy();
-                toaster.show({
-                    action: { onClick, text: "action" },
-                    message: "message",
-                    timeout: 0,
-                });
-                await waitFor(() => {
-                    /* noop */
-                });
-                // action is first descendant button
-                const action = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
-                action?.click();
-                assert.isTrue(onClick.calledOnce, "expected onClick to be called once");
-            });
-
-            it("onDismiss callback invoked when close button clicked", async () => {
-                const handleDismiss = spy();
-                toaster.show({
-                    message: "dismiss",
-                    onDismiss: handleDismiss,
-                    timeout: 0,
-                });
-                await waitFor(() => {
-                    /* noop */
-                });
-                // without action, dismiss is first descendant button
-                const dismiss = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
-                dismiss?.click();
-                await waitFor(() => assert.isTrue(handleDismiss.calledOnce));
-            });
-
-            it("onDismiss callback invoked on toaster.dismiss()", async () => {
-                const onDismiss = spy();
-                const key = toaster.show({ message: "dismiss me", onDismiss });
-                toaster.dismiss(key);
-                await waitFor(() => assert.isTrue(onDismiss.calledOnce, "onDismiss not called"));
-            });
-
-            it("onDismiss callback invoked on toaster.clear()", async () => {
-                const onDismiss = spy();
-                toaster.show({ message: "dismiss me", onDismiss });
-                await waitFor(() => {
-                    /* noop */
-                });
-                toaster.clear();
-                await waitFor(() => assert.isTrue(onDismiss.calledOnce, "onDismiss not called"));
-            });
-
-            it("reusing props object does not produce React errors", () => {
-                const errorSpy = spy(console, "error");
-                try {
-                    // if Toaster doesn't clone the props object before injecting key then there will be a
-                    // React error that both toasts have the same key, because both instances refer to the
-                    // same object.
-                    const toast = { message: "repeat" };
-                    toaster.show(toast);
-                    toaster.show(toast);
-                    assert.isFalse(errorSpy.calledWithMatch("two children with the same key"), "mutation side effect!");
-                } finally {
-                    // Restore console.error. Otherwise other tests will fail
-                    // with "TypeError: Attempted to wrap error which is already
-                    // wrapped" when attempting to spy on console.error again.
-                    sinon.restore();
-                }
-            });
-        });
-
-        describe("with maxToasts set to finite value", () => {
-            before(async () => {
-                testsContainerElement = document.createElement("div");
-                document.documentElement.appendChild(testsContainerElement);
-                toaster = await spec.create({ maxToasts: 3 }, testsContainerElement);
-            });
-
-            after(() => {
-                unmountReact16Toaster(testsContainerElement);
-                document.documentElement.removeChild(testsContainerElement);
-            });
-
-            it("does not exceed the maximum toast limit set", async () => {
-                toaster.show({ message: "one" });
-                toaster.show({ message: "two" });
-                toaster.show({ message: "three" });
-                toaster.show({ message: "oh no" });
-                await waitFor(
-                    () => {
-                        assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
-                    },
-                    { timeout: 4 * OVERLAY_TOASTER_DELAY_MS },
-                );
-            });
-
-            it("does not dismiss toasts when updating an existing toast at the limit", async () => {
-                toaster.show({ message: "one" });
-                toaster.show({ message: "two" });
-                toaster.show({ message: "three" }, "3");
-                toaster.show({ message: "three updated" }, "3");
-                await waitFor(
-                    () => {
-                        assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
-                    },
-                    { timeout: 4 * OVERLAY_TOASTER_DELAY_MS },
-                );
-            });
-        });
-
-        describe("with autoFocus set to true", () => {
-            before(async () => {
-                testsContainerElement = document.createElement("div");
-                document.documentElement.appendChild(testsContainerElement);
-                toaster = await spec.create({ autoFocus: true }, testsContainerElement);
-            });
-
-            after(() => {
-                spec.cleanup(testsContainerElement);
-                document.documentElement.removeChild(testsContainerElement);
-            });
-
-            it("focuses inside toast container", async () => {
-                toaster.show({ message: "focus near me" });
-                await waitFor(() => {
-                    const toastElement = testsContainerElement.querySelector(`.${Classes.TOAST_CONTAINER}`);
-                    assert.isTrue(toastElement?.contains(document.activeElement));
-                });
-            });
-        });
-
-        it("throws an error if used within a React lifecycle method", () => {
+    describe("with default props", () => {
+        before(async () => {
             testsContainerElement = document.createElement("div");
+            document.documentElement.appendChild(testsContainerElement);
+            toaster = await OverlayToaster.create(
+                {},
+                {
+                    container: testsContainerElement,
+                    domRenderer,
+                },
+            );
+        });
 
-            class LifecycleToaster extends React.Component {
-                public render() {
-                    return React.createElement("div");
-                }
+        afterEach(() => {
+            toaster.clear();
+        });
 
-                public componentDidMount() {
-                    try {
-                        spec.create({}, testsContainerElement);
-                    } catch (err: any) {
-                        assert.equal(err.message, TOASTER_CREATE_NULL);
-                    } finally {
-                        spec.cleanup(testsContainerElement);
-                    }
-                }
+        after(() => {
+            document.documentElement.removeChild(testsContainerElement);
+        });
+
+        it("does not attach toast container to body on script load", () => {
+            assert.lengthOf(document.getElementsByClassName(Classes.TOAST_CONTAINER), 0, "unexpected toast container");
+        });
+
+        it("show() renders toast on next tick", async () => {
+            toaster.show({
+                message: "Hello world",
+            });
+            await waitFor(() => {
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+            });
+            assert.isNotNull(
+                document.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`),
+                "expected toast container element to have 'overlay open' class name",
+            );
+        });
+
+        it("multiple show()s renders them all", async () => {
+            toaster.show({ message: "one" });
+            toaster.show({ message: "two" });
+            toaster.show({ message: "six" });
+            await waitFor(() => assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts"), {
+                timeout: 3 * OVERLAY_TOASTER_DELAY_MS,
+            });
+        });
+
+        it("multiple shows() get queued if provided too quickly", async () => {
+            toaster.show({ message: "one" });
+            toaster.show({ message: "two" });
+            toaster.show({ message: "three" });
+            await waitFor(() => assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast"));
+            await waitFor(() => assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts after delay"), {
+                timeout: 3 * OVERLAY_TOASTER_DELAY_MS,
+            });
+            // clock.restore();
+        });
+
+        it("show() immediately displays a toast when waiting after the previous show()", async () => {
+            toaster.show({ message: "one" });
+            await waitFor(() => assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast"));
+            await waitFor(
+                () => {
+                    toaster.show({ message: "two" });
+                    assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
+                },
+                { timeout: 2 * OVERLAY_TOASTER_DELAY_MS },
+            );
+        });
+
+        it("show() updates existing toast", async () => {
+            const key = toaster.show({ message: "one" });
+            await waitFor(() => {
+                assert.deepEqual(toaster.getToasts()[0].message, "one");
+            });
+            toaster.show({ message: "two" }, key);
+            await waitFor(() => {
+                assert.lengthOf(toaster.getToasts(), 1, "expected 1 toast");
+                assert.deepEqual(toaster.getToasts()[0].message, "two");
+            });
+        });
+
+        it("show() updates existing toast in queue", async () => {
+            toaster.show({ message: "one" });
+            const key = toaster.show({ message: "two" });
+            toaster.show({ message: "two updated" }, key);
+            await waitFor(
+                () => {
+                    assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
+                    assert.deepEqual(toaster.getToasts()[0].message, "two updated");
+                },
+                { timeout: 2 * OVERLAY_TOASTER_DELAY_MS },
+            );
+        });
+
+        it("dismiss() removes just the toast in question", async () => {
+            toaster.show({ message: "one" });
+            const key = toaster.show({ message: "two" });
+            toaster.show({ message: "six" });
+            await waitFor(() => assert.lengthOf(toaster.getToasts(), 3));
+            toaster.dismiss(key);
+            await waitFor(
+                () => {
+                    assert.deepEqual(
+                        toaster.getToasts().map(t => t.message),
+                        ["six", "one"],
+                    );
+                },
+                { timeout: 3 * OVERLAY_TOASTER_DELAY_MS },
+            );
+        });
+
+        it("clear() removes all toasts", async () => {
+            toaster.show({ message: "one" });
+            toaster.show({ message: "two" });
+            toaster.show({ message: "six" });
+            await waitFor(() => {
+                assert.lengthOf(toaster.getToasts(), 2, "expected 2 toasts");
+            });
+            toaster.clear();
+            await waitFor(
+                () => {
+                    // Ensure the queue is cleared
+                    assert.lengthOf(toaster.getToasts(), 0, "expected 0 toasts");
+                },
+                { timeout: 2 * OVERLAY_TOASTER_DELAY_MS },
+            );
+        });
+
+        it("action onClick callback invoked when action clicked", async () => {
+            const onClick = spy();
+            toaster.show({
+                action: { onClick, text: "action" },
+                message: "message",
+                timeout: 0,
+            });
+            await waitFor(() => {
+                /* noop */
+            });
+            // action is first descendant button
+            const action = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
+            action?.click();
+            assert.isTrue(onClick.calledOnce, "expected onClick to be called once");
+        });
+
+        it("onDismiss callback invoked when close button clicked", async () => {
+            const handleDismiss = spy();
+            toaster.show({
+                message: "dismiss",
+                onDismiss: handleDismiss,
+                timeout: 0,
+            });
+            await waitFor(() => {
+                /* noop */
+            });
+            // without action, dismiss is first descendant button
+            const dismiss = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
+            dismiss?.click();
+            await waitFor(() => assert.isTrue(handleDismiss.calledOnce));
+        });
+
+        it("onDismiss callback invoked on toaster.dismiss()", async () => {
+            const onDismiss = spy();
+            const key = toaster.show({ message: "dismiss me", onDismiss });
+            toaster.dismiss(key);
+            await waitFor(() => assert.isTrue(onDismiss.calledOnce, "onDismiss not called"));
+        });
+
+        it("onDismiss callback invoked on toaster.clear()", async () => {
+            const onDismiss = spy();
+            toaster.show({ message: "dismiss me", onDismiss });
+            await waitFor(() => {
+                /* noop */
+            });
+            toaster.clear();
+            await waitFor(() => assert.isTrue(onDismiss.calledOnce, "onDismiss not called"));
+        });
+
+        it("reusing props object does not produce React errors", () => {
+            const errorSpy = spy(console, "error");
+            try {
+                // if Toaster doesn't clone the props object before injecting key then there will be a
+                // React error that both toasts have the same key, because both instances refer to the
+                // same object.
+                const toast = { message: "repeat" };
+                toaster.show(toast);
+                toaster.show(toast);
+                assert.isFalse(errorSpy.calledWithMatch("two children with the same key"), "mutation side effect!");
+            } finally {
+                // Restore console.error. Otherwise other tests will fail
+                // with "TypeError: Attempted to wrap error which is already
+                // wrapped" when attempting to spy on console.error again.
+                sinon.restore();
             }
-            mount(React.createElement(LifecycleToaster));
+        });
+    });
+
+    describe("with maxToasts set to finite value", () => {
+        before(async () => {
+            testsContainerElement = document.createElement("div");
+            document.documentElement.appendChild(testsContainerElement);
+            toaster = await OverlayToaster.create({ maxToasts: 3 }, { container: testsContainerElement, domRenderer });
+        });
+
+        after(() => {
+            document.documentElement.removeChild(testsContainerElement);
+        });
+
+        it("does not exceed the maximum toast limit set", async () => {
+            toaster.show({ message: "one" });
+            toaster.show({ message: "two" });
+            toaster.show({ message: "three" });
+            toaster.show({ message: "oh no" });
+            await waitFor(
+                () => {
+                    assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+                },
+                { timeout: 4 * OVERLAY_TOASTER_DELAY_MS },
+            );
+        });
+
+        it("does not dismiss toasts when updating an existing toast at the limit", async () => {
+            toaster.show({ message: "one" });
+            toaster.show({ message: "two" });
+            toaster.show({ message: "three" }, "3");
+            toaster.show({ message: "three updated" }, "3");
+            await waitFor(
+                () => {
+                    assert.lengthOf(toaster.getToasts(), 3, "expected 3 toasts");
+                },
+                { timeout: 4 * OVERLAY_TOASTER_DELAY_MS },
+            );
+        });
+    });
+
+    describe("with autoFocus set to true", () => {
+        before(async () => {
+            testsContainerElement = document.createElement("div");
+            document.documentElement.appendChild(testsContainerElement);
+            toaster = await OverlayToaster.create(
+                { autoFocus: true },
+                { container: testsContainerElement, domRenderer },
+            );
+        });
+
+        after(() => {
+            document.documentElement.removeChild(testsContainerElement);
+        });
+
+        it("focuses inside toast container", async () => {
+            toaster.show({ message: "focus near me" });
+            await waitFor(() => {
+                const toastElement = testsContainerElement.querySelector(`.${Classes.TOAST_CONTAINER}`);
+                assert.isTrue(toastElement?.contains(document.activeElement));
+            });
         });
     });
 

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -275,10 +275,7 @@ describe("OverlayToaster", () => {
         before(async () => {
             containerElement = document.createElement("div");
             document.documentElement.appendChild(containerElement);
-            toaster = await OverlayToaster.create(
-                { autoFocus: true },
-                { container: containerElement, domRenderer },
-            );
+            toaster = await OverlayToaster.create({ autoFocus: true }, { container: containerElement, domRenderer });
         });
 
         after(() => {

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -127,7 +127,7 @@ const FileDeletionAlert: React.FC<AlertExampleProps> = ({
     const [isLoading, setIsLoading] = React.useState(false);
     const [isOpen, setIsOpen] = React.useState(false);
 
-    const toaster = OverlayToaster.createAsync({ className: themeName });
+    const toaster = OverlayToaster.create({ className: themeName });
 
     const handleClick = React.useCallback(() => setIsOpen(true), []);
 

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -39,7 +39,7 @@ export const OmnibarExample: React.FC<ExampleProps<BlueprintExampleData>> = prop
     const [resetOnSelect, setResetOnSelect] = React.useState(true);
 
     const toaster = React.useMemo(
-        () => OverlayToaster.createAsync({ className: classNames({ [Classes.DARK]: useDarkTheme }) }),
+        () => OverlayToaster.create({ className: classNames({ [Classes.DARK]: useDarkTheme }) }),
         [useDarkTheme],
     );
 


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7166


#### Changes proposed in this pull request:
This PR removes the old `OverlayToaster.create` synchronous implementation. Instead, `.create()` and `.createAsync()` have the same async implementation and `.create()` is now the preferred method to call. The `createAsync` method is now deprecated.