### PR TITLE
Allow non-control input elements to be visible inside of control components

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -194,6 +194,7 @@ export const TEXT_AREA = `${NS}-text-area`;
 export const TEXT_AREA_AUTO_RESIZE = `${TEXT_AREA}-auto-resize`;
 
 export const CONTROL = `${NS}-control`;
+export const CONTROL_INPUT = `${CONTROL}-input`;
 export const CONTROL_INDICATOR = `${CONTROL}-indicator`;
 export const CONTROL_INDICATOR_CHILD = `${CONTROL_INDICATOR}-child`;
 export const CHECKBOX = `${NS}-checkbox`;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -144,7 +144,7 @@ $control-indicator-spacing: $pt-grid-size !default;
     margin-inline-end: $pt-grid-size * 2;
   }
 
-  input {
+  .#{$ns}-control-input {
     left: 0;
     opacity: 0;
     position: absolute;

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -69,7 +69,7 @@ const ControlInternal: React.FC<ControlInternalProps> = React.forwardRef<HTMLLab
         return React.createElement(
             tagName,
             { className: classes, ref, style },
-            <input {...htmlProps} ref={inputRef} type={type} />,
+            <input className={Classes.CONTROL_INPUT} {...htmlProps} ref={inputRef} type={type} />,
             <span className={Classes.CONTROL_INDICATOR}>{indicatorChildren}</span>,
             label,
             labelElement,


### PR DESCRIPTION
#### Fixes #7491

#### Changes

Adds a class to the `input` element of control components (Checkbox/Switch/Radio) to add more specificity around styles that hide the native input control. This prevents non-control inputs like InputGroup components from being inadvertently hidden when nested inside of a control component.

Example:

```tsx
<RadioGroup label="Lunch special" {...}>
    <Radio label="Soup" value="one" />
    <Radio label="Salad" value="two" />
    <Radio label="Sandwich" value="three" />
    <Radio labelElement={<InputGroup placeholder="Enter value..." />} value="tbd" />
</RadioGroup>
```

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/a5cc903a-6c89-4615-960f-67186451f8e7) | ![after](https://github.com/user-attachments/assets/65e6947f-132f-426d-af9c-0f8c77ab4896) |