### PR TITLE
fix: text-ellipsis

### DIFF
--- a/packages/docs-app/src/examples/core-examples/collapsePlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsePlaygroundExample.tsx
@@ -42,7 +42,7 @@ export const CollapsePlaygroundExample: React.FC<ExampleProps> = props => {
                 <Button onClick={handleClick}>{isOpen ? "Hide" : "Show"} build logs</Button>
                 <Collapse isOpen={isOpen} keepChildrenMounted={keepChildrenMounted}>
                     <InputGroup placeholder="Search logs..." />
-                    <Pre>
+                    <Pre style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                         [11:53:30] Finished 'typescript-bundle-blueprint' after 769 ms
                         <br />
                         [11:53:30] Starting 'typescript-typings-blueprint'...


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Applied `style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}` to the `<Pre>` element to fix a UI issue where long log lines would overflow their container.

This change enables single-line text truncation with an ellipsis, preserving layout integrity in the log display area.

#### Reviewers should focus on:

Ensuring the style change does not negatively impact other log-rendering behaviors.

Verifying whether single-line truncation is appropriate for the user experience (e.g., consider tooltip or expandable UI if needed).

Checking that the new styling behaves well across responsive layouts and different screen sizes.

#### Screenshot

[AS-IS]

![스크린샷 2025-05-30 18 37 22](https://github.com/user-attachments/assets/2f65db38-f62c-400a-8bcb-c7e6d55f09d2)

[TO-BE]

![스크린샷 2025-05-30 18 36 54](https://github.com/user-attachments/assets/50fd6801-2773-43d5-a11c-10eaa2e956b0)
