### PR TITLE
Remove new tags from docs

### DIFF
--- a/packages/core/src/components/card-list/card-list.md
+++ b/packages/core/src/components/card-list/card-list.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Card List
 
 **CardList** is a lightweight wrapper around the [**Card**](#core/components/card) component.

--- a/packages/core/src/components/control-card/control-card.md
+++ b/packages/core/src/components/control-card/control-card.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Control card
 
 A control card is an interactive [**Card**](#core/components/card) with an embedded form control.

--- a/packages/core/src/components/entity-title/entity-title.md
+++ b/packages/core/src/components/entity-title/entity-title.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Entity Title
 
 **EntityTitle** is a component that handles rendering a common UI pattern consisting of title, icon, subtitle and tag.

--- a/packages/core/src/components/overlay2/overlay2.md
+++ b/packages/core/src/components/overlay2/overlay2.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Overlay2
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">

--- a/packages/core/src/components/section/section.md
+++ b/packages/core/src/components/section/section.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Section
 
 The **Section** component can be used to contain, structure, and create hierarchy for information in your UI. It makes use of some concepts from other more atomic Blueprint components:

--- a/packages/core/src/components/segmented-control/segmented-control.md
+++ b/packages/core/src/components/segmented-control/segmented-control.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Segmented control
 
 A **SegmentedControl** is a linear collection of buttons which allows a user to choose an option from multiple choices,

--- a/packages/core/src/components/tag/compound-tag.md
+++ b/packages/core/src/components/tag/compound-tag.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Compound Tag
 
 **Compound Tag** is a variant of [**Tag**](#core/components/tag) which renders textual information in

--- a/packages/core/src/context/blueprint-provider.md
+++ b/packages/core/src/context/blueprint-provider.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# BlueprintProvider
 
 **BlueprintProvider** is a compound [React context](https://react.dev/learn/passing-data-deeply-with-context)

--- a/packages/core/src/context/overlays/overlays-provider.md
+++ b/packages/core/src/context/overlays/overlays-provider.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# OverlaysProvider
 
 <div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">

--- a/packages/core/src/context/portal/portal-provider.md
+++ b/packages/core/src/context/portal/portal-provider.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# PortalProvider
 
 PortalProvider generates a React context necessary for customizing global [Portal](#core/components/portal)

--- a/packages/icons/src/loading-icons.md
+++ b/packages/icons/src/loading-icons.md
@@ -1,7 +1,3 @@
----
-tag: new
----
-
 @# Loading icons
 
 As of Blueprint v5.0, icons are no longer loaded by default through the main package entry points. This allows you the flexibility


### PR DESCRIPTION

#### Changes proposed in this pull request:
These docs have been around for a while, don't need to mark them as "new" anymore.