### PR TITLE
[chore] Update component React imports following New JSX Transform

### DIFF
--- a/packages/core/src/accessibility/useInteractiveAttributes.ts
+++ b/packages/core/src/accessibility/useInteractiveAttributes.ts
@@ -2,7 +2,7 @@
  * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { mergeRefs, Utils } from "../common";
 
@@ -35,13 +35,13 @@ export function useInteractiveAttributes<E extends HTMLElement>(
     const { defaultTabIndex, disabledTabIndex } = options;
     const { active, onClick, onFocus, onKeyDown, onKeyUp, onBlur, tabIndex = defaultTabIndex } = props;
     // the current key being pressed
-    const [currentKeyPressed, setCurrentKeyPressed] = React.useState<string | undefined>();
+    const [currentKeyPressed, setCurrentKeyPressed] = useState<string | undefined>();
     // whether the button is in "active" state
-    const [isActive, setIsActive] = React.useState(false);
+    const [isActive, setIsActive] = useState(false);
     // our local ref for the interactive element, merged with the consumer's own ref in this hook's return value
-    const elementRef = React.useRef<E | null>(null);
+    const elementRef = useRef<E | null>(null);
 
-    const handleBlur = React.useCallback(
+    const handleBlur = useCallback(
         (e: React.FocusEvent<E>) => {
             if (isActive) {
                 setIsActive(false);
@@ -52,7 +52,7 @@ export function useInteractiveAttributes<E extends HTMLElement>(
         [isActive, onBlur],
     );
 
-    const handleKeyDown = React.useCallback(
+    const handleKeyDown = useCallback(
         (e: React.KeyboardEvent<E>) => {
             if (Utils.isKeyboardClick(e)) {
                 e.preventDefault();
@@ -67,7 +67,7 @@ export function useInteractiveAttributes<E extends HTMLElement>(
         [currentKeyPressed, onKeyDown],
     );
 
-    const handleKeyUp = React.useCallback(
+    const handleKeyUp = useCallback(
         (e: React.KeyboardEvent<E>) => {
             if (Utils.isKeyboardClick(e)) {
                 setIsActive(false);

--- a/packages/core/src/common/abstractComponent.ts
+++ b/packages/core/src/common/abstractComponent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Component } from "react";
 
 import { isNodeEnv } from "./utils";
 
@@ -23,7 +23,7 @@ import { isNodeEnv } from "./utils";
  * in order to add some common functionality like runtime props validation.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export abstract class AbstractComponent<P, S = {}, SS = {}> extends React.Component<P, S, SS> {
+export abstract class AbstractComponent<P, S = {}, SS = {}> extends Component<P, S, SS> {
     // unsafe lifecycle methods
     public componentWillUpdate!: never;
 

--- a/packages/core/src/common/abstractPureComponent.ts
+++ b/packages/core/src/common/abstractPureComponent.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { isNodeEnv } from "./utils";
 
@@ -23,7 +23,7 @@ import { isNodeEnv } from "./utils";
  * in order to add some common functionality like runtime props validation.
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export abstract class AbstractPureComponent<P, S = {}, SS = {}> extends React.PureComponent<P, S, SS> {
+export abstract class AbstractPureComponent<P, S = {}, SS = {}> extends PureComponent<P, S, SS> {
     // unsafe lifecycle method
     public componentWillUpdate!: never;
 

--- a/packages/core/src/common/props.ts
+++ b/packages/core/src/common/props.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 import type { IconName } from "@blueprintjs/icons";
 
 import type { Intent } from "./intent";

--- a/packages/core/src/common/refs.ts
+++ b/packages/core/src/common/refs.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 export function isRefObject<T>(value: React.Ref<T> | undefined): value is React.RefObject<T> {
     return value != null && typeof value !== "function";
 }

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { cloneElement, createElement } from "react";
 
 import { isEmptyString } from "./jsUtils";
 
@@ -69,11 +69,11 @@ export function ensureElement(
         isReactNodeArray(child)
     ) {
         // wrap the child element
-        return React.createElement(tagName, props, child);
+        return createElement(tagName, props, child);
     } else if (isReactElement(child)) {
         if (Object.keys(props).length > 0) {
             // clone the element and merge props
-            return React.cloneElement(child, props);
+            return cloneElement(child, props);
         } else {
             // nothing to do, it's a valid ReactElement
             return child;

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, type Intent, type MaybeElement, type Props } from "../../common";
 import {
@@ -170,7 +170,7 @@ export const Alert: React.FC<AlertProps> = props => {
         }
     }, [canEscapeKeyCancel, canOutsideClickCancel, cancelButtonText, onCancel, onClose]);
 
-    const internalHandleCallbacks = React.useCallback(
+    const internalHandleCallbacks = useCallback(
         (confirmed: boolean, event?: React.SyntheticEvent<HTMLElement>) => {
             (confirmed ? onConfirm : onCancel)?.(event);
             onClose?.(confirmed, event);
@@ -178,12 +178,12 @@ export const Alert: React.FC<AlertProps> = props => {
         [onCancel, onClose, onConfirm],
     );
 
-    const handleCancel = React.useCallback(
+    const handleCancel = useCallback(
         (event?: React.SyntheticEvent<HTMLElement>) => internalHandleCallbacks(false, event),
         [internalHandleCallbacks],
     );
 
-    const handleConfirm = React.useCallback(
+    const handleConfirm = useCallback(
         (event: React.SyntheticEvent<HTMLElement>) => internalHandleCallbacks(true, event),
         [internalHandleCallbacks],
     );

--- a/packages/core/src/components/breadcrumbs/breadcrumb.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { type ActionProps, Classes, type LinkProps } from "../../common";
 import { Icon } from "../icon/icon";

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Boundary, Classes, type Props, removeNonHTMLProps } from "../../common";
 import { Menu } from "../menu/menu";

--- a/packages/core/src/components/button/buttonGroup.tsx
+++ b/packages/core/src/components/button/buttonGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { type Alignment, type ButtonVariant, Classes, type Size } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
@@ -92,40 +92,38 @@ export interface ButtonGroupProps extends Props, HTMLDivProps, React.RefAttribut
  *
  * @see https://blueprintjs.com/docs/#core/components/button-group
  */
-export const ButtonGroup: React.FC<ButtonGroupProps> = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
-    (props, ref) => {
-        const {
-            alignText,
-            className,
-            fill,
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            minimal,
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            outlined,
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            large,
-            size = "medium",
-            variant = "solid",
-            vertical,
-            ...htmlProps
-        } = props;
+export const ButtonGroup: React.FC<ButtonGroupProps> = forwardRef<HTMLDivElement, ButtonGroupProps>((props, ref) => {
+    const {
+        alignText,
+        className,
+        fill,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        minimal,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        outlined,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        large,
+        size = "medium",
+        variant = "solid",
+        vertical,
+        ...htmlProps
+    } = props;
 
-        const buttonGroupClasses = classNames(
-            Classes.BUTTON_GROUP,
-            {
-                [Classes.FILL]: fill,
-                [Classes.VERTICAL]: vertical,
-            },
-            Classes.alignmentClass(alignText),
-            Classes.sizeClass(size, { large }),
-            Classes.variantClass(variant, { minimal, outlined }),
-            className,
-        );
-        return (
-            <div {...htmlProps} ref={ref} className={buttonGroupClasses}>
-                {props.children}
-            </div>
-        );
-    },
-);
+    const buttonGroupClasses = classNames(
+        Classes.BUTTON_GROUP,
+        {
+            [Classes.FILL]: fill,
+            [Classes.VERTICAL]: vertical,
+        },
+        Classes.alignmentClass(alignText),
+        Classes.sizeClass(size, { large }),
+        Classes.variantClass(variant, { minimal, outlined }),
+        className,
+    );
+    return (
+        <div {...htmlProps} ref={ref} className={buttonGroupClasses}>
+            {props.children}
+        </div>
+    );
+});
 ButtonGroup.displayName = `${DISPLAYNAME_PREFIX}.ButtonGroup`;

--- a/packages/core/src/components/button/buttonProps.ts
+++ b/packages/core/src/components/button/buttonProps.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 import type { ActionProps, Alignment, ButtonVariant, MaybeElement } from "../../common";
 import type { Size } from "../../common/size";
 import type { IconName } from "../icon/icon";

--- a/packages/core/src/components/button/buttons.tsx
+++ b/packages/core/src/components/button/buttons.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import {
     useInteractiveAttributes,
@@ -34,7 +34,7 @@ import type { AnchorButtonProps, ButtonProps } from "./buttonProps";
  *
  * @see https://blueprintjs.com/docs/#core/components/button
  */
-export const Button: React.FC<ButtonProps> = React.forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+export const Button: React.FC<ButtonProps> = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
     const commonAttributes = useSharedButtonAttributes(props, ref);
 
     return (
@@ -50,7 +50,7 @@ Button.displayName = `${DISPLAYNAME_PREFIX}.Button`;
  *
  * @see https://blueprintjs.com/docs/#core/components/button
  */
-export const AnchorButton: React.FC<AnchorButtonProps> = React.forwardRef<HTMLAnchorElement, AnchorButtonProps>(
+export const AnchorButton: React.FC<AnchorButtonProps> = forwardRef<HTMLAnchorElement, AnchorButtonProps>(
     (props, ref) => {
         const { href } = props;
         const commonProps = useSharedButtonAttributes(props, ref, {

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Error, type IconName, InfoSign, type SVGIconProps, Tick, WarningSign } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/card-list/cardList.tsx
+++ b/packages/core/src/components/card-list/cardList.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Elevation, type HTMLDivProps, type Props } from "../../common";
 import { Card } from "../card/card";
@@ -44,7 +44,7 @@ export interface CardListProps extends Props, HTMLDivProps, React.RefAttributes<
     compact?: boolean;
 }
 
-export const CardList: React.FC<CardListProps> = React.forwardRef((props, ref) => {
+export const CardList: React.FC<CardListProps> = forwardRef((props, ref) => {
     const { bordered = true, className, children, compact = false, ...htmlProps } = props;
 
     const classes = classNames(className, Classes.CARD_LIST, {

--- a/packages/core/src/components/card/card.tsx
+++ b/packages/core/src/components/card/card.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes, Elevation } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
@@ -67,7 +67,7 @@ export interface CardProps extends Props, HTMLDivProps, React.RefAttributes<HTML
  *
  * @see https://blueprintjs.com/docs/#core/components/card
  */
-export const Card: React.FC<CardProps> = React.forwardRef((props, ref) => {
+export const Card: React.FC<CardProps> = forwardRef((props, ref) => {
     const { className, elevation = Elevation.ZERO, interactive = false, selected, compact, ...htmlProps } = props;
     const classes = classNames(className, Classes.CARD, Classes.elevationClass(elevation!), {
         [Classes.INTERACTIVE]: interactive,

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
@@ -195,7 +195,7 @@ export class Collapse extends AbstractPureComponent<CollapseProps, CollapseState
             transition: isAutoHeight ? "none" : undefined,
         };
 
-        return React.createElement(
+        return createElement(
             this.props.component!,
             {
                 className: classNames(Classes.COLLAPSE, this.props.className),

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, type Props, Utils } from "../../common";
 import { TooltipContext, TooltipProvider } from "../popover/tooltipContext";
@@ -115,7 +115,7 @@ export interface ContextMenuProps
  *
  * @see https://blueprintjs.com/docs/#core/components/context-menu
  */
-export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, ContextMenuProps>((props, userRef) => {
+export const ContextMenu: React.FC<ContextMenuProps> = forwardRef<any, ContextMenuProps>((props, userRef) => {
     const {
         className,
         children,
@@ -131,25 +131,25 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
     // ancestor TooltipContext state doesn't affect us since we don't care about parent ContextMenus, we only want to
     // force disable parent Tooltips in certain cases through dispatching actions
     // N.B. any calls to this dispatch function will be no-ops if there is no TooltipProvider ancestor of this component
-    const [, tooltipCtxDispatch] = React.useContext(TooltipContext);
+    const [, tooltipCtxDispatch] = useContext(TooltipContext);
     // click target offset relative to the viewport (e.clientX/clientY), since the target will be rendered in a Portal
-    const [targetOffset, setTargetOffset] = React.useState<Offset | undefined>(undefined);
+    const [targetOffset, setTargetOffset] = useState<Offset | undefined>(undefined);
     // hold a reference to the click mouse event to pass to content/child render functions
-    const [mouseEvent, setMouseEvent] = React.useState<React.MouseEvent<HTMLElement>>();
-    const [isOpen, setIsOpen] = React.useState<boolean>(false);
+    const [mouseEvent, setMouseEvent] = useState<React.MouseEvent<HTMLElement>>();
+    const [isOpen, setIsOpen] = useState<boolean>(false);
     // we need a ref on the child element (or the wrapper we generate) to check for dark theme
-    const childRef = React.useRef<HTMLDivElement>(null);
+    const childRef = useRef<HTMLDivElement>(null);
 
     // If disabled prop is changed, we don't want our old context menu to stick around.
     // If it has just been enabled (disabled = false), then the menu ought to be opened by
     // a new mouse event. Users should not be updating this prop in the onContextMenu callback
     // for this component (that will lead to unpredictable behavior).
-    React.useEffect(() => {
+    useEffect(() => {
         setIsOpen(false);
         tooltipCtxDispatch({ type: "RESET_DISABLED_STATE" });
     }, [disabled, tooltipCtxDispatch]);
 
-    const handlePopoverClose = React.useCallback(() => {
+    const handlePopoverClose = useCallback(() => {
         setIsOpen(false);
         setMouseEvent(undefined);
         tooltipCtxDispatch({ type: "RESET_DISABLED_STATE" });
@@ -158,9 +158,9 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
 
     // if the menu was just opened, we should check for dark theme (but don't do this on every render)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const isDarkTheme = React.useMemo(() => Utils.isDarkTheme(childRef.current), [childRef, isOpen]);
+    const isDarkTheme = useMemo(() => Utils.isDarkTheme(childRef.current), [childRef, isOpen]);
 
-    const contentProps: ContextMenuContentProps = React.useMemo(
+    const contentProps: ContextMenuContentProps = useMemo(
         () => ({
             isOpen,
             mouseEvent,
@@ -170,12 +170,12 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
     );
     // create a memoized function to render the menu so that we can call it if necessary in the "contextmenu" event
     // handler which runs before this render function has a chance to re-run and update the `menu` variable
-    const renderMenu = React.useCallback(
+    const renderMenu = useCallback(
         (menuContentProps: ContextMenuContentProps) =>
             disabled ? undefined : Utils.isFunction(content) ? content(menuContentProps) : content,
         [disabled, content],
     );
-    const menuContent = React.useMemo(() => renderMenu(contentProps), [contentProps, renderMenu]);
+    const menuContent = useMemo(() => renderMenu(contentProps), [contentProps, renderMenu]);
 
     // only render the popover if there is content in the context menu;
     // this avoid doing unnecessary rendering & computation
@@ -191,7 +191,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
             />
         );
 
-    const handleContextMenu = React.useCallback(
+    const handleContextMenu = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
             // support nested menus (inner menu target would have called preventDefault())
             if (e.defaultPrevented) {
@@ -241,7 +241,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.forwardRef<any, Con
     ) : (
         <>
             {maybePopover}
-            {React.createElement<React.HTMLAttributes<any> & React.ClassAttributes<any>>(
+            {createElement<React.HTMLAttributes<any> & React.ClassAttributes<any>>(
                 tagName,
                 {
                     className: containerClassName,

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { memo, useCallback } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Popover } from "../popover/popover";
@@ -40,7 +40,7 @@ export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
  *
  * @see https://blueprintjs.com/docs/#core/components/context-menu-popover
  */
-export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: ContextMenuPopoverProps) {
+export const ContextMenuPopover = memo(function ContextMenuPopover(props: ContextMenuPopoverProps) {
     const {
         content,
         popoverClassName,
@@ -51,10 +51,10 @@ export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: 
         transitionDuration = 100,
         ...popoverProps
     } = props;
-    const cancelContextMenu = React.useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
+    const cancelContextMenu = useCallback((e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault(), []);
 
     // Popover should attach its ref to the virtual target we render inside a Portal, not the "inline" child target
-    const renderTarget = React.useCallback(
+    const renderTarget = useCallback(
         ({ ref }: PopoverTargetProps) => (
             <Portal>
                 <div className={Classes.CONTEXT_MENU_VIRTUAL_TARGET} style={targetOffset} ref={ref} />
@@ -63,7 +63,7 @@ export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: 
         [targetOffset],
     );
 
-    const handleInteraction = React.useCallback(
+    const handleInteraction = useCallback(
         (nextOpenState: boolean) => {
             if (!nextOpenState) {
                 onClose?.();

--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-import * as ReactDOMClient from "react-dom/client";
+import { useCallback, useState } from "react";
+import { createRoot } from "react-dom/client";
 
 import { Classes } from "../../common";
 import { OverlaysProvider } from "../../context/overlays/overlaysProvider";
@@ -99,7 +99,7 @@ export function showContextMenu(props: Omit<ContextMenuPopoverProps, "isOpen">, 
 }
 
 const defaultDomRenderer: ShowContextMenuDOMRenderer = (element, container) => {
-    const root = ReactDOMClient.createRoot(container);
+    const root = createRoot(container);
     root.render(element);
     return () => root.unmount();
 };
@@ -122,8 +122,8 @@ export function hideContextMenu() {
  * It closes when a user clicks outside the popover.
  */
 function UncontrolledContextMenuPopover({ onClose, ...props }: Omit<ContextMenuPopoverProps, "isOpen">) {
-    const [isOpen, setIsOpen] = React.useState(true);
-    const handleClose = React.useCallback(() => {
+    const [isOpen, setIsOpen] = useState(true);
+    const handleClose = useCallback(() => {
         setIsOpen(false);
         onClose?.();
     }, [onClose]);

--- a/packages/core/src/components/control-card/checkboxCard.tsx
+++ b/packages/core/src/components/control-card/checkboxCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
@@ -29,7 +29,7 @@ export type CheckboxCardProps = Omit<ControlCardProps, "controlKind">;
  *
  * @see https://blueprintjs.com/docs/#core/components/control-card.checkbox-card
  */
-export const CheckboxCard: React.FC<CheckboxCardProps> = React.forwardRef((props, ref) => {
+export const CheckboxCard: React.FC<CheckboxCardProps> = forwardRef((props, ref) => {
     const { alignIndicator = Alignment.START, className, ...rest } = props;
     return (
         <ControlCard

--- a/packages/core/src/components/control-card/controlCard.tsx
+++ b/packages/core/src/components/control-card/controlCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Alignment, Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLInputProps } from "../../common/props";
@@ -69,7 +69,7 @@ export interface ControlCardProps extends SupportedCardProps, SupportedControlPr
  *
  * @internal
  */
-export const ControlCard: React.FC<ControlCardProps> = React.forwardRef((props, ref) => {
+export const ControlCard: React.FC<ControlCardProps> = forwardRef((props, ref) => {
     const {
         alignIndicator = Alignment.END,
         checked: _checked,

--- a/packages/core/src/components/control-card/radioCard.tsx
+++ b/packages/core/src/components/control-card/radioCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
@@ -29,7 +29,7 @@ export type RadioCardProps = Omit<ControlCardProps, "controlKind">;
  *
  * @see https://blueprintjs.com/docs/#core/components/control-card.radio-card
  */
-export const RadioCard: React.FC<RadioCardProps> = React.forwardRef((props, ref) => {
+export const RadioCard: React.FC<RadioCardProps> = forwardRef((props, ref) => {
     const className = classNames(props.className, Classes.RADIO_CONTROL_CARD);
     return <ControlCard {...props} className={className} controlKind="radio" ref={ref} />;
 });

--- a/packages/core/src/components/control-card/switchCard.tsx
+++ b/packages/core/src/components/control-card/switchCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
@@ -29,7 +29,7 @@ export type SwitchCardProps = Omit<ControlCardProps, "controlKind">;
  *
  * @see https://blueprintjs.com/docs/#core/components/control-card.switch-card
  */
-export const SwitchCard: React.FC<SwitchCardProps> = React.forwardRef((props, ref) => {
+export const SwitchCard: React.FC<SwitchCardProps> = forwardRef((props, ref) => {
     const className = classNames(props.className, Classes.SWITCH_CONTROL_CARD);
     return <ControlCard {...props} className={className} controlKind="switch" ref={ref} />;
 });

--- a/packages/core/src/components/control-card/useCheckedControl.ts
+++ b/packages/core/src/components/control-card/useCheckedControl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import type { CheckedControlProps } from "../forms/controlProps";
 

--- a/packages/core/src/components/control-card/useCheckedControl.ts
+++ b/packages/core/src/components/control-card/useCheckedControl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState, useCallback } from "react";
 
 import type { CheckedControlProps } from "../forms/controlProps";
 
@@ -22,14 +22,14 @@ import type { CheckedControlProps } from "../forms/controlProps";
  * Keep track of a control's checked state in both controlled and uncontrolled modes
  */
 export function useCheckedControl(props: CheckedControlProps) {
-    const [checkedStateForUncontrolledMode, setChecked] = React.useState(() => props.defaultChecked ?? false);
+    const [checkedStateForUncontrolledMode, setChecked] = useState(() => props.defaultChecked ?? false);
 
     // If the checked prop is passed, this input is in "controlled mode" and
     // should always reflect the value of the controlled prop. Any internal
     // state tracked for "uncontrolled mode" should be ignored.
     const checked = props.checked ?? checkedStateForUncontrolledMode;
 
-    const onChange = React.useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+    const onChange = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
         e => {
             setChecked(c => !c);
             props.onChange?.(e);

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createRef } from "react";
 
 import { type IconName, IconSize, SmallCross } from "@blueprintjs/icons";
 
@@ -119,7 +119,7 @@ export class Dialog extends AbstractPureComponent<DialogProps> {
         isOpen: false,
     };
 
-    private childRef = React.createRef<HTMLDivElement>();
+    private childRef = createRef<HTMLDivElement>();
 
     private titleId: string;
 

--- a/packages/core/src/components/dialog/dialogBody.tsx
+++ b/packages/core/src/components/dialog/dialogBody.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import type { HTMLDivProps, Props } from "../../common/props";
@@ -37,7 +37,7 @@ export interface DialogBodyProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/dialog.dialog-body-props
  */
-export const DialogBody = React.forwardRef<HTMLDivElement, DialogBodyProps>((props, ref) => {
+export const DialogBody = forwardRef<HTMLDivElement, DialogBodyProps>((props, ref) => {
     const { children, className, useOverflowScrollContainer = true, ...htmlProps } = props;
     return (
         <div

--- a/packages/core/src/components/dialog/dialogFooter.tsx
+++ b/packages/core/src/components/dialog/dialogFooter.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import type { HTMLDivProps, Props } from "../../common/props";
@@ -52,7 +52,7 @@ export interface DialogFooterProps extends Props, HTMLDivProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/dialog.dialog-footer-props
  */
-export const DialogFooter = React.forwardRef<HTMLDivElement, DialogFooterProps>((props, ref) => {
+export const DialogFooter = forwardRef<HTMLDivElement, DialogFooterProps>((props, ref) => {
     const { actions, children, className, minimal = false, ...htmlProps } = props;
     return (
         <div

--- a/packages/core/src/components/dialog/dialogStep.tsx
+++ b/packages/core/src/components/dialog/dialogStep.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children } from "react";
 
 import { AbstractPureComponent, Classes, type Position, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
@@ -276,7 +276,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
 
     /** Filters children to only `<DialogStep>`s */
     private getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode } = this.props) {
-        return React.Children.toArray(props.children).filter(isDialogStepElement);
+        return Children.toArray(props.children).filter(isDialogStepElement);
     }
 
     private getInitialIndexFromProps(props: MultistepDialogProps) {

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
@@ -46,7 +46,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
  */
 export const Divider: React.FC<DividerProps> = ({ className, compact = false, tagName = "div", ...htmlProps }) => {
     const classes = classNames(Classes.DIVIDER, { [Classes.COMPACT]: compact }, className);
-    return React.createElement(tagName, {
+    return createElement(tagName, {
         ...htmlProps,
         className: classes,
     });

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { type IconName, IconSize, SmallCross } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import {

--- a/packages/core/src/components/entity-title/entityTitle.tsx
+++ b/packages/core/src/components/entity-title/entityTitle.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef, useMemo } from "react";
 
 import { type IconName, IconNames } from "@blueprintjs/icons";
 
@@ -80,98 +80,96 @@ export interface EntityTitleProps extends Props {
  *
  * @see https://blueprintjs.com/docs/#core/components/entity-title
  */
-export const EntityTitle: React.FC<EntityTitleProps> = React.forwardRef<HTMLDivElement, EntityTitleProps>(
-    (props, ref) => {
-        const {
-            className,
-            ellipsize = false,
-            fill = false,
-            heading = Text,
-            icon,
-            loading = false,
-            subtitle,
-            tags,
-            title,
-            titleURL,
-        } = props;
+export const EntityTitle: React.FC<EntityTitleProps> = forwardRef<HTMLDivElement, EntityTitleProps>((props, ref) => {
+    const {
+        className,
+        ellipsize = false,
+        fill = false,
+        heading = Text,
+        icon,
+        loading = false,
+        subtitle,
+        tags,
+        title,
+        titleURL,
+    } = props;
 
-        const titleElement = React.useMemo(() => {
-            const maybeTitleWithURL =
-                titleURL != null ? (
-                    <a target="_blank" href={titleURL} rel="noreferrer">
-                        {title}
-                    </a>
-                ) : (
-                    title
-                );
-
-            return React.createElement(
-                heading,
-                {
-                    className: classNames(Classes.ENTITY_TITLE_TITLE, {
-                        [Classes.SKELETON]: loading,
-                        [Classes.TEXT_OVERFLOW_ELLIPSIS]: heading !== Text && ellipsize,
-                    }),
-                    ellipsize: heading === Text ? ellipsize : undefined,
-                },
-                maybeTitleWithURL,
+    const titleElement = useMemo(() => {
+        const maybeTitleWithURL =
+            titleURL != null ? (
+                <a target="_blank" href={titleURL} rel="noreferrer">
+                    {title}
+                </a>
+            ) : (
+                title
             );
-        }, [titleURL, title, heading, loading, ellipsize]);
 
-        const maybeSubtitle = React.useMemo(() => {
-            if (subtitle == null) {
-                return null;
-            }
+        return createElement(
+            heading,
+            {
+                className: classNames(Classes.ENTITY_TITLE_TITLE, {
+                    [Classes.SKELETON]: loading,
+                    [Classes.TEXT_OVERFLOW_ELLIPSIS]: heading !== Text && ellipsize,
+                }),
+                ellipsize: heading === Text ? ellipsize : undefined,
+            },
+            maybeTitleWithURL,
+        );
+    }, [titleURL, title, heading, loading, ellipsize]);
 
-            return (
-                <Text
-                    className={classNames(Classes.TEXT_MUTED, Classes.ENTITY_TITLE_SUBTITLE, {
-                        [Classes.SKELETON]: loading,
-                    })}
-                    ellipsize={ellipsize}
-                >
-                    {subtitle}
-                </Text>
-            );
-        }, [ellipsize, loading, subtitle]);
+    const maybeSubtitle = useMemo(() => {
+        if (subtitle == null) {
+            return null;
+        }
 
         return (
-            <div
-                className={classNames(className, Classes.ENTITY_TITLE, getClassNameFromHeading(heading), {
-                    [Classes.ENTITY_TITLE_ELLIPSIZE]: ellipsize,
-                    [Classes.FILL]: fill,
+            <Text
+                className={classNames(Classes.TEXT_MUTED, Classes.ENTITY_TITLE_SUBTITLE, {
+                    [Classes.SKELETON]: loading,
                 })}
-                ref={ref}
+                ellipsize={ellipsize}
             >
-                {icon != null && (
-                    <div
-                        className={classNames(Classes.ENTITY_TITLE_ICON_CONTAINER, {
-                            [Classes.ENTITY_TITLE_HAS_SUBTITLE]: maybeSubtitle != null,
-                        })}
-                    >
-                        <Icon
-                            aria-hidden={true}
-                            className={classNames(Classes.TEXT_MUTED, { [Classes.SKELETON]: loading })}
-                            icon={loading ? IconNames.SQUARE : icon}
-                            tabIndex={-1}
-                        />
-                    </div>
-                )}
-                <div className={Classes.ENTITY_TITLE_TEXT}>
-                    <div
-                        className={classNames(Classes.ENTITY_TITLE_TITLE_AND_TAGS, {
-                            [Classes.SKELETON]: loading,
-                        })}
-                    >
-                        {titleElement}
-                        {tags != null && <div className={Classes.ENTITY_TITLE_TAGS_CONTAINER}>{tags}</div>}
-                    </div>
-                    {maybeSubtitle}
-                </div>
-            </div>
+                {subtitle}
+            </Text>
         );
-    },
-);
+    }, [ellipsize, loading, subtitle]);
+
+    return (
+        <div
+            className={classNames(className, Classes.ENTITY_TITLE, getClassNameFromHeading(heading), {
+                [Classes.ENTITY_TITLE_ELLIPSIZE]: ellipsize,
+                [Classes.FILL]: fill,
+            })}
+            ref={ref}
+        >
+            {icon != null && (
+                <div
+                    className={classNames(Classes.ENTITY_TITLE_ICON_CONTAINER, {
+                        [Classes.ENTITY_TITLE_HAS_SUBTITLE]: maybeSubtitle != null,
+                    })}
+                >
+                    <Icon
+                        aria-hidden={true}
+                        className={classNames(Classes.TEXT_MUTED, { [Classes.SKELETON]: loading })}
+                        icon={loading ? IconNames.SQUARE : icon}
+                        tabIndex={-1}
+                    />
+                </div>
+            )}
+            <div className={Classes.ENTITY_TITLE_TEXT}>
+                <div
+                    className={classNames(Classes.ENTITY_TITLE_TITLE_AND_TAGS, {
+                        [Classes.SKELETON]: loading,
+                    })}
+                >
+                    {titleElement}
+                    {tags != null && <div className={Classes.ENTITY_TITLE_TAGS_CONTAINER}>{tags}</div>}
+                </div>
+                {maybeSubtitle}
+            </div>
+        </div>
+    );
+});
 EntityTitle.displayName = `${DISPLAYNAME_PREFIX}.EntityTitle`;
 
 /**

--- a/packages/core/src/components/forms/asyncControllableInput.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
 export type AsyncControllableInputProps = React.InputHTMLAttributes<HTMLInputElement> & {

--- a/packages/core/src/components/forms/asyncControllableTextArea.tsx
+++ b/packages/core/src/components/forms/asyncControllableTextArea.tsx
@@ -2,7 +2,7 @@
  * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { DISPLAYNAME_PREFIX } from "../../common";
 import { useAsyncControllableValue } from "../../hooks/useAsyncControllableValue";
@@ -13,7 +13,7 @@ export type AsyncControllableTextAreaProps = React.TextareaHTMLAttributes<HTMLTe
  * A wrapper around the low-level <textarea> component which works around a React bug
  * the same way <AsyncControllableInput> does.
  */
-export const AsyncControllableTextArea = React.forwardRef<HTMLTextAreaElement, AsyncControllableTextAreaProps>(
+export const AsyncControllableTextArea = forwardRef<HTMLTextAreaElement, AsyncControllableTextAreaProps>(
     function AsyncControllableTextArea(props, ref) {
         const {
             value: parentValue,

--- a/packages/core/src/components/forms/controlGroup.tsx
+++ b/packages/core/src/components/forms/controlGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
@@ -46,24 +46,22 @@ export interface ControlGroupProps extends Props, HTMLDivProps, React.RefAttribu
  *
  * @see https://blueprintjs.com/docs/#core/components/control-group
  */
-export const ControlGroup: React.FC<ControlGroupProps> = React.forwardRef<HTMLDivElement, ControlGroupProps>(
-    (props, ref) => {
-        const { children, className, fill, vertical, ...htmlProps } = props;
+export const ControlGroup: React.FC<ControlGroupProps> = forwardRef<HTMLDivElement, ControlGroupProps>((props, ref) => {
+    const { children, className, fill, vertical, ...htmlProps } = props;
 
-        const rootClasses = classNames(
-            Classes.CONTROL_GROUP,
-            {
-                [Classes.FILL]: fill,
-                [Classes.VERTICAL]: vertical,
-            },
-            className,
-        );
+    const rootClasses = classNames(
+        Classes.CONTROL_GROUP,
+        {
+            [Classes.FILL]: fill,
+            [Classes.VERTICAL]: vertical,
+        },
+        className,
+    );
 
-        return (
-            <div role="group" {...htmlProps} ref={ref} className={rootClasses}>
-                {children}
-            </div>
-        );
-    },
-);
+    return (
+        <div role="group" {...htmlProps} ref={ref} className={rootClasses}>
+            {children}
+        </div>
+    );
+});
 ControlGroup.displayName = `${DISPLAYNAME_PREFIX}.ControlGroup`;

--- a/packages/core/src/components/forms/controlProps.ts
+++ b/packages/core/src/components/forms/controlProps.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 import type { Alignment, NonSmallSize } from "../../common";
 import type { HTMLInputProps, Props } from "../../common/props";
 

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef, useCallback, useEffect, useRef, useState } from "react";
 
 import { Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
@@ -33,7 +33,7 @@ interface ControlInternalProps extends ControlProps {
  * Renders common control elements, with additional props to customize appearance.
  * This component is not exported and is only used within this module for `Checkbox`, `Radio`, and `Switch` below.
  */
-const ControlInternal: React.FC<ControlInternalProps> = React.forwardRef<HTMLLabelElement, ControlInternalProps>(
+const ControlInternal: React.FC<ControlInternalProps> = forwardRef<HTMLLabelElement, ControlInternalProps>(
     (props, ref) => {
         const {
             alignIndicator,
@@ -66,7 +66,7 @@ const ControlInternal: React.FC<ControlInternalProps> = React.forwardRef<HTMLLab
             className,
         );
 
-        return React.createElement(
+        return createElement(
             tagName,
             { className: classes, ref, style },
             <input className={Classes.CONTROL_INPUT} {...htmlProps} ref={inputRef} type={type} />,
@@ -107,7 +107,7 @@ export interface SwitchProps extends ControlProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/switch
  */
-export const Switch: React.FC<SwitchProps> = React.forwardRef((props, ref) => {
+export const Switch: React.FC<SwitchProps> = forwardRef((props, ref) => {
     const { innerLabelChecked, innerLabel, ...controlProps } = props;
     const switchLabels =
         innerLabel || innerLabelChecked
@@ -148,7 +148,7 @@ export type RadioProps = ControlProps;
  *
  * @see https://blueprintjs.com/docs/#core/components/radio
  */
-export const Radio: React.FC<RadioProps> = React.forwardRef((props, ref) => {
+export const Radio: React.FC<RadioProps> = forwardRef((props, ref) => {
     return <ControlInternal {...props} ref={ref} type="radio" typeClassName={Classes.RADIO} />;
 });
 Radio.displayName = `${DISPLAYNAME_PREFIX}.Radio`;
@@ -180,17 +180,15 @@ export interface CheckboxProps extends ControlProps {
  *
  * @see https://blueprintjs.com/docs/#core/components/checkbox
  */
-export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) => {
+export const Checkbox: React.FC<CheckboxProps> = forwardRef((props, ref) => {
     const { defaultIndeterminate, indeterminate, onChange, ...controlProps } = props;
 
-    const [isIndeterminate, setIsIndeterminate] = React.useState<boolean>(
-        indeterminate || defaultIndeterminate || false,
-    );
+    const [isIndeterminate, setIsIndeterminate] = useState<boolean>(indeterminate || defaultIndeterminate || false);
 
-    const localInputRef = React.useRef<HTMLInputElement>(null);
+    const localInputRef = useRef<HTMLInputElement>(null);
     const inputRef = mergeRefs(props.inputRef, localInputRef);
 
-    const handleChange = React.useCallback(
+    const handleChange = useCallback(
         (evt: React.ChangeEvent<HTMLInputElement>) => {
             // update state immediately only if uncontrolled
             if (indeterminate === undefined) {
@@ -202,13 +200,13 @@ export const Checkbox: React.FC<CheckboxProps> = React.forwardRef((props, ref) =
         [indeterminate, onChange],
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (indeterminate !== undefined) {
             setIsIndeterminate(indeterminate);
         }
     }, [indeterminate]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (localInputRef.current != null) {
             localInputRef.current.indeterminate = isIndeterminate;
         }

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";

--- a/packages/core/src/components/forms/formGroup.tsx
+++ b/packages/core/src/components/forms/formGroup.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes, type Intent } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type IntentProps, type Props } from "../../common/props";

--- a/packages/core/src/components/forms/inputGroup.tsx
+++ b/packages/core/src/components/forms/inputGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import { AbstractPureComponent, Classes } from "../../common";
 import { INPUT_WARN_LEFT_ELEMENT_LEFT_ICON_MUTEX } from "../../common/errors";
@@ -170,7 +170,7 @@ export class InputGroup extends AbstractPureComponent<InputGroupProps, InputGrou
             <input {...inputProps} ref={inputRef} />
         );
 
-        return React.createElement(
+        return createElement(
             tagName,
             { className: inputGroupClasses },
             this.maybeRenderLeftElement(),

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { ChevronDown, ChevronUp } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children, cloneElement, useCallback, useMemo } from "react";
 
 import {
     Classes,
@@ -89,9 +89,9 @@ export const RadioGroup: React.FC<RadioGroupProps> = props => {
         props;
 
     // a unique name for this group, which can be overridden by `name` prop.
-    const autoGroupName = React.useMemo(() => nextName(), []);
+    const autoGroupName = useMemo(() => nextName(), []);
 
-    const labelId = React.useMemo(() => uniqueId("label"), []);
+    const labelId = useMemo(() => uniqueId("label"), []);
 
     useValidateProps(() => {
         if (children != null && options != null) {
@@ -99,7 +99,7 @@ export const RadioGroup: React.FC<RadioGroupProps> = props => {
         }
     }, [children, options]);
 
-    const getRadioProps = React.useCallback(
+    const getRadioProps = useCallback(
         (optionProps: OptionProps): Omit<RadioProps, "ref"> => {
             const { className: optionClassName, disabled: optionDisabled, value } = optionProps;
             return {
@@ -116,9 +116,9 @@ export const RadioGroup: React.FC<RadioGroupProps> = props => {
     );
 
     const renderChildren = () => {
-        return React.Children.map(children, child => {
+        return Children.map(children, child => {
             if (isElementOfType(child, Radio) || isElementOfType(child, RadioCard)) {
-                return React.cloneElement(
+                return cloneElement(
                     // Need this cast here to suppress a TS error caused by differing `ref` types for the Radio and
                     // RadioCard components. We aren't injecting a ref, so we don't need to be strict about that
                     // incompatibility.

--- a/packages/core/src/components/forms/textArea.tsx
+++ b/packages/core/src/components/forms/textArea.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Classes, refHandler, setRef } from "../../common";
 import { DISPLAYNAME_PREFIX, type IntentProps, type Props } from "../../common/props";

--- a/packages/core/src/components/hotkeys/hotkeys.tsx
+++ b/packages/core/src/components/hotkeys/hotkeys.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children } from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import { HOTKEYS_HOTKEY_CHILDREN } from "../../common/errors";
@@ -57,10 +57,7 @@ export class Hotkeys extends AbstractPureComponent<HotkeysProps> {
             return null;
         }
 
-        const hotkeys = React.Children.map(
-            this.props.children,
-            (child: React.ReactElement<HotkeyProps>) => child.props,
-        );
+        const hotkeys = Children.map(this.props.children, (child: React.ReactElement<HotkeyProps>) => child.props);
 
         // sort by group label alphabetically, prioritize globals
         hotkeys.sort((a, b) => {
@@ -89,7 +86,7 @@ export class Hotkeys extends AbstractPureComponent<HotkeysProps> {
             return;
         }
 
-        React.Children.forEach(props.children, (child: React.JSX.Element) => {
+        Children.forEach(props.children, (child: React.JSX.Element) => {
             if (!isElementOfType(child, Hotkey)) {
                 throw new Error(HOTKEYS_HOTKEY_CHILDREN);
             }

--- a/packages/core/src/components/hotkeys/hotkeysDialog.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysDialog.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import type { HotkeyConfig } from "../../hooks";

--- a/packages/core/src/components/hotkeys/hotkeysTarget.tsx
+++ b/packages/core/src/components/hotkeys/hotkeysTarget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useEffect } from "react";
 
 import * as Errors from "../../common/errors";
 import { isFunction, isNodeEnv } from "../../common/utils";
@@ -54,7 +54,7 @@ export const HotkeysTarget = ({ children, hotkeys, options }: HotkeysTargetProps
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys, options);
 
     // run props validation
-    React.useEffect(() => {
+    useEffect(() => {
         if (!isNodeEnv("production")) {
             if (typeof children !== "function" && hotkeys.some(h => !h.global)) {
                 console.error(Errors.HOTKEYS_TARGET_CHILDREN_LOCAL_HOTKEYS);

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Fragment } from "react";
 
 import {
     ArrowDown,
@@ -107,7 +107,7 @@ export class KeyComboTagInternal extends AbstractPureComponent<KeyComboTagIntern
     private renderMinimalKey = (key: string, index: number, isLastKey: boolean) => {
         const icon = this.getKeyIcon(key);
         if (icon == null) {
-            return isLastKey ? key : <React.Fragment key={`key-${index}`}>{key}&nbsp;+&nbsp;</React.Fragment>;
+            return isLastKey ? key : <Fragment key={`key-${index}`}>{key}&nbsp;+&nbsp;</Fragment>;
         }
         return <Icon icon={icon.icon} title={icon.iconTitle} key={`key-${index}`} />;
     };

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { CaretDown, DoubleCaretVertical, type IconName, type SVGIconProps } from "@blueprintjs/icons";
 
@@ -81,7 +81,7 @@ export interface HTMLSelectProps
  *
  * @see https://blueprintjs.com/docs/#core/components/html-select
  */
-export const HTMLSelect: React.FC<HTMLSelectProps> = React.forwardRef((props, ref) => {
+export const HTMLSelect: React.FC<HTMLSelectProps> = forwardRef((props, ref) => {
     const {
         className,
         children,

--- a/packages/core/src/components/html-table/htmlTable.tsx
+++ b/packages/core/src/components/html-table/htmlTable.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 
@@ -42,7 +42,7 @@ export interface HTMLTableProps
  *
  * @see https://blueprintjs.com/docs/#core/components/html-table
  */
-export const HTMLTable: React.FC<HTMLTableProps> = React.forwardRef((props, ref) => {
+export const HTMLTable: React.FC<HTMLTableProps> = forwardRef((props, ref) => {
     const { bordered, className, compact, interactive, striped, ...htmlProps } = props;
     const classes = classNames(
         Classes.HTML_TABLE,

--- a/packages/core/src/components/html/html.tsx
+++ b/packages/core/src/components/html/html.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef } from "react";
 
 import { BLOCKQUOTE, CODE, CODE_BLOCK, HEADING, LABEL, LIST } from "../../common/classes";
 
@@ -24,9 +24,9 @@ function htmlElement<E extends HTMLElement>(
     tagClassName: string,
 ): React.FC<React.AllHTMLAttributes<E> & React.RefAttributes<E>> {
     /* eslint-disable-next-line react/display-name */
-    return React.forwardRef<E, React.AllHTMLAttributes<E>>((props, ref) => {
+    return forwardRef<E, React.AllHTMLAttributes<E>>((props, ref) => {
         const { className, children, ...htmlProps } = props;
-        return React.createElement(
+        return createElement(
             tagName,
             {
                 ...htmlProps,

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef, useEffect, useState } from "react";
 
 import {
     type DefaultSVGIconProps,
@@ -101,7 +101,7 @@ export interface IconComponent extends React.FC<IconProps<Element>> {
  *
  * @see https://blueprintjs.com/docs/#core/components/icon
  */
-export const Icon: IconComponent = React.forwardRef(<T extends Element>(props: IconProps<T>, ref: React.Ref<T>) => {
+export const Icon: IconComponent = forwardRef(<T extends Element>(props: IconProps<T>, ref: React.Ref<T>) => {
     const {
         autoLoad = true,
         className,
@@ -117,11 +117,11 @@ export const Icon: IconComponent = React.forwardRef(<T extends Element>(props: I
 
     const size = props.size ?? IconSize.STANDARD;
 
-    const [iconPaths, setIconPaths] = React.useState<IconPaths | undefined>(() =>
+    const [iconPaths, setIconPaths] = useState<IconPaths | undefined>(() =>
         typeof icon === "string" ? Icons.getPaths(icon, size) : undefined,
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         let shouldCancelIconLoading = false;
         if (typeof icon === "string") {
             // The icon may have been loaded already, in which case we can simply grab it.
@@ -168,7 +168,7 @@ export const Icon: IconComponent = React.forwardRef(<T extends Element>(props: I
                 : size === IconSize.LARGE
                   ? Classes.ICON_LARGE
                   : undefined;
-        return React.createElement(tagName || "span", {
+        return createElement(tagName || "span", {
             "aria-hidden": title ? undefined : true,
             ...removeNonHTMLProps(htmlProps),
             className: classNames(

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";

--- a/packages/core/src/components/menu/menuDivider.tsx
+++ b/packages/core/src/components/menu/menuDivider.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import { H6 } from "../html/html";

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef } from "react";
 
 import { CaretRight, SmallTick } from "@blueprintjs/icons";
 
@@ -170,7 +170,7 @@ export interface MenuItemProps
  *
  * @see https://blueprintjs.com/docs/#core/components/menu.menu-item
  */
-export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => {
+export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => {
     const {
         active = false,
         className,
@@ -247,7 +247,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             </span>
         );
 
-    const target = React.createElement(
+    const target = createElement(
         tagName,
         {
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this

--- a/packages/core/src/components/navbar/navbar.tsx
+++ b/packages/core/src/components/navbar/navbar.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarDivider.tsx
+++ b/packages/core/src/components/navbar/navbarDivider.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";

--- a/packages/core/src/components/navbar/navbarGroup.tsx
+++ b/packages/core/src/components/navbar/navbarGroup.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Alignment, Classes } from "../../common";
 import { NAVBAR_GROUP_ALIGN_CENTER } from "../../common/errors";

--- a/packages/core/src/components/navbar/navbarHeading.tsx
+++ b/packages/core/src/components/navbar/navbarHeading.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";

--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { type IconName, IconSize } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component, createElement } from "react";
 
 import { Boundary, Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import { OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED } from "../../common/errors";
@@ -119,7 +119,7 @@ export interface OverflowListState<T> {
  *
  * @see https://blueprintjs.com/docs/#core/components/overflow-list
  */
-export class OverflowList<T> extends React.Component<OverflowListProps<T>, OverflowListState<T>> {
+export class OverflowList<T> extends Component<OverflowListProps<T>, OverflowListState<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.OverflowList`;
 
     public static defaultProps: Partial<OverflowListProps<any>> = {
@@ -200,7 +200,7 @@ export class OverflowList<T> extends React.Component<OverflowListProps<T>, Overf
     public render() {
         const { className, collapseFrom, observeParents, style, tagName = "div", visibleItemRenderer } = this.props;
         const overflow = this.maybeRenderOverflow();
-        const list = React.createElement(
+        const list = createElement(
             tagName,
             {
                 className: classNames(Classes.OVERFLOW_LIST, className),

--- a/packages/core/src/components/overlay/overlay.tsx
+++ b/packages/core/src/components/overlay/overlay.tsx
@@ -22,7 +22,7 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children, cloneElement, createRef } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { AbstractPureComponent, Classes } from "../../common";
@@ -81,13 +81,13 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
     };
 
     /** Ref for container element, containing all children and the backdrop */
-    public containerElement = React.createRef<HTMLDivElement>();
+    public containerElement = createRef<HTMLDivElement>();
 
     // An empty, keyboard-focusable div at the beginning of the Overlay content
-    private startFocusTrapElement = React.createRef<HTMLDivElement>();
+    private startFocusTrapElement = createRef<HTMLDivElement>();
 
     // An empty, keyboard-focusable div at the end of the Overlay content
-    private endFocusTrapElement = React.createRef<HTMLDivElement>();
+    private endFocusTrapElement = createRef<HTMLDivElement>();
 
     public render() {
         // oh snap! no reason to render anything at all if we're being truly lazy
@@ -100,7 +100,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
         // TransitionGroup types require single array of children; does not support nested arrays.
         // So we must collapse backdrop and children into one array, and every item must be wrapped in a
         // Transition element (no ReactText allowed).
-        const childrenWithTransitions = isOpen ? React.Children.map(children, this.maybeRenderChild) ?? [] : [];
+        const childrenWithTransitions = isOpen ? Children.map(children, this.maybeRenderChild) ?? [] : [];
 
         const maybeBackdrop = this.maybeRenderBackdrop();
         if (maybeBackdrop !== null) {
@@ -217,7 +217,7 @@ export class Overlay extends AbstractPureComponent<OverlayProps, OverlayState> {
         const tabIndex = this.props.enforceFocus || this.props.autoFocus ? 0 : undefined;
         const decoratedChild =
             typeof child === "object" ? (
-                React.cloneElement(child as React.ReactElement, {
+                cloneElement(child as React.ReactElement, {
                     className: classNames((child as React.ReactElement).props.className, Classes.OVERLAY_CONTENT),
                     tabIndex,
                 })

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -15,7 +15,17 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import {
+    Children,
+    forwardRef,
+    useCallback,
+    useEffect,
+    useId,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, mergeRefs } from "../../common";
@@ -83,7 +93,7 @@ export const OVERLAY2_DEFAULT_PROPS = {
  *
  * @see https://blueprintjs.com/docs/#core/components/overlay2
  */
-export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props, forwardedRef) => {
+export const Overlay2 = forwardRef<OverlayInstance, Overlay2Props>((props, forwardedRef) => {
     const {
         autoFocus,
         backdropClassName,
@@ -114,29 +124,29 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     useOverlay2Validation(props);
     const { closeOverlay, getLastOpened, getThisOverlayAndDescendants, openOverlay } = useOverlayStack();
 
-    const [isAutoFocusing, setIsAutoFocusing] = React.useState(false);
-    const [hasEverOpened, setHasEverOpened] = React.useState(false);
-    const lastActiveElementBeforeOpened = React.useRef<Element>(null);
+    const [isAutoFocusing, setIsAutoFocusing] = useState(false);
+    const [hasEverOpened, setHasEverOpened] = useState(false);
+    const lastActiveElementBeforeOpened = useRef<Element>(null);
 
     /** Ref for container element, containing all children and the backdrop */
-    const containerElement = React.useRef<HTMLDivElement>(null);
+    const containerElement = useRef<HTMLDivElement>(null);
 
     /** Ref for backdrop element */
-    const backdropElement = React.useRef<HTMLDivElement>(null);
+    const backdropElement = useRef<HTMLDivElement>(null);
 
     /* An empty, keyboard-focusable div at the beginning of the Overlay content */
-    const startFocusTrapElement = React.useRef<HTMLDivElement>(null);
+    const startFocusTrapElement = useRef<HTMLDivElement>(null);
 
     /* An empty, keyboard-focusable div at the end of the Overlay content */
-    const endFocusTrapElement = React.useRef<HTMLDivElement>(null);
+    const endFocusTrapElement = useRef<HTMLDivElement>(null);
 
     /**
      * Locally-generated DOM ref for a singleton child element.
      * This is only used iff the user does not specify the `childRef` or `childRefs` props.
      */
-    const localChildRef = React.useRef<HTMLElement>(null);
+    const localChildRef = useRef<HTMLElement>(null);
 
-    const bringFocusInsideOverlay = React.useCallback(() => {
+    const bringFocusInsideOverlay = useCallback(() => {
         // always delay focus manipulation to just before repaint to prevent scroll jumping
         return requestAnimationFrame(() => {
             // container element may be undefined between component mounting and Portal rendering
@@ -162,13 +172,13 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
 
     // N.B. use `null` here and not simply `undefined` because `useImperativeHandle` will set `null` on unmount,
     // and we need the following code to be resilient to that value.
-    const instance = React.useRef<OverlayInstance>(null);
+    const instance = useRef<OverlayInstance>(null);
 
     /**
      * When multiple `enforceFocus` Overlays are open, this event handler is only active for the most
      * recently opened one to avoid Overlays competing with each other for focus.
      */
-    const handleDocumentFocus = React.useCallback(
+    const handleDocumentFocus = useCallback(
         (e: FocusEvent) => {
             // get the actual target even in the Shadow DOM
             // see https://github.com/palantir/blueprint/issues/4220
@@ -185,7 +195,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     );
 
     // N.B. this listener is only kept attached when `isOpen={true}` and `canOutsideClickClose={true}`
-    const handleDocumentMousedown = React.useCallback(
+    const handleDocumentMousedown = useCallback(
         (e: MouseEvent) => {
             // get the actual target even in the Shadow DOM
             // see https://github.com/palantir/blueprint/issues/4220
@@ -210,8 +220,8 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     );
 
     // send this instance's imperative handle to the the forwarded ref as well as our local ref
-    const ref = React.useMemo(() => mergeRefs(forwardedRef, instance), [forwardedRef]);
-    React.useImperativeHandle(
+    const ref = useMemo(() => mergeRefs(forwardedRef, instance), [forwardedRef]);
+    useImperativeHandle(
         ref,
         () => ({
             bringFocusInsideOverlay,
@@ -238,7 +248,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         ],
     );
 
-    const handleContainerKeyDown = React.useCallback(
+    const handleContainerKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLElement>) => {
             if (e.key === "Escape" && canEscapeKeyClose) {
                 onClose?.(e);
@@ -251,7 +261,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         [canEscapeKeyClose, onClose],
     );
 
-    const overlayWillOpen = React.useCallback(() => {
+    const overlayWillOpen = useCallback(() => {
         if (instance.current == null) {
             return;
         }
@@ -270,7 +280,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         setRef(lastActiveElementBeforeOpened, getActiveElement(getRef(containerElement)));
     }, [autoFocus, bringFocusInsideOverlay, getLastOpened, openOverlay]);
 
-    const overlayWillClose = React.useCallback(() => {
+    const overlayWillClose = useCallback(() => {
         document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
         document.removeEventListener("mousedown", handleDocumentMousedown);
 
@@ -292,7 +302,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     }, [closeOverlay, getLastOpened, handleDocumentFocus, handleDocumentMousedown, id]);
 
     const prevIsOpen = usePrevious(isOpen) ?? false;
-    React.useEffect(() => {
+    useEffect(() => {
         if (isOpen) {
             setHasEverOpened(true);
         }
@@ -309,10 +319,10 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     }, [isOpen, overlayWillOpen, overlayWillClose, prevIsOpen]);
 
     // Important: clean up old document-level event listeners if their memoized values change (this is rare, but
-    // may happen, for example, if a user forgets to use `React.useCallback` in the `props.onClose` value).
+    // may happen, for example, if a user forgets to use `useCallback` in the `props.onClose` value).
     // Otherwise, we will lose the reference to those values and create a memory leak since we won't be able
     // to successfully detach them inside overlayWillClose.
-    React.useEffect(() => {
+    useEffect(() => {
         if (!isOpen || !(canOutsideClickClose && !hasBackdrop)) {
             return;
         }
@@ -323,7 +333,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
             document.removeEventListener("mousedown", handleDocumentMousedown);
         };
     }, [handleDocumentMousedown, isOpen, canOutsideClickClose, hasBackdrop]);
-    React.useEffect(() => {
+    useEffect(() => {
         if (!isOpen || !enforceFocus) {
             return;
         }
@@ -345,9 +355,9 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         };
     }, [handleDocumentFocus, enforceFocus, isOpen, getLastOpened, id]);
 
-    const overlayWillCloseRef = React.useRef(overlayWillClose);
+    const overlayWillCloseRef = useRef(overlayWillClose);
     overlayWillCloseRef.current = overlayWillClose;
-    React.useEffect(() => {
+    useEffect(() => {
         // run cleanup code once on unmount, ensuring we call the most recent overlayWillClose callback
         // by storing in a ref and keeping up to date
         return () => {
@@ -355,7 +365,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         };
     }, []);
 
-    const handleTransitionExited = React.useCallback(
+    const handleTransitionExited = useCallback(
         (node: HTMLElement) => {
             const lastActiveElement = getRef(lastActiveElementBeforeOpened);
             if (shouldReturnFocusOnClose && lastActiveElement instanceof HTMLElement) {
@@ -367,7 +377,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     );
 
     // N.B. CSSTransition requires this callback to be defined, even if it's unused.
-    const handleTransitionAddEnd = React.useCallback(() => {
+    const handleTransitionAddEnd = useCallback(() => {
         // no-op
     }, []);
 
@@ -381,7 +391,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
      *
      * @see https://reactcommunity.org/react-transition-group/css-transition
      */
-    const getUserChildRef = React.useCallback(
+    const getUserChildRef = useCallback(
         (child: React.ReactNode) => {
             if (childRef != null) {
                 return childRef;
@@ -400,7 +410,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         [childRef, childRefs],
     );
 
-    const maybeRenderChild = React.useCallback(
+    const maybeRenderChild = useCallback(
         (child: React.ReactNode | undefined) => {
             if (child == null || isEmptyString(child)) {
                 return null;
@@ -451,7 +461,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         ],
     );
 
-    const handleBackdropMouseDown = React.useCallback(
+    const handleBackdropMouseDown = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
             if (canOutsideClickClose) {
                 onClose?.(e);
@@ -464,7 +474,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         [backdropProps, bringFocusInsideOverlay, canOutsideClickClose, enforceFocus, onClose],
     );
 
-    const renderDummyElement = React.useCallback(
+    const renderDummyElement = useCallback(
         (key: string, dummyElementProps: HTMLDivProps & { ref?: React.Ref<HTMLDivElement> }) => (
             <CSSTransition
                 addEndListener={handleTransitionAddEnd}
@@ -486,7 +496,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
      * the `startFocusTrapElement`), depending on whether the element losing focus is inside the
      * Overlay.
      */
-    const handleStartFocusTrapElementFocus = React.useCallback(
+    const handleStartFocusTrapElementFocus = useCallback(
         (e: React.FocusEvent<HTMLDivElement>) => {
             if (!enforceFocus || isAutoFocusing) {
                 return;
@@ -511,7 +521,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     /**
      * Wrap around to the end of the dialog if `enforceFocus` is enabled.
      */
-    const handleStartFocusTrapElementKeyDown = React.useCallback(
+    const handleStartFocusTrapElementKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLDivElement>) => {
             if (!enforceFocus) {
                 return;
@@ -534,7 +544,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
      * `startFocusTrapElement`), depending on whether the element losing focus is inside the
      * Overlay.
      */
-    const handleEndFocusTrapElementFocus = React.useCallback(
+    const handleEndFocusTrapElementFocus = useCallback(
         (e: React.FocusEvent<HTMLDivElement>) => {
             // No need for this.props.enforceFocus check here because this element is only rendered
             // when that prop is true.
@@ -568,7 +578,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         [isAutoFocusing],
     );
 
-    const maybeBackdrop = React.useMemo(
+    const maybeBackdrop = useMemo(
         () =>
             hasBackdrop && isOpen ? (
                 <CSSTransition
@@ -606,7 +616,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
     // TransitionGroup types require single array of children; does not support nested arrays.
     // So we must collapse backdrop and children into one array, and every item must be wrapped in a
     // Transition element (no ReactText allowed).
-    const childrenWithTransitions = isOpen ? React.Children.map(children, maybeRenderChild) ?? [] : [];
+    const childrenWithTransitions = isOpen ? Children.map(children, maybeRenderChild) ?? [] : [];
 
     // const maybeBackdrop = maybeRenderBackdrop();
     if (maybeBackdrop !== null) {
@@ -667,8 +677,8 @@ Overlay2.defaultProps = OVERLAY2_DEFAULT_PROPS;
 Overlay2.displayName = `${DISPLAYNAME_PREFIX}.Overlay2`;
 
 function useOverlay2Validation({ childRef, childRefs, children }: Overlay2Props) {
-    const numChildren = React.Children.count(children);
-    React.useEffect(() => {
+    const numChildren = Children.count(children);
+    useEffect(() => {
         if (isNodeEnv("production")) {
             return;
         }
@@ -687,7 +697,7 @@ function useOverlay2Validation({ childRef, childRefs, children }: Overlay2Props)
  * Generates a unique ID for a given Overlay which persists across the component's lifecycle.
  */
 function useOverlay2ID(): string {
-    const id = React.useId();
+    const id = useId();
     return `${Overlay2.displayName}-${id}`;
 }
 

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useMemo, useState } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
@@ -99,15 +99,15 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
     } = props;
     const isControlled = propsStack != null;
 
-    const [localStack, setLocalStack] = React.useState<T[]>(initialPanel !== undefined ? [initialPanel] : []);
-    const stack = React.useMemo(
+    const [localStack, setLocalStack] = useState<T[]>(initialPanel !== undefined ? [initialPanel] : []);
+    const stack = useMemo(
         () => (isControlled ? propsStack.slice().reverse() : localStack),
         [localStack, isControlled, propsStack],
     );
     const prevStackLength = usePrevious(stack.length) ?? stack.length;
     const direction = stack.length - prevStackLength < 0 ? "pop" : "push";
 
-    const handlePanelOpen = React.useCallback(
+    const handlePanelOpen = useCallback(
         (panel: T) => {
             onOpen?.(panel);
             if (!isControlled) {
@@ -116,7 +116,7 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
         },
         [onOpen, isControlled],
     );
-    const handlePanelClose = React.useCallback(
+    const handlePanelClose = useCallback(
         (panel: T) => {
             onClose?.(panel);
             if (!isControlled) {

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useMemo } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Button } from "../button/buttons";
@@ -58,7 +58,7 @@ export const PanelView: PanelViewComponent = <T extends Panel<object>>({
     showHeader,
 }: PanelViewProps<T>) => {
     const hasPreviousPanel = previousPanel !== undefined;
-    const handleClose = React.useCallback(() => {
+    const handleClose = useCallback(() => {
         // only remove this panel if it is not the only one.
         if (hasPreviousPanel) {
             onClose(panel);
@@ -82,7 +82,7 @@ export const PanelView: PanelViewComponent = <T extends Panel<object>>({
     // `panel.renderPanel` is simply a function that returns a React.JSX.Element. It may be an FC which
     // uses hooks. In order to avoid React errors due to inconsistent hook calls, we must encapsulate
     // those hooks with their own lifecycle through a very simple wrapper component.
-    const PanelWrapper: React.FC = React.useMemo(
+    const PanelWrapper: React.FC = useMemo(
         () => () =>
             // N.B. A type cast is required because of error TS2345, where technically `panel.props` could be
             // instantiated with a type unrelated to our generic constraint `T` here. We know

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -16,7 +16,7 @@
 
 import type { State as PopperState, PositioningStrategy } from "@popperjs/core";
 import classNames from "classnames";
-import * as React from "react";
+import { Children, cloneElement, createElement, createRef } from "react";
 import {
     Manager,
     type Modifier,
@@ -195,12 +195,12 @@ export class Popover<
      *
      * @public for testing
      */
-    public targetRef = React.createRef<HTMLElement>();
+    public targetRef = createRef<HTMLElement>();
 
     /**
      * Overlay2 transition container element ref.
      */
-    private transitionContainerElement = React.createRef<HTMLDivElement>();
+    private transitionContainerElement = createRef<HTMLDivElement>();
 
     private cancelOpenTimeout?: () => void;
 
@@ -308,7 +308,7 @@ export class Popover<
             console.warn(Errors.POPOVER_WARN_PLACEMENT_AND_POSITION_MUTEX);
         }
 
-        const childrenCount = React.Children.count(props.children);
+        const childrenCount = Children.count(props.children);
         const hasRenderTargetProp = props.renderTarget !== undefined;
         const hasTargetPropsProp = props.targetProps !== undefined;
 
@@ -411,20 +411,20 @@ export class Popover<
                 tabIndex: targetTabIndex,
             });
         } else {
-            const childTarget = Utils.ensureElement(React.Children.toArray(children)[0]);
+            const childTarget = Utils.ensureElement(Children.toArray(children)[0]);
 
             if (childTarget === undefined) {
                 return null;
             }
 
-            const clonedTarget: React.JSX.Element = React.cloneElement(childTarget, {
+            const clonedTarget: React.JSX.Element = cloneElement(childTarget, {
                 ...childTargetProps,
                 className: classNames(childTarget.props.className, targetModifierClasses),
                 // force disable single Tooltip child when popover is open
                 disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip) ? true : childTarget.props.disabled,
                 tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
             });
-            const wrappedTarget = React.createElement(
+            const wrappedTarget = createElement(
                 targetTagName!,
                 {
                     ...ownTargetProps,

--- a/packages/core/src/components/popover/popoverArrow.tsx
+++ b/packages/core/src/components/popover/popoverArrow.tsx
@@ -15,7 +15,6 @@
  */
 
 import type { Placement } from "@popperjs/core";
-import * as React from "react";
 import type { PopperArrowProps } from "react-popper";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -15,7 +15,6 @@
  */
 
 import type { Boundary, Modifier, Placement, RootBoundary, StrictModifiers } from "@popperjs/core";
-import type * as React from "react";
 import type { StrictModifier } from "react-popper";
 
 import type { Props } from "../../common";

--- a/packages/core/src/components/popover/tooltipContext.tsx
+++ b/packages/core/src/components/popover/tooltipContext.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { createContext, useEffect, useMemo, useReducer } from "react";
 
 export interface TooltipContextState {
     forceDisabled?: boolean;
@@ -23,7 +23,7 @@ export interface TooltipContextState {
 type TooltipAction = { type: "FORCE_DISABLED_STATE" } | { type: "RESET_DISABLED_STATE" };
 const noOpDispatch: React.Dispatch<TooltipAction> = () => null;
 
-export const TooltipContext = React.createContext<readonly [TooltipContextState, React.Dispatch<TooltipAction>]>([
+export const TooltipContext = createContext<readonly [TooltipContextState, React.Dispatch<TooltipAction>]>([
     {},
     noOpDispatch,
 ]);
@@ -45,10 +45,10 @@ interface TooltipProviderProps {
 }
 
 export const TooltipProvider = ({ children, forceDisable }: TooltipProviderProps) => {
-    const [state, dispatch] = React.useReducer(tooltipContextReducer, {});
-    const contextValue = React.useMemo(() => [state, dispatch] as const, [state, dispatch]);
+    const [state, dispatch] = useReducer(tooltipContextReducer, {});
+    const contextValue = useMemo(() => [state, dispatch] as const, [state, dispatch]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (forceDisable) {
             dispatch({ type: "FORCE_DISABLED_STATE" });
         } else {

--- a/packages/core/src/components/portal/portal.tsx
+++ b/packages/core/src/components/portal/portal.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import { PortalContext } from "../../context/portal/portalProvider";
@@ -60,14 +60,14 @@ export function Portal(
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     { className, stopPropagationEvents, container, onChildrenMount, children }: PortalProps,
 ) {
-    const context = React.useContext(PortalContext);
+    const context = useContext(PortalContext);
 
     const portalContainer =
         container ?? context.portalContainer ?? (typeof document !== "undefined" ? document.body : undefined);
 
-    const [portalElement, setPortalElement] = React.useState<HTMLElement>();
+    const [portalElement, setPortalElement] = useState<HTMLElement>();
 
-    const createPortalElement = React.useCallback(() => {
+    const createPortalElement = useCallback(() => {
         const newPortalElement = document.createElement("div");
         newPortalElement.classList.add(Classes.PORTAL);
         maybeAddClass(newPortalElement.classList, className); // directly added to this portal element
@@ -78,7 +78,7 @@ export function Portal(
     }, [className, context.portalClassName, stopPropagationEvents]);
 
     // create the container element & attach it to the DOM
-    React.useEffect(() => {
+    useEffect(() => {
         if (portalContainer == null) {
             return;
         }
@@ -94,13 +94,13 @@ export function Portal(
     }, [portalContainer, createPortalElement, stopPropagationEvents]);
 
     // wait until next successful render to invoke onChildrenMount callback
-    React.useEffect(() => {
+    useEffect(() => {
         if (portalElement != null) {
             onChildrenMount?.();
         }
     }, [portalElement, onChildrenMount]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (portalElement != null) {
             maybeAddClass(portalElement.classList, className);
             return () => maybeRemoveClass(portalElement.classList, className);
@@ -108,7 +108,7 @@ export function Portal(
         return undefined;
     }, [className, portalElement]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (portalElement != null) {
             addStopPropagationListeners(portalElement, stopPropagationEvents);
             return () => removeStopPropagationListeners(portalElement, stopPropagationEvents);
@@ -122,7 +122,7 @@ export function Portal(
     if (typeof document === "undefined" || portalElement == null) {
         return null;
     } else {
-        return ReactDOM.createPortal(children, portalElement);
+        return createPortal(children, portalElement);
     }
 }
 

--- a/packages/core/src/components/progress-bar/progressBar.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type IntentProps, type Props } from "../../common/props";

--- a/packages/core/src/components/resize-sensor/resizeSensor.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children, cloneElement, createRef } from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX } from "../../common";
 
@@ -70,23 +70,23 @@ export interface ResizeSensorProps {
 export class ResizeSensor extends AbstractPureComponent<ResizeSensorProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.ResizeSensor`;
 
-    private targetRef = this.props.targetRef ?? React.createRef<HTMLElement>();
+    private targetRef = this.props.targetRef ?? createRef<HTMLElement>();
 
     private prevElement: HTMLElement | undefined = undefined;
 
     private observer: ResizeObserver | undefined;
 
     public render(): React.ReactNode {
-        const onlyChild = React.Children.only(this.props.children);
+        const onlyChild = Children.only(this.props.children);
 
         // If we're provided a mutable ref to the child element already, we must re-use that one. This is necessary
-        // in cases where the child node is not a native DOM element and does not use `React.forwardRef`, since
+        // in cases where the child node is not a native DOM element and does not use `forwardRef`, since
         // there's no way for us to know how to attach to the underlying DOM node.
         if (this.props.targetRef !== undefined) {
             return onlyChild;
         }
 
-        return React.cloneElement(onlyChild, { ref: this.targetRef });
+        return cloneElement(onlyChild, { ref: this.targetRef });
     }
 
     public componentDidMount() {

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef, useCallback, useState } from "react";
 
 import { ChevronDown, ChevronUp, type IconName } from "@blueprintjs/icons";
 
@@ -127,7 +127,7 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
  *
  * @see https://blueprintjs.com/docs/#core/components/section
  */
-export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => {
+export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
     const {
         children,
         className,
@@ -146,11 +146,11 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
     const isControlled = collapseProps?.isOpen != null;
 
     // The initial useState value is negated in order to conform to the `isCollapsed` expectation.
-    const [isCollapsedUncontrolled, setIsCollapsed] = React.useState<boolean>(!(collapseProps?.defaultIsOpen ?? true));
+    const [isCollapsedUncontrolled, setIsCollapsed] = useState<boolean>(!(collapseProps?.defaultIsOpen ?? true));
 
     const isCollapsed = isControlled ? !collapseProps?.isOpen : isCollapsedUncontrolled;
 
-    const toggleIsCollapsed = React.useCallback(() => {
+    const toggleIsCollapsed = useCallback(() => {
         if (isControlled) {
             collapseProps?.onToggle?.();
         } else {
@@ -185,7 +185,7 @@ export const Section: React.FC<SectionProps> = React.forwardRef((props, ref) => 
                     <div className={Classes.SECTION_HEADER_LEFT}>
                         {icon && <Icon icon={icon} aria-hidden={true} tabIndex={-1} className={Classes.TEXT_MUTED} />}
                         <div>
-                            {React.createElement(
+                            {createElement(
                                 titleRenderer,
                                 { className: Classes.SECTION_HEADER_TITLE, id: sectionTitleId },
                                 title,

--- a/packages/core/src/components/section/sectionCard.tsx
+++ b/packages/core/src/components/section/sectionCard.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/props";
@@ -34,7 +34,7 @@ export interface SectionCardProps extends Props, HTMLDivProps, React.RefAttribut
  *
  * @see https://blueprintjs.com/docs/#core/components/section.section-card
  */
-export const SectionCard: React.FC<SectionCardProps> = React.forwardRef((props, ref) => {
+export const SectionCard: React.FC<SectionCardProps> = forwardRef((props, ref) => {
     const { className, children, padded = true, ...htmlProps } = props;
     const classes = classNames(Classes.SECTION_CARD, { [Classes.PADDED]: padded }, className);
     return (

--- a/packages/core/src/components/segmented-control/segmentedControl.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef, useCallback, useRef, useState } from "react";
 
 import { Classes, Intent, mergeRefs, Utils } from "../../common";
 import {
@@ -112,7 +112,7 @@ export interface SegmentedControlProps
  *
  * @see https://blueprintjs.com/docs/#core/components/segmented-control
  */
-export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRef((props, ref) => {
+export const SegmentedControl: React.FC<SegmentedControlProps> = forwardRef((props, ref) => {
     const {
         className,
         defaultValue,
@@ -132,12 +132,12 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRe
         ...htmlProps
     } = props;
 
-    const [localValue, setLocalValue] = React.useState<string | undefined>(defaultValue);
+    const [localValue, setLocalValue] = useState<string | undefined>(defaultValue);
     const selectedValue = controlledValue ?? localValue;
 
-    const outerRef = React.useRef<HTMLDivElement>(null);
+    const outerRef = useRef<HTMLDivElement>(null);
 
-    const handleOptionClick = React.useCallback(
+    const handleOptionClick = useCallback(
         (newSelectedValue: string, targetElement: HTMLElement) => {
             setLocalValue(newSelectedValue);
             onValueChange?.(newSelectedValue, targetElement);
@@ -145,7 +145,7 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = React.forwardRe
         [onValueChange],
     );
 
-    const handleKeyDown = React.useCallback(
+    const handleKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLDivElement>) => {
             if (role === "radiogroup" || role === "menu") {
                 // in a `radiogroup`, arrow keys select next item, not tab key.
@@ -252,7 +252,7 @@ function SegmentedControlOption({
     value,
     ...buttonProps
 }: SegmentedControlOptionComponentProps) {
-    const handleClick = React.useCallback(
+    const handleClick = useCallback(
         (event: React.MouseEvent<HTMLElement>) => onClick?.(value, event.currentTarget),
         [onClick, value],
     );

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Classes, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children } from "react";
 
 import {
     AbstractPureComponent,
@@ -242,7 +242,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
         }
 
         let anyInvalidChildren = false;
-        React.Children.forEach(props.children, child => {
+        Children.forEach(props.children, child => {
             // allow boolean coercion to omit nulls and false values
             if (child && !Utils.isElementOfType(child, MultiSliderHandle)) {
                 anyInvalidChildren = true;
@@ -508,7 +508,7 @@ function getSortedInteractiveHandleProps(props: React.PropsWithChildren<MultiSli
 }
 
 function getSortedHandleProps({ children }: MultiSliderProps, predicate: (props: HandleProps) => boolean = () => true) {
-    const maybeHandles = React.Children.map(children, child =>
+    const maybeHandles = Children.map(children, child =>
         Utils.isElementOfType(child, MultiSliderHandle) && predicate(child.props) ? child.props : null,
     );
     let handles = maybeHandles != null ? maybeHandles : [];

--- a/packages/core/src/components/spinner/spinner.tsx
+++ b/packages/core/src/components/spinner/spinner.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import { Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
@@ -104,7 +104,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
     // multiple DOM elements around SVG are necessary to properly isolate animation:
     // - SVG elements in IE do not support anim/trans so they must be set on a parent HTML element.
     // - SPINNER_ANIMATION isolates svg from parent display and is always centered inside root element.
-    return React.createElement(
+    return createElement(
         tagName,
         {
             "aria-label": "loading",
@@ -115,7 +115,7 @@ export const Spinner: React.FC<SpinnerProps> = props => {
             role: "progressbar",
             ...htmlProps,
         },
-        React.createElement(
+        createElement(
             tagName,
             { className: Classes.SPINNER_ANIMATION },
             <svg width={sizePx} height={sizePx} strokeWidth={strokeWidth.toFixed(2)} viewBox={getViewBox(strokeWidth)}>

--- a/packages/core/src/components/tabs/tab.tsx
+++ b/packages/core/src/components/tabs/tab.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import type { IconName } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractPureComponent, Classes, Intent } from "../../common";
 import { DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";

--- a/packages/core/src/components/tabs/tabs.tsx
+++ b/packages/core/src/components/tabs/tabs.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children } from "react";
 
 import { AbstractPureComponent, Classes, DISPLAYNAME_PREFIX, type NonSmallSize, type Props, Utils } from "../../common";
 
@@ -178,7 +178,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
         } = this.props;
         const { indicatorWrapperStyle, selectedTabId } = this.state;
 
-        const tabTitles = React.Children.map(children, this.renderTabTitle);
+        const tabTitles = Children.map(children, this.renderTabTitle);
 
         const tabPanels = this.getTabChildren()
             .filter(renderActiveTabPanelOnly ? tab => tab.props.id === selectedTabId : () => true)
@@ -255,7 +255,7 @@ export class Tabs extends AbstractPureComponent<TabsProps, TabsState> {
 
     /** Filters children to only `<Tab>`s */
     private getTabChildren(props: TabsProps & { children?: React.ReactNode } = this.props) {
-        return React.Children.toArray(props.children).filter(isTabElement);
+        return Children.toArray(props.children).filter(isTabElement);
     }
 
     /** Queries root HTML element for all tabs with optional filter selector */

--- a/packages/core/src/components/tag-input/resizableInput.tsx
+++ b/packages/core/src/components/tag-input/resizableInput.tsx
@@ -2,18 +2,18 @@
  * (c) Copyright 2022 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, type HTMLInputProps } from "../../common";
 
 export type Ref = HTMLInputElement;
 
-export const ResizableInput = React.forwardRef<Ref, HTMLInputProps>(function ResizableInput(props, ref) {
-    const [content, setContent] = React.useState("");
-    const [width, setWidth] = React.useState(0);
-    const span = React.useRef<HTMLSpanElement>(null);
+export const ResizableInput = forwardRef<Ref, HTMLInputProps>(function ResizableInput(props, ref) {
+    const [content, setContent] = useState("");
+    const [width, setWidth] = useState(0);
+    const span = useRef<HTMLSpanElement>(null);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (span.current != null) {
             setWidth(span.current.offsetWidth);
         }

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { type IconName, IconSize } from "@blueprintjs/icons";
 

--- a/packages/core/src/components/tag/compoundTag.tsx
+++ b/packages/core/src/components/tag/compoundTag.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
 import { isReactNodeEmpty } from "../../common/utils";
@@ -52,7 +52,7 @@ export interface CompoundTagProps
  *
  * @see https://blueprintjs.com/docs/#core/components/compound-tag
  */
-export const CompoundTag: React.FC<CompoundTagProps> = React.forwardRef((props, ref) => {
+export const CompoundTag: React.FC<CompoundTagProps> = forwardRef((props, ref) => {
     const {
         active = false,
         children,

--- a/packages/core/src/components/tag/tag.tsx
+++ b/packages/core/src/components/tag/tag.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef } from "react";
 
 import type { IconName } from "@blueprintjs/icons";
 
@@ -89,7 +89,7 @@ export interface TagProps
  *
  * @see https://blueprintjs.com/docs/#core/components/tag
  */
-export const Tag: React.FC<TagProps> = React.forwardRef((props, ref) => {
+export const Tag: React.FC<TagProps> = forwardRef((props, ref) => {
     const {
         children,
         className,

--- a/packages/core/src/components/tag/tagRemoveButton.tsx
+++ b/packages/core/src/components/tag/tagRemoveButton.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { IconSize, SmallCross } from "@blueprintjs/icons";
 
@@ -29,7 +29,7 @@ export const TagRemoveButton = (props: TagRemoveButtonProps) => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { className, large, onRemove, size, tabIndex } = props;
     const isLarge = large || size === "large" || className?.includes(Classes.LARGE);
-    const handleRemoveClick = React.useCallback(
+    const handleRemoveClick = useCallback(
         (e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove?.(e, props as any);
         },

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef, useMemo, useRef, useState } from "react";
 
 import { Classes, mergeRefs } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
@@ -53,12 +53,12 @@ export interface TextProps
  *
  * @see https://blueprintjs.com/docs/#core/components/text
  */
-export const Text: React.FC<TextProps> = React.forwardRef<HTMLElement, TextProps>(
+export const Text: React.FC<TextProps> = forwardRef<HTMLElement, TextProps>(
     ({ children, tagName = "div", title, className, ellipsize = false, ...htmlProps }, forwardedRef) => {
-        const contentMeasuringRef = React.useRef<HTMLElement>();
-        const textRef = React.useMemo(() => mergeRefs(contentMeasuringRef, forwardedRef), [forwardedRef]);
-        const [textContent, setTextContent] = React.useState<string>("");
-        const [isContentOverflowing, setIsContentOverflowing] = React.useState<boolean>();
+        const contentMeasuringRef = useRef<HTMLElement>();
+        const textRef = useMemo(() => mergeRefs(contentMeasuringRef, forwardedRef), [forwardedRef]);
+        const [textContent, setTextContent] = useState<string>("");
+        const [isContentOverflowing, setIsContentOverflowing] = useState<boolean>();
 
         // try to be conservative about running this effect, since querying scrollWidth causes the browser to reflow / recalculate styles,
         // which can be very expensive for long lists (for example, in long Menus)
@@ -71,7 +71,7 @@ export const Text: React.FC<TextProps> = React.forwardRef<HTMLElement, TextProps
             }
         }, [contentMeasuringRef, children, ellipsize]);
 
-        return React.createElement(
+        return createElement(
             tagName,
             {
                 ...htmlProps,

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -15,8 +15,8 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
-import * as ReactDOMClient from "react-dom/client";
+import { createRef } from "react";
+import { createRoot } from "react-dom/client";
 
 import { AbstractPureComponent, Classes, Position } from "../../common";
 import { TOASTER_CREATE_NULL, TOASTER_MAX_TOASTS_INVALID, TOASTER_WARN_INLINE } from "../../common/errors";
@@ -56,7 +56,7 @@ export type OverlayToasterDOMRenderer = (
 ) => void;
 
 const defaultDomRenderer: OverlayToasterDOMRenderer = (element, container) => {
-    ReactDOMClient.createRoot(container).render(element);
+    createRoot(container).render(element);
 };
 
 interface OverlayToasterQueueState {
@@ -155,7 +155,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
     /** Compute a new collection of toast refs (usually after updating toasts) */
     private getToastRefs = (toasts: ToastOptions[]) => {
         return toasts.reduce<typeof this.toastRefs>((refs, toast) => {
-            refs[toast.key!] = React.createRef<HTMLElement>();
+            refs[toast.key!] = createRef<HTMLElement>();
             return refs;
         }, {});
     };

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef, useCallback, useEffect, useState } from "react";
 
 import { Cross } from "@blueprintjs/icons";
 
@@ -33,12 +33,12 @@ import type { ToastProps } from "./toastProps";
  *
  * @see https://blueprintjs.com/docs/#core/components/toast
  */
-export const Toast = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
+export const Toast = forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
     const { action, className, icon, intent, isCloseButtonShown = true, message, onDismiss, timeout = 5000 } = props;
 
-    const [isTimeoutStarted, setIsTimeoutStarted] = React.useState(false);
-    const startTimeout = React.useCallback(() => setIsTimeoutStarted(true), []);
-    const clearTimeout = React.useCallback(() => setIsTimeoutStarted(false), []);
+    const [isTimeoutStarted, setIsTimeoutStarted] = useState(false);
+    const startTimeout = useCallback(() => setIsTimeoutStarted(true), []);
+    const clearTimeout = useCallback(() => setIsTimeoutStarted(false), []);
 
     // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
     const isTimeoutEnabled = timeout != null && timeout > 0;
@@ -52,7 +52,7 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) =
     );
 
     // start timeout on mount or change, cancel on unmount
-    React.useEffect(() => {
+    useEffect(() => {
         if (isTimeoutEnabled) {
             startTimeout();
         } else {
@@ -61,7 +61,7 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) =
         return clearTimeout;
     }, [clearTimeout, startTimeout, isTimeoutEnabled, timeout]);
 
-    const triggerDismiss = React.useCallback(
+    const triggerDismiss = useCallback(
         (didTimeoutExpire: boolean) => {
             clearTimeout();
             onDismiss?.(didTimeoutExpire);
@@ -69,9 +69,9 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>((props, ref) =
         [clearTimeout, onDismiss],
     );
 
-    const handleCloseClick = React.useCallback(() => triggerDismiss(false), [triggerDismiss]);
+    const handleCloseClick = useCallback(() => triggerDismiss(false), [triggerDismiss]);
 
-    const handleActionClick = React.useCallback(
+    const handleActionClick = useCallback(
         (e: React.MouseEvent<HTMLElement>) => {
             action?.onClick?.(e);
             triggerDismiss(false);

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createRef } from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
@@ -98,7 +98,7 @@ export class Tooltip<
         transitionDuration: 100,
     };
 
-    private popoverRef = React.createRef<Popover<T>>();
+    private popoverRef = createRef<Popover<T>>();
 
     public render() {
         // if we have an ancestor TooltipContext, we should take its state into account in this render path,

--- a/packages/core/src/components/tree/tree.tsx
+++ b/packages/core/src/components/tree/tree.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 
@@ -78,7 +78,7 @@ export interface TreeProps<T = {}> extends Props {
  * @see https://blueprintjs.com/docs/#core/components/tree
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export class Tree<T = {}> extends React.Component<TreeProps<T>> {
+export class Tree<T = {}> extends Component<TreeProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Tree`;
 
     public static ofType<U>() {

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children, Component } from "react";
 
 import { ChevronRight } from "@blueprintjs/icons";
 
@@ -47,7 +47,7 @@ export interface TreeNodeProps<T = {}> extends TreeNodeInfo<T> {
  * @see https://blueprintjs.com/docs/#core/components/tree.tree-node
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export class TreeNode<T = {}> extends React.Component<TreeNodeProps<T>> {
+export class TreeNode<T = {}> extends Component<TreeNodeProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TreeNode`;
 
     /** @deprecated no longer necessary now that the TypeScript parser supports type arguments on JSX element tags */
@@ -97,7 +97,7 @@ export class TreeNode<T = {}> extends React.Component<TreeNodeProps<T>> {
     }
 
     private maybeRenderCaret() {
-        const { children, isExpanded, disabled, hasCaret = React.Children.count(children) > 0 } = this.props;
+        const { children, isExpanded, disabled, hasCaret = Children.count(children) > 0 } = this.props;
         if (hasCaret) {
             const caretClasses = classNames(
                 Classes.TREE_NODE_CARET,

--- a/packages/core/src/context/hotkeys/hotkeysProvider.tsx
+++ b/packages/core/src/context/hotkeys/hotkeysProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { createContext, useCallback, useMemo, useReducer } from "react";
 
 import { shallowCompareKeys } from "../../common/utils";
 import { HotkeysDialog, type HotkeysDialogProps } from "../../components/hotkeys/hotkeysDialog";
@@ -54,7 +54,7 @@ const noOpDispatch: React.Dispatch<HotkeysAction> = () => null;
  *
  * For more information, see the [HotkeysProvider documentation](https://blueprintjs.com/docs/#core/context/hotkeys-provider).
  */
-export const HotkeysContext = React.createContext<HotkeysContextInstance>([initialHotkeysState, noOpDispatch]);
+export const HotkeysContext = createContext<HotkeysContextInstance>([initialHotkeysState, noOpDispatch]);
 
 const hotkeysReducer = (state: HotkeysContextState, action: HotkeysAction) => {
     switch (action.type) {
@@ -111,11 +111,11 @@ export const HotkeysProvider = ({
     value,
 }: React.PropsWithChildren<HotkeysProviderProps>) => {
     const hasExistingContext = value != null;
-    const fallbackReducer = React.useReducer(hotkeysReducer, { ...initialHotkeysState, hasProvider: true });
+    const fallbackReducer = useReducer(hotkeysReducer, { ...initialHotkeysState, hasProvider: true });
     const [state, dispatch] = value ?? fallbackReducer;
     // The `useState` array isn't stable between renders -- so memo it outselves
-    const contextValue = React.useMemo(() => [state, dispatch] as const, [state, dispatch]);
-    const handleDialogClose = React.useCallback(() => dispatch({ type: "CLOSE_DIALOG" }), [dispatch]);
+    const contextValue = useMemo(() => [state, dispatch] as const, [state, dispatch]);
+    const handleDialogClose = useCallback(() => dispatch({ type: "CLOSE_DIALOG" }), [dispatch]);
 
     const dialog = renderDialog?.(state, { handleDialogClose }) ?? (
         <HotkeysDialog

--- a/packages/core/src/context/overlays/overlaysProvider.tsx
+++ b/packages/core/src/context/overlays/overlaysProvider.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { createContext, useMemo, useRef } from "react";
 
 import type { OverlayInstance } from "../../components/overlay2/overlayInstance";
 
 // N.B. using a mutable ref for the stack is much easier to work with in the world of hooks and FCs.
 // This matches the mutable global behavior of the old Overlay implementation in Blueprint v5. An alternative
 // approach was considered with an immutable array data structure and a reducer, but that implementation
-// caused lots of unnecessary invalidation of `React.useCallback()` for document-level event handlers, which
+// caused lots of unnecessary invalidation of `useCallback()` for document-level event handlers, which
 // led to memory leaks and bugs.
 export interface OverlaysContextState {
     /**
@@ -50,7 +50,7 @@ export interface OverlaysContextState {
  *
  * For more information, see the [OverlaysProvider documentation](https://blueprintjs.com/docs/#core/context/overlays-provider).
  */
-export const OverlaysContext = React.createContext<OverlaysContextState>({
+export const OverlaysContext = createContext<OverlaysContextState>({
     hasProvider: false,
     stack: { current: [] },
 });
@@ -66,7 +66,7 @@ export interface OverlaysProviderProps {
  * @see https://blueprintjs.com/docs/#core/context/overlays-provider
  */
 export const OverlaysProvider = ({ children }: OverlaysProviderProps) => {
-    const stack = React.useRef<OverlayInstance[]>([]);
-    const contextValue = React.useMemo(() => ({ hasProvider: true, stack }), [stack]);
+    const stack = useRef<OverlayInstance[]>([]);
+    const contextValue = useMemo(() => ({ hasProvider: true, stack }), [stack]);
     return <OverlaysContext.Provider value={contextValue}>{children}</OverlaysContext.Provider>;
 };

--- a/packages/core/src/context/portal/portalProvider.tsx
+++ b/packages/core/src/context/portal/portalProvider.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { createContext, useMemo } from "react";
 
 export interface PortalContextOptions {
     /** Additional CSS classes to add to all `Portal` elements in this React context. */
@@ -27,7 +27,7 @@ export interface PortalContextOptions {
  * A React context to set options for all portals in a given subtree.
  * Do not use this PortalContext directly, instead use PortalProvider to set the options.
  */
-export const PortalContext = React.createContext<PortalContextOptions>({});
+export const PortalContext = createContext<PortalContextOptions>({});
 
 /**
  * Portal context provider.
@@ -39,7 +39,7 @@ export const PortalProvider = ({
     portalClassName,
     portalContainer,
 }: React.PropsWithChildren<PortalContextOptions>) => {
-    const contextOptions = React.useMemo<PortalContextOptions>(
+    const contextOptions = useMemo<PortalContextOptions>(
         () => ({
             portalClassName,
             portalContainer,

--- a/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useLegacyOverlayStack.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import { useCallback } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 import { Classes } from "../../common";
@@ -61,9 +61,9 @@ export function useLegacyOverlayStack(): UseOverlayStackReturnValue {
         legacyGlobalOverlayStackStore.getSnapshot,
     );
 
-    const getLastOpened = React.useCallback(() => stack[stack.length - 1], [stack]);
+    const getLastOpened = useCallback(() => stack[stack.length - 1], [stack]);
 
-    const getThisOverlayAndDescendants = React.useCallback(
+    const getThisOverlayAndDescendants = useCallback(
         (id: string) => {
             const stackIndex = stack.findIndex(o => o.id === id);
             return stack.slice(stackIndex);
@@ -71,11 +71,11 @@ export function useLegacyOverlayStack(): UseOverlayStackReturnValue {
         [stack],
     );
 
-    const resetStack = React.useCallback(() => {
+    const resetStack = useCallback(() => {
         modifyGlobalStack(s => s.splice(0, s.length));
     }, []);
 
-    const openOverlay = React.useCallback((overlay: OverlayInstance) => {
+    const openOverlay = useCallback((overlay: OverlayInstance) => {
         globalStack.push(overlay);
         if (overlay.props.usePortal && overlay.props.hasBackdrop) {
             // add a class to the body to prevent scrolling of content below the overlay
@@ -83,7 +83,7 @@ export function useLegacyOverlayStack(): UseOverlayStackReturnValue {
         }
     }, []);
 
-    const closeOverlay = React.useCallback(
+    const closeOverlay = useCallback(
         (id: string) => {
             const otherOverlaysWithBackdrop = stack.filter(
                 o => o.props.usePortal && o.props.hasBackdrop && o.id !== id,

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React from "react";
+import { useContext, useCallback } from "react";
 
 import { Classes } from "../../common";
 import { OVERLAY2_REQUIRES_OVERLAY_PROVDER } from "../../common/errors";
@@ -66,14 +66,14 @@ export interface UseOverlayStackReturnValue {
  */
 export function useOverlayStack(): UseOverlayStackReturnValue {
     // get the overlay stack from application-wide React context
-    const { stack, hasProvider } = React.useContext(OverlaysContext);
+    const { stack, hasProvider } = useContext(OverlaysContext);
     const legacyOverlayStack = useLegacyOverlayStack();
 
-    const getLastOpened = React.useCallback(() => {
+    const getLastOpened = useCallback(() => {
         return stack.current[stack.current.length - 1];
     }, [stack]);
 
-    const getThisOverlayAndDescendants = React.useCallback(
+    const getThisOverlayAndDescendants = useCallback(
         (id: string) => {
             const index = stack.current.findIndex(o => o.id === id);
             if (index === -1) {
@@ -84,11 +84,11 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
         [stack],
     );
 
-    const resetStack = React.useCallback(() => {
+    const resetStack = useCallback(() => {
         stack.current = [];
     }, [stack]);
 
-    const openOverlay = React.useCallback(
+    const openOverlay = useCallback(
         (overlay: OverlayInstance) => {
             stack.current.push(overlay);
             if (overlay.props.usePortal && overlay.props.hasBackdrop) {
@@ -99,7 +99,7 @@ export function useOverlayStack(): UseOverlayStackReturnValue {
         [stack],
     );
 
-    const closeOverlay = React.useCallback(
+    const closeOverlay = useCallback(
         (id: string) => {
             const otherOverlaysWithBackdrop = stack.current.filter(
                 o => o.props.usePortal && o.props.hasBackdrop && o.id !== id,

--- a/packages/core/src/hooks/overlays/useOverlayStack.ts
+++ b/packages/core/src/hooks/overlays/useOverlayStack.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useContext, useCallback } from "react";
+import { useCallback, useContext } from "react";
 
 import { Classes } from "../../common";
 import { OVERLAY2_REQUIRES_OVERLAY_PROVDER } from "../../common/errors";

--- a/packages/core/src/hooks/useAsyncControllableValue.ts
+++ b/packages/core/src/hooks/useAsyncControllableValue.ts
@@ -2,7 +2,7 @@
  * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { useCallback, useRef, useState } from "react";
 
 interface UseAsyncControllableValueProps<E extends HTMLInputElement | HTMLTextAreaElement> {
     value?: React.InputHTMLAttributes<E>["value"];
@@ -31,20 +31,20 @@ export function useAsyncControllableValue<E extends HTMLInputElement | HTMLTextA
 
     // The source of truth for the input value. This is not updated during IME composition.
     // It may be updated by a parent component.
-    const [value, setValue] = React.useState(propValue);
+    const [value, setValue] = useState(propValue);
 
     // The latest input value, which updates during IME composition.
-    const [nextValue, setNextValue] = React.useState(propValue);
+    const [nextValue, setNextValue] = useState(propValue);
 
     // Whether we are in the middle of a composition event.
-    const [isComposing, setIsComposing] = React.useState(false);
+    const [isComposing, setIsComposing] = useState(false);
 
     // Whether there is a pending update we are expecting from a parent component.
-    const [hasPendingUpdate, setHasPendingUpdate] = React.useState(false);
+    const [hasPendingUpdate, setHasPendingUpdate] = useState(false);
 
-    const cancelPendingCompositionEnd = React.useRef<() => void>();
+    const cancelPendingCompositionEnd = useRef<() => void>();
 
-    const handleCompositionStart: React.CompositionEventHandler<E> = React.useCallback(
+    const handleCompositionStart: React.CompositionEventHandler<E> = useCallback(
         event => {
             cancelPendingCompositionEnd.current?.();
             setIsComposing(true);
@@ -55,7 +55,7 @@ export function useAsyncControllableValue<E extends HTMLInputElement | HTMLTextA
 
     // creates a timeout which will set `isComposing` to false after a delay
     // returns a function which will cancel the timeout if called before it fires
-    const createOnCancelPendingCompositionEnd = React.useCallback(() => {
+    const createOnCancelPendingCompositionEnd = useCallback(() => {
         const timeoutId = window.setTimeout(
             () => setIsComposing(false),
             ASYNC_CONTROLLABLE_VALUE_COMPOSITION_END_DELAY,
@@ -63,7 +63,7 @@ export function useAsyncControllableValue<E extends HTMLInputElement | HTMLTextA
         return () => window.clearTimeout(timeoutId);
     }, []);
 
-    const handleCompositionEnd: React.CompositionEventHandler<E> = React.useCallback(
+    const handleCompositionEnd: React.CompositionEventHandler<E> = useCallback(
         event => {
             // In some non-latin languages, a keystroke can end a composition event and immediately afterwards start another.
             // This can lead to unexpected characters showing up in the text input. In order to circumvent this problem, we
@@ -76,7 +76,7 @@ export function useAsyncControllableValue<E extends HTMLInputElement | HTMLTextA
         [createOnCancelPendingCompositionEnd, onCompositionEnd],
     );
 
-    const handleChange: React.ChangeEventHandler<E> = React.useCallback(
+    const handleChange: React.ChangeEventHandler<E> = useCallback(
         event => {
             const { value: targetValue } = event.target;
             setNextValue(targetValue);

--- a/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useLayoutEffect, useEffect } from "react";
 
 import { hasDOMEnvironment } from "../common/utils/domUtils";
 
 /**
  * @returns the appropriate React layout effect hook for the current environment (server or client).
  */
-export const useIsomorphicLayoutEffect = hasDOMEnvironment() ? React.useLayoutEffect : React.useEffect;
+export const useIsomorphicLayoutEffect = hasDOMEnvironment() ? useLayoutEffect : useEffect;

--- a/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/packages/core/src/hooks/useIsomorphicLayoutEffect.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useLayoutEffect, useEffect } from "react";
+import { useEffect, useLayoutEffect } from "react";
 
 import { hasDOMEnvironment } from "../common/utils/domUtils";
 

--- a/packages/core/src/hooks/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef, useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 /** React hook which tracks the previous state of a given value. */
 export function usePrevious<T>(value: T) {

--- a/packages/core/src/hooks/usePrevious.ts
+++ b/packages/core/src/hooks/usePrevious.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useRef, useEffect } from "react";
 
 /** React hook which tracks the previous state of a given value. */
 export function usePrevious<T>(value: T) {
     // create a new reference
-    const ref = React.useRef<T>();
+    const ref = useRef<T>();
 
     // store current value in ref
-    React.useEffect(() => {
+    useEffect(() => {
         ref.current = value;
     }, [value]);
 

--- a/packages/core/src/hooks/useTimeout.ts
+++ b/packages/core/src/hooks/useTimeout.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef, useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 

--- a/packages/core/src/hooks/useTimeout.ts
+++ b/packages/core/src/hooks/useTimeout.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useRef, useEffect } from "react";
 
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
 
@@ -26,7 +26,7 @@ import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
  * @see https://usehooks-ts.com/react-hook/use-timeout
  */
 export function useTimeout(callback: () => void, delay: number | null) {
-    const savedCallback = React.useRef(callback);
+    const savedCallback = useRef(callback);
 
     // remember the latest callback if it changes
     useIsomorphicLayoutEffect(() => {
@@ -34,7 +34,7 @@ export function useTimeout(callback: () => void, delay: number | null) {
     }, [callback]);
 
     // set up the timeout
-    React.useEffect(() => {
+    useEffect(() => {
         // Don't schedule if no delay is specified.
         // Note: 0 is a valid value for delay.
         if (!delay && delay !== 0) {

--- a/packages/core/src/hooks/useValidateProps.ts
+++ b/packages/core/src/hooks/useValidateProps.ts
@@ -2,7 +2,7 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { type DependencyList, useEffect } from "react";
 
 import { isNodeEnv } from "../common/utils";
 
@@ -19,8 +19,8 @@ import { isNodeEnv } from "../common/utils";
  *     if (value < 0) console.warn("Value must be positive");
  * }, [value]);
  */
-export function useValidateProps(validator: () => void, dependencies: React.DependencyList = []) {
-    React.useEffect(() => {
+export function useValidateProps(validator: () => void, dependencies: DependencyList = []) {
+    useEffect(() => {
         if (!isNodeEnv("production")) {
             validator();
         }

--- a/packages/core/test/buttons/buttonTests.tsx
+++ b/packages/core/test/buttons/buttonTests.tsx
@@ -17,7 +17,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { IconNames } from "@blueprintjs/icons";
@@ -28,7 +28,7 @@ describe("<Button>", () => {
     commonTests(Button);
 
     it("should attach ref", () => {
-        const ref = React.createRef<HTMLButtonElement>();
+        const ref = createRef<HTMLButtonElement>();
         render(<Button ref={ref} />);
 
         expect(ref.current).to.exist;
@@ -40,7 +40,7 @@ describe("<AnchorButton>", () => {
     commonTests(AnchorButton);
 
     it("should attach ref", () => {
-        const ref = React.createRef<HTMLAnchorElement>();
+        const ref = createRef<HTMLAnchorElement>();
         render(<AnchorButton ref={ref} />);
 
         expect(ref.current).to.exist;

--- a/packages/core/test/card-list/cardListTests.tsx
+++ b/packages/core/test/card-list/cardListTests.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
+import { createRef } from "react";
 
 import { Card, CardList, Classes } from "../../src";
 import { hasClass } from "../utils";
@@ -44,7 +44,7 @@ describe("<CardList>", () => {
     });
 
     it("should support ref prop", () => {
-        const elementRef = React.createRef<HTMLDivElement>();
+        const elementRef = createRef<HTMLDivElement>();
         render(<CardList ref={elementRef}>Test</CardList>);
 
         expect(elementRef.current).to.exist;

--- a/packages/core/test/card/cardTests.tsx
+++ b/packages/core/test/card/cardTests.tsx
@@ -17,7 +17,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
+import { createRef } from "react";
 import sinon from "sinon";
 
 import { Card, Classes, H4 } from "../../src";
@@ -72,7 +72,7 @@ describe("<Card>", () => {
     });
 
     it("should support ref prop", () => {
-        const elementRef = React.createRef<HTMLDivElement>();
+        const elementRef = createRef<HTMLDivElement>();
         render(<Card ref={elementRef}>Test</Card>);
 
         expect(elementRef.current).to.exist;

--- a/packages/core/test/common/utilsTests.tsx
+++ b/packages/core/test/common/utilsTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import * as React from "react";
+import { Fragment } from "react/jsx-runtime";
 import { type SinonSpy, spy } from "sinon";
 
 import * as Utils from "../../src/common/utils";
@@ -123,7 +123,7 @@ describe("Utils", () => {
         });
 
         // React 16 only
-        if (React.Fragment !== undefined) {
+        if (Fragment !== undefined) {
             it("wraps JSX fragments in element", () => {
                 const el = Utils.ensureElement(
                     <>

--- a/packages/core/test/context-menu/contextMenuTests.tsx
+++ b/packages/core/test/context-menu/contextMenuTests.tsx
@@ -17,7 +17,7 @@
 import { assert } from "chai";
 import classNames from "classnames";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { createRef, useCallback } from "react";
 import { spy } from "sinon";
 
 import {
@@ -83,7 +83,7 @@ describe("ContextMenu", () => {
         });
 
         it("supports custom refs", () => {
-            const ref = React.createRef<HTMLElement>();
+            const ref = createRef<HTMLElement>();
             mountTestMenu({ className: "test-container", ref });
             assert.isDefined(ref.current);
             assert.isTrue(ref.current?.classList.contains("test-container"));
@@ -263,7 +263,7 @@ describe("ContextMenu", () => {
         }
 
         function TestMenuWithChangingContent({ useAltContent } = { useAltContent: false }) {
-            const content = React.useCallback(
+            const content = useCallback(
                 (contentProps: ContextMenuContentProps) =>
                     useAltContent ? renderAlternativeContent() : renderContent(contentProps),
                 [useAltContent],

--- a/packages/core/test/controls/inputGroupTests.tsx
+++ b/packages/core/test/controls/inputGroupTests.tsx
@@ -17,7 +17,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { expect } from "chai";
-import * as React from "react";
+import { createRef, useState } from "react";
 import { spy } from "sinon";
 
 import { Classes, InputGroup } from "../../src";
@@ -86,7 +86,7 @@ describe("<InputGroup>", () => {
     });
 
     it("should support inputRef", () => {
-        const inputRef = React.createRef<HTMLInputElement>();
+        const inputRef = createRef<HTMLInputElement>();
         render(<InputGroup inputRef={inputRef} />);
 
         expect(inputRef.current).to.be.instanceOf(HTMLInputElement);
@@ -97,7 +97,7 @@ describe("<InputGroup>", () => {
     it("should accept controlled update truncating input value", () => {
         function TestComponent(props: { initialValue: string; transformInput: (value: string) => string }) {
             const { initialValue, transformInput } = props;
-            const [value, setValue] = React.useState(initialValue);
+            const [value, setValue] = useState(initialValue);
 
             const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
                 setValue(transformInput(event.target.value));

--- a/packages/core/test/controls/numericInputTests.tsx
+++ b/packages/core/test/controls/numericInputTests.tsx
@@ -21,7 +21,7 @@ import {
     mount as untypedMount,
     shallow as untypedShallow,
 } from "enzyme";
-import * as React from "react";
+import { act, PureComponent } from "react";
 import { type SinonStub, spy, stub } from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
@@ -1099,7 +1099,7 @@ describe("<NumericInput>", () => {
             incrementButton.simulate("mousedown", { shiftKey: true });
             expect(component.find("input").prop("value")).to.equal("1.101");
 
-            React.act(() => {
+            act(() => {
                 // one significant digit too many
                 setNextValue(component, "1.0001");
             });
@@ -1366,7 +1366,7 @@ describe("<NumericInput>", () => {
                 minorStepSize: null,
             });
 
-            React.act(() => {
+            act(() => {
                 setNextValue(component, "3e2"); // i.e. 300
             });
 
@@ -1425,7 +1425,7 @@ describe("<NumericInput>", () => {
 /**
  * Wraps NumericInput to make it behave like a controlled component, treating props.value as a default value
  */
-class ControlledNumericInput extends React.PureComponent<NumericInputProps, { value?: string }> {
+class ControlledNumericInput extends PureComponent<NumericInputProps, { value?: string }> {
     public state = {
         // treat value as "defaultValue"
         value: this.props.value?.toString(),

--- a/packages/core/test/dialog/dialogTests.tsx
+++ b/packages/core/test/dialog/dialogTests.tsx
@@ -17,7 +17,7 @@
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { Button, Classes, Dialog, DialogBody, DialogFooter, type DialogProps } from "../../src";
@@ -187,7 +187,7 @@ describe("<Dialog>", () => {
         });
 
         it("supports ref objects attached to container", async () => {
-            const containerRef = React.createRef<HTMLDivElement>();
+            const containerRef = createRef<HTMLDivElement>();
             mountDialog({ containerRef });
 
             // wait for the whole lifecycle to run

--- a/packages/core/test/drawer/drawerTests.tsx
+++ b/packages/core/test/drawer/drawerTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import { spy } from "sinon";
 
 import { Button, Classes, Drawer, type DrawerProps, Position } from "../../src";

--- a/packages/core/test/editable-text/editableTextTests.tsx
+++ b/packages/core/test/editable-text/editableTextTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import { spy } from "sinon";
 
 import { EditableText } from "../../src";
@@ -228,11 +228,11 @@ describe("<EditableText>", () => {
             const confirmSpy = spy();
             const wrapper = mount(<EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} />);
             simulateHelper(wrapper, "control", { ctrlKey: true, key: "Enter" });
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ isEditing: true });
             });
             simulateHelper(wrapper, "meta", { key: "Enter", metaKey: true });
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ isEditing: true });
             });
             simulateHelper(wrapper, "shift", {
@@ -240,7 +240,7 @@ describe("<EditableText>", () => {
                 preventDefault: (): void => undefined,
                 shiftKey: true,
             });
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ isEditing: true });
             });
             simulateHelper(wrapper, "alt", {

--- a/packages/core/test/forms/asyncControllableInputTests.tsx
+++ b/packages/core/test/forms/asyncControllableInputTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { PureComponent } from "react";
 import { spy } from "sinon";
 
 // this component is not part of the public API, but we want to test its implementation in isolation
@@ -148,7 +148,7 @@ describe("asyncControllable tests", () => {
                 });
 
                 it("accepts async controlled update, optimistically rendering new value while waiting for update", async () => {
-                    class TestComponent extends React.PureComponent<{ initialValue: string }, { value: string }> {
+                    class TestComponent extends PureComponent<{ initialValue: string }, { value: string }> {
                         public state = { value: this.props.initialValue };
 
                         public render() {

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 
 import { TextArea } from "../../src";
 
@@ -130,8 +130,8 @@ describe("<TextArea>", () => {
     });
 
     it("accepts object refs created with React.createRef and updates on change", () => {
-        const textAreaRef = React.createRef<HTMLTextAreaElement>();
-        const textAreaNewRef = React.createRef<HTMLTextAreaElement>();
+        const textAreaRef = createRef<HTMLTextAreaElement>();
+        const textAreaNewRef = createRef<HTMLTextAreaElement>();
 
         const textAreawrapper = mount(<TextArea inputRef={textAreaRef} />, { attachTo: containerElement });
         assert.instanceOf(textAreaRef.current, HTMLTextAreaElement);

--- a/packages/core/test/forms/textAreaTests.tsx
+++ b/packages/core/test/forms/textAreaTests.tsx
@@ -129,7 +129,7 @@ describe("<TextArea>", () => {
         assert.instanceOf(textAreaNew, HTMLTextAreaElement);
     });
 
-    it("accepts object refs created with React.createRef and updates on change", () => {
+    it("accepts object refs created with createRef and updates on change", () => {
         const textAreaRef = createRef<HTMLTextAreaElement>();
         const textAreaNewRef = createRef<HTMLTextAreaElement>();
 

--- a/packages/core/test/hooks/useHotkeysTests.tsx
+++ b/packages/core/test/hooks/useHotkeysTests.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
+import { useMemo } from "react";
 import { type SinonStub, spy, stub } from "sinon";
 
 // N.B. { fireEvent } from "@testing-library/react" does not generate "real" enough events which
@@ -38,7 +38,7 @@ interface TestComponentContainerProps {
 }
 
 const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputReadOnly, onKeyA, onKeyB }) => {
-    const hotkeys = React.useMemo(() => {
+    const hotkeys = useMemo(() => {
         const keys = [
             {
                 combo: "A",

--- a/packages/core/test/hooks/useOverlayStackTests.tsx
+++ b/packages/core/test/hooks/useOverlayStackTests.tsx
@@ -16,7 +16,7 @@
 
 import { render } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
+import { createRef, useEffect, useId, useMemo } from "react";
 import { spy } from "sinon";
 
 import type { OverlayProps } from "../../src/components/overlay/overlayProps";
@@ -42,8 +42,8 @@ const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
 }) => {
     const { openOverlay, getLastOpened, closeOverlay } = useOverlayStack();
 
-    const id = React.useId();
-    const instance = React.useMemo<OverlayInstance>(
+    const id = useId();
+    const instance = useMemo<OverlayInstance>(
         () => ({
             containerElement,
             id,
@@ -58,7 +58,7 @@ const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
     );
 
     const prevIsOpen = usePrevious(isOpen) ?? false;
-    React.useEffect(() => {
+    useEffect(() => {
         if (!prevIsOpen && isOpen) {
             // just opened
             openOverlay(instance);
@@ -71,7 +71,7 @@ const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
     }, [isOpen, openOverlay, closeOverlay, prevIsOpen, instance, id]);
 
     // run once on unmount
-    React.useEffect(() => {
+    useEffect(() => {
         return () => {
             if (isOpen) {
                 closeOverlay(id);
@@ -82,7 +82,7 @@ const TestComponentWithoutProvider: React.FC<TestComponentProps> = ({
 
     const lastOpened = getLastOpened();
     const prevLastOpened = usePrevious(lastOpened);
-    React.useEffect(() => {
+    useEffect(() => {
         if (prevLastOpened !== lastOpened) {
             handleLastOpenedChange?.(lastOpened);
         }
@@ -101,7 +101,7 @@ const TestComponentWithProvider: React.FC<TestComponentProps> = props => {
 
 describe("useOverlayStack()", () => {
     const handleLastOpenedChange = spy();
-    const containerRef = React.createRef<HTMLDivElement>();
+    const containerRef = createRef<HTMLDivElement>();
     const TEST_PROPS_CLOSED: TestComponentProps = {
         autoFocus: true,
         containerRef,

--- a/packages/core/test/hooks/useValidatePropsTests.tsx
+++ b/packages/core/test/hooks/useValidatePropsTests.tsx
@@ -4,7 +4,6 @@
 
 import { render } from "@testing-library/react";
 import { expect } from "chai";
-import * as React from "react";
 import * as sinon from "sinon";
 
 import { useValidateProps } from "../../src/hooks/useValidateProps";

--- a/packages/core/test/icon/iconTests.tsx
+++ b/packages/core/test/icon/iconTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import { type SinonStub, stub } from "sinon";
 
 import { type IconName, Icons, IconSize } from "@blueprintjs/icons";

--- a/packages/core/test/isotest.mjs
+++ b/packages/core/test/isotest.mjs
@@ -16,13 +16,14 @@
 // @ts-check
 
 import "@blueprintjs/test-commons/bootstrap";
-import React from "react";
+
+import { createElement } from "react";
 
 import { generateIsomorphicTests } from "@blueprintjs/test-commons";
 
 import Core from "../lib/cjs/index.js";
 
-const requiredChild = React.createElement("button");
+const requiredChild = createElement("button");
 const EXAMPLE_HOTKEY_CONFIG = { combo: "mod+s", global: true, label: "save" };
 
 describe("@blueprintjs/core isomorphic rendering", () => {
@@ -39,7 +40,7 @@ describe("@blueprintjs/core isomorphic rendering", () => {
                 props: { items: [] },
             },
             ContextMenu: {
-                props: { children: React.createElement("div"), content: React.createElement("div") },
+                props: { children: createElement("div"), content: createElement("div") },
             },
             Dialog: {
                 props: { isOpen: true, lazy: false, usePortal: false },
@@ -51,7 +52,7 @@ describe("@blueprintjs/core isomorphic rendering", () => {
                 props: EXAMPLE_HOTKEY_CONFIG,
             },
             Hotkeys: {
-                children: React.createElement(Core.Hotkey, EXAMPLE_HOTKEY_CONFIG),
+                children: createElement(Core.Hotkey, EXAMPLE_HOTKEY_CONFIG),
             },
             HotkeysDialog2: {
                 props: {
@@ -82,11 +83,11 @@ describe("@blueprintjs/core isomorphic rendering", () => {
             },
             MultistepDialog: {
                 props: { isOpen: true, lazy: false, usePortal: false },
-                children: React.createElement(Core.DialogStep, {
+                children: createElement(Core.DialogStep, {
                     key: 1,
                     id: 1,
                     title: "Step one",
-                    panel: React.createElement("div"),
+                    panel: createElement("div"),
                 }),
             },
             KeyComboTag: {
@@ -106,7 +107,7 @@ describe("@blueprintjs/core isomorphic rendering", () => {
             },
             OverlayToaster: {
                 props: { usePortal: false },
-                children: React.createElement(Core.Toast, { message: "Toast" }),
+                children: createElement(Core.Toast, { message: "Toast" }),
             },
             PanelStack: {
                 props: {
@@ -131,7 +132,7 @@ describe("@blueprintjs/core isomorphic rendering", () => {
                 className: false,
             },
             Tabs: {
-                children: React.createElement(Core.Tab, { key: 1, id: 1, title: "Tab one" }),
+                children: createElement(Core.Tab, { key: 1, id: 1, title: "Tab one" }),
             },
             TabsExpander: {
                 className: false,
@@ -140,7 +141,7 @@ describe("@blueprintjs/core isomorphic rendering", () => {
                 props: { values: ["foo", "bar", "baz"] },
             },
             Tooltip: {
-                props: { content: React.createElement("h1", {}, "content") },
+                props: { content: createElement("h1", {}, "content") },
                 children: requiredChild,
             },
         },

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
-import * as React from "react";
 import { spy } from "sinon";
 
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";

--- a/packages/core/test/multistep-dialog/multistepDialogTests.tsx
+++ b/packages/core/test/multistep-dialog/multistepDialogTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons";
 
@@ -178,7 +178,7 @@ describe("<MultistepDialog>", () => {
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const step = dialog.find(`.${Classes.DIALOG_STEP}`);
         step.at(0).simulate("focus");
-        React.act(() => {
+        act(() => {
             dispatchTestKeyboardEvent(step.at(0).getDOMNode(), "keydown", "Enter");
         });
         assert.strictEqual(dialog.state("selectedIndex"), 0);

--- a/packages/core/test/overflow-list/overflowListTests.tsx
+++ b/packages/core/test/overflow-list/overflowListTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import { spy } from "sinon";
 
 import {

--- a/packages/core/test/overlay/overlayTests.tsx
+++ b/packages/core/test/overlay/overlayTests.tsx
@@ -24,7 +24,7 @@
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
@@ -302,8 +302,8 @@ describe("<Overlay>", () => {
         });
 
         it("returns focus to overlay if enforceFocus=true", async () => {
-            const buttonRef = React.createRef<HTMLButtonElement>();
-            const inputRef = React.createRef<HTMLInputElement>();
+            const buttonRef = createRef<HTMLButtonElement>();
+            const inputRef = createRef<HTMLInputElement>();
             mountWrapper(
                 <div>
                     <button ref={buttonRef} />

--- a/packages/core/test/overlay2/overlay2Tests.tsx
+++ b/packages/core/test/overlay2/overlay2Tests.tsx
@@ -17,7 +17,7 @@
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
@@ -337,8 +337,8 @@ describe("<Overlay2>", () => {
         });
 
         it("returns focus to overlay if enforceFocus=true", async () => {
-            const buttonRef = React.createRef<HTMLButtonElement>();
-            const inputRef = React.createRef<HTMLInputElement>();
+            const buttonRef = createRef<HTMLButtonElement>();
+            const inputRef = createRef<HTMLInputElement>();
             mountWrapper(
                 <div>
                     <button ref={buttonRef} />
@@ -391,7 +391,7 @@ describe("<Overlay2>", () => {
         });
 
         it("does not result in maximum call stack if two overlays open with enforceFocus=true", () => {
-            const firstOverlayInstance = React.createRef<OverlayInstance>();
+            const firstOverlayInstance = createRef<OverlayInstance>();
             const secondOverlayInputID = "inputId";
 
             const firstOverlay = {

--- a/packages/core/test/panel-stack/panelStackTests.tsx
+++ b/packages/core/test/panel-stack/panelStackTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { useState } from "react";
 import { spy } from "sinon";
 
 import { Classes, NumericInput, type Panel, type PanelProps, PanelStack, type PanelStackProps } from "../../src";
@@ -26,7 +26,7 @@ type TestPanelInfo = {};
 type TestPanelType = Panel<TestPanelInfo>;
 
 const TestPanel: React.FC<PanelProps<TestPanelInfo>> = props => {
-    const [counter, setCounter] = React.useState(0);
+    const [counter, setCounter] = useState(0);
     const newPanel = { renderPanel: TestPanel, title: "New Panel 1" };
 
     return (

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -17,7 +17,7 @@
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import sinon from "sinon";
 
 import { dispatchMouseEvent } from "@blueprintjs/test-commons";
@@ -154,7 +154,7 @@ describe("<Popover>", () => {
         it("adds POPOVER_OPEN class to target when the popover is open", () => {
             wrapper = renderPopover();
             assert.isFalse(wrapper.findClass(Classes.POPOVER_TARGET).hasClass(Classes.POPOVER_OPEN));
-            React.act(() => {
+            act(() => {
                 wrapper!.setState({ isOpen: true });
             });
             assert.isTrue(wrapper.findClass(Classes.POPOVER_TARGET).hasClass(Classes.POPOVER_OPEN));
@@ -266,13 +266,13 @@ describe("<Popover>", () => {
             }
 
             wrapper = renderPopover({ ...commonProps, onOpened: handleOpened });
-            React.act(() => wrapper!.targetButton.focus());
+            act(() => wrapper!.targetButton.focus());
             wrapper.simulateTarget("click");
         });
 
         it("returns focus to target element when closed", async () => {
             wrapper = renderPopover(commonProps);
-            React.act(() => wrapper!.targetButton.focus());
+            act(() => wrapper!.targetButton.focus());
             assert.strictEqual(
                 document.activeElement,
                 wrapper.targetElement.querySelector("button"),
@@ -899,7 +899,7 @@ describe("<Popover>", () => {
             it("when autoFocus={true}", async () => {
                 wrapper = renderPopover({ autoFocus: true });
                 const button = wrapper.find(BUTTON_ID_SELECTOR).hostNodes();
-                React.act(() => button.getDOMNode<HTMLElement>().focus());
+                act(() => button.getDOMNode<HTMLElement>().focus());
                 button.simulate("keyDown", SPACE_KEYSTROKE);
 
                 // Wait for focus to change
@@ -923,7 +923,7 @@ describe("<Popover>", () => {
             it("when autoFocus={false}", async () => {
                 wrapper = renderPopover({ autoFocus: false });
                 const button = wrapper.find(BUTTON_ID_SELECTOR).hostNodes();
-                React.act(() => button.getDOMNode<HTMLElement>().focus());
+                act(() => button.getDOMNode<HTMLElement>().focus());
                 button.simulate("keyDown", SPACE_KEYSTROKE);
 
                 // Wait for focus to change (it shouldn't)

--- a/packages/core/test/resize-sensor/resizeSensorTests.tsx
+++ b/packages/core/test/resize-sensor/resizeSensorTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { ResizeSensor, type ResizeSensorProps } from "../../src/components/resize-sensor/resizeSensor";
@@ -80,7 +80,7 @@ describe("<ResizeSensor>", () => {
 
     it("still works when user sets their own targetRef", async () => {
         const onResize = spy();
-        const targetRef = React.createRef<HTMLElement>();
+        const targetRef = createRef<HTMLElement>();
         const RESIZE_WIDTH = 200;
         mountResizeSensor({ onResize, targetRef });
         await resize({ width: RESIZE_WIDTH });

--- a/packages/core/test/slider/rangeSliderTests.tsx
+++ b/packages/core/test/slider/rangeSliderTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";

--- a/packages/core/test/slider/sliderTests.tsx
+++ b/packages/core/test/slider/sliderTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import sinon from "sinon";
 
 import { Classes, Slider } from "../../src";

--- a/packages/core/test/tabs/tabsTests.tsx
+++ b/packages/core/test/tabs/tabsTests.tsx
@@ -16,7 +16,7 @@
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import { spy } from "sinon";
 
 import { Classes } from "../../src/common";
@@ -82,7 +82,7 @@ describe("<Tabs>", () => {
     it("renders all Tab children, active is not aria-hidden", () => {
         const activeIndex = 1;
         const wrapper = mount(<Tabs id={ID}>{getTabsContents()}</Tabs>);
-        React.act(() => {
+        act(() => {
             wrapper.setState({ selectedTabId: TAB_IDS[activeIndex] });
         });
         const tabPanels = wrapper.find(TAB_PANEL_SELECTOR);
@@ -163,7 +163,7 @@ describe("<Tabs>", () => {
             </Tabs>,
         );
         for (const selectedTabId of TAB_IDS) {
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ selectedTabId });
             });
             assert.lengthOf(wrapper.find("strong"), 1);

--- a/packages/core/test/tag-input/tagInputTests.tsx
+++ b/packages/core/test/tag-input/tagInputTests.tsx
@@ -17,7 +17,7 @@
 import { waitFor } from "@testing-library/dom";
 import { assert, expect } from "chai";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import sinon from "sinon";
 
 import { Button, Classes, Intent, Tag, TagInput, type TagInputProps } from "../../src";
@@ -209,7 +209,7 @@ describe("<TagInput>", () => {
         it("does not clear the input if onAdd returns false", () => {
             const onAdd = sinon.stub().returns(false);
             const wrapper = mountTagInput(onAdd);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
                 pressEnterInInput(wrapper, NEW_VALUE);
             });
@@ -219,7 +219,7 @@ describe("<TagInput>", () => {
         it("clears the input if onAdd returns true", () => {
             const onAdd = sinon.stub().returns(true);
             const wrapper = mountTagInput(onAdd);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
                 pressEnterInInput(wrapper, NEW_VALUE);
             });
@@ -229,7 +229,7 @@ describe("<TagInput>", () => {
         it("clears the input if onAdd returns nothing", () => {
             const onAdd = sinon.stub();
             const wrapper = mountTagInput(onAdd);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
                 pressEnterInInput(wrapper, NEW_VALUE);
             });
@@ -386,7 +386,7 @@ describe("<TagInput>", () => {
         it("does not clear the input if onChange returns false", () => {
             const onChange = sinon.stub().returns(false);
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
                 pressEnterInInput(wrapper, NEW_VALUE);
             });
@@ -396,7 +396,7 @@ describe("<TagInput>", () => {
         it("clears the input if onChange returns true", () => {
             const onChange = sinon.stub().returns(true);
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
                 pressEnterInInput(wrapper, NEW_VALUE);
             });
@@ -406,7 +406,7 @@ describe("<TagInput>", () => {
         it("clears the input if onChange returns nothing", () => {
             const onChange = sinon.spy();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
                 pressEnterInInput(wrapper, NEW_VALUE);
             });
@@ -620,7 +620,7 @@ function runKeyPressTest(callbackName: "onKeyDown" | "onKeyUp", startIndex: numb
     const inputProps = { [callbackName]: sinon.spy() };
     const wrapper = mount(<TagInput values={VALUES} inputProps={inputProps} {...{ [callbackName]: callbackSpy }} />);
 
-    React.act(() => {
+    act(() => {
         wrapper.setState({ activeIndex: startIndex });
     });
 

--- a/packages/core/test/tag/compoundTagTests.tsx
+++ b/packages/core/test/tag/compoundTagTests.tsx
@@ -17,7 +17,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { assert, expect } from "chai";
 import { mount, shallow } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { Classes, CompoundTag, Icon } from "../../src";
@@ -107,7 +107,7 @@ describe("<CompoundTag>", () => {
     });
 
     it("supports ref objects", async () => {
-        const elementRef = React.createRef<HTMLSpanElement>();
+        const elementRef = createRef<HTMLSpanElement>();
         const wrapper = mount(
             <CompoundTag ref={elementRef} leftContent="Hello">
                 World

--- a/packages/core/test/tag/tagTests.tsx
+++ b/packages/core/test/tag/tagTests.tsx
@@ -17,7 +17,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { assert, expect } from "chai";
 import { mount, shallow } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import { spy } from "sinon";
 
 import { Classes, Icon, Tag, Text } from "../../src";
@@ -107,7 +107,7 @@ describe("<Tag>", () => {
     });
 
     it("supports ref objects", async () => {
-        const elementRef = React.createRef<HTMLSpanElement>();
+        const elementRef = createRef<HTMLSpanElement>();
         const wrapper = mount(<Tag ref={elementRef}>Hello</Tag>);
 
         // wait for the whole lifecycle to run

--- a/packages/core/test/toast/overlayToasterTests.tsx
+++ b/packages/core/test/toast/overlayToasterTests.tsx
@@ -16,7 +16,7 @@
 
 import { waitFor } from "@testing-library/dom";
 import { assert } from "chai";
-import * as ReactDOMClient from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import sinon, { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
@@ -25,7 +25,7 @@ import { Classes, OverlayToaster, type Toaster } from "../../src";
 import { TOASTER_MAX_TOASTS_INVALID } from "../../src/common/errors";
 import { OVERLAY_TOASTER_DELAY_MS, type OverlayToasterDOMRenderer } from "../../src/components/toast/overlayToaster";
 
-let react18Root: ReactDOMClient.Root | undefined;
+let react18Root: Root | undefined;
 
 describe("OverlayToaster", () => {
     let containerElement: HTMLElement;
@@ -33,7 +33,7 @@ describe("OverlayToaster", () => {
 
     const domRenderer: OverlayToasterDOMRenderer = (element, container) => {
         react18Root?.unmount();
-        react18Root = ReactDOMClient.createRoot(container);
+        react18Root = createRoot(container);
         react18Root.render(element);
     };
 

--- a/packages/core/test/toast/toastTests.tsx
+++ b/packages/core/test/toast/toastTests.tsx
@@ -16,7 +16,6 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
-import * as React from "react";
 import { type SinonSpy, spy } from "sinon";
 
 import { AnchorButton, Button, Toast } from "../../src";

--- a/packages/core/test/utils.tsx
+++ b/packages/core/test/utils.tsx
@@ -15,7 +15,6 @@
  */
 
 import { ReactWrapper } from "enzyme";
-import * as React from "react";
 
 import { Portal, type PortalProps } from "../src";
 

--- a/packages/datetime/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime/src/common/dateFnsLocaleUtils.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Locale } from "date-fns";
-import * as React from "react";
+import { useState, useEffect } from "react";
 
 import { Utils } from "@blueprintjs/core";
 
@@ -49,11 +49,11 @@ export function useDateFnsLocale(
     dateFnsLocaleLoader: DateFnsLocaleLoader = loadDateFnsLocale,
 ) {
     // make sure to set the locale correctly on first render if it is available
-    const [locale, setLocale] = React.useState<Locale | undefined>(
+    const [locale, setLocale] = useState<Locale | undefined>(
         typeof localeOrCode === "object" ? localeOrCode : undefined,
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         setLocale(prevLocale => {
             if (typeof localeOrCode === "string") {
                 dateFnsLocaleLoader(localeOrCode).then(setLocale);

--- a/packages/datetime/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime/src/common/dateFnsLocaleUtils.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Locale } from "date-fns";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Utils } from "@blueprintjs/core";
 

--- a/packages/datetime/src/common/useMonthSelectRightOffset.ts
+++ b/packages/datetime/src/common/useMonthSelectRightOffset.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { type RefObject, useState } from "react";
 
 import { useIsomorphicLayoutEffect } from "@blueprintjs/core";
 import { IconSize } from "@blueprintjs/icons";
@@ -24,11 +24,11 @@ import { DatePickerUtils } from "../components/date-picker/datePickerUtils";
 import { Classes } from ".";
 
 export function useMonthSelectRightOffset(
-    monthSelectElement: React.RefObject<HTMLSelectElement>,
-    containerElement: React.RefObject<HTMLElement>,
+    monthSelectElement: RefObject<HTMLSelectElement>,
+    containerElement: RefObject<HTMLElement>,
     displayedMonthText: string,
 ): number {
-    const [monthRightOffset, setMonthRightOffset] = React.useState<number>(0);
+    const [monthRightOffset, setMonthRightOffset] = useState<number>(0);
 
     useIsomorphicLayoutEffect(() => {
         if (containerElement.current == null) {

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
     type ButtonProps,
@@ -67,7 +67,7 @@ export const DATEINPUT_DEFAULT_PROPS: DateInputDefaultProps = {
  *
  * @see https://blueprintjs.com/docs/#datetime/date-input
  */
-export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput(props) {
+export const DateInput: React.FC<DateInputProps> = memo(function DateInput(props) {
     const {
         closeOnSelection,
         dateFnsFormat,
@@ -104,37 +104,37 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
     // Refs
     // ------------------------------------------------------------------------
 
-    const inputRef = React.useRef<HTMLInputElement | null>(null);
-    const popoverContentRef = React.useRef<HTMLDivElement | null>(null);
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const popoverContentRef = useRef<HTMLDivElement | null>(null);
     const popoverId = Utils.uniqueId("date-picker");
 
     // State
     // ------------------------------------------------------------------------
 
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [timezoneValue, setTimezoneValue] = React.useState(getInitialTimezoneValue(props));
-    const valueFromProps = React.useMemo(
+    const [isOpen, setIsOpen] = useState(false);
+    const [timezoneValue, setTimezoneValue] = useState(getInitialTimezoneValue(props));
+    const valueFromProps = useMemo(
         () => TimezoneUtils.getDateObjectFromIsoString(value, timezoneValue),
         [timezoneValue, value],
     );
     const isControlled = valueFromProps !== undefined;
-    const defaultValueFromProps = React.useMemo(
+    const defaultValueFromProps = useMemo(
         () => TimezoneUtils.getDateObjectFromIsoString(defaultValue, timezoneValue),
         [defaultValue, timezoneValue],
     );
-    const [valueAsDate, setValue] = React.useState<Date | null | undefined>(
+    const [valueAsDate, setValue] = useState<Date | null | undefined>(
         isControlled ? valueFromProps : defaultValueFromProps,
     );
 
-    const [selectedShortcutIndex, setSelectedShortcutIndex] = React.useState<number | undefined>(undefined);
-    const [isInputFocused, setIsInputFocused] = React.useState(false);
+    const [selectedShortcutIndex, setSelectedShortcutIndex] = useState<number | undefined>(undefined);
+    const [isInputFocused, setIsInputFocused] = useState(false);
 
     // rendered as the text input's value
-    const formattedDateString = React.useMemo(
+    const formattedDateString = useMemo(
         () => (valueAsDate === null ? undefined : formatDateString(valueAsDate)),
         [valueAsDate, formatDateString],
     );
-    const [inputValue, setInputValue] = React.useState(formattedDateString ?? undefined);
+    const [inputValue, setInputValue] = useState(formattedDateString ?? undefined);
 
     const isErrorState =
         valueAsDate != null &&
@@ -143,27 +143,27 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
     // Effects
     // ------------------------------------------------------------------------
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (isControlled) {
             setValue(valueFromProps);
         }
     }, [isControlled, valueFromProps]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         // uncontrolled mode, updating initial timezone value
         if (defaultTimezone !== undefined && TimezoneNameUtils.isValidTimezone(defaultTimezone)) {
             setTimezoneValue(defaultTimezone);
         }
     }, [defaultTimezone]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         // controlled mode, updating timezone value
         if (controlledTimezone !== undefined && TimezoneNameUtils.isValidTimezone(controlledTimezone)) {
             setTimezoneValue(controlledTimezone);
         }
     }, [controlledTimezone]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (isControlled && !isInputFocused) {
             setInputValue(formattedDateString);
         }
@@ -172,7 +172,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
     // Popover contents (date picker)
     // ------------------------------------------------------------------------
 
-    const handlePopoverClose = React.useCallback(
+    const handlePopoverClose = useCallback(
         (e: React.SyntheticEvent<HTMLElement>) => {
             popoverProps.onClose?.(e);
             setIsOpen(false);
@@ -180,7 +180,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         [popoverProps],
     );
 
-    const handleDateChange = React.useCallback(
+    const handleDateChange = useCallback(
         (newDate: Date | null, isUserChange: boolean, didSubmitWithEnter = false) => {
             const prevDate = valueAsDate;
 
@@ -241,11 +241,11 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         },
     };
 
-    const handleShortcutChange = React.useCallback((_: DatePickerShortcut, index: number) => {
+    const handleShortcutChange = useCallback((_: DatePickerShortcut, index: number) => {
         setSelectedShortcutIndex(index);
     }, []);
 
-    const handleStartFocusBoundaryFocusIn = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    const handleStartFocusBoundaryFocusIn = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
         if (popoverContentRef.current?.contains(getRelatedTargetWithFallback(e))) {
             // Not closing Popover to allow user to freely switch between manually entering a date
             // string in the input and selecting one via the Popover
@@ -255,7 +255,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         }
     }, []);
 
-    const handleEndFocusBoundaryFocusIn = React.useCallback(
+    const handleEndFocusBoundaryFocusIn = useCallback(
         (e: React.FocusEvent<HTMLDivElement>) => {
             if (popoverContentRef.current?.contains(getRelatedTargetWithFallback(e))) {
                 inputRef.current?.focus();
@@ -298,7 +298,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
 
     // we need a date which is guaranteed to be non-null here; if necessary,
     // we use today's date and shift it to the desired/current timezone
-    const tzSelectDate = React.useMemo(
+    const tzSelectDate = useMemo(
         () =>
             valueAsDate != null && DateUtils.isDateValid(valueAsDate)
                 ? valueAsDate
@@ -309,7 +309,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
     const isTimezoneSelectHidden = timePrecision === undefined || showTimezoneSelect === false;
     const isTimezoneSelectDisabled = disabled || disableTimezoneSelect;
 
-    const handleTimezoneChange = React.useCallback(
+    const handleTimezoneChange = useCallback(
         (newTimezone: string) => {
             if (controlledTimezone === undefined) {
                 // uncontrolled timezone
@@ -329,7 +329,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         [onChange, onTimezoneChange, valueAsDate, timePrecision, controlledTimezone],
     );
 
-    const maybeTimezonePicker = React.useMemo(
+    const maybeTimezonePicker = useMemo(
         () =>
             isTimezoneSelectHidden ? undefined : (
                 <TimezoneSelect
@@ -355,7 +355,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
     // Text input
     // ------------------------------------------------------------------------
 
-    const handleInputFocus = React.useCallback(
+    const handleInputFocus = useCallback(
         (e: React.FocusEvent<HTMLInputElement>) => {
             setIsInputFocused(true);
             setIsOpen(true);
@@ -365,7 +365,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         [formattedDateString, inputProps],
     );
 
-    const handleInputBlur = React.useCallback(
+    const handleInputBlur = useCallback(
         (e: React.FocusEvent<HTMLInputElement>) => {
             if (inputValue == null || valueAsDate == null) {
                 setIsInputFocused(false);
@@ -417,7 +417,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         ],
     );
 
-    const handleInputChange = React.useCallback(
+    const handleInputChange = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
             const valueString = e.target.value;
             const inputValueAsDate = parseDateString(valueString);
@@ -450,7 +450,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         [isControlled, minDate, maxDate, timezoneValue, timePrecision, parseDateString, onChange, inputProps],
     );
 
-    const handleInputClick = React.useCallback(
+    const handleInputClick = useCallback(
         (e: React.MouseEvent<HTMLInputElement>) => {
             // stop propagation to the Popover's internal handleTargetClick handler;
             // otherwise, the popover will flicker closed as soon as it opens.
@@ -460,7 +460,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         [inputProps],
     );
 
-    const handleInputKeyDown = React.useCallback(
+    const handleInputKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
             if (e.key === "Tab" && e.shiftKey) {
                 // close popover on SHIFT+TAB key press
@@ -491,7 +491,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         !isInputFocused || inputValue === outOfRangeMessage || inputValue === invalidDateMessage;
 
     // We use the renderTarget API to flatten the rendered DOM and make it easier to implement features like the "fill" prop.
-    const renderTarget = React.useCallback(
+    const renderTarget = useCallback(
         ({ isOpen: targetIsOpen, ref, ...targetProps }: PopoverTargetProps & PopoverClickTargetHandlers) => {
             return (
                 <InputGroup

--- a/packages/datetime/src/components/date-input/useDateFormatter.ts
+++ b/packages/datetime/src/components/date-input/useDateFormatter.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Locale } from "date-fns";
-import * as React from "react";
+import { useCallback } from "react";
 
 import { DateUtils } from "../../common";
 import { getDateFnsFormatter, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
@@ -42,7 +42,7 @@ export function useDateFormatter(props: DateInputProps, locale: Locale | undefin
         timePrecision,
     } = props as DateInputPropsWithDefaults;
 
-    return React.useCallback(
+    return useCallback(
         (date: Date | undefined) => {
             if (date === undefined) {
                 return "";

--- a/packages/datetime/src/components/date-input/useDateParser.ts
+++ b/packages/datetime/src/components/date-input/useDateParser.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Locale } from "date-fns";
-import * as React from "react";
+import { useCallback } from "react";
 
 import { getDateFnsParser, getDefaultDateFnsFormat } from "../../common/dateFnsFormatUtils";
 import { getLocaleCodeFromProps } from "../../common/dateFnsLocaleProps";
@@ -41,7 +41,7 @@ export function useDateParser(props: DateInputProps, locale: Locale | undefined)
         timePrecision,
     } = props as DateInputPropsWithDefaults;
 
-    return React.useCallback(
+    return useCallback(
         (dateString: string): Date | null => {
             if (dateString === outOfRangeMessage || dateString === invalidDateMessage) {
                 return null;

--- a/packages/datetime/src/components/date-picker/datePicker.tsx
+++ b/packages/datetime/src/components/date-picker/datePicker.tsx
@@ -16,7 +16,6 @@
 
 import classNames from "classnames";
 import { format } from "date-fns";
-import * as React from "react";
 import { type ActiveModifiers, type DateFormatter, DayPicker } from "react-day-picker";
 
 import { Button, DISPLAYNAME_PREFIX, Divider } from "@blueprintjs/core";

--- a/packages/datetime/src/components/date-picker/datePickerContext.tsx
+++ b/packages/datetime/src/components/date-picker/datePickerContext.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { createContext } from "react";
 
 import type { DatePickerBaseProps } from "../../common";
 
@@ -27,7 +27,7 @@ export type DatePickerContextState = Pick<DatePickerBaseProps, "reverseMonthAndY
  * Context used to pass DatePicker & DateRangePicker props and state down to custom react-day-picker components
  * like DatePickerCaption.
  */
-export const DatePickerContext = React.createContext<DatePickerContextState>({
+export const DatePickerContext = createContext<DatePickerContextState>({
     locale: undefined,
 });
 

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 import { isSameDay, isValid } from "date-fns";
-import * as React from "react";
+import { createElement } from "react";
 
 import {
     Boundary,
@@ -249,7 +249,7 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         ({ isOpen, ...targetProps }: PopoverTargetProps & PopoverClickTargetHandlers) => {
             const { fill, popoverProps = {} } = this.props;
             const { targetTagName = "div" } = popoverProps;
-            return React.createElement(
+            return createElement(
                 targetTagName,
                 {
                     ...targetProps,

--- a/packages/datetime/src/components/date-range-picker/contiguousDayRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/contiguousDayRangePicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DayPicker, type MonthChangeEventHandler, type SelectRangeEventHandler } from "react-day-picker";
 
 import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
@@ -51,7 +51,7 @@ export const ContiguousDayRangePicker: React.FC<DayRangePickerProps> = ({
         dayPickerProps?.onMonthChange,
     );
 
-    const handleRangeSelect = React.useCallback<SelectRangeEventHandler>(
+    const handleRangeSelect = useCallback<SelectRangeEventHandler>(
         (range, selectedDay, activeModifiers, e) => {
             dayPickerProps?.onSelect?.(range, selectedDay, activeModifiers, e);
 
@@ -115,12 +115,12 @@ function useContiguousCalendarViews(
     selectedRange: DateRange,
     userOnMonthChange: MonthChangeEventHandler | undefined,
 ): ContiguousCalendarViews {
-    const [displayMonth, setDisplayMonth] = React.useState(initialMonthAndYear);
-    const prevSelectedRange = React.useRef<DateRange>(selectedRange);
-    const isInitialRender = React.useRef<boolean>(true);
+    const [displayMonth, setDisplayMonth] = useState(initialMonthAndYear);
+    const prevSelectedRange = useRef<DateRange>(selectedRange);
+    const isInitialRender = useRef<boolean>(true);
 
     // use an effect to react to external value updates (such as shortcut item selections)
-    React.useEffect(() => {
+    useEffect(() => {
         // upon first render, we shouldn't update the display month; instead just use the initially computed value.
         // this is important in cases where the user sets `initialMonth` and a controlled `value`.
         if (isInitialRender.current) {
@@ -191,11 +191,11 @@ function useContiguousCalendarViews(
         });
     }, [setDisplayMonth, selectedRange, singleMonthOnly]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         prevSelectedRange.current = selectedRange;
     }, [selectedRange]);
 
-    const handleMonthChange = React.useCallback<MonthChangeEventHandler>(
+    const handleMonthChange = useCallback<MonthChangeEventHandler>(
         newMonth => {
             const newDisplayMonth = MonthAndYear.fromDate(newMonth);
             if (newDisplayMonth) {

--- a/packages/datetime/src/components/date-range-picker/nonContiguousDayRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/nonContiguousDayRangePicker.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
     DayPicker,
     type DayPickerRangeProps,
@@ -55,7 +55,7 @@ export const NonContiguousDayRangePicker: React.FC<DayRangePickerProps> = ({
         maxDate,
     );
 
-    const handleDaySelect = React.useCallback<SelectRangeEventHandler>(
+    const handleDaySelect = useCallback<SelectRangeEventHandler>(
         (range, selectedDay, activeModifiers, e) => {
             dayPickerProps?.onSelect?.(range, selectedDay, activeModifiers, e);
 
@@ -142,12 +142,12 @@ function useNonContiguousCalendarViews(
     // show the selected end date's encompassing month in the right view if
     // the calendars don't have to be contiguous.
     // if left view and right view months are the same, show next month in the right view.
-    const [views, setViews] = React.useState<LeftAndRightDisplayMonths>({
+    const [views, setViews] = useState<LeftAndRightDisplayMonths>({
         left: initialMonthAndYear,
         right: getInitialRightView(selectedRange[1], initialMonthAndYear),
     });
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (selectedRange == null) {
             return;
         }
@@ -209,7 +209,7 @@ function useNonContiguousCalendarViews(
         });
     }, [setViews, selectedRange]);
 
-    const handleLeftMonthChange = React.useCallback(
+    const handleLeftMonthChange = useCallback(
         (newDate: Date) => {
             const newLeftView = MonthAndYear.fromDate(newDate);
             if (newLeftView == null) {
@@ -229,7 +229,7 @@ function useNonContiguousCalendarViews(
         [minDate, maxDate, setViews, userOnMonthChange],
     );
 
-    const handleRightMonthChange = React.useCallback(
+    const handleRightMonthChange = useCallback(
         (newDate: Date) => {
             const newRightView = MonthAndYear.fromDate(newDate);
             if (newRightView == null) {

--- a/packages/datetime/src/components/react-day-picker/datePickerCaption.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerCaption.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useContext, useMemo, useRef } from "react";
 import { CaptionLabel, type CaptionProps, useDayPicker, useNavigation } from "react-day-picker";
 import innerText from "react-innertext";
 
@@ -37,7 +37,7 @@ import { DatePickerContext } from "../date-picker/datePickerContext";
  */
 export const DatePickerCaption = (props: CaptionProps) => {
     const { classNames: rdpClassNames, formatters, fromDate, toDate, labels } = useDayPicker();
-    const { locale, reverseMonthAndYearMenus } = React.useContext(DatePickerContext);
+    const { locale, reverseMonthAndYearMenus } = useContext(DatePickerContext);
 
     // non-null assertion because we define these values in defaultProps
     const minYear = fromDate!.getFullYear();
@@ -46,15 +46,15 @@ export const DatePickerCaption = (props: CaptionProps) => {
     const displayMonth = props.displayMonth.getMonth();
     const displayYear = props.displayMonth.getFullYear();
 
-    const containerElement = React.useRef<HTMLDivElement>(null);
-    const monthSelectElement = React.useRef<HTMLSelectElement>(null);
+    const containerElement = useRef<HTMLDivElement>(null);
+    const monthSelectElement = useRef<HTMLSelectElement>(null);
     const { currentMonth, goToMonth, nextMonth, previousMonth } = useNavigation();
 
-    const handlePreviousClick = React.useCallback(
+    const handlePreviousClick = useCallback(
         () => previousMonth && goToMonth(previousMonth),
         [previousMonth, goToMonth],
     );
-    const handleNextClick = React.useCallback(() => nextMonth && goToMonth(nextMonth), [nextMonth, goToMonth]);
+    const handleNextClick = useCallback(() => nextMonth && goToMonth(nextMonth), [nextMonth, goToMonth]);
 
     const prevButton = (
         <Button
@@ -83,7 +83,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
     // build the list of available years, relying on react-day-picker's default date-fns formatter or a
     // user-provided formatter to localize the year "names"
     const { formatYearCaption } = formatters;
-    const allYearOptions = React.useMemo<OptionProps[]>(() => {
+    const allYearOptions = useMemo<OptionProps[]>(() => {
         const years: OptionProps[] = [];
         for (let year = minYear; year <= maxYear; year++) {
             const yearDate = new Date(year, 0);
@@ -101,7 +101,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
         allYearOptions.push({ disabled: true, label: innerText(displayYearCaption), value: displayYear });
     }
 
-    const handleMonthSelectChange = React.useCallback(
+    const handleMonthSelectChange = useCallback(
         (e: React.FormEvent<HTMLSelectElement>) => {
             const newMonth = parseInt((e.target as HTMLSelectElement).value, 10);
             // ignore change events with invalid values to prevent crash on iOS Safari (#4178)
@@ -121,7 +121,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
     // build the list of available months, relying on react-day-picker's default date-fns formatter or a
     // user-provided formatter to localize the month names
     const { formatMonthCaption } = formatters;
-    const allMonths = React.useMemo<string[]>(() => {
+    const allMonths = useMemo<string[]>(() => {
         const months: string[] = [];
         for (let i = Months.JANUARY; i <= Months.DECEMBER; i++) {
             const monthDate = new Date(displayYear, i);
@@ -149,7 +149,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
         />
     );
 
-    const handleYearSelectChange = React.useCallback(
+    const handleYearSelectChange = useCallback(
         (e: React.FormEvent<HTMLSelectElement>) => {
             const newYear = parseInt((e.target as HTMLSelectElement).value, 10);
             // ignore change events with invalid values to prevent crash on iOS Safari (#4178)

--- a/packages/datetime/src/components/react-day-picker/datePickerDropdown.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useRef, useMemo } from "react";
+import { useMemo, useRef } from "react";
 import type { DropdownProps } from "react-day-picker";
 
 import { HTMLSelect } from "@blueprintjs/core";

--- a/packages/datetime/src/components/react-day-picker/datePickerDropdown.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useRef, useMemo } from "react";
 import type { DropdownProps } from "react-day-picker";
 
 import { HTMLSelect } from "@blueprintjs/core";
@@ -28,14 +28,14 @@ import { useMonthSelectRightOffset } from "../../common/useMonthSelectRightOffse
  * @see https://daypicker.dev/guides/custom-components
  */
 export function DatePickerDropdown({ caption, children, ...props }: DropdownProps) {
-    const containerElement = React.useRef<HTMLDivElement>(null);
-    const selectElement = React.useRef<HTMLSelectElement>(null);
+    const containerElement = useRef<HTMLDivElement>(null);
+    const selectElement = useRef<HTMLSelectElement>(null);
 
     // Use a custom hook to adjust the position of the position of the HTMLSelect icon to appear right next to
     // the month name. N.B. we expect props.caption to be a simple string representing the month name.
     const displayedMonthText = typeof caption === "string" ? caption : "";
     const monthSelectRightOffset = useMonthSelectRightOffset(selectElement, containerElement, displayedMonthText);
-    const iconProps = React.useMemo(
+    const iconProps = useMemo(
         () => (props.name === "months" ? { style: { right: monthSelectRightOffset } } : {}),
         [props.name, monthSelectRightOffset],
     );

--- a/packages/datetime/src/components/shortcuts/shortcuts.tsx
+++ b/packages/datetime/src/components/shortcuts/shortcuts.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 
@@ -122,7 +122,7 @@ const ShortcutMenuItem: React.FC<ShortcutMenuItemProps> = props => {
 
     const isShortcutInRange = isDayRangeInRange(shortcut.dateRange, [minDate, maxDate]);
 
-    const handleClick = React.useCallback(() => onShortcutClick(shortcut, index), [index, onShortcutClick, shortcut]);
+    const handleClick = useCallback(() => onShortcutClick(shortcut, index), [index, onShortcutClick, shortcut]);
 
     return (
         <MenuItem

--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import {
     Classes as CoreClasses,
@@ -55,7 +55,7 @@ export interface TimePickerState {
  *
  * @see https://blueprintjs.com/docs/#datetime/timepicker
  */
-export class TimePicker extends React.Component<TimePickerProps, TimePickerState> {
+export class TimePicker extends Component<TimePickerProps, TimePickerState> {
     public static defaultProps: TimePickerProps = {
         autoFocus: false,
         disabled: false,

--- a/packages/datetime/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime/src/components/timezone-select/timezoneSelect.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -19,7 +19,7 @@ import { intlFormat, isEqual, parseISO } from "date-fns";
 import enUSLocale from "date-fns/locale/en-US";
 import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 import * as sinon from "sinon";
 
 import { Classes as CoreClasses, InputGroup, Popover, Tag } from "@blueprintjs/core";
@@ -120,7 +120,7 @@ describe("<DateInput>", () => {
         });
 
         it("supports inputProps.inputRef", () => {
-            const inputRef = React.createRef<HTMLInputElement>();
+            const inputRef = createRef<HTMLInputElement>();
             mount(<DateInput {...DEFAULT_PROPS} inputProps={{ inputRef }} />);
             assert.instanceOf(inputRef.current, HTMLInputElement);
         });

--- a/packages/datetime/test/components/datePickerTests.tsx
+++ b/packages/datetime/test/components/datePickerTests.tsx
@@ -17,7 +17,6 @@
 import { assert } from "chai";
 import enUSLocale from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import { Day } from "react-day-picker";
 import sinon from "sinon";
 

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -19,7 +19,7 @@ import { format, parse } from "date-fns";
 import * as Locales from "date-fns/locale";
 import esLocale from "date-fns/locale/es";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";
 import * as sinon from "sinon";
 
@@ -139,7 +139,7 @@ describe("<DateRangeInput>", () => {
                 popoverProps={{ className: CLASS_2, usePortal: false }}
             />,
         );
-        React.act(() => {
+        act(() => {
             wrapper.setState({ isOpen: true });
         });
 
@@ -150,7 +150,7 @@ describe("<DateRangeInput>", () => {
 
     it("inner DateRangePicker receives all supported props", () => {
         const component = mount(<DateRangeInput {...DATE_FORMAT} locale="uk" contiguousCalendarMonths={false} />);
-        React.act(() => {
+        act(() => {
             component.setState({ isOpen: true });
         });
         component.update();
@@ -172,7 +172,7 @@ describe("<DateRangeInput>", () => {
         it("<TimePicker /> should not lose focus on increment/decrement with up/down arrows", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -189,7 +189,7 @@ describe("<DateRangeInput>", () => {
                 true,
             );
 
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -197,7 +197,7 @@ describe("<DateRangeInput>", () => {
             getDayElement(1).simulate("click");
             getDayElement(10).simulate("click");
 
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -210,7 +210,7 @@ describe("<DateRangeInput>", () => {
         it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />, true);
 
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
@@ -385,7 +385,7 @@ describe("<DateRangeInput>", () => {
     describe("closeOnSelection", () => {
         it("if closeOnSelection=false, popover stays open when full date range is selected", () => {
             const { root, getDayElement } = wrap(<DateRangeInput {...DATE_FORMAT} closeOnSelection={false} />, true);
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -397,7 +397,7 @@ describe("<DateRangeInput>", () => {
 
         it("if closeOnSelection=true, popover closes when full date range is selected", () => {
             const { root, getDayElement } = wrap(<DateRangeInput {...DATE_FORMAT} />, true);
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -412,7 +412,7 @@ describe("<DateRangeInput>", () => {
                 <DateRangeInput {...DATE_FORMAT} timePrecision={TimePrecision.MINUTE} />,
                 true,
             );
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -426,7 +426,7 @@ describe("<DateRangeInput>", () => {
 
     it("accepts contiguousCalendarMonths prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} contiguousCalendarMonths={false} />);
-        React.act(() => {
+        act(() => {
             root.setState({ isOpen: true });
         });
         root.update();
@@ -435,7 +435,7 @@ describe("<DateRangeInput>", () => {
 
     it("accepts singleMonthOnly prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} singleMonthOnly={false} />);
-        React.act(() => {
+        act(() => {
             root.setState({ isOpen: true });
         });
         root.update();
@@ -444,7 +444,7 @@ describe("<DateRangeInput>", () => {
 
     it("accepts shortcuts prop and passes it to the date range picker", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} shortcuts={false} />);
-        React.act(() => {
+        act(() => {
             root.setState({ isOpen: true });
         });
         root.update();
@@ -455,7 +455,7 @@ describe("<DateRangeInput>", () => {
         const selectedShortcut = 1;
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} />);
 
-        React.act(() => {
+        act(() => {
             root.setState({ isOpen: true });
         });
         root.update();
@@ -518,7 +518,7 @@ describe("<DateRangeInput>", () => {
                 true,
             );
 
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             // getDay is 0-indexed, but getDayElement is 1-indexed
@@ -606,7 +606,7 @@ describe("<DateRangeInput>", () => {
             const startInputProps = { onKeyDown: sinon.spy() };
             const endInputProps = { onKeyDown: sinon.spy() };
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} {...{ endInputProps, startInputProps }} />);
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
 
@@ -645,7 +645,7 @@ describe("<DateRangeInput>", () => {
                     onChange={onChange}
                 />,
             );
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -1416,7 +1416,7 @@ describe("<DateRangeInput>", () => {
 
             beforeEach(() => {
                 // need to set wasLastFocusChangeDueToHover=false to fully reset state between tests.
-                React.act(() => {
+                act(() => {
                     root.setState({ isOpen: true, wasLastFocusChangeDueToHover: false });
                 });
                 // clear the inputs to start from a fresh state, but do so
@@ -2632,7 +2632,7 @@ describe("<DateRangeInput>", () => {
 
         it("Updating value changes the text accordingly in both fields", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} value={DATE_RANGE} />);
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
             root.update();
@@ -2645,7 +2645,7 @@ describe("<DateRangeInput>", () => {
         it.skip("Pressing Enter saves the inputted date and closes the popover", () => {
             const onChange = sinon.spy();
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} onChange={onChange} value={[null, null]} />);
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
 
@@ -2673,7 +2673,7 @@ describe("<DateRangeInput>", () => {
 
         it("pressing Escape closes the popover", () => {
             const { root } = wrap(<DateRangeInput {...DATE_FORMAT} value={[null, null]} />);
-            React.act(() => {
+            act(() => {
                 root.setState({ isOpen: true });
             });
 

--- a/packages/datetime/test/components/dateRangePickerTests.tsx
+++ b/packages/datetime/test/components/dateRangePickerTests.tsx
@@ -18,7 +18,6 @@ import { assert } from "chai";
 import { addDays, format, parse } from "date-fns";
 import enUSLocale from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
 import { type DayModifiers, DayPicker, type ModifiersClassNames } from "react-day-picker";
 import sinon from "sinon";
 

--- a/packages/datetime/test/components/timePickerTests.tsx
+++ b/packages/datetime/test/components/timePickerTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
@@ -139,7 +139,7 @@ describe("<TimePicker>", () => {
         assert.strictEqual(hourInput?.value, "0");
 
         hourInput.value = "2";
-        React.act(() => TestUtils.Simulate.change(hourInput));
+        act(() => TestUtils.Simulate.change(hourInput));
         assert.strictEqual(hourInput.value, "2");
         assert.isFalse(hourInput.classList.contains(CoreClasses.intentClass(Intent.DANGER)));
     });
@@ -150,7 +150,7 @@ describe("<TimePicker>", () => {
         assert.strictEqual(hourInput.value, "0");
 
         hourInput.value = "ab";
-        React.act(() => TestUtils.Simulate.change(hourInput));
+        act(() => TestUtils.Simulate.change(hourInput));
         assert.strictEqual(hourInput.value, "");
     });
 
@@ -160,7 +160,7 @@ describe("<TimePicker>", () => {
         assert.strictEqual(hourInput.value, "0");
 
         hourInput.value = "300";
-        React.act(() => TestUtils.Simulate.change(hourInput));
+        act(() => TestUtils.Simulate.change(hourInput));
         assert.strictEqual(hourInput.value, "300");
         assert.isTrue(hourInput.classList.contains(CoreClasses.intentClass(Intent.DANGER)));
     });
@@ -171,8 +171,8 @@ describe("<TimePicker>", () => {
         assert.strictEqual(hourInput.value, "0");
 
         hourInput.value = "ab";
-        React.act(() => TestUtils.Simulate.change(hourInput));
-        React.act(() => TestUtils.Simulate.blur(hourInput));
+        act(() => TestUtils.Simulate.change(hourInput));
+        act(() => TestUtils.Simulate.blur(hourInput));
         assert.strictEqual(hourInput.value, "0");
     });
 
@@ -363,10 +363,10 @@ describe("<TimePicker>", () => {
             const secondInput = findInputElement(Classes.TIMEPICKER_SECOND);
             const millisecondInput = findInputElement(Classes.TIMEPICKER_MILLISECOND);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
-            React.act(() => TestUtils.Simulate.keyDown(minuteInput, { key: "ArrowDown" }));
-            React.act(() => TestUtils.Simulate.keyDown(secondInput, { key: "ArrowDown" }));
-            React.act(() => TestUtils.Simulate.keyDown(millisecondInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(minuteInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(secondInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(millisecondInput, { key: "ArrowDown" }));
 
             assertTimeIs(timePicker.state.value, 15, 32, 20, 600);
         });
@@ -383,10 +383,10 @@ describe("<TimePicker>", () => {
             const secondInput = findInputElement(Classes.TIMEPICKER_SECOND);
             const millisecondInput = findInputElement(Classes.TIMEPICKER_MILLISECOND);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
-            React.act(() => TestUtils.Simulate.keyDown(minuteInput, { key: "ArrowUp" }));
-            React.act(() => TestUtils.Simulate.keyDown(secondInput, { key: "ArrowUp" }));
-            React.act(() => TestUtils.Simulate.keyDown(millisecondInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(minuteInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(secondInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(millisecondInput, { key: "ArrowUp" }));
 
             assertTimeIs(timePicker.state.value, 14, 55, 30, 200);
         });
@@ -461,10 +461,10 @@ describe("<TimePicker>", () => {
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assertTimeIs(timePicker.state.value, 14, 15);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
             assertTimeIs(timePicker.state.value, 14, 15);
         });
 
@@ -478,7 +478,7 @@ describe("<TimePicker>", () => {
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
             assertTimeIs(timePicker.state.value, 17, 20);
         });
 
@@ -492,7 +492,7 @@ describe("<TimePicker>", () => {
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assertTimeIs(timePicker.state.value, 12, 20);
         });
 
@@ -506,7 +506,7 @@ describe("<TimePicker>", () => {
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assertTimeIs(timePicker.state.value, 17, 20);
         });
 
@@ -520,7 +520,7 @@ describe("<TimePicker>", () => {
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowDown" }));
             assertTimeIs(timePicker.state.value, 12, 20);
         });
     });
@@ -543,7 +543,7 @@ describe("<TimePicker>", () => {
             assert.isTrue(onTimePickerChange.notCalled);
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assert.isTrue(onTimePickerChange.calledOnce);
             assert.isTrue((onTimePickerChange.firstCall.args[0] as Date).getHours() === 1);
         });
@@ -554,7 +554,7 @@ describe("<TimePicker>", () => {
             assert.strictEqual(hourInput.value, "0");
             assert.strictEqual(timePicker.state.value?.getHours(), 0);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assert.strictEqual(hourInput.value, "1");
             assert.strictEqual(timePicker.state.value?.getHours(), 1);
         });
@@ -564,8 +564,8 @@ describe("<TimePicker>", () => {
             assert.isTrue(onTimePickerChange.notCalled);
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
             hourInput.value = "8";
-            React.act(() => TestUtils.Simulate.change(hourInput));
-            React.act(() => TestUtils.Simulate.blur(hourInput));
+            act(() => TestUtils.Simulate.change(hourInput));
+            act(() => TestUtils.Simulate.blur(hourInput));
             assert.isTrue(onTimePickerChange.calledOnce);
             assert.strictEqual((onTimePickerChange.firstCall.args[0] as Date).getHours(), 8);
         });
@@ -577,8 +577,8 @@ describe("<TimePicker>", () => {
             assert.strictEqual(timePicker.state.value?.getMinutes(), 0);
 
             minuteInput.value = "8";
-            React.act(() => TestUtils.Simulate.change(minuteInput));
-            React.act(() => TestUtils.Simulate.blur(minuteInput));
+            act(() => TestUtils.Simulate.change(minuteInput));
+            act(() => TestUtils.Simulate.blur(minuteInput));
             assert.strictEqual(minuteInput.value, "08");
             assert.strictEqual(timePicker.state.value?.getMinutes(), 8);
         });
@@ -652,7 +652,7 @@ describe("<TimePicker>", () => {
             assert.isTrue(onTimePickerChange.notCalled);
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assert.isTrue(onTimePickerChange.calledOnce);
             assert.strictEqual((onTimePickerChange.firstCall.args[0] as Date).getHours(), 1);
         });
@@ -663,7 +663,7 @@ describe("<TimePicker>", () => {
             assert.strictEqual(hourInput.value, "0");
             assert.strictEqual(timePicker.state.value?.getHours(), 0);
 
-            React.act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
+            act(() => TestUtils.Simulate.keyDown(hourInput, { key: "ArrowUp" }));
             assert.strictEqual(hourInput.value, "0");
             assert.strictEqual(timePicker.state.value?.getHours(), 0);
         });
@@ -674,8 +674,8 @@ describe("<TimePicker>", () => {
 
             const hourInput = findInputElement(Classes.TIMEPICKER_HOUR);
             hourInput.value = "8";
-            React.act(() => TestUtils.Simulate.change(hourInput));
-            React.act(() => TestUtils.Simulate.blur(hourInput));
+            act(() => TestUtils.Simulate.change(hourInput));
+            act(() => TestUtils.Simulate.blur(hourInput));
             assert.isTrue(onTimePickerChange.calledOnce);
             assert.strictEqual((onTimePickerChange.firstCall.args[0] as Date).getHours(), 8);
         });
@@ -687,8 +687,8 @@ describe("<TimePicker>", () => {
             assert.strictEqual(timePicker.state.value?.getMinutes(), 0);
 
             minuteInput.value = "8";
-            React.act(() => TestUtils.Simulate.change(minuteInput));
-            React.act(() => TestUtils.Simulate.blur(minuteInput));
+            act(() => TestUtils.Simulate.change(minuteInput));
+            act(() => TestUtils.Simulate.blur(minuteInput));
             assert.strictEqual(minuteInput.value, "00");
             assert.strictEqual(timePicker.state.value?.getMinutes(), 0);
         });
@@ -716,20 +716,20 @@ describe("<TimePicker>", () => {
 
     function clickIncrementBtn(className: string) {
         const arrowBtns = document.querySelectorAll(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${className}`);
-        React.act(() => TestUtils.Simulate.click(arrowBtns[0]));
+        act(() => TestUtils.Simulate.click(arrowBtns[0]));
     }
 
     function clickDecrementBtn(className: string) {
         const arrowBtns = document.querySelectorAll(`.${Classes.TIMEPICKER_ARROW_BUTTON}.${className}`);
-        React.act(() => TestUtils.Simulate.click(arrowBtns[1]));
+        act(() => TestUtils.Simulate.click(arrowBtns[1]));
     }
 
     function focusOnInput(className: string) {
-        React.act(() => TestUtils.Simulate.focus(findInputElement(className)));
+        act(() => TestUtils.Simulate.focus(findInputElement(className)));
     }
 
     function keyDownOnInput(className: string, key: string) {
-        React.act(() => TestUtils.Simulate.keyDown(findInputElement(className), { key }));
+        act(() => TestUtils.Simulate.keyDown(findInputElement(className), { key }));
     }
 
     function findInputElement(className: string): HTMLInputElement {
@@ -741,8 +741,8 @@ describe("<TimePicker>", () => {
 
     function changeInputThenBlur(input: HTMLInputElement, value: string) {
         input.value = value;
-        React.act(() => TestUtils.Simulate.change(input));
-        React.act(() => TestUtils.Simulate.blur(input));
+        act(() => TestUtils.Simulate.change(input));
+        act(() => TestUtils.Simulate.blur(input));
     }
 
     function renderTimePicker(props?: Partial<TimePickerProps>) {

--- a/packages/datetime/test/components/timezoneSelectTests.tsx
+++ b/packages/datetime/test/components/timezoneSelectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as sinon from "sinon";
 
 import {
@@ -78,7 +78,7 @@ describe("<TimezoneSelect>", () => {
 
     it("if query is not empty, shows all items", () => {
         const timezoneSelect = mountTS();
-        React.act(() => {
+        act(() => {
             timezoneSelect.setState({ query: "not empty" });
         });
         timezoneSelect.update();

--- a/packages/datetime/test/dateInputMigrationUtilsTests.tsx
+++ b/packages/datetime/test/dateInputMigrationUtilsTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { useCallback, useMemo } from "react";
 
 import { DateInput as DateInput2, DateInputMigrationUtils, TimePrecision } from "../src";
 
@@ -95,11 +95,11 @@ describe("DateInput2MigrationUtils", () => {
     it("Adapters work in common usage pattern with React.useCallback + React.useMemo", () => {
         function TestComponent() {
             // eslint-disable-next-line react-hooks/exhaustive-deps
-            const handleChange = React.useCallback(
+            const handleChange = useCallback(
                 DateInputMigrationUtils.onChangeAdapter(controlledDateInputProps.onChange),
                 [],
             );
-            const value = React.useMemo(() => DateInputMigrationUtils.valueAdapter(controlledDateInputProps.value), []);
+            const value = useMemo(() => DateInputMigrationUtils.valueAdapter(controlledDateInputProps.value), []);
 
             return <DateInput2 {...dateFormattingProps} onChange={handleChange} value={value} />;
         }

--- a/packages/demo-app/src/examples/BreadcrumbExample.tsx
+++ b/packages/demo-app/src/examples/BreadcrumbExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { type BreadcrumbProps, Breadcrumbs } from "@blueprintjs/core";
 
@@ -29,7 +29,7 @@ const ITEMS: BreadcrumbProps[] = [
     { current: true, icon: "document", text: "Selected" },
 ];
 
-export const BreadcrumbExample = React.memo(() => {
+export const BreadcrumbExample = memo(() => {
     return (
         <ExampleCard label="Breadcrumbs">
             <Breadcrumbs items={ITEMS} />

--- a/packages/demo-app/src/examples/ButtonExample.tsx
+++ b/packages/demo-app/src/examples/ButtonExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Button, Intent } from "@blueprintjs/core";
 
@@ -22,7 +22,7 @@ import { ExampleCard } from "./ExampleCard";
 
 const WIDTH = 150;
 
-export const ButtonExample = React.memo(() => {
+export const ButtonExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Button" subLabel="Default" width={WIDTH}>

--- a/packages/demo-app/src/examples/ButtonGroupExample.tsx
+++ b/packages/demo-app/src/examples/ButtonGroupExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Button, ButtonGroup, Intent } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const ButtonGroupExample = React.memo(() => {
+export const ButtonGroupExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="ButtonGroup" width={325}>

--- a/packages/demo-app/src/examples/CalloutExample.tsx
+++ b/packages/demo-app/src/examples/CalloutExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Callout, Intent } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const CalloutExample = React.memo(() => {
+export const CalloutExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Callout">

--- a/packages/demo-app/src/examples/CheckboxRadioExample.tsx
+++ b/packages/demo-app/src/examples/CheckboxRadioExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Checkbox, Radio } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const CheckboxRadioExample = React.memo(() => {
+export const CheckboxRadioExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Checkbox" width={200}>

--- a/packages/demo-app/src/examples/DatePickerExample.tsx
+++ b/packages/demo-app/src/examples/DatePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { DatePicker } from "@blueprintjs/datetime";
@@ -23,7 +23,7 @@ import { ExampleCard } from "./ExampleCard";
 
 const WIDTH = 300;
 
-export const DatePickerExample = React.memo(() => {
+export const DatePickerExample = memo(() => {
     return (
         <ExampleCard width={WIDTH} horizontal={true} label="Date picker">
             <DatePicker className={Classes.ELEVATION_1} />

--- a/packages/demo-app/src/examples/DateRangePickerExample.tsx
+++ b/packages/demo-app/src/examples/DateRangePickerExample.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { DateRangePicker } from "@blueprintjs/datetime";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const DateRangePickerExample = React.memo(() => {
+export const DateRangePickerExample = memo(() => {
     return (
         <ExampleCard width={700} horizontal={true} label="Date range picker">
             <DateRangePicker className={Classes.ELEVATION_1} />

--- a/packages/demo-app/src/examples/DialogExample.tsx
+++ b/packages/demo-app/src/examples/DialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo, useState, useCallback } from "react";
 
 import { Button, Dialog, DialogBody } from "@blueprintjs/core";
 
@@ -24,10 +24,10 @@ export interface DialogExampleProps {
     className?: string;
 }
 
-export const DialogExample = React.memo<DialogExampleProps>(({ className }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
+export const DialogExample = memo<DialogExampleProps>(({ className }) => {
+    const [isOpen, setIsOpen] = useState(false);
 
-    const toggleDialog = React.useCallback(() => {
+    const toggleDialog = useCallback(() => {
         setIsOpen(!isOpen);
     }, [isOpen]);
 

--- a/packages/demo-app/src/examples/DialogExample.tsx
+++ b/packages/demo-app/src/examples/DialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, useState, useCallback } from "react";
+import { memo, useCallback, useState } from "react";
 
 import { Button, Dialog, DialogBody } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/EditableTextExample.tsx
+++ b/packages/demo-app/src/examples/EditableTextExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { EditableText, H1 } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const EditableTextExample = React.memo(() => {
+export const EditableTextExample = memo(() => {
     return (
         <ExampleCard label="Editable text">
             <H1>

--- a/packages/demo-app/src/examples/EntityTitleExample.tsx
+++ b/packages/demo-app/src/examples/EntityTitleExample.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes, EntityTitle, H4, Intent, Tag, UL } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const EntityTitleExample = React.memo(() => {
+export const EntityTitleExample = memo(() => {
     return (
         <ExampleCard label="Entity title">
             <UL className={Classes.LIST_UNSTYLED}>

--- a/packages/demo-app/src/examples/ExampleCard.tsx
+++ b/packages/demo-app/src/examples/ExampleCard.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Card, H5 } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/Examples.tsx
+++ b/packages/demo-app/src/examples/Examples.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 

--- a/packages/demo-app/src/examples/HtmlCodeExample.tsx
+++ b/packages/demo-app/src/examples/HtmlCodeExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Code } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const HtmlCodeExample = React.memo(() => {
+export const HtmlCodeExample = memo(() => {
     return (
         <ExampleCard label="HTML Code">
             <div>

--- a/packages/demo-app/src/examples/HtmlTableExample.tsx
+++ b/packages/demo-app/src/examples/HtmlTableExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes, HTMLTable } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const HtmlTableExample = React.memo(() => {
+export const HtmlTableExample = memo(() => {
     return (
         <ExampleCard label="HTML Table">
             <HTMLTable className="html-table-example" interactive={true} striped={true}>

--- a/packages/demo-app/src/examples/IconExample.tsx
+++ b/packages/demo-app/src/examples/IconExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Icon, Intent } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const IconExample = React.memo(() => {
+export const IconExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Icon" horizontal={true}>

--- a/packages/demo-app/src/examples/InputExample.tsx
+++ b/packages/demo-app/src/examples/InputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { InputGroup, Intent, NumericInput } from "@blueprintjs/core";
 
@@ -22,7 +22,7 @@ import { ExampleCard } from "./ExampleCard";
 
 const WIDTH = 300;
 
-export const InputExample = React.memo(() => {
+export const InputExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Input" subLabel="Default" width={WIDTH}>

--- a/packages/demo-app/src/examples/MenuExample.tsx
+++ b/packages/demo-app/src/examples/MenuExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes, Intent, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const MenuExample = React.memo(() => {
+export const MenuExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Menu" subLabel="Default" width={250}>

--- a/packages/demo-app/src/examples/NonIdealStateExample.tsx
+++ b/packages/demo-app/src/examples/NonIdealStateExample.tsx
@@ -13,13 +13,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Button, NonIdealState } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const NonIdealStateExample = React.memo(() => {
+export const NonIdealStateExample = memo(() => {
     const description = (
         <div>
             Your search didn't match any files.

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Button, Classes, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
 
@@ -40,7 +40,7 @@ const textEditorMenu = (
     </Menu>
 );
 
-export const PopoverExample = React.memo(() => {
+export const PopoverExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Popover" subLabel="Text content" width={200}>

--- a/packages/demo-app/src/examples/SliderExample.tsx
+++ b/packages/demo-app/src/examples/SliderExample.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo, useState } from "react";
 
 import { Slider } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const SliderExample = React.memo(() => {
-    const [value, setValue] = React.useState(5);
+export const SliderExample = memo(() => {
+    const [value, setValue] = useState(5);
 
     return (
         <div className="example-row">

--- a/packages/demo-app/src/examples/SpinnerExample.tsx
+++ b/packages/demo-app/src/examples/SpinnerExample.tsx
@@ -2,13 +2,13 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Intent, Spinner, SpinnerSize } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const SpinnerExample = React.memo(() => {
+export const SpinnerExample = memo(() => {
     return (
         <ExampleCard label="Spinner">
             {Object.values(Intent).map(intent => (

--- a/packages/demo-app/src/examples/SwitchExample.tsx
+++ b/packages/demo-app/src/examples/SwitchExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Switch } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const SwitchExample = React.memo(() => {
+export const SwitchExample = memo(() => {
     return (
         <ExampleCard label="Switch" width={250} horizontal={true}>
             <div>

--- a/packages/demo-app/src/examples/TableExample.tsx
+++ b/packages/demo-app/src/examples/TableExample.tsx
@@ -27,10 +27,7 @@ export const TableExample = memo(() => {
         (rowIndex: number, columnIndex: number) => <Cell>{`${rowIndex}, ${columnIndex}`}</Cell>,
         [],
     );
-    const columnHeaderCellRenderer = useCallback(
-        (index: number) => <ColumnHeaderCell name={`Column ${index}`} />,
-        [],
-    );
+    const columnHeaderCellRenderer = useCallback((index: number) => <ColumnHeaderCell name={`Column ${index}`} />, []);
     return (
         <ExampleCard width={WIDTH} horizontal={true} label="Table">
             <Table numRows={4}>

--- a/packages/demo-app/src/examples/TableExample.tsx
+++ b/packages/demo-app/src/examples/TableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo, useCallback } from "react";
 
 import { Cell, Column, ColumnHeaderCell, Table } from "@blueprintjs/table";
 
@@ -22,12 +22,12 @@ import { ExampleCard } from "./ExampleCard";
 
 const WIDTH = 600;
 
-export const TableExample = React.memo(() => {
-    const cellRenderer = React.useCallback(
+export const TableExample = memo(() => {
+    const cellRenderer = useCallback(
         (rowIndex: number, columnIndex: number) => <Cell>{`${rowIndex}, ${columnIndex}`}</Cell>,
         [],
     );
-    const columnHeaderCellRenderer = React.useCallback(
+    const columnHeaderCellRenderer = useCallback(
         (index: number) => <ColumnHeaderCell name={`Column ${index}`} />,
         [],
     );

--- a/packages/demo-app/src/examples/TabsExample.tsx
+++ b/packages/demo-app/src/examples/TabsExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Tab, Tabs } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const TabsExample = React.memo(() => {
+export const TabsExample = memo(() => {
     return (
         <ExampleCard label="Tabs">
             <Tabs>

--- a/packages/demo-app/src/examples/TagExample.tsx
+++ b/packages/demo-app/src/examples/TagExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo, useCallback } from "react";
 
 import { Intent, Tag } from "@blueprintjs/core";
 
@@ -22,8 +22,8 @@ import { ExampleCard } from "./ExampleCard";
 
 const WIDTH = 200;
 
-export const TagExample = React.memo(() => {
-    const handleRemove = React.useCallback(() => {
+export const TagExample = memo(() => {
+    const handleRemove = useCallback(() => {
         return;
     }, []);
 

--- a/packages/demo-app/src/examples/TagInputExample.tsx
+++ b/packages/demo-app/src/examples/TagInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Intent, TagInput, type TagProps } from "@blueprintjs/core";
 
@@ -33,7 +33,7 @@ const getMinimalTagProps = (_v: React.ReactNode, index: number): TagProps => ({
     minimal: true,
 });
 
-export const TagInputExample = React.memo(() => {
+export const TagInputExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Tag input" subLabel="Default">

--- a/packages/demo-app/src/examples/TextExample.tsx
+++ b/packages/demo-app/src/examples/TextExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes, Intent, Text } from "@blueprintjs/core";
 
@@ -23,7 +23,7 @@ import { ExampleCard } from "./ExampleCard";
 
 const WIDTH = 200;
 
-export const TextExample = React.memo(() => {
+export const TextExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Text" width={WIDTH}>

--- a/packages/demo-app/src/examples/ToastExample.tsx
+++ b/packages/demo-app/src/examples/ToastExample.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo, useCallback } from "react";
 
 import { Intent, Toast } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const ToastExample = React.memo(() => {
-    const handleDismiss = React.useCallback(() => {
+export const ToastExample = memo(() => {
+    const handleDismiss = useCallback(() => {
         return;
     }, []);
 

--- a/packages/demo-app/src/examples/TooltipExample.tsx
+++ b/packages/demo-app/src/examples/TooltipExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { memo } from "react";
 
 import { Classes, Icon, Tooltip } from "@blueprintjs/core";
 
 import { ExampleCard } from "./ExampleCard";
 
-export const TooltipExample = React.memo(() => {
+export const TooltipExample = memo(() => {
     return (
         <ExampleCard label="Tooltip" width={200}>
             <Tooltip

--- a/packages/demo-app/src/examples/TreeExample.tsx
+++ b/packages/demo-app/src/examples/TreeExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import cloneDeep from "lodash/cloneDeep";
-import * as React from "react";
+import { memo, useCallback, useReducer } from "react";
 
 import { Classes, ContextMenu, Icon, Intent, Tooltip, Tree, type TreeNodeInfo } from "@blueprintjs/core";
 
@@ -62,31 +62,28 @@ function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
     }
 }
 
-export const TreeExample = React.memo(() => {
-    const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
+export const TreeExample = memo(() => {
+    const [nodes, dispatch] = useReducer(treeExampleReducer, INITIAL_STATE);
 
-    const handleNodeClick = React.useCallback(
-        (node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
-            const originallySelected = node.isSelected;
-            if (!e.shiftKey) {
-                dispatch({ type: "DESELECT_ALL" });
-            }
-            dispatch({
-                payload: { isSelected: originallySelected == null ? true : !originallySelected, path: nodePath },
-                type: "SET_IS_SELECTED",
-            });
-        },
-        [],
-    );
+    const handleNodeClick = useCallback((node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
+        const originallySelected = node.isSelected;
+        if (!e.shiftKey) {
+            dispatch({ type: "DESELECT_ALL" });
+        }
+        dispatch({
+            payload: { isSelected: originallySelected == null ? true : !originallySelected, path: nodePath },
+            type: "SET_IS_SELECTED",
+        });
+    }, []);
 
-    const handleNodeCollapse = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
+    const handleNodeCollapse = useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { isExpanded: false, path: nodePath },
             type: "SET_IS_EXPANDED",
         });
     }, []);
 
-    const handleNodeExpand = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
+    const handleNodeExpand = useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { isExpanded: true, path: nodePath },
             type: "SET_IS_EXPANDED",

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import * as ReactDOM from "react-dom/client";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
 import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
 
@@ -22,17 +23,17 @@ import { Examples } from "./examples/Examples";
 FocusStyleManager.onlyShowFocusOnTabs();
 
 const container = document.getElementById("blueprint-demo-app");
-const root = ReactDOM.createRoot(container);
+const root = createRoot(container);
 
 (async () => {
     // Wait until CSS is loaded before rendering components because some of them (like Table)
     // rely on those styles to take accurate DOM measurements.
     await import("./index.scss");
     root.render(
-        <React.StrictMode>
+        <StrictMode>
             <BlueprintProvider>
                 <Examples />
             </BlueprintProvider>
-        </React.StrictMode>,
+        </StrictMode>,
     );
 })();

--- a/packages/docs-app/src/common/RadioSelect.tsx
+++ b/packages/docs-app/src/common/RadioSelect.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Radio, RadioGroup } from "@blueprintjs/core";
 import { handleNumberChange } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/common/dateFnsLocaleSelect.tsx
+++ b/packages/docs-app/src/common/dateFnsLocaleSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { Button, MenuItem } from "@blueprintjs/core";
 import { CaretDown } from "@blueprintjs/icons";
@@ -39,7 +39,7 @@ export interface DateFnsLocaleSelectProps {
 }
 
 export const DateFnsLocaleSelect: React.FC<DateFnsLocaleSelectProps> = props => {
-    const renderLocaleItem: ItemRenderer<CommonDateFnsLocale> = React.useCallback(
+    const renderLocaleItem: ItemRenderer<CommonDateFnsLocale> = useCallback(
         (locale, { handleClick, handleFocus, modifiers, ref }) => {
             const { matchesPredicate, ...menuItemModifiers } = modifiers;
             if (!matchesPredicate) {

--- a/packages/docs-app/src/common/dateFormatSelector.tsx
+++ b/packages/docs-app/src/common/dateFormatSelector.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Radio, RadioGroup } from "@blueprintjs/core";
 import type { DateFormatProps } from "@blueprintjs/datetime";
 import { handleNumberChange } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/common/formattedDateRange.tsx
+++ b/packages/docs-app/src/common/formattedDateRange.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Tag } from "@blueprintjs/core";
 import type { DateRange } from "@blueprintjs/datetime";
 import { ArrowRight } from "@blueprintjs/icons";

--- a/packages/docs-app/src/common/formattedDateTag.tsx
+++ b/packages/docs-app/src/common/formattedDateTag.tsx
@@ -15,7 +15,6 @@
  */
 
 import { format } from "date-fns";
-import * as React from "react";
 
 import { Tag } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/common/propCodeTooltip.tsx
+++ b/packages/docs-app/src/common/propCodeTooltip.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Code, Tooltip, type TooltipProps } from "@blueprintjs/core";
 
 /**

--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -16,7 +16,7 @@
 
 import { type HeadingNode, isPageNode, type PageData, type TsDocBase } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import { AnchorButton, BlueprintProvider, Classes, type Intent, Tag } from "@blueprintjs/core";
 import type { DocsCompleteData } from "@blueprintjs/docs-data";
@@ -69,7 +69,7 @@ export interface BlueprintDocsProps {
     useNextVersion: boolean;
 }
 
-export class BlueprintDocs extends React.Component<BlueprintDocsProps, { themeName: string }> {
+export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: string }> {
     public state = { themeName: getTheme() };
 
     public render() {

--- a/packages/docs-app/src/components/clickToCopy.tsx
+++ b/packages/docs-app/src/components/clickToCopy.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef, useCallback, useRef, useState } from "react";
 
 import { type HTMLDivProps, type Props, removeNonHTMLProps } from "@blueprintjs/core";
 import { createKeyEventHandler } from "@blueprintjs/docs-theme";
@@ -44,7 +44,7 @@ export interface ClickToCopyProps extends Props, React.RefAttributes<any>, HTMLD
  *  - `[data-copied-message="<message>"]` will be shown when the element has been copied.
  * The message is reset to default when the user mouses off the element after copying it.
  */
-export const ClickToCopy: React.FC<ClickToCopyProps> = React.forwardRef<any, ClickToCopyProps>((props, ref) => {
+export const ClickToCopy: React.FC<ClickToCopyProps> = forwardRef<any, ClickToCopyProps>((props, ref) => {
     const {
         className,
         children,
@@ -54,16 +54,16 @@ export const ClickToCopy: React.FC<ClickToCopyProps> = React.forwardRef<any, Cli
         onKeyDown,
         value = "",
     } = props;
-    const [hasCopied, setHasCopied] = React.useState(false);
-    const inputRef = React.useRef<HTMLInputElement>();
+    const [hasCopied, setHasCopied] = useState(false);
+    const inputRef = useRef<HTMLInputElement>();
 
-    const copy = React.useCallback(async () => {
+    const copy = useCallback(async () => {
         inputRef.current?.select();
         await navigator.clipboard.writeText(inputRef.current.value);
         setHasCopied(true);
     }, [inputRef]);
 
-    const handleClick = React.useCallback(
+    const handleClick = useCallback(
         async (e: React.MouseEvent<HTMLDivElement>) => {
             await copy();
             onClick?.(e);
@@ -71,7 +71,7 @@ export const ClickToCopy: React.FC<ClickToCopyProps> = React.forwardRef<any, Cli
         [copy, onClick],
     );
 
-    const handleMouseLeave = React.useCallback(
+    const handleMouseLeave = useCallback(
         (e: React.MouseEvent<HTMLDivElement>) => {
             setHasCopied(false);
             onMouseLeave?.(e);
@@ -79,12 +79,12 @@ export const ClickToCopy: React.FC<ClickToCopyProps> = React.forwardRef<any, Cli
         [onMouseLeave],
     );
 
-    const handleInputBlur = React.useCallback(() => {
+    const handleInputBlur = useCallback(() => {
         setHasCopied(false);
     }, []);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const handleKeyDown = React.useCallback(
+    const handleKeyDown = useCallback(
         createKeyEventHandler(
             {
                 Enter: copy,

--- a/packages/docs-app/src/components/colorPalettes.tsx
+++ b/packages/docs-app/src/components/colorPalettes.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes, Colors, Pre } from "@blueprintjs/core";
 

--- a/packages/docs-app/src/components/colorSchemes.tsx
+++ b/packages/docs-app/src/components/colorSchemes.tsx
@@ -16,7 +16,7 @@
 
 import chroma from "chroma-js";
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, RadioGroup } from "@blueprintjs/core";
 import { createKeyEventHandler, handleNumberChange } from "@blueprintjs/docs-theme";
@@ -83,7 +83,7 @@ export interface ColorSchemeState {
     steps?: number;
 }
 
-export class ColorScheme extends React.PureComponent<ColorSchemeProps, ColorSchemeState> {
+export class ColorScheme extends PureComponent<ColorSchemeProps, ColorSchemeState> {
     public state: ColorSchemeState = {
         activePalette: 0,
         activeSchema: 0,

--- a/packages/docs-app/src/components/docsIcon.tsx
+++ b/packages/docs-app/src/components/docsIcon.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 import download from "downloadjs";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, ContextMenu, Icon, type IconName, Menu, MenuItem } from "@blueprintjs/core";
 import { IconSize } from "@blueprintjs/icons";
@@ -36,7 +36,7 @@ function downloadIconFile(iconName: IconName, iconSize: 16 | 20) {
     download(`${GITHUB_RAW_PATH}/${iconSize}px/${iconName}.svg`);
 }
 
-export class DocsIcon extends React.PureComponent<DocsIconProps> {
+export class DocsIcon extends PureComponent<DocsIconProps> {
     public render() {
         const { iconName, displayName, tags } = this.props;
         return (

--- a/packages/docs-app/src/components/icons.tsx
+++ b/packages/docs-app/src/components/icons.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, H3, InputGroup, NonIdealState } from "@blueprintjs/core";
 import { smartSearch } from "@blueprintjs/docs-theme";
@@ -33,7 +33,7 @@ export interface IconsProps {
     icons?: Icon[];
 }
 
-export class Icons extends React.PureComponent<IconsProps, IconsState> {
+export class Icons extends PureComponent<IconsProps, IconsState> {
     public static defaultProps: IconsProps = {
         iconFilter: isIconFiltered,
         iconRenderer: renderIcon,

--- a/packages/docs-app/src/components/logo.tsx
+++ b/packages/docs-app/src/components/logo.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 export const Logo: React.FC = () => (
     <svg width="65" height="76" xmlns="http://www.w3.org/2000/svg">
         <g fillRule="nonzero">

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { NpmPackageInfo } from "@documentalist/client";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, HotkeysTarget, type Intent, Menu, MenuItem, NavbarHeading, Popover, Tag } from "@blueprintjs/core";
 import { NavButton } from "@blueprintjs/docs-theme";
@@ -29,7 +29,7 @@ export interface NavHeaderProps {
     packageInfo: NpmPackageInfo;
 }
 
-export class NavHeader extends React.PureComponent<NavHeaderProps> {
+export class NavHeader extends PureComponent<NavHeaderProps> {
     public render() {
         const { useDarkTheme } = this.props;
         return (

--- a/packages/docs-app/src/components/navIcons.tsx
+++ b/packages/docs-app/src/components/navIcons.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 export const NavIcon: React.FC<{ route: string }> = ({ route }) => {
     return (
         <svg className="docs-nav-package-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg">

--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Card, H4, Icon, type IconName } from "@blueprintjs/core";
 
-export class Welcome extends React.PureComponent {
+export class Welcome extends PureComponent {
     public render() {
         return (
             <div className="blueprint-welcome">

--- a/packages/docs-app/src/examples/core-examples/alertExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/alertExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Alert, Button, H5, Intent, OverlayToaster, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -23,9 +23,9 @@ import { IconNames } from "@blueprintjs/icons";
 import type { BlueprintExampleData } from "../../tags/types";
 
 export const AlertExample: React.FC<ExampleProps<BlueprintExampleData>> = props => {
-    const [canEscapeKeyCancel, setCanEscapeKeyCancel] = React.useState(false);
-    const [canOutsideClickCancel, setCanOutsideClickCancel] = React.useState(false);
-    const [willLoad, setWillLoad] = React.useState(false);
+    const [canEscapeKeyCancel, setCanEscapeKeyCancel] = useState(false);
+    const [canOutsideClickCancel, setCanOutsideClickCancel] = useState(false);
+    const [willLoad, setWillLoad] = useState(false);
 
     const options = (
         <>
@@ -79,12 +79,12 @@ const FileErrorAlert: React.FC<AlertExampleProps> = ({
     themeName,
     willLoad,
 }) => {
-    const [isLoading, setIsLoading] = React.useState(false);
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
-    const handleClick = React.useCallback(() => setIsOpen(true), []);
+    const handleClick = useCallback(() => setIsOpen(true), []);
 
-    const handleClose = React.useCallback(() => {
+    const handleClose = useCallback(() => {
         const close = () => {
             setIsOpen(false);
             setIsLoading(false);
@@ -124,16 +124,16 @@ const FileDeletionAlert: React.FC<AlertExampleProps> = ({
     themeName,
     willLoad,
 }) => {
-    const [isLoading, setIsLoading] = React.useState(false);
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
     const toaster = OverlayToaster.create({ className: themeName });
 
-    const handleClick = React.useCallback(() => setIsOpen(true), []);
+    const handleClick = useCallback(() => setIsOpen(true), []);
 
-    const handleCancel = React.useCallback(() => setIsOpen(false), []);
+    const handleCancel = useCallback(() => setIsOpen(false), []);
 
-    const handleConfirm = React.useCallback(() => {
+    const handleConfirm = useCallback(() => {
         const close = async () => {
             setIsOpen(false);
             setIsLoading(false);

--- a/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
+++ b/packages/docs-app/src/examples/core-examples/audio/pianoKey.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useEffect, useState } from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -31,13 +31,13 @@ interface PianoKeyProps {
 }
 
 export const PianoKey: React.FC<PianoKeyProps> = ({ context, hotkey, note, pressed }) => {
-    const [envelope, setEnvelope] = React.useState<Envelope | undefined>();
+    const [envelope, setEnvelope] = useState<Envelope | undefined>();
     // use this flag to defer connecting to main audio output until we actually press a note, which prevents
     // a bug where all keys were being played on component mount
-    const [isOutputEnabled, setIsOutputEnabeld] = React.useState<boolean>(false);
+    const [isOutputEnabled, setIsOutputEnabeld] = useState<boolean>(false);
 
     // only create oscillator and envelope once on mount
-    React.useEffect(() => {
+    useEffect(() => {
         const oscillator = new Oscillator(context, Scale[note]);
         const newEnvelope = new Envelope(context);
         oscillator.oscillator.connect(newEnvelope.gain);
@@ -51,7 +51,7 @@ export const PianoKey: React.FC<PianoKeyProps> = ({ context, hotkey, note, press
     }, [context, note]);
 
     // start/stop envelope when this key is pressed down/up
-    React.useEffect(() => {
+    useEffect(() => {
         if (pressed) {
             if (!isOutputEnabled) {
                 // connect to audio output if we haven't already

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { Breadcrumb, Breadcrumbs, Icon } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/breadcrumbsPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/breadcrumbsPlaygroundExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Boundary,
@@ -59,14 +59,14 @@ const ITEMS_FOR_ALWAYS_RENDER: BreadcrumbProps[] = [
 const breadcrumbWidthLabelId = "num-visible-items-label";
 
 export const BreadcrumbsPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [alwaysRenderOverflow, setAlwaysRenderOverflow] = React.useState(false);
-    const [collapseFrom, setCollapseFrom] = React.useState<Boundary>(Boundary.START);
-    const [renderCurrentAsInput, setRenderCurrentAsInput] = React.useState(false);
-    const [width, setWidth] = React.useState(50);
+    const [alwaysRenderOverflow, setAlwaysRenderOverflow] = useState(false);
+    const [collapseFrom, setCollapseFrom] = useState<Boundary>(Boundary.START);
+    const [renderCurrentAsInput, setRenderCurrentAsInput] = useState(false);
+    const [width, setWidth] = useState(50);
 
     const handleChangeCollapse = handleStringChange(value => setCollapseFrom(value as Boundary));
 
-    const renderBreadcrumbInput = React.useCallback(({ text }: BreadcrumbProps) => {
+    const renderBreadcrumbInput = useCallback(({ text }: BreadcrumbProps) => {
         return <BreadcrumbInput defaultValue={typeof text === "string" ? text : undefined} />;
     }, []);
 
@@ -124,6 +124,6 @@ export const BreadcrumbsPlaygroundExample: React.FC<ExampleProps> = props => {
 const asPercentage = (value: number | string) => `${value}%`;
 
 const BreadcrumbInput: React.FC<BreadcrumbProps & { defaultValue: string | undefined }> = props => {
-    const [text, setText] = React.useState(props.defaultValue ?? "");
+    const [text, setText] = useState(props.defaultValue ?? "");
     return <InputGroup placeholder="rename me" value={text} onValueChange={setText} />;
 };

--- a/packages/docs-app/src/examples/core-examples/buttonExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { AnchorButton, Button, Icon, Tooltip } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/buttonGroupExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { Button, ButtonGroup } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPlaygroundExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import {
     AnchorButton,
@@ -39,14 +39,14 @@ import { TextAlignmentSelect } from "./common/textAlignmentSelect";
 import { VariantSelect } from "./common/variantSelect";
 
 export const ButtonGroupPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [alignText, setAlignText] = React.useState<TextAlignment>(TextAlignment.CENTER);
-    const [fill, setFill] = React.useState(false);
-    const [iconOnly, setIconOnly] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [large, setLarge] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
-    const [variant, setVariant] = React.useState<ButtonVariant>("solid");
-    const [vertical, setVertical] = React.useState(false);
+    const [alignText, setAlignText] = useState<TextAlignment>(TextAlignment.CENTER);
+    const [fill, setFill] = useState(false);
+    const [iconOnly, setIconOnly] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [large, setLarge] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
+    const [variant, setVariant] = useState<ButtonVariant>("solid");
+    const [vertical, setVertical] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import {
     Button,
@@ -36,12 +36,12 @@ import { TextAlignmentSelect } from "./common/textAlignmentSelect";
 import { VariantSelect } from "./common/variantSelect";
 
 export const ButtonGroupPopoverExample: React.FC<ExampleProps> = props => {
-    const [alignText, setAlignText] = React.useState<TextAlignment>(TextAlignment.CENTER);
-    const [fill, setFill] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
-    const [variant, setVariant] = React.useState<ButtonVariant>("solid");
-    const [vertical, setVertical] = React.useState(false);
+    const [alignText, setAlignText] = useState<TextAlignment>(TextAlignment.CENTER);
+    const [fill, setFill] = useState(false);
+    const [large, setLarge] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
+    const [variant, setVariant] = useState<ButtonVariant>("solid");
+    const [vertical, setVertical] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/buttonPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonPlaygroundExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
     AnchorButton,
@@ -40,26 +40,26 @@ import { TextAlignmentSelect } from "./common/textAlignmentSelect";
 import { VariantSelect } from "./common/variantSelect";
 
 export const ButtonPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [active, setActive] = React.useState(false);
-    const [alignText, setAlignText] = React.useState<TextAlignment>(TextAlignment.CENTER);
-    const [disabled, setDisabled] = React.useState(false);
-    const [ellipsizeText, setEllipsizeText] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [iconOnly, setIconOnly] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [loading, setLoading] = React.useState(false);
-    const [longText, setLongText] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
-    const [variant, setVariant] = React.useState<ButtonVariant>("solid");
-    const [wiggling, setWiggling] = React.useState(false);
+    const [active, setActive] = useState(false);
+    const [alignText, setAlignText] = useState<TextAlignment>(TextAlignment.CENTER);
+    const [disabled, setDisabled] = useState(false);
+    const [ellipsizeText, setEllipsizeText] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [iconOnly, setIconOnly] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [loading, setLoading] = useState(false);
+    const [longText, setLongText] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
+    const [variant, setVariant] = useState<ButtonVariant>("solid");
+    const [wiggling, setWiggling] = useState(false);
 
-    const wiggleTimeoutId = React.useRef<number>();
+    const wiggleTimeoutId = useRef<number>();
 
-    React.useEffect(() => {
+    useEffect(() => {
         return () => window.clearTimeout(wiggleTimeoutId.current);
     }, []);
 
-    const beginWiggling = React.useCallback(() => {
+    const beginWiggling = useCallback(() => {
         window.clearTimeout(wiggleTimeoutId.current);
         setWiggling(true);
         wiggleTimeoutId.current = window.setTimeout(() => setWiggling(false), 300);

--- a/packages/docs-app/src/examples/core-examples/calloutExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { Callout } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/calloutPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutPlaygroundExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, Callout, Code, H5, HTMLSelect, type Intent, Label, Switch } from "@blueprintjs/core";
 import { type DocsExampleProps, Example, handleBooleanChange, handleNumberChange } from "@blueprintjs/docs-theme";
@@ -24,12 +24,12 @@ import { IconSelect } from "./common/iconSelect";
 import { IntentSelect } from "./common/intentSelect";
 
 export const CalloutPlaygroundExample: React.FC<DocsExampleProps> = props => {
-    const [compact, setCompact] = React.useState(false);
-    const [contentIndex, setContentIndex] = React.useState(0);
-    const [icon, setIcon] = React.useState<IconName>();
-    const [intent, setIntent] = React.useState<Intent>();
-    const [minimal, setMinimal] = React.useState(false);
-    const [showTitle, setShowTitle] = React.useState(true);
+    const [compact, setCompact] = useState(false);
+    const [contentIndex, setContentIndex] = useState(0);
+    const [icon, setIcon] = useState<IconName>();
+    const [intent, setIntent] = useState<Intent>();
+    const [minimal, setMinimal] = useState(false);
+    const [showTitle, setShowTitle] = useState(true);
 
     const options = (
         <>
@@ -71,11 +71,11 @@ export const CalloutPlaygroundExample: React.FC<DocsExampleProps> = props => {
 const EXAMPLE_CONTENT_OPTIONS = [
     {
         content: (
-            <React.Fragment>
+            <>
                 Long-form information about the important content. This text is styled as{" "}
                 <a href="#core/typography.running-text">"Running text"</a>, so it may contain things like headers,
                 links, lists, <Code>code</Code> etc.
-            </React.Fragment>
+            </>
         ),
         label: "Text with formatting",
     },

--- a/packages/docs-app/src/examples/core-examples/cardExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { Button, Card, Elevation, H3 } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/cardListExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardListExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { Card, CardList, Section, SectionCard } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/cardListPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardListPlaygroundExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, Card, CardList, Classes, Code, H5, Section, SectionCard, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -26,12 +26,12 @@ import { PropCodeTooltip } from "../../common/propCodeTooltip";
 const ingredients = ["Basil", "Olive oil", "Kosher salt", "Garlic", "Pine nuts", "Parmigiano Reggiano"];
 
 export const CardListPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [bordered, setBordered] = React.useState(true);
-    const [compact, setCompact] = React.useState(false);
-    const [interactive, setInteractive] = React.useState(true);
-    const [padded, setPadded] = React.useState(false);
-    const [useScrollableContainer, setUseScrollableContainer] = React.useState(false);
-    const [useSectionContainer, setUseSectionContainer] = React.useState(false);
+    const [bordered, setBordered] = useState(true);
+    const [compact, setCompact] = useState(false);
+    const [interactive, setInteractive] = useState(true);
+    const [padded, setPadded] = useState(false);
+    const [useScrollableContainer, setUseScrollableContainer] = useState(false);
+    const [useSectionContainer, setUseSectionContainer] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/cardPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/cardPlaygroundExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Button, Card, Classes, Elevation, FormGroup, H5, Slider, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,12 +22,12 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 const MAX_ELEVATION = 4;
 
 export const CardPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [compact, setCompact] = React.useState(false);
-    const [elevation, setElevation] = React.useState<Elevation>(Elevation.ZERO);
-    const [interactive, setInteractive] = React.useState(false);
-    const [selected, setSelected] = React.useState(false);
+    const [compact, setCompact] = useState(false);
+    const [elevation, setElevation] = useState<Elevation>(Elevation.ZERO);
+    const [interactive, setInteractive] = useState(false);
+    const [selected, setSelected] = useState(false);
 
-    const handleElevationChange = React.useCallback((value: number) => setElevation(value as Elevation), []);
+    const handleElevationChange = useCallback((value: number) => setElevation(value as Elevation), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/checkboxCardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxCardExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useState } from "react";
 
 import {
     Alignment,
@@ -34,11 +34,11 @@ import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export const CheckboxCardExample: React.FC<ExampleProps> = props => {
-    const [alignIndicator, setAlignIndicator] = React.useState<Alignment>(Alignment.START);
-    const [compact, setCompact] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = React.useState(true);
-    const [showSubtext, setShowSubtext] = React.useState(true);
+    const [alignIndicator, setAlignIndicator] = useState<Alignment>(Alignment.START);
+    const [compact, setCompact] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = useState(true);
+    const [showSubtext, setShowSubtext] = useState(true);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/checkboxExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Alignment, Card, Checkbox, type CheckboxProps, FormGroup, H5, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,10 +22,10 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export const CheckboxExample: React.FC<ExampleProps> = props => {
-    const [alignIndicator, setAlignIndicator] = React.useState<Alignment>(Alignment.START);
-    const [disabled, setDisabled] = React.useState(false);
-    const [inline, setInline] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
+    const [alignIndicator, setAlignIndicator] = useState<Alignment>(Alignment.START);
+    const [disabled, setDisabled] = useState(false);
+    const [inline, setInline] = useState(false);
+    const [large, setLarge] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/collapseExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapseExamples.tsx
@@ -3,16 +3,16 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, Classes, Collapse, FormGroup, InputGroup } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const CollapseBasicExample: React.FC<ExampleProps> = props => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
     const code = dedent`
         function CollapseExample() {
-            const [isOpen, setIsOpen] = React.useState(false);
+            const [isOpen, setIsOpen] = useState(false);
 
             return (
                 <div>
@@ -57,10 +57,10 @@ export const CollapseBasicExample: React.FC<ExampleProps> = props => {
 };
 
 export const CollapseMountedExample: React.FC<ExampleProps> = props => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
     const code = dedent`
         function CollapseMountedExample() {
-            const [isOpen, setIsOpen] = React.useState(false);
+            const [isOpen, setIsOpen] = useState(false);
 
             return (
                 <div>

--- a/packages/docs-app/src/examples/core-examples/collapsePlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/collapsePlaygroundExample.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Button, Collapse, H5, InputGroup, Pre, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const CollapsePlaygroundExample: React.FC<ExampleProps> = props => {
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [keepChildrenMounted, setKeepChildrenMounted] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
+    const [keepChildrenMounted, setKeepChildrenMounted] = useState(false);
 
-    const handleClick = React.useCallback(() => setIsOpen(!isOpen), [isOpen]);
+    const handleClick = useCallback(() => setIsOpen(!isOpen), [isOpen]);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/alignmentSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { Alignment, FormGroup, SegmentedControl } from "@blueprintjs/core";
 
@@ -30,7 +30,7 @@ interface AlignmentSelectProps {
 }
 
 export const AlignmentSelect: React.FC<AlignmentSelectProps> = ({ align, label = "Align text", onChange }) => {
-    const handleChange = React.useCallback((value: string) => onChange(value as Alignment), [onChange]);
+    const handleChange = useCallback((value: string) => onChange(value as Alignment), [onChange]);
     return (
         <FormGroup label={label}>
             <SegmentedControl fill={true} options={options} onValueChange={handleChange} size="small" value={align} />

--- a/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/booleanOrUndefinedSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { FormGroup, SegmentedControl } from "@blueprintjs/core";
 
@@ -33,7 +33,7 @@ export const BooleanOrUndefinedSelect: React.FC<BooleanOrUndefinedSelectProps> =
     value,
     onChange,
 }) => {
-    const handleChange = React.useCallback(
+    const handleChange = useCallback(
         (newValue: string) => onChange(newValue === "undefined" ? undefined : newValue === "true" ? true : false),
         [onChange],
     );

--- a/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/fileMenu.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Menu, MenuDivider, MenuItem, type Props } from "@blueprintjs/core";
 
 export interface FileMenuProps extends Props {

--- a/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/iconSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Alignment, Button, Classes, MenuItem } from "@blueprintjs/core";
 import type { IconName } from "@blueprintjs/icons";
@@ -31,7 +31,7 @@ export interface IconSelectProps {
     onChange: (iconName?: IconName) => void;
 }
 
-export class IconSelect extends React.PureComponent<IconSelectProps> {
+export class IconSelect extends PureComponent<IconSelectProps> {
     public render() {
         const { disabled, iconName } = this.props;
         return (

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { Button, ControlGroup, FormGroup, HTMLSelect, Intent } from "@blueprintjs/core";
 import { handleValueChange } from "@blueprintjs/docs-theme";
@@ -37,7 +37,7 @@ export interface IntentSelectProps {
 
 export const IntentSelect: React.FC<IntentSelectProps> = ({ label = "Intent", intent, showClearButton, onChange }) => {
     const handleChange = handleValueChange(onChange);
-    const handleClear = React.useCallback(() => onChange("none"), [onChange]);
+    const handleClear = useCallback(() => onChange("none"), [onChange]);
     return (
         <FormGroup label={label}>
             <ControlGroup>

--- a/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/layoutSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { FormGroup, SegmentedControl } from "@blueprintjs/core";
 
@@ -27,7 +27,7 @@ export interface LayoutSelectProps {
 
 /** Button radio group to switch between horizontal and vertical layouts. */
 export const LayoutSelect: React.FC<LayoutSelectProps> = ({ layout, onChange }) => {
-    const handleChange = React.useCallback((value: string) => onChange(value as Layout), [onChange]);
+    const handleChange = useCallback((value: string) => onChange(value as Layout), [onChange]);
 
     return (
         <FormGroup label="Layout">

--- a/packages/docs-app/src/examples/core-examples/common/legacySizeSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/legacySizeSelect.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { FormGroup, SegmentedControl } from "@blueprintjs/core";
 
@@ -35,7 +35,7 @@ export const LegacySizeSelect: React.FC<LegacySizeSelectProps> = ({
     optionLabels = labels,
     onChange,
 }) => {
-    const handleChange = React.useCallback((value: string) => onChange(value as Size), [onChange]);
+    const handleChange = useCallback((value: string) => onChange(value as Size), [onChange]);
 
     return (
         <FormGroup label={label}>

--- a/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/sizeSelect.tsx
@@ -2,7 +2,7 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { FormGroup, SegmentedControl, type Size } from "@blueprintjs/core";
 
@@ -24,7 +24,7 @@ const options: Option[] = [
 ];
 
 export const SizeSelect: React.FC<SizeSelectProps> = ({ label = "Size", onChange, size }) => {
-    const handleChange = React.useCallback((value: string) => onChange(value as Size), [onChange]);
+    const handleChange = useCallback((value: string) => onChange(value as Size), [onChange]);
     return (
         <FormGroup label={label}>
             <SegmentedControl fill={true} onValueChange={handleChange} options={options} size="small" value={size} />

--- a/packages/docs-app/src/examples/core-examples/common/textAlignmentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/textAlignmentSelect.tsx
@@ -2,7 +2,7 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { FormGroup, SegmentedControl, TextAlignment } from "@blueprintjs/core";
 
@@ -19,7 +19,7 @@ interface AlignmentSelectProps {
 }
 
 export const TextAlignmentSelect: React.FC<AlignmentSelectProps> = ({ align, label = "Align text", onChange }) => {
-    const handleChange = React.useCallback((value: string) => onChange(value as TextAlignment), [onChange]);
+    const handleChange = useCallback((value: string) => onChange(value as TextAlignment), [onChange]);
     return (
         <FormGroup label={label}>
             <SegmentedControl fill={true} options={options} onValueChange={handleChange} size="small" value={align} />

--- a/packages/docs-app/src/examples/core-examples/common/variantSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/variantSelect.tsx
@@ -2,8 +2,6 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
-
 import { type ButtonVariant, ControlGroup, FormGroup, HTMLSelect } from "@blueprintjs/core";
 import { handleValueChange } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/examples/core-examples/compoundTagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/compoundTagExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Button, CompoundTag, H5, Intent, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -25,21 +25,21 @@ import { IntentSelect } from "./common/intentSelect";
 const INITIAL_TAGS = ["London", "New York", "San Francisco", "Seattle"];
 
 export const CompoundTagExample: React.FC<ExampleProps> = props => {
-    const [active, setActive] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [icon, setIcon] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [interactive, setInteractive] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(false);
-    const [removable, setRemovable] = React.useState(false);
-    const [endIcon, setEndIcon] = React.useState(false);
-    const [round, setRound] = React.useState(false);
-    const [tags, setTags] = React.useState(INITIAL_TAGS);
+    const [active, setActive] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [icon, setIcon] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [interactive, setInteractive] = useState(false);
+    const [large, setLarge] = useState(false);
+    const [minimal, setMinimal] = useState(false);
+    const [removable, setRemovable] = useState(false);
+    const [endIcon, setEndIcon] = useState(false);
+    const [round, setRound] = useState(false);
+    const [tags, setTags] = useState(INITIAL_TAGS);
 
-    const handleRemove = React.useCallback((tag: string) => () => setTags(tags.filter(t => t !== tag)), [tags]);
+    const handleRemove = useCallback((tag: string) => () => setTags(tags.filter(t => t !== tag)), [tags]);
 
-    const handleReset = React.useCallback(() => setTags(INITIAL_TAGS), []);
+    const handleReset = useCallback(() => setTags(INITIAL_TAGS), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback } from "react";
 
 import {
     Classes,
@@ -74,7 +74,7 @@ const ContextMenuContent: React.FC<Omit<ContextMenuContentProps, "isOpen" | "mou
 );
 
 const GraphNode: React.FC = () => {
-    const children = React.useCallback(
+    const children = useCallback(
         (props: ContextMenuChildrenProps) => (
             <div
                 className={classNames("docs-context-menu-node", props.className, {

--- a/packages/docs-app/src/examples/core-examples/contextMenuPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/contextMenuPopoverExample.tsx
@@ -15,20 +15,20 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { Classes, hideContextMenu, Menu, MenuDivider, MenuItem, showContextMenu } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const ContextMenuPopoverExample: React.FC<ExampleProps> = props => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
-    const handleClose = React.useCallback(() => {
+    const handleClose = useCallback(() => {
         setIsOpen(false);
         hideContextMenu();
     }, []);
 
-    const menu = React.useMemo(
+    const menu = useMemo(
         () => (
             <Menu>
                 <MenuItem icon="cross-circle" intent="danger" text="Click me to close" onClick={handleClose} />
@@ -43,7 +43,7 @@ export const ContextMenuPopoverExample: React.FC<ExampleProps> = props => {
         [handleClose],
     );
 
-    const handleContextMenu = React.useCallback(
+    const handleContextMenu = useCallback(
         (event: React.MouseEvent<HTMLElement>) => {
             // ensure `preventDefault` is called just before `showContextMenu` and in the same event handler to prevent the
             // default browser context menu from hiding your custom context menu

--- a/packages/docs-app/src/examples/core-examples/controlCardListExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlCardListExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import {
     CardList,
@@ -32,9 +32,9 @@ import { Cog, Moon, PageLayout } from "@blueprintjs/icons";
 import { PropCodeTooltip } from "../../common/propCodeTooltip";
 
 export const ControlCardListExample: React.FC<ExampleProps> = props => {
-    const [compact, setCompact] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = React.useState(true);
+    const [compact, setCompact] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = useState(true);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/controlGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, ControlGroup, HTMLSelect, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,8 +22,8 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 const FILTER_OPTIONS = ["Filter", "Name - ascending", "Name - descending", "Price - ascending", "Price - descending"];
 
 export const ControlGroupExample: React.FC<ExampleProps> = props => {
-    const [fill, setFill] = React.useState(false);
-    const [vertical, setVertical] = React.useState(false);
+    const [fill, setFill] = useState(false);
+    const [vertical, setVertical] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/dialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     AnchorButton,
@@ -36,12 +36,12 @@ import { IconNames } from "@blueprintjs/icons";
 import type { BlueprintExampleData } from "../../tags/types";
 
 export const DialogExample: React.FC<ExampleProps<BlueprintExampleData>> = props => {
-    const [autoFocus, setAutoFocus] = React.useState(true);
-    const [canEscapeKeyClose, setCanEscapeKeyClose] = React.useState(true);
-    const [canOutsideClickClose, setCanOutsideClickClose] = React.useState(true);
-    const [enforceFocus, setEnforceFocus] = React.useState(true);
-    const [shouldReturnFocusOnClose, setShouldReturnFocusOnClose] = React.useState(true);
-    const [usePortal, setUsePortal] = React.useState(true);
+    const [autoFocus, setAutoFocus] = useState(true);
+    const [canEscapeKeyClose, setCanEscapeKeyClose] = useState(true);
+    const [canOutsideClickClose, setCanOutsideClickClose] = useState(true);
+    const [enforceFocus, setEnforceFocus] = useState(true);
+    const [shouldReturnFocusOnClose, setShouldReturnFocusOnClose] = useState(true);
+    const [usePortal, setUsePortal] = useState(true);
 
     const options = (
         <>
@@ -124,11 +124,11 @@ const ButtonWithDialog: React.FC<ButtonWithDialogProps> = ({
     footerStyle,
     ...props
 }: Omit<DialogProps, "isOpen"> & { buttonText: string; footerStyle: "default" | "minimal" | "none" }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
-    const handleClick = React.useCallback(() => setIsOpen(value => !value), []);
+    const handleClick = useCallback(() => setIsOpen(value => !value), []);
 
-    const handleClose = React.useCallback(() => setIsOpen(false), []);
+    const handleClose = useCallback(() => setIsOpen(false), []);
 
     const footerActions = (
         <>

--- a/packages/docs-app/src/examples/core-examples/dividerExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/dividerExamples.tsx
@@ -3,7 +3,6 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
 
 import { Divider } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";

--- a/packages/docs-app/src/examples/core-examples/dividerPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dividerPlaygroundExample.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, ButtonGroup, Divider, H5, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const DividerPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [vertical, setVertical] = React.useState(false);
-    const [compact, setCompact] = React.useState(false);
+    const [vertical, setVertical] = useState(false);
+    const [compact, setCompact] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/drawerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/drawerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Button,
@@ -40,21 +40,21 @@ import { IconNames } from "@blueprintjs/icons";
 import type { BlueprintExampleData } from "../../tags/types";
 
 export const DrawerExample: React.FC<ExampleProps<BlueprintExampleData>> = props => {
-    const [autoFocus, setAutoFocus] = React.useState(true);
-    const [canEscapeKeyClose, setCanEscapeKeyClose] = React.useState(true);
-    const [canOutsideClickClose, setCanOutsideClickClose] = React.useState(true);
-    const [enforceFocus, setEnforceFocus] = React.useState(true);
-    const [hasBackdrop, setHasBackdrop] = React.useState(true);
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [position, setPosition] = React.useState<Position>(Position.RIGHT);
-    const [size, setSize] = React.useState<string | undefined>(undefined);
-    const [usePortal, setUsePortal] = React.useState(true);
+    const [autoFocus, setAutoFocus] = useState(true);
+    const [canEscapeKeyClose, setCanEscapeKeyClose] = useState(true);
+    const [canOutsideClickClose, setCanOutsideClickClose] = useState(true);
+    const [enforceFocus, setEnforceFocus] = useState(true);
+    const [hasBackdrop, setHasBackdrop] = useState(true);
+    const [isOpen, setIsOpen] = useState(false);
+    const [position, setPosition] = useState<Position>(Position.RIGHT);
+    const [size, setSize] = useState<string | undefined>(undefined);
+    const [usePortal, setUsePortal] = useState(true);
 
-    const handlePositionChange = React.useCallback((value: string) => setPosition(value as Position), []);
+    const handlePositionChange = useCallback((value: string) => setPosition(value as Position), []);
 
-    const handleOpen = React.useCallback(() => setIsOpen(true), []);
+    const handleOpen = useCallback(() => setIsOpen(true), []);
 
-    const handleClose = React.useCallback(() => setIsOpen(false), []);
+    const handleClose = useCallback(() => setIsOpen(false), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Alignment, Button, Card, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { IconNames } from "@blueprintjs/icons";

--- a/packages/docs-app/src/examples/core-examples/editableTextExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextExamples.tsx
@@ -3,24 +3,21 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
+import { useCallback, useRef } from "react";
 
 import { EditableText, Intent, OverlayToaster } from "@blueprintjs/core";
 import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const EditableTextBasicExample: React.FC<ExampleProps> = props => {
     const code = `<EditableText placeholder="Click to edit..." onConfirm={...} onCancel={...} />`;
-    const toaster = React.useRef<OverlayToaster>(null);
+    const toaster = useRef<OverlayToaster>(null);
 
-    const handleConfirm = React.useCallback(
+    const handleConfirm = useCallback(
         (value: string) => toaster.current.show({ intent: Intent.SUCCESS, message: `Confirmed: ${value}` }),
         [],
     );
 
-    const handleCancel = React.useCallback(
-        () => toaster.current.show({ intent: Intent.DANGER, message: "Canceled" }),
-        [],
-    );
+    const handleCancel = useCallback(() => toaster.current.show({ intent: Intent.DANGER, message: "Canceled" }), []);
 
     return (
         <CodeExample code={code} {...props}>

--- a/packages/docs-app/src/examples/core-examples/editableTextPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/editableTextPlaygroundExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Classes, EditableText, FormGroup, H1, H5, type Intent, NumericInput, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -24,15 +24,15 @@ import { IntentSelect } from "./common/intentSelect";
 const INPUT_ID = "EditableTextExample-max-length";
 
 export const EditableTextPlaygroundExample: React.FC<ExampleProps> = props => {
-    const [alwaysRenderInput, setAlwaysRenderInput] = React.useState(false);
-    const [confirmOnEnterKey, setConfirmOnEnterKey] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent | undefined>(undefined);
-    const [maxLength, setMaxLength] = React.useState<number | undefined>(undefined);
-    const [report, setReport] = React.useState("");
-    const [selectAllOnFocus, setSelectAllOnFocus] = React.useState(false);
+    const [alwaysRenderInput, setAlwaysRenderInput] = useState(false);
+    const [confirmOnEnterKey, setConfirmOnEnterKey] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [intent, setIntent] = useState<Intent | undefined>(undefined);
+    const [maxLength, setMaxLength] = useState<number | undefined>(undefined);
+    const [report, setReport] = useState("");
+    const [selectAllOnFocus, setSelectAllOnFocus] = useState(false);
 
-    const handleMaxLengthChange = React.useCallback(
+    const handleMaxLengthChange = useCallback(
         (value: number) => {
             if (maxLength === 0) {
                 setMaxLength(undefined);
@@ -44,7 +44,7 @@ export const EditableTextPlaygroundExample: React.FC<ExampleProps> = props => {
         [maxLength, report],
     );
 
-    const handleReportChange = React.useCallback((value: string) => setReport(value), []);
+    const handleReportChange = useCallback((value: string) => setReport(value), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import {
     ControlGroup,
@@ -42,13 +42,13 @@ const WIDTH_LIMIT = 200;
 const HEADINGS = ["Default", "H1", "H2", "H3", "H4", "H5", "H6"].map(value => ({ label: value, value }));
 
 export const EntityTitleExample: React.FC<ExampleProps> = props => {
-    const [ellipsize, setEllipsize] = React.useState<boolean>(false);
-    const [fill, setFill] = React.useState<boolean>(false);
-    const [heading, setHeading] = React.useState<string>("Default");
-    const [icon, setIcon] = React.useState<boolean>(true);
-    const [loading, setLoading] = React.useState<boolean>(false);
-    const [withSubtitle, setWithSubtitle] = React.useState<boolean>(false);
-    const [withTag, setWithTag] = React.useState<boolean>(false);
+    const [ellipsize, setEllipsize] = useState<boolean>(false);
+    const [fill, setFill] = useState<boolean>(false);
+    const [heading, setHeading] = useState<string>("Default");
+    const [icon, setIcon] = useState<boolean>(true);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [withSubtitle, setWithSubtitle] = useState<boolean>(false);
+    const [withTag, setWithTag] = useState<boolean>(false);
 
     const handleHeadingChange = (event: React.FormEvent<HTMLSelectElement>) => {
         setHeading(event.currentTarget.value);

--- a/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/fileInputExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { FileInput, FormGroup, H5, InputGroup, type Size } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -21,9 +21,9 @@ import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { SizeSelect } from "./common/sizeSelect";
 
 export const FileInputExample: React.FC<ExampleProps> = props => {
-    const [buttonText, setButtonText] = React.useState("");
-    const [size, setSize] = React.useState<Size>("medium");
-    const [text, setText] = React.useState(undefined);
+    const [buttonText, setButtonText] = useState("");
+    const [size, setSize] = useState<Size>("medium");
+    const [text, setText] = useState(undefined);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/focusExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/focusExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, Classes, FocusStyleManager, InputGroup, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const FocusExample: React.FC<ExampleProps> = props => {
-    const [isFocusActive, setIsFocusActive] = React.useState(true);
+    const [isFocusActive, setIsFocusActive] = useState(true);
 
     const toggleFocus = handleBooleanChange(enabled => {
         if (enabled) {

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import {
     Card,
@@ -34,14 +34,14 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { IntentSelect } from "./common/intentSelect";
 
 export const FormGroupExample: React.FC<ExampleProps> = props => {
-    const [disabled, setDisabled] = React.useState(false);
-    const [helperText, setHelperText] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [inline, setInline] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [label, setLabel] = React.useState(true);
-    const [requiredLabel, setRequiredLabel] = React.useState(true);
-    const [subLabel, setSubLabel] = React.useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [helperText, setHelperText] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [inline, setInline] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [label, setLabel] = useState(true);
+    const [requiredLabel, setRequiredLabel] = useState(true);
+    const [subLabel, setSubLabel] = useState(false);
 
     const intentLabelInfo = (
         <Tooltip

--- a/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeyTesterExample.tsx
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Code, getKeyComboString, KeyComboTag } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const HotkeyTesterExample: React.FC<ExampleProps> = props => {
-    const [combo, setCombo] = React.useState<string | null>(null);
+    const [combo, setCombo] = useState<string | null>(null);
 
-    const handleKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
         event.preventDefault();
         event.stopPropagation();
         setCombo(getKeyComboString(event.nativeEvent));
     }, []);
 
-    const handleBlur = React.useCallback(() => setCombo(null), []);
+    const handleBlur = useCallback(() => setCombo(null), []);
 
     return (
         <Example options={false} {...props}>

--- a/packages/docs-app/src/examples/core-examples/hotkeysTargetExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/hotkeysTargetExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { createRef, PureComponent } from "react";
 
 import { type HotkeyProps, HotkeysTarget, NonIdealState } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -31,12 +31,12 @@ export interface HotkeysTargetExampleState {
  * Similar to UseHotkeysExample, but using a component class API pattern.
  * We may deprecate and remove this in the future if we encourage everyone to switch to hooks.
  */
-export class HotkeysTargetExample extends React.PureComponent<ExampleProps, HotkeysTargetExampleState> {
+export class HotkeysTargetExample extends PureComponent<ExampleProps, HotkeysTargetExampleState> {
     public state: HotkeysTargetExampleState = {
         keys: Array.apply(null, Array(24)).map(() => false),
     };
 
-    private pianoRef = React.createRef<HTMLDivElement>();
+    private pianoRef = createRef<HTMLDivElement>();
 
     private focusPiano = () => {
         this.pianoRef.current.focus();

--- a/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Divider, FormGroup, H5, HTMLSelect, type HTMLSelectIconName, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
@@ -24,11 +24,11 @@ const SUPPORTED_ICON_NAMES: HTMLSelectIconName[] = ["double-caret-vertical", "ca
 const SELECT_OPTIONS = ["One", "Two", "Three", "Four"];
 
 export const HTMLSelectExample: React.FC<ExampleProps> = props => {
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [iconName, setIconName] = React.useState<HTMLSelectIconName>(undefined);
-    const [large, setLarge] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [iconName, setIconName] = useState<HTMLSelectIconName>(undefined);
+    const [large, setLarge] = useState(false);
+    const [minimal, setMinimal] = useState(false);
 
     const handleIconChange = handleStringChange(value => setIconName(value as HTMLSelectIconName));
 

--- a/packages/docs-app/src/examples/core-examples/iconExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { H5, Icon, Intent, Label, Slider } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -28,9 +28,9 @@ const MAX_ICON_SIZE = 100;
 const iconSizeLabelId = "icon-size-label";
 
 export const IconExample: React.FC<ExampleProps> = props => {
-    const [icon, setIcon] = React.useState<IconName>(IconNames.CALENDAR);
-    const [iconSize, setIconSize] = React.useState<IconSize>(IconSize.STANDARD);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
+    const [icon, setIcon] = useState<IconName>(IconNames.CALENDAR);
+    const [iconSize, setIconSize] = useState<IconSize>(IconSize.STANDARD);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/iconGeneratedComponentExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconGeneratedComponentExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { H5, Label, Slider } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -25,7 +25,7 @@ const MAX_ICON_SIZE = 100;
 const iconSizeLabelId = "icon-size-label";
 
 export const IconGeneratedComponentExample: React.FC<ExampleProps> = props => {
-    const [iconSize, setIconSize] = React.useState<IconSize>(IconSize.STANDARD);
+    const [iconSize, setIconSize] = useState<IconSize>(IconSize.STANDARD);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Button,
@@ -40,10 +40,10 @@ import { IntentSelect } from "./common/intentSelect";
 import { SizeSelect } from "./common/sizeSelect";
 
 export const InputGroupExample: React.FC<ExampleProps> = props => {
-    const [disabled, setDisabled] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [readOnly, setReadOnly] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
+    const [disabled, setDisabled] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [readOnly, setReadOnly] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
 
     const options = (
         <>
@@ -69,7 +69,7 @@ export const InputGroupExample: React.FC<ExampleProps> = props => {
 };
 
 const AsyncInputGroup: React.FC<InputGroupProps> = props => {
-    const [filterValue, setFilterValue] = React.useState("");
+    const [filterValue, setFilterValue] = useState("");
 
     const handleFilterChange = handleStringChange(value => window.setTimeout(() => setFilterValue(value), 10));
 
@@ -89,9 +89,9 @@ const AsyncInputGroup: React.FC<InputGroupProps> = props => {
 };
 
 const PasswordInputGroup: React.FC<InputGroupProps> = props => {
-    const [showPassword, setShowPassword] = React.useState(false);
+    const [showPassword, setShowPassword] = useState(false);
 
-    const handleLockClick = React.useCallback(() => setShowPassword(value => !value), []);
+    const handleLockClick = useCallback(() => setShowPassword(value => !value), []);
 
     return (
         <InputGroup
@@ -114,7 +114,7 @@ const PasswordInputGroup: React.FC<InputGroupProps> = props => {
 };
 
 const TagInputGroup: React.FC<InputGroupProps> = props => {
-    const [tagValue, setTagValue] = React.useState("");
+    const [tagValue, setTagValue] = useState("");
 
     return (
         <InputGroup

--- a/packages/docs-app/src/examples/core-examples/menuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Classes, H5, Icon, InputGroup, Menu, MenuDivider, MenuItem, type Size } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -22,8 +22,8 @@ import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { SizeSelect } from "./common/sizeSelect";
 
 export function MenuExample(props: ExampleProps) {
-    const [count, setCount] = React.useState(0);
-    const [size, setSize] = React.useState<Size>("medium");
+    const [count, setCount] = useState(0);
+    const [size, setSize] = useState<Size>("medium");
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState, useCallback } from "react";
 
 import {
     Classes,
@@ -36,15 +36,15 @@ import { BooleanOrUndefinedSelect } from "./common/booleanOrUndefinedSelect";
 import { IntentSelect } from "./common/intentSelect";
 
 export function MenuItemExample(props: ExampleProps) {
-    const [active, setActive] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [selected, setSelected] = React.useState<boolean | undefined>(undefined);
-    const [intent, setIntent] = React.useState<Intent>("none");
-    const [iconEnabled, setIconEnabled] = React.useState(true);
-    const [submenuEnabled, setSubmenuEnabled] = React.useState(true);
-    const [roleStructure, setRoleStructure] = React.useState<MenuItemProps["roleStructure"]>("menuitem");
+    const [active, setActive] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [selected, setSelected] = useState<boolean | undefined>(undefined);
+    const [intent, setIntent] = useState<Intent>("none");
+    const [iconEnabled, setIconEnabled] = useState(true);
+    const [submenuEnabled, setSubmenuEnabled] = useState(true);
+    const [roleStructure, setRoleStructure] = useState<MenuItemProps["roleStructure"]>("menuitem");
 
-    const handleRoleStructureChange = React.useCallback(
+    const handleRoleStructureChange = useCallback(
         (newValue: string) => setRoleStructure(newValue as MenuItemProps["roleStructure"]),
         [],
     );

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import {
     Classes,

--- a/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multiSliderExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     H5,
@@ -47,16 +47,16 @@ const initialValues = {
 };
 
 export const MultiSliderExample: React.FC<ExampleProps> = props => {
-    const [interactionKind, setInteractionKind] = React.useState<HandleInteractionKind>(HandleInteractionKind.PUSH);
-    const [shownIntents, setShownIntents] = React.useState<ShownIntents>("both");
-    const [showTrackFill, setShowTrackFill] = React.useState(true);
-    const [values, setValues] = React.useState<SliderValues>(initialValues);
-    const [vertical, setVertical] = React.useState<boolean>(false);
+    const [interactionKind, setInteractionKind] = useState<HandleInteractionKind>(HandleInteractionKind.PUSH);
+    const [shownIntents, setShownIntents] = useState<ShownIntents>("both");
+    const [showTrackFill, setShowTrackFill] = useState(true);
+    const [values, setValues] = useState<SliderValues>(initialValues);
+    const [vertical, setVertical] = useState<boolean>(false);
 
     const showDanger = shownIntents !== "warning";
     const showWarning = shownIntents !== "danger";
 
-    const getUpdatedHandles = React.useCallback(
+    const getUpdatedHandles = useCallback(
         (newValues: number[]): Partial<SliderValues> => {
             switch (shownIntents) {
                 case "both": {
@@ -79,7 +79,7 @@ export const MultiSliderExample: React.FC<ExampleProps> = props => {
         [shownIntents],
     );
 
-    const handleChange = React.useCallback(
+    const handleChange = useCallback(
         (rawValues: number[]) => {
             // newValues is always in sorted order, and handled cannot be unsorted by dragging with lock/push interactions.
             const newValuesMap = { ...values, ...getUpdatedHandles(rawValues) };

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Button,
@@ -42,30 +42,30 @@ import type { BlueprintExampleData } from "../../tags/types";
 const NAV_POSITIONS = ["left", "top", "right"];
 
 export const MultistepDialogExample: React.FC<ExampleProps<BlueprintExampleData>> = props => {
-    const [autoFocus, setAutoFocus] = React.useState(true);
-    const [canEscapeKeyClose, setCanEscapeKeyClose] = React.useState(true);
-    const [canOutsideClickClose, setCanOutsideClickClose] = React.useState(true);
-    const [enforceFocus, setEnforceFocus] = React.useState(true);
-    const [hasTitle, setHasTitle] = React.useState(true);
-    const [initialStepIndex, setInitialStepIndex] = React.useState(0);
-    const [isCloseButtonShown, setIsCloseButtonShown] = React.useState(true);
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [navPosition, setNavPosition] = React.useState<MultistepDialogNavPosition>("left");
-    const [showCloseButtonInFooter, setShowCloseButtonInFooter] = React.useState(true);
-    const [usePortal, setUsePortal] = React.useState(true);
-    const [value, setValue] = React.useState<string>();
+    const [autoFocus, setAutoFocus] = useState(true);
+    const [canEscapeKeyClose, setCanEscapeKeyClose] = useState(true);
+    const [canOutsideClickClose, setCanOutsideClickClose] = useState(true);
+    const [enforceFocus, setEnforceFocus] = useState(true);
+    const [hasTitle, setHasTitle] = useState(true);
+    const [initialStepIndex, setInitialStepIndex] = useState(0);
+    const [isCloseButtonShown, setIsCloseButtonShown] = useState(true);
+    const [isOpen, setIsOpen] = useState(false);
+    const [navPosition, setNavPosition] = useState<MultistepDialogNavPosition>("left");
+    const [showCloseButtonInFooter, setShowCloseButtonInFooter] = useState(true);
+    const [usePortal, setUsePortal] = useState(true);
+    const [value, setValue] = useState<string>();
 
-    const handleNavPositionChange = React.useCallback(
+    const handleNavPositionChange = useCallback(
         (newNavPosition: string) => setNavPosition(newNavPosition as MultistepDialogNavPosition),
         [],
     );
 
-    const handleOpen = React.useCallback(() => {
+    const handleOpen = useCallback(() => {
         setIsOpen(true);
         setValue(undefined);
     }, []);
 
-    const handleClose = React.useCallback(() => setIsOpen(false), []);
+    const handleClose = useCallback(() => setIsOpen(false), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/navbarExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/navbarExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
+import { useState } from "react";
 
 import {
     Alignment,
@@ -31,7 +31,7 @@ import {
 import { CodeExample, Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const NavbarExample: React.FC<ExampleProps> = props => {
-    const [alignEnd, setAlignEnd] = React.useState(false);
+    const [alignEnd, setAlignEnd] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/nonIdealStateExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Button,
@@ -34,15 +34,15 @@ import { type Layout, LayoutSelect } from "./common/layoutSelect";
 import { LegacySizeSelect, type Size } from "./common/legacySizeSelect";
 
 export const NonIdealStateExample: React.FC<ExampleProps> = props => {
-    const [icon, setIcon] = React.useState<IconName>(IconNames.SEARCH);
-    const [iconSize, setIconSize] = React.useState(NonIdealStateIconSize.STANDARD);
-    const [layout, setLayout] = React.useState<Layout>("vertical");
-    const [showAction, setShowAction] = React.useState(true);
-    const [showDescription, setShowDescription] = React.useState(true);
-    const [showTitle, setShowTitle] = React.useState(true);
-    const [visual, setVisual] = React.useState<NonIdealStateVisualKind>("icon");
+    const [icon, setIcon] = useState<IconName>(IconNames.SEARCH);
+    const [iconSize, setIconSize] = useState(NonIdealStateIconSize.STANDARD);
+    const [layout, setLayout] = useState<Layout>("vertical");
+    const [showAction, setShowAction] = useState(true);
+    const [showDescription, setShowDescription] = useState(true);
+    const [showTitle, setShowTitle] = useState(true);
+    const [visual, setVisual] = useState<NonIdealStateVisualKind>("icon");
 
-    const handleSizeChange = React.useCallback((size: Size) => setIconSize(sizeToNonIdealStateIconSize[size]), []);
+    const handleSizeChange = useCallback((size: Size) => setIconSize(sizeToNonIdealStateIconSize[size]), []);
 
     const options = (
         <>
@@ -107,7 +107,7 @@ interface NonIdealStateVisualSelectProps {
 
 /** Button radio group to switch between icon and spinner visuals. */
 const NonIdealStateVisualSelect: React.FC<NonIdealStateVisualSelectProps> = ({ onChange, visual }) => {
-    const handleChange = React.useCallback((value: string) => onChange(value as NonIdealStateVisualKind), [onChange]);
+    const handleChange = useCallback((value: string) => onChange(value as NonIdealStateVisualKind), [onChange]);
     return (
         <FormGroup label="Visual">
             <SegmentedControl

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Button,
@@ -69,22 +69,22 @@ const BUTTON_POSITIONS = [
 const LOCALE_OPTIONS = [{ label: "Default", value: "default" }, ...LOCALES];
 
 export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
-    const [allowNumericCharactersOnly, setAllowNumericCharactersOnly] = React.useState(true);
-    const [buttonPosition, setButtonPosition] = React.useState<NumericInputProps["buttonPosition"]>("right");
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [leftElement, setLeftElement] = React.useState(false);
-    const [leftIcon, setLeftIcon] = React.useState(false);
-    const [locale, setLocale] = React.useState<string>();
-    const [max, setMax] = React.useState(100);
-    const [min, setMin] = React.useState(0);
-    const [selectAllOnFocus, setSelectAllOnFocus] = React.useState(false);
-    const [selectAllOnIncrement, setSelectAllOnIncrement] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
-    const [value, setValue] = React.useState("");
+    const [allowNumericCharactersOnly, setAllowNumericCharactersOnly] = useState(true);
+    const [buttonPosition, setButtonPosition] = useState<NumericInputProps["buttonPosition"]>("right");
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [leftElement, setLeftElement] = useState(false);
+    const [leftIcon, setLeftIcon] = useState(false);
+    const [locale, setLocale] = useState<string>();
+    const [max, setMax] = useState(100);
+    const [min, setMin] = useState(0);
+    const [selectAllOnFocus, setSelectAllOnFocus] = useState(false);
+    const [selectAllOnIncrement, setSelectAllOnIncrement] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
+    const [value, setValue] = useState("");
 
-    const handleInputValueChange = React.useCallback(
+    const handleInputValueChange = useCallback(
         (_valueAsNumber: number, valueAsString: string) => setValue(valueAsString),
         [],
     );

--- a/packages/docs-app/src/examples/core-examples/numericInputExtendedExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputExtendedExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { NumericInput } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -28,9 +28,9 @@ const NUMBER_ABBREVIATION_REGEX = /((\.\d+)|(\d+(\.\d+)?))(k|m|b)\b/gi;
 const SCIENTIFIC_NOTATION_REGEX = /((\.\d+)|(\d+(\.\d+)?))(e\d+)\b/gi;
 
 export const NumericInputExtendedExample: React.FC<ExampleProps> = props => {
-    const [value, setValue] = React.useState<string>("");
+    const [value, setValue] = useState<string>("");
 
-    const handleConfirm = React.useCallback((newValue: string) => {
+    const handleConfirm = useCallback((newValue: string) => {
         let result = newValue;
         result = expandScientificNotationTerms(result);
         result = expandNumberAbbreviationTerms(result);
@@ -39,14 +39,14 @@ export const NumericInputExtendedExample: React.FC<ExampleProps> = props => {
         setValue(result);
     }, []);
 
-    const handleBlur = React.useCallback(
+    const handleBlur = useCallback(
         (event: React.FocusEvent<HTMLInputElement>) => {
             handleConfirm(event.target.value);
         },
         [handleConfirm],
     );
 
-    const handleKeyDown = React.useCallback(
+    const handleKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLInputElement>) => {
             if (event.key === "Enter") {
                 handleConfirm(event.currentTarget.value);
@@ -55,7 +55,7 @@ export const NumericInputExtendedExample: React.FC<ExampleProps> = props => {
         [handleConfirm],
     );
 
-    const handleValueChange = React.useCallback((_valueAsNumber: number, valueAsString: string) => {
+    const handleValueChange = useCallback((_valueAsNumber: number, valueAsString: string) => {
         setValue(valueAsString);
     }, []);
 

--- a/packages/docs-app/src/examples/core-examples/overlay2Example.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlay2Example.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { StrictMode, useCallback, useRef, useState } from "react";
 
 import { Button, Classes, Code, H3, H5, Intent, Overlay2, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -25,27 +25,27 @@ const OVERLAY_EXAMPLE_CLASS = "docs-overlay-example-transition";
 const OVERLAY_TALL_CLASS = "docs-overlay-example-tall";
 
 export const Overlay2Example: React.FC<ExampleProps<BlueprintExampleData>> = props => {
-    const [autoFocus, setAutoFocus] = React.useState(true);
-    const [canEscapeKeyClose, setCanEscapeKeyClose] = React.useState(true);
-    const [canOutsideClickClose, setCanOutsideClickClose] = React.useState(true);
-    const [enforceFocus, setEnforceFocus] = React.useState(true);
-    const [hasBackdrop, setHasBackdrop] = React.useState(true);
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [usePortal, setUsePortal] = React.useState(true);
-    const [useTallContent, setUseTallContent] = React.useState(false);
+    const [autoFocus, setAutoFocus] = useState(true);
+    const [canEscapeKeyClose, setCanEscapeKeyClose] = useState(true);
+    const [canOutsideClickClose, setCanOutsideClickClose] = useState(true);
+    const [enforceFocus, setEnforceFocus] = useState(true);
+    const [hasBackdrop, setHasBackdrop] = useState(true);
+    const [isOpen, setIsOpen] = useState(false);
+    const [usePortal, setUsePortal] = useState(true);
+    const [useTallContent, setUseTallContent] = useState(false);
 
-    const buttonRef = React.useRef<HTMLButtonElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
 
-    const handleOpen = React.useCallback(() => setIsOpen(true), [setIsOpen]);
+    const handleOpen = useCallback(() => setIsOpen(true), [setIsOpen]);
 
-    const handleClose = React.useCallback(() => {
+    const handleClose = useCallback(() => {
         setIsOpen(false);
         setUseTallContent(false);
     }, [setIsOpen, setUseTallContent]);
 
-    const focusButton = React.useCallback(() => buttonRef.current?.focus(), [buttonRef]);
+    const focusButton = useCallback(() => buttonRef.current?.focus(), [buttonRef]);
 
-    const toggleScrollButton = React.useCallback(() => setUseTallContent(use => !use), [setUseTallContent]);
+    const toggleScrollButton = useCallback(() => setUseTallContent(use => !use), [setUseTallContent]);
 
     const classes = classNames(Classes.CARD, Classes.ELEVATION_4, OVERLAY_EXAMPLE_CLASS, props.data.themeName, {
         [OVERLAY_TALL_CLASS]: useTallContent,
@@ -75,7 +75,7 @@ export const Overlay2Example: React.FC<ExampleProps<BlueprintExampleData>> = pro
 
     return (
         <Example options={options} {...props}>
-            <React.StrictMode>
+            <StrictMode>
                 <Button ref={buttonRef} onClick={handleOpen} text="Show overlay" />
                 <Overlay2
                     onClose={handleClose}
@@ -127,7 +127,7 @@ export const Overlay2Example: React.FC<ExampleProps<BlueprintExampleData>> = pro
                         </div>
                     </div>
                 </Overlay2>
-            </React.StrictMode>
+            </StrictMode>
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Button, Classes, Code, H3, H5, Intent, Overlay, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -42,7 +42,7 @@ export interface OverlayExampleState {
     useTallContent: boolean;
 }
 
-export class OverlayExample extends React.PureComponent<ExampleProps<BlueprintExampleData>, OverlayExampleState> {
+export class OverlayExample extends PureComponent<ExampleProps<BlueprintExampleData>, OverlayExampleState> {
     public state: OverlayExampleState = {
         autoFocus: true,
         canEscapeKeyClose: true,

--- a/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/panelStackExample.tsx
@@ -21,7 +21,7 @@
  * Panel1 renders either a new Panel2 or Panel3. Panel2 and Panel3 both render a new Panel1.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Button,
@@ -42,7 +42,7 @@ interface Panel1Info {
 }
 
 const Panel1: React.FC<PanelProps<Panel1Info>> = props => {
-    const [counter, setCounter] = React.useState(0);
+    const [counter, setCounter] = useState(0);
     const shouldOpenPanelType2 = counter % 2 === 0;
 
     const openNewPanel = () => {
@@ -123,21 +123,21 @@ const initialPanel: Panel<Panel1Info> = {
 };
 
 export const PanelStackExample: React.FC<ExampleProps> = props => {
-    const [activePanelOnly, setActivePanelOnly] = React.useState(false);
-    const [showHeader, setShowHeader] = React.useState(true);
-    const [currentPanelStack, setCurrentPanelStack] = React.useState<
-        Array<Panel<Panel1Info | Panel2Info | Panel3Info>>
-    >([initialPanel]);
+    const [activePanelOnly, setActivePanelOnly] = useState(false);
+    const [showHeader, setShowHeader] = useState(true);
+    const [currentPanelStack, setCurrentPanelStack] = useState<Array<Panel<Panel1Info | Panel2Info | Panel3Info>>>([
+        initialPanel,
+    ]);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const toggleActiveOnly = React.useCallback(handleBooleanChange(setActivePanelOnly), []);
+    const toggleActiveOnly = useCallback(handleBooleanChange(setActivePanelOnly), []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const toggleShowHeader = React.useCallback(handleBooleanChange(setShowHeader), []);
-    const addToPanelStack = React.useCallback(
+    const toggleShowHeader = useCallback(handleBooleanChange(setShowHeader), []);
+    const addToPanelStack = useCallback(
         (newPanel: Panel<Panel1Info | Panel2Info | Panel3Info>) => setCurrentPanelStack(stack => [...stack, newPanel]),
         [],
     );
-    const removeFromPanelStack = React.useCallback(() => setCurrentPanelStack(stack => stack.slice(0, -1)), []);
+    const removeFromPanelStack = useCallback(() => setCurrentPanelStack(stack => stack.slice(0, -1)), []);
 
     const stackList = (
         <>

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button, Callout, Classes, Intent, Popover, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const PopoverDismissExample: React.FC<ExampleProps> = props => {
-    const [captureDismiss, setCaptureDismiss] = React.useState(true);
-    const [isPopoverOpen, setIsPopoverOpen] = React.useState(true);
+    const [captureDismiss, setCaptureDismiss] = useState(true);
+    const [isPopoverOpen, setIsPopoverOpen] = useState(true);
 
-    const timeoutId = React.useRef<number>();
+    const timeoutId = useRef<number>();
 
-    React.useEffect(() => {
+    useEffect(() => {
         return () => {
             if (timeoutId.current) {
                 window.clearTimeout(timeoutId.current);
@@ -33,11 +33,11 @@ export const PopoverDismissExample: React.FC<ExampleProps> = props => {
         };
     }, []);
 
-    const handleDismissChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const handleDismissChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         setCaptureDismiss(event.target.checked);
     }, []);
 
-    const reopen = React.useCallback(() => {
+    const reopen = useCallback(() => {
         window.clearTimeout(timeoutId.current);
         timeoutId.current = window.setTimeout(() => setIsPopoverOpen(true), 150);
     }, []);

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useRef, useState } from "react";
 
 import {
     AnchorButton,
@@ -67,35 +67,35 @@ const DEFAULT_MODIFIERS = {
 };
 
 export const PopoverExample: React.FC<ExampleProps> = props => {
-    const [boundary, setBoundary] = React.useState<Boundary>("scrollParent");
-    const [buttonText, setButtonText] = React.useState("Popover target");
-    const [canEscapeKeyClose, setCanEscapeKeyClose] = React.useState(true);
-    const [exampleIndex, setExampleIndex] = React.useState(0);
-    const [hasBackdrop, setHasBackdrop] = React.useState(false);
-    const [inheritDarkTheme, setInheritDarkTheme] = React.useState(true);
-    const [interactionKind, setInteractionKind] = React.useState<PopoverInteractionKind>(PopoverInteractionKind.CLICK);
-    const [isControlled, setIsControlled] = React.useState(false);
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [matchTargetWidth, setMatchTargetWidth] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(false);
-    const [modifiers, setModifiers] = React.useState<PopperModifierOverrides>(DEFAULT_MODIFIERS);
-    const [openOnTargetFocus, setOpenOnTargetFocus] = React.useState(true);
-    const [placement, setPlacement] = React.useState<Placement>("auto");
-    const [rangeSliderValue, setRangeSliderValue] = React.useState<[number, number]>([0, 10]);
-    const [shouldReturnFocusOnClose, setShouldReturnFocusOnClose] = React.useState(false);
-    const [sliderValue, setSliderValue] = React.useState(5);
-    const [usePortal, setUsePortal] = React.useState(true);
+    const [boundary, setBoundary] = useState<Boundary>("scrollParent");
+    const [buttonText, setButtonText] = useState("Popover target");
+    const [canEscapeKeyClose, setCanEscapeKeyClose] = useState(true);
+    const [exampleIndex, setExampleIndex] = useState(0);
+    const [hasBackdrop, setHasBackdrop] = useState(false);
+    const [inheritDarkTheme, setInheritDarkTheme] = useState(true);
+    const [interactionKind, setInteractionKind] = useState<PopoverInteractionKind>(PopoverInteractionKind.CLICK);
+    const [isControlled, setIsControlled] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
+    const [matchTargetWidth, setMatchTargetWidth] = useState(false);
+    const [minimal, setMinimal] = useState(false);
+    const [modifiers, setModifiers] = useState<PopperModifierOverrides>(DEFAULT_MODIFIERS);
+    const [openOnTargetFocus, setOpenOnTargetFocus] = useState(true);
+    const [placement, setPlacement] = useState<Placement>("auto");
+    const [rangeSliderValue, setRangeSliderValue] = useState<[number, number]>([0, 10]);
+    const [shouldReturnFocusOnClose, setShouldReturnFocusOnClose] = useState(false);
+    const [sliderValue, setSliderValue] = useState(5);
+    const [usePortal, setUsePortal] = useState(true);
 
-    const scrollParentElement = React.useRef<HTMLElement | null>(null);
+    const scrollParentElement = useRef<HTMLElement | null>(null);
 
-    const bodyElement = React.useRef<HTMLElement | null>(null);
+    const bodyElement = useRef<HTMLElement | null>(null);
 
     // popper.js requires this modiifer for "auto" placement
     const forceFlipEnabled = placement.startsWith("auto");
 
     const isHoverInteractionKind = interactionKind === "hover" || interactionKind === "hover-target";
 
-    const getModifierChangeHandler = React.useCallback(
+    const getModifierChangeHandler = useCallback(
         <Name extends StrictModifierNames>(name: Name) =>
             handleBooleanChange(enabled => {
                 const newModifiers = { ...modifiers, [name]: { ...modifiers[name], enabled } };
@@ -224,7 +224,7 @@ export const PopoverExample: React.FC<ExampleProps> = props => {
         </>
     );
 
-    const getContents = React.useCallback(
+    const getContents = useCallback(
         (index: number): React.JSX.Element => {
             return [
                 <div key="text">
@@ -275,7 +275,7 @@ export const PopoverExample: React.FC<ExampleProps> = props => {
         [rangeSliderValue, sliderValue],
     );
 
-    const centerScroll = React.useCallback((overflowingDiv: HTMLDivElement) => {
+    const centerScroll = useCallback((overflowingDiv: HTMLDivElement) => {
         scrollParentElement.current = overflowingDiv?.parentElement;
 
         if (overflowingDiv != null) {

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Button, Intent, Popover, type PopoverInteractionKind } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Button, Intent, Popover } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Button, Classes, Code, ControlGroup, type Placement, Popover } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button, Code, H5, Popover, type PopoverProps, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -31,38 +31,38 @@ const POPOVER_PROPS: Partial<PopoverProps> = {
 };
 
 export const PopoverPortalExample: React.FC<ExampleProps> = props => {
-    const [isOpen, setIsOpen] = React.useState(true);
+    const [isOpen, setIsOpen] = useState(true);
 
-    const scrollContainerLeftRef = React.useRef<HTMLDivElement>(null);
-    const scrollContainerRightRef = React.useRef<HTMLDivElement>(null);
+    const scrollContainerLeftRef = useRef<HTMLDivElement>(null);
+    const scrollContainerRightRef = useRef<HTMLDivElement>(null);
 
-    const scrollToCenter = React.useCallback((scrollContainer: HTMLDivElement) => {
+    const scrollToCenter = useCallback((scrollContainer: HTMLDivElement) => {
         if (scrollContainer != null) {
             const contentWidth = scrollContainer.children[0].clientWidth;
             scrollContainer.scrollLeft = contentWidth / 4;
         }
     }, []);
 
-    const recenter = React.useCallback(() => {
+    const recenter = useCallback(() => {
         scrollToCenter(scrollContainerLeftRef.current);
         scrollToCenter(scrollContainerRightRef.current);
     }, [scrollToCenter]);
 
-    const syncScroll = React.useCallback((sourceContainer: HTMLDivElement, otherContainer: HTMLDivElement) => {
+    const syncScroll = useCallback((sourceContainer: HTMLDivElement, otherContainer: HTMLDivElement) => {
         if (sourceContainer != null && otherContainer != null) {
             otherContainer.scrollLeft = sourceContainer.scrollLeft;
         }
     }, []);
 
-    const syncScrollLeft = React.useCallback(() => {
+    const syncScrollLeft = useCallback(() => {
         return requestAnimationFrame(() => syncScroll(scrollContainerLeftRef.current, scrollContainerRightRef.current));
     }, [syncScroll]);
 
-    const syncScrollRight = React.useCallback(() => {
+    const syncScrollRight = useCallback(() => {
         return requestAnimationFrame(() => syncScroll(scrollContainerRightRef.current, scrollContainerLeftRef.current));
     }, [syncScroll]);
 
-    React.useEffect(() => {
+    useEffect(() => {
         const checkAndRecenter = () => {
             if (scrollContainerLeftRef.current && scrollContainerRightRef.current) {
                 recenter();

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Button, Popover } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 

--- a/packages/docs-app/src/examples/core-examples/progressExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/progressExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Card, H5, type Intent, ProgressBar, Slider, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,11 +22,11 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { IntentSelect } from "./common/intentSelect";
 
 export const ProgressExample: React.FC<ExampleProps> = props => {
-    const [hasValue, setHasValue] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>();
-    const [value, setValue] = React.useState(0.7);
+    const [hasValue, setHasValue] = useState(false);
+    const [intent, setIntent] = useState<Intent>();
+    const [value, setValue] = useState(0.7);
 
-    const handleValueChange = React.useCallback((newValue: number) => setValue(newValue), []);
+    const handleValueChange = useCallback((newValue: number) => setValue(newValue), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/radioCardGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/radioCardGroupExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useState } from "react";
 
 import {
     Alignment,
@@ -35,12 +35,12 @@ import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export const RadioCardGroupExample: React.FC<ExampleProps> = props => {
-    const [alignIndicator, setAlignIndicator] = React.useState<Alignment>(Alignment.START);
-    const [compact, setCompact] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [groupValue, setGroupValue] = React.useState<string>();
-    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = React.useState(true);
-    const [showSubtext, setShowSubtext] = React.useState(true);
+    const [alignIndicator, setAlignIndicator] = useState<Alignment>(Alignment.START);
+    const [compact, setCompact] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [groupValue, setGroupValue] = useState<string>();
+    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = useState(true);
+    const [showSubtext, setShowSubtext] = useState(true);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/radioExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/radioExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Alignment, Card, H5, Radio, RadioGroup, type RadioProps, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange, handleStringChange } from "@blueprintjs/docs-theme";
@@ -22,11 +22,11 @@ import { Example, type ExampleProps, handleBooleanChange, handleStringChange } f
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export const RadioExample: React.FC<ExampleProps> = props => {
-    const [alignIndicator, setAlignIndicator] = React.useState<Alignment>(Alignment.START);
-    const [disabled, setDisabled] = React.useState(false);
-    const [inline, setInline] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
-    const [value, setValue] = React.useState<string>();
+    const [alignIndicator, setAlignIndicator] = useState<Alignment>(Alignment.START);
+    const [disabled, setDisabled] = useState(false);
+    const [inline, setInline] = useState(false);
+    const [large, setLarge] = useState(false);
+    const [value, setValue] = useState<string>();
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/rangeSliderExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { H5, type NumberRange, RangeSlider, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -29,8 +29,8 @@ const LABEL_STEP_SIZE = 20;
 const htmlProps = { end: { "aria-label": "example end" }, start: { "aria-label": "example start" } };
 
 export const RangeSliderExample: React.FC<ExampleProps> = props => {
-    const [range, setRange] = React.useState<NumberRange>(INITIAL_RANGE);
-    const [vertical, setVertical] = React.useState(false);
+    const [range, setRange] = useState<NumberRange>(INITIAL_RANGE);
+    const [vertical, setVertical] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/searchInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { H5, InputGroup, type Size, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,9 +22,9 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { SizeSelect } from "./common/sizeSelect";
 
 export const SearchInputExample: React.FC<ExampleProps> = props => {
-    const [disabled, setDisabled] = React.useState(false);
-    const [readOnly, setReadOnly] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
+    const [disabled, setDisabled] = useState(false);
+    const [readOnly, setReadOnly] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import dedent from "dedent";
-import * as React from "react";
+import { useCallback, useRef, useState } from "react";
 
 import {
     Button,
@@ -55,28 +55,28 @@ const BASIL_DESCRIPTION_TEXT = dedent`
 `;
 
 export const SectionExample: React.FC<ExampleProps> = props => {
-    const [collapsible, setCollapsible] = React.useState(false);
-    const [defaultIsOpen, setDefaultIsOpen] = React.useState(true);
-    const [elevation, setElevation] = React.useState<SectionElevation>(Elevation.ZERO);
-    const [hasDescription, setHasDescription] = React.useState(false);
-    const [hasIcon, setHasIcon] = React.useState(false);
-    const [hasMultipleCards, setHasMultipleCards] = React.useState(false);
-    const [hasRightElement, setHasRightElement] = React.useState(true);
-    const [isCompact, setIsCompact] = React.useState(false);
-    const [isControlled, setIsControlled] = React.useState(false);
-    const [isOpen, setIsOpen] = React.useState(true);
-    const [isPanelPadded, setIsPanelPadded] = React.useState(true);
+    const [collapsible, setCollapsible] = useState(false);
+    const [defaultIsOpen, setDefaultIsOpen] = useState(true);
+    const [elevation, setElevation] = useState<SectionElevation>(Elevation.ZERO);
+    const [hasDescription, setHasDescription] = useState(false);
+    const [hasIcon, setHasIcon] = useState(false);
+    const [hasMultipleCards, setHasMultipleCards] = useState(false);
+    const [hasRightElement, setHasRightElement] = useState(true);
+    const [isCompact, setIsCompact] = useState(false);
+    const [isControlled, setIsControlled] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
+    const [isPanelPadded, setIsPanelPadded] = useState(true);
 
-    const editableTextRef = React.useRef<HTMLDivElement>(null);
+    const editableTextRef = useRef<HTMLDivElement>(null);
 
-    const handleEditContent = React.useCallback((event: React.MouseEvent) => {
+    const handleEditContent = useCallback((event: React.MouseEvent) => {
         event.stopPropagation();
         editableTextRef.current.focus();
     }, []);
 
-    const handleElevationChange = React.useCallback((value: SectionElevation) => setElevation(value), []);
+    const handleElevationChange = useCallback((value: SectionElevation) => setElevation(value), []);
 
-    const handleToggle = React.useCallback(() => setIsOpen(value => !value), []);
+    const handleToggle = useCallback(() => setIsOpen(value => !value), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/segmentedControlExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     Divider,
@@ -31,17 +31,14 @@ import { IconNames } from "@blueprintjs/icons";
 import { SizeSelect } from "./common/sizeSelect";
 
 export const SegmentedControlExample: React.FC<ExampleProps> = props => {
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [inline, setInline] = React.useState(false);
-    const [intent, setIntent] = React.useState<SegmentedControlIntent>("none");
-    const [size, setSize] = React.useState<Size>("medium");
-    const [withIcons, setWithIcons] = React.useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [inline, setInline] = useState(false);
+    const [intent, setIntent] = useState<SegmentedControlIntent>("none");
+    const [size, setSize] = useState<Size>("medium");
+    const [withIcons, setWithIcons] = useState(false);
 
-    const handleIntentChange = React.useCallback(
-        (newIntent: string) => setIntent(newIntent as SegmentedControlIntent),
-        [],
-    );
+    const handleIntentChange = useCallback((newIntent: string) => setIntent(newIntent as SegmentedControlIntent), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Card, H5, Slider, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const SliderExample: React.FC<ExampleProps> = props => {
-    const [value1, setValue1] = React.useState(2.5);
-    const [value2, setValue2] = React.useState(0);
-    const [value3, setValue3] = React.useState(30);
-    const [vertical, setVertical] = React.useState(false);
+    const [value1, setValue1] = useState(2.5);
+    const [value2, setValue2] = useState(0);
+    const [value3, setValue3] = useState(30);
+    const [vertical, setVertical] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/spinnerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Card, H5, type Intent, Label, Slider, Spinner, SpinnerSize, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -24,10 +24,10 @@ import { IntentSelect } from "./common/intentSelect";
 const spinnerSizeLabelId = "spinner-size-label";
 
 export const SpinnerExample: React.FC<ExampleProps> = props => {
-    const [hasValue, setHasValue] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>();
-    const [size, setSize] = React.useState(SpinnerSize.STANDARD);
-    const [value, setValue] = React.useState(0.7);
+    const [hasValue, setHasValue] = useState(false);
+    const [intent, setIntent] = useState<Intent>();
+    const [size, setSize] = useState(SpinnerSize.STANDARD);
+    const [value, setValue] = useState(0.7);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/switchCardExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchCardExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Alignment, Divider, FormGroup, H5, Switch, SwitchCard, type SwitchCardProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -24,10 +24,10 @@ import { PropCodeTooltip } from "../../common/propCodeTooltip";
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export const SwitchCardExample: React.FC<ExampleProps> = props => {
-    const [alignIndicator, setAlignIndicator] = React.useState<Alignment>(Alignment.END);
-    const [compact, setCompact] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = React.useState(true);
+    const [alignIndicator, setAlignIndicator] = useState<Alignment>(Alignment.END);
+    const [compact, setCompact] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [showAsSelectedWhenChecked, setShowAsSelectedWhenChecked] = useState(true);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/switchExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/switchExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Alignment, Card, Code, FormGroup, H5, Switch, type SwitchProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,10 +22,10 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { AlignmentSelect } from "./common/alignmentSelect";
 
 export const SwitchExample: React.FC<ExampleProps> = props => {
-    const [alignIndicator, setAlignIndicator] = React.useState<Alignment>(Alignment.START);
-    const [disabled, setDisabled] = React.useState(false);
-    const [inline, setInline] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
+    const [alignIndicator, setAlignIndicator] = useState<Alignment>(Alignment.START);
+    const [disabled, setDisabled] = useState(false);
+    const [inline, setInline] = useState(false);
+    const [large, setLarge] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/tabsExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tabsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import {
     Alignment,
@@ -40,15 +40,15 @@ import { PropCodeTooltip } from "../../common/propCodeTooltip";
 const NAVBAR_PARENT_ID = "navbar";
 
 export const TabsExample: React.FC<ExampleProps> = props => {
-    const [activePanelOnly, setActivePanelOnly] = React.useState(false);
-    const [animate, setAnimate] = React.useState(true);
-    const [fill, setFill] = React.useState(true);
-    const [large, setLarge] = React.useState(false);
-    const [navbarTabId, setNavbarTabId] = React.useState<TabId>("Home");
-    const [showIcon, setShowIcon] = React.useState(false);
-    const [showTags, setShowTags] = React.useState(false);
-    const [useRoundTags, setUseRoundTags] = React.useState(false);
-    const [vertical, setVertical] = React.useState(false);
+    const [activePanelOnly, setActivePanelOnly] = useState(false);
+    const [animate, setAnimate] = useState(true);
+    const [fill, setFill] = useState(true);
+    const [large, setLarge] = useState(false);
+    const [navbarTabId, setNavbarTabId] = useState<TabId>("Home");
+    const [showIcon, setShowIcon] = useState(false);
+    const [showTags, setShowTags] = useState(false);
+    const [useRoundTags, setUseRoundTags] = useState(false);
+    const [vertical, setVertical] = useState(false);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Button, H5, Intent, Switch, Tag } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -24,21 +24,21 @@ import { IntentSelect } from "./common/intentSelect";
 const INITIAL_TAGS = ["London", "New York", "San Francisco", "Seattle"];
 
 export const TagExample: React.FC<ExampleProps> = props => {
-    const [active, setActive] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [icon, setIcon] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [interactive, setInteractive] = React.useState(false);
-    const [large, setLarge] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(false);
-    const [removable, setRemovable] = React.useState(false);
-    const [endIcon, setEndIcon] = React.useState(false);
-    const [round, setRound] = React.useState(false);
-    const [tags, setTags] = React.useState(INITIAL_TAGS);
+    const [active, setActive] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [icon, setIcon] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [interactive, setInteractive] = useState(false);
+    const [large, setLarge] = useState(false);
+    const [minimal, setMinimal] = useState(false);
+    const [removable, setRemovable] = useState(false);
+    const [endIcon, setEndIcon] = useState(false);
+    const [round, setRound] = useState(false);
+    const [tags, setTags] = useState(INITIAL_TAGS);
 
-    const handleRemove = React.useCallback((tag: string) => () => setTags(tags.filter(t => t !== tag)), [tags]);
+    const handleRemove = useCallback((tag: string) => () => setTags(tags.filter(t => t !== tag)), [tags]);
 
-    const handleReset = React.useCallback(() => setTags(INITIAL_TAGS), []);
+    const handleReset = useCallback(() => setTags(INITIAL_TAGS), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Button, Divider, H5, Intent, Switch, TagInput, type TagProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -35,26 +35,26 @@ const VALUES = [
 ];
 
 export const TagInputExample: React.FC<ExampleProps> = props => {
-    const [addOnBlur, setAddOnBlur] = React.useState(false);
-    const [addOnPaste, setAddOnPaste] = React.useState(true);
-    const [autoResize, setAutoResize] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [large, setLarge] = React.useState(false);
-    const [leftIcon, setLeftIcon] = React.useState(true);
-    const [tagIntents, setTagIntents] = React.useState(false);
-    const [tagMinimal, setTagMinimal] = React.useState(false);
-    const [values, setValues] = React.useState<React.ReactNode[]>(VALUES);
+    const [addOnBlur, setAddOnBlur] = useState(false);
+    const [addOnPaste, setAddOnPaste] = useState(true);
+    const [autoResize, setAutoResize] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [large, setLarge] = useState(false);
+    const [leftIcon, setLeftIcon] = useState(true);
+    const [tagIntents, setTagIntents] = useState(false);
+    const [tagMinimal, setTagMinimal] = useState(false);
+    const [values, setValues] = useState<React.ReactNode[]>(VALUES);
 
-    const handleClear = React.useCallback(() => {
+    const handleClear = useCallback(() => {
         setValues(values.length > 0 ? [] : VALUES);
     }, [values]);
 
     // define a new function every time so switch changes will cause it to re-render
     // NOTE: avoid this pattern in your app (use this.getTagProps instead); this is only for
     // example purposes!!
-    const getTagProps = React.useCallback(
+    const getTagProps = useCallback(
         (_v: React.ReactNode, index: number): TagProps => ({
             intent: tagIntents ? INTENTS[index % INTENTS.length] : Intent.NONE,
             minimal: tagMinimal,

--- a/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textAreaExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import {
     AnchorButton,
@@ -39,17 +39,17 @@ const CONTROLLED_TEXT_TO_APPEND =
     "The approach will not be easy. You are required to maneuver straight down this trench and skim the surface to this point. The target area is only two meters wide. It's a small thermal exhaust port, right below the main port. The shaft leads directly to the reactor system.";
 
 export const TextAreaExample: React.FC<ExampleProps> = props => {
-    const [autoResize, setAutoResize] = React.useState(false);
-    const [controlled, setControlled] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [intent, setIntent] = React.useState<Intent>(Intent.NONE);
-    const [readOnly, setReadOnly] = React.useState(false);
-    const [size, setSize] = React.useState<Size>("medium");
-    const [value, setValue] = React.useState(INTITIAL_CONTROLLED_TEXT);
+    const [autoResize, setAutoResize] = useState(false);
+    const [controlled, setControlled] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [intent, setIntent] = useState<Intent>(Intent.NONE);
+    const [readOnly, setReadOnly] = useState(false);
+    const [size, setSize] = useState<Size>("medium");
+    const [value, setValue] = useState(INTITIAL_CONTROLLED_TEXT);
 
-    const appendControlledText = React.useCallback(() => setValue(prev => prev + " " + CONTROLLED_TEXT_TO_APPEND), []);
+    const appendControlledText = useCallback(() => setValue(prev => prev + " " + CONTROLLED_TEXT_TO_APPEND), []);
 
-    const resetControlledText = React.useCallback(() => setValue(INTITIAL_CONTROLLED_TEXT), []);
+    const resetControlledText = useCallback(() => setValue(INTITIAL_CONTROLLED_TEXT), []);
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, Menu, MenuItem, Popover, Text, TextArea } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 import { type Film, TOP_100_FILMS } from "@blueprintjs/select/examples";
 
 export const TextExample: React.FC<ExampleProps> = props => {
-    const [textContent, setTextContent] = React.useState(
+    const [textContent, setTextContent] = useState(
         "You can change the text in the input below. Hover to see full text. " +
             "If the text is long enough, then the content will overflow. This is done by setting " +
             "ellipsize to true.",

--- a/packages/docs-app/src/examples/core-examples/toastCreateAsyncExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastCreateAsyncExample.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-import * as ReactDOMClient from "react-dom/client";
+import { useCallback, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
 
 import { Button, Intent, OverlayToaster } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -27,9 +27,9 @@ import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 // clicks the button. This avoids creating a singleton Toaster for the entire
 // Blueprint docs app.
 export const ToastCreateAsyncExample: React.FC<ExampleProps> = props => {
-    const [isToastShown, setIsToastShown] = React.useState(false);
+    const [isToastShown, setIsToastShown] = useState(false);
 
-    const handleClick = React.useCallback(async () => {
+    const handleClick = useCallback(async () => {
         setIsToastShown(true);
         try {
             await showMessageFromNewToaster();
@@ -60,7 +60,7 @@ export const ToastCreateAsyncExample: React.FC<ExampleProps> = props => {
  */
 async function showMessageFromNewToaster() {
     const container = document.createElement("div");
-    let root: ReactDOMClient.Root | undefined;
+    let root: Root | undefined;
     // Since this toaster isn't created in a portal, a fixed position container
     // is required for it to show at the top of the viewport. Otherwise the
     // toaster won't be visible until the user scrolls upward.
@@ -87,7 +87,7 @@ async function showMessageFromNewToaster() {
             {
                 container,
                 domRenderer: (element, domContainer) => {
-                    root = ReactDOMClient.createRoot(domContainer);
+                    root = createRoot(domContainer);
                     root.render(element);
                 },
             },

--- a/packages/docs-app/src/examples/core-examples/toastExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/toastExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import {
     Button,
@@ -49,7 +49,7 @@ const POSITIONS = [
     Position.BOTTOM_RIGHT,
 ];
 
-export class ToastExample extends React.PureComponent<ExampleProps<BlueprintExampleData>, OverlayToasterProps> {
+export class ToastExample extends PureComponent<ExampleProps<BlueprintExampleData>, OverlayToasterProps> {
     public state: OverlayToasterProps = {
         autoFocus: false,
         canEscapeKeyClear: true,

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Button, ButtonGroup, Classes, Code, H1, Popover, Switch, Tooltip } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const TooltipExample: React.FC<ExampleProps> = props => {
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpen, setIsOpen] = useState(false);
 
     // using JSX instead of strings for all content so the tooltips will re-render
     // with every update for dark theme inheritance.

--- a/packages/docs-app/src/examples/core-examples/treeExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/treeExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import cloneDeep from "lodash/cloneDeep";
-import * as React from "react";
+import { useCallback, useReducer, useState } from "react";
 
 import {
     Card,
@@ -73,31 +73,28 @@ function treeExampleReducer(state: TreeNodeInfo[], action: TreeAction) {
 }
 
 export const TreeExample: React.FC<ExampleProps> = props => {
-    const [compact, setCompact] = React.useState(false);
-    const [nodes, dispatch] = React.useReducer(treeExampleReducer, INITIAL_STATE);
+    const [compact, setCompact] = useState(false);
+    const [nodes, dispatch] = useReducer(treeExampleReducer, INITIAL_STATE);
 
-    const handleNodeClick = React.useCallback(
-        (node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
-            const originallySelected = node.isSelected;
-            if (!e.shiftKey) {
-                dispatch({ type: "DESELECT_ALL" });
-            }
-            dispatch({
-                payload: { isSelected: originallySelected == null ? true : !originallySelected, path: nodePath },
-                type: "SET_IS_SELECTED",
-            });
-        },
-        [],
-    );
+    const handleNodeClick = useCallback((node: TreeNodeInfo, nodePath: NodePath, e: React.MouseEvent<HTMLElement>) => {
+        const originallySelected = node.isSelected;
+        if (!e.shiftKey) {
+            dispatch({ type: "DESELECT_ALL" });
+        }
+        dispatch({
+            payload: { isSelected: originallySelected == null ? true : !originallySelected, path: nodePath },
+            type: "SET_IS_SELECTED",
+        });
+    }, []);
 
-    const handleNodeCollapse = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
+    const handleNodeCollapse = useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { isExpanded: false, path: nodePath },
             type: "SET_IS_EXPANDED",
         });
     }, []);
 
-    const handleNodeExpand = React.useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
+    const handleNodeExpand = useCallback((_node: TreeNodeInfo, nodePath: NodePath) => {
         dispatch({
             payload: { isExpanded: true, path: nodePath },
             type: "SET_IS_EXPANDED",

--- a/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/useHotkeysExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { NonIdealState, useHotkeys } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -22,25 +22,25 @@ import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { PianoKey } from "./audio";
 
 export const UseHotkeysExample: React.FC<ExampleProps> = props => {
-    const [audioContext, setAudioContext] = React.useState<AudioContext>();
+    const [audioContext, setAudioContext] = useState<AudioContext>();
 
-    const pianoRef = React.useRef<HTMLDivElement>();
-    const focusPiano = React.useCallback(() => {
+    const pianoRef = useRef<HTMLDivElement>();
+    const focusPiano = useCallback(() => {
         pianoRef?.current.focus();
         if (typeof window.AudioContext !== "undefined" && audioContext === undefined) {
             setAudioContext(new AudioContext());
         }
     }, [audioContext, pianoRef]);
 
-    const [keyPressed, setKeyPressed] = React.useState<readonly boolean[]>(new Array(25).fill(false));
+    const [keyPressed, setKeyPressed] = useState<readonly boolean[]>(new Array(25).fill(false));
 
-    const setKeyState = React.useCallback((targetIndex: number, newValue: boolean) => {
+    const setKeyState = useCallback((targetIndex: number, newValue: boolean) => {
         setKeyPressed(previouslySelected =>
             previouslySelected.map((value, index) => (index === targetIndex ? newValue : value)),
         );
     }, []);
 
-    const hotkeys = React.useMemo(
+    const hotkeys = useMemo(
         () => [
             {
                 combo: "shift + P",
@@ -221,7 +221,7 @@ export const UseHotkeysExample: React.FC<ExampleProps> = props => {
     );
     const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys);
 
-    const pianoWithAudioContext = React.useMemo(
+    const pianoWithAudioContext = useMemo(
         () => (
             <>
                 <div>

--- a/packages/docs-app/src/examples/datetime-examples/common/dateFnsFormatSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/dateFnsFormatSelect.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { PropCodeTooltip } from "../../../common/propCodeTooltip";
 import { RadioSelect, type RadioSelectProps } from "../../../common/RadioSelect";
 

--- a/packages/docs-app/src/examples/datetime-examples/common/minMaxDateSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/minMaxDateSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import { add } from "date-fns";
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { FormGroup, HTMLSelect } from "@blueprintjs/core";
 import { handleNumberChange } from "@blueprintjs/docs-theme";
@@ -34,10 +34,10 @@ export interface DateSelectProps {
 }
 
 const DateSelect: React.FC<DateSelectProps> = ({ label, onChange, options }) => {
-    const [selectedOptionIndex, setSelectedOptionIndex] = React.useState(0);
+    const [selectedOptionIndex, setSelectedOptionIndex] = useState(0);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    const handleSelectChange = React.useCallback(
+    const handleSelectChange = useCallback(
         handleNumberChange(optionIndex => {
             setSelectedOptionIndex(optionIndex);
             onChange(options[optionIndex].value);

--- a/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes, HTMLSelect } from "@blueprintjs/core";
 import { TimePrecision } from "@blueprintjs/datetime";

--- a/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateInputExample.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useState } from "react";
 
 import { Classes, Code, FormGroup, H5, Icon, Switch } from "@blueprintjs/core";
 import { DateInput, TimePrecision } from "@blueprintjs/datetime";
@@ -29,21 +29,21 @@ import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { DATE_FNS_FORMAT_OPTIONS, DateFnsFormatSelect } from "./common/dateFnsFormatSelect";
 
 export const DateInputExample: React.FC<ExampleProps> = props => {
-    const [closeOnSelection, setCloseOnSelection] = React.useState(true);
-    const [dateFnsFormat, setDateFnsFormat] = React.useState(DATE_FNS_FORMAT_OPTIONS[0]);
-    const [disableTimezoneSelect, setDisableTimezoneSelect] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [localeCode, setLocaleCode] = React.useState<CommonDateFnsLocale>("en-US");
-    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = React.useState(false);
-    const [shortcuts, setShortcuts] = React.useState(false);
-    const [showActionsBar, setShowActionsBar] = React.useState(false);
-    const [showRightElement, setShowRightElement] = React.useState(false);
-    const [showArrowButtons, setShowArrowButtons] = React.useState(false);
-    const [showTimezoneSelect, setShowTimezoneSelect] = React.useState(true);
-    const [timePrecision, setTimePrecision] = React.useState<TimePrecision | undefined>(TimePrecision.MINUTE);
-    const [useAmPm, setUseAmPm] = React.useState(false);
-    const [value, setValue] = React.useState<string>(null);
+    const [closeOnSelection, setCloseOnSelection] = useState(true);
+    const [dateFnsFormat, setDateFnsFormat] = useState(DATE_FNS_FORMAT_OPTIONS[0]);
+    const [disableTimezoneSelect, setDisableTimezoneSelect] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [localeCode, setLocaleCode] = useState<CommonDateFnsLocale>("en-US");
+    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = useState(false);
+    const [shortcuts, setShortcuts] = useState(false);
+    const [showActionsBar, setShowActionsBar] = useState(false);
+    const [showRightElement, setShowRightElement] = useState(false);
+    const [showArrowButtons, setShowArrowButtons] = useState(false);
+    const [showTimezoneSelect, setShowTimezoneSelect] = useState(true);
+    const [timePrecision, setTimePrecision] = useState<TimePrecision | undefined>(TimePrecision.MINUTE);
+    const [useAmPm, setUseAmPm] = useState(false);
+    const [value, setValue] = useState<string>(null);
 
     const showTimePicker = timePrecision !== undefined;
 

--- a/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Callout, Classes, H5, Switch } from "@blueprintjs/core";
 import { DatePicker, type TimePrecision } from "@blueprintjs/datetime";
@@ -27,19 +27,19 @@ import { PrecisionSelect } from "../datetime-examples/common/precisionSelect";
 import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
 
 export const DatePickerExample: React.FC<ExampleProps> = props => {
-    const [highlightCurrentDay, setHighlightCurrentDay] = React.useState(false);
-    const [maxDate, setMaxDate] = React.useState<Date>(undefined);
-    const [minDate, setMinDate] = React.useState<Date>(undefined);
-    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = React.useState(false);
-    const [shortcuts, setShortcuts] = React.useState(false);
-    const [showActionsBar, setShowActionsBar] = React.useState(true);
-    const [showFooterElement, setShowFooterElement] = React.useState(false);
-    const [showOutsideDays, setShowOutsideDays] = React.useState(true);
-    const [showArrowButtons, setShowArrowButtons] = React.useState(false);
-    const [showWeekNumber, setShowWeekNumber] = React.useState(false);
-    const [timePrecision, setTimePrecision] = React.useState<TimePrecision>(undefined);
-    const [useAmPm, setUseAmPm] = React.useState(false);
-    const [value, setValue] = React.useState<Date>(null);
+    const [highlightCurrentDay, setHighlightCurrentDay] = useState(false);
+    const [maxDate, setMaxDate] = useState<Date>(undefined);
+    const [minDate, setMinDate] = useState<Date>(undefined);
+    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = useState(false);
+    const [shortcuts, setShortcuts] = useState(false);
+    const [showActionsBar, setShowActionsBar] = useState(true);
+    const [showFooterElement, setShowFooterElement] = useState(false);
+    const [showOutsideDays, setShowOutsideDays] = useState(true);
+    const [showArrowButtons, setShowArrowButtons] = useState(false);
+    const [showWeekNumber, setShowWeekNumber] = useState(false);
+    const [timePrecision, setTimePrecision] = useState<TimePrecision>(undefined);
+    const [useAmPm, setUseAmPm] = useState(false);
+    const [value, setValue] = useState<Date>(null);
 
     const showTimePicker = timePrecision !== undefined;
 

--- a/packages/docs-app/src/examples/datetime-examples/datePickerLocalizedExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerLocalizedExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { H5 } from "@blueprintjs/core";
 import { DatePicker } from "@blueprintjs/datetime";
@@ -23,7 +23,7 @@ import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { type CommonDateFnsLocale, DateFnsLocaleSelect } from "../../common/dateFnsLocaleSelect";
 
 export const DatePickerLocalizedExample: React.FC<ExampleProps> = props => {
-    const [localeCode, setlocaleCode] = React.useState<CommonDateFnsLocale>("fr");
+    const [localeCode, setlocaleCode] = useState<CommonDateFnsLocale>("fr");
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/datetime-examples/datePickerModifierExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/datePickerModifierExample.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback } from "react";
 
 import { DatePicker } from "@blueprintjs/datetime";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export function DatePickerModifierExample(props: ExampleProps) {
-    const isDayNumberOdd = React.useCallback((d: Date) => d.getDate() % 2 === 1, []);
+    const isDayNumberOdd = useCallback((d: Date) => d.getDate() % 2 === 1, []);
 
     return (
         <Example options={false} {...props}>

--- a/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangeInputExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Callout, Code, FormGroup, H5, Switch } from "@blueprintjs/core";
 import { type DateRange, DateRangeInput, TimePrecision } from "@blueprintjs/datetime";
@@ -28,23 +28,23 @@ import { DATE_FNS_FORMAT_OPTIONS, DateFnsFormatSelect } from "./common/dateFnsFo
 import { PrecisionSelect } from "./common/precisionSelect";
 
 export const DateRangeInputExample: React.FC<ExampleProps> = props => {
-    const [allowSingleDayRange, setAllowSingleDayRange] = React.useState(false);
-    const [closeOnSelection, setCloseOnSelection] = React.useState(false);
-    const [contiguousCalendarMonths, setContiguousCalendarMonths] = React.useState(true);
-    const [dateFnsFormat, setDateFnsFormat] = React.useState(DATE_FNS_FORMAT_OPTIONS[0]);
-    const [disabled, setDisabled] = React.useState(false);
-    const [enableTimePicker, setEnableTimePicker] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [localeCode, setLocaleCode] = React.useState<CommonDateFnsLocale>("en-US");
-    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = React.useState(false);
-    const [selectAllOnFocus, setSelectAllOnFocus] = React.useState(false);
-    const [shortcuts, setShortcuts] = React.useState(true);
-    const [showFooterElement, setShowFooterElement] = React.useState(false);
-    const [showArrowButtons, setShowArrowButtons] = React.useState(false);
-    const [singleMonthOnly, setSingleMonthOnly] = React.useState(false);
-    const [precision, setPrecision] = React.useState<TimePrecision>(TimePrecision.MINUTE);
-    const [useAmPm, setUseAmPm] = React.useState(false);
-    const [value, setValue] = React.useState<DateRange>([null, null]);
+    const [allowSingleDayRange, setAllowSingleDayRange] = useState(false);
+    const [closeOnSelection, setCloseOnSelection] = useState(false);
+    const [contiguousCalendarMonths, setContiguousCalendarMonths] = useState(true);
+    const [dateFnsFormat, setDateFnsFormat] = useState(DATE_FNS_FORMAT_OPTIONS[0]);
+    const [disabled, setDisabled] = useState(false);
+    const [enableTimePicker, setEnableTimePicker] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [localeCode, setLocaleCode] = useState<CommonDateFnsLocale>("en-US");
+    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = useState(false);
+    const [selectAllOnFocus, setSelectAllOnFocus] = useState(false);
+    const [shortcuts, setShortcuts] = useState(true);
+    const [showFooterElement, setShowFooterElement] = useState(false);
+    const [showArrowButtons, setShowArrowButtons] = useState(false);
+    const [singleMonthOnly, setSingleMonthOnly] = useState(false);
+    const [precision, setPrecision] = useState<TimePrecision>(TimePrecision.MINUTE);
+    const [useAmPm, setUseAmPm] = useState(false);
+    const [value, setValue] = useState<DateRange>([null, null]);
 
     const handlePrecisionChange = handleValueChange((timePrecision: TimePrecision | "none") =>
         setPrecision(timePrecision === "none" ? undefined : timePrecision),

--- a/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/dateRangePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { Classes, FormGroup, Switch } from "@blueprintjs/core";
 import { type DateRange, DateRangePicker, type TimePrecision } from "@blueprintjs/datetime";
@@ -28,18 +28,18 @@ import { MaxDateSelect, MinDateSelect } from "./common/minMaxDateSelect";
 import { PrecisionSelect } from "./common/precisionSelect";
 
 export const DateRangePickerExample: React.FC<ExampleProps> = props => {
-    const [allowSingleDayRange, setAllowSingleDayRange] = React.useState(false);
-    const [contiguousCalendarMonths, setContiguousCalendarMonths] = React.useState(true);
-    const [localeCode, setLocaleCode] = React.useState<CommonDateFnsLocale>("en-US");
-    const [maxDate, setMaxDate] = React.useState<Date>(undefined);
-    const [minDate, setMinDate] = React.useState<Date>(undefined);
-    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = React.useState(false);
-    const [shortcuts, setShortcuts] = React.useState(true);
-    const [showArrowButtons, setShowArrowButtons] = React.useState(false);
-    const [singleMonthOnly, setSingleMonthOnly] = React.useState(false);
-    const [precision, setPrecision] = React.useState<TimePrecision>(undefined);
-    const [useAmPm, setUseAmPm] = React.useState(false);
-    const [value, setValue] = React.useState<DateRange>([null, null]);
+    const [allowSingleDayRange, setAllowSingleDayRange] = useState(false);
+    const [contiguousCalendarMonths, setContiguousCalendarMonths] = useState(true);
+    const [localeCode, setLocaleCode] = useState<CommonDateFnsLocale>("en-US");
+    const [maxDate, setMaxDate] = useState<Date>(undefined);
+    const [minDate, setMinDate] = useState<Date>(undefined);
+    const [reverseMonthAndYearMenus, setReverseMonthAndYearMenus] = useState(false);
+    const [shortcuts, setShortcuts] = useState(true);
+    const [showArrowButtons, setShowArrowButtons] = useState(false);
+    const [singleMonthOnly, setSingleMonthOnly] = useState(false);
+    const [precision, setPrecision] = useState<TimePrecision>(undefined);
+    const [useAmPm, setUseAmPm] = useState(false);
+    const [value, setValue] = useState<DateRange>([null, null]);
 
     const showTimePicker = precision !== undefined;
 

--- a/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timePickerExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { Classes, H5, HTMLSelect, Switch } from "@blueprintjs/core";
 import { TimePicker, TimePrecision } from "@blueprintjs/datetime";
@@ -42,18 +42,18 @@ enum MaximumHours {
 }
 
 export const TimePickerExample: React.FC<ExampleProps> = props => {
-    const [autoFocus, setAutoFocus] = React.useState(true);
-    const [disabled, setDisabled] = React.useState(false);
-    const [maxTime, setMaxTime] = React.useState<Date>(getDefaultMaxTime());
-    const [minTime, setMinTime] = React.useState<Date>(getDefaultMinTime());
-    const [precision, setPrecision] = React.useState<TimePrecision>(TimePrecision.MINUTE);
-    const [selectAllOnFocus, setSelectAllOnFocus] = React.useState(false);
-    const [showArrowButtons, setShowArrowButtons] = React.useState(false);
-    const [useAmPm, setUseAmPm] = React.useState(false);
+    const [autoFocus, setAutoFocus] = useState(true);
+    const [disabled, setDisabled] = useState(false);
+    const [maxTime, setMaxTime] = useState<Date>(getDefaultMaxTime());
+    const [minTime, setMinTime] = useState<Date>(getDefaultMinTime());
+    const [precision, setPrecision] = useState<TimePrecision>(TimePrecision.MINUTE);
+    const [selectAllOnFocus, setSelectAllOnFocus] = useState(false);
+    const [showArrowButtons, setShowArrowButtons] = useState(false);
+    const [useAmPm, setUseAmPm] = useState(false);
 
     const handlePrecisionChange = handleValueChange((timePrecision: TimePrecision) => setPrecision(timePrecision));
 
-    const handleMaxChange = React.useCallback((hour: MaximumHours) => {
+    const handleMaxChange = useCallback((hour: MaximumHours) => {
         let newMaxTime = new Date(1995, 6, 30, hour);
         if (hour === MaximumHours.NONE) {
             newMaxTime = getDefaultMaxTime();
@@ -61,7 +61,7 @@ export const TimePickerExample: React.FC<ExampleProps> = props => {
         setMaxTime(newMaxTime);
     }, []);
 
-    const handleMinChange = React.useCallback((hour: MinimumHours) => {
+    const handleMinChange = useCallback((hour: MinimumHours) => {
         let newMinTime = new Date(1995, 6, 30, hour);
         if (hour === MinimumHours.NONE) {
             newMinTime = getDefaultMinTime();

--- a/packages/docs-app/src/examples/datetime-examples/timezoneSelectExample.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/timezoneSelectExample.tsx
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useState } from "react";
 
 import { H5, Position, Radio, RadioGroup, Switch } from "@blueprintjs/core";
 import { TimezoneDisplayFormat, TimezoneSelect } from "@blueprintjs/datetime";
 import { Example, type ExampleProps, handleBooleanChange, handleValueChange } from "@blueprintjs/docs-theme";
 
 export const TimezoneSelectExample: React.FC<ExampleProps> = props => {
-    const [disabled, setDisabled] = React.useState(false);
-    const [displayFormat, setDisplayFormat] = React.useState(TimezoneDisplayFormat.COMPOSITE);
-    const [fill, setFill] = React.useState(false);
-    const [showLocalTimezone, setShowLocalTimezone] = React.useState(true);
-    const [value, setValue] = React.useState("");
+    const [disabled, setDisabled] = useState(false);
+    const [displayFormat, setDisplayFormat] = useState(TimezoneDisplayFormat.COMPOSITE);
+    const [fill, setFill] = useState(false);
+    const [showLocalTimezone, setShowLocalTimezone] = useState(true);
+    const [value, setValue] = useState("");
 
     const options = (
         <>

--- a/packages/docs-app/src/examples/select-examples/multiSelectCustomTarget.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectCustomTarget.tsx
@@ -2,8 +2,6 @@
  * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
-
 import { Tag, Text } from "@blueprintjs/core";
 
 interface IMultiSelectCustomTargetProps {

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { Code, H5, Intent, MenuItem, type Popover, Switch, type TagProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -39,25 +39,25 @@ import { MultiSelectCustomTarget } from "./multiSelectCustomTarget";
 const INTENTS = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.DANGER, Intent.WARNING];
 
 export const MultiSelectExample: React.FC<ExampleProps> = props => {
-    const [allowCreate, setAllowCreate] = React.useState(false);
-    const [createdItems, setCreatedItems] = React.useState<Film[]>([]);
-    const [customTarget, setCustomTarget] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [films, setFilms] = React.useState<Film[]>([]);
-    const [hasInitialContent, setHasInitialContent] = React.useState(false);
-    const [intent, setIntent] = React.useState(false);
-    const [items, setItems] = React.useState<Film[]>(TOP_100_FILMS);
-    const [matchTargetWidth, setMatchTargetWidth] = React.useState(false);
-    const [openOnKeyDown, setOpenOnKeyDown] = React.useState(false);
-    const [popoverMinimal, setPopoverMinimal] = React.useState(true);
-    const [resetOnSelect, setResetOnSelect] = React.useState(true);
-    const [showClearButton, setShowClearButton] = React.useState(true);
-    const [tagMinimal, setTagMinimal] = React.useState(false);
+    const [allowCreate, setAllowCreate] = useState(false);
+    const [createdItems, setCreatedItems] = useState<Film[]>([]);
+    const [customTarget, setCustomTarget] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [films, setFilms] = useState<Film[]>([]);
+    const [hasInitialContent, setHasInitialContent] = useState(false);
+    const [intent, setIntent] = useState(false);
+    const [items, setItems] = useState<Film[]>(TOP_100_FILMS);
+    const [matchTargetWidth, setMatchTargetWidth] = useState(false);
+    const [openOnKeyDown, setOpenOnKeyDown] = useState(false);
+    const [popoverMinimal, setPopoverMinimal] = useState(true);
+    const [resetOnSelect, setResetOnSelect] = useState(true);
+    const [showClearButton, setShowClearButton] = useState(true);
+    const [tagMinimal, setTagMinimal] = useState(false);
 
-    const popoverRef = React.useRef<Popover>(null);
+    const popoverRef = useRef<Popover>(null);
 
-    const selectFilms = React.useCallback(
+    const selectFilms = useCallback(
         (filmsToSelect: Film[]) => {
             let nextCreatedItems = [...createdItems];
             let nextFilms = [...films];
@@ -80,14 +80,14 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
         [createdItems, films, items],
     );
 
-    const selectFilm = React.useCallback(
+    const selectFilm = useCallback(
         (film: Film) => {
             selectFilms([film]);
         },
         [selectFilms],
     );
 
-    const deselectFilm = React.useCallback(
+    const deselectFilm = useCallback(
         (index: number) => {
             const film = films[index];
             const { createdItems: nextCreatedItems, items: nextItems } = maybeDeleteCreatedFilmFromArrays(
@@ -104,11 +104,11 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
         [createdItems, films, items],
     );
 
-    const getSelectedFilmIndex = React.useCallback((film: Film) => films.indexOf(film), [films]);
+    const getSelectedFilmIndex = useCallback((film: Film) => films.indexOf(film), [films]);
 
-    const isFilmSelected = React.useCallback((film: Film) => getSelectedFilmIndex(film) !== -1, [getSelectedFilmIndex]);
+    const isFilmSelected = useCallback((film: Film) => getSelectedFilmIndex(film) !== -1, [getSelectedFilmIndex]);
 
-    const handleFilmSelect = React.useCallback(
+    const handleFilmSelect = useCallback(
         (film: Film) => {
             if (!isFilmSelected(film)) {
                 selectFilm(film);
@@ -119,12 +119,9 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
         [deselectFilm, getSelectedFilmIndex, isFilmSelected, selectFilm],
     );
 
-    const handleTagRemove = React.useCallback(
-        (_tag: React.ReactNode, index: number) => deselectFilm(index),
-        [deselectFilm],
-    );
+    const handleTagRemove = useCallback((_tag: React.ReactNode, index: number) => deselectFilm(index), [deselectFilm]);
 
-    const handleFilmsPaste = React.useCallback(
+    const handleFilmsPaste = useCallback(
         (newFilms: Film[]) => {
             // On paste, don't bother with deselecting already selected values,
             // just add the new ones.
@@ -133,9 +130,9 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
         [selectFilms],
     );
 
-    const handleClear = React.useCallback(() => setFilms([]), []);
+    const handleClear = useCallback(() => setFilms([]), []);
 
-    const renderFilm: ItemRenderer<Film> = React.useCallback(
+    const renderFilm: ItemRenderer<Film> = useCallback(
         (film, rendererProps) => {
             if (!rendererProps.modifiers.matchesPredicate) {
                 return null;
@@ -153,7 +150,7 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
         [isFilmSelected],
     );
 
-    const getTagProps = React.useCallback(
+    const getTagProps = useCallback(
         (_value: React.ReactNode, index: number): TagProps => ({
             intent: intent ? INTENTS[index % INTENTS.length] : Intent.NONE,
             minimal: tagMinimal,

--- a/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/omnibarExample.tsx
@@ -13,7 +13,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { Button, Classes, H5, HotkeysTarget, KeyComboTag, MenuItem, OverlayToaster, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -33,21 +33,21 @@ import type { BlueprintExampleData } from "../../tags/types";
 export const OmnibarExample: React.FC<ExampleProps<BlueprintExampleData>> = props => {
     const useDarkTheme = props.data.themeName === Classes.DARK;
 
-    const [allowCreate, setAllowCreate] = React.useState(false);
-    const [isOpen, setIsOpen] = React.useState(false);
-    const [overlayHasBackdrop, setOverlayHasBackdrop] = React.useState(true);
-    const [resetOnSelect, setResetOnSelect] = React.useState(true);
+    const [allowCreate, setAllowCreate] = useState(false);
+    const [isOpen, setIsOpen] = useState(false);
+    const [overlayHasBackdrop, setOverlayHasBackdrop] = useState(true);
+    const [resetOnSelect, setResetOnSelect] = useState(true);
 
-    const toaster = React.useMemo(
+    const toaster = useMemo(
         () => OverlayToaster.create({ className: classNames({ [Classes.DARK]: useDarkTheme }) }),
         [useDarkTheme],
     );
 
-    const handleOpen = React.useCallback(() => setIsOpen(true), []);
+    const handleOpen = useCallback(() => setIsOpen(true), []);
 
-    const handleClose = React.useCallback(() => setIsOpen(false), []);
+    const handleClose = useCallback(() => setIsOpen(false), []);
 
-    const handleItemSelect = React.useCallback(
+    const handleItemSelect = useCallback(
         async (film: Film) => {
             setIsOpen(false);
 

--- a/packages/docs-app/src/examples/select-examples/selectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/selectExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { H5, Menu, MenuDivider, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -22,21 +22,21 @@ import type { ItemListRendererProps } from "@blueprintjs/select";
 import { type Film, FilmSelect, filterFilm, TOP_100_FILMS } from "@blueprintjs/select/examples";
 
 export const SelectExample: React.FC<ExampleProps> = props => {
-    const [allowCreate, setAllowCreate] = React.useState(false);
-    const [createFirst, setCreateFirst] = React.useState(false);
-    const [disableItems, setDisableItems] = React.useState(false);
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [filterable, setFilterable] = React.useState(true);
-    const [grouped, setGrouped] = React.useState(false);
-    const [hasInitialContent, setHasInitialContent] = React.useState(false);
-    const [matchTargetWidth, setMatchTargetWidth] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(false);
-    const [resetOnClose, setResetOnClose] = React.useState(false);
-    const [resetOnQuery, setResetOnQuery] = React.useState(true);
-    const [resetOnSelect, setResetOnSelect] = React.useState(false);
+    const [allowCreate, setAllowCreate] = useState(false);
+    const [createFirst, setCreateFirst] = useState(false);
+    const [disableItems, setDisableItems] = useState(false);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [filterable, setFilterable] = useState(true);
+    const [grouped, setGrouped] = useState(false);
+    const [hasInitialContent, setHasInitialContent] = useState(false);
+    const [matchTargetWidth, setMatchTargetWidth] = useState(false);
+    const [minimal, setMinimal] = useState(false);
+    const [resetOnClose, setResetOnClose] = useState(false);
+    const [resetOnQuery, setResetOnQuery] = useState(true);
+    const [resetOnSelect, setResetOnSelect] = useState(false);
 
-    const initialContent = React.useMemo(
+    const initialContent = useMemo(
         () =>
             hasInitialContent ? (
                 <MenuItem disabled={true} text={`${TOP_100_FILMS.length} items loaded.`} roleStructure="listoption" />
@@ -44,9 +44,9 @@ export const SelectExample: React.FC<ExampleProps> = props => {
         [hasInitialContent],
     );
 
-    const isItemDisabled = React.useCallback((film: Film) => disableItems && film.year < 2000, [disableItems]);
+    const isItemDisabled = useCallback((film: Film) => disableItems && film.year < 2000, [disableItems]);
 
-    const renderGroupedMenuContent = React.useCallback(
+    const renderGroupedMenuContent = useCallback(
         (listProps: ItemListRendererProps<Film>, noResults?: React.ReactNode) => {
             if (listProps.query.length === 0 && initialContent !== undefined) {
                 return initialContent;
@@ -65,7 +65,7 @@ export const SelectExample: React.FC<ExampleProps> = props => {
         [initialContent],
     );
 
-    const renderGroupedItemList = React.useCallback(
+    const renderGroupedItemList = useCallback(
         (listProps: ItemListRendererProps<Film>) => {
             const noResults = <MenuItem disabled={true} text="No results." roleStructure="listoption" />;
 

--- a/packages/docs-app/src/examples/select-examples/suggestExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/suggestExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useState } from "react";
 
 import { H5, MenuItem, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -32,21 +32,21 @@ import {
 } from "@blueprintjs/select/examples";
 
 export const SuggestExample: React.FC<ExampleProps> = props => {
-    const [allowCreate, setAllowCreate] = React.useState(false);
-    const [closeOnSelect, setCloseOnSelect] = React.useState(true);
-    const [createdItems, setCreatedItems] = React.useState<Film[]>([]);
-    const [disabled, setDisabled] = React.useState(false);
-    const [fill, setFill] = React.useState(false);
-    const [items, setItems] = React.useState([...TOP_100_FILMS]);
-    const [matchTargetWidth, setMatchTargetWidth] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(true);
-    const [openOnKeyDown, setOpenOnKeyDown] = React.useState(false);
-    const [resetOnClose, setResetOnClose] = React.useState(false);
-    const [resetOnQuery, setResetOnQuery] = React.useState(true);
-    const [resetOnSelect, setResetOnSelect] = React.useState(false);
-    const [selectedFilm, setSelectedFilm] = React.useState(TOP_100_FILMS[0]);
+    const [allowCreate, setAllowCreate] = useState(false);
+    const [closeOnSelect, setCloseOnSelect] = useState(true);
+    const [createdItems, setCreatedItems] = useState<Film[]>([]);
+    const [disabled, setDisabled] = useState(false);
+    const [fill, setFill] = useState(false);
+    const [items, setItems] = useState([...TOP_100_FILMS]);
+    const [matchTargetWidth, setMatchTargetWidth] = useState(false);
+    const [minimal, setMinimal] = useState(true);
+    const [openOnKeyDown, setOpenOnKeyDown] = useState(false);
+    const [resetOnClose, setResetOnClose] = useState(false);
+    const [resetOnQuery, setResetOnQuery] = useState(true);
+    const [resetOnSelect, setResetOnSelect] = useState(false);
+    const [selectedFilm, setSelectedFilm] = useState(TOP_100_FILMS[0]);
 
-    const renderFilmItem: ItemRenderer<Film> = React.useCallback(
+    const renderFilmItem: ItemRenderer<Film> = useCallback(
         (film, rendererProps) => {
             if (!rendererProps.modifiers.matchesPredicate) {
                 return null;
@@ -62,7 +62,7 @@ export const SuggestExample: React.FC<ExampleProps> = props => {
         [selectedFilm],
     );
 
-    const handleValueChange = React.useCallback(
+    const handleValueChange = useCallback(
         (newSelectedFilm: Film) => {
             // delete the old film from the list if it was newly created
             const { createdItems: currentCreatedItems, items: currentItems } = maybeDeleteCreatedFilmFromArrays(

--- a/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/cellLoadingExample.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { RadioGroup } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
@@ -48,7 +48,7 @@ export interface CellLoadingExampleState {
     randomNumbers?: number[];
 }
 
-export class CellLoadingExample extends React.PureComponent<ExampleProps, CellLoadingExampleState> {
+export class CellLoadingExample extends PureComponent<ExampleProps, CellLoadingExampleState> {
     public state: CellLoadingExampleState = {
         configuration: CellsLoadingConfiguration.ALL,
     };

--- a/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/columnLoadingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { FormGroup, HTMLSelect } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleNumberChange } from "@blueprintjs/docs-theme";
@@ -31,7 +31,7 @@ export interface ColumnLoadingExampleState {
     loadingColumn?: number;
 }
 
-export class ColumnLoadingExample extends React.PureComponent<ExampleProps, ColumnLoadingExampleState> {
+export class ColumnLoadingExample extends PureComponent<ExampleProps, ColumnLoadingExampleState> {
     public state: ColumnLoadingExampleState = {
         loadingColumn: 1,
     };

--- a/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableDollarExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -23,7 +23,7 @@ import { Cell, Column, ColumnHeaderCell, Table } from "@blueprintjs/table";
 // this will obviously get outdated, it's valid only as of August 2021
 const USD_TO_EURO_CONVERSION = 0.85;
 
-export class TableDollarExample extends React.PureComponent<ExampleProps> {
+export class TableDollarExample extends PureComponent<ExampleProps> {
     public render() {
         const dollarCellRenderer = (rowIndex: number) => <Cell>{`$${(rowIndex * 10).toFixed(2)}`}</Cell>;
         const euroCellRenderer = (rowIndex: number) => (

--- a/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableEditableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Intent } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -27,7 +27,7 @@ export interface TableEditableExampleState {
     sparseColumnIntents?: Intent[];
 }
 
-export class TableEditableExample extends React.PureComponent<ExampleProps, TableEditableExampleState> {
+export class TableEditableExample extends PureComponent<ExampleProps, TableEditableExampleState> {
     public static dataKey = (rowIndex: number, columnIndex: number) => {
         return `${rowIndex}-${columnIndex}`;
     };

--- a/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFormatsExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, JSONFormat, Table, TruncatedFormat } from "@blueprintjs/table";
@@ -78,7 +78,7 @@ const TIME_ZONES: Timezone[] = (
     };
 });
 
-export class TableFormatsExample extends React.PureComponent<ExampleProps> {
+export class TableFormatsExample extends PureComponent<ExampleProps> {
     private data = TIME_ZONES;
 
     private date = new Date();

--- a/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableFreezingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { Cell, Column, Table, Utils } from "@blueprintjs/table";
@@ -29,7 +29,7 @@ const NUM_COLUMNS = 20;
 const NUM_FROZEN_ROWS = 2;
 const NUM_FROZEN_COLUMNS = 1;
 
-export class TableFreezingExample extends React.PureComponent<ExampleProps, TableFreezingExampleState> {
+export class TableFreezingExample extends PureComponent<ExampleProps, TableFreezingExampleState> {
     public render() {
         return (
             <Example options={false} showOptionsBelowExample={true} {...this.props}>

--- a/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableLoadingExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -33,7 +33,7 @@ export interface TableLoadingExampleState {
     rowHeadersLoading?: boolean;
 }
 
-export class TableLoadingExample extends React.PureComponent<ExampleProps, TableLoadingExampleState> {
+export class TableLoadingExample extends PureComponent<ExampleProps, TableLoadingExampleState> {
     public state: TableLoadingExampleState = {
         cellsLoading: true,
         columnHeadersLoading: true,

--- a/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableReorderableExample.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children, cloneElement, PureComponent } from "react";
 
 import { Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
@@ -34,7 +34,7 @@ const REORDERABLE_TABLE_DATA = [
     ["E", "Eggplant", "Elk", "Eritrea", "El Paso"],
 ].map(([letter, fruit, animal, country, city]) => ({ animal, city, country, fruit, letter }));
 
-export class TableReorderableExample extends React.PureComponent<ExampleProps, TableReorderableExampleState> {
+export class TableReorderableExample extends PureComponent<ExampleProps, TableReorderableExampleState> {
     public state: TableReorderableExampleState = {
         columns: [
             // these cellRenderers are only created once and then cloned on updates
@@ -55,8 +55,8 @@ export class TableReorderableExample extends React.PureComponent<ExampleProps, T
     public componentDidUpdate(_nextProps: ExampleProps, nextState: TableReorderableExampleState) {
         const { enableColumnInteractionBar } = this.state;
         if (nextState.enableColumnInteractionBar !== enableColumnInteractionBar) {
-            const nextColumns = React.Children.map(this.state.columns, (column: React.JSX.Element) => {
-                return React.cloneElement(column, { enableColumnInteractionBar });
+            const nextColumns = Children.map(this.state.columns, (column: React.JSX.Element) => {
+                return cloneElement(column, { enableColumnInteractionBar });
             });
             this.setState({ columns: nextColumns });
         }

--- a/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
+++ b/packages/docs-app/src/examples/table-examples/tableSortableExample.tsx
@@ -16,7 +16,7 @@
 
 /* eslint-disable max-classes-per-file */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
@@ -184,7 +184,7 @@ class RecordSortableColumn extends AbstractSortableColumn {
     };
 }
 
-export class TableSortableExample extends React.PureComponent<ExampleProps> {
+export class TableSortableExample extends PureComponent<ExampleProps> {
     public state = {
         columns: [
             new TextSortableColumn("Rikishi", 0),

--- a/packages/docs-app/src/index.tsx
+++ b/packages/docs-app/src/index.tsx
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-import * as ReactDOM from "react-dom/client";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
 import { docsData } from "@blueprintjs/docs-data";
 import {
@@ -43,9 +44,9 @@ const tagRenderers = {
 };
 
 const container = document.getElementById("blueprint-documentation");
-const root = ReactDOM.createRoot(container);
+const root = createRoot(container);
 root.render(
-    <React.StrictMode>
+    <StrictMode>
         <BlueprintDocs defaultPageId="blueprint" docs={docsData} tagRenderers={tagRenderers} useNextVersion={false} />
-    </React.StrictMode>,
+    </StrictMode>,
 );

--- a/packages/docs-app/src/tags/reactExamples.ts
+++ b/packages/docs-app/src/tags/reactExamples.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { type ComponentClass, createElement } from "react";
 
 import type { ExampleMap, ExampleProps } from "@blueprintjs/docs-theme";
 
@@ -30,14 +30,14 @@ const SRC_HREF_BASE = "https://github.com/palantir/blueprint/blob/develop/packag
 
 function getPackageExamples(
     packageName: string,
-    packageExamples: { [name: string]: React.ComponentClass<ExampleProps<BlueprintExampleData>> },
+    packageExamples: { [name: string]: ComponentClass<ExampleProps<BlueprintExampleData>> },
 ) {
     const ret: ExampleMap = {};
     for (const exampleName of Object.keys(packageExamples)) {
         const example = packageExamples[exampleName];
         const fileName = exampleName.charAt(0).toLowerCase() + exampleName.slice(1) + ".tsx";
         ret[exampleName] = {
-            render: props => React.createElement(example, { ...props, data: { themeName: getTheme() } }),
+            render: props => createElement(example, { ...props, data: { themeName: getTheme() } }),
             sourceUrl: [SRC_HREF_BASE, `${packageName}-examples`, fileName].join("/"),
         };
     }

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -22,7 +22,7 @@ import type {
     TsDocBase,
     TypescriptPluginData,
 } from "@documentalist/client";
-import * as React from "react";
+import { createContext, type ReactNode } from "react";
 
 /* eslint-disable @typescript-eslint/no-empty-object-type */
 /** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
@@ -53,19 +53,19 @@ export interface DocumentationContextApi {
     getDocsData: () => DocsData;
 
     /** Render a block of Documentalist documentation to a React node. */
-    renderBlock: (block: Block) => React.ReactNode;
+    renderBlock: (block: Block) => ReactNode;
 
     /** Render a Documentalist Typescript type string to a React node. */
-    renderType: (type: string) => React.ReactNode;
+    renderType: (type: string) => ReactNode;
 
     /** Render the text of a "View source" link. */
-    renderViewSourceLinkText: (entry: TsDocBase) => React.ReactNode;
+    renderViewSourceLinkText: (entry: TsDocBase) => ReactNode;
 
     /** Open the API browser to the given member name. */
     showApiDocs: (name: string) => void;
 }
 
-export const DocumentationContext = React.createContext<DocumentationContextApi>({
+export const DocumentationContext = createContext<DocumentationContextApi>({
     getDocsData: () => ({}) as DocsData,
     renderBlock: (_block: Block) => undefined,
     renderType: (type: string) => type,

--- a/packages/docs-theme/src/components/banner.tsx
+++ b/packages/docs-theme/src/components/banner.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, Intent, type Props } from "@blueprintjs/core";
 
@@ -37,7 +37,7 @@ export interface BannerProps extends Props {
  * Render `Banner` before `Documentation` for a full-width colored banner link across the top of the page.
  * Use this to alert users to make changes or new pages.
  */
-export class Banner extends React.PureComponent<BannerProps> {
+export class Banner extends PureComponent<BannerProps> {
     public render() {
         const { children, className, href, intent = Intent.PRIMARY } = this.props;
         const classes = classNames("docs-banner", Classes.intentClass(intent), className);

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -16,7 +16,7 @@
 
 import type { Block } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import { Classes, Code, H3 } from "@blueprintjs/core";
 
@@ -43,7 +43,7 @@ export function renderBlock(
             if (renderer === undefined) {
                 throw new Error(`Unknown @tag: ${node.tag}`);
             }
-            return React.createElement(renderer, { ...node, key: i });
+            return createElement(renderer, { ...node, key: i });
         } catch (ex: any) {
             console.error(ex.message);
             return (

--- a/packages/docs-theme/src/components/codeExample.tsx
+++ b/packages/docs-theme/src/components/codeExample.tsx
@@ -3,7 +3,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Pre } from "@blueprintjs/core";
 

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -23,7 +23,7 @@ import {
     type TsDocBase,
 } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, Drawer, FocusStyleManager, HotkeysTarget, type Props } from "@blueprintjs/core";
 import { Search } from "@blueprintjs/icons";
@@ -130,7 +130,7 @@ export interface DocumentationState {
     isNavigatorOpen: boolean;
 }
 
-export class Documentation extends React.PureComponent<DocumentationProps, DocumentationState> {
+export class Documentation extends PureComponent<DocumentationProps, DocumentationState> {
     /** Map of section route to containing page reference. */
     private routeToPage: { [route: string]: string };
 

--- a/packages/docs-theme/src/components/example.tsx
+++ b/packages/docs-theme/src/components/example.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -87,10 +87,13 @@ export interface DocsExampleProps extends ExampleProps {
  * Container for an example and its options.
  *
  * ```tsx
+ * import { PureComponent } from "react";
+ *
  * import { Example, ExampleProps } from "@blueprintjs/docs-theme";
+ *
  * // use ExampleProps as your props type,
  * // then spread it to <Example> below
- * export class MyExample extends React.PureComponent<ExampleProps, [your state]> {
+ * export class MyExample extends PureComponent<ExampleProps, [your state]> {
  *     public render() {
  *         const options = (
  *             <>
@@ -105,7 +108,7 @@ export interface DocsExampleProps extends ExampleProps {
  *     }
  * ```
  */
-export class Example extends React.PureComponent<DocsExampleProps> {
+export class Example extends PureComponent<DocsExampleProps> {
     public static defaultProps: Partial<DocsExampleProps> = {
         forceUpdate: true,
         showOptionsBelowExample: false,

--- a/packages/docs-theme/src/components/modifierTable.tsx
+++ b/packages/docs-theme/src/components/modifierTable.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children } from "react";
 
 import { Classes, HTMLTable } from "@blueprintjs/core";
 
@@ -33,7 +33,7 @@ export interface ModifierTableProps {
     descriptionTitle?: string;
 }
 
-export const ModifierTable: React.FunctionComponent<ModifierTableProps> = ({
+export const ModifierTable: React.FC<ModifierTableProps> = ({
     children,
     descriptionTitle = "Description",
     emptyMessage,
@@ -53,7 +53,7 @@ export const ModifierTable: React.FunctionComponent<ModifierTableProps> = ({
 );
 
 function isEmpty(children: React.ReactNode) {
-    const array = React.Children.toArray(children);
+    const array = Children.toArray(children);
     return array.length === 0 || array.filter(item => !!item).length === 0;
 }
 

--- a/packages/docs-theme/src/components/navButton.tsx
+++ b/packages/docs-theme/src/components/navButton.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes, Icon, KeyComboTag } from "@blueprintjs/core";
 import type { IconName } from "@blueprintjs/icons";
@@ -27,7 +26,7 @@ export interface NavButtonProps {
     onClick: () => void;
 }
 
-export const NavButton: React.FunctionComponent<NavButtonProps> = ({ icon, onClick, hotkey, text }) => (
+export const NavButton: React.FC<NavButtonProps> = ({ icon, onClick, hotkey, text }) => (
     <div className={classNames("docs-nav-button", Classes.TEXT_MUTED)} onClick={onClick}>
         <Icon icon={icon} />
         <span className={Classes.FILL}>{text}</span>

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -16,7 +16,6 @@
 
 import { type HeadingNode, isPageNode, type PageNode } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes, type Props } from "@blueprintjs/core";
 
@@ -33,7 +32,7 @@ export interface NavMenuProps extends Props {
     renderNavMenuItem?: (props: NavMenuItemProps) => React.JSX.Element;
 }
 
-export const NavMenu: React.FunctionComponent<NavMenuProps> = props => {
+export const NavMenu: React.FC<NavMenuProps> = props => {
     const { renderNavMenuItem = NavMenuItem } = props;
     const menu = props.items.map(section => {
         const isActive = props.activeSectionId === section.route;

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -16,7 +16,6 @@
 
 import type { HeadingNode, PageNode } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -44,7 +43,7 @@ export interface NavMenuItemProps {
     section: PageNode | HeadingNode;
 }
 
-export const NavMenuItem: React.FunctionComponent<NavMenuItemProps> = props => {
+export const NavMenuItem: React.FC<NavMenuItemProps> = props => {
     const { className, isActive, isExpanded, section, ...htmlProps } = props;
     return (
         <a className={classNames(Classes.MENU_ITEM, className)} {...htmlProps}>

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -17,7 +17,7 @@
 import type { HeadingNode, PageNode } from "@documentalist/client";
 import classNames from "classnames";
 import { filter } from "fuzzaldrin-plus";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Classes, MenuItem } from "@blueprintjs/core";
 import { CaretRight } from "@blueprintjs/icons";
@@ -53,7 +53,7 @@ export interface NavigationSection {
     title: string;
 }
 
-export class Navigator extends React.PureComponent<NavigatorProps> {
+export class Navigator extends PureComponent<NavigatorProps> {
     private sections: NavigationSection[] | undefined;
 
     public componentDidMount() {

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -15,7 +15,6 @@
  */
 
 import type { PageData } from "@documentalist/client";
-import * as React from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -29,7 +28,7 @@ export interface PageProps {
     tagRenderers: TagRendererMap;
 }
 
-export const Page: React.FunctionComponent<PageProps> = ({ page, renderActions, tagRenderers }) => {
+export const Page: React.FC<PageProps> = ({ page, renderActions, tagRenderers }) => {
     // apply running text styles to blocks in pages (but not on blocks in examples)
     const pageContents = renderBlock(page, tagRenderers, Classes.TEXT_LARGE);
     return (

--- a/packages/docs-theme/src/components/typescript/apiHeader.tsx
+++ b/packages/docs-theme/src/components/typescript/apiHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import { isTsClass, isTsInterface, type TsDocBase } from "@documentalist/client";
-import * as React from "react";
+import { useContext } from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";
 import { DocumentationContext } from "../../common/context";
@@ -25,7 +25,7 @@ interface ApiHeaderProps extends TsDocBase {
 }
 
 export const ApiHeader: React.FC<ApiHeaderProps> = props => {
-    const { renderType, renderViewSourceLinkText } = React.useContext(DocumentationContext);
+    const { renderType, renderViewSourceLinkText } = useContext(DocumentationContext);
     let inheritance: React.ReactNode = "";
 
     if (isTsClass(props) || isTsInterface(props)) {

--- a/packages/docs-theme/src/components/typescript/apiLink.tsx
+++ b/packages/docs-theme/src/components/typescript/apiLink.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { useCallback, useContext } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -30,8 +30,8 @@ export interface ApiLinkProps extends Props {
  * Renders a link to open a symbol in the API Browser.
  */
 export const ApiLink: React.FC<ApiLinkProps> = ({ className, name }) => {
-    const { showApiDocs } = React.useContext(DocumentationContext);
-    const handleClick = React.useCallback(
+    const { showApiDocs } = useContext(DocumentationContext);
+    const handleClick = useCallback(
         (evt: React.MouseEvent<HTMLAnchorElement>) => {
             evt.preventDefault();
             showApiDocs(name);

--- a/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
+++ b/packages/docs-theme/src/components/typescript/deprecatedTag.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { Intent, Tag } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../../common";

--- a/packages/docs-theme/src/components/typescript/enumTable.tsx
+++ b/packages/docs-theme/src/components/typescript/enumTable.tsx
@@ -16,7 +16,7 @@
 
 import type { TsEnum, TsEnumMember } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useContext } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -32,9 +32,9 @@ export interface EnumTableProps extends Props {
 }
 
 export const EnumTable: React.FC<EnumTableProps> = props => {
-    const { renderBlock } = React.useContext(DocumentationContext);
+    const { renderBlock } = useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback(
+    const renderPropRow = useCallback(
         (entry: TsEnumMember) => {
             const { flags, name } = entry;
 

--- a/packages/docs-theme/src/components/typescript/interfaceTable.tsx
+++ b/packages/docs-theme/src/components/typescript/interfaceTable.tsx
@@ -24,7 +24,7 @@ import {
     type TsSignature,
 } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useContext } from "react";
 
 import { Classes, Intent, type Props, Tag } from "@blueprintjs/core";
 
@@ -44,9 +44,9 @@ export interface InterfaceTableProps extends Props {
 /* eslint-disable @blueprintjs/html-components */
 
 export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data, title }) => {
-    const { renderBlock, renderType } = React.useContext(DocumentationContext);
+    const { renderBlock, renderType } = useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback(
+    const renderPropRow = useCallback(
         (entry: TsProperty | TsMethod) => {
             const { flags, name, inheritedFrom } = entry;
             const { documentation } = isTsProperty(entry) ? entry : entry.signatures[0]!;
@@ -101,7 +101,7 @@ export const InterfaceTable: React.FC<InterfaceTableProps> = ({ className, data,
         [renderBlock, renderType],
     );
 
-    const renderIndexSignature = React.useCallback(
+    const renderIndexSignature = useCallback(
         (entry?: TsSignature) => {
             if (entry == null) {
                 return null;

--- a/packages/docs-theme/src/components/typescript/methodTable.tsx
+++ b/packages/docs-theme/src/components/typescript/methodTable.tsx
@@ -16,7 +16,7 @@
 
 import { isTag, type TsMethod, type TsParameter, type TsSignature } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useContext } from "react";
 
 import { Code, Intent, type Props, Tag } from "@blueprintjs/core";
 
@@ -32,9 +32,9 @@ export interface MethodTableProps extends Props {
 }
 
 export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => {
-    const { renderBlock, renderType } = React.useContext(DocumentationContext);
+    const { renderBlock, renderType } = useContext(DocumentationContext);
 
-    const renderPropRow = React.useCallback(
+    const renderPropRow = useCallback(
         (parameter: TsParameter) => {
             const { flags, name } = parameter;
             const { documentation } = parameter;
@@ -79,7 +79,7 @@ export const MethodTable: React.FC<MethodTableProps> = ({ className, data }) => 
         [renderBlock, renderType],
     );
 
-    const renderReturnSignature = React.useCallback(
+    const renderReturnSignature = useCallback(
         (entry?: TsSignature) => {
             if (entry == null) {
                 return null;

--- a/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
+++ b/packages/docs-theme/src/components/typescript/typeAliasTable.tsx
@@ -16,7 +16,7 @@
 
 import type { TsTypeAlias } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { useContext } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -30,7 +30,7 @@ export interface TypeAliasTableProps extends Props {
 }
 
 export const TypeAliasTable: React.FC<TypeAliasTableProps> = ({ className, data }) => {
-    const { renderBlock, renderType } = React.useContext(DocumentationContext);
+    const { renderBlock, renderType } = useContext(DocumentationContext);
     const aliases = data.type.split(" | ").map((type, i) => (
         <div key={i}>
             {i === 0 ? "=" : "|"} {renderType(type)}

--- a/packages/docs-theme/src/tags/css.tsx
+++ b/packages/docs-theme/src/tags/css.tsx
@@ -16,7 +16,7 @@
 
 import type { KssPluginData, Tag } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { useCallback, useContext, useState } from "react";
 
 import { Checkbox, Classes, Code } from "@blueprintjs/core";
 
@@ -28,10 +28,10 @@ const MODIFIER_ATTR_REGEXP = /\{\{:modifier}}/g;
 const MODIFIER_CLASS_REGEXP = /\{\{\.modifier}}/g;
 
 export const CssExample: React.FC<Tag> = ({ value }) => {
-    const { getDocsData } = React.useContext(DocumentationContext);
-    const [activeModifiers, setActiveModifiers] = React.useState<Set<string>>(new Set());
+    const { getDocsData } = useContext(DocumentationContext);
+    const [activeModifiers, setActiveModifiers] = useState<Set<string>>(new Set());
 
-    const getModifiers = React.useCallback(
+    const getModifiers = useCallback(
         (prefix: "." | ":") => {
             return Array.from(activeModifiers.keys())
                 .filter(mod => mod.charAt(0) === prefix)

--- a/packages/docs-theme/src/tags/defaults.ts
+++ b/packages/docs-theme/src/tags/defaults.ts
@@ -15,7 +15,6 @@
  */
 
 import type { Tag } from "@documentalist/client";
-import type * as React from "react";
 
 import { CssExample } from "./css";
 import { Heading } from "./heading";

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -16,7 +16,7 @@
 
 import { isHeadingTag, type Tag } from "@documentalist/client";
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import { Classes } from "@blueprintjs/core";
 import { Link } from "@blueprintjs/icons";
@@ -39,6 +39,6 @@ export const Heading: React.FC<Tag> = props => {
     ];
 
     // use createElement so we can dynamically choose tag based on depth
-    return React.createElement(`h${level}`, { className }, children);
+    return createElement(`h${level}`, { className }, children);
 };
 Heading.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.Heading`;

--- a/packages/docs-theme/src/tags/method.tsx
+++ b/packages/docs-theme/src/tags/method.tsx
@@ -15,7 +15,7 @@
  */
 
 import { isTsClass, isTsMethod, type Tag, type TsClass, type TypescriptPluginData } from "@documentalist/client";
-import * as React from "react";
+import { useContext } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -24,7 +24,7 @@ import { DocumentationContext } from "../common/context";
 import { MethodTable } from "../components/typescript/methodTable";
 
 export const Method: React.FC<Tag & Props> = ({ className, value }) => {
-    const { getDocsData } = React.useContext(DocumentationContext);
+    const { getDocsData } = useContext(DocumentationContext);
     const { typescript } = getDocsData() as TypescriptPluginData;
     const member = typescript[value];
 

--- a/packages/docs-theme/src/tags/reactCodeExample.tsx
+++ b/packages/docs-theme/src/tags/reactCodeExample.tsx
@@ -3,7 +3,6 @@
  */
 
 import type { Tag } from "@documentalist/client";
-import type * as React from "react";
 
 import type { ExampleMap } from "./reactExample";
 

--- a/packages/docs-theme/src/tags/reactDocs.tsx
+++ b/packages/docs-theme/src/tags/reactDocs.tsx
@@ -15,7 +15,7 @@
  */
 
 import type { Tag } from "@documentalist/client";
-import * as React from "react";
+import { createElement } from "react";
 
 export interface DocsMap {
     [name: string]: React.ComponentClass;
@@ -38,6 +38,6 @@ export class ReactDocsTagRenderer {
         if (docsComponent == null) {
             throw new Error(`Unknown @reactDocs component: ${componentName}`);
         }
-        return React.createElement(docsComponent);
+        return createElement(docsComponent);
     };
 }

--- a/packages/docs-theme/src/tags/reactExample.tsx
+++ b/packages/docs-theme/src/tags/reactExample.tsx
@@ -15,7 +15,6 @@
  */
 
 import type { Tag } from "@documentalist/client";
-import * as React from "react";
 
 import { AnchorButton, Intent } from "@blueprintjs/core";
 import { Code } from "@blueprintjs/icons";

--- a/packages/docs-theme/src/tags/see.tsx
+++ b/packages/docs-theme/src/tags/see.tsx
@@ -15,13 +15,13 @@
  */
 
 import type { Tag } from "@documentalist/client";
-import * as React from "react";
+import { useContext } from "react";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 import { DocumentationContext } from "../common/context";
 
 export const SeeTag: React.FC<Tag> = ({ value }) => {
-    const { renderType } = React.useContext(DocumentationContext);
+    const { renderType } = useContext(DocumentationContext);
     return <p>See: {renderType(value)}</p>;
 };
 SeeTag.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.SeeTag`;

--- a/packages/docs-theme/src/tags/typescript.tsx
+++ b/packages/docs-theme/src/tags/typescript.tsx
@@ -22,7 +22,7 @@ import {
     type Tag,
     type TypescriptPluginData,
 } from "@documentalist/client";
-import * as React from "react";
+import { useContext } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -33,7 +33,7 @@ import { InterfaceTable } from "../components/typescript/interfaceTable";
 import { TypeAliasTable } from "../components/typescript/typeAliasTable";
 
 export const TypescriptExample: React.FC<Tag & Props> = ({ className, value }) => {
-    const { getDocsData } = React.useContext(DocumentationContext);
+    const { getDocsData } = useContext(DocumentationContext);
     const { typescript } = getDocsData() as TypescriptPluginData;
     if (typescript == null || typescript[value] == null) {
         return null;

--- a/packages/icons/src/svgIconContainer.tsx
+++ b/packages/icons/src/svgIconContainer.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, forwardRef } from "react";
 
 import * as Classes from "./classes";
 import type { IconName } from "./iconNames";
@@ -45,7 +45,7 @@ export interface SVGIconContainerComponent extends React.FC<SVGIconContainerProp
     <T extends Element = Element>(props: SVGIconContainerProps<T>): React.ReactNode;
 }
 
-export const SVGIconContainer: SVGIconContainerComponent = React.forwardRef(
+export const SVGIconContainer: SVGIconContainerComponent = forwardRef(
     <T extends Element>(props: SVGIconContainerProps<T>, ref: React.Ref<T>) => {
         const {
             children,
@@ -89,7 +89,7 @@ export const SVGIconContainer: SVGIconContainerComponent = React.forwardRef(
             );
         } else {
             // N.B. styles for `Classes.ICON` are defined in @blueprintjs/core in `_icon.scss`
-            return React.createElement(
+            return createElement(
                 tagName,
                 {
                     "aria-hidden": title ? undefined : true,

--- a/packages/icons/src/svgIconProps.ts
+++ b/packages/icons/src/svgIconProps.ts
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 type OmittedDOMAttributes = "children" | "dangerouslySetInnerHTML";
 
 /**

--- a/packages/icons/test/generatedIconsTests.tsx
+++ b/packages/icons/test/generatedIconsTests.tsx
@@ -3,7 +3,6 @@
  */
 
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { Add } from "../src/generated/components";
 

--- a/packages/icons/test/isotest.mjs
+++ b/packages/icons/test/isotest.mjs
@@ -16,7 +16,7 @@
 // @ts-check
 
 import "@blueprintjs/test-commons/bootstrap";
-import React from "react";
+import { createElement } from "react";
 
 import { generateIsomorphicTests } from "@blueprintjs/test-commons";
 
@@ -30,7 +30,7 @@ describe("@blueprintjs/icons isomorphic rendering", () => {
                 props: {
                     iconName: "add",
                 },
-                children: React.createElement("path"),
+                children: createElement("path"),
             },
         },
         { excludedSymbols: ["Icons"] },

--- a/packages/icons/test/svgIconContainerTests.tsx
+++ b/packages/icons/test/svgIconContainerTests.tsx
@@ -3,7 +3,6 @@
  */
 
 import { mount } from "enzyme";
-import * as React from "react";
 
 import { SVGIconContainer } from "../src/svgIconContainer";
 

--- a/packages/landing-app/src/index.tsx
+++ b/packages/landing-app/src/index.tsx
@@ -21,7 +21,6 @@ import { initializeSVGs } from "./svgs";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
-/* eslint-disable @blueprintjs/classes-constants */
 initializeLogo(
     document.getElementById("pt-logo") as HTMLCanvasElement,
     document.getElementById("pt-logo-background") as HTMLCanvasElement,

--- a/packages/select/src/__examples__/filmSelect.tsx
+++ b/packages/select/src/__examples__/filmSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { Button, Classes, MenuItem } from "@blueprintjs/core";
 

--- a/packages/select/src/__examples__/filmSelect.tsx
+++ b/packages/select/src/__examples__/filmSelect.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { useState, useCallback } from "react";
 
 import { Button, Classes, MenuItem } from "@blueprintjs/core";
 
@@ -49,10 +49,10 @@ type FilmSelectProps = Omit<
 };
 
 export function FilmSelect({ allowCreate = false, fill, ...restProps }: FilmSelectProps) {
-    const [items, setItems] = React.useState([...TOP_100_FILMS]);
-    const [createdItems, setCreatedItems] = React.useState<Film[]>([]);
-    const [selectedFilm, setSelectedFilm] = React.useState<Film | undefined>(undefined);
-    const handleItemSelect = React.useCallback(
+    const [items, setItems] = useState([...TOP_100_FILMS]);
+    const [createdItems, setCreatedItems] = useState<Film[]>([]);
+    const [selectedFilm, setSelectedFilm] = useState<Film | undefined>(undefined);
+    const handleItemSelect = useCallback(
         (newFilm: Film) => {
             // Delete the old film from the list if it was newly created.
             const step1Result = maybeDeleteCreatedFilmFromArrays(items, createdItems, selectedFilm);
@@ -65,7 +65,7 @@ export function FilmSelect({ allowCreate = false, fill, ...restProps }: FilmSele
         [createdItems, items, selectedFilm],
     );
 
-    const itemRenderer = React.useCallback<ItemRenderer<Film>>(
+    const itemRenderer = useCallback<ItemRenderer<Film>>(
         (film, props) => {
             if (!props.modifiers.matchesPredicate) {
                 return null;

--- a/packages/select/src/__examples__/films.tsx
+++ b/packages/select/src/__examples__/films.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { MenuItem, type MenuItemProps } from "@blueprintjs/core";
 
 import type { ItemPredicate, ItemRenderer, ItemRendererProps } from "../common";

--- a/packages/select/src/common/itemRenderer.ts
+++ b/packages/select/src/common/itemRenderer.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 export interface ItemModifiers {
     /** Whether this is the "active" (focused) item, meaning keyboard interactions will act upon it. */
     active: boolean;

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement, createRef } from "react";
 
 import {
     AbstractPureComponent,
@@ -172,7 +172,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
         queryList: React.RefCallback<QueryList<T>>;
     } = {
         input: refHandler(this, "input", this.props.tagInputProps?.inputRef),
-        popover: React.createRef(),
+        popover: createRef(),
         queryList: (ref: QueryList<T> | null) => (this.queryList = ref),
     };
 
@@ -277,7 +277,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
 
             const { targetTagName = "div" } = popoverProps;
 
-            return React.createElement(
+            return createElement(
                 targetTagName,
                 {
                     "aria-autocomplete": "list",

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { DISPLAYNAME_PREFIX, InputGroup, type InputGroupProps, Overlay2, type OverlayProps } from "@blueprintjs/core";
 import { Search } from "@blueprintjs/icons";
@@ -58,7 +58,7 @@ export interface OmnibarProps<T> extends ListItemsProps<T> {
  *
  * @see https://blueprintjs.com/docs/#select/omnibar
  */
-export class Omnibar<T> extends React.PureComponent<OmnibarProps<T>> {
+export class Omnibar<T> extends PureComponent<OmnibarProps<T>> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Omnibar`;
 
     public static ofType<U>() {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { AbstractComponent, DISPLAYNAME_PREFIX, Menu, type Props, Utils } from "@blueprintjs/core";
 
 import {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createElement } from "react";
 
 import {
     AbstractPureComponent,
@@ -228,7 +228,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
             const { disabled, popoverProps = {}, popoverTargetProps } = this.props;
             const { handleKeyDown, handleKeyUp } = listProps;
             const { targetTagName = "div" } = popoverProps;
-            return React.createElement(
+            return createElement(
                 targetTagName,
                 {
                     "aria-controls": this.listboxId,

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/select/test/itemRendererTests.tsx
+++ b/packages/select/test/itemRendererTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { shallow } from "enzyme";
-import * as React from "react";
+import { createRef } from "react";
 
 import { Menu, MenuItem } from "@blueprintjs/core";
 
@@ -64,7 +64,7 @@ describe("ItemRenderer", () => {
 
         it("with ref prop", () => {
             function getItemProps(_item: Film): ItemRendererProps {
-                const ref = React.createRef<HTMLLIElement>();
+                const ref = createRef<HTMLLIElement>();
                 return {
                     // @ts-expect-error -- extra properties should not be allowed
                     blah: "foo",

--- a/packages/select/test/multiSelectTests.tsx
+++ b/packages/select/test/multiSelectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { type HTMLAttributes, mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import sinon from "sinon";
 
 import { Button, Classes as CoreClasses, Popover, Tag } from "@blueprintjs/core";
@@ -174,7 +174,7 @@ describe("<MultiSelect>", () => {
             </MultiSelect>,
         );
         if (query !== undefined) {
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ query });
             });
         }

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper, shallow } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import sinon from "sinon";
 
 import { Menu } from "@blueprintjs/core";
@@ -117,10 +117,10 @@ describe("<QueryList>", () => {
             const filmQueryList = mount(
                 <QueryList<Film> {...testProps} items={[myItem]} activeItem={myItem} query="" />,
             );
-            React.act(() => {
+            act(() => {
                 filmQueryList.setState({ query: "query" });
             });
-            React.act(() => {
+            act(() => {
                 filmQueryList.setState({ activeItem: undefined });
             });
             assert.equal(testProps.onActiveItemChange.callCount, 0);
@@ -276,7 +276,7 @@ describe("<QueryList>", () => {
             const pastedValue2 = item2.title;
             const pastedValue3 = item3.title;
 
-            React.act(() => {
+            act(() => {
                 handlePaste([pastedValue1, pastedValue2, pastedValue3]);
             });
 
@@ -299,7 +299,7 @@ describe("<QueryList>", () => {
             const pastedValue3 = "unrecognized2";
             const pastedValue4 = item4.title;
 
-            React.act(() => {
+            act(() => {
                 handlePaste([pastedValue1, pastedValue2, pastedValue3, pastedValue4]);
             });
 
@@ -333,7 +333,7 @@ describe("<QueryList>", () => {
             // Paste this item last.
             const pastedValue3 = "unrecognized";
 
-            React.act(() => {
+            act(() => {
                 handlePaste([pastedValue1, pastedValue2, pastedValue3]);
             });
 

--- a/packages/select/test/renderFilteredItemsTests.tsx
+++ b/packages/select/test/renderFilteredItemsTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { assert } from "chai";
-import * as React from "react";
 import sinon from "sinon";
 
 import { type ItemListRendererProps, renderFilteredItems } from "../src";

--- a/packages/select/test/selectTests.tsx
+++ b/packages/select/test/selectTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { type HTMLAttributes, mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as sinon from "sinon";
 
 import { Button, Classes, InputGroup, MenuItem, Popover } from "@blueprintjs/core";
@@ -187,7 +187,7 @@ describe("<Select>", () => {
             { attachTo: containerElement },
         );
         if (query !== undefined) {
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ query });
             });
         }

--- a/packages/select/test/suggestTests.tsx
+++ b/packages/select/test/suggestTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as sinon from "sinon";
 
 import { InputGroup, MenuItem, Popover, type PopoverProps } from "@blueprintjs/core";
@@ -107,11 +107,11 @@ describe("Suggest", () => {
             const wrapper = suggest();
             const queryList = (wrapper.instance() as Suggest<Film> as any).queryList; // private ref
             const scrollActiveItemIntoViewSpy = sinon.spy(queryList, "scrollActiveItemIntoView");
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ isOpen: false });
             });
             assert.isFalse(scrollActiveItemIntoViewSpy.called);
-            React.act(() => {
+            act(() => {
                 wrapper.setState({ isOpen: true });
             });
             assert.strictEqual(scrollActiveItemIntoViewSpy.callCount, 1, "should call scrollActiveItemIntoView");

--- a/packages/table-dev-app/src/features.tsx
+++ b/packages/table-dev-app/src/features.tsx
@@ -16,8 +16,8 @@
 
 /* eslint-disable max-classes-per-file, react/jsx-no-bind */
 
-import * as React from "react";
-import * as ReactDOM from "react-dom/client";
+import { Component } from "react";
+import { createRoot } from "react-dom/client";
 
 import { Button, Classes, H4, Intent, Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
 import {
@@ -40,7 +40,8 @@ import {
 } from "@blueprintjs/table";
 
 import { Nav } from "./nav";
-const navRoot = ReactDOM.createRoot(document.getElementById("nav"));
+
+const navRoot = createRoot(document.getElementById("nav"));
 navRoot.render(<Nav selected="features" />);
 
 function getTableComponent(numCols: number, numRows: number, columnProps?: any, tableProps?: any) {
@@ -79,10 +80,10 @@ const renderTestMenu = () => (
     </Menu>
 );
 
-const table0Root = ReactDOM.createRoot(document.getElementById("table-0"));
+const table0Root = createRoot(document.getElementById("table-0"));
 table0Root.render(getTableComponent(3, 7));
 
-class FormatsTable extends React.Component {
+class FormatsTable extends Component {
     private static ROWS = 1000;
 
     private objects = Utils.times(FormatsTable.ROWS, (row: number) => {
@@ -169,7 +170,7 @@ class FormatsTable extends React.Component {
     );
 }
 
-const formatsTableRoot = ReactDOM.createRoot(document.getElementById("table-formats"));
+const formatsTableRoot = createRoot(document.getElementById("table-formats"));
 formatsTableRoot.render(<FormatsTable />);
 
 interface EditableTableState {
@@ -180,7 +181,7 @@ interface EditableTableState {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-class EditableTable extends React.Component<{}, EditableTableState> {
+class EditableTable extends Component<{}, EditableTableState> {
     public static dataKey = (rowIndex: number, columnIndex: number) => {
         return `${rowIndex}-${columnIndex}`;
     };
@@ -291,10 +292,10 @@ class EditableTable extends React.Component<{}, EditableTableState> {
     }
 }
 
-const editableTableRoot = ReactDOM.createRoot(document.getElementById("table-editable-names"));
+const editableTableRoot = createRoot(document.getElementById("table-editable-names"));
 editableTableRoot.render(<EditableTable />);
 
-const tableGhostRoot = ReactDOM.createRoot(document.getElementById("table-ghost"));
+const tableGhostRoot = createRoot(document.getElementById("table-ghost"));
 tableGhostRoot.render(
     getTableComponent(
         2,
@@ -307,7 +308,7 @@ tableGhostRoot.render(
     ),
 );
 
-const tableInlineGhostRoot = ReactDOM.createRoot(document.getElementById("table-inline-ghost"));
+const tableInlineGhostRoot = createRoot(document.getElementById("table-inline-ghost"));
 tableInlineGhostRoot.render(
     getTableComponent(
         2,
@@ -320,7 +321,7 @@ tableInlineGhostRoot.render(
     ),
 );
 
-const tableBigRoot = ReactDOM.createRoot(document.getElementById("table-big"));
+const tableBigRoot = createRoot(document.getElementById("table-big"));
 tableBigRoot.render(
     getTableComponent(
         200,
@@ -333,7 +334,7 @@ tableBigRoot.render(
     ),
 );
 
-class RowSelectableTable extends React.Component {
+class RowSelectableTable extends Component {
     public state = {
         selectedRegions: [Regions.row(2)],
     };
@@ -379,15 +380,15 @@ class RowSelectableTable extends React.Component {
     };
 }
 
-const tableSelectRowsRoot = ReactDOM.createRoot(document.getElementById("table-select-rows"));
+const tableSelectRowsRoot = createRoot(document.getElementById("table-select-rows"));
 tableSelectRowsRoot.render(<RowSelectableTable />);
 
 document.getElementById("table-ledger").classList.add(Classes.HTML_TABLE_STRIPED);
 
-const tableLedgerRoot = ReactDOM.createRoot(document.getElementById("table-ledger"));
+const tableLedgerRoot = createRoot(document.getElementById("table-ledger"));
 tableLedgerRoot.render(getTableComponent(3, 7, {}, { className: "" }));
 
-class AdjustableColumnsTable extends React.Component {
+class AdjustableColumnsTable extends Component {
     public state = {
         columns: [<Column name="First" key={0} id={0} />, <Column name="Second" key={1} id={1} />],
     };
@@ -432,12 +433,12 @@ class AdjustableColumnsTable extends React.Component {
     }
 }
 
-const tableColsRoot = ReactDOM.createRoot(document.getElementById("table-cols"));
+const tableColsRoot = createRoot(document.getElementById("table-cols"));
 tableColsRoot.render(<AdjustableColumnsTable />);
 
 const intentRows: Intent[] = [Intent.NONE, Intent.PRIMARY, Intent.SUCCESS, Intent.WARNING, Intent.DANGER];
 
-const table1Root = ReactDOM.createRoot(document.getElementById("table-1"));
+const table1Root = createRoot(document.getElementById("table-1"));
 table1Root.render(
     getTableComponent(
         3,
@@ -467,7 +468,7 @@ const bodyContextMenuRenderer = (context: MenuContext) => {
     );
 };
 
-const table2Root = ReactDOM.createRoot(document.getElementById("table-2"));
+const table2Root = createRoot(document.getElementById("table-2"));
 table2Root.render(
     getTableComponent(
         3,
@@ -483,7 +484,7 @@ table2Root.render(
     ),
 );
 
-const table3Root = ReactDOM.createRoot(document.getElementById("table-3"));
+const table3Root = createRoot(document.getElementById("table-3"));
 table3Root.render(
     getTableComponent(
         3,
@@ -498,7 +499,7 @@ table3Root.render(
 
 const customRowHeaders = ["Superman", "Harry James Potter", "Deadpool", "Ben Folds", "Bitcoin", "Thorsday", "."];
 
-const table4Root = ReactDOM.createRoot(document.getElementById("table-4"));
+const table4Root = createRoot(document.getElementById("table-4"));
 table4Root.render(
     getTableComponent(
         3,
@@ -512,7 +513,7 @@ table4Root.render(
     ),
 );
 
-const table5Root = ReactDOM.createRoot(document.getElementById("table-5"));
+const table5Root = createRoot(document.getElementById("table-5"));
 table5Root.render(
     getTableComponent(
         3,
@@ -533,7 +534,7 @@ table5Root.render(
     ),
 );
 
-const table6Root = ReactDOM.createRoot(document.getElementById("table-6"));
+const table6Root = createRoot(document.getElementById("table-6"));
 table6Root.render(
     getTableComponent(
         10,
@@ -560,13 +561,13 @@ table6Root.render(
     ),
 );
 
-class CustomHeaderCell extends React.Component<ColumnHeaderCellProps> {
+class CustomHeaderCell extends Component<ColumnHeaderCellProps> {
     public render() {
         return <ColumnHeaderCell {...this.props}>Hey dawg.</ColumnHeaderCell>;
     }
 }
 
-const table7Root = ReactDOM.createRoot(document.getElementById("table-7"));
+const table7Root = createRoot(document.getElementById("table-7"));
 table7Root.render(
     getTableComponent(
         2,
@@ -585,7 +586,7 @@ const longContentRenderCell = () => {
     return <Cell tooltip={long}>{long}</Cell>;
 };
 
-const table8Root = ReactDOM.createRoot(document.getElementById("table-8"));
+const table8Root = createRoot(document.getElementById("table-8"));
 table8Root.render(
     <Table numRows={4}>
         <Column name="My" />
@@ -593,7 +594,7 @@ table8Root.render(
     </Table>,
 );
 
-const table9Root = ReactDOM.createRoot(document.getElementById("table-9"));
+const table9Root = createRoot(document.getElementById("table-9"));
 table9Root.render(
     <div style={{ position: "relative" }}>
         <div style={{ zIndex: 0 }} className="stack-fill">
@@ -632,7 +633,7 @@ const REORDERABLE_TABLE_DATA = [
 ].map(([letter, fruit, animal, country, city]) => ({ animal, city, country, fruit, letter }));
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-class ReorderableTableExample extends React.Component<{}, ReorderableTableExampleState> {
+class ReorderableTableExample extends Component<{}, ReorderableTableExampleState> {
     public state: ReorderableTableExampleState = {
         data: REORDERABLE_TABLE_DATA,
     };
@@ -688,10 +689,10 @@ class ReorderableTableExample extends React.Component<{}, ReorderableTableExampl
     };
 }
 
-const table10Root = ReactDOM.createRoot(document.getElementById("table-10"));
+const table10Root = createRoot(document.getElementById("table-10"));
 table10Root.render(<ReorderableTableExample />);
 
-const table11Root = ReactDOM.createRoot(document.getElementById("table-11"));
+const table11Root = createRoot(document.getElementById("table-11"));
 table11Root.render(
     <div style={{ height: 335, width: 300 }}>
         <Table numRows={10} defaultRowHeight={30} enableGhostCells={true}>
@@ -708,7 +709,7 @@ function renderName() {
     );
 }
 
-const table12Root = ReactDOM.createRoot(document.getElementById("table-12"));
+const table12Root = createRoot(document.getElementById("table-12"));
 table12Root.render(
     <div style={{ height: "auto", width: "180px" }}>
         <Table numRows={5} defaultRowHeight={30} enableGhostCells={true}>

--- a/packages/table-dev-app/src/index.tsx
+++ b/packages/table-dev-app/src/index.tsx
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import * as ReactDOM from "react-dom/client";
+import { createRoot } from "react-dom/client";
 
 import { HotkeysProvider, OverlaysProvider } from "@blueprintjs/core";
 
 import { MutableTable } from "./mutableTable";
 import { Nav } from "./nav";
 
-const navRoot = ReactDOM.createRoot(document.getElementById("nav"));
+const navRoot = createRoot(document.getElementById("nav"));
 navRoot.render(<Nav selected="index" />);
 
-const contentRoot = ReactDOM.createRoot(document.getElementById("page-content"));
+const contentRoot = createRoot(document.getElementById("page-content"));
 contentRoot.render(
     <OverlaysProvider>
         <HotkeysProvider>

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -17,7 +17,7 @@
 /* eslint-disable react/jsx-no-bind */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import {
     Button,
@@ -318,7 +318,7 @@ const DEFAULT_STATE: MutableTableState = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export class MutableTable extends React.Component<{}, MutableTableState> {
+export class MutableTable extends Component<{}, MutableTableState> {
     private store = new DenseGridMutableStore<any>();
 
     private tableInstance: Table;

--- a/packages/table-dev-app/src/nav.tsx
+++ b/packages/table-dev-app/src/nav.tsx
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import {
     Alignment,
@@ -30,7 +30,7 @@ export interface NavProps {
     selected: "index" | "features";
 }
 
-export class Nav extends React.PureComponent<NavProps> {
+export class Nav extends PureComponent<NavProps> {
     public render() {
         const darkThemeToggleStyles = { marginBottom: 0 };
         const isIndex = this.props.selected === "index";

--- a/packages/table-dev-app/src/slowLayoutStack.tsx
+++ b/packages/table-dev-app/src/slowLayoutStack.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Component } from "react";
 
 import { Utils } from "@blueprintjs/table/src";
 
@@ -73,7 +73,7 @@ export interface SlowLayoutStackProps {
  *
  * To mimic slowness in the native "Update Layer Tree", try: `overflow: auto`.
  */
-export class SlowLayoutStack extends React.Component<SlowLayoutStackProps> {
+export class SlowLayoutStack extends Component<SlowLayoutStackProps> {
     public render() {
         const { children, depth, enabled, rootClassName, branchClassName } = this.props;
         let elements = children;

--- a/packages/table/src/cell/cell.tsx
+++ b/packages/table/src/cell/cell.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children, cloneElement, Component, isValidElement } from "react";
 
 import {
     Classes as CoreClasses,
@@ -121,7 +121,7 @@ export const emptyCellRenderer = () => <Cell />;
  *
  * @see https://blueprintjs.com/docs/#table/api.cell
  */
-export class Cell extends React.Component<CellProps> {
+export class Cell extends Component<CellProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Cell`;
 
     public static defaultProps = {
@@ -172,11 +172,11 @@ export class Cell extends React.Component<CellProps> {
 
         // add width and height to the children, for use in shouldComponentUpdate in truncatedFormat
         // note: these aren't actually used by truncated format, just in shouldComponentUpdate
-        const modifiedChildren = React.Children.map(this.props.children, child => {
+        const modifiedChildren = Children.map(this.props.children, child => {
             const isFormatElement =
                 CoreUtils.isElementOfType(child, TruncatedFormat) || CoreUtils.isElementOfType(child, JSONFormat);
-            if (style != null && React.isValidElement(child) && isFormatElement) {
-                return React.cloneElement(child as React.ReactElement<any>, {
+            if (style != null && isValidElement(child) && isFormatElement) {
+                return cloneElement(child as React.ReactElement<any>, {
                     parentCellHeight: style.height === undefined ? undefined : parseInt(style.height.toString(), 10),
                     parentCellWidth: style.width === undefined ? undefined : parseInt(style.width.toString(), 10),
                 });

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component, createRef } from "react";
 
 import {
     Utils as CoreUtils,
@@ -85,7 +85,7 @@ export interface EditableCellState {
  *
  * @see https://blueprintjs.com/docs/#table/api.editablecell
  */
-export class EditableCell extends React.Component<EditableCellProps, EditableCellState> {
+export class EditableCell extends Component<EditableCellProps, EditableCellState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.EditableCell`;
 
     public static defaultProps = {
@@ -93,9 +93,9 @@ export class EditableCell extends React.Component<EditableCellProps, EditableCel
         wrapText: false,
     };
 
-    private cellRef = React.createRef<HTMLDivElement>();
+    private cellRef = createRef<HTMLDivElement>();
 
-    private contentsRef = React.createRef<HTMLDivElement>();
+    private contentsRef = createRef<HTMLDivElement>();
 
     public state: EditableCellState = {
         isEditing: false,

--- a/packages/table/src/cell/formats/jsonFormat.tsx
+++ b/packages/table/src/cell/formats/jsonFormat.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import { DISPLAYNAME_PREFIX } from "@blueprintjs/core";
 
@@ -48,7 +48,7 @@ export interface JSONFormatProps extends TruncatedFormatProps {
  *
  * @see https://blueprintjs.com/docs/#table/api.jsonformat
  */
-export class JSONFormat extends React.Component<JSONFormatProps> {
+export class JSONFormat extends Component<JSONFormatProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.JSONFormat`;
 
     public static defaultProps: JSONFormatProps = {

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { DISPLAYNAME_PREFIX, Popover, type Props } from "@blueprintjs/core";
 import { More } from "@blueprintjs/icons";
@@ -155,7 +155,7 @@ export interface TruncatedFormatState {
  *
  * @see https://blueprintjs.com/docs/#table/api.truncatedformat
  */
-export class TruncatedFormat extends React.PureComponent<TruncatedFormatProps, TruncatedFormatState> {
+export class TruncatedFormat extends PureComponent<TruncatedFormatProps, TruncatedFormatState> {
     public static displayName = `${DISPLAYNAME_PREFIX}.TruncatedFormat`;
 
     public static defaultProps: TruncatedFormatProps = {

--- a/packages/table/src/column.tsx
+++ b/packages/table/src/column.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { DISPLAYNAME_PREFIX, type Props } from "@blueprintjs/core";
 
@@ -61,7 +61,7 @@ export interface ColumnProps extends ColumnNameProps, Props {
  *
  * @see https://blueprintjs.com/docs/#table/api.column
  */
-export class Column extends React.PureComponent<ColumnProps> {
+export class Column extends PureComponent<ColumnProps> {
     public static displayName = `${DISPLAYNAME_PREFIX}.Column`;
 
     public static defaultProps: ColumnProps = {

--- a/packages/table/src/common/loadableContent.tsx
+++ b/packages/table/src/common/loadableContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children, PureComponent } from "react";
 
 import { Classes } from "@blueprintjs/core";
 
@@ -36,7 +36,7 @@ export interface LoadableContentProps {
 }
 
 // This class expects a single, non-string child.
-export class LoadableContent extends React.PureComponent<LoadableContentProps> {
+export class LoadableContent extends PureComponent<LoadableContentProps> {
     private style: React.CSSProperties;
 
     public constructor(props: LoadableContentProps) {
@@ -55,7 +55,7 @@ export class LoadableContent extends React.PureComponent<LoadableContentProps> {
             return <div className={Classes.SKELETON} style={this.style} />;
         }
 
-        return React.Children.only(this.props.children);
+        return Children.only(this.props.children);
     }
 
     private calculateStyle(variableLength = false) {

--- a/packages/table/src/common/rect.ts
+++ b/packages/table/src/common/rect.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import type * as React from "react";
-
 export type AnyRect = Rect | DOMRect;
 
 /**

--- a/packages/table/src/common/utils.ts
+++ b/packages/table/src/common/utils.ts
@@ -82,7 +82,7 @@ export const Utils = {
         let str = "";
         while (true) {
             const letter = num % 26;
-            // eslint-disable-next-line id-blacklist
+
             str = String.fromCharCode(65 + letter) + str;
             num = num - letter;
             if (num <= 0) {

--- a/packages/table/src/headers/columnHeader.tsx
+++ b/packages/table/src/headers/columnHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import * as Classes from "../common/classes";
 import type { ColumnIndices } from "../common/grid";
@@ -62,7 +62,7 @@ export interface ColumnHeaderProps extends React.PropsWithChildren<HeaderProps>,
     onMount?: (whichHeader: "column" | "row") => void;
 }
 
-export class ColumnHeader extends React.Component<ColumnHeaderProps> {
+export class ColumnHeader extends Component<ColumnHeaderProps> {
     public static defaultProps = {
         isReorderable: false,
         isResizable: true,

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -14,7 +14,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import {
     AbstractPureComponent,

--- a/packages/table/src/headers/editableName.tsx
+++ b/packages/table/src/headers/editableName.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { forwardRef, useCallback, useEffect, useState } from "react";
 
 import { DISPLAYNAME_PREFIX, EditableText, type IntentProps, type Props } from "@blueprintjs/core";
 
@@ -65,23 +65,23 @@ export interface EditableNameState {
  *
  * @see https://blueprintjs.com/docs/#table/api.editablename
  */
-export const EditableName: React.FC<EditableNameProps> = React.forwardRef((props, ref) => {
+export const EditableName: React.FC<EditableNameProps> = forwardRef((props, ref) => {
     const { className, name, index, intent, onCancel, onChange, onConfirm } = props;
-    const [dirtyName, setDirtyName] = React.useState(name);
-    const [isEditing, setIsEditing] = React.useState(false);
-    const [savedName, setSavedName] = React.useState(name);
+    const [dirtyName, setDirtyName] = useState(name);
+    const [isEditing, setIsEditing] = useState(false);
+    const [savedName, setSavedName] = useState(name);
 
-    React.useEffect(() => {
+    useEffect(() => {
         setDirtyName(name);
         setSavedName(name);
     }, [name]);
 
-    const handleEdit = React.useCallback(() => {
+    const handleEdit = useCallback(() => {
         setIsEditing(true);
         setDirtyName(savedName);
     }, [savedName]);
 
-    const handleCancel = React.useCallback(
+    const handleCancel = useCallback(
         (value: string) => {
             // don't strictly need to clear the dirtyName, but it's better hygiene
             setIsEditing(false);
@@ -91,7 +91,7 @@ export const EditableName: React.FC<EditableNameProps> = React.forwardRef((props
         [onCancel, index],
     );
 
-    const handleChange = React.useCallback(
+    const handleChange = useCallback(
         (value: string) => {
             setDirtyName(value);
             onChange?.(value, index);
@@ -99,7 +99,7 @@ export const EditableName: React.FC<EditableNameProps> = React.forwardRef((props
         [onChange, index],
     );
 
-    const handleConfirm = React.useCallback(
+    const handleConfirm = useCallback(
         (value: string) => {
             setIsEditing(false);
             setSavedName(value);

--- a/packages/table/src/headers/header.tsx
+++ b/packages/table/src/headers/header.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { cloneElement, Component, createRef } from "react";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
 import { DragHandleVertical } from "@blueprintjs/icons";
@@ -255,7 +255,7 @@ export interface HeaderState {
 
 const SHALLOW_COMPARE_PROP_KEYS_DENYLIST: Array<keyof InternalHeaderProps> = ["focusedRegion", "selectedRegions"];
 
-export class Header extends React.Component<InternalHeaderProps, HeaderState> {
+export class Header extends Component<InternalHeaderProps, HeaderState> {
     protected activationIndex: number | null = null;
 
     private cellRefs: Map<number, React.RefObject<HTMLElement>> = new Map();
@@ -414,7 +414,7 @@ export class Header extends React.Component<InternalHeaderProps, HeaderState> {
                     orientation={this.props.resizeOrientation}
                     size={this.props.getCellSize(index)}
                 >
-                    {React.cloneElement(cell, cellProps)}
+                    {cloneElement(cell, cellProps)}
                 </Resizable>
             </DragSelectable>
         );
@@ -538,7 +538,7 @@ function getOrCreateRef<T>(refMap: Map<number, React.RefObject<T>>, index: numbe
     if (refMap.has(index)) {
         return refMap.get(index)!;
     } else {
-        const newRef = React.createRef<T>();
+        const newRef = createRef<T>();
         refMap.set(index, newRef);
         return newRef;
     }

--- a/packages/table/src/headers/headerCell.tsx
+++ b/packages/table/src/headers/headerCell.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import { ContextMenu, Classes as CoreClasses, Utils as CoreUtils, type Props } from "@blueprintjs/core";
 
@@ -98,7 +98,7 @@ export interface HeaderCellState {
     isActive: boolean;
 }
 
-export class HeaderCell extends React.Component<InternalHeaderCellProps, HeaderCellState> {
+export class HeaderCell extends Component<InternalHeaderCellProps, HeaderCellState> {
     public state: HeaderCellState = {
         isActive: false,
     };

--- a/packages/table/src/headers/horizontalCellDivider.tsx
+++ b/packages/table/src/headers/horizontalCellDivider.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import * as Classes from "../common/classes";
 
 export function HorizontalCellDivider(): React.JSX.Element {

--- a/packages/table/src/headers/rowHeader.tsx
+++ b/packages/table/src/headers/rowHeader.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import * as Classes from "../common/classes";
 import type { RowIndices } from "../common/grid";
@@ -52,7 +52,7 @@ export interface RowHeaderProps extends HeaderProps, RowHeights, RowIndices {
     onMount?: (whichHeader: "column" | "row") => void;
 }
 
-export class RowHeader extends React.Component<RowHeaderProps> {
+export class RowHeader extends Component<RowHeaderProps> {
     public static defaultProps = {
         rowHeaderCellRenderer: renderDefaultRowHeader,
     };

--- a/packages/table/src/headers/rowHeaderCell.tsx
+++ b/packages/table/src/headers/rowHeaderCell.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { AbstractPureComponent, type Props } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/interactions/dragTypes.ts
+++ b/packages/table/src/interactions/dragTypes.ts
@@ -120,10 +120,10 @@ export interface DraggableChildrenProps {
      * This may look something like:
      *
      *  ```tsx
-     *  import * as React from "react";
+     *  import { createRef } from "react";
      *
      *  function MyDraggableComponent() {
-     *      const myRef = React.createRef<HTMLElement();
+     *      const myRef = createRef<HTMLElement();
      *      return (
      *          <Draggable targetRef={myRef}>
      *              <div ref={myRef} />

--- a/packages/table/src/interactions/draggable.tsx
+++ b/packages/table/src/interactions/draggable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children, cloneElement, createRef, PureComponent } from "react";
 
 import { Utils as CoreUtils, type Props } from "@blueprintjs/core";
 
@@ -52,7 +52,7 @@ const REATTACH_PROPS_KEYS = ["stopPropagation", "preventDefault"] as Array<keyof
  * If `false` is returned from the onActivate callback, no further events
  * will be fired until the next activation.
  */
-export class Draggable extends React.PureComponent<DraggableProps> {
+export class Draggable extends PureComponent<DraggableProps> {
     public static defaultProps = {
         preventDefault: true,
         stopPropagation: false,
@@ -60,17 +60,17 @@ export class Draggable extends React.PureComponent<DraggableProps> {
 
     private events = new DragEvents();
 
-    private targetRef = this.props.targetRef ?? React.createRef<HTMLElement>();
+    private targetRef = this.props.targetRef ?? createRef<HTMLElement>();
 
     public render() {
-        const onlyChild = React.Children.only(this.props.children);
+        const onlyChild = Children.only(this.props.children);
 
         // if we're provided a ref to the child already, we don't need to attach one ourselves
         if (this.props.targetRef !== undefined) {
             return onlyChild;
         }
 
-        return React.cloneElement(onlyChild, { ref: this.targetRef });
+        return cloneElement(onlyChild, { ref: this.targetRef });
     }
 
     public componentDidUpdate(prevProps: DraggableProps) {
@@ -97,7 +97,7 @@ export class Draggable extends React.PureComponent<DraggableProps> {
 
 /**
  * Used to ensure that target elements are valid at runtime for use by DragEvents.
- * This check is done at runtime instead of compile time because of our use of `React.cloneElement<any>()`
+ * This check is done at runtime instead of compile time because of our use of `cloneElement<any>()`
  * and the associated untyped `ref` injection.
  *
  * @see https://github.com/palantir/blueprint/issues/6248

--- a/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
+++ b/packages/table/src/interactions/menus/copyCellsMenuItem.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { MenuItem, type MenuItemProps } from "@blueprintjs/core";
 
@@ -49,7 +49,7 @@ export interface CopyCellsMenuItemProps extends Omit<MenuItemProps, "onCopy"> {
     onCopy?: (success: boolean) => void;
 }
 
-export class CopyCellsMenuItem extends React.PureComponent<CopyCellsMenuItemProps> {
+export class CopyCellsMenuItem extends PureComponent<CopyCellsMenuItemProps> {
     public render() {
         const { context, getCellData, onCopy, ...menuItemProps } = this.props;
         return <MenuItem {...menuItemProps} onClick={this.handleClick} />;

--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Utils as CoreUtils } from "@blueprintjs/core";
 
@@ -101,7 +101,7 @@ export interface DragReorderableProps extends ReorderableProps, DraggableChildre
     toRegion: (index1: number, index2?: number) => Region;
 }
 
-export class DragReorderable extends React.PureComponent<DragReorderableProps> {
+export class DragReorderable extends PureComponent<DragReorderableProps> {
     public static defaultProps: Partial<DragReorderableProps> = {
         selectedRegions: [],
     };

--- a/packages/table/src/interactions/resizable.tsx
+++ b/packages/table/src/interactions/resizable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children, cloneElement } from "react";
 
 import { AbstractPureComponent, type Props } from "@blueprintjs/core";
 
@@ -115,15 +115,15 @@ export class Resizable extends AbstractPureComponent<ResizableProps, ResizeableS
     }
 
     public render() {
-        const child = React.Children.only(this.props.children) as React.ReactElement;
+        const child = Children.only(this.props.children) as React.ReactElement;
         const style = { ...child.props.style, ...this.getStyle() };
 
         if (this.props.isResizable === false) {
-            return React.cloneElement(child, { style });
+            return cloneElement(child, { style });
         }
 
         const resizeHandle = this.renderResizeHandle();
-        return React.cloneElement(child, { resizeHandle, style });
+        return cloneElement(child, { resizeHandle, style });
     }
 
     private renderResizeHandle() {

--- a/packages/table/src/interactions/resizeHandle.tsx
+++ b/packages/table/src/interactions/resizeHandle.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { PureComponent } from "react";
 
 import type { Props } from "@blueprintjs/core";
 
@@ -69,7 +69,7 @@ export interface ResizeHandleState {
     isDragging: boolean;
 }
 
-export class ResizeHandle extends React.PureComponent<ResizeHandleProps, ResizeHandleState> {
+export class ResizeHandle extends PureComponent<ResizeHandleProps, ResizeHandleState> {
     public state: ResizeHandleState = {
         isDragging: false,
     };

--- a/packages/table/src/interactions/selectable.tsx
+++ b/packages/table/src/interactions/selectable.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { PureComponent } from "react";
 
 import { Utils as CoreUtils, DISPLAYNAME_PREFIX } from "@blueprintjs/core";
 
@@ -144,7 +144,7 @@ export interface DragSelectableProps extends SelectableProps, DraggableChildrenP
     locateDrag: (event: MouseEvent, coords: CoordinateData, returnEndOnly?: boolean) => Region | undefined;
 }
 
-export class DragSelectable extends React.PureComponent<DragSelectableProps> {
+export class DragSelectable extends PureComponent<DragSelectableProps> {
     public static defaultProps: Partial<DragSelectableProps> = {
         disabled: false,
         enableMultipleSelection: false,

--- a/packages/table/src/layers/guides.tsx
+++ b/packages/table/src/layers/guides.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import { Utils as CoreUtils, type Props } from "@blueprintjs/core";
 
@@ -33,7 +33,7 @@ export interface GuideLayerProps extends Props {
     horizontalGuides: number[];
 }
 
-export class GuideLayer extends React.Component<GuideLayerProps> {
+export class GuideLayer extends Component<GuideLayerProps> {
     public shouldComponentUpdate(nextProps: GuideLayerProps) {
         if (this.props.className !== nextProps.className) {
             return true;

--- a/packages/table/src/layers/regions.tsx
+++ b/packages/table/src/layers/regions.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Component } from "react";
 
 import { Utils as CoreUtils, type Props } from "@blueprintjs/core";
 
@@ -41,7 +41,7 @@ export interface RegionLayerProps extends Props {
 // don't include "regions" or "regionStyles" in here, because they can't be shallowly compared
 const UPDATE_PROPS_KEYS = ["className"] as Array<keyof RegionLayerProps>;
 
-export class RegionLayer extends React.Component<RegionLayerProps> {
+export class RegionLayer extends Component<RegionLayerProps> {
     public shouldComponentUpdate(nextProps: RegionLayerProps) {
         // shallowly comparable props like "className" tend not to change in the default table
         // implementation, so do that check last with hope that we return earlier and avoid it

--- a/packages/table/src/quadrants/tableQuadrant.tsx
+++ b/packages/table/src/quadrants/tableQuadrant.tsx
@@ -15,7 +15,6 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
 
 import { AbstractComponent, type Props } from "@blueprintjs/core";
 

--- a/packages/table/src/quadrants/tableQuadrantStack.tsx
+++ b/packages/table/src/quadrants/tableQuadrantStack.tsx
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import * as React from "react";
-
 import { AbstractComponent, Utils as CoreUtils, type Props, setRef } from "@blueprintjs/core";
 
 import * as Classes from "../common/classes";

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -14,7 +14,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { Children, cloneElement } from "react";
 import innerText from "react-innertext";
 
 import {
@@ -119,7 +119,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
             rowHeights = state.rowHeights;
         }
 
-        const newChildrenArray = React.Children.toArray(children) as Array<React.ReactElement<ColumnProps>>;
+        const newChildrenArray = Children.toArray(children) as Array<React.ReactElement<ColumnProps>>;
         const didChildrenChange = !compareChildren(newChildrenArray, state.childrenArray);
         const numCols = newChildrenArray.length;
 
@@ -271,7 +271,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
             enableColumnHeader,
         } = props;
 
-        const childrenArray = React.Children.toArray(children) as Array<React.ReactElement<ColumnProps>>;
+        const childrenArray = Children.toArray(children) as Array<React.ReactElement<ColumnProps>>;
         const columnIdToIndex = Table.createColumnIdIndex(childrenArray);
 
         // Create height/width arrays using the lengths from props and
@@ -545,7 +545,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
                     isHorizontalScrollDisabled={this.shouldDisableHorizontalScroll()}
                     isVerticalScrollDisabled={this.shouldDisableVerticalScroll()}
                     loadingOptions={loadingOptions}
-                    numColumns={React.Children.count(children)}
+                    numColumns={Children.count(children)}
                     numFrozenColumns={numFrozenColumnsClamped}
                     numFrozenRows={numFrozenRowsClamped}
                     numRows={numRows}
@@ -607,7 +607,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
         this.hotkeysImpl.setProps(this.props);
 
         const didChildrenChange = !compareChildren(
-            React.Children.toArray(this.props.children) as Array<React.ReactElement<ColumnProps>>,
+            Children.toArray(this.props.children) as Array<React.ReactElement<ColumnProps>>,
             this.state.childrenArray,
         );
 
@@ -667,7 +667,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
 
     protected validateProps(props: TableProps) {
         const { children, columnWidths, numFrozenColumns, numFrozenRows, numRows, rowHeights } = props;
-        const numColumns = React.Children.count(children);
+        const numColumns = Children.count(children);
 
         // do cheap error-checking first.
         if (numRows != null && numRows < 0) {
@@ -685,7 +685,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
         if (numColumns != null && columnWidths != null && columnWidths.length !== numColumns) {
             throw new Error(Errors.TABLE_NUM_COLUMNS_COLUMN_WIDTHS_MISMATCH);
         }
-        React.Children.forEach(children, child => {
+        Children.forEach(children, child => {
             if (!CoreUtils.isElementOfType(child, Column)) {
                 throw new Error(Errors.TABLE_NON_COLUMN_CHILDREN_WARNING);
             }
@@ -703,9 +703,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
 
     private gridDimensionsMatchProps() {
         const { children, numRows } = this.props;
-        return (
-            this.grid != null && this.grid.numCols === React.Children.count(children) && this.grid.numRows === numRows
-        );
+        return this.grid != null && this.grid.numCols === Children.count(children) && this.grid.numRows === numRows;
     }
 
     // Quadrant refs
@@ -826,7 +824,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
         if (columnHeaderCellRenderer != null) {
             const columnHeaderCell = columnHeaderCellRenderer(columnIndex);
             if (columnHeaderCell != null) {
-                return React.cloneElement(columnHeaderCell, {
+                return cloneElement(columnHeaderCell, {
                     enableColumnInteractionBar: this.props.enableColumnInteractionBar,
                     loading: columnHeaderCell.props.loading ?? columnLoading,
                 });
@@ -1028,7 +1026,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
             hasLoadingOption(columnProps.loadingOptions, ColumnLoadingOption.CELLS) ||
             hasLoadingOption(this.props.loadingOptions, TableLoadingOption.CELLS);
 
-        return React.cloneElement(cell, {
+        return cloneElement(cell, {
             ...restColumnProps,
             loading: cell.props.loading ?? inheritedIsLoading,
         });

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { createRef } from "react";
 
 import { AbstractComponent, ContextMenu, type ContextMenuContentProps, Utils as CoreUtils } from "@blueprintjs/core";
 
@@ -74,7 +74,7 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
 
     private activationCell: CellCoordinates | null = null;
 
-    private containerRef = React.createRef<HTMLDivElement>();
+    private containerRef = createRef<HTMLDivElement>();
 
     public shouldComponentUpdate(nextProps: TableBodyProps) {
         return (

--- a/packages/table/src/tableBodyCells.tsx
+++ b/packages/table/src/tableBodyCells.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import * as React from "react";
+import { cloneElement } from "react";
 
 import { AbstractComponent, Utils as CoreUtils, type Props } from "@blueprintjs/core";
 
@@ -223,7 +223,7 @@ export class TableBodyCells extends AbstractComponent<TableBodyCellsProps> {
 
         const style = { ...baseCell.props.style, ...Rect.style(rect) };
         const isFocused = this.isCellFocused(rowIndex, columnIndex);
-        return React.cloneElement(baseCell, {
+        return cloneElement(baseCell, {
             className,
             isFocused,
             key,

--- a/packages/table/src/tableHotkeys.ts
+++ b/packages/table/src/tableHotkeys.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children } from "react";
 
 import { type FocusedCell, type FocusedRegion, type FocusedRow, FocusMode } from "./common/cellTypes";
 import { Clipboard } from "./common/clipboard";
@@ -126,7 +126,7 @@ export class TableHotkeys {
     private updateSelectedRegionAtIndex(region: Region, index: number) {
         const { children, numRows } = this.props;
         const { selectedRegions } = this.state;
-        const numColumns = React.Children.count(children);
+        const numColumns = Children.count(children);
 
         const maxRowIndex = Math.max(0, numRows! - 1);
         const maxColumnIndex = Math.max(0, numColumns - 1);

--- a/packages/table/src/tableUtils.ts
+++ b/packages/table/src/tableUtils.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Children, type ReactElement } from "react";
 
 import type { HotkeyConfig } from "@blueprintjs/core";
 
@@ -27,7 +27,7 @@ import type { TablePropsWithDefaults } from "./tableProps";
 
 export function clampNumFrozenColumns(props: TablePropsWithDefaults) {
     const { numFrozenColumns } = props;
-    const numColumns = React.Children.count(props.children);
+    const numColumns = Children.count(props.children);
     return maybeClampValue(numFrozenColumns, numColumns);
 }
 
@@ -53,7 +53,7 @@ export function isSelectionModeEnabled(
     selectionModes = props.selectionModes,
 ): boolean {
     const { children, numRows } = props;
-    const numColumns = React.Children.count(children);
+    const numColumns = Children.count(children);
     return selectionModes.indexOf(selectionMode) >= 0 && numRows > 0 && numColumns > 0;
 }
 
@@ -196,8 +196,8 @@ function getFocusHotkeys(focusMode: FocusMode | undefined, hotkeysImpl: TableHot
  * @returns true if new and old children arrays are the same
  */
 export function compareChildren(
-    newChildren: Array<React.ReactElement<ColumnProps>>,
-    oldChildren: Array<React.ReactElement<ColumnProps>>,
+    newChildren: Array<ReactElement<ColumnProps>>,
+    oldChildren: Array<ReactElement<ColumnProps>>,
 ): boolean {
     return (
         newChildren.length === oldChildren.length &&

--- a/packages/table/test/common/internal/scrollUtilsTests.tsx
+++ b/packages/table/test/common/internal/scrollUtilsTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 
 import * as ScrollUtils from "../../../src/common/internal/scrollUtils";
 import { type Region, Regions } from "../../../src/regions";

--- a/packages/table/test/editableCellTests.tsx
+++ b/packages/table/test/editableCellTests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as sinon from "sinon";
 
 import { Classes } from "@blueprintjs/core";
@@ -74,7 +74,7 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        React.act(() => {
+        act(() => {
             elem.setState({ dirtyValue: "test-value-5000", isEditing: true });
         });
         const input = elem.find("input");
@@ -103,7 +103,7 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        React.act(() => {
+        act(() => {
             elem.setState({ dirtyValue: "test-value-5000", isEditing: true });
         });
         const input = elem.find(`.${TableClasses.TABLE_EDITABLE_TEXT} input`);
@@ -149,7 +149,7 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        React.act(() => {
+        act(() => {
             elem.setState({ dirtyValue: "", isEditing: true });
         });
 
@@ -192,7 +192,7 @@ describe("<EditableCell>", () => {
         );
 
         // start editing
-        React.act(() => {
+        act(() => {
             elem.setState({ dirtyValue: "test-value-5000", isEditing: true });
         });
         const input = elem.find("input");

--- a/packages/table/test/formats/truncatedFormatTests.tsx
+++ b/packages/table/test/formats/truncatedFormatTests.tsx
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
 
 import { TruncatedFormat, TruncatedPopoverMode } from "../../src/cell/formats/truncatedFormat";
 import * as Classes from "../../src/common/classes";

--- a/packages/table/test/harness.ts
+++ b/packages/table/test/harness.ts
@@ -17,7 +17,7 @@
 /* eslint-disable  max-classes-per-file */
 
 import { mount, type ReactWrapper } from "enzyme";
-import * as React from "react";
+import { act, createElement, type ReactElement } from "react";
 
 import { BlueprintProvider } from "@blueprintjs/core";
 
@@ -111,14 +111,14 @@ export class ElementHarness {
     }
 
     public focus() {
-        React.act(() => {
+        act(() => {
             (this.element as HTMLElement | null)?.focus();
         });
         return this;
     }
 
     public blur() {
-        React.act(() => {
+        act(() => {
             (this.element as HTMLElement | null)?.blur();
         });
         return this;
@@ -166,7 +166,7 @@ export class ElementHarness {
                 shiftKey: isShiftKeyDown,
                 view: window,
             });
-            React.act(() => {
+            act(() => {
                 this.element!.dispatchEvent(event);
             });
         }
@@ -175,7 +175,7 @@ export class ElementHarness {
 
     public keyboard(eventType: KeyboardEventType = "keypress", key = "", modKey = false) {
         if (this.exists()) {
-            React.act(() => {
+            act(() => {
                 dispatchTestKeyboardEvent(this.element!, eventType, key, modKey);
             });
         }
@@ -184,7 +184,7 @@ export class ElementHarness {
 
     public change(value?: string) {
         if (this.exists()) {
-            React.act(() => {
+            act(() => {
                 if (value != null) {
                     (this.element as HTMLInputElement).value = value;
                 }
@@ -224,9 +224,9 @@ export class ReactHarness {
         document.body.appendChild(this.container);
     }
 
-    public mount(component: React.ReactElement<any>) {
+    public mount(component: ReactElement<any>) {
         // wrap in a root provider to avoid console warnings
-        this.wrapper = mount(React.createElement(BlueprintProvider, { children: component }), {
+        this.wrapper = mount(createElement(BlueprintProvider, { children: component }), {
             attachTo: this.container,
         });
         return new ElementHarness(this.container);

--- a/packages/table/test/loadingOptionsTests.tsx
+++ b/packages/table/test/loadingOptionsTests.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as React from "react";
+import { Component } from "react";
 
 import { Cell, Column, ColumnHeaderCell, ColumnLoadingOption, RowHeaderCell, Table, TableLoadingOption } from "../src";
 import * as Classes from "../src/common/classes";
@@ -27,7 +27,7 @@ interface TableLoadingOptionsTesterProps {
     tableLoadingOptions: TableLoadingOption[];
 }
 
-class TableLoadingOptionsTester extends React.Component<TableLoadingOptionsTesterProps> {
+class TableLoadingOptionsTester extends Component<TableLoadingOptionsTesterProps> {
     public static isCellLoading = (index: number) => {
         if (index === 0) {
             return true;

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -16,7 +16,6 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 

--- a/packages/table/test/resizableTests.tsx
+++ b/packages/table/test/resizableTests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
-import * as React from "react";
+import { Component } from "react";
 import sinon from "sinon";
 
 import * as Classes from "../src/common/classes";
@@ -30,7 +30,7 @@ interface ResizableDivProps {
     style?: React.CSSProperties;
 }
 
-class ResizableDiv extends React.Component<ResizableDivProps> {
+class ResizableDiv extends Component<ResizableDivProps> {
     public render() {
         const { style } = this.props;
         return (

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -16,7 +16,7 @@
 
 import { expect } from "chai";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";
-import * as React from "react";
+import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
@@ -333,19 +333,19 @@ describe("<Table>", function (this) {
             });
 
             it("resizes each row to fit its respective tallest cell", () => {
-                React.act(() => table!.resizeRowsByApproximateHeight(getCellText));
+                act(() => table!.resizeRowsByApproximateHeight(getCellText));
 
                 expect(table!.state.rowHeights).to.deep.equal([36, 144, 144, 144]);
             });
 
             it("still uses defaults if an empty `options` object is passed", () => {
-                React.act(() => table!.resizeRowsByApproximateHeight(getCellText, {}));
+                act(() => table!.resizeRowsByApproximateHeight(getCellText, {}));
 
                 expect(table!.state.rowHeights).to.deep.equal([36, 144, 144, 144]);
             });
 
             it("can customize options", () => {
-                React.act(() => table!.resizeRowsByApproximateHeight(getCellText, { getNumBufferLines: 2 }));
+                act(() => table!.resizeRowsByApproximateHeight(getCellText, { getNumBufferLines: 2 }));
 
                 expect(table!.state.rowHeights).to.deep.equal([54, 162, 162, 162]);
             });
@@ -370,21 +370,21 @@ describe("<Table>", function (this) {
                     </Table>,
                 );
 
-                React.act(() => table!.resizeRowsByTallestCell(0));
+                act(() => table!.resizeRowsByTallestCell(0));
                 expect(table!.state.rowHeights[0], "resizes by first column").to.equal(MAX_HEIGHT);
 
-                React.act(() => table!.resizeRowsByTallestCell(1));
+                act(() => table!.resizeRowsByTallestCell(1));
                 expect(table!.state.rowHeights[0], "resizes by second column").to.equal(DEFAULT_RESIZE_HEIGHT);
 
-                React.act(() => table!.resizeRowsByTallestCell([0, 1]));
+                act(() => table!.resizeRowsByTallestCell([0, 1]));
                 expect(table!.state.rowHeights[0], "resizes by both column").to.equal(MAX_HEIGHT);
 
-                React.act(() => table!.resizeRowsByTallestCell([1]));
+                act(() => table!.resizeRowsByTallestCell([1]));
                 expect(table!.state.rowHeights[0], "resizes by second column via array").to.equal(
                     DEFAULT_RESIZE_HEIGHT,
                 );
 
-                React.act(() => table!.resizeRowsByTallestCell());
+                act(() => table!.resizeRowsByTallestCell());
                 expect(table!.state.rowHeights[0], "resizes by visible columns").to.equal(MAX_HEIGHT);
             });
 
@@ -422,7 +422,7 @@ describe("<Table>", function (this) {
                 // scroll the frozen column out of view in the MAIN quadrant,
                 // and expect a non-zero height.
                 const tableInstance = table.instance() as Table;
-                React.act(() => {
+                act(() => {
                     tableInstance.scrollToRegion(Regions.column(columnWidths.length - 1));
                     tableInstance.resizeRowsByTallestCell(FROZEN_COLUMN_INDEX);
                 });
@@ -638,7 +638,7 @@ describe("<Table>", function (this) {
                     <Column />
                 </Table>,
             );
-            React.act(() => {
+            act(() => {
                 table.setState({ selectedRegions: [Regions.column(0)] });
             });
             table.setProps({ selectionModes: [] });
@@ -1670,7 +1670,7 @@ describe("<Table>", function (this) {
         function scrollTable(table: ReactWrapper<any>, scrollLeft: number, scrollTop: number, callback: () => void) {
             // make the viewport small enough to fit only one cell
             updateLocatorElements(table, scrollLeft, scrollTop, COL_WIDTH, ROW_HEIGHT);
-            React.act(() => table.find(TableQuadrant).first().simulate("scroll"));
+            act(() => table.find(TableQuadrant).first().simulate("scroll"));
 
             callback();
         }
@@ -1899,7 +1899,7 @@ describe("<Table>", function (this) {
         describe("clears all uncontrolled selections", () => {
             it("when numRows becomes 0", () => {
                 table = mountTable(1, 1);
-                React.act(() => {
+                act(() => {
                     table.setState({ selectedRegions: SELECTED_REGIONS });
                 });
                 table.setProps({ numRows: 0 });
@@ -1908,7 +1908,7 @@ describe("<Table>", function (this) {
 
             it("when numCols becomes 0", () => {
                 table = mountTable(1, 1);
-                React.act(() => {
+                act(() => {
                     table.setState({ selectedRegions: SELECTED_REGIONS });
                 });
                 table.setProps({ children: [] });

--- a/packages/test-commons/src/generateIsomorphicTests.ts
+++ b/packages/test-commons/src/generateIsomorphicTests.ts
@@ -4,9 +4,9 @@
 
 import { strictEqual } from "assert";
 import Enzyme from "enzyme";
-import * as React from "react";
+import { type ComponentClass, createElement, type FC, type ReactNode } from "react";
 
-function isReactClass(Component: any): Component is React.ComponentClass<any> {
+function isReactClass(Component: any): Component is ComponentClass<any> {
     return (
         typeof Component !== "undefined" &&
         typeof Component.prototype !== "undefined" &&
@@ -16,13 +16,13 @@ function isReactClass(Component: any): Component is React.ComponentClass<any> {
 }
 
 /** Janky heuristic for detecting function components. */
-function isReactFunctionComponent(Component: any, name: string): Component is React.FC<any> {
+function isReactFunctionComponent(Component: any, name: string): Component is FC<any> {
     return typeof Component === "function" && name.charAt(0) === name.charAt(0).toUpperCase();
 }
 
 export interface IsomorphicTestConfig {
     /** Required `children` for successful render. */
-    children?: React.ReactNode;
+    children?: ReactNode;
     /** Whether to test `className`. */
     className?: boolean;
     /** Required `props` for successful render. */
@@ -65,7 +65,7 @@ export function generateIsomorphicTests<T extends { [name: string]: any }>(
         // Render to static HTML, just as a server would.
         // We care merely that `render()` succeeds: it can be server-rendered.
         // Errors will fail the test and log full stack traces to the console. Nifty!
-        const element = React.createElement(Components[name], finalProps, children);
+        const element = createElement(Components[name], finalProps, children);
         return Enzyme.render(element);
     }
 

--- a/packages/test-commons/src/testErrorBoundary.ts
+++ b/packages/test-commons/src/testErrorBoundary.ts
@@ -14,10 +14,10 @@
  */
 
 import { expect } from "chai";
-import * as React from "react";
+import { Component, type ReactNode } from "react";
 
 export interface TestErrorBoundaryProps {
-    children?: React.ReactNode;
+    children?: ReactNode;
     expectedErrorString: string;
 }
 
@@ -29,7 +29,7 @@ export interface TestErrorBoundaryState {
  * Use this component when you want to validate component errors _during the component lifecycle_.
  * Note that this is not useful in validating errors thrown in component constructors.
  */
-export class TestErrorBoundary extends React.Component<TestErrorBoundaryProps, TestErrorBoundaryState> {
+export class TestErrorBoundary extends Component<TestErrorBoundaryProps, TestErrorBoundaryState> {
     public state = {
         didCatch: false,
     };

--- a/packages/test-commons/src/utils.ts
+++ b/packages/test-commons/src/utils.ts
@@ -15,7 +15,6 @@
  */
 
 import { expect } from "chai";
-import type * as React from "react";
 
 /**
  * Dispatch a native KeyBoardEvent on the target element with the given type


### PR DESCRIPTION
## Changes

FLUP to https://github.com/palantir/blueprint/pull/7499

Updates React import syntax across all components to drop the namespaced React import:
```tsx
import * as React from "react";
// Usage:
const [state, setState] = React.useState();
```
and replaces it with named/specific imports for React:
```tsx
import { useState, useCallback, useRef } from "react";
// Usage:
const [state, setState] = useState();
```

## Comparison

> _✨ Note: This comparison is AI-generated_

### Namespace Import (`import * as React`)

#### Advantages:
- Consistent with older React codebases (pre-React 17).
- Avoids naming conflicts with local variables.
#### Disadvantages:
- More verbose (`React.useState()` vs `useState()`).
- Imports the whole module namespace, even if you only use a few functions.
- Not needed in React 17+ with the [new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).

### Named Import (`import { useState } from "react"`)

#### Advantages:
- Cleaner and less verbose.
- Tree-shakable: only imports what you use (potentially smaller bundles).
- Preferred in modern React (React 17+)
- Easier to see what hooks/components are used in a file.
#### Disadvantages:
- Possible naming conflicts if there are local variables with the same name.
- If you use many exports, the import line can get long.

## Methods

A majority of files in this PR were updated via the `update-react-imports` react-codemod, which is described in ["Removing Unused React Imports"](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports).