### PR TITLE
Fix DateInput not recognizing repeat inputs

### DIFF
--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -22,12 +22,12 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     Intent,
-    mergeRefs,
     Popover,
     type PopoverClickTargetHandlers,
     type PopoverTargetProps,
     Tag,
     Utils,
+    mergeRefs,
 } from "@blueprintjs/core";
 import {
     type DatePickerShortcut,
@@ -119,9 +119,10 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function DateInp
 
     const [isOpen, setIsOpen] = React.useState(false);
     const [timezoneValue, setTimezoneValue] = React.useState(getInitialTimezoneValue(props));
+    const [validInputUpdateCounter, setValidInputUpdateCounter] = React.useState(0);
     const valueFromProps = React.useMemo(
         () => TimezoneUtils.getDateObjectFromIsoString(value, timezoneValue),
-        [timezoneValue, value],
+        [timezoneValue, validInputUpdateCounter, value],
     );
     const isControlled = valueFromProps !== undefined;
     const defaultValueFromProps = React.useMemo(
@@ -433,6 +434,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function DateInp
                 DateUtils.isDayInRange(inputValueAsDate, [minDate, maxDate])
             ) {
                 if (isControlled) {
+                    setValidInputUpdateCounter(prev => prev + 1);
                     setInputValue(valueString);
                 } else {
                     setValue(inputValueAsDate);

--- a/packages/datetime2/src/components/date-input3/dateInput3.tsx
+++ b/packages/datetime2/src/components/date-input3/dateInput3.tsx
@@ -22,12 +22,12 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     Intent,
+    mergeRefs,
     Popover,
     type PopoverClickTargetHandlers,
     type PopoverTargetProps,
     Tag,
     Utils,
-    mergeRefs,
 } from "@blueprintjs/core";
 import {
     type DatePickerShortcut,
@@ -122,6 +122,7 @@ export const DateInput3: React.FC<DateInput3Props> = React.memo(function DateInp
     const [validInputUpdateCounter, setValidInputUpdateCounter] = React.useState(0);
     const valueFromProps = React.useMemo(
         () => TimezoneUtils.getDateObjectFromIsoString(value, timezoneValue),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [timezoneValue, validInputUpdateCounter, value],
     );
     const isControlled = valueFromProps !== undefined;


### PR DESCRIPTION
#### Fixes #7107.

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Currently, when a user enters an invalid date in DateInput3's textbox and then tries to type the original date again, the internal state is not updated to reflect this correction. This results in an error being displayed, even though the text input is valid. 

This PR aims to resolve this by forcing `valueFromProps` to update whenever valid input is entered, which triggers a `useEffect` and updates the internal state.

#### Reviewers should focus on:

Possibly exploring a less hacky solution, though this would probably require a significant refactor.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
