### PR TITLE
[MultistepDialog] Add dark-mode color variant for active step title

### DIFF
--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -214,6 +214,10 @@ $step-radius: $pt-border-radius * 2 !default;
   // step title is active only when the step is selected
   .#{$ns}-active.#{$ns}-dialog-step-viewed & {
     color: $blue3;
+
+    .#{$ns}-dark & {
+      color: $blue5;
+    }
   }
 
   .#{$ns}-dialog-step-viewed:not(.#{$ns}-active) & {


### PR DESCRIPTION
#### Fixes #7505

#### Changes

Improves color contrast of the MultistepDialog LHP active title step in dark mode. The current `blue3` text has a failing contrast ratio of [2.28:1](https://webaim.org/resources/contrastchecker/?fcolor=2D72D2&bcolor=383E47). This change adds dark mode styles to change the text color to `blue5` and improve the contrast ratio to [5.45:1](https://webaim.org/resources/contrastchecker/?fcolor=8ABBFF&bcolor=383E47).

#### Screenshots

| [Before](https://blueprintjs.com/docs/#core/components/dialog.multistep-dialog) | [After](https://output.circle-artifacts.com/output/job/beb1b3f4-78c4-45fc-a821-f67872da1700/artifacts/0/packages/docs-app/dist/index.html#core/components/dialog.multistep-dialog)    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/b4a6e936-ac8d-456c-b342-67043641043b) | ![after](https://github.com/user-attachments/assets/8a71d5eb-5630-4d1e-b1c5-2cffca3e52c0) |

| Before | After    |
| ------  | ------  |
| ![before](https://github.com/user-attachments/assets/c719d4c0-d695-413a-bfe0-0f5797452e31) | ![after](https://github.com/user-attachments/assets/0938d111-9dcb-4b42-9fe9-5939b61cdf56) |

![diff](https://github.com/user-attachments/assets/df0bc4a2-73c8-4f52-beb6-11a08f82799c)
