### PR TITLE
chore: bump CI to latest stable Chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,10 +150,10 @@ jobs:
       - run: sudo corepack enable
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
-      - browser-tools/install-chrome:
-          chrome-version: "137.0.7151.68"
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install_chrome:
+          chrome_version: "137.0.7151.68"
+      - browser-tools/install_chrome
+      - browser-tools/install_chromedriver
       - run:
           name: Verify Chrome browser installed
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
       - browser-tools/install_chrome:
-          chrome_version: "137.0.7151.68"
+          chrome_version: "124.0.6367.201"
       - browser-tools/install_chrome
       - browser-tools/install_chromedriver
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@2.1.0
 
 aliases:
   - &docker-node-image
@@ -151,7 +151,7 @@ jobs:
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: "124.0.6367.201"
+          chrome-version: "137.0.7151.68"
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:


### PR DESCRIPTION
Trying to fix CI failures like this one: https://app.circleci.com/pipelines/github/palantir/blueprint/8434/workflows/035978be-c883-4890-a6c3-126068617d92/jobs/108301

This bumps the [`circleci/browser-tools` orb](https://circleci.com/developer/orbs/orb/circleci/browser-tools) and also Chrome to the [latest stable version](https://chromereleases.googleblog.com/2025/06/stable-channel-update-for-desktop.html).