### PR TITLE
[chore] Update Config to Use New JSX Transform

### DIFF
--- a/config/tsconfig.web.json
+++ b/config/tsconfig.web.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig.base",
     "compilerOptions": {
-        "jsx": "react",
+        "jsx": "react-jsx",
         "lib": ["dom", "dom.iterable", "es2019"],
         "module": "es2020",
         "moduleResolution": "node",

--- a/packages/core/src/components/dialog/dialogStepButton.tsx
+++ b/packages/core/src/components/dialog/dialogStepButton.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import type { ButtonSharedPropsAndAttributes } from "../button/buttonProps";
 import { AnchorButton } from "../button/buttons";
 import { Tooltip, type TooltipProps } from "../tooltip/tooltip";

--- a/packages/core/src/components/hotkeys/hotkey.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import type { HotkeyConfig } from "../../hooks";

--- a/packages/core/src/components/slider/rangeSlider.tsx
+++ b/packages/core/src/components/slider/rangeSlider.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, Intent } from "../../common";
 import * as Errors from "../../common/errors";
 

--- a/packages/core/src/components/slider/slider.tsx
+++ b/packages/core/src/components/slider/slider.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { AbstractPureComponent, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
 

--- a/packages/core/src/components/tabs/tabPanel.tsx
+++ b/packages/core/src/components/tabs/tabPanel.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Classes, Utils } from "../../common";
 

--- a/packages/core/src/context/blueprintProvider.tsx
+++ b/packages/core/src/context/blueprintProvider.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { HotkeysProvider, type HotkeysProviderProps } from "./hotkeys/hotkeysProvider";
 import { OverlaysProvider, type OverlaysProviderProps } from "./overlays/overlaysProvider";
 import { type PortalContextOptions, PortalProvider } from "./portal/portalProvider";

--- a/packages/core/test/alert/alertTests.tsx
+++ b/packages/core/test/alert/alertTests.tsx
@@ -17,7 +17,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
 import { type SinonStub, spy, stub } from "sinon";
 
 import { Alert, Classes } from "../../src";

--- a/packages/core/test/breadcrumbs/breadcrumbTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbTests.tsx
@@ -17,7 +17,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
 import { spy } from "sinon";
 
 import { Breadcrumb, Classes } from "../../src";

--- a/packages/core/test/breadcrumbs/breadcrumbsTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbsTests.tsx
@@ -16,7 +16,6 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes } from "../../src/common";

--- a/packages/core/test/callout/calloutTests.tsx
+++ b/packages/core/test/callout/calloutTests.tsx
@@ -16,7 +16,6 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
 
 import { IconNames } from "@blueprintjs/icons";
 

--- a/packages/core/test/collapse/collapseTests.tsx
+++ b/packages/core/test/collapse/collapseTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
-import * as React from "react";
 
 import { Classes, MenuItem } from "../../src";
 import { AnimationStates, Collapse } from "../../src/components/collapse/collapse";

--- a/packages/core/test/context-menu/contextMenuSingletonTests.tsx
+++ b/packages/core/test/context-menu/contextMenuSingletonTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { assert } from "chai";
-import * as React from "react";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 

--- a/packages/core/test/control-card/controlCardTests.tsx
+++ b/packages/core/test/control-card/controlCardTests.tsx
@@ -17,7 +17,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
 import { spy } from "sinon";
 
 import { CheckboxCard, Classes, RadioCard, RadioGroup, SwitchCard } from "../../src";

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -16,7 +16,6 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
 
 import { Classes } from "../../src";
 import { Checkbox, Radio, Switch } from "../../src/components/forms/controls";

--- a/packages/core/test/controls/radioGroupTests.tsx
+++ b/packages/core/test/controls/radioGroupTests.tsx
@@ -17,7 +17,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
 import { spy, stub } from "sinon";
 
 import { Classes, type OptionProps, Radio, RadioGroup } from "../../src";

--- a/packages/core/test/entity-title/entityTitleTests.tsx
+++ b/packages/core/test/entity-title/entityTitleTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Tag } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";

--- a/packages/core/test/forms/fileInputTests.tsx
+++ b/packages/core/test/forms/fileInputTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, FileInput } from "../../src";

--- a/packages/core/test/forms/formGroupTests.tsx
+++ b/packages/core/test/forms/formGroupTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import * as React from "react";
 
 import { Classes, FormGroup, Intent } from "../../src";
 

--- a/packages/core/test/hotkeys/hotkeyTests.tsx
+++ b/packages/core/test/hotkeys/hotkeyTests.tsx
@@ -16,7 +16,6 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
 import { type SinonStub, stub } from "sinon";
 
 import { Hotkey } from "../../src/components/hotkeys";

