### PR TITLE
Fix button group stacking context

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7441.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7441.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix button group stacking context
+  links:
+  - https://github.com/palantir/blueprint/pull/7441

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -43,7 +43,7 @@ Styleguide button-group
 
 .#{$ns}-button-group {
   display: inline-flex;
-  z-index: 0; // needed for a fresh stacking context for z-indexes applied in below styles
+  @include new-render-layer(); // fresh stacking context for z-indexes applied below
 
   .#{$ns}-button {
     // ensure button can never be smaller than its default size

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -43,7 +43,7 @@ Styleguide button-group
 
 .#{$ns}-button-group {
   display: inline-flex;
-  @include new-render-layer(); // fresh stacking context for z-indexes applied below
+  z-index: 0; // fresh stacking context for z-indexes applied below
 
   .#{$ns}-button {
     // ensure button can never be smaller than its default size

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -43,6 +43,7 @@ Styleguide button-group
 
 .#{$ns}-button-group {
   display: inline-flex;
+  z-index: 0; // needed for a fresh stacking context for z-indexes applied in below styles
 
   .#{$ns}-button {
     // ensure button can never be smaller than its default size

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -43,7 +43,9 @@ Styleguide button-group
 
 .#{$ns}-button-group {
   display: inline-flex;
-  z-index: 0; // fresh stacking context for z-indexes applied below
+
+  // fresh stacking context for z-indexes applied below
+  z-index: 0;
 
   .#{$ns}-button {
     // ensure button can never be smaller than its default size

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -89,7 +89,6 @@ Styleguide control-group
   .#{$ns}-input,
   .#{$ns}-select {
     // create a new stacking context
-    //
     // NOTE - per https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context#features_creating_stacking_contexts
     // this will not actually create a new stacking context, but leaving in to avoid possible breaking changes by any
     // styles that may rely on this being set

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -89,13 +89,13 @@ Styleguide control-group
   .#{$ns}-input,
   .#{$ns}-select {
     // create a new stacking context
+    //
     // NOTE - per https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context#features_creating_stacking_contexts
     // this will not actually create a new stacking context, but leaving in to avoid possible breaking changes by any
     // styles that may rely on this being set
+    // new stacking context is actually created above in the new-render-layer() call, but this was not removed
     position: relative;
   }
-
-  z-index: 0; // actually create new stacking context
 
   .#{$ns}-input {
     z-index: index($control-group-stack, "input-default");

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -89,8 +89,13 @@ Styleguide control-group
   .#{$ns}-input,
   .#{$ns}-select {
     // create a new stacking context
+    // NOTE - per https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Stacking_context#features_creating_stacking_contexts
+    // this will not actually create a new stacking context, but leaving in to avoid possible breaking changes by any
+    // styles that may rely on this being set
     position: relative;
   }
+
+  z-index: 0; // actually create new stacking context
 
   .#{$ns}-input {
     z-index: index($control-group-stack, "input-default");


### PR DESCRIPTION
#### Fixes https://github.com/palantir/blueprint/issues/7440

#### Checklist

-   [n/a] Includes tests
-   [n/a] Update documentation

#### Changes proposed in this pull request:
Reset stacking context of button group component

#### Reviewers should focus on:
Could this unintentionally override any consumer land styling?

#### Screenshot
<img width="1415" alt="Screenshot 2025-04-15 at 11 37 47 PM" src="https://github.com/user-attachments/assets/cbde31f0-4a0f-4945-b0ab-8b5fc9c8839b" />
<img width="1364" alt="Screenshot 2025-04-15 at 11 37 41 PM" src="https://github.com/user-attachments/assets/033c4633-bf4a-4f93-81cf-5025ea02df83" />

This PR ended up using the `translateZ(0)` method to reset the stacking context like we do for control groups but anything that resets the stacking context should be valid.