### PR TITLE
Export deprecated aliases

### DIFF
--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -169,3 +169,4 @@ PanelStack.displayName = `${DISPLAYNAME_PREFIX}.PanelStack`;
 
 /** @deprecated Use `PanelStack` instead */
 export const PanelStack2 = PanelStack;
+export type PanelStack2 = PanelStackComponent;

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -107,3 +107,4 @@ Toast.displayName = `${DISPLAYNAME_PREFIX}.Toast`;
 
 /** @deprecated Use `Toast` instead */
 export const Toast2 = Toast;
+export type Toast2 = typeof Toast;

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+
 import classNames from "classnames";
 import * as React from "react";
 
@@ -268,6 +269,7 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
 
 /** @deprecated Use `EditableCell` instead */
 export const EditableCell2 = EditableCell;
+export type EditableCell2 = InstanceType<typeof EditableCell2>;
 
 /** @deprecated Use `EditableCellProps` instead */
 export type EditableCell2Props = EditableCellProps;

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-
 import classNames from "classnames";
 import * as React from "react";
 

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -1634,3 +1634,4 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
 
 /** @deprecated Use `Table` instead */
 export const Table2 = Table;
+export type Table2 = InstanceType<typeof Table2>;


### PR DESCRIPTION

#### Changes proposed in this pull request:
When exporting a deprecated alias of something that used to be a class component (or maybe still is), exporting just the alias only exports a value which can't be used as a type. In this PR we also make sure that these can be used as types.