--- a/packages/core/test/hotkeys/keyComboTagTests.tsx
+++ b/packages/core/test/hotkeys/keyComboTagTests.tsx
@@ -16,7 +16,6 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
 
 import { KeyComboTagInternal } from "../../src/components/hotkeys/keyComboTag";
 

--- a/packages/core/test/html-select/htmlSelectTests.tsx
+++ b/packages/core/test/html-select/htmlSelectTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { HTMLSelect, type OptionProps } from "../../src";
 

--- a/packages/core/test/html/htmlTests.tsx
+++ b/packages/core/test/html/htmlTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Label } from "../../src";
 

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import * as React from "react";
 
 import { Classes, H6, Menu, MenuDivider, MenuItem } from "../../src";
 

--- a/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
+++ b/packages/core/test/non-ideal-state/nonIdealStateTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { shallow } from "enzyme";
-import * as React from "react";
 
 import { Classes, H4, NonIdealState } from "../../src";
 

--- a/packages/core/test/portal/portalTests.tsx
+++ b/packages/core/test/portal/portalTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 
 import { Classes, Portal, type PortalProps, PortalProvider } from "../../src";
 

--- a/packages/core/test/progress/progressBarTests.tsx
+++ b/packages/core/test/progress/progressBarTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Classes, ProgressBar } from "../../src";
 

--- a/packages/core/test/section/sectionTests.tsx
+++ b/packages/core/test/section/sectionTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 
 import { IconNames } from "@blueprintjs/icons";
 

--- a/packages/core/test/segmented-control/segmentedControlTests.tsx
+++ b/packages/core/test/segmented-control/segmentedControlTests.tsx
@@ -18,7 +18,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { assert, expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { IconNames } from "@blueprintjs/icons";

--- a/packages/core/test/slider/handleTests.tsx
+++ b/packages/core/test/slider/handleTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Handle, type HandleState, type InternalHandleProps } from "../../src/components/slider/handle";

--- a/packages/core/test/slider/multiSliderTests.tsx
+++ b/packages/core/test/slider/multiSliderTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";

--- a/packages/core/test/spinner/spinnerTests.tsx
+++ b/packages/core/test/spinner/spinnerTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
-import * as React from "react";
 import { stub } from "sinon";
 
 import { Classes, Spinner, SpinnerSize } from "../../src";

--- a/packages/core/test/text/textTests.tsx
+++ b/packages/core/test/text/textTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Classes, Text } from "../../src";
 

--- a/packages/core/test/tooltip/tooltipTests.tsx
+++ b/packages/core/test/tooltip/tooltipTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import { spy, stub } from "sinon";
 
 import { Classes } from "../../src/common";

--- a/packages/core/test/tree/treeTests.tsx
+++ b/packages/core/test/tree/treeTests.tsx
@@ -17,7 +17,6 @@
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import { spy } from "sinon";
 
 import { Classes, Tree, type TreeNodeInfo, type TreeProps } from "../../src";

--- a/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
@@ -16,7 +16,6 @@
 
 import classNames from "classnames";
 import { addDays, format } from "date-fns";
-import * as React from "react";
 import type { DateFormatter, DayModifiers, DayMouseEventHandler, ModifiersClassNames } from "react-day-picker";
 
 import { Boundary, DISPLAYNAME_PREFIX, Divider } from "@blueprintjs/core";

--- a/packages/datetime/src/components/react-day-picker/datePickerNavIcons.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerNavIcons.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
 import type { StyledComponent } from "react-day-picker";
 
 import { ChevronLeft, ChevronRight } from "@blueprintjs/icons";

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
 import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -13,7 +13,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
 import { docsData } from "@blueprintjs/docs-data";

--- a/packages/select/test/omnibarTests.tsx
+++ b/packages/select/test/omnibarTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Omnibar } from "../src";
 

--- a/packages/select/test/selectComponentSuite.tsx
+++ b/packages/select/test/selectComponentSuite.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import type { ReactWrapper } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, type HTMLInputProps } from "@blueprintjs/core";

--- a/packages/table-dev-app/src/index.tsx
+++ b/packages/table-dev-app/src/index.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
 import { HotkeysProvider, OverlaysProvider } from "@blueprintjs/core";

--- a/packages/table/test/cellTests.tsx
+++ b/packages/table/test/cellTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 
 import { Classes as CoreClasses, Intent } from "@blueprintjs/core";
 

