### PR TITLE
[core]: Remove deprecated `Classes.SELECT` class from CSS API

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -177,8 +177,6 @@ export const ENTITY_TITLE_TITLE_AND_TAGS = `${ENTITY_TITLE}-title-and-tags`;
 export const FLEX_EXPANDER = `${NS}-flex-expander`;
 
 export const HTML_SELECT = `${NS}-html-select`;
-/** @deprecated use `<HTMLSelect>` component or `Classes.HTML_SELECT` instead */
-export const SELECT = `${NS}-select`;
 
 export const HTML_TABLE = `${NS}-html-table`;
 export const HTML_TABLE_BORDERED = `${HTML_TABLE}-bordered`;

--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -67,18 +67,3 @@
     }
   }
 }
-
-.#{$ns}-html-select {
-  .#{$ns}-icon {
-    @extend %pt-select-icon;
-  }
-}
-
-// N.B. this icon implementation is deprecated and will be removed in Blueprint 6.0
-.#{$ns}-select {
-  &::after {
-    @extend %pt-select-icon;
-    @include pt-icon();
-    content: map-get($blueprint-icon-codepoints, "double-caret-vertical");
-  }
-}


### PR DESCRIPTION
#### Fixes #7427

#### Changes proposed in this pull request:

Removes deprecated `Classes.SELECT` from the CSS API along with associated styles.
