### PR TITLE
[datetime] Merge legacy and v3 datetime props

### DIFF
--- a/packages/datetime/src/common/dateFormatProps.tsx
+++ b/packages/datetime/src/common/dateFormatProps.tsx
@@ -26,7 +26,7 @@ export interface DateFormatProps {
     invalidDateMessage?: string;
 
     /**
-     * The locale name, which is passed to `formatDate`, `parseDate`, and the functions in `localeUtils`.
+     * The locale name, which is passed to `formatDate`, `parseDate`
      */
     locale?: string;
 

--- a/packages/datetime/src/common/datePickerBaseProps.ts
+++ b/packages/datetime/src/common/datePickerBaseProps.ts
@@ -65,8 +65,7 @@ export interface DatePickerBaseProps {
     initialMonth?: Date;
 
     /**
-     * The locale name, which is passed to the functions in `localeUtils`
-     * (and `formatDate` and `parseDate` if supported).
+     * The locale name, which is passed to `formatDate`, `parseDate`
      */
     locale?: string;
 

--- a/packages/datetime/src/components/date-input/dateInputProps.ts
+++ b/packages/datetime/src/components/date-input/dateInputProps.ts
@@ -4,13 +4,20 @@
 
 import type { InputGroupProps, Props } from "@blueprintjs/core";
 
-import type { DateFormatProps, DatePickerBaseProps } from "../../common";
 import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { DateFormatProps } from "../../common/dateFormatProps";
+import type { DatePickerBaseProps } from "../../common/datePickerBaseProps";
 import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
 import type { DatePickerShortcut } from "../shortcuts/shortcuts";
 
-interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
+export interface DateInputProps
+    extends Omit<DatePickerBaseProps, "dayPickerProps" | "locale" | "modifiers">,
+        ReactDayPickerSingleProps,
+        DateFnsLocaleProps,
+        Partial<Omit<DateFormatProps, "locale">>,
+        DatetimePopoverProps,
+        Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      * Passed to `DatePicker` component.
@@ -35,6 +42,15 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
     closeOnSelection?: boolean;
 
     /**
+     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
+     *
+     * Mutually exclusive with the `formatDate` and `parseDate` props.
+     *
+     * See date-fns [format](https://date-fns.org/docs/format).
+     */
+    dateFnsFormat?: string;
+
+    /**
      * The default timezone selected. Defaults to the user's local timezone.
      *
      * Mutually exclusive with `timezone` prop.
@@ -42,13 +58,6 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
      * @see https://www.iana.org/time-zones
      */
     defaultTimezone?: string;
-
-    /**
-     * Whether to disable the timezone select.
-     *
-     * @default false
-     */
-    disableTimezoneSelect?: boolean;
 
     /**
      * The default date to be used in the component when uncontrolled, represented as an ISO string.
@@ -61,6 +70,13 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
      * @default false
      */
     disabled?: boolean;
+
+    /**
+     * Whether to disable the timezone select.
+     *
+     * @default false
+     */
+    disableTimezoneSelect?: boolean;
 
     /**
      * Whether the component should take up the full width of its container.
@@ -108,6 +124,16 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
     rightElement?: React.JSX.Element;
 
     /**
+     * Whether shortcuts to quickly select a date are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     *
+     * @default false
+     */
+    shortcuts?: boolean | DatePickerShortcut[];
+
+    /**
      * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown below the calendar.
      *
      * @default false
@@ -121,16 +147,6 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
      * @default false
      */
     showTimezoneSelect?: boolean;
-
-    /**
-     * Whether shortcuts to quickly select a date are displayed or not.
-     * If `true`, preset shortcuts will be displayed.
-     * If `false`, no shortcuts will be displayed.
-     * If an array is provided, the custom shortcuts will be displayed.
-     *
-     * @default false
-     */
-    shortcuts?: boolean | DatePickerShortcut[];
 
     /**
      * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".
@@ -154,32 +170,6 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
 
     /** An ISO string representing the selected time. */
     value?: string | null;
-}
-
-/**
- * Props shared between DateInput v1 and v3.
- *
- * Note that we exclude formatDate and parseDate so that we can make those optional in DateInput3 and provide a default
- * implementation for those functions using date-fns.
- */
-type DateInputSharedProps = Omit<
-    LegacyDateInputProps,
-    "dayPickerProps" | "formatDate" | "locale" | "modifiers" | "parseDate"
->;
-
-export interface DateInputProps
-    extends DateInputSharedProps,
-        ReactDayPickerSingleProps,
-        DateFnsLocaleProps,
-        Partial<Omit<DateFormatProps, "locale">> {
-    /**
-     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
-     *
-     * Mutually exclusive with the `formatDate` and `parseDate` props.
-     *
-     * See date-fns [format](https://date-fns.org/docs/format).
-     */
-    dateFnsFormat?: string;
 }
 
 export type DateInputDefaultProps = Required<

--- a/packages/datetime/src/components/date-input/dateInputProps.ts
+++ b/packages/datetime/src/components/date-input/dateInputProps.ts
@@ -164,7 +164,7 @@ interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, Dat
  */
 type DateInputSharedProps = Omit<
     LegacyDateInputProps,
-    "dayPickerProps" | "formatDate" | "locale" | "localeUtils" | "modifiers" | "parseDate"
+    "dayPickerProps" | "formatDate" | "locale" | "modifiers" | "parseDate"
 >;
 
 export interface DateInputProps

--- a/packages/datetime/src/components/date-input/dateInputProps.ts
+++ b/packages/datetime/src/components/date-input/dateInputProps.ts
@@ -10,7 +10,7 @@ import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
 import type { DatePickerShortcut } from "../shortcuts/shortcuts";
 
-export interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
+interface LegacyDateInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      * Passed to `DatePicker` component.

--- a/packages/datetime/src/components/date-picker/datePickerProps.ts
+++ b/packages/datetime/src/components/date-picker/datePickerProps.ts
@@ -82,7 +82,7 @@ interface LegacyDatePickerProps extends DatePickerBaseProps, Props {
 /** Props shared between DatePicker v1 and v3 */
 type DatePickerSharedProps = Omit<
     LegacyDatePickerProps,
-    "dayPickerProps" | "defaultValue" | "locale" | "localeUtils" | "modifiers" | "onChange" | "value"
+    "dayPickerProps" | "defaultValue" | "locale" | "modifiers" | "onChange" | "value"
 >;
 
 export interface DatePickerProps extends DatePickerSharedProps, DateFnsLocaleProps, ReactDayPickerSingleProps {

--- a/packages/datetime/src/components/date-picker/datePickerProps.ts
+++ b/packages/datetime/src/components/date-picker/datePickerProps.ts
@@ -4,12 +4,16 @@
 
 import type { Props } from "@blueprintjs/core";
 
-import type { DatePickerBaseProps } from "../../common";
 import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { DatePickerBaseProps } from "../../common/datePickerBaseProps";
 import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
 import type { DatePickerShortcut } from "../shortcuts/shortcuts";
 
-interface LegacyDatePickerProps extends DatePickerBaseProps, Props {
+export interface DatePickerProps
+    extends Omit<DatePickerBaseProps, "dayPickerProps" | "locale" | "modifiers">,
+        DateFnsLocaleProps,
+        ReactDayPickerSingleProps,
+        Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      * If disabled, the "Clear" Button in the Actions Bar will also be disabled.
@@ -19,73 +23,12 @@ interface LegacyDatePickerProps extends DatePickerBaseProps, Props {
     canClearSelection?: boolean;
 
     /**
-     * Initial day the calendar will display as selected.
-     * This should not be set if `value` is set.
-     */
-    defaultValue?: Date;
-
-    /**
-     * Called when the user selects a day.
-     * If being used in an uncontrolled manner, `selectedDate` will be `null` if the user clicks the currently selected
-     * day. If being used in a controlled manner, `selectedDate` will contain the day clicked no matter what.
-     * `isUserChange` is true if the user selected a day, and false if the date was automatically changed
-     * by the user navigating to a new month or year rather than explicitly clicking on a date in the calendar.
-     */
-    onChange?: (selectedDate: Date, isUserChange: boolean) => void;
-
-    /**
-     * Called when the `shortcuts` props is enabled and the user changes the shortcut.
-     */
-    onShortcutChange?: (shortcut: DatePickerShortcut, index: number) => void;
-
-    /**
-     * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
-     *
-     * @default false
-     */
-    showActionsBar?: boolean;
-
-    /**
-     * Whether shortcuts to quickly select a date are displayed or not.
-     * If `true`, preset shortcuts will be displayed.
-     * If `false`, no shortcuts will be displayed.
-     * If an array is provided, the custom shortcuts will be displayed.
-     */
-    shortcuts?: boolean | DatePickerShortcut[];
-
-    /**
-     * The currently selected shortcut.
-     * If this prop is provided, the component acts in a controlled manner.
-     */
-    selectedShortcutIndex?: number;
-
-    /**
-     * Text for the today button in the action bar.
-     *
-     * @default "Today"
-     */
-    todayButtonText?: string;
-
-    /**
      * Text for the reset button in the action bar.
      *
      * @default "Clear"
      */
     clearButtonText?: string;
 
-    /**
-     * The currently selected day. If this prop is provided, the component acts in a controlled manner.
-     */
-    value?: Date | null;
-}
-
-/** Props shared between DatePicker v1 and v3 */
-type DatePickerSharedProps = Omit<
-    LegacyDatePickerProps,
-    "dayPickerProps" | "defaultValue" | "locale" | "modifiers" | "onChange" | "value"
->;
-
-export interface DatePickerProps extends DatePickerSharedProps, DateFnsLocaleProps, ReactDayPickerSingleProps {
     /**
      * Initial day the calendar will display as selected.
      * This should not be set if `value` is set.
@@ -102,9 +45,30 @@ export interface DatePickerProps extends DatePickerSharedProps, DateFnsLocalePro
     onChange?: (selectedDate: Date | null, isUserChange: boolean) => void;
 
     /**
-     * The currently selected day. If this prop is provided, the component acts in a controlled manner.
+     * Called when the `shortcuts` props is enabled and the user changes the shortcut.
      */
-    value?: Date | null;
+    onShortcutChange?: (shortcut: DatePickerShortcut, index: number) => void;
+
+    /**
+     * The currently selected shortcut.
+     * If this prop is provided, the component acts in a controlled manner.
+     */
+    selectedShortcutIndex?: number;
+
+    /**
+     * Whether shortcuts to quickly select a date are displayed or not.
+     * If `true`, preset shortcuts will be displayed.
+     * If `false`, no shortcuts will be displayed.
+     * If an array is provided, the custom shortcuts will be displayed.
+     */
+    shortcuts?: boolean | DatePickerShortcut[];
+
+    /**
+     * Whether the bottom bar displaying "Today" and "Clear" buttons should be shown.
+     *
+     * @default false
+     */
+    showActionsBar?: boolean;
 
     /**
      * The currently selected timezone UTC identifier, e.g. "Pacific/Honolulu".
@@ -115,4 +79,16 @@ export interface DatePickerProps extends DatePickerSharedProps, DateFnsLocalePro
      * See [IANA Time Zones](https://www.iana.org/time-zones).
      */
     timezone?: string;
+
+    /**
+     * Text for the today button in the action bar.
+     *
+     * @default "Today"
+     */
+    todayButtonText?: string;
+
+    /**
+     * The currently selected day. If this prop is provided, the component acts in a controlled manner.
+     */
+    value?: Date | null;
 }

--- a/packages/datetime/src/components/date-picker/datePickerProps.ts
+++ b/packages/datetime/src/components/date-picker/datePickerProps.ts
@@ -9,7 +9,7 @@ import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
 import type { ReactDayPickerSingleProps } from "../../common/reactDayPickerProps";
 import type { DatePickerShortcut } from "../shortcuts/shortcuts";
 
-export interface LegacyDatePickerProps extends DatePickerBaseProps, Props {
+interface LegacyDatePickerProps extends DatePickerBaseProps, Props {
     /**
      * Allows the user to clear the selection by clicking the currently selected day.
      * If disabled, the "Clear" Button in the Actions Bar will also be disabled.

--- a/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
+++ b/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
@@ -135,7 +135,7 @@ interface LegacyDateRangeInputProps extends DatePickerBaseProps, DateFormatProps
  */
 type DateRangeInputSharedProps = Omit<
     LegacyDateRangeInputProps,
-    "dayPickerProps" | "formatDate" | "locale" | "localeUtils" | "modifiers" | "parseDate"
+    "dayPickerProps" | "formatDate" | "locale" | "modifiers" | "parseDate"
 >;
 
 export interface DateRangeInputProps

--- a/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
+++ b/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
@@ -10,7 +10,7 @@ import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
 import type { DateRangeShortcut } from "../shortcuts/shortcuts";
 
-export interface LegacyDateRangeInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
+interface LegacyDateRangeInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.

--- a/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
+++ b/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
@@ -4,13 +4,21 @@
 
 import type { InputGroupProps, Props } from "@blueprintjs/core";
 
-import type { DateFormatProps, DatePickerBaseProps, DateRange } from "../../common";
 import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { DateFormatProps } from "../../common/dateFormatProps";
+import type { DatePickerBaseProps } from "../../common/datePickerBaseProps";
+import type { DateRange } from "../../common/dateRange";
 import type { DatetimePopoverProps } from "../../common/datetimePopoverProps";
 import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
 import type { DateRangeShortcut } from "../shortcuts/shortcuts";
 
-interface LegacyDateRangeInputProps extends DatePickerBaseProps, DateFormatProps, DatetimePopoverProps, Props {
+export interface DateRangeInputProps
+    extends Omit<DatePickerBaseProps, "dayPickerProps" | "locale" | "modifiers">,
+        ReactDayPickerRangeProps,
+        DateFnsLocaleProps,
+        Partial<Omit<DateFormatProps, "locale">>,
+        DatetimePopoverProps,
+        Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.
@@ -34,6 +42,15 @@ interface LegacyDateRangeInputProps extends DatePickerBaseProps, DateFormatProps
      * @default true
      */
     contiguousCalendarMonths?: boolean;
+
+    /**
+     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
+     *
+     * Mutually exclusive with the `formatDate` and `parseDate` props.
+     *
+     * See date-fns [format](https://date-fns.org/docs/format).
+     */
+    dateFnsFormat?: string;
 
     /**
      * The default date range to be used in the component when uncontrolled.
@@ -125,32 +142,6 @@ interface LegacyDateRangeInputProps extends DatePickerBaseProps, DateFormatProps
      * for the appropriate date in the value prop.
      */
     value?: DateRange;
-}
-
-/**
- * Props shared between DateRangeInput v1 and v3
- *
- * Note that we exclude formatDate and parseDate so that we can make those optional in DateInput3 and provide a default
- * implementation for those functions using date-fns.
- */
-type DateRangeInputSharedProps = Omit<
-    LegacyDateRangeInputProps,
-    "dayPickerProps" | "formatDate" | "locale" | "modifiers" | "parseDate"
->;
-
-export interface DateRangeInputProps
-    extends DateRangeInputSharedProps,
-        ReactDayPickerRangeProps,
-        DateFnsLocaleProps,
-        Partial<Omit<DateFormatProps, "locale">> {
-    /**
-     * [date-fns format](https://date-fns.org/docs/format) string used to format & parse date strings.
-     *
-     * Mutually exclusive with the `formatDate` and `parseDate` props.
-     *
-     * See date-fns [format](https://date-fns.org/docs/format).
-     */
-    dateFnsFormat?: string;
 }
 
 export type DateRangeInputDefaultProps = Required<

--- a/packages/datetime/src/components/date-range-picker/dateRangePickerProps.ts
+++ b/packages/datetime/src/components/date-range-picker/dateRangePickerProps.ts
@@ -96,10 +96,7 @@ interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
 }
 
 /** Props shared between DateRangePicker v1 and v3 */
-type DateRangePickerSharedProps = Omit<
-    LegacyDateRangePickerProps,
-    "dayPickerProps" | "locale" | "localeUtils" | "modifiers"
->;
+type DateRangePickerSharedProps = Omit<LegacyDateRangePickerProps, "dayPickerProps" | "locale" | "modifiers">;
 
 export type DateRangePickerProps = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;
 

--- a/packages/datetime/src/components/date-range-picker/dateRangePickerProps.ts
+++ b/packages/datetime/src/components/date-range-picker/dateRangePickerProps.ts
@@ -9,7 +9,7 @@ import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
 import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
 import type { DateRangeShortcut } from "../shortcuts/shortcuts";
 
-export interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
+interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.

--- a/packages/datetime/src/components/date-range-picker/dateRangePickerProps.ts
+++ b/packages/datetime/src/components/date-range-picker/dateRangePickerProps.ts
@@ -4,12 +4,17 @@
 
 import type { Boundary, Props } from "@blueprintjs/core";
 
-import type { DatePickerBaseProps, DateRange } from "../../common";
 import type { DateFnsLocaleProps } from "../../common/dateFnsLocaleProps";
+import type { DatePickerBaseProps } from "../../common/datePickerBaseProps";
+import type { DateRange } from "../../common/dateRange";
 import type { ReactDayPickerRangeProps } from "../../common/reactDayPickerProps";
 import type { DateRangeShortcut } from "../shortcuts/shortcuts";
 
-interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
+export interface DateRangePickerProps
+    extends Omit<DatePickerBaseProps, "dayPickerProps" | "locale" | "modifiers">,
+        DateFnsLocaleProps,
+        ReactDayPickerRangeProps,
+        Props {
     /**
      * Whether the start and end dates of the range can be the same day.
      * If `true`, clicking a selected date will create a one-day range.
@@ -66,6 +71,12 @@ interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
     onShortcutChange?: (shortcut: DateRangeShortcut, index: number) => void;
 
     /**
+     * The currently selected shortcut.
+     * If this prop is provided, the component acts in a controlled manner.
+     */
+    selectedShortcutIndex?: number;
+
+    /**
      * Whether shortcuts to quickly select a range of dates are displayed or not.
      * If `true`, preset shortcuts will be displayed.
      * If `false`, no shortcuts will be displayed.
@@ -74,12 +85,6 @@ interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
      * @default true
      */
     shortcuts?: boolean | DateRangeShortcut[];
-
-    /**
-     * The currently selected shortcut.
-     * If this prop is provided, the component acts in a controlled manner.
-     */
-    selectedShortcutIndex?: number;
 
     /**
      * Whether to show only a single month calendar.
@@ -94,11 +99,6 @@ interface LegacyDateRangePickerProps extends DatePickerBaseProps, Props {
      */
     value?: DateRange;
 }
-
-/** Props shared between DateRangePicker v1 and v3 */
-type DateRangePickerSharedProps = Omit<LegacyDateRangePickerProps, "dayPickerProps" | "locale" | "modifiers">;
-
-export type DateRangePickerProps = DateRangePickerSharedProps & DateFnsLocaleProps & ReactDayPickerRangeProps;
 
 export type DateRangePickerDefaultProps = Required<
     Pick<


### PR DESCRIPTION
#### Part of #7293

#### Proposed changes:

Consolidates types from legacy (formerly unversioned) datetime components with new component props from v3 components.
