### PR TITLE
Feature/divider compact prop

### DIFF
--- a/packages/core/changelog/@unreleased/divider-minimal-prop.v2.yml
+++ b/packages/core/changelog/@unreleased/divider-minimal-prop.v2.yml
@@ -1,0 +1,3 @@
+type: feature
+feature:
+  description: Add `minimal` prop to Divider component which sets margin to 0.

--- a/packages/core/changelog/@unreleased/divider-minimal-prop.v2.yml
+++ b/packages/core/changelog/@unreleased/divider-minimal-prop.v2.yml
@@ -1,3 +1,0 @@
-type: feature
-feature:
-  description: Add `minimal` prop to Divider component which sets margin to 0.

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -16,7 +16,7 @@ $divider-margin: $pt-grid-size * 0.5 !default;
     border-color: $pt-dark-divider-white;
   }
 
-  &-compact {
+  .#{$ns}-compact {
     margin: 0;
   }
 }

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -15,4 +15,8 @@ $divider-margin: $pt-grid-size * 0.5 !default;
   .#{$ns}-dark & {
     border-color: $pt-dark-divider-white;
   }
+
+  &-minimal {
+    margin: 0;
+  }
 }

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -16,7 +16,7 @@ $divider-margin: $pt-grid-size * 0.5 !default;
     border-color: $pt-dark-divider-white;
   }
 
-  &-minimal {
+  &-compact {
     margin: 0;
   }
 }

--- a/packages/core/src/components/divider/divider.md
+++ b/packages/core/src/components/divider/divider.md
@@ -16,6 +16,14 @@ Use **Divider** to separate blocks of content within a page or container. By def
 
 @reactCodeExample DividerBasicExample
 
+@## Minimal
+
+The `minimal` prop removes the margin from the divider, making it flush with adjacent content.
+
+```tsx
+<Divider minimal />
+```
+
 @## Vertical
 
 When used inside a flex container, **Divider** adapts to the layout's direction. It becomes a vertical divider when placed between flex items.

--- a/packages/core/src/components/divider/divider.md
+++ b/packages/core/src/components/divider/divider.md
@@ -16,12 +16,12 @@ Use **Divider** to separate blocks of content within a page or container. By def
 
 @reactCodeExample DividerBasicExample
 
-@## Minimal
+@## Compact
 
-The `minimal` prop removes the margin from the divider, making it flush with adjacent content.
+The `compact` prop removes the margin from the divider, making it flush with adjacent content.
 
 ```tsx
-<Divider minimal />
+<Divider compact />
 ```
 
 @## Vertical

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { DIVIDER } from "../../common/classes";
+import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
 
 export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
