### PR TITLE
break: Drop React 16 and 17 as peer dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,9 +60,9 @@
         "use-sync-external-store": "^1.2.0"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,9 +60,9 @@
         "use-sync-external-store": "^1.2.0"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -51,9 +51,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -51,9 +51,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -40,9 +40,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -40,9 +40,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -44,9 +44,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -44,9 +44,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -47,9 +47,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -47,9 +47,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -46,9 +46,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -46,9 +46,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -46,9 +46,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^17 || 18",
-        "react": "^17 || 18",
-        "react-dom": "^17 || 18"
+        "@types/react": "18",
+        "react": "18",
+        "react-dom": "18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -46,9 +46,9 @@
         "tslib": "~2.6.2"
     },
     "peerDependencies": {
-        "@types/react": "^16.14.41 || 17 || 18",
-        "react": "^16.8 || 17 || 18",
-        "react-dom": "^16.8 || 17 || 18"
+        "@types/react": "^17 || 18",
+        "react": "^17 || 18",
+        "react-dom": "^17 || 18"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,9 +474,9 @@ __metadata:
     use-sync-external-store: "npm:^1.2.0"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -502,9 +502,9 @@ __metadata:
     tslib: "npm:~2.6.2"
     typescript: "npm:~5.3.3"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -538,9 +538,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -646,9 +646,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -717,9 +717,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -888,9 +888,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -955,9 +955,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack: "npm:^5.90.0"
   peerDependencies:
-    "@types/react": ^17 || 18
-    react: ^17 || 18
-    react-dom: ^17 || 18
+    "@types/react": 18
+    react: 18
+    react-dom: 18
   peerDependenciesMeta:
     "@types/react":
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,9 +474,9 @@ __metadata:
     use-sync-external-store: "npm:^1.2.0"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -502,9 +502,9 @@ __metadata:
     tslib: "npm:~2.6.2"
     typescript: "npm:~5.3.3"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -538,9 +538,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -646,9 +646,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -717,9 +717,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -888,9 +888,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack-cli: "npm:^5.1.4"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true
@@ -955,9 +955,9 @@ __metadata:
     typescript: "npm:~5.3.3"
     webpack: "npm:^5.90.0"
   peerDependencies:
-    "@types/react": ^16.14.41 || 17 || 18
-    react: ^16.8 || 17 || 18
-    react-dom: ^16.8 || 17 || 18
+    "@types/react": ^17 || 18
+    react: ^17 || 18
+    react-dom: ^17 || 18
   peerDependenciesMeta:
     "@types/react":
       optional: true


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7350

#### Changes proposed in this pull request:
Not much to say here, dropping React 16 and 17 as peer deps.