### PR TITLE
Add ref access to `DialogBody`/`DialogFooter` components.

### DIFF
--- a/packages/core/src/components/dialog/dialogBody.tsx
+++ b/packages/core/src/components/dialog/dialogBody.tsx
@@ -37,7 +37,7 @@ export interface DialogBodyProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/dialog.dialog-body-props
  */
-export const DialogBody: React.FC<DialogBodyProps> = props => {
+export const DialogBody = React.forwardRef<HTMLDivElement, DialogBodyProps>((props, ref) => {
     const { children, className, useOverflowScrollContainer = true, ...htmlProps } = props;
     return (
         <div
@@ -45,10 +45,11 @@ export const DialogBody: React.FC<DialogBodyProps> = props => {
             className={classNames(Classes.DIALOG_BODY, className, {
                 [Classes.DIALOG_BODY_SCROLL_CONTAINER]: useOverflowScrollContainer,
             })}
+            ref={ref}
         >
             {children}
         </div>
     );
-};
+});
 
 DialogBody.displayName = `${DISPLAYNAME_PREFIX}.DialogBody`;

--- a/packages/core/src/components/dialog/dialogFooter.tsx
+++ b/packages/core/src/components/dialog/dialogFooter.tsx
@@ -52,7 +52,7 @@ export interface DialogFooterProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/dialog.dialog-footer-props
  */
-export const DialogFooter: React.FC<DialogFooterProps> = props => {
+export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>((props, ref) => {
     const { actions, children, className, minimal = false, ...htmlProps } = props;
     return (
         <div
@@ -60,11 +60,12 @@ export const DialogFooter: React.FC<DialogFooterProps> = props => {
             className={classNames(Classes.DIALOG_FOOTER, className, {
                 [Classes.DIALOG_FOOTER_FIXED]: !minimal,
             })}
+            ref={ref}
         >
             <div className={Classes.DIALOG_FOOTER_MAIN_SECTION}>{children}</div>
             {actions != null && <div className={Classes.DIALOG_FOOTER_ACTIONS}>{actions}</div>}
         </div>
     );
-};
+});
 
 DialogFooter.displayName = `${DISPLAYNAME_PREFIX}.DialogFooter`;


### PR DESCRIPTION
#### Changes proposed in this pull request:

Wraps the `DialogBody` and `DialogFooter` components with `React.forwardRef` so consumers can attach refs to their root `<div>` elements.
