### PR TITLE
Add ability to control TextArea resize via `resize` prop

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -192,6 +192,10 @@ export const RESIZABLE_INPUT_SPAN = `${NS}-resizable-input-span`;
 
 export const TEXT_AREA = `${NS}-text-area`;
 export const TEXT_AREA_AUTO_RESIZE = `${TEXT_AREA}-auto-resize`;
+export const TEXT_AREA_RESIZE_NONE = `${TEXT_AREA}-resize-none`;
+export const TEXT_AREA_RESIZE_VERTICAL = `${TEXT_AREA}-resize-vertical`;
+export const TEXT_AREA_RESIZE_HORIZONTAL = `${TEXT_AREA}-resize-horizontal`;
+export const TEXT_AREA_RESIZE_BOTH = `${TEXT_AREA}-resize-both`;
 
 export const CONTROL = `${NS}-control`;
 export const CONTROL_INDICATOR = `${CONTROL}-indicator`;

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -78,4 +78,20 @@ textarea.#{$ns}-input {
     // we are controlling vertical resizing automatically, so restrict user resizing to horizontal dimension only
     resize: horizontal;
   }
+
+  &.#{$ns}-text-area-resize-none {
+    resize: none;
+  }
+
+  &.#{$ns}-text-area-resize-vertical {
+    resize: vertical;
+  }
+
+  &.#{$ns}-text-area-resize-horizontal {
+    resize: horizontal;
+  }
+
+  &.#{$ns}-text-area-resize-both {
+    resize: both;
+  }
 }

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -62,6 +62,12 @@ export interface TextAreaProps extends IntentProps, Props, React.TextareaHTMLAtt
     large?: boolean;
 
     /**
+     * Controls the CSS `resize` property of the textarea. Set to control whether the text area can be manually resized
+     * and in which direction(s). If not set, the default browser behavior applies.
+     */
+    resize?: "none" | "vertical" | "horizontal" | "both";
+
+    /**
      * Whether the text area should appear with small styling.
      *
      * @deprecated use `size="small"` instead.
@@ -162,6 +168,7 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
             intent,
             // eslint-disable-next-line @typescript-eslint/no-deprecated
             large,
+            resize,
             size = "medium",
             // eslint-disable-next-line @typescript-eslint/no-deprecated
             small,
@@ -176,6 +183,10 @@ export class TextArea extends AbstractPureComponent<TextAreaProps, TextAreaState
             {
                 [Classes.FILL]: fill,
                 [Classes.TEXT_AREA_AUTO_RESIZE]: autoResize,
+                [Classes.TEXT_AREA_RESIZE_NONE]: resize === "none",
+                [Classes.TEXT_AREA_RESIZE_VERTICAL]: resize === "vertical",
+                [Classes.TEXT_AREA_RESIZE_HORIZONTAL]: resize === "horizontal",
+                [Classes.TEXT_AREA_RESIZE_BOTH]: resize === "both",
             },
             className,
         );

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -19,7 +19,9 @@ import * as React from "react";
 import {
     AnchorButton,
     ControlGroup,
+    FormGroup,
     H5,
+    HTMLSelect,
     Intent,
     type Size,
     Switch,
@@ -27,7 +29,7 @@ import {
     type TextAreaProps,
     Tooltip,
 } from "@blueprintjs/core";
-import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
+import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
@@ -44,6 +46,7 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
     const [disabled, setDisabled] = React.useState(false);
     const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
     const [readOnly, setReadOnly] = React.useState(false);
+    const [resize, setResize] = React.useState<undefined | "none" | "vertical" | "horizontal" | "both">(undefined);
     const [size, setSize] = React.useState<Size>("medium");
     const [value, setValue] = React.useState(INTITIAL_CONTROLLED_TEXT);
 
@@ -74,6 +77,7 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
                     <AnchorButton disabled={!controlled} icon="reset" onClick={resetControlledText} />
                 </Tooltip>
             </ControlGroup>
+            <ResizeSelect label="Resize" onChange={setResize} value={resize} />
         </>
     );
 
@@ -82,6 +86,7 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
         disabled,
         intent,
         readOnly,
+        resize,
         size,
     };
 
@@ -96,3 +101,28 @@ export const TextAreaExample: React.FC<ExampleProps> = props => {
         </Example>
     );
 };
+
+const RESIZE_OPTIONS: Array<{ label: string; value: TextAreaProps["resize"] }> = [
+    { label: "Default", value: undefined },
+    { label: "None", value: "none" },
+    { label: "Vertical", value: "vertical" },
+    { label: "Horizontal", value: "horizontal" },
+    { label: "Both", value: "both" },
+];
+
+export interface ResizeSelectProps {
+    label?: React.ReactNode;
+    onChange: (resize: TextAreaProps["resize"]) => void;
+    value: TextAreaProps["resize"];
+}
+
+function ResizeSelect({ label, onChange, value }: ResizeSelectProps) {
+    const handleChange = handleValueChange(onChange);
+    return (
+        <FormGroup label={label}>
+            <ControlGroup>
+                <HTMLSelect value={value} onChange={handleChange} options={RESIZE_OPTIONS} fill={true} />
+            </ControlGroup>
+        </FormGroup>
+    );
+}


### PR DESCRIPTION
#### Part of #7478

#### Checklist

-   [ ] Includes tests
-   [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes

Adds a new `resize` prop to the `<TextArea>` component to give more direct control over the [CSS resize](https://developer.mozilla.org/en-US/docs/Web/CSS/resize) attribute applied to the textarea.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
