### PR TITLE
chore: Refactor Control tests

### DIFF
--- a/packages/core/test/control-card/controlCardTests.tsx
+++ b/packages/core/test/control-card/controlCardTests.tsx
@@ -14,67 +14,180 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
-import { type EnzymePropSelector, mount, type ReactWrapper } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { expect } from "chai";
 import * as React from "react";
-import { type SinonSpy, spy } from "sinon";
+import { spy } from "sinon";
 
 import { CheckboxCard, Classes, RadioCard, RadioGroup, SwitchCard } from "../../src";
+import { hasClass } from "../utils";
 
 describe("ControlCard", () => {
-    let containerElement: HTMLElement;
-
-    beforeEach(() => {
-        containerElement = document.createElement("div");
-        document.body.appendChild(containerElement);
-    });
-
-    afterEach(() => {
-        containerElement.remove();
-    });
-
     describe("SwitchCard", () => {
-        const handleControlChangeSpy = spy() as SinonSpy<[React.FormEvent<HTMLInputElement>], void>;
+        it("should render switch control inside a card", () => {
+            render(<SwitchCard label="Test Switch" />);
+            const card = screen.getByRole("checkbox", { name: "Test Switch" }).closest(`.${Classes.CARD}`);
 
-        beforeEach(() => {
-            handleControlChangeSpy.resetHistory();
+            expect(card).to.exist;
+            expect(hasClass(card!, Classes.CONTROL_CARD)).to.be.true;
         });
 
-        it("clicking on label element toggles switch state", () => {
-            const wrapper = mount(<SwitchCard defaultChecked={false} onChange={handleControlChangeSpy} />, {
-                attachTo: containerElement,
-            });
-            wrapper.find("input").simulate("change");
-            assert.isTrue(handleControlChangeSpy.calledOnce, "expected onChange to be called");
+        it("should be end-aligned by default", () => {
+            render(<SwitchCard label="Test Switch" />);
+            const control = screen.getByRole("checkbox", { name: "Test Switch" }).closest(`.${Classes.CONTROL}`);
+
+            expect(control).to.exist;
+            expect(hasClass(control!, Classes.ALIGN_RIGHT)).to.be.true;
+        });
+
+        it("should be start-aligned when alignIndicator is start", () => {
+            render(<SwitchCard label="Test Switch" alignIndicator="start" />);
+            const control = screen.getByRole("checkbox", { name: "Test Switch" }).closest(`.${Classes.CONTROL}`);
+
+            expect(control).to.exist;
+            expect(hasClass(control!, Classes.ALIGN_LEFT)).to.be.true;
+        });
+
+        it("should toggle switch state when clicked", async () => {
+            const handleChange = spy();
+            render(<SwitchCard onChange={handleChange} label="Test Switch" data-testid="test-switch" />);
+            const switchInput = screen.getByRole("checkbox", { name: "Test Switch" });
+
+            await userEvent.click(switchInput);
+
+            expect(handleChange.calledOnce).to.be.true;
+        });
+
+        it("should show as selected when checked", () => {
+            render(<SwitchCard defaultChecked={true} label="Test Switch" data-testid="test-switch" />);
+            const card = screen.getByTestId("test-switch");
+
+            expect(hasClass(card, Classes.SELECTED)).to.be.true;
+        });
+
+        it("should not show selected state on card when showAsSelectedWhenChecked is false", () => {
+            render(
+                <SwitchCard
+                    defaultChecked={true}
+                    showAsSelectedWhenChecked={false}
+                    label="Test Switch"
+                    data-testid="test-switch"
+                />,
+            );
+            const card = screen.getByTestId("test-switch");
+
+            expect(hasClass(card, Classes.SELECTED)).to.be.false;
         });
     });
 
     describe("CheckboxCard", () => {
-        it("is left-aligned by default", () => {
-            const wrapper = mount(<CheckboxCard />, { attachTo: containerElement });
-            assert.isTrue(
-                wrapper.find(`.${Classes.CONTROL}.${Classes.ALIGN_LEFT}`).exists(),
-                "expected left alignment",
-            );
+        it("should render checkbox control inside a card", () => {
+            render(<CheckboxCard label="Test Checkbox" />);
+            const card = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CARD}`);
+
+            expect(card).to.exist;
+            expect(hasClass(card!, Classes.CONTROL_CARD)).to.be.true;
+        });
+
+        it("should be start-aligned by default", () => {
+            render(<CheckboxCard label="Test Checkbox" />);
+            const control = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CONTROL}`);
+
+            expect(control).to.exist;
+            expect(hasClass(control!, Classes.ALIGN_LEFT)).to.be.true;
+        });
+
+        it("should be end-aligned when alignIndicator is end", () => {
+            render(<CheckboxCard label="Test Checkbox" alignIndicator="end" />);
+            const control = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CONTROL}`);
+
+            expect(control).to.exist;
+            expect(hasClass(control!, Classes.ALIGN_RIGHT)).to.be.true;
+        });
+
+        it("should show as selected when checked", async () => {
+            render(<CheckboxCard label="Test Checkbox" defaultChecked={true} />);
+            const card = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CARD}`);
+
+            expect(card).to.exist;
+            expect(hasClass(card!, Classes.SELECTED)).to.be.true;
+        });
+
+        it("should not show selected state on card when showAsSelectedWhenChecked is false", () => {
+            render(<CheckboxCard label="Test Checkbox" defaultChecked={true} showAsSelectedWhenChecked={false} />);
+            const card = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CARD}`);
+
+            expect(card).to.exist;
+            expect(hasClass(card!, Classes.SELECTED)).to.be.false;
         });
     });
 
     describe("RadioCard", () => {
-        it("works like a Radio component inside a RadioGroup", () => {
+        it("should render radio control inside a card", () => {
+            render(<RadioCard label="Test Radio" value="test" />);
+            const card = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CARD}`);
+
+            expect(card).to.exist;
+            expect(hasClass(card!, Classes.CONTROL_CARD)).to.be.true;
+        });
+
+        it("should be end-aligned by default", () => {
+            render(<RadioCard label="Test Radio" value="test" />);
+            const control = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CONTROL}`);
+
+            expect(control).to.exist;
+            expect(hasClass(control!, Classes.ALIGN_RIGHT)).to.be.true;
+        });
+
+        it("should be start-aligned when alignIndicator is start", () => {
+            render(<RadioCard label="Test Radio" value="test" alignIndicator="start" />);
+            const control = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CONTROL}`);
+
+            expect(control).to.exist;
+            expect(hasClass(control!, Classes.ALIGN_LEFT)).to.be.true;
+        });
+
+        it("should show as selected when checked", () => {
+            const onChange = spy();
+            render(
+                <RadioGroup selectedValue="one" onChange={onChange}>
+                    <RadioCard value="one" label="One" />
+                    <RadioCard value="two" label="Two" />
+                </RadioGroup>,
+            );
+
+            const cardOne = screen.getByRole("radio", { name: "One" }).closest(`.${Classes.CARD}`);
+            const cardTwo = screen.getByRole("radio", { name: "Two" }).closest(`.${Classes.CARD}`);
+
+            expect(hasClass(cardOne!, Classes.SELECTED)).to.be.true;
+            expect(hasClass(cardTwo!, Classes.SELECTED)).to.be.false;
+        });
+
+        it("should not show selected state on card when showAsSelectedWhenChecked is false", () => {
+            render(<RadioCard label="Test Radio" value="test" showAsSelectedWhenChecked={false} />);
+            const card = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CARD}`);
+
+            expect(card).to.exist;
+            expect(hasClass(card!, Classes.SELECTED)).to.be.false;
+        });
+
+        it("should work within a RadioGroup", async () => {
             const changeSpy = spy();
-            const group = mount(
+            render(
                 <RadioGroup onChange={changeSpy}>
                     <RadioCard value="one" label="One" />
                     <RadioCard value="two" label="Two" />
                 </RadioGroup>,
             );
-            findInput(group, { value: "one" }).simulate("change");
-            findInput(group, { value: "two" }).simulate("change");
-            assert.equal(changeSpy.callCount, 2);
+
+            const radioOne = screen.getByRole("radio", { name: "One" });
+            const radioTwo = screen.getByRole("radio", { name: "Two" });
+
+            await userEvent.click(radioOne);
+            await userEvent.click(radioTwo);
+
+            expect(changeSpy.callCount).to.equal(2);
         });
     });
-
-    function findInput(wrapper: ReactWrapper<any, any>, props: EnzymePropSelector) {
-        return wrapper.find("input").filter(props);
-    }
 });

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -14,105 +14,138 @@
  * limitations under the License.
  */
 
-import { assert } from "chai";
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import { expect } from "chai";
 import * as React from "react";
 
 import { Classes } from "../../src";
-import type { ControlProps } from "../../src/components/forms/controlProps";
 import { Checkbox, Radio, Switch } from "../../src/components/forms/controls";
 
-type ControlType = typeof Checkbox | typeof Radio | typeof Switch;
+describe("Controls", () => {
+    describe("Checkbox", () => {
+        it("should render", () => {
+            render(<Checkbox />);
+            const checkbox = screen.getByRole("checkbox");
+            const control = checkbox.closest(`.${Classes.CONTROL}`);
 
-describe("Controls:", () => {
-    controlsTests(Checkbox, "checkbox", Classes.CHECKBOX, () => {
-        describe("indeterminate", () => {
-            const inputRef = React.createRef<HTMLInputElement>();
+            expect(checkbox).to.exist;
+            expect(control).to.exist;
+            expect(checkbox.getAttribute("type")).to.equal("checkbox");
+            expect([...control!.classList]).to.include(Classes.CHECKBOX);
+        });
 
-            it("prop sets element state", () => {
-                mount(<Checkbox indeterminate={true} inputRef={inputRef} />);
-                assert.isTrue(inputRef.current?.indeterminate);
-            });
+        it("should support JSX children", () => {
+            render(
+                <Checkbox>
+                    <span>Label Text</span>
+                </Checkbox>,
+            );
 
-            it("default prop sets element state", () => {
-                mount(<Checkbox defaultIndeterminate={true} inputRef={inputRef} />);
-                assert.isTrue(inputRef.current?.indeterminate);
-            });
+            expect(screen.getByText("Label Text")).to.exist;
+        });
+
+        it("should support JSX labelElement", () => {
+            render(<Checkbox labelElement={<span>Label Text</span>} />);
+
+            expect(screen.getByText("Label Text")).to.exist;
+        });
+
+        it("should support indeterminate state", () => {
+            render(<Checkbox indeterminate={true} />);
+
+            expect(screen.getByRole<HTMLInputElement>("checkbox").indeterminate).to.be.true;
+        });
+
+        it("should support defaultIndeterminate state", () => {
+            render(<Checkbox defaultIndeterminate={true} />);
+
+            expect(screen.getByRole<HTMLInputElement>("checkbox").indeterminate).to.be.true;
         });
     });
 
-    controlsTests(Switch, "checkbox", Classes.SWITCH, () => {
-        describe("internal text", () => {
-            it("renders both innerLabels when both defined", () => {
-                const switchWithText = mount(<Switch innerLabelChecked="checked" innerLabel="unchecked" />);
-                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
-                const checkedTest = innerTextNodes.first().text();
-                const uncheckedText = innerTextNodes.last().text();
-                assert.lengthOf(innerTextNodes, 2);
-                assert.equal(checkedTest.trim(), "checked");
-                assert.equal(uncheckedText.trim(), "unchecked");
-            });
-            it("does not render innerLabel components when neither defined", () => {
-                const switchWithoutText = mount(<Switch />);
-                const innerTextNodes = switchWithoutText.find(`.${Classes.SWITCH_INNER_TEXT}`);
-                assert.lengthOf(innerTextNodes, 0);
-            });
-            it("renders innerLabel when innerLabelChecked is undefined", () => {
-                const switchWithText = mount(<Switch innerLabel="onlyInnerLabel" />);
-                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
-                const checkedText = innerTextNodes.last().text();
-                const uncheckedText = innerTextNodes.first().text();
-                assert.equal(checkedText.trim(), "onlyInnerLabel");
-                assert.equal(checkedText.trim(), uncheckedText.trim());
-            });
-            it("renders innerLabelChecked only when checked", () => {
-                const switchWithText = mount(<Switch innerLabelChecked="onlyChecked" />);
-                const innerTextNodes = switchWithText.find(`.${Classes.SWITCH_INNER_TEXT}`);
-                const checked = innerTextNodes.first().text();
-                const uncheckedText = innerTextNodes.last().text();
-                assert.equal(checked.trim(), "onlyChecked");
-                assert.equal(uncheckedText.trim(), "");
-            });
+    describe("Radio", () => {
+        it("should render", () => {
+            render(<Radio />);
+            const radio = screen.getByRole("radio");
+            const control = radio.closest(`.${Classes.CONTROL}`);
+
+            expect(radio).to.exist;
+            expect(control).to.exist;
+            expect(radio.getAttribute("type")).to.equal("radio");
+            expect([...control!.classList]).to.include(Classes.RADIO);
+        });
+
+        it("should support JSX children", () => {
+            render(
+                <Radio>
+                    <span>Label Text</span>
+                </Radio>,
+            );
+
+            expect(screen.getByText("Label Text")).to.exist;
+        });
+
+        it("should support JSX labelElement", () => {
+            render(<Radio labelElement={<span>Label Text</span>} />);
+
+            expect(screen.getByText("Label Text")).to.exist;
         });
     });
 
-    controlsTests(Radio, "radio", Classes.RADIO);
+    describe("Switch", () => {
+        it("should render", () => {
+            render(<Switch />);
+            const checkbox = screen.getByRole("checkbox");
+            const control = checkbox.closest(`.${Classes.CONTROL}`);
 
-    function controlsTests(classType: ControlType, propType: string, className: string, moreTests?: () => void) {
-        describe(`<${classType.displayName!.split(".")[1]}>`, () => {
-            it(`renders .${Classes.CONTROL}.${className}`, () => {
-                const control = mountControl();
-                assert.isTrue(control.find(`.${Classes.CONTROL}`).hasClass(className));
-            });
-
-            it(`renders input[type=${propType}]`, () => {
-                // ensure that `type` prop always comes out as expected, regardless of given value
-                const control = mountControl({ type: "failure" });
-                assert.equal(control.find("input").prop("type"), propType);
-            });
-
-            it("supports JSX children", () => {
-                const control = mountControl({}, <span className="jsx-child" key="jsx" />, "Label Text");
-                assert.lengthOf(control.find(".jsx-child"), 1);
-                assert.equal(control.text().trim(), "Label Text");
-            });
-
-            it("supports JSX labelElement", () => {
-                // uncommenting this line should present a tsc error on label prop:
-                // <Checkbox label={<strong>boom</strong>} />;
-
-                const control = mountControl({ labelElement: <strong>boom</strong> });
-                assert.lengthOf(control.find("strong"), 1);
-                assert.equal(control.text().trim(), "boom");
-            });
-
-            if (moreTests != null) {
-                moreTests();
-            }
+            expect(checkbox).to.exist;
+            expect(control).to.exist;
+            expect(checkbox.getAttribute("type")).to.equal("checkbox");
+            expect([...control!.classList]).to.include(Classes.SWITCH);
         });
 
-        function mountControl(props?: ControlProps, ...children: React.ReactNode[]) {
-            return mount(React.createElement(classType, props, children));
-        }
-    }
+        it("should support JSX children", () => {
+            render(
+                <Switch>
+                    <span>Label Text</span>
+                </Switch>,
+            );
+
+            expect(screen.getByText("Label Text")).to.exist;
+        });
+
+        it("should support JSX labelElement", () => {
+            render(<Switch labelElement={<span>Label Text</span>} />);
+
+            expect(screen.getByText("Label Text")).to.exist;
+        });
+
+        it("should render both innerLabels when both defined", () => {
+            render(<Switch innerLabelChecked="checked" innerLabel="unchecked" />);
+
+            expect(screen.getByText("checked")).to.exist;
+            expect(screen.getByText("unchecked")).to.exist;
+        });
+
+        it("should not render innerLabel components when neither defined", () => {
+            render(<Switch />);
+
+            expect(screen.queryByText("checked")).to.not.exist;
+            expect(screen.queryByText("unchecked")).to.not.exist;
+        });
+
+        it("should render innerLabel when innerLabelChecked is defined", () => {
+            render(<Switch innerLabelChecked="checked" />);
+            const labels = screen.getAllByText("checked");
+
+            expect(labels).to.have.length(1);
+        });
+
+        it("should render two innerLabels when innerLabel is defined and innerLabelChecked is not", () => {
+            render(<Switch innerLabel="test" />);
+            const labels = screen.getAllByText("test");
+
+            expect(labels).to.have.length(2);
+        });
+    });
 });


### PR DESCRIPTION
#### Part of #7444

#### Proposed changes:

Refactor control component tests to use RTL instead of Enzyme.