### PR TITLE
fix(eslint): enable all rules in plugin package

### DIFF
--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -19,6 +19,8 @@ import rules from "./rules";
 
 type ConfigName = "recommended";
 
+const pluginPrefix = "@blueprintjs";
+
 const blueprintPlugin = {
     configs: { recommended: {} } as Record<ConfigName, TSESLint.ClassicConfig.Config>,
     flatConfigs: { recommended: {} } as Record<ConfigName, TSESLint.FlatConfig.Config>,
@@ -27,17 +29,12 @@ const blueprintPlugin = {
 
 // The recommended config enables all Blueprint-specific lint rules defined in this package.
 const config: TSESLint.ClassicConfig.Config = {
-    plugins: ["@blueprintjs"],
-    rules: {
-        "@blueprintjs/classes-constants": "error",
-        "@blueprintjs/html-components": "error",
-        "@blueprintjs/no-deprecated-components": "error",
-        "@blueprintjs/no-deprecated-type-references": "error",
-    },
+    plugins: [pluginPrefix],
+    rules: Object.fromEntries(Object.keys(rules).map(rule => [`${pluginPrefix}/${rule}`, "error"])),
 };
 const flatConfig: TSESLint.FlatConfig.Config = {
     ...config,
-    plugins: { "@blueprintjs": blueprintPlugin },
+    plugins: { [pluginPrefix]: blueprintPlugin },
 };
 
 // Assign the config here so that we can reference blueprintPlugin.


### PR DESCRIPTION
#### Changes proposed in this pull request:

<!-- Fill this out. -->
Based on the comments in this file it seems like the intention is for the plugin to enable all the exported rules, but that's not the case today (e.g. `no-deprecated-popover2-components` isn't included here).

#### Reviewers should focus on:

<!-- Fill this out. -->
Whether enabling all rules makes sense here. If it doesn't, then I can instead remove the misleading comment.