--- a/packages/table/test/columnHeaderCellTests.tsx
+++ b/packages/table/test/columnHeaderCellTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import * as sinon from "sinon";
 
 import { Classes as CoreClasses, H4, Menu, MenuItem } from "@blueprintjs/core";

--- a/packages/table/test/columnTests.tsx
+++ b/packages/table/test/columnTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 
 import { Cell, Column, ColumnLoadingOption, Table } from "../src";
 import * as Classes from "../src/common/classes";

--- a/packages/table/test/editableNameTests.tsx
+++ b/packages/table/test/editableNameTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { EditableText } from "@blueprintjs/core";

--- a/packages/table/test/formats/jsonFormatTests.tsx
+++ b/packages/table/test/formats/jsonFormatTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 
 import { JSONFormat } from "../../src/cell/formats/jsonFormat";
 import { TruncatedPopoverMode } from "../../src/cell/formats/truncatedFormat";

--- a/packages/table/test/guidesTests.tsx
+++ b/packages/table/test/guidesTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 
 import * as Classes from "../src/common/classes";
 import { GuideLayer } from "../src/layers/guides";

--- a/packages/table/test/loadableContentTests.tsx
+++ b/packages/table/test/loadableContentTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/table/test/locatorTests.tsx
+++ b/packages/table/test/locatorTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Utils } from "../src";
 import { Grid } from "../src/common/grid";

--- a/packages/table/test/menusTests.tsx
+++ b/packages/table/test/menusTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, Menu } from "@blueprintjs/core";

--- a/packages/table/test/mocks/table.tsx
+++ b/packages/table/test/mocks/table.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Cell, Column, type ColumnProps, RenderMode, Table, type TableProps, Utils } from "../../src";
 
 export function createStringOfLength(length: number) {

--- a/packages/table/test/quadrants/tableQuadrantTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import * as Classes from "../../src/common/classes";

--- a/packages/table/test/reorderableTests.tsx
+++ b/packages/table/test/reorderableTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Regions } from "../src/";

--- a/packages/table/test/rowHeaderCellTests.tsx
+++ b/packages/table/test/rowHeaderCellTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { shallow } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { H4 } from "@blueprintjs/core";

--- a/packages/table/test/selectableTests.tsx
+++ b/packages/table/test/selectableTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 import sinon from "sinon";
 
 import { type FocusedCellCoordinates, FocusMode } from "../src/common/cellTypes";

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Cell } from "../src/cell/cell";

--- a/packages/webpack-build-scripts/webpack.config.base.mjs
+++ b/packages/webpack-build-scripts/webpack.config.base.mjs
@@ -43,15 +43,13 @@ const PACKAGE_NAME = getPackageName();
  * @type {webpack.WebpackPluginInstance[]}
  */
 const plugins = [
-    new ForkTsCheckerPlugin(
-      {
+    new ForkTsCheckerPlugin({
         async: IS_PRODUCTION ? false : undefined,
         typescript: {
             configFile: "src/tsconfig.json",
             memoryLimit: 4096,
         },
-      },
-    ),
+    }),
 
     // CSS extraction is only enabled in production (see scssLoaders below).
     new MiniCssExtractPlugin({ filename: "[name].css" }),
@@ -179,7 +177,7 @@ export default {
                             legacyDecorator: true,
                             react: {
                                 refresh: !IS_PRODUCTION,
-                                runtime: "classic",
+                                runtime: "automatic",
                                 useBuiltins: true,
                             },
                         },

--- a/packages/webpack-build-scripts/webpack.config.karma.mjs
+++ b/packages/webpack-build-scripts/webpack.config.karma.mjs
@@ -65,6 +65,7 @@ export default {
                             legacyDecorator: true,
                             react: {
                                 refresh: false,
+                                runtime: "automatic",
                             },
                         },
                     },


### PR DESCRIPTION
## Changes

- Updates base, web/docs, and test configurations to use the [new JSX transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
- Also updates any components where the React import is no longer used (enforced by linter).

Configuration changes are committed in 3ac7db9fc27faf649cd63658d66ada4c498ee218 and 4b7efad512613d6203a7eb3af9ef918e01fdb735.

This PR is a scoped down version of https://github.com/palantir/blueprint/pull/7419 that modifies only files essential to updating to use the new transform.

The following FLUP to this PR (https://github.com/palantir/blueprint/pull/7500) modifies the remaining files in the repo.

## Context

This new transform has a few advantages:

- It simplifies and modernizes syntax around React imports
- Compiled output from the transform may slightly improve the bundle size
- React will eventually require the new transform (see [note](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-jsx-transform-is-now-required) in React 19 upgrade guide).