### PR TITLE
[WIP] Dropdown component

### DIFF
--- a/packages/docs-app/src/examples/core-examples/calloutPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutPlaygroundExample.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { range } from "lodash";
 import * as React from "react";
 
-import { Button, Callout, Code, H5, HTMLSelect, type Intent, Label, Switch } from "@blueprintjs/core";
-import { type DocsExampleProps, Example, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs-theme";
+import { Button, Callout, Code, H5, type Intent, Label, Switch } from "@blueprintjs/core";
+import { type DocsExampleProps, Example, handleBooleanChange } from "@blueprintjs/docs-theme";
 import type { IconName } from "@blueprintjs/icons";
+import { Dropdown } from "@blueprintjs/select";
 
 import { IconSelect } from "./common/iconSelect";
 import { IntentSelect } from "./common/intentSelect";
@@ -42,13 +44,14 @@ export const CalloutPlaygroundExample: React.FC<DocsExampleProps> = props => {
             <H5>Children</H5>
             <Label>
                 Example content
-                <HTMLSelect value={contentIndex} onChange={handleNumberChange(setContentIndex)}>
-                    {EXAMPLE_CONTENT_OPTIONS.map((opt, i) => (
-                        <option key={i} value={i}>
-                            {opt.label}
-                        </option>
-                    ))}
-                </HTMLSelect>
+                <Dropdown
+                    buttonProps={{ style: { minWidth: 175 } }}
+                    fill={true}
+                    itemLabel={index => EXAMPLE_CONTENT_OPTIONS[index].label}
+                    items={range(0, EXAMPLE_CONTENT_OPTIONS.length)}
+                    onItemSelect={setContentIndex}
+                    selectedItem={contentIndex}
+                />
             </Label>
         </>
     );

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
+import { capitalize } from "lodash";
 import * as React from "react";
 
-import { Button, ControlGroup, FormGroup, HTMLSelect, Intent } from "@blueprintjs/core";
-import { handleValueChange } from "@blueprintjs/docs-theme";
+import { Button, ButtonGroup, FormGroup, Intent } from "@blueprintjs/core";
+import { Dropdown } from "@blueprintjs/select";
 
-const INTENTS = [
-    { label: "None", value: Intent.NONE },
-    { label: "Primary", value: Intent.PRIMARY },
-    { label: "Success", value: Intent.SUCCESS },
-    { label: "Warning", value: Intent.WARNING },
-    { label: "Danger", value: Intent.DANGER },
-];
+const INTENTS: Intent[] = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.WARNING, Intent.DANGER];
 
 export interface IntentSelectProps {
     intent: Intent;
@@ -35,17 +30,21 @@ export interface IntentSelectProps {
     showClearButton?: boolean;
 }
 
-export const IntentSelect: React.FC<IntentSelectProps> = ({ label = "Intent", intent, showClearButton, onChange }) => {
-    const handleChange = handleValueChange(onChange);
+export const IntentSelect: React.FC<IntentSelectProps> = ({
+    label = "Intent",
+    intent = "none",
+    showClearButton,
+    onChange,
+}) => {
     const handleClear = React.useCallback(() => onChange("none"), [onChange]);
     return (
         <FormGroup label={label}>
-            <ControlGroup>
-                <HTMLSelect value={intent} onChange={handleChange} options={INTENTS} fill={true} />
+            <ButtonGroup fill={true}>
+                <Dropdown fill={true} items={INTENTS} itemLabel={capitalize} onItemSelect={onChange} selectedItem={intent} />
                 {showClearButton && (
                     <Button aria-label="Clear" disabled={intent === "none"} icon="cross" onClick={handleClear} />
                 )}
-            </ControlGroup>
+            </ButtonGroup>
         </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -40,7 +40,13 @@ export const IntentSelect: React.FC<IntentSelectProps> = ({
     return (
         <FormGroup label={label}>
             <ButtonGroup fill={true}>
-                <Dropdown fill={true} items={INTENTS} itemLabel={capitalize} onItemSelect={onChange} selectedItem={intent} />
+                <Dropdown
+                    fill={true}
+                    items={INTENTS}
+                    itemLabel={capitalize}
+                    onItemSelect={onChange}
+                    selectedItem={intent}
+                />
                 {showClearButton && (
                     <Button aria-label="Clear" disabled={intent === "none"} icon="cross" onClick={handleClear} />
                 )}

--- a/packages/docs-app/src/examples/core-examples/common/variantSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/variantSelect.tsx
@@ -2,10 +2,11 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
+import { capitalize } from "lodash";
 import * as React from "react";
 
-import { type ButtonVariant, ControlGroup, FormGroup, HTMLSelect } from "@blueprintjs/core";
-import { handleValueChange } from "@blueprintjs/docs-theme";
+import { type ButtonVariant, FormGroup } from "@blueprintjs/core";
+import { Dropdown } from "@blueprintjs/select";
 
 export interface VariantSelectProps {
     label?: React.ReactNode;
@@ -13,21 +14,23 @@ export interface VariantSelectProps {
     variant: ButtonVariant;
 }
 
-interface Option {
-    label: string;
-    value: ButtonVariant;
-}
+/* eslint-disable sort-keys */
+const VARIANTS_RECORD: Record<ButtonVariant, true> = {
+    solid: true,
+    minimal: true,
+    outlined: true,
+};
 
-const options: Option[] = [
-    { label: "Solid", value: "solid" },
-    { label: "Minimal", value: "minimal" },
-    { label: "Outlined", value: "outlined" },
-];
+const VARIANTS = Object.keys(VARIANTS_RECORD) as ButtonVariant[];
 
 export const VariantSelect: React.FC<VariantSelectProps> = ({ label = "Variant", onChange, variant }) => (
     <FormGroup label={label}>
-        <ControlGroup>
-            <HTMLSelect fill={true} onChange={handleValueChange(onChange)} options={options} value={variant} />
-        </ControlGroup>
+        <Dropdown<ButtonVariant>
+            fill={true}
+            itemLabel={capitalize}
+            items={VARIANTS}
+            onItemSelect={onChange}
+            selectedItem={variant}
+        />
     </FormGroup>
 );

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -16,14 +16,16 @@
 
 import * as React from "react";
 
-import { Button, ControlGroup, HTMLSelect, InputGroup, Switch } from "@blueprintjs/core";
+import { Button, ControlGroup, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
 
 const FILTER_OPTIONS = ["Filter", "Name - ascending", "Name - descending", "Price - ascending", "Price - descending"];
 
 export const ControlGroupExample: React.FC<ExampleProps> = props => {
     const [fill, setFill] = React.useState(false);
     const [vertical, setVertical] = React.useState(false);
+    const [filterOption, setFilterOption] = React.useState(FILTER_OPTIONS[0]);
 
     const options = (
         <>
@@ -35,7 +37,13 @@ export const ControlGroupExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={options} {...props}>
             <ControlGroup fill={fill} vertical={vertical}>
-                <HTMLSelect options={FILTER_OPTIONS} />
+                <Dropdown
+                    buttonProps={{ style: { minWidth: 170 } }}
+                    items={FILTER_OPTIONS}
+                    onItemSelect={setFilterOption}
+                    popoverProps={{ matchTargetWidth: fill }}
+                    selectedItem={filterOption}
+                />
                 <InputGroup placeholder="Find filters..." />
                 <Button icon="arrow-right" />
             </ControlGroup>

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -26,15 +26,14 @@ import {
     DrawerSize,
     FormGroup,
     H5,
-    HTMLSelect,
     Menu,
     MenuItem,
-    type OptionProps,
     Position,
     SegmentedControl,
     Switch,
 } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
 
 import type { BlueprintExampleData } from "../../tags/types";
 
@@ -58,7 +57,7 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
         hasBackdrop: true,
         isOpen: false,
         position: Position.RIGHT,
-        size: undefined,
+        size: DrawerSize.STANDARD,
         usePortal: true,
     };
 
@@ -76,7 +75,7 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
 
     private handleOutsideClickChange = handleBooleanChange(val => this.setState({ canOutsideClickClose: val }));
 
-    private handleSizeChange = handleStringChange(size => this.setState({ size }));
+    private handleSizeChange = (size: string) => this.setState({ size });
 
     public render() {
         const { size, ...drawerProps } = this.state;
@@ -89,7 +88,7 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
                     icon="info-sign"
                     onClose={this.handleClose}
                     title="Palantir Foundry"
-                    size={size === "default" ? undefined : size}
+                    size={size}
                     {...drawerProps}
                 >
                     <div className={Classes.DRAWER_BODY}>
@@ -141,8 +140,16 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
     }
 
     private renderOptions() {
-        const { autoFocus, enforceFocus, canEscapeKeyClose, canOutsideClickClose, hasBackdrop, position, usePortal } =
-            this.state;
+        const {
+            autoFocus,
+            enforceFocus,
+            canEscapeKeyClose,
+            canOutsideClickClose,
+            hasBackdrop,
+            position,
+            size,
+            usePortal,
+        } = this.state;
         return (
             <>
                 <H5>Props</H5>
@@ -161,7 +168,13 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
                     />
                 </FormGroup>
                 <FormGroup label="Size">
-                    <HTMLSelect options={SIZES} onChange={this.handleSizeChange} />
+                    <Dropdown
+                        fill={true}
+                        itemLabel={getDrawerSizeLabel}
+                        items={[DrawerSize.SMALL, DrawerSize.STANDARD, DrawerSize.LARGE, "72%", "560px"]}
+                        onItemSelect={this.handleSizeChange}
+                        selectedItem={size}
+                    />
                 </FormGroup>
                 <Divider />
                 <Switch checked={autoFocus} label="Auto focus" onChange={this.handleAutoFocusChange} />
@@ -185,11 +198,15 @@ export class DrawerExample extends React.PureComponent<ExampleProps<BlueprintExa
     private handleClose = () => this.setState({ isOpen: false });
 }
 
-const SIZES: Array<string | OptionProps> = [
-    { label: "Default", value: "default" },
-    { label: "Small", value: DrawerSize.SMALL },
-    { label: "Standard", value: DrawerSize.STANDARD },
-    { label: "Large", value: DrawerSize.LARGE },
-    "72%",
-    "560px",
-];
+function getDrawerSizeLabel(size: string): string {
+    switch (size) {
+        case DrawerSize.SMALL:
+            return "Small";
+        case DrawerSize.STANDARD:
+            return "Standard";
+        case DrawerSize.LARGE:
+            return "Large";
+        default:
+            return size;
+    }
+}

--- a/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
@@ -26,7 +26,6 @@ import {
     H4,
     H5,
     H6,
-    HTMLSelect,
     Intent,
     Switch,
     Tag,
@@ -34,12 +33,13 @@ import {
 } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { IconNames } from "@blueprintjs/icons";
+import { Dropdown } from "@blueprintjs/select";
 
 // Limit width to display ellipsizing behavior.
 const WIDTH_LIMIT = 200;
 
 // Headings selector.
-const HEADINGS = ["Default", "H1", "H2", "H3", "H4", "H5", "H6"].map(value => ({ label: value, value }));
+const HEADINGS = ["Default", "H1", "H2", "H3", "H4", "H5", "H6"];
 
 export const EntityTitleExample: React.FC<ExampleProps> = props => {
     const [ellipsize, setEllipsize] = React.useState<boolean>(false);
@@ -50,16 +50,12 @@ export const EntityTitleExample: React.FC<ExampleProps> = props => {
     const [withSubtitle, setWithSubtitle] = React.useState<boolean>(false);
     const [withTag, setWithTag] = React.useState<boolean>(false);
 
-    const handleHeadingChange = (event: React.FormEvent<HTMLSelectElement>) => {
-        setHeading(event.currentTarget.value);
-    };
-
     const options = (
         <>
             <H5>Props</H5>
             <FormGroup label="Heading">
                 <ControlGroup>
-                    <HTMLSelect value={heading} onChange={handleHeadingChange} options={HEADINGS} fill={true} />
+                    <Dropdown fill={true} items={HEADINGS} onItemSelect={setHeading} selectedItem={heading} />
                 </ControlGroup>
             </FormGroup>
             <Switch checked={ellipsize} label="Ellipsize" onChange={handleBooleanChange(setEllipsize)} />

--- a/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
@@ -17,17 +17,16 @@
 import * as React from "react";
 
 import { Divider, FormGroup, H5, HTMLSelect, type HTMLSelectIconName, Switch } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
 
 export interface HTMLSelectExampleState {
     disabled: boolean;
     fill: boolean;
-    iconName?: "double-caret-vertical" | "caret-down";
+    iconName: "double-caret-vertical" | "caret-down";
     large: boolean;
     minimal: boolean;
 }
-
-const SUPPORTED_ICON_NAMES: HTMLSelectIconName[] = ["double-caret-vertical", "caret-down"];
 
 const SELECT_OPTIONS = ["One", "Two", "Three", "Four"];
 
@@ -35,7 +34,7 @@ export class HTMLSelectExample extends React.PureComponent<ExampleProps, HTMLSel
     public state: HTMLSelectExampleState = {
         disabled: false,
         fill: false,
-        iconName: undefined, // use component default
+        iconName: "double-caret-vertical",
         large: false,
         minimal: false,
     };
@@ -44,9 +43,7 @@ export class HTMLSelectExample extends React.PureComponent<ExampleProps, HTMLSel
 
     private handleFillChange = handleBooleanChange(fill => this.setState({ fill }));
 
-    private handleIconChange = handleStringChange(iconName =>
-        this.setState({ iconName: iconName as HTMLSelectIconName }),
-    );
+    private handleIconChange = (iconName: HTMLSelectIconName) => this.setState({ iconName });
 
     private handleLargeChange = handleBooleanChange(large => this.setState({ large }));
 
@@ -62,10 +59,12 @@ export class HTMLSelectExample extends React.PureComponent<ExampleProps, HTMLSel
                 <Switch checked={this.state.disabled} label="Disabled" onChange={this.handleDisabledChange} />
                 <Divider />
                 <FormGroup label="Icon">
-                    <HTMLSelect
-                        placeholder="Choose an item..."
-                        options={SUPPORTED_ICON_NAMES}
-                        onChange={this.handleIconChange}
+                    <Dropdown<HTMLSelectIconName>
+                        buttonProps={{ style: { minWidth: 185 } }}
+                        fill={true}
+                        items={["double-caret-vertical", "caret-down"]}
+                        onItemSelect={this.handleIconChange}
+                        selectedItem={this.state.iconName}
                     />
                 </FormGroup>
             </>

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+import { capitalize } from "lodash";
 import * as React from "react";
 
 import {
@@ -20,7 +21,6 @@ import {
     Divider,
     FormGroup,
     H5,
-    HTMLSelect,
     Intent,
     Menu,
     MenuItem,
@@ -28,45 +28,18 @@ import {
     type NumericInputProps,
     type OptionProps,
     Popover,
-    Position,
     type Size,
     Switch,
 } from "@blueprintjs/core";
-import {
-    Example,
-    type ExampleProps,
-    handleBooleanChange,
-    handleNumberChange,
-    handleStringChange,
-    handleValueChange,
-} from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { IconNames } from "@blueprintjs/icons";
+import { Dropdown } from "@blueprintjs/select";
 
 import { IntentSelect } from "./common/intentSelect";
 import { LOCALES } from "./common/locales";
 import { SizeSelect } from "./common/sizeSelect";
 
-const MIN_VALUES = [
-    { label: "None", value: -Infinity },
-    { label: "-10", value: -10 },
-    { label: "0", value: 0 },
-    { label: "20", value: 20 },
-];
-
-const MAX_VALUES = [
-    { label: "None", value: +Infinity },
-    { label: "20", value: 20 },
-    { label: "50", value: 50 },
-    { label: "100", value: 100 },
-];
-
-const BUTTON_POSITIONS = [
-    { label: "None", value: "none" },
-    { label: "Left", value: Position.LEFT },
-    { label: "Right", value: Position.RIGHT },
-];
-
-const LOCALE_OPTIONS = [{ label: "Default", value: "default" }, ...LOCALES];
+const LOCALE_OPTIONS: Array<OptionProps<string>> = [{ label: "Default", value: "default" }, ...LOCALES];
 
 export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
     const [allowNumericCharactersOnly, setAllowNumericCharactersOnly] = React.useState(true);
@@ -76,7 +49,7 @@ export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
     const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
     const [leftElement, setLeftElement] = React.useState(false);
     const [leftIcon, setLeftIcon] = React.useState(false);
-    const [locale, setLocale] = React.useState<string>();
+    const [locale, setLocale] = React.useState<OptionProps<string>>(LOCALE_OPTIONS[0]);
     const [max, setMax] = React.useState(100);
     const [min, setMin] = React.useState(0);
     const [selectAllOnFocus, setSelectAllOnFocus] = React.useState(false);
@@ -87,10 +60,6 @@ export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
     const handleInputValueChange = React.useCallback(
         (_valueAsNumber: number, valueAsString: string) => setValue(valueAsString),
         [],
-    );
-
-    const handleLocaleChange = handleStringChange(newLocale =>
-        setLocale(newLocale === "default" ? undefined : newLocale),
     );
 
     const options = (
@@ -116,16 +85,43 @@ export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
                 onChange={handleBooleanChange(setSelectAllOnIncrement)}
             />
             <Divider />
-            <SelectMenu label="Minimum value" onChange={handleNumberChange(setMin)} options={MIN_VALUES} value={min} />
-            <SelectMenu label="Maximum value" onChange={handleNumberChange(setMax)} options={MAX_VALUES} value={max} />
-            <SelectMenu
-                label="Button position"
-                onChange={handleValueChange(setButtonPosition)}
-                options={BUTTON_POSITIONS}
-                value={buttonPosition}
-            />
+            <FormGroup label="Minimum value">
+                <Dropdown
+                    fill={true}
+                    itemLabel={getValueLabel}
+                    items={[-Infinity, -10, 0, 20]}
+                    onItemSelect={setMin}
+                    selectedItem={min}
+                />
+            </FormGroup>
+            <FormGroup label="Maximum value">
+                <Dropdown
+                    fill={true}
+                    itemLabel={getValueLabel}
+                    items={[Infinity, 20, 50, 100]}
+                    onItemSelect={setMax}
+                    selectedItem={max}
+                />
+            </FormGroup>
+            <FormGroup label="Button position">
+                <Dropdown
+                    itemLabel={capitalize}
+                    items={["none", "left", "right"]}
+                    onItemSelect={setButtonPosition}
+                    selectedItem={buttonPosition}
+                />
+            </FormGroup>
             <IntentSelect intent={intent} onChange={setIntent} />
-            <SelectMenu label="Locale" onChange={handleLocaleChange} options={LOCALE_OPTIONS} value={locale} />
+            <FormGroup label="Locale">
+                <Dropdown
+                    fill={true}
+                    itemKey="value"
+                    itemLabel="label"
+                    items={LOCALE_OPTIONS}
+                    onItemSelect={setLocale}
+                    selectedItem={locale}
+                />
+            </FormGroup>
             <SizeSelect onChange={setSize} size={size} />
         </>
     );
@@ -140,6 +136,7 @@ export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
                 intent={intent}
                 leftElement={leftElement ? <FilterMenu /> : undefined}
                 leftIcon={leftIcon ? IconNames.DOLLAR : undefined}
+                locale={locale.value === "default" ? undefined : locale.value}
                 max={max}
                 min={min}
                 onValueChange={handleInputValueChange}
@@ -168,15 +165,10 @@ const FilterMenu: React.FC = () => (
     </Popover>
 );
 
-interface SelectMenuProps {
-    label: string;
-    onChange: React.FormEventHandler;
-    options: OptionProps[];
-    value: number | string;
+function getValueLabel(value: number | undefined) {
+    if (isFinite(value)) {
+        return value;
+    } else {
+        return "None";
+    }
 }
-
-const SelectMenu: React.FC<SelectMenuProps> = ({ label, onChange, options, value }) => (
-    <FormGroup label={label}>
-        <HTMLSelect onChange={onChange} options={options} value={value} />
-    </FormGroup>
-);

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -185,8 +185,8 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                             boundary === "scrollParent"
                                 ? this.scrollParentElement ?? undefined
                                 : boundary === "body"
-                                    ? this.bodyElement ?? undefined
-                                    : boundary
+                                  ? this.bodyElement ?? undefined
+                                  : boundary
                         }
                         enforceFocus={false}
                         isOpen={this.state.isControlled ? this.state.isOpen : undefined}

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { capitalize } from "lodash";
 import * as React from "react";
 
 import {
@@ -24,7 +25,6 @@ import {
     Divider,
     FormGroup,
     H5,
-    HTMLSelect,
     Intent,
     Menu,
     MenuDivider,
@@ -41,13 +41,8 @@ import {
     type StrictModifierNames,
     Switch,
 } from "@blueprintjs/core";
-import {
-    Example,
-    type ExampleProps,
-    handleBooleanChange,
-    handleNumberChange,
-    handleValueChange,
-} from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
 import { FilmSelect } from "@blueprintjs/select/examples";
 
 const POPPER_DOCS_URL = "https://popper.js.org/docs/v2/";
@@ -63,7 +58,7 @@ export interface PopoverExampleState {
     boundary?: "scrollParent" | "body" | "clippingParents";
     buttonText: string;
     canEscapeKeyClose?: boolean;
-    exampleIndex?: number;
+    contentsType?: ContentsType;
     hasBackdrop?: boolean;
     inheritDarkTheme?: boolean;
     interactionKind?: PopoverInteractionKind;
@@ -80,6 +75,8 @@ export interface PopoverExampleState {
     usePortal?: boolean;
 }
 
+type ContentsType = "text" | "input" | "sliders" | "menu" | "select" | "empty";
+
 export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExampleState> {
     public static displayName = "PopoverExample";
 
@@ -87,7 +84,7 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
         boundary: "scrollParent",
         buttonText: "Popover target",
         canEscapeKeyClose: true,
-        exampleIndex: 0,
+        contentsType: "text",
         hasBackdrop: false,
         inheritDarkTheme: true,
         interactionKind: "click",
@@ -116,18 +113,16 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
 
     private handleSliderChange = (sliderValue: number) => this.setState({ sliderValue });
 
-    private handleExampleIndexChange = handleNumberChange(exampleIndex => this.setState({ exampleIndex }));
+    private handleContentsTypeChange = (contentsType: ContentsType) => this.setState({ contentsType });
 
     private handleInteractionChange = handleValueChange((interactionKind: PopoverInteractionKind) => {
         const hasBackdrop = this.state.hasBackdrop && interactionKind === "click";
         this.setState({ hasBackdrop, interactionKind });
     });
 
-    private handlePlacementChange = handleValueChange((placement: Placement) => this.setState({ placement }));
+    private handlePlacementChange = (placement: Placement) => this.setState({ placement });
 
-    private handleBoundaryChange = handleValueChange((boundary: PopoverExampleState["boundary"]) =>
-        this.setState({ boundary }),
-    );
+    private handleBoundaryChange = (boundary: PopoverExampleState["boundary"]) => this.setState({ boundary });
 
     private toggleEscapeKey = handleBooleanChange(canEscapeKeyClose => this.setState({ canEscapeKeyClose }));
 
@@ -173,21 +168,25 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
     }
 
     public render() {
-        const { boundary, buttonText, exampleIndex, sliderValue, ...popoverProps } = this.state;
+        const { boundary, buttonText, contentsType, sliderValue, ...popoverProps } = this.state;
         return (
             <Example options={this.renderOptions()} {...this.props}>
                 <div className="docs-popover-example-scroll" ref={this.centerScroll}>
                     <Popover
-                        popoverClassName={exampleIndex <= 2 ? Classes.POPOVER_CONTENT_SIZING : ""}
+                        popoverClassName={
+                            contentsType === "text" || contentsType === "input" || contentsType === "sliders"
+                                ? Classes.POPOVER_CONTENT_SIZING
+                                : ""
+                        }
                         portalClassName="docs-popover-example-portal"
                         {...popoverProps}
-                        content={this.getContents(exampleIndex)}
+                        content={this.getContents(contentsType)}
                         boundary={
                             boundary === "scrollParent"
                                 ? this.scrollParentElement ?? undefined
                                 : boundary === "body"
-                                  ? this.bodyElement ?? undefined
-                                  : boundary
+                                    ? this.bodyElement ?? undefined
+                                    : boundary
                         }
                         enforceFocus={false}
                         isOpen={this.state.isControlled ? this.state.isOpen : undefined}
@@ -221,17 +220,21 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                     label="Position when opened"
                     labelFor="position"
                 >
-                    <HTMLSelect value={placement} onChange={this.handlePlacementChange} options={PopperPlacements} />
+                    <Dropdown
+                        fill={true}
+                        items={PopperPlacements}
+                        onItemSelect={this.handlePlacementChange}
+                        selectedItem={placement}
+                    />
                 </FormGroup>
                 <FormGroup label="Example content">
-                    <HTMLSelect value={this.state.exampleIndex} onChange={this.handleExampleIndexChange}>
-                        <option value="0">Text</option>
-                        <option value="1">Input</option>
-                        <option value="2">Sliders</option>
-                        <option value="3">Menu</option>
-                        <option value="4">Select</option>
-                        <option value="5">Empty</option>
-                    </HTMLSelect>
+                    <Dropdown<ContentsType>
+                        fill={true}
+                        itemLabel={capitalize}
+                        items={["text", "input", "sliders", "menu", "select", "empty"]}
+                        onItemSelect={this.handleContentsTypeChange}
+                        selectedItem={this.state.contentsType}
+                    />
                 </FormGroup>
                 <Switch checked={this.state.usePortal} onChange={this.toggleUsePortal}>
                     Use <Code>Portal</Code>
@@ -288,14 +291,12 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                 >
                     <br />
                     <div style={{ marginTop: 5 }} />
-                    <HTMLSelect
+                    <Dropdown<PopoverExampleState["boundary"]>
                         disabled={!preventOverflow.enabled}
-                        value={this.state.boundary}
-                        onChange={this.handleBoundaryChange}
-                    >
-                        <option value="scrollParent">scrollParent</option>
-                        <option value="window">window</option>
-                    </HTMLSelect>
+                        items={["body", "scrollParent", "clippingParents"]}
+                        onItemSelect={this.handleBoundaryChange}
+                        selectedItem={this.state.boundary}
+                    />
                 </Switch>
                 <Switch checked={matchTargetWidth} label="Match target width" onChange={this.toggleMatchTargetWidth} />
 
@@ -316,9 +317,26 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
         );
     }
 
-    private getContents(index: number): React.JSX.Element {
-        return [
-            <div key="text">
+    private getContents(contentsType: ContentsType): React.JSX.Element {
+        switch (contentsType) {
+            case "text":
+                return this.renderText();
+            case "input":
+                return this.renderInput();
+            case "sliders":
+                return this.renderSliders();
+            case "menu":
+                return this.renderMenu();
+            case "select":
+                return this.renderSelect();
+            case "empty":
+                return null;
+        }
+    }
+
+    private renderText() {
+        return (
+            <div>
                 <H5>Confirm deletion</H5>
                 <p>Are you sure you want to delete these items? You won't be able to recover them.</p>
                 <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 15 }}>
@@ -329,14 +347,24 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                         Delete
                     </Button>
                 </div>
-            </div>,
-            <div key="input">
+            </div>
+        );
+    }
+
+    private renderInput() {
+        return (
+            <div>
                 <label className={Classes.LABEL}>
                     Enter some text
                     <input autoFocus={true} className={Classes.INPUT} type="text" />
                 </label>
-            </div>,
-            <div key="sliders">
+            </div>
+        );
+    }
+
+    private renderSliders() {
+        return (
+            <div>
                 <Slider min={0} max={10} onChange={this.handleSliderChange} value={this.state.sliderValue} />
                 <RangeSlider
                     min={0}
@@ -344,8 +372,13 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                     onChange={this.handleRangeSliderChange}
                     value={this.state.rangeSliderValue}
                 />
-            </div>,
-            <Menu key="menu">
+            </div>
+        );
+    }
+
+    private renderMenu() {
+        return (
+            <Menu>
                 <MenuDivider title="Edit" />
                 <MenuItem icon="cut" text="Cut" label="⌘X" />
                 <MenuItem icon="duplicate" text="Copy" label="⌘C" />
@@ -362,11 +395,16 @@ export class PopoverExample extends React.PureComponent<ExampleProps, PopoverExa
                     <MenuItem icon="italic" text="Italic" />
                     <MenuItem icon="underline" text="Underline" />
                 </MenuItem>
-            </Menu>,
-            <div key="filmselect" style={{ padding: 20 }}>
+            </Menu>
+        );
+    }
+
+    private renderSelect() {
+        return (
+            <div style={{ padding: 20 }}>
                 <FilmSelect popoverProps={{ captureDismiss: true }} />
-            </div>,
-        ][index];
+            </div>
+        );
     }
 
     private centerScroll = (overflowingDiv: HTMLDivElement) => {

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -22,7 +22,6 @@ import {
     Classes,
     FormGroup,
     H5,
-    HTMLSelect,
     Intent,
     NumericInput,
     OverlayToaster,
@@ -34,7 +33,8 @@ import {
     type ToasterPosition,
     type ToastProps,
 } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
 
 import type { BlueprintExampleData } from "../../tags/types";
 
@@ -135,7 +135,7 @@ export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExam
 
     private progressToastInterval?: number;
 
-    private handlePositionChange = handleValueChange((position: ToasterPosition) => this.setState({ position }));
+    private handlePositionChange = (position: ToasterPosition) => this.setState({ position });
 
     private toggleAutoFocus = handleBooleanChange(autoFocus => this.setState({ autoFocus }));
 
@@ -159,7 +159,12 @@ export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExam
             <>
                 <H5>Props</H5>
                 <FormGroup label="Position">
-                    <HTMLSelect value={position} onChange={this.handlePositionChange} options={POSITIONS} />
+                    <Dropdown
+                        fill={true}
+                        items={POSITIONS}
+                        onItemSelect={this.handlePositionChange}
+                        selectedItem={position}
+                    />
                 </FormGroup>
                 <FormGroup label="Maximum active toasts">
                     <NumericInput

--- a/packages/docs-app/src/examples/datetime2-examples/common/minMaxDateSelect.tsx
+++ b/packages/docs-app/src/examples/datetime2-examples/common/minMaxDateSelect.tsx
@@ -15,10 +15,11 @@
  */
 
 import { add } from "date-fns";
+import { range } from "lodash";
 import * as React from "react";
 
-import { FormGroup, HTMLSelect } from "@blueprintjs/core";
-import { handleNumberChange } from "@blueprintjs/docs-theme";
+import { FormGroup } from "@blueprintjs/core";
+import { Dropdown } from "@blueprintjs/select";
 
 interface DateOption {
     label: string;
@@ -36,22 +37,25 @@ export interface DateSelectProps {
 const DateSelect: React.FC<DateSelectProps> = ({ label, onChange, options }) => {
     const [selectedOptionIndex, setSelectedOptionIndex] = React.useState(0);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     const handleSelectChange = React.useCallback(
-        handleNumberChange(optionIndex => {
+        (optionIndex: number) => {
             setSelectedOptionIndex(optionIndex);
             onChange(options[optionIndex].value);
-        }),
+        },
         [onChange, options],
     );
 
+    const itemLabel = React.useCallback((index: number) => options[index].label, [options]);
+
     return (
         <FormGroup label={label}>
-            <HTMLSelect value={selectedOptionIndex} onChange={handleSelectChange}>
-                {options.map((opt, i) => (
-                    <option key={i} value={i} label={opt.label} />
-                ))}
-            </HTMLSelect>
+            <Dropdown
+                fill={true}
+                itemLabel={itemLabel}
+                items={range(0, options.length)}
+                onItemSelect={handleSelectChange}
+                selectedItem={selectedOptionIndex}
+            />
         </FormGroup>
     );
 };

--- a/packages/docs-app/src/examples/select-examples/dropdownExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/dropdownExample.tsx
@@ -1,0 +1,107 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import * as React from "react";
+
+import { Button, type ButtonVariant, H5, type IconName, type Intent, type Size, Switch } from "@blueprintjs/core";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+
+import { Dropdown } from "../../../../select/src/components/dropdown/dropdown";
+import { PropCodeTooltip } from "../../common/propCodeTooltip";
+import { IntentSelect } from "../core-examples/common/intentSelect";
+import { SizeSelect } from "../core-examples/common/sizeSelect";
+import { VariantSelect } from "../core-examples/common/variantSelect";
+
+type ChartType = {
+    name: string;
+    icon: IconName;
+    disabled?: boolean;
+};
+
+const CHART_TYPES: ChartType[] = [
+    { icon: "timeline-area-chart", name: "Area chart" },
+    { disabled: true, icon: "timeline-bar-chart", name: "Bar chart" },
+    { icon: "pie-chart", name: "Pie chart" },
+    { icon: "gantt-chart", name: "Gantt chart" },
+    { disabled: true, icon: "timeline-line-chart", name: "Line chart" },
+];
+
+export const DropdownExample: React.FC<ExampleProps> = props => {
+    const [value, setValue] = React.useState<ChartType | undefined>(CHART_TYPES[0]);
+
+    const [disabled, setDisabled] = React.useState(false);
+    const [disabledItems, setDisabledItems] = React.useState(false);
+    const [fill, setFill] = React.useState(false);
+    const [intent, setIntent] = React.useState<Intent>("none");
+    const [showIcons, setShowIcons] = React.useState(true);
+    const [matchTargetWidth, setMatchTargetWidth] = React.useState(false);
+    const [minimal, setMinimal] = React.useState(true);
+    const [size, setSize] = React.useState<Size>("medium");
+    const [variant, setVariant] = React.useState<ButtonVariant>("solid");
+
+    const handleClearSelect = React.useCallback(() => {
+        setValue(undefined);
+    }, []);
+    const options = (
+        <>
+            <H5>Props</H5>
+            <PropCodeTooltip snippet={`disabled={${disabled}}`}>
+                <Switch checked={disabled} label="Disabled" onChange={handleBooleanChange(setDisabled)} />
+            </PropCodeTooltip>
+            <PropCodeTooltip snippet={`itemDisabled=${disabledItems ? '"disabled-property"' : "{undefined}"}`}>
+                <Switch
+                    checked={disabledItems}
+                    label="Disabled items"
+                    onChange={handleBooleanChange(setDisabledItems)}
+                />
+            </PropCodeTooltip>
+            <PropCodeTooltip snippet={`fill={${fill}}`}>
+                <Switch checked={fill} label="Fill container width" onChange={handleBooleanChange(setFill)} />
+            </PropCodeTooltip>
+            <PropCodeTooltip snippet={`itemIcon=${showIcons ? '"icon-property"' : "{undefined}"}`}>
+                <Switch checked={showIcons} label="Show item icons" onChange={handleBooleanChange(setShowIcons)} />
+            </PropCodeTooltip>
+            <H5>Button props</H5>
+            <PropCodeTooltip snippet={`buttonProps={{ size: ${size} }}`}>
+                <SizeSelect onChange={setSize} size={size} />
+            </PropCodeTooltip>
+            <PropCodeTooltip snippet={`buttonProps={{ intent: ${intent} }}`}>
+                <IntentSelect intent={intent} onChange={setIntent} />
+            </PropCodeTooltip>
+            <PropCodeTooltip snippet={`buttonProps={{ variant: ${variant} }}`}>
+                <VariantSelect variant={variant} onChange={setVariant} />
+            </PropCodeTooltip>
+            <H5>Popover props</H5>
+            <PropCodeTooltip snippet={`popoverProps={{ matchTargetWidth: ${matchTargetWidth} }}`}>
+                <Switch
+                    checked={matchTargetWidth}
+                    label="Match target width"
+                    onChange={handleBooleanChange(setMatchTargetWidth)}
+                />
+            </PropCodeTooltip>
+            <PropCodeTooltip snippet={`popoverProps={{ minimal: ${minimal} }}`}>
+                <Switch checked={minimal} label="Minimal popover style" onChange={handleBooleanChange(setMinimal)} />
+            </PropCodeTooltip>
+            <H5>Example</H5>
+            <Button fill={true} onClick={handleClearSelect} text="Clear selection" />
+        </>
+    );
+    return (
+        <Example options={options} {...props}>
+            <Dropdown
+                disabled={disabled}
+                buttonProps={{ intent, size, variant }}
+                fill={fill}
+                itemDisabled={disabledItems ? "disabled" : undefined}
+                itemIcon={showIcons ? "icon" : undefined}
+                itemKey="name"
+                itemLabel="name"
+                items={CHART_TYPES}
+                onItemSelect={setValue}
+                popoverProps={{ matchTargetWidth, minimal }}
+                selectedItem={value}
+            />
+        </Example>
+    );
+};

--- a/packages/docs-app/src/examples/select-examples/dropdownExamples.tsx
+++ b/packages/docs-app/src/examples/select-examples/dropdownExamples.tsx
@@ -1,0 +1,56 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import dedent from "dedent";
+import { noop } from "lodash";
+import * as React from "react";
+
+import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
+
+export const DropdownBasicExample: React.FC<ExampleProps> = props => {
+    const code = dedent`
+        const names = ["Alice", "Bob", "Courtney", "David"];
+        const [selectedName, setSelectedName] = React.useState(names[0]);
+        <Dropdown items={names} onItemSelect={setSelectedName} selectedValue={selectedName} />`;
+
+    const names = ["Alice", "Bob", "Courtney", "David"];
+    const [selectedName, setSelectedName] = React.useState(names[0]);
+    return (
+        <CodeExample code={code} {...props}>
+            <Dropdown items={names} onItemSelect={setSelectedName} selectedItem={selectedName} />
+        </CodeExample>
+    );
+};
+
+export const DropdownLabelExample: React.FC<ExampleProps> = props => {
+    const code = dedent`
+        type Person = { id: number; name: string; age: number; };
+        const people: Person[] = [/* ... */];
+        <Dropdown items={people} {/* ... */} itemLabel="name" itemKey="id" />
+        `;
+
+    type Person = { id: number; name: string, age: number };
+    const people = ["Alice", "Bob", "Courtney", "David"].map((name, index): Person => ({ age: (index + 1) * 10, id: index, name }));
+    const [selectedPerson, setSelectedPerson] = React.useState(people[0]);
+    return (
+        <CodeExample code={code} {...props}>
+            <Dropdown items={people} onItemSelect={setSelectedPerson} selectedItem={selectedPerson} itemLabel="name" itemKey="id" />
+        </CodeExample>
+    );
+}
+
+export const DropdownFillExample: React.FC<ExampleProps> = props => {
+    const code = `<Dropdown items={["Alice", "Bob", "Courtney"]} fill={true} />`;
+
+    return (
+        <CodeExample code={code} {...props}>
+            <Dropdown items={["Alice", "Bob", "Courtney"]} fill={true} selectedItem="Alice" onItemSelect={noop} />
+        </CodeExample>
+    );
+};
+
+export const DropdownDisabledExample: React.FC<ExampleProps> = _props => {
+    return null;
+};

--- a/packages/docs-app/src/examples/select-examples/dropdownExamples.tsx
+++ b/packages/docs-app/src/examples/select-examples/dropdownExamples.tsx
@@ -31,15 +31,23 @@ export const DropdownLabelExample: React.FC<ExampleProps> = props => {
         <Dropdown items={people} {/* ... */} itemLabel="name" itemKey="id" />
         `;
 
-    type Person = { id: number; name: string, age: number };
-    const people = ["Alice", "Bob", "Courtney", "David"].map((name, index): Person => ({ age: (index + 1) * 10, id: index, name }));
+    type Person = { id: number; name: string; age: number };
+    const people = ["Alice", "Bob", "Courtney", "David"].map(
+        (name, index): Person => ({ age: (index + 1) * 10, id: index, name }),
+    );
     const [selectedPerson, setSelectedPerson] = React.useState(people[0]);
     return (
         <CodeExample code={code} {...props}>
-            <Dropdown items={people} onItemSelect={setSelectedPerson} selectedItem={selectedPerson} itemLabel="name" itemKey="id" />
+            <Dropdown
+                items={people}
+                onItemSelect={setSelectedPerson}
+                selectedItem={selectedPerson}
+                itemLabel="name"
+                itemKey="id"
+            />
         </CodeExample>
     );
-}
+};
 
 export const DropdownFillExample: React.FC<ExampleProps> = props => {
     const code = `<Dropdown items={["Alice", "Bob", "Courtney"]} fill={true} />`;

--- a/packages/docs-app/src/examples/select-examples/index.ts
+++ b/packages/docs-app/src/examples/select-examples/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export * from "./dropdownExamples";
+export * from "./dropdownExample";
 export * from "./multiSelectExample";
 export * from "./omnibarExample";
 export * from "./selectExample";

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+import { range } from "lodash";
 import * as React from "react";
 
-import { FormGroup, HTMLSelect } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleNumberChange } from "@blueprintjs/docs-theme";
+import { FormGroup } from "@blueprintjs/core";
+import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
+import { Dropdown } from "@blueprintjs/select";
 import { Cell, Column, ColumnLoadingOption, Table2 } from "@blueprintjs/table";
 
 interface BigSpaceRock {
@@ -36,7 +38,7 @@ export class ColumnLoadingExample extends React.PureComponent<ExampleProps, Colu
         loadingColumn: 1,
     };
 
-    private handleLoadingColumnChange = handleNumberChange(loadingColumn => this.setState({ loadingColumn }));
+    private handleLoadingColumnChange = (loadingColumn: number) => this.setState({ loadingColumn });
 
     public render() {
         return (
@@ -49,16 +51,15 @@ export class ColumnLoadingExample extends React.PureComponent<ExampleProps, Colu
     protected renderOptions() {
         const firstSpaceRock = bigSpaceRocks[0];
         const numColumns = Object.keys(firstSpaceRock).length;
-        const options: React.JSX.Element[] = [];
-        for (let i = 0; i < numColumns; i++) {
-            const label = this.formatColumnName(Object.keys(firstSpaceRock)[i]);
-            options.push(<option key={i} value={i} label={label} />);
-        }
+
         return (
             <FormGroup label="Loading column">
-                <HTMLSelect value={this.state.loadingColumn} onChange={this.handleLoadingColumnChange}>
-                    {options}
-                </HTMLSelect>
+                <Dropdown
+                    itemLabel={i => this.formatColumnName(Object.keys(firstSpaceRock)[i])}
+                    items={range(0, numColumns)}
+                    onItemSelect={this.handleLoadingColumnChange}
+                    selectedItem={this.state.loadingColumn}
+                />
             </FormGroup>
         );
     }

--- a/packages/select/src/components/dropdown/dropdown.md
+++ b/packages/select/src/components/dropdown/dropdown.md
@@ -1,0 +1,16 @@
+---
+tag: new
+---
+
+@# Dropdown
+
+The **Dropdown** component renders a simple UI to choose one item from a list. This component is a simplified version of the [**Select**](#select/select-component) component that operates similarly an [**HTMLSelect**](#core/components/html-select) with more Blueprint styling.
+
+@## Basic usage
+
+@reactExample DropdownBasicExample
+@reactExample DropdownLabelExample
+@reactExample DropdownFillExample
+@reactExample DropdownDisabledExample
+
+@reactExample DropdownExample

--- a/packages/select/src/components/dropdown/dropdown.tsx
+++ b/packages/select/src/components/dropdown/dropdown.tsx
@@ -1,0 +1,149 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import * as React from "react";
+
+import {
+    Button,
+    type ButtonProps,
+    DISPLAYNAME_PREFIX,
+    type IconName,
+    type MaybeElement,
+    MenuItem,
+    type PopoverProps,
+    type Props,
+} from "@blueprintjs/core";
+
+import { type ItemRenderer } from "../../common";
+import { Select } from "../select/select";
+
+type KeysOfType<T, U> = Extract<
+    keyof T,
+    keyof {
+        [K in keyof T as[T[K]] extends [U] ? K : never]: 1;
+    }
+>;
+
+type ItemProperty<T, U> = KeysOfType<T, U> | ((item: T) => U);
+
+interface DropdownBaseProps<T> extends Props {
+    buttonProps?: ButtonProps;
+    disabled?: boolean;
+    fill?: boolean;
+    itemDisabled?: ItemProperty<T, boolean>;
+    itemIcon?: ItemProperty<T, IconName | MaybeElement>;
+    items: T[];
+    onItemSelect: (item: T, event?: React.SyntheticEvent<HTMLElement>) => void;
+    placeholder?: React.ReactNode;
+    popoverProps?: PopoverProps;
+    selectedItem: T;
+}
+
+interface RequiredNonSerializableProps<T> {
+    itemLabel: ItemProperty<T, React.ReactNode>;
+    itemKey: ItemProperty<T, React.Key>;
+}
+
+interface SerializableDropdownProps<T> extends DropdownBaseProps<T>, Partial<RequiredNonSerializableProps<T>> { }
+interface NonSerializableDropdownProps<T> extends DropdownBaseProps<T>, RequiredNonSerializableProps<T> { }
+
+type SerializableType = string | number;
+
+export type DropdownProps<T> = DropdownBaseProps<T> &
+    ([T] extends [SerializableType] ? SerializableDropdownProps<T> : NonSerializableDropdownProps<T>);
+
+interface DropdownComponent {
+    <T>(props: DropdownProps<T>): React.JSX.Element | null;
+    displayName: string;
+}
+
+/**
+ * Dropdown component.
+ *
+ * @see https://blueprintjs.com/docs/#select/dropdown
+ */
+export const Dropdown: DropdownComponent = <T,>(props: DropdownProps<T>) => {
+    const {
+        className,
+        buttonProps,
+        disabled,
+        fill,
+        itemDisabled,
+        itemIcon,
+        itemKey = String,
+        itemLabel = String,
+        items,
+        onItemSelect,
+        popoverProps,
+        selectedItem,
+    } = props as SerializableDropdownProps<T>;
+    const itemRenderer: ItemRenderer<T> = React.useCallback(
+        (item, { handleClick, handleFocus, modifiers }) => (
+            <MenuItem
+                active={modifiers.active}
+                disabled={modifiers.disabled}
+                icon={getProperty(item, itemIcon)}
+                key={getProperty(item, itemKey)}
+                onClick={handleClick}
+                onFocus={handleFocus}
+                roleStructure="listoption"
+                selected={selectedItem === item}
+                text={getProperty(item, itemLabel)}
+            />
+        ),
+        [itemIcon, itemKey, itemLabel, selectedItem],
+    );
+
+    const handleSelect = React.useCallback(
+        (newValue: T, event: React.SyntheticEvent<HTMLElement> | undefined) => {
+            onItemSelect?.(newValue, event);
+        },
+        [onItemSelect],
+    );
+
+    const resolvedPopoverProps = React.useMemo(
+        (): PopoverProps => ({
+            matchTargetWidth: fill,
+            minimal: true,
+            ...popoverProps,
+        }),
+        [fill, popoverProps],
+    );
+
+    return (
+        <Select
+            className={className}
+            disabled={disabled}
+            fill={fill}
+            filterable={false}
+            itemDisabled={itemDisabled}
+            itemRenderer={itemRenderer}
+            items={items}
+            onItemSelect={handleSelect}
+            popoverProps={resolvedPopoverProps}
+        >
+            <Button
+                alignText="start"
+                disabled={disabled}
+                endIcon="caret-down"
+                fill={true}
+                icon={getProperty(selectedItem, itemIcon)}
+                text={getProperty(selectedItem, itemLabel)}
+                {...buttonProps}
+            />
+        </Select>
+    );
+};
+
+Dropdown.displayName = `${DISPLAYNAME_PREFIX}.PanelStack`;
+
+function getProperty<T, U>(item: T, itemProperty: ItemProperty<T, U> | undefined): U | undefined {
+    if (typeof itemProperty === "function") {
+        return itemProperty(item);
+    } else if (itemProperty != null) {
+        return item[itemProperty as keyof T] as U;
+    } else {
+        return undefined;
+    }
+}

--- a/packages/select/src/components/dropdown/dropdown.tsx
+++ b/packages/select/src/components/dropdown/dropdown.tsx
@@ -21,7 +21,7 @@ import { Select } from "../select/select";
 type KeysOfType<T, U> = Extract<
     keyof T,
     keyof {
-        [K in keyof T as[T[K]] extends [U] ? K : never]: 1;
+        [K in keyof T as [T[K]] extends [U] ? K : never]: 1;
     }
 >;
 
@@ -45,8 +45,8 @@ interface RequiredNonSerializableProps<T> {
     itemKey: ItemProperty<T, React.Key>;
 }
 
-interface SerializableDropdownProps<T> extends DropdownBaseProps<T>, Partial<RequiredNonSerializableProps<T>> { }
-interface NonSerializableDropdownProps<T> extends DropdownBaseProps<T>, RequiredNonSerializableProps<T> { }
+interface SerializableDropdownProps<T> extends DropdownBaseProps<T>, Partial<RequiredNonSerializableProps<T>> {}
+interface NonSerializableDropdownProps<T> extends DropdownBaseProps<T>, RequiredNonSerializableProps<T> {}
 
 type SerializableType = string | number;
 

--- a/packages/select/src/components/index.ts
+++ b/packages/select/src/components/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { Dropdown, type DropdownProps } from "./dropdown/dropdown";
 export { MultiSelect, type MultiSelectProps } from "./multi-select/multiSelect";
 export { Omnibar, type OmnibarProps } from "./omnibar/omnibar";
 export { QueryList, type QueryListProps, type QueryListRendererProps } from "./query-list/queryList";

--- a/packages/select/src/index.md
+++ b/packages/select/src/index.md
@@ -7,6 +7,7 @@ reference: select
 The [**@blueprintjs/select** package](https://www.npmjs.com/package/@blueprintjs/select)
 provides React components for to selecting items from a list:
 
+-   [Dropdown](#select/dropdown) for being badass
 -   [Select](#select/select-component) for selecting items in a list.
 -   [Suggest](#select/suggest) for selecting items in a list, from a text input.
 -   [MultiSelect](#select/multi-select) for selecting multiple items in a list.
@@ -31,6 +32,7 @@ Import the package stylesheet in Sass:
 <link href="path/to/node_modules/@blueprintjs/select/lib/css/blueprint-select.css" rel="stylesheet" />
 ```
 
+@page dropdown
 @page select-component
 @page suggest
 @page multi-select


### PR DESCRIPTION

#### Changes proposed in this pull request:
This PR introduces a simplified `Select` style component in the form of `Dropdown` which makes it easy to render quick lists of selectable items. Like other Select components, this component is always controlled and uses similar API designs. One simplification that this component makes is that for string and number values, it automatically infers how to render those into text. For non-serializable items, it provides a call back to render each list item into text.