### PR TITLE
Switch from exec to execFile in `get-publishable-paths-from-semver-tags`

### DIFF
--- a/scripts/get-publishable-paths-from-semver-tags.mjs
+++ b/scripts/get-publishable-paths-from-semver-tags.mjs
@@ -6,7 +6,7 @@
 
 // @ts-check
 
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { join } from "node:path";
 import { argv } from "node:process";
 import yargs from "yargs";
@@ -16,7 +16,7 @@ const args = await cli.argv;
 const commitish = args._[0] || "HEAD";
 const monorepoRootDir = join(import.meta.dirname, "..");
 
-exec(`git tag --points-at ${commitish}`, async (err, stdout) => {
+execFile("git", ["tag", "--points-at", `${commitish}`], async (err, stdout) => {
     if (err) {
         throw err;
     }


### PR DESCRIPTION
#### Proposed Changes

Modifies the `get-publishable-paths-from-semver-tags.mjs` script to use `execFile` instead of `exec` to avoid the arguments of the script being vulnerable to shell interpolation.

This script is called here: https://github.com/palantir/blueprint/blob/79e27bdefdfc96ad18db8e16dab74c43ef8b4a81/scripts/publish-npm-semver-tagged#L10

