### PR TITLE
break: Update component display name prefix

### DIFF
--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -20,7 +20,7 @@ import type { IconName } from "@blueprintjs/icons";
 
 import type { Intent } from "./intent";
 
-export const DISPLAYNAME_PREFIX = "Blueprint5";
+export const DISPLAYNAME_PREFIX = "Blueprint6";
 
 /**
  * Alias for all valid HTML props for `<div>` element.

--- a/packages/icons/scripts/iconComponent.tsx.hbs
+++ b/packages/icons/scripts/iconComponent.tsx.hbs
@@ -37,5 +37,5 @@ export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<
 {{pascalCase iconName}}.defaultProps = {
     size: IconSize.STANDARD,
 };
-{{pascalCase iconName}}.displayName = `Blueprint5.Icon.{{pascalCase iconName}}`;
+{{pascalCase iconName}}.displayName = `Blueprint6.Icon.{{pascalCase iconName}}`;
 export default {{pascalCase iconName}};

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -115,4 +115,4 @@ export const SVGIconContainer: SVGIconContainerComponent = React.forwardRef(func
         );
     }
 });
-SVGIconContainer.displayName = "Blueprint5.SVGIconContainer";
+SVGIconContainer.displayName = "Blueprint6.SVGIconContainer";


### PR DESCRIPTION

#### Changes proposed in this pull request:
This is only kind of a breaking change but marking it as breaking to be safe. Updates our component display name prefix to be `Blueprint6` instead of 5.