### PR TITLE
break(Callout): Add border to minimal callouts

### DIFF
--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -14,16 +14,6 @@ $callout-padding-compact: $pt-grid-size;
   position: relative;
   width: 100%;
 
-  &.#{$ns}-minimal {
-    border: 1px solid rgba($pt-text-color-muted, 0.6);
-
-    @each $intent, $color in $pt-intent-text-colors {
-      &.#{$ns}-intent-#{$intent} {
-        border-color: rgba($color, 0.6);
-      }
-    }
-  }
-
   &:not(.#{$ns}-minimal) {
     background-color: rgba($gray3, 0.15);
   }
@@ -93,12 +83,24 @@ $callout-padding-compact: $pt-grid-size;
     }
   }
 
+  &.#{$ns}-minimal {
+    border: 1px solid rgba($pt-text-color-muted, 0.6);
+
+    .#{$ns}-dark & {
+      border: 1px solid rgba($pt-dark-text-color-muted, 0.6);
+    }
+  }
+
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
       color: map-get($pt-intent-text-colors, $intent);
 
       &:not(.#{$ns}-minimal) {
         background-color: rgba($color, 0.1);
+      }
+
+      &.#{$ns}-minimal {
+        border-color: rgba(map-get($pt-intent-text-colors, $color), 0.6);
       }
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -116,6 +118,10 @@ $callout-padding-compact: $pt-grid-size;
 
         &:not(.#{$ns}-minimal) {
           background-color: rgba($color, 0.2);
+        }
+
+        &.#{$ns}-minimal {
+          border-color: rgba(map-get($pt-intent-text-colors, $color), 0.6);
         }
 
         &[class*="#{$ns}-icon-"]::before,

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -100,7 +100,7 @@ $callout-padding-compact: $pt-grid-size;
       }
 
       &.#{$ns}-minimal {
-        border-color: rgba(map-get($pt-intent-text-colors, $color), 0.6);
+        border-color: rgba(map-get($pt-intent-text-colors, $intent), 0.6);
       }
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -121,7 +121,7 @@ $callout-padding-compact: $pt-grid-size;
         }
 
         &.#{$ns}-minimal {
-          border-color: rgba(map-get($pt-intent-text-colors, $color), 0.6);
+          border-color: rgba(map-get($pt-dark-intent-text-colors, $intent), 0.6);
         }
 
         &[class*="#{$ns}-icon-"]::before,

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -14,6 +14,16 @@ $callout-padding-compact: $pt-grid-size;
   position: relative;
   width: 100%;
 
+  &.#{$ns}-minimal {
+    border: 1px solid rgba($pt-text-color-muted, 0.6);
+
+    @each $intent, $color in $pt-intent-text-colors {
+      &.#{$ns}-intent-#{$intent} {
+        border-color: rgba($color, 0.6);
+      }
+    }
+  }
+
   &:not(.#{$ns}-minimal) {
     background-color: rgba($gray3, 0.15);
   }

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -21,6 +21,12 @@ The `intent` prop sets the visual style of the **Callout**, reflecting its purpo
 
 @reactCodeExample CalloutIntentExample
 
+@## Minimal
+
+The `minimal` prop offers a callout without background or background, ideal for less prominent sections that shouldn't draw too much attention.
+
+@reactCodeExample CalloutMinimalExample
+
 @## Icon
 
 The `icon` prop allows customization of the **Callout** icon. Provide a custom

--- a/packages/core/src/components/callout/callout.md
+++ b/packages/core/src/components/callout/callout.md
@@ -23,7 +23,7 @@ The `intent` prop sets the visual style of the **Callout**, reflecting its purpo
 
 @## Minimal
 
-The `minimal` prop offers a callout without background or background, ideal for less prominent sections that shouldn't draw too much attention.
+The `minimal` prop offers a callout without a background color, ideal for less prominent information that shouldn't draw too much attention.
 
 @reactCodeExample CalloutMinimalExample
 

--- a/packages/docs-app/src/examples/core-examples/calloutExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExamples.tsx
@@ -44,13 +44,21 @@ export const CalloutMinimalExample: React.FC<ExampleProps> = props => {
     return (
         <CodeExample code={code} {...props}>
             <Callout minimal={true}>This is a minimal default Callout</Callout>
-            <Callout intent="primary" minimal={true}>This is a minimal primary Callout</Callout>
-            <Callout intent="success" minimal={true}>This is a minimal success Callout</Callout>
-            <Callout intent="warning" minimal={true}>This is a minimal warning Callout</Callout>
-            <Callout intent="danger" minimal={true}>This is a minimal danger Callout</Callout>
+            <Callout intent="primary" minimal={true}>
+                This is a minimal primary Callout
+            </Callout>
+            <Callout intent="success" minimal={true}>
+                This is a minimal success Callout
+            </Callout>
+            <Callout intent="warning" minimal={true}>
+                This is a minimal warning Callout
+            </Callout>
+            <Callout intent="danger" minimal={true}>
+                This is a minimal danger Callout
+            </Callout>
         </CodeExample>
     );
-}
+};
 
 export const CalloutIconExample: React.FC<ExampleProps> = props => {
     const code = dedent`

--- a/packages/docs-app/src/examples/core-examples/calloutExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExamples.tsx
@@ -34,6 +34,24 @@ export const CalloutIntentExample: React.FC<ExampleProps> = props => {
     );
 };
 
+export const CalloutMinimalExample: React.FC<ExampleProps> = props => {
+    const code = dedent`
+        <Callout minimal={true}>This is a minimal default Callout</Callout>
+        <Callout intent="primary" minimal={true}>This is a minimal primary Callout</Callout>
+        <Callout intent="success" minimal={true}>This is a minimal success Callout</Callout>
+        <Callout intent="warning" minimal={true}>This is a minimal warning Callout</Callout>
+        <Callout intent="danger" minimal={true}>This is a minimal danger Callout</Callout>`;
+    return (
+        <CodeExample code={code} {...props}>
+            <Callout minimal={true}>This is a minimal default Callout</Callout>
+            <Callout intent="primary" minimal={true}>This is a minimal primary Callout</Callout>
+            <Callout intent="success" minimal={true}>This is a minimal success Callout</Callout>
+            <Callout intent="warning" minimal={true}>This is a minimal warning Callout</Callout>
+            <Callout intent="danger" minimal={true}>This is a minimal danger Callout</Callout>
+        </CodeExample>
+    );
+}
+
 export const CalloutIconExample: React.FC<ExampleProps> = props => {
     const code = dedent`
         <Callout icon="clean" intent="primary">

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -145,6 +145,7 @@
 
 #{example("CalloutIntent")},
 #{example("CalloutIcon")},
+#{example("CalloutMinimal")},
 #{example("CalloutCompact")} {
   .docs-code-example {
     flex-direction: column;


### PR DESCRIPTION
#### Changes proposed in this pull request:
This PR updates the styling for minimal callouts to add a border around the outside for better identification of the callout space.

Light mode:
<img width="756" alt="Screenshot 2025-03-28 at 3 47 47 PM" src="https://github.com/user-attachments/assets/b2c4d0a1-9afb-441a-a8ad-c587c45c7642" />

Dark mode:
<img width="756" alt="Screenshot 2025-03-28 at 4 03 59 PM" src="https://github.com/user-attachments/assets/6ad88e7c-4e39-44b8-963b-8724eed3b700" />



