### PR TITLE
chore: Remove react-uid in favor of React.useId

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,6 @@
         "normalize.css": "^8.0.1",
         "react-popper": "^2.3.0",
         "react-transition-group": "^4.4.5",
-        "react-uid": "^2.3.3",
         "tslib": "~2.6.2",
         "use-sync-external-store": "^1.2.0"
     },

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -17,7 +17,6 @@
 import classNames from "classnames";
 import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
-import { useUID } from "react-uid";
 
 import { Classes, mergeRefs } from "../../common";
 import {
@@ -680,8 +679,7 @@ function useOverlay2Validation({ childRef, childRefs, children }: Overlay2Props)
  * Generates a unique ID for a given Overlay which persists across the component's lifecycle.
  */
 function useOverlay2ID(): string {
-    // TODO: migrate to React.useId() in React 18
-    const id = useUID();
+    const id = React.useId();
     return `${Overlay2.displayName}-${id}`;
 }
 

--- a/packages/core/src/hooks/overlays/use-overlay-stack.md
+++ b/packages/core/src/hooks/overlays/use-overlay-stack.md
@@ -22,7 +22,6 @@ Then, use the hook to interact with the global overlay stack:
 ```tsx
 import { OverlayInstance, OverlayProps, Portal, useOverlayStack, usePrevious } from "@blueprintjs/core";
 import * as React from "react";
-import { useUID } from "react-uid";
 
 export function Example(props: OverlayProps) {
     const { autoFocus, children, enforceFocus, hasBackdrop, isOpen, usePortal } = props;
@@ -38,7 +37,7 @@ export function Example(props: OverlayProps) {
         // TODO: implement
     }, []);
 
-    const id = useUID();
+    const id = React.useId();
     const instance = React.useMemo<OverlayInstance>(
         () => ({
             bringFocusInsideOverlay,

--- a/packages/core/test/hooks/useOverlayStackTests.tsx
+++ b/packages/core/test/hooks/useOverlayStackTests.tsx
@@ -17,7 +17,6 @@
 import { render } from "@testing-library/react";
 import { expect } from "chai";
 import * as React from "react";
-import { useUID } from "react-uid";
 import { spy } from "sinon";
 
 import type { OverlayProps } from "../../src/components/overlay/overlayProps";
@@ -43,7 +42,7 @@ const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
 }) => {
     const { openOverlay, getLastOpened, closeOverlay } = useOverlayStack();
 
-    const id = useUID();
+    const id = React.useId();
     const instance = React.useMemo<OverlayInstance>(
         () => ({
             containerElement,

--- a/yarn.lock
+++ b/yarn.lock
@@ -469,7 +469,6 @@ __metadata:
     react-popper: "npm:^2.3.0"
     react-test-renderer: "npm:^18.3.1"
     react-transition-group: "npm:^4.4.5"
-    react-uid: "npm:^2.3.3"
     tslib: "npm:~2.6.2"
     typescript: "npm:~5.3.3"
     use-sync-external-store: "npm:^1.2.0"
@@ -13975,21 +13974,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-uid@npm:^2.3.3":
-  version: 2.3.3
-  resolution: "react-uid@npm:2.3.3"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": ^16.8.0 || ^17.0.0 || ^18.0.0
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 8aa30e92ee03561d25779c68ba6d9409ba4ea83386a8798729b6eb5977bbdc4a5ff199b758d2a29e958d7560b2a7517cab8671932b83e8fcd50092631c209b4c
-  languageName: node
-  linkType: hard
-
 "react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -16089,7 +16073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:~2.6.2":
+"tslib@npm:^2.0.3, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.5.0, tslib@npm:~2.6.2":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7416

#### Changes proposed in this pull request:
Since we're on React 18 we can drop `react-uid` and replace with the native `React.useId` hook.