### PR TITLE
[datetime] Export `TIMEZONES` and `MINIMAL_TIMEZONES`

### DIFF
--- a/packages/datetime/src/common/timezoneItems.ts
+++ b/packages/datetime/src/common/timezoneItems.ts
@@ -313,8 +313,14 @@ const minimalTimezonesWithoutOffset: TimezoneWithoutOffset[] = [
     { label: "Kiritimati", ianaCode: "Pacific/Kiritimati" },
 ];
 
-/** List of standard timezones */
-export const TIMEZONE_ITEMS = timezonesWithoutOffset.map(tz => lookupTimezoneOffset(tz));
+/**
+ * Comprehensive list of timezones with their IANA codes, labels, and UTC offsets.
+ * Useful for building custom timezone selection components.
+ */
+export const TIMEZONES = timezonesWithoutOffset.map(tz => lookupTimezoneOffset(tz));
 
-/** Minimal list of timezones */
-export const MINIMAL_TIMEZONE_ITEMS = minimalTimezonesWithoutOffset.map(tz => lookupTimezoneOffset(tz));
+/**
+ * Curated minimal list of timezones covering major world regions.
+ * Useful for simplified timezone selection UI where a full list would be overwhelming.
+ */
+export const MINIMAL_TIMEZONES = minimalTimezonesWithoutOffset.map(tz => lookupTimezoneOffset(tz));

--- a/packages/datetime/src/common/timezoneMetadata.ts
+++ b/packages/datetime/src/common/timezoneMetadata.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TIMEZONE_ITEMS } from "./timezoneItems";
+import { TIMEZONES } from "./timezoneItems";
 import { getTimezoneNames } from "./timezoneNameUtils";
 import type { Timezone, TimezoneWithNames } from "./timezoneTypes";
 