@@ -45,7 +45,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
  * @see https://blueprintjs.com/docs/#core/components/divider
  */
 export const Divider: React.FC<DividerProps> = ({ className, tagName = "div", compact, ...htmlProps }) => {
-    const classes = classNames(DIVIDER, { [`${DIVIDER}-compact`]: compact }, className);
+    const classes = classNames(Classes.DIVIDER, { [Classes.COMPACT]: compact }, className);
     return React.createElement(tagName, {
         ...htmlProps,
         className: classes,

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -27,6 +27,13 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
      * @default "div"
      */
     tagName?: keyof React.JSX.IntrinsicElements;
+
+    /**
+     * If true, sets margin to 0.
+     * 
+     * @default false
+     */
+    minimal?: boolean;
 }
 
 // this component is simple enough that tests would be purely tautological.
@@ -37,8 +44,8 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
  *
  * @see https://blueprintjs.com/docs/#core/components/divider
  */
-export const Divider: React.FC<DividerProps> = ({ className, tagName = "div", ...htmlProps }) => {
-    const classes = classNames(DIVIDER, className);
+export const Divider: React.FC<DividerProps> = ({ className, tagName = "div", minimal, ...htmlProps }) => {
+    const classes = classNames(DIVIDER, { [`${DIVIDER}-minimal`]: minimal }, className);
     return React.createElement(tagName, {
         ...htmlProps,
         className: classes,

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -33,7 +33,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
      *
      * @default false
      */
-    minimal?: boolean;
+    compact?: boolean;
 }
 
 // this component is simple enough that tests would be purely tautological.
@@ -44,8 +44,8 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
  *
  * @see https://blueprintjs.com/docs/#core/components/divider
  */
-export const Divider: React.FC<DividerProps> = ({ className, tagName = "div", minimal, ...htmlProps }) => {
-    const classes = classNames(DIVIDER, { [`${DIVIDER}-minimal`]: minimal }, className);
+export const Divider: React.FC<DividerProps> = ({ className, tagName = "div", compact, ...htmlProps }) => {
+    const classes = classNames(DIVIDER, { [`${DIVIDER}-compact`]: compact }, className);
     return React.createElement(tagName, {
         ...htmlProps,
         className: classes,

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -44,7 +44,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
  *
  * @see https://blueprintjs.com/docs/#core/components/divider
  */
-export const Divider: React.FC<DividerProps> = ({ className, compact, tagName = "div", ...htmlProps }) => {
+export const Divider: React.FC<DividerProps> = ({ className, compact = false, tagName = "div", ...htmlProps }) => {
     const classes = classNames(Classes.DIVIDER, { [Classes.COMPACT]: compact }, className);
     return React.createElement(tagName, {
         ...htmlProps,

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -22,18 +22,18 @@ import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
 
 export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
     /**
-     * HTML tag to use for element.
-     *
-     * @default "div"
-     */
-    tagName?: keyof React.JSX.IntrinsicElements;
-
-    /**
      * If true, makes the Divider flush with adjacent content.
      *
      * @default false
      */
     compact?: boolean;
+
+    /**
+     * HTML tag to use for element.
+     *
+     * @default "div"
+     */
+    tagName?: keyof React.JSX.IntrinsicElements;
 }
 
 // this component is simple enough that tests would be purely tautological.
@@ -44,7 +44,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
  *
  * @see https://blueprintjs.com/docs/#core/components/divider
  */
-export const Divider: React.FC<DividerProps> = ({ className, tagName = "div", compact, ...htmlProps }) => {
+export const Divider: React.FC<DividerProps> = ({ className, compact, tagName = "div", ...htmlProps }) => {
     const classes = classNames(Classes.DIVIDER, { [Classes.COMPACT]: compact }, className);
     return React.createElement(tagName, {
         ...htmlProps,

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -30,7 +30,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
 
     /**
      * If true, sets margin to 0.
-     * 
+     *
      * @default false
      */
     minimal?: boolean;

--- a/packages/core/src/components/divider/divider.tsx
+++ b/packages/core/src/components/divider/divider.tsx
@@ -29,7 +29,7 @@ export interface DividerProps extends Props, React.HTMLAttributes<HTMLElement> {
     tagName?: keyof React.JSX.IntrinsicElements;
 
     /**
-     * If true, sets margin to 0.
+     * If true, makes the Divider flush with adjacent content.
      *
      * @default false
      */

--- a/packages/docs-app/src/examples/core-examples/dividerPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dividerPlaygroundExample.tsx
@@ -21,13 +21,13 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 
 export const DividerPlaygroundExample: React.FC<ExampleProps> = props => {
     const [vertical, setVertical] = React.useState(false);
-    const [minimal, setMinimal] = React.useState(false);
+    const [compact, setCompact] = React.useState(false);
 
     const options = (
         <>
             <H5>Example props</H5>
             <Switch checked={vertical} label="Vertical" onChange={handleBooleanChange(setVertical)} />
-            <Switch checked={minimal} label="Minimal" onChange={handleBooleanChange(setMinimal)} />
+            <Switch checked={compact} label="Compact" onChange={handleBooleanChange(setCompact)} />
         </>
     );
 
@@ -36,10 +36,10 @@ export const DividerPlaygroundExample: React.FC<ExampleProps> = props => {
             <ButtonGroup vertical={vertical} variant="minimal">
                 <Button text="File" />
                 <Button text="Edit" />
-                <Divider minimal={minimal} />
+                <Divider compact={compact} />
                 <Button text="Create" />
                 <Button text="Delete" />
-                <Divider minimal={minimal} />
+                <Divider compact={compact} />
                 <Button icon="add" />
                 <Button icon="remove" />
             </ButtonGroup>

--- a/packages/docs-app/src/examples/core-examples/dividerPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dividerPlaygroundExample.tsx
@@ -21,11 +21,13 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 
 export const DividerPlaygroundExample: React.FC<ExampleProps> = props => {
     const [vertical, setVertical] = React.useState(false);
+    const [minimal, setMinimal] = React.useState(false);
 
     const options = (
         <>
             <H5>Example props</H5>
             <Switch checked={vertical} label="Vertical" onChange={handleBooleanChange(setVertical)} />
+            <Switch checked={minimal} label="Minimal" onChange={handleBooleanChange(setMinimal)} />
         </>
     );
 
@@ -34,10 +36,10 @@ export const DividerPlaygroundExample: React.FC<ExampleProps> = props => {
             <ButtonGroup vertical={vertical} variant="minimal">
                 <Button text="File" />
                 <Button text="Edit" />
-                <Divider />
+                <Divider minimal={minimal} />
                 <Button text="Create" />
                 <Button text="Delete" />
-                <Divider />
+                <Divider minimal={minimal} />
                 <Button icon="add" />
                 <Button icon="remove" />
             </ButtonGroup>

--- a/packages/table/changelog/@unreleased/pr-7501.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-7501.v2.yml
@@ -1,6 +1,6 @@
 type: feature
 feature:
-  description: Adds a `minimal` prop to Divider which removes its margin, making it
+  description: Adds a `compact` prop to Divider which removes its margin, making it
     flush with adjacent content.
   links:
   - https://github.com/palantir/blueprint/pull/7501

--- a/packages/table/changelog/@unreleased/pr-7501.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-7501.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Adds a `minimal` prop to Divider which removes its margin, making it
+    flush with adjacent content.
+  links:
+  - https://github.com/palantir/blueprint/pull/7501


### PR DESCRIPTION
## Summary
  - Add a `compact` prop to the `Divider` component that sets margin to 0
  - Update documentation to reflect the new prop
  - Add SCSS styling for the compact variant
  - Update the interactive playground example to demonstrate the compact prop

  ## Test plan
  - Verify the Divider renders correctly with `compact={true}`
  - Verify the Divider has margin: 0 when compact prop is set
  - Verify the interactive playground allows toggling the compact prop
  - Verify existing Divider functionality works as expected

Smoketest (replace anything that says minimal with compact, just didn't update video):

https://github.com/user-attachments/assets/a30de8d7-4089-4562-bf84-7a9429cb8e3a

