### PR TITLE
fix: Add bp6 as a banned prefix in no-prefix-literal stylelint rule

### DIFF
--- a/packages/stylelint-plugin/changelog/@unreleased/pr-7486.v2.yml
+++ b/packages/stylelint-plugin/changelog/@unreleased/pr-7486.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add bp6 as a banned prefix in no-prefix-literal stylelint rule
+  links:
+  - https://github.com/palantir/blueprint/pull/7486

--- a/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
@@ -35,7 +35,7 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
     expected: (unfixed: any, fixed: any) => `Use the \`${fixed}\` variable instead of the \`${unfixed}\` literal`,
 });
 
-const bannedPrefixes = ["bp3", "bp4", "bp5"];
+const bannedPrefixes = ["bp3", "bp4", "bp5", "bp6"];
 
 interface Options {
     disableFix?: boolean;


### PR DESCRIPTION
This rule should report an error when `bp6` is used now that bp6 is starting to roll out