### PR TITLE
chore: Refactor Alert tests to use RTL

### DIFF
--- a/packages/core/test/utils.tsx
+++ b/packages/core/test/utils.tsx
@@ -38,3 +38,5 @@ export function findInPortal<P>(overlay: ReactWrapper<P>, selector: string) {
 export async function sleep(timeout?: number) {
     return new Promise(resolve => window.setTimeout(resolve, timeout));
 }
+
+export const hasClass = (element: Element, className: string) => element.classList.contains(className);


### PR DESCRIPTION
#### Part of #7444

#### Proposed changes:

Refactor `<Alert>` component tests to use RTL instead of Enzyme.