### PR TITLE
Wrap docs-app and demo-app in React `<StrictMode>`

### DIFF
--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -30,8 +30,10 @@ const root = ReactDOM.createRoot(container);
     // rely on those styles to take accurate DOM measurements.
     await import("./index.scss");
     root.render(
-        <BlueprintProvider>
-            <Examples />
-        </BlueprintProvider>,
+        <React.StrictMode>
+            <BlueprintProvider>
+                <Examples />
+            </BlueprintProvider>
+        </React.StrictMode>,
     );
 })();

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -46,5 +46,7 @@ const tagRenderers = {
 const container = document.getElementById("blueprint-documentation");
 const root = ReactDOM.createRoot(container);
 root.render(
-    <BlueprintDocs defaultPageId="blueprint" docs={docsData} tagRenderers={tagRenderers} useNextVersion={false} />,
+    <React.StrictMode>
+        <BlueprintDocs defaultPageId="blueprint" docs={docsData} tagRenderers={tagRenderers} useNextVersion={false} />
+    </React.StrictMode>,
 );


### PR DESCRIPTION
## Changes

Wraps `docs-app` and `demo-app` in React [`<StrictMode>`](https://react.dev/reference/react/StrictMode) to help catch bugs during development and catch deprecation warnings for future version upgrades of React.
