### PR TITLE
Lower RadioGroup label margin to match FormGroup

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7451.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7451.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Lower RadioGroup label margin to match FormGroup
+  links:
+  - https://github.com/palantir/blueprint/pull/7451

--- a/packages/core/src/components/forms/_index.scss
+++ b/packages/core/src/components/forms/_index.scss
@@ -14,6 +14,7 @@
 @import "./input";
 @import "./label";
 @import "./numeric-input";
+@import "./radio-group";
 
 form {
   display: block;

--- a/packages/core/src/components/forms/_radio-group.scss
+++ b/packages/core/src/components/forms/_radio-group.scss
@@ -1,0 +1,8 @@
+// Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+.#{$ns}-radio-group {
+  label.#{$ns}-label {
+    margin-bottom: $pt-grid-size * 0.5;
+  }
+}


### PR DESCRIPTION
#### Changes proposed in this pull request:

Before this change, RadioGroups used alongside FormGroups had inconsistent label spacing. BP by default sets the bottom label margin to 15px. FormGroup overrides this to 5px. RadioGroup should do the same for visual consistency.

#### Reviewers should focus on:

🤷🏻‍♂️

#### Screenshot
Before:
<img width="175" alt="Screenshot 2025-05-08 at 14 25 17" src="https://github.com/user-attachments/assets/5bbe7fb3-a6c4-4f7b-98d2-702f57bd59f8" />
After:
<img width="180" alt="Screenshot 2025-05-08 at 14 25 09" src="https://github.com/user-attachments/assets/dc956010-d157-4cd6-b870-e9ca9030c17a" />

FormGroup for reference:
<img width="274" alt="Screenshot 2025-05-08 at 14 25 25" src="https://github.com/user-attachments/assets/b6ff9225-95c1-4ca4-a924-c59c31745adb" />