### PR TITLE
Default copy selection when highlighting text in table cell

### DIFF
--- a/packages/table/changelog/@unreleased/pr-7475.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-7475.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Default copy selection when highlighting text in table cell
+  links:
+  - https://github.com/palantir/blueprint/pull/7475

--- a/packages/table/src/tableHotkeys.ts
+++ b/packages/table/src/tableHotkeys.ts
@@ -452,6 +452,10 @@ export class TableHotkeys {
         const { getCellClipboardData, onCopy } = this.props;
         const { selectedRegions } = this.state;
 
+        if (window.getSelection()?.toString()) {
+            return;
+        }
+
         if (getCellClipboardData == null || this.grid === undefined) {
             return;
         }

--- a/packages/table/src/tableHotkeys.ts
+++ b/packages/table/src/tableHotkeys.ts
@@ -452,11 +452,7 @@ export class TableHotkeys {
         const { getCellClipboardData, onCopy } = this.props;
         const { selectedRegions } = this.state;
 
-        if (window.getSelection()?.toString()) {
-            return;
-        }
-
-        if (getCellClipboardData == null || this.grid === undefined) {
+        if (getCellClipboardData == null || this.grid === undefined || window.getSelection()?.toString()) {
             return;
         }
 


### PR DESCRIPTION
#### Fixes #0000

Default to normal copy behavior when highlighting text in a cell popover. Currently, the whole cell selected will be copied
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/7680c761-13ce-4e99-8288-05d04fbd35e9" />


#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
