### PR TITLE
Target `es2019` in `tsconfig.web.json`

### DIFF
--- a/config/tsconfig.web.json
+++ b/config/tsconfig.web.json
@@ -5,6 +5,6 @@
         "lib": ["dom", "dom.iterable", "es5", "es2015.collection", "es2015.iterable"],
         "module": "es2020",
         "moduleResolution": "node",
-        "target": "es5"
+        "target": "es2019"
     }
 }

--- a/config/tsconfig.web.json
+++ b/config/tsconfig.web.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.base",
     "compilerOptions": {
         "jsx": "react",
-        "lib": ["dom", "dom.iterable", "es5", "es2015.collection", "es2015.iterable"],
+        "lib": ["dom", "dom.iterable", "es2019"],
         "module": "es2020",
         "moduleResolution": "node",
         "target": "es2019"


### PR DESCRIPTION
#### Fixes #6292

#### Proposed changes

Change target `tsc` compilation from `es5` to `es2019` to better reflect modern browsers and optimize compilation. 

#### Rough package size comparison:

**Before with `es5`: (uncompressed size from tgz)**
- [blueprintjs-colors](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-colors-5.1.8.tgz) (71 KB)
- [blueprintjs-core](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-core-5.17.5.tgz) (6 MB)
- [blueprintjs-datetime](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-datetime-5.3.29.tgz) (2 MB)
- [blueprintjs-datetime2](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-datetime2-2.3.29.tgz) (107 KB)
- [blueprintjs-icons](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-icons-5.19.1.tgz) (22.1 MB)
- [blueprintjs-select](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-select-5.3.17.tgz) (791 KB)
- [blueprintjs-table](https://output.circle-artifacts.com/output/job/b39eccee-6d25-4ffc-a616-3d34f267ca46/artifacts/0/artifacts/blueprintjs-table-5.3.11.tgz) (3.1 MB)

**After with `es2019`: (uncompressed size from tgz)**
- [blueprintjs-colors](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-colors-5.1.8.tgz) (71 KB)
- [blueprintjs-core](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-core-5.17.5.tgz) (5.9 MB)
- [blueprintjs-datetime](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-datetime-5.3.29.tgz) (2 MB)
- [blueprintjs-datetime2](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-datetime2-2.3.29.tgz) (107 KB)
- [blueprintjs-icons](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-icons-5.19.1.tgz) (22.1 MB)
- [blueprintjs-select](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-select-5.3.17.tgz) (774 KB)
- [blueprintjs-table](https://output.circle-artifacts.com/output/job/60ac5526-6842-4d42-be63-841fcb15e064/artifacts/0/artifacts/blueprintjs-table-5.3.11.tgz) (3 MB)