### PR TITLE
break(Portal): Remove PortalLegacyContext type

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -93,7 +93,7 @@ export type {
 } from "./popover/popoverSharedProps";
 export { PopperPlacements } from "./popover/popperUtils";
 export { PopupKind } from "./popover/popupKind";
-export { Portal, type PortalProps, type PortalLegacyContext } from "./portal/portal";
+export { Portal, type PortalProps } from "./portal/portal";
 export { ProgressBar, type ProgressBarProps } from "./progress-bar/progressBar";
 export { type ResizeEntry, ResizeSensor, type ResizeSensorProps } from "./resize-sensor/resizeSensor";
 export { type HandleHtmlProps, HandleInteractionKind, type HandleProps, HandleType } from "./slider/handleProps";

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -47,11 +47,6 @@ export interface PortalProps extends Props {
     stopPropagationEvents?: Array<keyof HTMLElementEventMap>;
 }
 
-export interface PortalLegacyContext {
-    /** Additional CSS classes to add to all `Portal` elements in this React context. */
-    blueprintPortalClassName?: string;
-}
-
 /**
  * Portal component.
  *

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -133,19 +133,4 @@ describe("<Portal>", () => {
             { attachTo: rootElement },
         );
     });
-
-    // TODO: remove legacy context support in Blueprint v6.0
-    // HACKHACK: skipped test resulting from React 18 upgrade. See: https://github.com/palantir/blueprint/issues/7168
-    it.skip("respects blueprintPortalClassName on legacy context", () => {
-        const CLASS_TO_TEST = "bp-test-klass bp-other-class";
-        portal = mount(
-            <Portal>
-                <p>test</p>
-            </Portal>,
-            { attachTo: rootElement, context: { blueprintPortalClassName: CLASS_TO_TEST } },
-        );
-
-        const portalElement = document.querySelector(`.${CLASS_TO_TEST.replace(" ", ".")}`);
-        assert.isTrue(portalElement?.classList.contains(Classes.PORTAL));
-    });
 });


### PR DESCRIPTION
#### Left over from https://github.com/palantir/blueprint/issues/7298

#### Changes proposed in this pull request:
Noticed that I missed a few places where these context options still exist in https://github.com/palantir/blueprint/pull/7374. This PR just removes those.
