### PR TITLE
Corrected date picker markdown links

### DIFF
--- a/packages/datetime/src/index.md
+++ b/packages/datetime/src/index.md
@@ -7,9 +7,9 @@ reference: datetime
 The [**@blueprintjs/datetime** package](https://www.npmjs.com/package/@blueprintjs/datetime)
 provides React components for interacting with dates and times:
 
--   [**DatePicker**](#datetime/datepicker) for selecting a single date (day, month, year).
+-   [**DatePicker**](#datetime/date-picker) for selecting a single date (day, month, year).
 
--   [**DateRangePicker**](#datetime/daterangepicker) for selecting date ranges.
+-   [**DateRangePicker**](#datetime/date-range-picker) for selecting date ranges.
 
 -   [**DateInput**](#datetime/date-input), which composes a text input with a DatePicker in
     a Popover, for use in forms.


### PR DESCRIPTION
Corrected markdown links to point to correct pages

#### Fixes #0000

#### Checklist

-   [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Updated links in markdown to point to correct pages. links are broken at [https://blueprintjs.com/docs/#datetime](https://blueprintjs.com/docs/#datetime)

#### Reviewers should focus on:

Updated Links