@@ -23,7 +23,7 @@ import type { Timezone, TimezoneWithNames } from "./timezoneTypes";
  * and abbreviation.
  */
 export function getTimezoneMetadata(timezoneIanaCode: string, date?: Date): TimezoneWithNames | undefined {
-    const timezone = TIMEZONE_ITEMS.find((tz: Timezone) => tz.ianaCode === timezoneIanaCode);
+    const timezone = TIMEZONES.find((tz: Timezone) => tz.ianaCode === timezoneIanaCode);
     if (timezone === undefined) {
         return undefined;
     }

--- a/packages/datetime/src/common/timezoneNameUtils.ts
+++ b/packages/datetime/src/common/timezoneNameUtils.ts
@@ -17,7 +17,7 @@
 import { formatInTimeZone } from "date-fns-tz";
 
 import { getCurrentTimezone } from "./getTimezone";
-import { MINIMAL_TIMEZONE_ITEMS, TIMEZONE_ITEMS } from "./timezoneItems";
+import { MINIMAL_TIMEZONES, TIMEZONES } from "./timezoneItems";
 import type { Timezone, TimezoneWithNames } from "./timezoneTypes";
 
 const CURRENT_DATE = Date.now();
@@ -59,7 +59,7 @@ export const mapTimezonesWithNames = (
 export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezone: boolean): TimezoneWithNames[] {
     const systemTimezone = getCurrentTimezone();
     const localTimezone = showLocalTimezone
-        ? TIMEZONE_ITEMS.find(timezone => timezone.ianaCode === systemTimezone)
+        ? TIMEZONES.find(timezone => timezone.ianaCode === systemTimezone)
         : undefined;
     const localTimezoneItem =
         localTimezone !== undefined
@@ -69,7 +69,7 @@ export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezon
                   shortName: formatInTimeZone(date ?? CURRENT_DATE, localTimezone.ianaCode, SHORT_NAME_FORMAT_STR),
               }
             : undefined;
-    const minimalTimezoneItemsWithNames = mapTimezonesWithNames(date, MINIMAL_TIMEZONE_ITEMS).filter(
+    const minimalTimezoneItemsWithNames = mapTimezonesWithNames(date, MINIMAL_TIMEZONES).filter(
         tz => tz.ianaCode !== localTimezoneItem?.ianaCode,
     );
     return localTimezoneItem === undefined

--- a/packages/datetime/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime/src/components/timezone-select/timezoneSelect.tsx
@@ -30,7 +30,7 @@ import { type ItemListPredicate, type ItemRenderer, Select, type SelectPopoverPr
 
 import { Classes, type TimezoneWithNames } from "../../common";
 import { formatTimezone, TimezoneDisplayFormat } from "../../common/timezoneDisplayFormat";
-import { TIMEZONE_ITEMS } from "../../common/timezoneItems";
+import { TIMEZONES } from "../../common/timezoneItems";
 import { getInitialTimezoneItems, mapTimezonesWithNames } from "../../common/timezoneNameUtils";
 
 export interface TimezoneSelectProps extends Props {
@@ -151,7 +151,7 @@ export class TimezoneSelect extends AbstractPureComponent<TimezoneSelectProps, T
 
         const { showLocalTimezone, inputProps = {}, date } = props;
         this.state = { query: inputProps.value || "" };
-        this.timezoneItems = mapTimezonesWithNames(date, TIMEZONE_ITEMS);
+        this.timezoneItems = mapTimezonesWithNames(date, TIMEZONES);
         this.initialTimezoneItems = getInitialTimezoneItems(date, showLocalTimezone!);
     }
 

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -27,7 +27,7 @@ export { MonthAndYear } from "./common/monthAndYear";
 export type { DayPickerProps } from "./common/reactDayPickerProps";
 export type { TimePickerProps } from "./common/timePickerProps";
 export { TimePrecision } from "./common/timePrecision";
-export { TIMEZONE_ITEMS, MINIMAL_TIMEZONE_ITEMS } from "./common/timezoneItems";
+export { TIMEZONES, MINIMAL_TIMEZONES } from "./common/timezoneItems";
 
 export { DatePickerUtils } from "./components/date-picker/datePickerUtils";
 export type { DatePickerBaseProps, DatePickerModifiers } from "./common/datePickerBaseProps";

--- a/packages/datetime/src/index.ts
+++ b/packages/datetime/src/index.ts
@@ -27,6 +27,7 @@ export { MonthAndYear } from "./common/monthAndYear";
 export type { DayPickerProps } from "./common/reactDayPickerProps";
 export type { TimePickerProps } from "./common/timePickerProps";
 export { TimePrecision } from "./common/timePrecision";
+export { TIMEZONE_ITEMS, MINIMAL_TIMEZONE_ITEMS } from "./common/timezoneItems";
 
 export { DatePickerUtils } from "./components/date-picker/datePickerUtils";
 export type { DatePickerBaseProps, DatePickerModifiers } from "./common/datePickerBaseProps";

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -35,15 +35,15 @@ import {
     TimezoneUtils,
 } from "../../src";
 import { DefaultDateFnsFormats, getDateFnsFormatter } from "../../src/common/dateFnsFormatUtils";
-import { TIMEZONE_ITEMS } from "../../src/common/timezoneItems";
+import { TIMEZONES } from "../../src/common/timezoneItems";
 import { DateInput, type DateInputProps } from "../../src/components/date-input/dateInput";
 import { DatePicker } from "../../src/components/date-picker/datePicker";
 import { INVALID_DATE_MESSAGE, LOCALE } from "../../src/components/dateConstants";
 import { loadDateFnsLocaleFake } from "../common/loadDateFnsLocaleFake";
 
-const NEW_YORK_TIMEZONE = TIMEZONE_ITEMS.find(item => item.label === "New York")!;
-const PARIS_TIMEZONE = TIMEZONE_ITEMS.find(item => item.label === "Paris")!;
-const TOKYO_TIMEZONE = TIMEZONE_ITEMS.find(item => item.label === "Tokyo")!;
+const NEW_YORK_TIMEZONE = TIMEZONES.find(item => item.label === "New York")!;
+const PARIS_TIMEZONE = TIMEZONES.find(item => item.label === "Paris")!;
+const TOKYO_TIMEZONE = TIMEZONES.find(item => item.label === "Tokyo")!;
 
 const VALUE = "2021-11-29T10:30:00z";
 

--- a/packages/datetime/test/components/timezoneSelectTests.tsx
+++ b/packages/datetime/test/components/timezoneSelectTests.tsx
@@ -32,7 +32,7 @@ import { QueryList, Select } from "@blueprintjs/select";
 
 import { TimezoneSelect, type TimezoneSelectProps } from "../../src";
 import { getCurrentTimezone } from "../../src/common/getTimezone";
-import { TIMEZONE_ITEMS } from "../../src/common/timezoneItems";
+import { TIMEZONES } from "../../src/common/timezoneItems";
 import { getInitialTimezoneItems, mapTimezonesWithNames } from "../../src/common/timezoneNameUtils";
 import type { TimezoneWithNames } from "../../src/common/timezoneTypes";
 
@@ -83,7 +83,7 @@ describe("<TimezoneSelect>", () => {
         });
         timezoneSelect.update();
         const items = timezoneSelect.find(Select).prop("items");
-        assert.lengthOf(items, TIMEZONE_ITEMS.length);
+        assert.lengthOf(items, TIMEZONES.length);
     });
 
     it("if inputProps.value is non-empty, all items are shown", () => {
@@ -92,7 +92,7 @@ describe("<TimezoneSelect>", () => {
         const timezoneSelect = mountTS({ date, inputProps: { value: query } });
         assert.strictEqual(timezoneSelect.state("query"), query);
         const items = findSelect(timezoneSelect).prop("items");
-        assert.deepEqual(items, mapTimezonesWithNames(date, TIMEZONE_ITEMS));
+        assert.deepEqual(items, mapTimezonesWithNames(date, TIMEZONES));
     });
 
     it("if showLocalTimezone=true, the local timezone is rendered at the top of the item list", () => {
@@ -136,7 +136,7 @@ describe("<TimezoneSelect>", () => {
 
     it("if value is non-empty, the selected timezone will stay in sync with that value", () => {
         const value = "Europe/Oslo";
-        const valueLabel = TIMEZONE_ITEMS.find(tz => tz.ianaCode === value)?.label;
+        const valueLabel = TIMEZONES.find(tz => tz.ianaCode === value)?.label;
         const timezoneSelect = mountTS({ onChange, value });
         clickFirstMenuItem(timezoneSelect);
         const buttonText = timezoneSelect.find(Button).prop("text")?.toString();

--- a/packages/demo-app/src/examples/DateInputTimezoneExample.tsx
+++ b/packages/demo-app/src/examples/DateInputTimezoneExample.tsx
@@ -1,0 +1,107 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { memo, useCallback, useMemo, useState } from "react";
+
+import { Pre } from "@blueprintjs/core";
+import { DateInput, MINIMAL_TIMEZONES, TimePrecision } from "@blueprintjs/datetime";
+
+import { ExampleCard } from "./ExampleCard";
+
+/**
+ * Converts offset string like "-08:00" or "+05:30" to minutes.
+ */
+function offsetStringToMinutes(offset: string): number {
+    const match = offset.match(/([+-])(\d{2}):?(\d{2})/);
+    if (!match) {
+        return 0;
+    }
+    const sign = match[1] === "-" ? -1 : 1;
+    const hours = parseInt(match[2], 10);
+    const minutes = parseInt(match[3], 10);
+    return sign * (hours * 60 + minutes);
+}
+
+/**
+ * Extracts the UTC offset from an ISO 8601 datetime string and returns it in minutes.
+ * Returns undefined if no offset is present.
+ *
+ * @example
+ * parseOffsetFromISOString("2025-12-01T00:00-08:00") // returns -480
+ * parseOffsetFromISOString("2025-12-01T00:00+05:30") // returns 330
+ * parseOffsetFromISOString("2025-12-01T00:00Z") // returns 0
+ */
+function parseOffsetFromISOString(isoString: string): number | undefined {
+    // Match timezone offset at the end: Z, +HH:MM, -HH:MM, +HHMM, -HHMM
+    const match = isoString.match(/([+-]\d{2}:?\d{2})$|Z$/);
+    if (!match) {
+        return undefined;
+    }
+    if (match[0] === "Z") {
+        return 0;
+    }
+    return offsetStringToMinutes(match[1]);
+}
+
+/**
+ * Finds a timezone from the list that matches the given offset in minutes.
+ * Returns the IANA code of the first matching timezone, or undefined if none found.
+ */
+function findTimezoneByOffset(offsetMinutes: number): string | undefined {
+    const match = MINIMAL_TIMEZONES.find(tz => offsetStringToMinutes(tz.offset) === offsetMinutes);
+    return match?.ianaCode;
+}
+
+/**
+ * Given an ISO datetime string, returns a matching timezone IANA code.
+ * Falls back to the provided default if no match is found.
+ */
+function getTimezoneFromISOString(isoString: string | null, defaultTimezone: string): string {
+    if (!isoString) {
+        return defaultTimezone;
+    }
+    const offsetMinutes = parseOffsetFromISOString(isoString);
+    if (offsetMinutes === undefined) {
+        return defaultTimezone;
+    }
+    return findTimezoneByOffset(offsetMinutes) ?? defaultTimezone;
+}
+
+const WIDTH = 350;
+
+// Simulate a value that might come from a database or API with a Pacific timezone offset
+const INITIAL_VALUE = "2025-12-01T00:00-08:00";
+const DEFAULT_TIMEZONE = "America/New_York";
+
+export const DateInputTimezoneExample = memo(() => {
+    // Initialize timezone from the ISO string's offset instead of hardcoding
+    const initialTimezone = useMemo(() => getTimezoneFromISOString(INITIAL_VALUE, DEFAULT_TIMEZONE), []);
+
+    const [value, setValue] = useState<string | null>(INITIAL_VALUE);
+    const [timezone, setTimezone] = useState<string>(initialTimezone);
+
+    const handleChange = useCallback((newValue: string | null) => {
+        setValue(newValue);
+    }, []);
+
+    const handleTimezoneChange = useCallback((newTimezone: string) => {
+        setTimezone(newTimezone);
+    }, []);
+
+    return (
+        <ExampleCard width={WIDTH} horizontal={false} label="DateInput with timezone persistence">
+            <DateInput
+                onChange={handleChange}
+                onTimezoneChange={handleTimezoneChange}
+                timePrecision={TimePrecision.MINUTE}
+                timezone={timezone}
+                value={value}
+            />
+            <Pre style={{ margin: 0 }}>value: {value ?? "null"}</Pre>
+            <Pre style={{ margin: 0 }}>timezone: {timezone}</Pre>
+        </ExampleCard>
+    );
+});
+
+DateInputTimezoneExample.displayName = "DemoApp.DateInputTimezoneExample";

--- a/packages/demo-app/src/examples/Examples.tsx
+++ b/packages/demo-app/src/examples/Examples.tsx
@@ -24,6 +24,7 @@ import { ButtonExample } from "./ButtonExample";
 import { ButtonGroupExample } from "./ButtonGroupExample";
 import { CalloutExample } from "./CalloutExample";
 import { CheckboxRadioExample } from "./CheckboxRadioExample";
+import { DateInputTimezoneExample } from "./DateInputTimezoneExample";
 import { DatePickerExample } from "./DatePickerExample";
 import { DateRangePickerExample } from "./DateRangePickerExample";
 import { DialogExample } from "./DialogExample";
@@ -71,6 +72,7 @@ const ExamplesContainer: React.FC<{ isDark?: boolean }> = ({ isDark = false }) =
             <CheckboxRadioExample />
             <DatePickerExample />
             <DateRangePickerExample />
+            <DateInputTimezoneExample />
             <DialogExample className={className} />
             <EditableTextExample />
             <EntityTitleExample />


### PR DESCRIPTION
Export `TIMEZONEs` and `MINIMAL_TIMEZONEs` lists to allow consumers to construct customized timezone selection components.

Also include example in demo app on how to leverage these exports to handle more advanced/custom use cases with timezones in DateInput:

<img width="373" alt="Screenshot 2026-01-07 at 14 04 57@2x" src="https://github.com/user-attachments/assets/9be5f1db-f847-4309-bccb-09d457230267" />
