### PR TITLE
[Demo] Explore replacing Popper v2 with Floating UI

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,6 +48,7 @@
     "dependencies": {
         "@blueprintjs/colors": "workspace:^",
         "@blueprintjs/icons": "workspace:^",
+        "@floating-ui/react": "^0.27.13",
         "@popperjs/core": "^2.11.8",
         "classnames": "^2.3.1",
         "normalize.css": "^8.0.1",

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -90,7 +90,7 @@ export interface BreadcrumbsProps extends Props {
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -103,6 +103,7 @@ export interface BreadcrumbsProps extends Props {
 export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
     public static defaultProps: Partial<BreadcrumbsProps> = {
         collapseFrom: Boundary.START,
+        floating: true,
     };
 
     public render() {

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,7 +21,8 @@ import { AbstractPureComponent, Boundary, Classes, type Props, removeNonHTMLProp
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
-import { Popover, type PopoverProps } from "../popover/popover";
+import { type PopoverProps } from "../popover/popover";
+import { PopoverFloating } from "../popover-floating/popoverFloating";
 
 import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
 
@@ -126,7 +127,7 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
 
         return (
             <li>
-                <Popover
+                <PopoverFloating
                     placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
                     disabled={orderedItems.length === 0}
                     content={<Menu>{orderedItems.map(this.renderOverflowBreadcrumb)}</Menu>}
@@ -139,7 +140,7 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
                         {...overflowButtonProps}
                         className={classNames(Classes.BREADCRUMBS_COLLAPSED, overflowButtonProps?.className)}
                     />
-                </Popover>
+                </PopoverFloating>
             </li>
         );
     };

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,7 +21,7 @@ import { AbstractPureComponent, Boundary, Classes, type Props, removeNonHTMLProp
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
-import { type PopoverProps } from "../popover/popover";
+import type { PopoverProps } from "../popover/popoverProps";
 import { PopoverFloating } from "../popover-floating/popoverFloating";
 
 import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,6 +21,7 @@ import { AbstractPureComponent, Boundary, Classes, type Props, removeNonHTMLProp
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
+import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
 import { PopoverFloating } from "../popover-floating/popoverFloating";
 
@@ -85,6 +86,13 @@ export interface BreadcrumbsProps extends Props {
     popoverProps?: Partial<
         Omit<PopoverProps, "content" | "defaultIsOpen" | "disabled" | "fill" | "renderTarget" | "targetTagName">
     >;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 /**
@@ -125,9 +133,11 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
             orderedItems = items.slice().reverse();
         }
 
+        const Component = this.props.floating ? PopoverFloating : Popover;
+
         return (
             <li>
-                <PopoverFloating
+                <Component
                     placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
                     disabled={orderedItems.length === 0}
                     content={<Menu>{orderedItems.map(this.renderOverflowBreadcrumb)}</Menu>}
@@ -140,7 +150,7 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
                         {...overflowButtonProps}
                         className={classNames(Classes.BREADCRUMBS_COLLAPSED, overflowButtonProps?.className)}
                     />
-                </PopoverFloating>
+                </Component>
             </li>
         );
     };

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
+import { Popover } from "../popover/popover";
 import type { PopoverTargetProps } from "../popover/popoverSharedProps";
 import { PopoverFloating } from "../popover-floating/popoverFloating";
 import { Portal } from "../portal/portal";
@@ -30,6 +31,13 @@ export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
     content: React.JSX.Element;
     onClose?: () => void;
     targetOffset: Offset | undefined;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 /**
@@ -43,6 +51,7 @@ export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
 export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: ContextMenuPopoverProps) {
     const {
         content,
+        floating = false,
         popoverClassName,
         onClose,
         isDarkTheme = false,
@@ -72,8 +81,10 @@ export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: 
         [onClose],
     );
 
+    const Component = floating ? PopoverFloating : Popover;
+
     return (
-        <PopoverFloating
+        <Component
             placement="right-start"
             rootBoundary={rootBoundary}
             transitionDuration={transitionDuration}

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -35,7 +35,7 @@ export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -51,7 +51,7 @@ export interface ContextMenuPopoverProps extends ContextMenuPopoverOptions {
 export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: ContextMenuPopoverProps) {
     const {
         content,
-        floating = false,
+        floating = true,
         popoverClassName,
         onClose,
         isDarkTheme = false,

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -18,8 +18,8 @@ import classNames from "classnames";
 import * as React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
-import { Popover } from "../popover/popover";
 import type { PopoverTargetProps } from "../popover/popoverSharedProps";
+import { PopoverFloating } from "../popover-floating/popoverFloating";
 import { Portal } from "../portal/portal";
 
 import type { ContextMenuPopoverOptions, Offset } from "./contextMenuShared";
@@ -73,7 +73,7 @@ export const ContextMenuPopover = React.memo(function ContextMenuPopover(props: 
     );
 
     return (
-        <Popover
+        <PopoverFloating
             placement="right-start"
             rootBoundary={rootBoundary}
             transitionDuration={transitionDuration}

--- a/packages/core/src/components/context-menu/contextMenuShared.ts
+++ b/packages/core/src/components/context-menu/contextMenuShared.ts
@@ -15,7 +15,7 @@
  */
 
 import type { OverlayLifecycleProps } from "../overlay/overlayProps";
-import type { PopoverProps } from "../popover/popover";
+import type { PopoverProps } from "../popover/popoverProps";
 
 export type Offset = {
     left: number;

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -78,7 +78,7 @@ export { Text, type TextProps } from "./text/text";
 export { PanelStack, type PanelStackProps, PanelStack2, type PanelStack2Props } from "./panel-stack/panelStack";
 export type { Panel, PanelProps } from "./panel-stack/panelTypes";
 export { type PopoverProps, Popover, PopoverInteractionKind } from "./popover/popover";
-export { PopoverFloating } from "./popover-floating/popoverFloating";
+export { PopoverFloating, type PopoverFloatingRef } from "./popover-floating/popoverFloating";
 export { PopoverPosition } from "./popover/popoverPosition";
 export type {
     DefaultPopoverTargetHTMLProps,

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -77,7 +77,8 @@ export type { OverlayInstance } from "./overlay2/overlayInstance";
 export { Text, type TextProps } from "./text/text";
 export { PanelStack, type PanelStackProps, PanelStack2, type PanelStack2Props } from "./panel-stack/panelStack";
 export type { Panel, PanelProps } from "./panel-stack/panelTypes";
-export { type PopoverProps, Popover, PopoverInteractionKind } from "./popover/popover";
+export { Popover } from "./popover/popover";
+export { PopoverInteractionKind, type PopoverProps } from "./popover/popoverProps";
 export { PopoverFloating, type PopoverFloatingRef } from "./popover-floating/popoverFloating";
 export { PopoverPosition } from "./popover/popoverPosition";
 export type {

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -78,6 +78,7 @@ export { Text, type TextProps } from "./text/text";
 export { PanelStack, type PanelStackProps, PanelStack2, type PanelStack2Props } from "./panel-stack/panelStack";
 export type { Panel, PanelProps } from "./panel-stack/panelTypes";
 export { type PopoverProps, Popover, PopoverInteractionKind } from "./popover/popover";
+export { PopoverFloating } from "./popover-floating/popoverFloating";
 export { PopoverPosition } from "./popover/popoverPosition";
 export type {
     DefaultPopoverTargetHTMLProps,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -169,7 +169,7 @@ export interface MenuItemProps
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -185,7 +185,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
         className,
         children,
         disabled = false,
-        floating = false,
+        floating = true,
         icon,
         intent,
         labelClassName,

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -23,7 +23,8 @@ import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
-import { Popover, type PopoverProps } from "../popover/popover";
+import { type PopoverProps } from "../popover/popover";
+import { PopoverFloating } from "../popover-floating/popoverFloating";
 import { Text } from "../text/text";
 
 import { Menu, type MenuProps } from "./menu";
@@ -280,7 +281,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
             {children == null ? (
                 target
             ) : (
-                <Popover
+                <PopoverFloating
                     autoFocus={false}
                     captureDismiss={false}
                     disabled={disabled}
@@ -297,7 +298,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
                     popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
                 >
                     {target}
-                </Popover>
+                </PopoverFloating>
             )}
         </li>
     );

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -23,6 +23,7 @@ import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
+import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
 import { PopoverFloating } from "../popover-floating/popoverFloating";
 import { Text } from "../text/text";
@@ -164,6 +165,13 @@ export interface MenuItemProps
      * HTML title to be passed to the <Text> component
      */
     htmlTitle?: string;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 /**
@@ -177,6 +185,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
         className,
         children,
         disabled = false,
+        floating = false,
         icon,
         intent,
         labelClassName,
@@ -276,12 +285,13 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
     );
 
     const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });
+    const Component = floating ? PopoverFloating : Popover;
     return (
         <li className={liClasses} ref={ref} role={liRole} aria-selected={ariaSelected}>
             {children == null ? (
                 target
             ) : (
-                <PopoverFloating
+                <Component
                     autoFocus={false}
                     captureDismiss={false}
                     disabled={disabled}
@@ -298,7 +308,7 @@ export const MenuItem: React.FC<MenuItemProps> = React.forwardRef<HTMLLIElement,
                     popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
                 >
                     {target}
-                </PopoverFloating>
+                </Component>
             )}
         </li>
     );

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -23,7 +23,7 @@ import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
-import { type PopoverProps } from "../popover/popover";
+import type { PopoverProps } from "../popover/popoverProps";
 import { PopoverFloating } from "../popover-floating/popoverFloating";
 import { Text } from "../text/text";
 

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -17,7 +17,7 @@ export interface PopoverFloatingRef {
 
 export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps>((props, ref) => {
     const {
-        boundary,
+        boundary = "clippingParents",
         canEscapeKeyClose = true,
         children,
         content,

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -1,0 +1,324 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import React, { useEffect } from "react";
+
+import { Classes, Utils } from "../../common";
+import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
+
+import { PopoverPopup } from "./popoverPopup";
+import { PopoverTarget } from "./popoverTarget";
+import { usePopover } from "./usePopover";
+
+export function PopoverFloating(props: PopoverProps) {
+    const {
+        children,
+        content,
+        disabled = false,
+        hoverCloseDelay = 300,
+        hoverOpenDelay = 150,
+        interactionKind = PopoverInteractionKind.CLICK,
+        onClose,
+        onInteraction,
+        openOnTargetFocus = true,
+        usePortal = true,
+    } = props;
+
+    const [hasDarkParent, setHasDarkParent] = React.useState(false);
+    const [isClosingViaEscapeKeypress, setIsClosingViaEscapeKeypress] = React.useState(false);
+
+    const cancelOpenTimeout = React.useRef<(() => void) | undefined>(undefined);
+    const isMouseInTargetOrPopover = React.useRef(false);
+    const lostFocusOnSamePage = React.useRef(true);
+    const targetRef = React.createRef<HTMLElement>();
+    const timeoutIds = React.useRef<number[]>([]);
+
+    const context = usePopover();
+
+    const popoverElement = context.refs.floating.current;
+
+    const isContentEmpty = content == null || Utils.isEmptyString(content);
+
+    const isControlled = props.isOpen !== undefined;
+
+    const isHoverInteractionKind =
+        interactionKind === PopoverInteractionKind.HOVER ||
+        interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
+
+    const getPopoverElement = React.useCallback(() => {
+        return popoverElement?.querySelector<HTMLElement>(`.${Classes.POPOVER}`);
+    }, [popoverElement]);
+
+    const isElementInPopover = React.useCallback(
+        (element: Element) => {
+            return getPopoverElement()?.contains(element) ?? false;
+        },
+        [getPopoverElement],
+    );
+
+    const setTimeout = React.useCallback((callback: () => void, timeout?: number) => {
+        const handle = window.setTimeout(callback, timeout);
+        timeoutIds.current.push(handle);
+        return () => window.clearTimeout(handle);
+    }, []);
+
+    // a wrapper around setIsOpen that will call props.onInteraction instead when in controlled mode.
+    // starts a timeout to delay changing the state if a non-zero duration is provided.
+    const setOpenState = React.useCallback(
+        (isOpen: boolean, event?: React.SyntheticEvent<HTMLElement>, timeout?: number) => {
+            // cancel any existing timeout because we have new state
+            cancelOpenTimeout.current?.();
+            if (timeout !== undefined && timeout > 0) {
+                // Persist the react event since it will be used in a later macrotask.
+                event?.persist();
+                cancelOpenTimeout.current = setTimeout(() => {
+                    setOpenState(isOpen, event);
+                }, timeout);
+            } else {
+                if (props.isOpen == null) {
+                    context.setIsOpen(isOpen);
+                } else {
+                    onInteraction?.(isOpen, event);
+                }
+                if (!isOpen) {
+                    // non-null assertion because the only time `e` is undefined is when in controlled mode
+                    // or the rare special case in uncontrolled mode when the `disabled` flag is toggled true
+                    onClose?.(event!);
+                    setIsClosingViaEscapeKeypress(isEscapeKeypressEvent(event?.nativeEvent));
+                }
+            }
+        },
+        [context, props.isOpen, onInteraction, onClose, setTimeout],
+    );
+
+    const handleTargetContextMenu = React.useCallback(
+        (event: React.MouseEvent<HTMLElement>) => {
+            // we assume that when someone prevents the default interaction on this event (a browser native context menu),
+            // they are showing a custom context menu (as ContextMenu2 does); in this case, we should close this popover/tooltip
+            if (event.defaultPrevented) {
+                setOpenState(false, event);
+            }
+        },
+        [setOpenState],
+    );
+
+    const handleMouseLeave = React.useCallback(
+        (event: React.MouseEvent<HTMLElement>) => {
+            isMouseInTargetOrPopover.current = false;
+
+            event.persist();
+            setTimeout(() => {
+                if (isMouseInTargetOrPopover.current) {
+                    return;
+                }
+                setOpenState(false, event, hoverCloseDelay);
+            });
+        },
+        [hoverCloseDelay, setOpenState, setTimeout],
+    );
+
+    const handleMouseEnter = React.useCallback(
+        (event: React.MouseEvent<HTMLElement>) => {
+            isMouseInTargetOrPopover.current = true;
+
+            // if we're entering the popover, and the mode is set to be HOVER_TARGET_ONLY, we want to manually
+            // trigger the mouse leave event, as hovering over the popover shouldn't count.
+            if (
+                !usePortal &&
+                isElementInPopover(event.target as Element) &&
+                interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY &&
+                !openOnTargetFocus
+            ) {
+                handleMouseLeave(event);
+            } else if (!disabled) {
+                // only begin opening popover when it is enabled
+                setOpenState(true, event, hoverOpenDelay);
+            }
+        },
+        [
+            disabled,
+            handleMouseLeave,
+            hoverOpenDelay,
+            interactionKind,
+            isElementInPopover,
+            openOnTargetFocus,
+            setOpenState,
+            usePortal,
+        ],
+    );
+
+    const handleTargetFocus = React.useCallback(
+        (event: React.FocusEvent<HTMLElement>) => {
+            if (openOnTargetFocus && isHoverInteractionKind) {
+                if (event.relatedTarget == null && !lostFocusOnSamePage.current) {
+                    // ignore this focus event -- the target was already focused but the page itself
+                    // lost focus (e.g. due to switching tabs).
+                    return;
+                }
+                handleMouseEnter(event as unknown as React.MouseEvent<HTMLElement>);
+            }
+        },
+        [handleMouseEnter, isHoverInteractionKind, openOnTargetFocus],
+    );
+
+    const handleTargetBlur = React.useCallback(
+        (event: React.FocusEvent<HTMLElement>) => {
+            if (openOnTargetFocus && isHoverInteractionKind) {
+                if (event.relatedTarget != null) {
+                    // if the next element to receive focus is within the popover, we'll want to leave the
+                    // popover open.
+                    if (
+                        event.relatedTarget !== popoverElement &&
+                        !isElementInPopover(event.relatedTarget as HTMLElement)
+                    ) {
+                        handleMouseLeave(event as unknown as React.MouseEvent<HTMLElement>);
+                    }
+                } else {
+                    handleMouseLeave(event as unknown as React.MouseEvent<HTMLElement>);
+                }
+            }
+            lostFocusOnSamePage.current = event.relatedTarget != null;
+        },
+        [handleMouseLeave, isHoverInteractionKind, isElementInPopover, openOnTargetFocus, popoverElement],
+    );
+
+    const handlePopoverClick = React.useCallback(
+        (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+            const eventTarget = event.target as HTMLElement;
+            const eventPopover = eventTarget.closest(`.${Classes.POPOVER}`);
+            const isEventFromSelf = eventPopover === getPopoverElement();
+            const isEventPopoverCapturing =
+                eventPopover?.classList.contains(Classes.POPOVER_CAPTURING_DISMISS) ?? false;
+
+            // an OVERRIDE inside a DISMISS does not dismiss, and a DISMISS inside an OVERRIDE will dismiss.
+            const dismissElement = eventTarget.closest(
+                `.${Classes.POPOVER_DISMISS}, .${Classes.POPOVER_DISMISS_OVERRIDE}`,
+            );
+            const shouldDismiss = dismissElement?.classList.contains(Classes.POPOVER_DISMISS) ?? false;
+            const isDisabled = eventTarget.closest(`:disabled, .${Classes.DISABLED}`) != null;
+
+            if (shouldDismiss && !isDisabled && (!isEventPopoverCapturing || isEventFromSelf)) {
+                setOpenState(false, event);
+            }
+        },
+        [getPopoverElement, setOpenState],
+    );
+
+    const handleOverlayClose = React.useCallback(
+        (event?: React.SyntheticEvent<HTMLElement>) => {
+            if (event === undefined) {
+                return;
+            }
+
+            if (event.nativeEvent instanceof KeyboardEvent) {
+                setOpenState(false, event);
+            }
+        },
+        [setOpenState],
+    );
+
+    const handleTargetClick = React.useCallback(
+        (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+            // Target element(s) may fire simulated click event upon pressing ENTER/SPACE, which we should ignore
+            // see: https://github.com/palantir/blueprint/issues/5775
+            const shouldIgnoreClick = context.isOpen && isSimulatedButtonClick(event);
+            if (!shouldIgnoreClick) {
+                // ensure click did not originate from within inline popover before closing
+                if (!disabled && !isElementInPopover(event.target as HTMLElement)) {
+                    if (context.isOpen == null) {
+                        context.setIsOpen(prevState => !prevState);
+                    } else {
+                        setOpenState(!context.isOpen, event);
+                    }
+                }
+            }
+        },
+        [context, disabled, isElementInPopover, setOpenState],
+    );
+
+    const handleKeyDown = React.useCallback(
+        (event: React.KeyboardEvent<HTMLElement>) => {
+            const isKeyboardClick = Utils.isKeyboardClick(event);
+
+            // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
+            if (isKeyboardClick) {
+                handleTargetClick(event);
+            }
+        },
+        [handleTargetClick],
+    );
+
+    const getIsOpen = React.useCallback(() => {
+        // disabled popovers should never be allowed to open.
+        if (disabled) {
+            return false;
+        } else {
+            return props.isOpen ?? props.defaultIsOpen!;
+        }
+    }, [disabled, props.defaultIsOpen, props.isOpen]);
+
+    const updateDarkParent = React.useCallback(() => {
+        if (usePortal && context.isOpen) {
+            setHasDarkParent(targetRef.current?.closest(`.${Classes.DARK}`) != null);
+        }
+    }, [context.isOpen, targetRef, usePortal]);
+
+    useEffect(() => {
+        updateDarkParent();
+
+        const nextIsOpen = getIsOpen();
+
+        if (props.isOpen != null && nextIsOpen !== context.isOpen) {
+            setOpenState(nextIsOpen);
+            // tricky: setOpenState calls setIsOpen only if props.isOpen is
+            // not controlled, so we need to invoke setIsOpen manually here.
+            context.setIsOpen(nextIsOpen);
+        } else if (props.disabled && context.isOpen && props.isOpen == null) {
+            // special case: close an uncontrolled popover when disabled is set to true
+            setOpenState(false);
+        }
+    }, [context, getIsOpen, props.disabled, props.isOpen, setOpenState, updateDarkParent]);
+
+    return (
+        <>
+            <PopoverTarget
+                context={context}
+                handleKeyDown={handleKeyDown}
+                handleMouseEnter={handleMouseEnter}
+                handleMouseLeave={handleMouseLeave}
+                handleTargetBlur={handleTargetBlur}
+                handleTargetClick={handleTargetClick}
+                handleTargetContextMenu={handleTargetContextMenu}
+                handleTargetFocus={handleTargetFocus}
+                isContentEmpty={isContentEmpty}
+                isControlled={isControlled}
+                isHoverInteractionKind={isHoverInteractionKind}
+                openOnTargetFocus={openOnTargetFocus}
+                ref={targetRef}
+                {...props}
+            >
+                {children}
+            </PopoverTarget>
+            <PopoverPopup
+                context={context}
+                handleMouseEnter={handleMouseEnter}
+                handleMouseLeave={handleMouseLeave}
+                handleOverlayClose={handleOverlayClose}
+                handlePopoverClick={handlePopoverClick}
+                hasDarkParent={hasDarkParent}
+                isClosingViaEscapeKeypress={isClosingViaEscapeKeypress}
+                isHoverInteractionKind={isHoverInteractionKind}
+                {...props}
+            />
+        </>
+    );
+}
+
+function isEscapeKeypressEvent(e?: Event) {
+    return e instanceof KeyboardEvent && e.key === "Escape";
+}
+
+const isSimulatedButtonClick = (e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+    return !e.isTrusted && (e.target as HTMLElement).matches(`.${Classes.BUTTON}`);
+};

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -20,6 +20,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
         boundary,
         children,
         content,
+        defaultIsOpen = false,
         disabled = false,
         hoverCloseDelay = 300,
         hoverOpenDelay = 150,
@@ -44,7 +45,15 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
     const targetRef = React.createRef<HTMLElement>();
     const timeoutIds = React.useRef<number[]>([]);
 
-    const context = usePopover({ boundary, matchTargetWidth, minimal, modifiers, placement, rootBoundary });
+    const context = usePopover({
+        boundary,
+        isOpen: props.isOpen ?? defaultIsOpen,
+        matchTargetWidth,
+        minimal,
+        modifiers,
+        placement,
+        rootBoundary,
+    });
 
     useImperativeHandle(
         ref,

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -51,6 +51,11 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
         matchTargetWidth,
         minimal,
         modifiers,
+        // Always provide onOpenChange for proper state synchronization
+        onOpenChange: (nextOpen, event) => {
+            // Use our setOpenState logic which handles both controlled and uncontrolled components
+            setOpenState(nextOpen, event as unknown as React.SyntheticEvent<HTMLElement>);
+        },
         placement,
         rootBoundary,
     });
@@ -106,6 +111,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
                 }, timeout);
             } else {
                 if (props.isOpen == null) {
+                    // For uncontrolled popovers, update the usePopover state directly
                     context.setIsOpen(isOpen);
                 } else {
                     onInteraction?.(isOpen, event);
@@ -236,15 +242,23 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
 
     const handleOverlayClose = React.useCallback(
         (event?: React.SyntheticEvent<HTMLElement>) => {
-            if (event === undefined) {
+            if (targetRef.current == null || event === undefined) {
                 return;
             }
 
-            if (event.nativeEvent instanceof KeyboardEvent) {
+            const nativeEvent = (event.nativeEvent ?? event) as Event;
+            const eventTarget = (
+                nativeEvent.composed ? nativeEvent.composedPath()[0] : nativeEvent.target
+            ) as HTMLElement;
+            // if click was in target, target event listener will handle things, so don't close
+            if (
+                !Utils.elementIsOrContains(targetRef.current, eventTarget) ||
+                event.nativeEvent instanceof KeyboardEvent
+            ) {
                 setOpenState(false, event);
             }
         },
-        [setOpenState],
+        [setOpenState, targetRef],
     );
 
     const handleTargetClick = React.useCallback(
@@ -255,28 +269,17 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
             if (!shouldIgnoreClick) {
                 // ensure click did not originate from within inline popover before closing
                 if (!disabled && !isElementInPopover(event.target as HTMLElement)) {
-                    if (context.isOpen == null) {
-                        context.setIsOpen(prevState => !prevState);
-                    } else {
-                        setOpenState(!context.isOpen, event);
-                    }
+                    setOpenState(!context.isOpen, event);
                 }
             }
         },
         [context, disabled, isElementInPopover, setOpenState],
     );
 
-    const handleKeyDown = React.useCallback(
-        (event: React.KeyboardEvent<HTMLElement>) => {
-            const isKeyboardClick = Utils.isKeyboardClick(event);
-
-            // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
-            if (isKeyboardClick) {
-                handleTargetClick(event);
-            }
-        },
-        [handleTargetClick],
-    );
+    const handleKeyDown = React.useCallback(() => {
+        // Floating UI's useClick hook already handles keyboard interactions (ENTER/SPACE)
+        // so we don't need to manually call handleTargetClick here
+    }, []);
 
     const getIsOpen = React.useCallback(() => {
         // disabled popovers should never be allowed to open.
@@ -300,9 +303,6 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
 
         if (props.isOpen != null && nextIsOpen !== context.isOpen) {
             setOpenState(nextIsOpen);
-            // tricky: setOpenState calls setIsOpen only if props.isOpen is
-            // not controlled, so we need to invoke setIsOpen manually here.
-            context.setIsOpen(nextIsOpen);
         } else if (props.disabled && context.isOpen && props.isOpen == null) {
             // special case: close an uncontrolled popover when disabled is set to true
             setOpenState(false);

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -2,16 +2,20 @@
  * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
  */
 
-import React, { useEffect } from "react";
+import React, { useEffect, useImperativeHandle } from "react";
 
-import { Classes, Utils } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
 import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
 
 import { PopoverPopup } from "./popoverPopup";
 import { PopoverTarget } from "./popoverTarget";
 import { usePopover } from "./usePopover";
 
-export function PopoverFloating(props: PopoverProps) {
+export interface PopoverFloatingRef {
+    reposition(): void;
+}
+
+export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps>((props, ref) => {
     const {
         children,
         content,
@@ -35,6 +39,16 @@ export function PopoverFloating(props: PopoverProps) {
     const timeoutIds = React.useRef<number[]>([]);
 
     const context = usePopover();
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            reposition: () => {
+                context.update();
+            },
+        }),
+        [context],
+    );
 
     const popoverElement = context.refs.floating.current;
 
@@ -313,7 +327,9 @@ export function PopoverFloating(props: PopoverProps) {
             />
         </>
     );
-}
+});
+
+PopoverFloating.displayName = `${DISPLAYNAME_PREFIX}.PopoverFloating`;
 
 function isEscapeKeypressEvent(e?: Event) {
     return e instanceof KeyboardEvent && e.key === "Escape";

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -50,6 +50,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
     const context = usePopover({
         boundary,
         canEscapeKeyClose,
+        interactionKind,
         isOpen: props.isOpen ?? defaultIsOpen,
         matchTargetWidth,
         minimal,

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -33,6 +33,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
         openOnTargetFocus = true,
         placement = "auto",
         rootBoundary,
+        shouldReturnFocusOnClose = false,
         usePortal = true,
     } = props;
 
@@ -338,6 +339,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
                 hasDarkParent={hasDarkParent}
                 isClosingViaEscapeKeypress={isClosingViaEscapeKeypress}
                 isHoverInteractionKind={isHoverInteractionKind}
+                shouldReturnFocusOnClose={shouldReturnFocusOnClose}
                 {...props}
             />
         </>

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useImperativeHandle } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
-import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
+import { PopoverInteractionKind, type PopoverProps } from "../popover/popoverProps";
 
 import { PopoverPopup } from "./popoverPopup";
 import { PopoverTarget } from "./popoverTarget";

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -17,15 +17,21 @@ export interface PopoverFloatingRef {
 
 export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps>((props, ref) => {
     const {
+        boundary,
         children,
         content,
         disabled = false,
         hoverCloseDelay = 300,
         hoverOpenDelay = 150,
         interactionKind = PopoverInteractionKind.CLICK,
+        matchTargetWidth = false,
+        minimal = false,
+        modifiers,
         onClose,
         onInteraction,
         openOnTargetFocus = true,
+        placement = "auto",
+        rootBoundary,
         usePortal = true,
     } = props;
 
@@ -38,7 +44,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
     const targetRef = React.createRef<HTMLElement>();
     const timeoutIds = React.useRef<number[]>([]);
 
-    const context = usePopover();
+    const context = usePopover({ boundary, matchTargetWidth, minimal, modifiers, placement, rootBoundary });
 
     useImperativeHandle(
         ref,

--- a/packages/core/src/components/popover-floating/popoverFloating.tsx
+++ b/packages/core/src/components/popover-floating/popoverFloating.tsx
@@ -18,6 +18,7 @@ export interface PopoverFloatingRef {
 export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps>((props, ref) => {
     const {
         boundary,
+        canEscapeKeyClose = true,
         children,
         content,
         defaultIsOpen = false,
@@ -48,6 +49,7 @@ export const PopoverFloating = React.forwardRef<PopoverFloatingRef, PopoverProps
 
     const context = usePopover({
         boundary,
+        canEscapeKeyClose,
         isOpen: props.isOpen ?? defaultIsOpen,
         matchTargetWidth,
         minimal,

--- a/packages/core/src/components/popover-floating/popoverPopup.tsx
+++ b/packages/core/src/components/popover-floating/popoverPopup.tsx
@@ -75,8 +75,8 @@ export function PopoverPopup(props: PopoverPopupProps) {
         context.placement,
         isArrowEnabled
             ? {
-                  left: arrowStyle.left != null ? `${arrowStyle.left}px` : "",
-                  top: arrowStyle.top != null ? `${arrowStyle.top}px` : "",
+                  left: cssPropertyToString(arrowStyle.left),
+                  top: cssPropertyToString(arrowStyle.top),
               }
             : undefined,
     );
@@ -160,4 +160,8 @@ export function PopoverPopup(props: PopoverPopupProps) {
             </div>
         </Overlay2>
     );
+}
+
+function cssPropertyToString(value: string | number | undefined): string {
+    return value != null && !isNaN(Number(value)) ? `${value}px` : "";
 }

--- a/packages/core/src/components/popover-floating/popoverPopup.tsx
+++ b/packages/core/src/components/popover-floating/popoverPopup.tsx
@@ -1,0 +1,155 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import classNames from "classnames";
+import React from "react";
+
+import { Classes, type HTMLDivProps, mergeRefs, Utils } from "../../common";
+import { Overlay2 } from "../overlay2/overlay2";
+import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
+import { PopoverArrow } from "../popover/popoverArrow";
+import { getBasePlacement, getTransformOrigin } from "../popover/popperUtils";
+
+import { type usePopover } from "./usePopover";
+
+interface PopoverPopupProps extends PopoverProps {
+    context: ReturnType<typeof usePopover>;
+    handleMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
+    handleMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
+    handleOverlayClose: (event?: React.SyntheticEvent<HTMLElement>) => void;
+    handlePopoverClick: (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
+    hasDarkParent: boolean;
+    isClosingViaEscapeKeypress: boolean;
+    isHoverInteractionKind: boolean;
+}
+
+export function PopoverPopup(props: PopoverPopupProps) {
+    const {
+        autoFocus = true,
+        backdropProps,
+        canEscapeKeyClose,
+        captureDismiss = false,
+        content,
+        context,
+        enforceFocus = true,
+        handleMouseEnter,
+        handleMouseLeave,
+        handleOverlayClose,
+        handlePopoverClick,
+        hasBackdrop = false,
+        hasDarkParent,
+        inheritDarkTheme = true,
+        interactionKind = PopoverInteractionKind.CLICK,
+        isClosingViaEscapeKeypress,
+        isHoverInteractionKind,
+        lazy = false,
+        matchTargetWidth = false,
+        minimal = false,
+        modifiers,
+        onClosed,
+        onClosing,
+        onOpened,
+        onOpening,
+        placement = "auto",
+        popoverClassName,
+        portalClassName,
+        portalContainer,
+        transitionDuration = 300,
+        usePortal = true,
+    } = props;
+
+    const transitionContainerElement = React.useRef<HTMLDivElement>(null);
+
+    const isArrowEnabled = !minimal && modifiers?.arrow?.enabled !== false;
+
+    const arrowStyle: React.CSSProperties = {
+        left: context.middlewareData.arrow?.x,
+        position: "absolute",
+        top: context.middlewareData.arrow?.y,
+    };
+
+    const isReferenceHidden = context.context.middlewareData.hide?.referenceHidden ?? false;
+    const hasPopperEscaped = context.context.middlewareData.hide?.escaped ?? false;
+
+    const transformOrigin = getTransformOrigin(placement, isArrowEnabled ? undefined : undefined);
+
+    const popoverHandlers: HTMLDivProps = {
+        // always check popover clicks for dismiss class
+        onClick: handlePopoverClick,
+        // treat ENTER/SPACE keys the same as a click for accessibility
+        onKeyDown: event => Utils.isKeyboardClick(event) && handlePopoverClick(event),
+    };
+    if (
+        interactionKind === PopoverInteractionKind.HOVER ||
+        (!usePortal && interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY)
+    ) {
+        popoverHandlers.onMouseEnter = handleMouseEnter;
+        popoverHandlers.onMouseLeave = handleMouseLeave;
+    }
+
+    const basePlacement = getBasePlacement(context.placement);
+    const popoverClasses = classNames(
+        Classes.POPOVER,
+        {
+            [Classes.DARK]: inheritDarkTheme && hasDarkParent,
+            [Classes.MINIMAL]: minimal,
+            [Classes.POPOVER_CAPTURING_DISMISS]: captureDismiss,
+            [Classes.POPOVER_MATCH_TARGET_WIDTH]: matchTargetWidth,
+            [Classes.POPOVER_REFERENCE_HIDDEN]: isReferenceHidden,
+            [Classes.POPOVER_POPPER_ESCAPED]: hasPopperEscaped,
+        },
+        `${Classes.POPOVER_CONTENT_PLACEMENT}-${basePlacement}`,
+        popoverClassName,
+    );
+
+    const defaultAutoFocus = isHoverInteractionKind ? false : undefined;
+    // if hover interaction, it doesn't make sense to take over focus control
+    const shouldReturnFocusOnClose = isHoverInteractionKind
+        ? false
+        : isClosingViaEscapeKeypress
+          ? true
+          : props.shouldReturnFocusOnClose;
+
+    return (
+        <Overlay2
+            autoFocus={autoFocus ?? defaultAutoFocus}
+            backdropClassName={Classes.POPOVER_BACKDROP}
+            backdropProps={backdropProps}
+            canEscapeKeyClose={canEscapeKeyClose}
+            canOutsideClickClose={interactionKind === PopoverInteractionKind.CLICK}
+            childRef={transitionContainerElement}
+            enforceFocus={enforceFocus}
+            hasBackdrop={hasBackdrop}
+            isOpen={context.isOpen}
+            lazy={lazy}
+            onClose={handleOverlayClose}
+            onClosed={onClosed}
+            onClosing={onClosing}
+            onOpened={onOpened}
+            onOpening={onOpening}
+            portalClassName={portalClassName}
+            portalContainer={portalContainer}
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            portalStopPropagationEvents={props.portalStopPropagationEvents}
+            shouldReturnFocusOnClose={shouldReturnFocusOnClose}
+            transitionDuration={transitionDuration}
+            transitionName={Classes.POPOVER}
+            usePortal={usePortal}
+        >
+            <div
+                className={Classes.POPOVER_TRANSITION_CONTAINER}
+                style={context.floatingStyles}
+                ref={mergeRefs(context.refs.setFloating, transitionContainerElement)}
+                {...popoverHandlers}
+            >
+                <div className={popoverClasses} style={{ transformOrigin }}>
+                    {isArrowEnabled && (
+                        <PopoverArrow arrowProps={{ ref: context.arrowRef, style: arrowStyle }} placement={placement} />
+                    )}
+                    <div className={Classes.POPOVER_CONTENT}>{content}</div>
+                </div>
+            </div>
+        </Overlay2>
+    );
+}

--- a/packages/core/src/components/popover-floating/popoverPopup.tsx
+++ b/packages/core/src/components/popover-floating/popoverPopup.tsx
@@ -71,7 +71,15 @@ export function PopoverPopup(props: PopoverPopupProps) {
     const isReferenceHidden = context.context.middlewareData.hide?.referenceHidden ?? false;
     const hasPopperEscaped = context.context.middlewareData.hide?.escaped ?? false;
 
-    const transformOrigin = getTransformOrigin(context.placement, isArrowEnabled ? undefined : undefined);
+    const transformOrigin = getTransformOrigin(
+        context.placement,
+        isArrowEnabled
+            ? {
+                  left: arrowStyle.left != null ? `${arrowStyle.left}px` : "",
+                  top: arrowStyle.top != null ? `${arrowStyle.top}px` : "",
+              }
+            : undefined,
+    );
 
     const popoverHandlers: HTMLDivProps = {
         // always check popover clicks for dismiss class

--- a/packages/core/src/components/popover-floating/popoverPopup.tsx
+++ b/packages/core/src/components/popover-floating/popoverPopup.tsx
@@ -7,8 +7,8 @@ import React from "react";
 
 import { Classes, type HTMLDivProps, mergeRefs, Utils } from "../../common";
 import { Overlay2 } from "../overlay2/overlay2";
-import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
 import { PopoverArrow } from "../popover/popoverArrow";
+import { PopoverInteractionKind, type PopoverProps } from "../popover/popoverProps";
 import { getBasePlacement, getTransformOrigin } from "../popover/popperUtils";
 
 import { type usePopover } from "./usePopover";
@@ -51,7 +51,6 @@ export function PopoverPopup(props: PopoverPopupProps) {
         onClosing,
         onOpened,
         onOpening,
-        placement = "auto",
         popoverClassName,
         portalClassName,
         portalContainer,

--- a/packages/core/src/components/popover-floating/popoverPopup.tsx
+++ b/packages/core/src/components/popover-floating/popoverPopup.tsx
@@ -72,7 +72,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
     const isReferenceHidden = context.context.middlewareData.hide?.referenceHidden ?? false;
     const hasPopperEscaped = context.context.middlewareData.hide?.escaped ?? false;
 
-    const transformOrigin = getTransformOrigin(placement, isArrowEnabled ? undefined : undefined);
+    const transformOrigin = getTransformOrigin(context.placement, isArrowEnabled ? undefined : undefined);
 
     const popoverHandlers: HTMLDivProps = {
         // always check popover clicks for dismiss class
@@ -145,7 +145,10 @@ export function PopoverPopup(props: PopoverPopupProps) {
             >
                 <div className={popoverClasses} style={{ transformOrigin }}>
                     {isArrowEnabled && (
-                        <PopoverArrow arrowProps={{ ref: context.arrowRef, style: arrowStyle }} placement={placement} />
+                        <PopoverArrow
+                            arrowProps={{ ref: context.arrowRef, style: arrowStyle }}
+                            placement={context.placement}
+                        />
                     )}
                     <div className={Classes.POPOVER_CONTENT}>{content}</div>
                 </div>

--- a/packages/core/src/components/popover-floating/popoverPopup.tsx
+++ b/packages/core/src/components/popover-floating/popoverPopup.tsx
@@ -129,8 +129,6 @@ export function PopoverPopup(props: PopoverPopupProps) {
             onOpening={onOpening}
             portalClassName={portalClassName}
             portalContainer={portalContainer}
-            // eslint-disable-next-line @typescript-eslint/no-deprecated
-            portalStopPropagationEvents={props.portalStopPropagationEvents}
             shouldReturnFocusOnClose={shouldReturnFocusOnClose}
             transitionDuration={transitionDuration}
             transitionName={Classes.POPOVER}

--- a/packages/core/src/components/popover-floating/popoverTarget.tsx
+++ b/packages/core/src/components/popover-floating/popoverTarget.tsx
@@ -64,9 +64,8 @@ export const PopoverTarget = React.forwardRef<HTMLElement, PopoverTargetProps>((
               onMouseLeave: handleMouseLeave,
           }
         : {
-              // CLICK needs only one handler
-              onClick: handleTargetClick,
-              // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
+              // For CLICK interactions, let Floating UI handle the click via context.getReferenceProps()
+              // Only keep keyboard accessibility handler
               onKeyDown: handleKeyDown,
           };
     // Ensure target is focusable if relevant prop enabled
@@ -100,9 +99,13 @@ export const PopoverTarget = React.forwardRef<HTMLElement, PopoverTargetProps>((
     let target: React.JSX.Element | undefined;
 
     if (renderTarget !== undefined) {
+        const floatingProps = context.getReferenceProps();
+
         target = renderTarget({
             ...ownTargetProps,
             ...childTargetProps,
+            // Apply Floating UI's interaction props for renderTarget case
+            ...floatingProps,
             className: classNames(ownTargetProps.className, targetModifierClasses),
             // if the consumer renders a tooltip target, it's their responsibility to disable that tooltip
             // when *this* popover is open
@@ -116,20 +119,19 @@ export const PopoverTarget = React.forwardRef<HTMLElement, PopoverTargetProps>((
             return null;
         }
 
-        const clonedTarget = React.cloneElement(
-            childTarget,
-            context.getReferenceProps({
-                ...childTargetProps,
-                className: classNames(childTarget.props.className, targetModifierClasses),
-                disabled: isOpen && isTooltipElement(childTarget) ? true : childTarget.props.disabled,
-                tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
-            }),
-        );
+        const clonedTarget = React.cloneElement(childTarget, {
+            ...childTargetProps,
+            className: classNames(childTarget.props.className, targetModifierClasses),
+            disabled: isOpen && isTooltipElement(childTarget) ? true : childTarget.props.disabled,
+            tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
+        });
         const wrappedTarget = React.createElement(
             tagName,
             {
                 ...ownTargetProps,
                 ...targetProps,
+                // Apply Floating UI's interaction props to the wrapper element (same element that has the ref)
+                ...context.getReferenceProps(),
             },
             clonedTarget,
         );

--- a/packages/core/src/components/popover-floating/popoverTarget.tsx
+++ b/packages/core/src/components/popover-floating/popoverTarget.tsx
@@ -6,12 +6,10 @@ import classNames from "classnames";
 import React from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Utils } from "../../common";
-import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
+import { PopoverInteractionKind, type PopoverProps } from "../popover/popoverProps";
 import type { PopoverClickTargetHandlers, PopoverHoverTargetHandlers } from "../popover/popoverSharedProps";
-import { Tooltip } from "../tooltip/tooltip";
 
 import { type usePopover } from "./usePopover";
-
 interface PopoverTargetProps extends PopoverProps {
     context: ReturnType<typeof usePopover>;
     handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
@@ -123,7 +121,7 @@ export const PopoverTarget = React.forwardRef<HTMLElement, PopoverTargetProps>((
             context.getReferenceProps({
                 ...childTargetProps,
                 className: classNames(childTarget.props.className, targetModifierClasses),
-                disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip) ? true : childTarget.props.disabled,
+                disabled: isOpen && isTooltipElement(childTarget) ? true : childTarget.props.disabled,
                 tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
             }),
         );
@@ -142,3 +140,17 @@ export const PopoverTarget = React.forwardRef<HTMLElement, PopoverTargetProps>((
 });
 
 PopoverTarget.displayName = `${DISPLAYNAME_PREFIX}.PopoverTarget`;
+
+/**
+ * Check if a React element is a Tooltip component by comparing its displayName.
+ * This avoids importing the Tooltip component directly, which would create a dependency cycle.
+ */
+function isTooltipElement(element: React.ReactElement): boolean {
+    return (
+        element?.type != null &&
+        typeof element.type !== "string" &&
+        typeof element.type === "function" &&
+        "displayName" in element.type &&
+        element.type.displayName === `${DISPLAYNAME_PREFIX}.Tooltip`
+    );
+}

--- a/packages/core/src/components/popover-floating/popoverTarget.tsx
+++ b/packages/core/src/components/popover-floating/popoverTarget.tsx
@@ -1,0 +1,144 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import classNames from "classnames";
+import React from "react";
+
+import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Utils } from "../../common";
+import { PopoverInteractionKind, type PopoverProps } from "../popover/popover";
+import type { PopoverClickTargetHandlers, PopoverHoverTargetHandlers } from "../popover/popoverSharedProps";
+import { Tooltip } from "../tooltip/tooltip";
+
+import { type usePopover } from "./usePopover";
+
+interface PopoverTargetProps extends PopoverProps {
+    context: ReturnType<typeof usePopover>;
+    handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+    handleMouseEnter: (event: React.MouseEvent<HTMLElement>) => void;
+    handleMouseLeave: (event: React.MouseEvent<HTMLElement>) => void;
+    handleTargetBlur: (event: React.FocusEvent<HTMLElement>) => void;
+    handleTargetClick: (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
+    handleTargetContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
+    handleTargetFocus: (event: React.FocusEvent<HTMLElement>) => void;
+    isContentEmpty: boolean;
+    isControlled: boolean;
+    isHoverInteractionKind: boolean;
+}
+
+export const PopoverTarget = React.forwardRef<HTMLElement, PopoverTargetProps>((props, targetRef) => {
+    const {
+        children,
+        className,
+        context,
+        disabled = false,
+        fill = false,
+        handleKeyDown,
+        handleMouseEnter,
+        handleMouseLeave,
+        handleTargetBlur,
+        handleTargetClick,
+        handleTargetContextMenu,
+        handleTargetFocus,
+        interactionKind = PopoverInteractionKind.CLICK,
+        isContentEmpty,
+        isControlled,
+        isHoverInteractionKind,
+        openOnTargetFocus = true,
+        popupKind,
+        renderTarget = undefined,
+        targetProps,
+        targetTagName = "span",
+    } = props;
+
+    const tagName = fill ? "div" : targetTagName;
+    const { isOpen } = context;
+
+    const ref = mergeRefs(context.refs.setReference, targetRef);
+
+    const targetEventHandlers: PopoverHoverTargetHandlers | PopoverClickTargetHandlers = isHoverInteractionKind
+        ? {
+              // HOVER handlers
+              onBlur: handleTargetBlur,
+              onContextMenu: handleTargetContextMenu,
+              onFocus: handleTargetFocus,
+              onMouseEnter: handleMouseEnter,
+              onMouseLeave: handleMouseLeave,
+          }
+        : {
+              // CLICK needs only one handler
+              onClick: handleTargetClick,
+              // For keyboard accessibility, trigger the same behavior as a click event upon pressing ENTER/SPACE
+              onKeyDown: handleKeyDown,
+          };
+    // Ensure target is focusable if relevant prop enabled
+    const targetTabIndex = !isContentEmpty && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
+
+    const ownTargetProps = {
+        // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
+        // If, instead, renderTarget is undefined and the target is provided as a child, props.className is
+        // applied to the generated target wrapper element.
+        className: classNames(className, Classes.POPOVER_TARGET, {
+            [Classes.POPOVER_OPEN]: isOpen,
+            // this class is mainly useful for button targets
+            [Classes.ACTIVE]: isOpen && !isControlled && !isHoverInteractionKind,
+        }),
+        ref,
+        ...targetEventHandlers,
+    } satisfies React.HTMLProps<HTMLElement>;
+    const childTargetProps = {
+        "aria-expanded": isHoverInteractionKind ? undefined : isOpen,
+        "aria-haspopup": interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY ? undefined : popupKind ?? "menu",
+    } satisfies React.HTMLProps<HTMLElement>;
+
+    const targetModifierClasses = {
+        // this class is mainly useful for Blueprint <Button> targets; we should only apply it for
+        // uncontrolled popovers when they are opened by a user interaction
+        [Classes.ACTIVE]: isOpen && !isControlled && !isHoverInteractionKind,
+        // similarly, this class is mainly useful for targets like <Button>, <InputGroup>, etc.
+        [Classes.FILL]: fill,
+    };
+
+    let target: React.JSX.Element | undefined;
+
+    if (renderTarget !== undefined) {
+        target = renderTarget({
+            ...ownTargetProps,
+            ...childTargetProps,
+            className: classNames(ownTargetProps.className, targetModifierClasses),
+            // if the consumer renders a tooltip target, it's their responsibility to disable that tooltip
+            // when *this* popover is open
+            isOpen,
+            tabIndex: targetTabIndex,
+        });
+    } else {
+        const childTarget = Utils.ensureElement(React.Children.toArray(children)[0]);
+
+        if (childTarget === undefined) {
+            return null;
+        }
+
+        const clonedTarget = React.cloneElement(
+            childTarget,
+            context.getReferenceProps({
+                ...childTargetProps,
+                className: classNames(childTarget.props.className, targetModifierClasses),
+                disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip) ? true : childTarget.props.disabled,
+                tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
+            }),
+        );
+        const wrappedTarget = React.createElement(
+            tagName,
+            {
+                ...ownTargetProps,
+                ...targetProps,
+            },
+            clonedTarget,
+        );
+        target = wrappedTarget;
+    }
+
+    return target;
+});
+
+PopoverTarget.displayName = `${DISPLAYNAME_PREFIX}.PopoverTarget`;

--- a/packages/core/src/components/popover-floating/popperMigrationUtils.ts
+++ b/packages/core/src/components/popover-floating/popperMigrationUtils.ts
@@ -1,0 +1,173 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { ArrowOptions, Boundary, FlipOptions, OffsetOptions, Placement, ShiftOptions } from "@floating-ui/react";
+import type { Boundary as PopperBoundary, Placement as PopperPlacement } from "@popperjs/core";
+
+import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
+
+export function isFloatingPlacement(placement: PopperPlacement | Placement): placement is Placement {
+    return !placement.startsWith("auto");
+}
+
+export function convertPopperPlacementToFloatingPlacement(placement: PopperPlacement): Placement | undefined {
+    if (isFloatingPlacement(placement)) {
+        return placement;
+    }
+    return undefined;
+}
+
+/**
+ * Converts a Popper boundary value to a Floating UI boundary value.
+ *
+ * @see https://popper.js.org/docs/v2/utils/detect-overflow/#boundary
+ * @see https://floating-ui.com/docs/detectoverflow#boundary
+ *
+ * @param boundary - The Popper boundary value to convert.
+ * @returns The Floating UI boundary value.
+ */
+export function convertPopperBoundaryToFloatingBoundary(boundary: PopperBoundary | undefined): Boundary | undefined {
+    if (boundary === "clippingParents") {
+        return "clippingAncestors";
+    }
+    return boundary;
+}
+
+export function convertFallbackPlacementsToFloatingFallbackPlacements(
+    fallbackPlacements: PopperPlacement[] | undefined,
+): Placement[] | undefined {
+    if (fallbackPlacements === undefined) {
+        return undefined;
+    }
+    return fallbackPlacements.filter(isFloatingPlacement);
+}
+
+/**
+ * Converts a Popper offset modifier to a Floating UI offset option.
+ *
+ * @see https://popper.js.org/docs/v2/modifiers/offset
+ * @see https://floating-ui.com/docs/offset
+ *
+ * @param offset - The Popper offset modifier to convert.
+ * @returns The Floating UI offset option.
+ */
+export function convertPopperOffsetToFloatingOffset(offset: PopperModifierOverrides["offset"]): OffsetOptions {
+    const offsetValue = offset?.options?.offset;
+
+    // Handle array offset format: [skidding, distance]
+    if (Array.isArray(offsetValue)) {
+        const skidding = offsetValue[0] ?? 0;
+        const distance = offsetValue[1] ?? 0;
+        return {
+            crossAxis: skidding,
+            mainAxis: distance,
+        };
+    }
+
+    // Handle function offset format - for migration purposes, use default values
+    // since we can't execute the function without Popper state
+    if (typeof offsetValue === "function") {
+        console.warn("Function offset format is not supported in Floating UI. Using default values.");
+        return {
+            crossAxis: 0,
+            mainAxis: 0,
+        };
+    }
+
+    // Default case - no offset specified
+    return {
+        crossAxis: 0,
+        mainAxis: 0,
+    };
+}
+
+/**
+ * Converts a Popper flip modifier to a Floating UI flip option.
+ *
+ * @see https://popper.js.org/docs/v2/modifiers/flip/
+ * @see https://floating-ui.com/docs/flip
+ *
+ * @param flip - The Popper flip modifier to convert.
+ * @returns The Floating UI flip option.
+ */
+export function convertPopperFlipToFloatingFlip(flip: PopperModifierOverrides["flip"]): FlipOptions {
+    const options = flip?.options;
+
+    // Convert fallbackPlacements, filtering out auto placements which Floating UI doesn't support
+    const fallbackPlacements = convertFallbackPlacementsToFloatingFallbackPlacements(options?.fallbackPlacements);
+
+    // Map Popper's flipVariations to Floating UI's flipAlignment
+    const flipAlignment = options?.flipVariations ?? true;
+
+    // Extract detectOverflow options that are compatible
+    const padding = options?.padding;
+    const boundary = convertPopperBoundaryToFloatingBoundary(options?.boundary);
+    const rootBoundary = options?.rootBoundary;
+    const altBoundary = options?.altBoundary;
+
+    // Handle allowedAutoPlacements - log warning since this concept doesn't exist in Floating UI
+    if (options?.allowedAutoPlacements) {
+        console.warn("allowedAutoPlacements is not supported in Floating UI. Skipping.");
+    }
+
+    return {
+        altBoundary,
+        boundary,
+        fallbackPlacements,
+        flipAlignment,
+        padding,
+        rootBoundary,
+    };
+}
+
+/**
+ * Converts a Popper preventOverflow modifier to a Floating UI shift option.
+ *
+ * @see https://popper.js.org/docs/v2/modifiers/prevent-overflow/
+ * @see https://floating-ui.com/docs/shift
+ *
+ * @param preventOverflow - The Popper preventOverflow modifier to convert.
+ * @returns The Floating UI shift option.
+ */
+export function convertPopperPreventOverflowToFloatingShift(
+    preventOverflow: PopperModifierOverrides["preventOverflow"],
+): ShiftOptions {
+    const options = preventOverflow?.options;
+    return {
+        altBoundary: options?.altBoundary,
+        boundary: convertPopperBoundaryToFloatingBoundary(options?.boundary),
+        padding: options?.padding,
+        rootBoundary: options?.rootBoundary,
+    };
+}
+
+/**
+ * Converts a Popper arrow modifier to a Floating UI arrow option.
+ *
+ * @see https://popper.js.org/docs/v2/modifiers/arrow/
+ * @see https://floating-ui.com/docs/arrow
+ *
+ * @param arrow - The Popper arrow modifier to convert.
+ * @param element - The arrow element to use (required since Floating UI needs actual element).
+ * @returns The Floating UI arrow option.
+ */
+export function convertPopperArrowToFloatingArrow(
+    arrow: PopperModifierOverrides["arrow"],
+    element: ArrowOptions["element"],
+): ArrowOptions {
+    const options = arrow?.options;
+
+    // Handle element option differences
+    if (typeof options?.element === "string") {
+        console.warn(`Popper arrow element selector "${options.element}" cannot be auto-converted. Skipping.`);
+    }
+
+    // Handle padding function - Floating UI doesn't support padding functions
+    if (typeof options?.padding === "function") {
+        console.warn("Popper arrow padding function is not supported in Floating UI. Using default padding instead.");
+        return { element, padding: 0 };
+    }
+
+    return { element, padding: options?.padding };
+}

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -39,6 +39,7 @@ interface PopoverOptions {
     placement?: Placement;
     matchTargetWidth?: boolean;
     rootBoundary?: RootBoundary;
+    onOpenChange?: (isOpen: boolean, event?: Event) => void;
 }
 
 function getIsFloatingPlacement(placement: Placement): placement is FloatingPlacement {
@@ -53,6 +54,7 @@ export function usePopover({
     placement = "auto",
     matchTargetWidth = false,
     rootBoundary,
+    onOpenChange,
 }: PopoverOptions = {}) {
     const arrowRef = React.useRef(null);
     const [isOpenState, setIsOpenState] = React.useState(isOpen);
@@ -60,6 +62,19 @@ export function usePopover({
     React.useEffect(() => {
         setIsOpenState(isOpen);
     }, [isOpen]);
+
+    const handleOpenChange = React.useCallback(
+        (nextOpen: boolean, event?: Event) => {
+            // Always update internal state for proper synchronization
+            setIsOpenState(nextOpen);
+
+            // Also call the external callback if provided (for controlled components)
+            if (onOpenChange) {
+                onOpenChange(nextOpen, event);
+            }
+        },
+        [onOpenChange],
+    );
 
     const isArrowEnabled = !minimal && modifiers?.arrow?.enabled !== false;
     const isFloatingPlacement = getIsFloatingPlacement(placement);
@@ -117,7 +132,7 @@ export function usePopover({
                   })
                 : undefined,
         ],
-        onOpenChange: setIsOpenState,
+        onOpenChange: handleOpenChange,
         open: isOpenState,
         placement: isFloatingPlacement ? placement : undefined,
         whileElementsMounted: autoUpdate,

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -105,7 +105,7 @@ export function usePopover({
                 ? size({
                       apply({ rects, elements }) {
                           Object.assign(elements.floating.style, {
-                              minWidth: `${rects.reference.width}px`,
+                              width: `${rects.reference.width}px`,
                           });
                       },
                   })

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -33,6 +33,7 @@ import {
 
 interface PopoverOptions {
     boundary?: Boundary;
+    canEscapeKeyClose?: boolean;
     isOpen?: boolean;
     minimal?: boolean;
     modifiers?: PopperModifierOverrides;
@@ -48,6 +49,7 @@ function getIsFloatingPlacement(placement: Placement): placement is FloatingPlac
 
 export function usePopover({
     boundary,
+    canEscapeKeyClose,
     isOpen = false,
     minimal,
     modifiers,
@@ -141,7 +143,9 @@ export function usePopover({
     const { context } = data;
 
     const click = useClick(context);
-    const dismiss = useDismiss(context);
+    const dismiss = useDismiss(context, {
+        escapeKey: canEscapeKeyClose,
+    });
     const role = useRole(context);
 
     const interactions = useInteractions([click, dismiss, role]);

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -1,0 +1,59 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import {
+    arrow,
+    autoUpdate,
+    offset,
+    type Placement,
+    useClick,
+    useDismiss,
+    useFloating,
+    useInteractions,
+    useRole,
+} from "@floating-ui/react";
+import React from "react";
+
+import { POPOVER_ARROW_SVG_SIZE } from "../popover/popoverArrow";
+
+interface PopoverOptions {
+    placement?: Placement;
+}
+
+export function usePopover({ placement = "top" }: PopoverOptions = {}) {
+    const arrowRef = React.useRef(null);
+    const [isOpen, setIsOpen] = React.useState(false);
+
+    const data = useFloating({
+        middleware: [
+            offset(POPOVER_ARROW_SVG_SIZE / 2),
+            arrow({
+                element: arrowRef,
+            }),
+        ],
+        onOpenChange: setIsOpen,
+        open: isOpen,
+        placement,
+        whileElementsMounted: autoUpdate,
+    });
+
+    const { context } = data;
+
+    const click = useClick(context);
+    const dismiss = useDismiss(context);
+    const role = useRole(context);
+
+    const interactions = useInteractions([click, dismiss, role]);
+
+    return React.useMemo(
+        () => ({
+            arrowRef,
+            isOpen,
+            setIsOpen,
+            ...interactions,
+            ...data,
+        }),
+        [data, interactions, isOpen],
+    );
+}

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -5,36 +5,113 @@
 import {
     arrow,
     autoUpdate,
+    flip,
+    type Placement as FloatingPlacement,
     offset,
-    type Placement,
+    shift,
+    size,
     useClick,
     useDismiss,
     useFloating,
     useInteractions,
     useRole,
 } from "@floating-ui/react";
+import type { Boundary, RootBoundary } from "@popperjs/core";
 import React from "react";
+import type { Modifier } from "react-popper";
 
 import { POPOVER_ARROW_SVG_SIZE } from "../popover/popoverArrow";
+import type { Placement, PopperModifierOverrides } from "../popover/popoverSharedProps";
+
+import {
+    convertPopperArrowToFloatingArrow,
+    convertPopperFlipToFloatingFlip,
+    convertPopperOffsetToFloatingOffset,
+    convertPopperPreventOverflowToFloatingShift,
+} from "./popperMigrationUtils";
 
 interface PopoverOptions {
+    boundary?: Boundary;
+    minimal?: boolean;
+    modifiers?: PopperModifierOverrides;
     placement?: Placement;
+    matchTargetWidth?: boolean;
+    rootBoundary?: RootBoundary;
 }
 
-export function usePopover({ placement = "top" }: PopoverOptions = {}) {
+function getIsFloatingPlacement(placement: Placement): placement is FloatingPlacement {
+    return placement !== "auto" && placement !== "auto-start" && placement !== "auto-end";
+}
+
+export function usePopover({
+    boundary,
+    minimal,
+    modifiers,
+    placement = "auto",
+    matchTargetWidth = false,
+    rootBoundary,
+}: PopoverOptions = {}) {
     const arrowRef = React.useRef(null);
     const [isOpen, setIsOpen] = React.useState(false);
 
+    const isArrowEnabled = !minimal && modifiers?.arrow?.enabled !== false;
+    const isFloatingPlacement = getIsFloatingPlacement(placement);
+
+    const offsetModifier: Modifier<"offset"> = {
+        enabled: isArrowEnabled,
+        name: "offset",
+        ...modifiers?.offset,
+        options: {
+            offset: [0, POPOVER_ARROW_SVG_SIZE / 2],
+            ...modifiers?.offset?.options,
+        },
+    };
+
+    const flipModifier: Modifier<"flip"> = {
+        name: "flip",
+        ...modifiers?.flip,
+        options: {
+            boundary,
+            rootBoundary,
+            ...modifiers?.flip?.options,
+        },
+    };
+
+    const preventOverflowModifier: Modifier<"preventOverflow"> = {
+        name: "preventOverflow",
+        ...modifiers?.preventOverflow,
+        options: {
+            boundary,
+            rootBoundary,
+            ...modifiers?.preventOverflow?.options,
+        },
+    };
+
+    const arrowModifier: Modifier<"arrow"> = {
+        enabled: isArrowEnabled,
+        name: "arrow",
+        ...modifiers?.arrow,
+    };
+
     const data = useFloating({
         middleware: [
-            offset(POPOVER_ARROW_SVG_SIZE / 2),
-            arrow({
-                element: arrowRef,
-            }),
+            isArrowEnabled ? offset(convertPopperOffsetToFloatingOffset(offsetModifier)) : undefined,
+            flip(convertPopperFlipToFloatingFlip(flipModifier)),
+            shift(convertPopperPreventOverflowToFloatingShift(preventOverflowModifier)),
+            isArrowEnabled ? arrow(convertPopperArrowToFloatingArrow(arrowModifier, arrowRef)) : undefined,
+            matchTargetWidth
+                ? size({
+                      apply({ rects, elements }) {
+                          Object.assign(elements.floating.style, {
+                              minWidth: `${rects.reference.width}px`,
+                          });
+                      },
+                  })
+                : undefined,
         ],
         onOpenChange: setIsOpen,
         open: isOpen,
-        placement,
+        placement: isFloatingPlacement ? placement : undefined,
         whileElementsMounted: autoUpdate,
     });
 

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -4,6 +4,7 @@
 
 import {
     arrow,
+    autoPlacement,
     autoUpdate,
     flip,
     type Placement as FloatingPlacement,
@@ -56,6 +57,7 @@ export function usePopover({
 
     const isArrowEnabled = !minimal && modifiers?.arrow?.enabled !== false;
     const isFloatingPlacement = getIsFloatingPlacement(placement);
+    const isAutoPlacement = placement === "auto" || placement === "auto-start" || placement === "auto-end";
 
     const offsetModifier: Modifier<"offset"> = {
         enabled: isArrowEnabled,
@@ -96,7 +98,7 @@ export function usePopover({
     const data = useFloating({
         middleware: [
             isArrowEnabled ? offset(convertPopperOffsetToFloatingOffset(offsetModifier)) : undefined,
-            flip(convertPopperFlipToFloatingFlip(flipModifier)),
+            isAutoPlacement ? autoPlacement() : flip(convertPopperFlipToFloatingFlip(flipModifier)),
             shift(convertPopperPreventOverflowToFloatingShift(preventOverflowModifier)),
             isArrowEnabled ? arrow(convertPopperArrowToFloatingArrow(arrowModifier, arrowRef)) : undefined,
             matchTargetWidth

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -33,6 +33,7 @@ import {
 
 interface PopoverOptions {
     boundary?: Boundary;
+    isOpen?: boolean;
     minimal?: boolean;
     modifiers?: PopperModifierOverrides;
     placement?: Placement;
@@ -46,6 +47,7 @@ function getIsFloatingPlacement(placement: Placement): placement is FloatingPlac
 
 export function usePopover({
     boundary,
+    isOpen = false,
     minimal,
     modifiers,
     placement = "auto",
@@ -53,7 +55,11 @@ export function usePopover({
     rootBoundary,
 }: PopoverOptions = {}) {
     const arrowRef = React.useRef(null);
-    const [isOpen, setIsOpen] = React.useState(false);
+    const [isOpenState, setIsOpenState] = React.useState(isOpen);
+
+    React.useEffect(() => {
+        setIsOpenState(isOpen);
+    }, [isOpen]);
 
     const isArrowEnabled = !minimal && modifiers?.arrow?.enabled !== false;
     const isFloatingPlacement = getIsFloatingPlacement(placement);
@@ -111,8 +117,8 @@ export function usePopover({
                   })
                 : undefined,
         ],
-        onOpenChange: setIsOpen,
-        open: isOpen,
+        onOpenChange: setIsOpenState,
+        open: isOpenState,
         placement: isFloatingPlacement ? placement : undefined,
         whileElementsMounted: autoUpdate,
     });
@@ -128,11 +134,11 @@ export function usePopover({
     return React.useMemo(
         () => ({
             arrowRef,
-            isOpen,
-            setIsOpen,
+            isOpen: isOpenState,
+            setIsOpen: setIsOpenState,
             ...interactions,
             ...data,
         }),
-        [data, interactions, isOpen],
+        [data, interactions, isOpenState],
     );
 }

--- a/packages/core/src/components/popover-floating/usePopover.ts
+++ b/packages/core/src/components/popover-floating/usePopover.ts
@@ -22,6 +22,7 @@ import React from "react";
 import type { Modifier } from "react-popper";
 
 import { POPOVER_ARROW_SVG_SIZE } from "../popover/popoverArrow";
+import { PopoverInteractionKind } from "../popover/popoverProps";
 import type { Placement, PopperModifierOverrides } from "../popover/popoverSharedProps";
 
 import {
@@ -34,6 +35,7 @@ import {
 interface PopoverOptions {
     boundary?: Boundary;
     canEscapeKeyClose?: boolean;
+    interactionKind?: PopoverInteractionKind;
     isOpen?: boolean;
     minimal?: boolean;
     modifiers?: PopperModifierOverrides;
@@ -50,6 +52,7 @@ function getIsFloatingPlacement(placement: Placement): placement is FloatingPlac
 export function usePopover({
     boundary,
     canEscapeKeyClose,
+    interactionKind,
     isOpen = false,
     minimal,
     modifiers,
@@ -145,6 +148,7 @@ export function usePopover({
     const click = useClick(context);
     const dismiss = useDismiss(context, {
         escapeKey: canEscapeKeyClose,
+        outsidePress: interactionKind !== PopoverInteractionKind.CLICK_TARGET_ONLY,
     });
     const role = useRole(context);
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -38,7 +38,6 @@ import {
 import * as Errors from "../../common/errors";
 import { Overlay2 } from "../overlay2/overlay2";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
-// eslint-disable-next-line import/no-cycle
 import { Tooltip } from "../tooltip/tooltip";
 
 import { matchReferenceWidthModifier } from "./customModifiers";
@@ -512,14 +511,14 @@ export class Popover<
                 onClosing={this.props.onClosing}
                 onOpened={this.props.onOpened}
                 onOpening={this.props.onOpening}
-                transitionDuration={this.props.transitionDuration}
-                transitionName={Classes.POPOVER}
-                usePortal={usePortal}
                 portalClassName={this.props.portalClassName}
                 portalContainer={this.props.portalContainer}
                 // eslint-disable-next-line @typescript-eslint/no-deprecated
                 portalStopPropagationEvents={this.props.portalStopPropagationEvents}
                 shouldReturnFocusOnClose={shouldReturnFocusOnClose}
+                transitionDuration={this.props.transitionDuration}
+                transitionName={Classes.POPOVER}
+                usePortal={usePortal}
             >
                 <div
                     className={Classes.POPOVER_TRANSITION_CONTAINER}

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { State as PopperState, PositioningStrategy } from "@popperjs/core";
+import type { State as PopperState } from "@popperjs/core";
 import classNames from "classnames";
 import * as React from "react";
 import {
@@ -43,86 +43,13 @@ import { Tooltip } from "../tooltip/tooltip";
 import { matchReferenceWidthModifier } from "./customModifiers";
 import { POPOVER_ARROW_SVG_SIZE, PopoverArrow } from "./popoverArrow";
 import { positionToPlacement } from "./popoverPlacementUtils";
+import { PopoverInteractionKind, type PopoverProps } from "./popoverProps";
 import type {
     DefaultPopoverTargetHTMLProps,
     PopoverClickTargetHandlers,
     PopoverHoverTargetHandlers,
-    PopoverSharedProps,
 } from "./popoverSharedProps";
 import { getBasePlacement, getTransformOrigin } from "./popperUtils";
-import type { PopupKind } from "./popupKind";
-
-export const PopoverInteractionKind = {
-    CLICK: "click" as const,
-    CLICK_TARGET_ONLY: "click-target" as const,
-    HOVER: "hover" as const,
-    HOVER_TARGET_ONLY: "hover-target" as const,
-};
-export type PopoverInteractionKind = (typeof PopoverInteractionKind)[keyof typeof PopoverInteractionKind];
-
-export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
-    extends PopoverSharedProps<TProps> {
-    /**
-     * Whether the popover/tooltip should acquire application focus when it first opens.
-     *
-     * @default true for click interactions, false for hover interactions
-     */
-    autoFocus?: boolean;
-
-    /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
-    backdropProps?: React.HTMLProps<HTMLDivElement>;
-
-    /**
-     * The kind of interaction that triggers the display of the popover.
-     *
-     * @default "click"
-     */
-    interactionKind?: PopoverInteractionKind;
-
-    /**
-     * The kind of popup displayed by the popover. Gets directly applied to the
-     * `aria-haspopup` attribute of the target element. This property is
-     * ignored if `interactionKind` is {@link PopoverInteractionKind.HOVER_TARGET_ONLY}.
-     *
-     * @default "menu" or undefined
-     */
-    popupKind?: PopupKind;
-
-    /**
-     * Enables an invisible overlay beneath the popover that captures clicks and
-     * prevents interaction with the rest of the document until the popover is
-     * closed. This prop is only available when `interactionKind` is
-     * `PopoverInteractionKind.CLICK`. When popovers with backdrop are opened,
-     * they become focused.
-     *
-     * @default false
-     */
-    hasBackdrop?: boolean;
-
-    /**
-     * Whether the application should return focus to the last active element in the
-     * document after this popover closes.
-     *
-     * This is automatically set (overridden) to:
-     *  - `false` for hover interaction popovers
-     *  - `true` when a popover closes due to an ESC keypress
-     *
-     * If you are attaching a popover _and_ a tooltip to the same target, you must take
-     * care to either disable this prop for the popover _or_ disable the tooltip's
-     * `openOnTargetFocus` prop.
-     *
-     * @default false
-     */
-    shouldReturnFocusOnClose?: boolean;
-
-    /**
-     * Popper.js positioning strategy.
-     *
-     * @see https://popper.js.org/docs/v2/constructors/#strategy
-     * @default "absolute"
-     */
-    positioningStrategy?: PositioningStrategy;
-}
 
 export interface PopoverState {
     hasDarkParent: boolean;

--- a/packages/core/src/components/popover/popoverProps.ts
+++ b/packages/core/src/components/popover/popoverProps.ts
@@ -1,0 +1,82 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { PositioningStrategy } from "@popperjs/core";
+import type * as React from "react";
+
+import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "./popoverSharedProps";
+import type { PopupKind } from "./popupKind";
+
+export const PopoverInteractionKind = {
+    CLICK: "click" as const,
+    CLICK_TARGET_ONLY: "click-target" as const,
+    HOVER: "hover" as const,
+    HOVER_TARGET_ONLY: "hover-target" as const,
+};
+
+export type PopoverInteractionKind = (typeof PopoverInteractionKind)[keyof typeof PopoverInteractionKind];
+
+export interface PopoverProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
+    extends PopoverSharedProps<TProps> {
+    /**
+     * Whether the popover/tooltip should acquire application focus when it first opens.
+     *
+     * @default true for click interactions, false for hover interactions
+     */
+    autoFocus?: boolean;
+
+    /** HTML props for the backdrop element. Can be combined with `backdropClassName`. */
+    backdropProps?: React.HTMLProps<HTMLDivElement>;
+
+    /**
+     * The kind of interaction that triggers the display of the popover.
+     *
+     * @default "click"
+     */
+    interactionKind?: PopoverInteractionKind;
+
+    /**
+     * The kind of popup displayed by the popover. Gets directly applied to the
+     * `aria-haspopup` attribute of the target element. This property is
+     * ignored if `interactionKind` is {@link PopoverInteractionKind.HOVER_TARGET_ONLY}.
+     *
+     * @default "menu" or undefined
+     */
+    popupKind?: PopupKind;
+
+    /**
+     * Enables an invisible overlay beneath the popover that captures clicks and
+     * prevents interaction with the rest of the document until the popover is
+     * closed. This prop is only available when `interactionKind` is
+     * `PopoverInteractionKind.CLICK`. When popovers with backdrop are opened,
+     * they become focused.
+     *
+     * @default false
+     */
+    hasBackdrop?: boolean;
+
+    /**
+     * Whether the application should return focus to the last active element in the
+     * document after this popover closes.
+     *
+     * This is automatically set (overridden) to:
+     *  - `false` for hover interaction popovers
+     *  - `true` when a popover closes due to an ESC keypress
+     *
+     * If you are attaching a popover _and_ a tooltip to the same target, you must take
+     * care to either disable this prop for the popover _or_ disable the tooltip's
+     * `openOnTargetFocus` prop.
+     *
+     * @default false
+     */
+    shouldReturnFocusOnClose?: boolean;
+
+    /**
+     * Popper.js positioning strategy.
+     *
+     * @see https://popper.js.org/docs/v2/constructors/#strategy
+     * @default "absolute"
+     */
+    positioningStrategy?: PositioningStrategy;
+}

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -82,7 +82,7 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -99,6 +99,7 @@ export class Tooltip<
 
     public static defaultProps: Partial<TooltipProps> = {
         compact: false,
+        floating: true,
         hoverCloseDelay: 0,
         hoverOpenDelay: 100,
         interactionKind: "hover-target",

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,11 +19,11 @@ import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
-import { type Popover, type PopoverInteractionKind } from "../popover/popover";
+import { type PopoverInteractionKind } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
-import { PopoverFloating } from "../popover-floating/popoverFloating";
+import { PopoverFloating, type PopoverFloatingRef } from "../popover-floating/popoverFloating";
 
 export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
     extends Omit<PopoverSharedProps<TProps>, "shouldReturnFocusOnClose">,
@@ -98,7 +98,7 @@ export class Tooltip<
         transitionDuration: 100,
     };
 
-    private popoverRef = React.createRef<Popover<T>>();
+    private popoverRef = React.createRef<PopoverFloatingRef>();
 
     public render() {
         // if we have an ancestor TooltipContext, we should take its state into account in this render path,

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,6 +19,7 @@ import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
+import { Popover } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
@@ -77,6 +78,13 @@ export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = Def
      * @default 100
      */
     transitionDuration?: number;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 /**
@@ -121,8 +129,10 @@ export class Tooltip<
             [Classes.COMPACT]: compact,
         });
 
+        const Component = this.props.floating ? PopoverFloating : Popover;
+
         return (
-            <PopoverFloating
+            <Component
                 modifiers={{
                     arrow: {
                         enabled: !this.props.minimal,
@@ -144,7 +154,7 @@ export class Tooltip<
                 ref={this.popoverRef}
             >
                 {children}
-            </PopoverFloating>
+            </Component>
         );
     };
 }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,8 +19,8 @@ import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
-import { type PopoverInteractionKind } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
+import type { PopoverInteractionKind } from "../popover/popoverProps";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
 import { PopoverFloating, type PopoverFloatingRef } from "../popover-floating/popoverFloating";

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,11 +19,11 @@ import * as React from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
-// eslint-disable-next-line import/no-cycle
-import { Popover, type PopoverInteractionKind } from "../popover/popover";
+import { type Popover, type PopoverInteractionKind } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
+import { PopoverFloating } from "../popover-floating/popoverFloating";
 
 export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
     extends Omit<PopoverSharedProps<TProps>, "shouldReturnFocusOnClose">,
@@ -122,7 +122,7 @@ export class Tooltip<
         });
 
         return (
-            <Popover
+            <PopoverFloating
                 modifiers={{
                     arrow: {
                         enabled: !this.props.minimal,
@@ -144,7 +144,7 @@ export class Tooltip<
                 ref={this.popoverRef}
             >
                 {children}
-            </Popover>
+            </PopoverFloating>
         );
     };
 }

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -2,5 +2,6 @@
     "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm",
+        "noUnusedLocals": false,
     },
 }

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -25,13 +25,9 @@ import { dispatchMouseEvent } from "@blueprintjs/test-commons";
 import { Classes } from "../../src/common";
 import * as Errors from "../../src/common/errors";
 import { Button, Overlay2, Portal } from "../../src/components";
-import {
-    Popover,
-    PopoverInteractionKind,
-    type PopoverProps,
-    type PopoverState,
-} from "../../src/components/popover/popover";
+import { Popover, type PopoverState } from "../../src/components/popover/popover";
 import { PopoverArrow } from "../../src/components/popover/popoverArrow";
+import { PopoverInteractionKind, type PopoverProps } from "../../src/components/popover/popoverProps";
 import { PopupKind } from "../../src/components/popover/popupKind";
 import { Tooltip } from "../../src/components/tooltip/tooltip";
 

--- a/packages/datetime/src/common/datetimePopoverProps.ts
+++ b/packages/datetime/src/common/datetimePopoverProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DefaultPopoverTargetHTMLProps, Popover, PopoverProps } from "@blueprintjs/core";
+import type { PopoverFloatingRef, PopoverProps } from "@blueprintjs/core";
 
 /**
  * Reusable collection of props for components in this package which render a popover
@@ -38,5 +38,5 @@ export interface DatetimePopoverProps {
      * Note that this is defined as a specific kind of Popover which should be compatible with
      * most use cases, since it uses the default target props interface.
      */
-    popoverRef?: React.RefObject<Popover<DefaultPopoverTargetHTMLProps>>;
+    popoverRef?: React.RefObject<PopoverFloatingRef>;
 }

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -55,6 +55,7 @@ const timezoneSelectButtonProps: Partial<ButtonProps> = {
 export const DATEINPUT_DEFAULT_PROPS: DateInputDefaultProps = {
     closeOnSelection: true,
     disabled: false,
+    floating: true,
     invalidDateMessage: "Invalid date",
     locale: "en-US",
     maxDate: DatePickerUtils.getDefaultMaxDate(),

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -23,8 +23,8 @@ import {
     InputGroup,
     Intent,
     mergeRefs,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverFloating,
     type PopoverTargetProps,
     Tag,
     Utils,
@@ -548,7 +548,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
 
     // N.B. no need to set `fill` since that is unused with the `renderTarget` API
     return (
-        <Popover
+        <PopoverFloating
             isOpen={isOpen && !disabled}
             {...popoverProps}
             autoFocus={false}

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -23,6 +23,7 @@ import {
     InputGroup,
     Intent,
     mergeRefs,
+    Popover,
     type PopoverClickTargetHandlers,
     PopoverFloating,
     type PopoverTargetProps,
@@ -77,6 +78,7 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         disabled,
         disableTimezoneSelect,
         fill,
+        floating = false,
         inputProps = {},
         invalidDateMessage,
         locale: localeOrCode,
@@ -546,9 +548,11 @@ export const DateInput: React.FC<DateInputProps> = React.memo(function DateInput
         ],
     );
 
+    const Component = floating ? PopoverFloating : Popover;
+
     // N.B. no need to set `fill` since that is unused with the `renderTarget` API
     return (
-        <PopoverFloating
+        <Component
             isOpen={isOpen && !disabled}
             {...popoverProps}
             autoFocus={false}

--- a/packages/datetime/src/components/date-input/dateInputProps.ts
+++ b/packages/datetime/src/components/date-input/dateInputProps.ts
@@ -170,6 +170,13 @@ export interface DateInputProps
 
     /** An ISO string representing the selected time. */
     value?: string | null;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 export type DateInputDefaultProps = Required<

--- a/packages/datetime/src/components/date-input/dateInputProps.ts
+++ b/packages/datetime/src/components/date-input/dateInputProps.ts
@@ -174,7 +174,7 @@ export interface DateInputProps
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -184,6 +184,7 @@ export type DateInputDefaultProps = Required<
         DateInputProps,
         | "closeOnSelection"
         | "disabled"
+        | "floating"
         | "invalidDateMessage"
         | "locale"
         | "maxDate"

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -24,8 +24,8 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     Intent,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverFloating,
     type PopoverTargetProps,
     refHandler,
     setRef,
@@ -219,7 +219,7 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
-            <Popover
+            <PopoverFloating
                 isOpen={this.state.isOpen}
                 placement="bottom-start"
                 {...popoverProps}

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -24,6 +24,7 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     Intent,
+    Popover,
     type PopoverClickTargetHandlers,
     PopoverFloating,
     type PopoverTargetProps,
@@ -216,10 +217,12 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
             />
         );
 
+        const Component = this.props.floating ? PopoverFloating : Popover;
+
         // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
-            <PopoverFloating
+            <Component
                 isOpen={this.state.isOpen}
                 placement="bottom-start"
                 {...popoverProps}

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -94,6 +94,7 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         dayPickerProps: {},
         disabled: false,
         endInputProps: {},
+        floating: true,
         invalidDateMessage: "Invalid date",
         locale: "en-US",
         maxDate: DatePickerUtils.getDefaultMaxDate(),

--- a/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
+++ b/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
@@ -146,7 +146,7 @@ export interface DateRangeInputProps
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -160,6 +160,7 @@ export type DateRangeInputDefaultProps = Required<
         | "dayPickerProps"
         | "disabled"
         | "endInputProps"
+        | "floating"
         | "invalidDateMessage"
         | "locale"
         | "maxDate"

--- a/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
+++ b/packages/datetime/src/components/date-range-input/dateRangeInputProps.ts
@@ -142,6 +142,13 @@ export interface DateRangeInputProps
      * for the appropriate date in the value prop.
      */
     value?: DateRange;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 export type DateRangeInputDefaultProps = Required<

--- a/packages/demo-app/src/examples/DateInputExample.tsx
+++ b/packages/demo-app/src/examples/DateInputExample.tsx
@@ -1,0 +1,22 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import * as React from "react";
+
+import { DateInput } from "@blueprintjs/datetime";
+
+export const DateInputExample = React.memo(() => {
+    return (
+        <div className="demo-example">
+            <div className="demo-example-content">
+                <DateInput />
+            </div>
+            <div className="demo-example-content">
+                <DateInput floating={true} />
+            </div>
+        </div>
+    );
+});
+
+DateInputExample.displayName = "DemoApp.DateInputExample";

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -15,17 +15,23 @@
 
 import * as React from "react";
 
-import { Button, Classes, H5, Intent, Popover } from "@blueprintjs/core";
+import { Button, Classes, H4, H5, Intent, Popover, PopoverFloating } from "@blueprintjs/core";
 
 export const PopoverExample = React.memo(() => {
     return (
         <div className="popover-example">
-            <Popover content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
-                <Button intent="primary" tabIndex={0} text="Popover target" />
-            </Popover>
-            <Popover content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
-                <Button intent="primary" tabIndex={0} text="Popover target" />
-            </Popover>
+            <div className="popover-example-content">
+                <H4>Popper.js Popover</H4>
+                <Popover content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+                    <Button intent="primary" tabIndex={0} text="Popover target" />
+                </Popover>
+            </div>
+            <div className="popover-example-content">
+                <H4>Floating UI Popover</H4>
+                <PopoverFloating content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+                    <Button intent="primary" tabIndex={0} text="Popover target" />
+                </PopoverFloating>
+            </div>
         </div>
     );
 });

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -15,56 +15,34 @@
 
 import * as React from "react";
 
-import { Button, Classes, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
-
-import { ExampleCard } from "./ExampleCard";
-
-const textEditorMenu = (
-    <Menu>
-        <MenuDivider title="Edit" />
-        <MenuItem icon="cut" text="Cut" label="⌘X" />
-        <MenuItem icon="duplicate" text="Copy" label="⌘C" />
-        <MenuItem icon="clipboard" text="Paste" label="⌘V" />
-        <MenuDivider title="Text" />
-        <MenuItem icon="align-left" text="Alignment">
-            <MenuItem icon="align-left" text="Left" />
-            <MenuItem icon="align-center" text="Center" />
-            <MenuItem icon="align-right" text="Right" />
-            <MenuItem icon="align-justify" text="Justify" />
-        </MenuItem>
-        <MenuItem icon="style" text="Style">
-            <MenuItem icon="bold" text="Bold" />
-            <MenuItem icon="italic" text="Italic" />
-            <MenuItem icon="underline" text="Underline" />
-        </MenuItem>
-    </Menu>
-);
+import { Button, Classes, H5, Intent, Popover } from "@blueprintjs/core";
 
 export const PopoverExample = React.memo(() => {
     return (
-        <div className="example-row">
-            <ExampleCard label="Popover" subLabel="Text content" width={200}>
-                <Popover
-                    content={
-                        <div style={{ minWidth: 100 }}>
-                            <em>This popover is always open.</em>
-                        </div>
-                    }
-                    fill={true}
-                    isOpen={true}
-                    placement="right"
-                    popoverClassName={Classes.POPOVER_CONTENT_SIZING}
-                >
-                    <Button fill={true} text="Always open" endIcon="caret-right" />
-                </Popover>
-            </ExampleCard>
-            <ExampleCard label="Popover" subLabel="Dropdown menu" width={200}>
-                <Popover content={textEditorMenu} fill={true} placement="bottom-start" minimal={true}>
-                    <Button fill={true} text="Click to open" endIcon="caret-down" />
-                </Popover>
-            </ExampleCard>
+        <div className="popover-example">
+            <Popover content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+                <Button intent="primary" tabIndex={0} text="Popover target" />
+            </Popover>
+            <Popover content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+                <Button intent="primary" tabIndex={0} text="Popover target" />
+            </Popover>
         </div>
     );
 });
+
+const content = (
+    <div>
+        <H5>Confirm deletion</H5>
+        <p>Are you sure you want to delete these items? You won't be able to recover them.</p>
+        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 15 }}>
+            <Button className={Classes.POPOVER_DISMISS} style={{ marginRight: 10 }}>
+                Cancel
+            </Button>
+            <Button className={Classes.POPOVER_DISMISS} intent={Intent.DANGER}>
+                Delete
+            </Button>
+        </div>
+    </div>
+);
 
 PopoverExample.displayName = "DemoApp.PopoverExample";

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -34,8 +34,8 @@ const modifiers: PopperModifierOverrides = {
 
 export const PopoverExample = React.memo(() => {
     return (
-        <div className="popover-example">
-            <div className="popover-example-content">
+        <div className="demo-example">
+            <div className="demo-example-content">
                 <H4>Popper.js Popover</H4>
                 <Popover
                     content={content}
@@ -46,7 +46,7 @@ export const PopoverExample = React.memo(() => {
                     <Button intent="primary" tabIndex={0} text="Popover target" />
                 </Popover>
             </div>
-            <div className="popover-example-content">
+            <div className="demo-example-content">
                 <H4>Floating UI Popover</H4>
                 <PopoverFloating
                     content={content}

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -15,20 +15,45 @@
 
 import * as React from "react";
 
-import { Button, Classes, H4, H5, Intent, Popover, PopoverFloating } from "@blueprintjs/core";
+import {
+    Button,
+    Classes,
+    H4,
+    H5,
+    Intent,
+    Popover,
+    PopoverFloating,
+    type PopperModifierOverrides,
+} from "@blueprintjs/core";
+
+const modifiers: PopperModifierOverrides = {
+    offset: {
+        options: { offset: [0, 10] },
+    },
+};
 
 export const PopoverExample = React.memo(() => {
     return (
         <div className="popover-example">
             <div className="popover-example-content">
                 <H4>Popper.js Popover</H4>
-                <Popover content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+                <Popover
+                    content={content}
+                    placement="bottom"
+                    popoverClassName={Classes.POPOVER_CONTENT_SIZING}
+                    modifiers={modifiers}
+                >
                     <Button intent="primary" tabIndex={0} text="Popover target" />
                 </Popover>
             </div>
             <div className="popover-example-content">
                 <H4>Floating UI Popover</H4>
-                <PopoverFloating content={content} placement="top" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+                <PopoverFloating
+                    content={content}
+                    placement="bottom"
+                    popoverClassName={Classes.POPOVER_CONTENT_SIZING}
+                    modifiers={modifiers}
+                >
                     <Button intent="primary" tabIndex={0} text="Popover target" />
                 </PopoverFloating>
             </div>

--- a/packages/demo-app/src/examples/SelectExample.tsx
+++ b/packages/demo-app/src/examples/SelectExample.tsx
@@ -1,0 +1,182 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import classNames from "classnames";
+import * as React from "react";
+
+import { Button, Classes, H4, MenuItem, type MenuItemProps } from "@blueprintjs/core";
+import { type ItemPredicate, type ItemRenderer, type ItemRendererProps, Select } from "@blueprintjs/select";
+
+const fruits = [
+    "apple",
+    "banana",
+    "cherry",
+    "date",
+    "elderberry",
+    "fig",
+    "grape",
+    "honeydew",
+    "kiwi",
+    "lemon",
+    "mango",
+    "nectarine",
+    "orange",
+    "pear",
+    "pineapple",
+    "plum",
+    "raspberry",
+    "strawberry",
+    "tangerine",
+    "watermelon",
+];
+
+export const SelectExample = React.memo(() => {
+    const [selectedItem, setSelectedItem] = React.useState<string | undefined>(undefined);
+    const [selectedItemFloating, setSelectedItemFloating] = React.useState<string | undefined>(undefined);
+
+    const handleItemSelect = React.useCallback((item: string) => {
+        setSelectedItem(item);
+    }, []);
+
+    const handleItemSelectFloating = React.useCallback((item: string) => {
+        setSelectedItemFloating(item);
+    }, []);
+
+    const itemRenderer = React.useCallback<ItemRenderer<string>>(
+        (item, props) => {
+            if (!props.modifiers.matchesPredicate) {
+                return null;
+            }
+            return (
+                <MenuItem {...getItemProps(item, props)} roleStructure="listoption" selected={item === selectedItem} />
+            );
+        },
+        [selectedItem],
+    );
+
+    const itemRendererFloating = React.useCallback<ItemRenderer<string>>(
+        (item, props) => {
+            if (!props.modifiers.matchesPredicate) {
+                return null;
+            }
+            return (
+                <MenuItem
+                    {...getItemProps(item, props)}
+                    roleStructure="listoption"
+                    selected={item === selectedItemFloating}
+                />
+            );
+        },
+        [selectedItemFloating],
+    );
+
+    return (
+        <div className="demo-example">
+            <div className="demo-example-content">
+                <H4>Select</H4>
+                <Select
+                    itemPredicate={filterItem}
+                    itemRenderer={itemRenderer}
+                    items={fruits}
+                    onItemSelect={handleItemSelect}
+                >
+                    <Button
+                        alignText="start"
+                        endIcon="caret-down"
+                        text={maybeRenderSelection(selectedItem) ?? "(No selection)"}
+                        textClassName={classNames({
+                            [Classes.TEXT_MUTED]: selectedItem === undefined,
+                        })}
+                    />
+                </Select>
+            </div>
+            <div className="demo-example-content">
+                <H4>Select with floating UI</H4>
+                <Select
+                    floating={true}
+                    itemPredicate={filterItem}
+                    itemRenderer={itemRendererFloating}
+                    items={fruits}
+                    onItemSelect={handleItemSelectFloating}
+                >
+                    <Button
+                        alignText="start"
+                        endIcon="caret-down"
+                        text={maybeRenderSelection(selectedItemFloating) ?? "(No selection)"}
+                        textClassName={classNames({
+                            [Classes.TEXT_MUTED]: selectedItemFloating === undefined,
+                        })}
+                    />
+                </Select>
+            </div>
+        </div>
+    );
+});
+
+function maybeRenderSelection(selectedItem: string | undefined) {
+    return selectedItem ? `${selectedItem}` : undefined;
+}
+
+export const filterItem: ItemPredicate<string> = (query, item, _index, exactMatch) => {
+    const normalizedTitle = item.toLowerCase();
+    const normalizedQuery = query.toLowerCase();
+
+    if (exactMatch) {
+        return normalizedTitle === normalizedQuery;
+    } else {
+        return `${item}`.indexOf(normalizedQuery) >= 0;
+    }
+};
+
+export function getItemProps(
+    item: string,
+    { handleClick, handleFocus, modifiers, query, ref }: ItemRendererProps,
+): MenuItemProps & React.Attributes {
+    return {
+        active: modifiers.active,
+        disabled: modifiers.disabled,
+        key: item,
+        onClick: handleClick,
+        onFocus: handleFocus,
+        ref,
+        text: highlightText(item, query),
+    };
+}
+
+function highlightText(text: string, query: string) {
+    let lastIndex = 0;
+    const words = query
+        .split(/\s+/)
+        .filter(word => word.length > 0)
+        .map(escapeRegExpChars);
+    if (words.length === 0) {
+        return [text];
+    }
+    const regexp = new RegExp(words.join("|"), "gi");
+    const tokens: React.ReactNode[] = [];
+    while (true) {
+        const match = regexp.exec(text);
+        if (!match) {
+            break;
+        }
+        const length = match[0].length;
+        const before = text.slice(lastIndex, regexp.lastIndex - length);
+        if (before.length > 0) {
+            tokens.push(before);
+        }
+        lastIndex = regexp.lastIndex;
+        tokens.push(<strong key={lastIndex}>{match[0]}</strong>);
+    }
+    const rest = text.slice(lastIndex);
+    if (rest.length > 0) {
+        tokens.push(rest);
+    }
+    return tokens;
+}
+
+function escapeRegExpChars(text: string) {
+    return text.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+}
+
+SelectExample.displayName = "DemoApp.SelectExample";

--- a/packages/demo-app/src/index.scss
+++ b/packages/demo-app/src/index.scss
@@ -8,3 +8,12 @@ body {
   margin: 0;
   overflow-y: scroll;
 }
+
+.popover-example {
+  padding: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  height: 100vh;
+}

--- a/packages/demo-app/src/index.scss
+++ b/packages/demo-app/src/index.scss
@@ -10,17 +10,17 @@ body {
 }
 
 .popover-example {
-  padding: 100px;
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: space-around;
   height: 100vh;
+  justify-content: space-around;
+  padding: 100px;
 }
 
 .popover-example-content {
+  align-items: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
 }

--- a/packages/demo-app/src/index.scss
+++ b/packages/demo-app/src/index.scss
@@ -9,18 +9,15 @@ body {
   overflow-y: scroll;
 }
 
-.popover-example {
-  align-items: center;
+.demo-example {
   display: flex;
-  flex-direction: column;
   height: 100vh;
   justify-content: space-around;
   padding: 100px;
 }
 
-.popover-example-content {
+.demo-example-content {
   align-items: center;
   display: flex;
   flex-direction: column;
-  justify-content: center;
 }

--- a/packages/demo-app/src/index.scss
+++ b/packages/demo-app/src/index.scss
@@ -17,3 +17,10 @@ body {
   justify-content: space-around;
   height: 100vh;
 }
+
+.popover-example-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -19,7 +19,8 @@ import * as ReactDOM from "react-dom/client";
 import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
 
 // import { PopoverExample } from "./examples/PopoverExample";
-import { SelectExample } from "./examples/SelectExample";
+// import { SelectExample } from "./examples/SelectExample";
+import { DateInputExample } from "./examples/DateInputExample";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -33,7 +34,7 @@ const root = ReactDOM.createRoot(container);
     root.render(
         <React.StrictMode>
             <BlueprintProvider>
-                <SelectExample />
+                <DateInputExample />
             </BlueprintProvider>
         </React.StrictMode>,
     );

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -18,7 +18,8 @@ import * as ReactDOM from "react-dom/client";
 
 import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
 
-import { PopoverExample } from "./examples/PopoverExample";
+// import { PopoverExample } from "./examples/PopoverExample";
+import { SelectExample } from "./examples/SelectExample";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -32,7 +33,7 @@ const root = ReactDOM.createRoot(container);
     root.render(
         <React.StrictMode>
             <BlueprintProvider>
-                <PopoverExample />
+                <SelectExample />
             </BlueprintProvider>
         </React.StrictMode>,
     );

--- a/packages/demo-app/src/index.tsx
+++ b/packages/demo-app/src/index.tsx
@@ -18,7 +18,7 @@ import * as ReactDOM from "react-dom/client";
 
 import { BlueprintProvider, FocusStyleManager } from "@blueprintjs/core";
 
-import { Examples } from "./examples/Examples";
+import { PopoverExample } from "./examples/PopoverExample";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -32,7 +32,7 @@ const root = ReactDOM.createRoot(container);
     root.render(
         <React.StrictMode>
             <BlueprintProvider>
-                <Examples />
+                <PopoverExample />
             </BlueprintProvider>
         </React.StrictMode>,
     );

--- a/packages/demo-app/src/tsconfig.json
+++ b/packages/demo-app/src/tsconfig.json
@@ -7,5 +7,6 @@
         "outDir": "../dist",
         "sourceMap": false,
         "strictNullChecks": false,
+        "noUnusedLocals": false,
     },
 }

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -22,7 +22,7 @@ import {
     type ButtonVariant,
     H5,
     type IconName,
-    Popover,
+    PopoverFloating,
     type Size,
     Switch,
     TextAlignment,
@@ -80,8 +80,8 @@ const PopoverButton: React.FC<{ text: string; iconName: IconName; vertical: bool
 }) => {
     const endIconName: IconName = vertical ? IconNames.CARET_RIGHT : IconNames.CARET_DOWN;
     return (
-        <Popover content={<FileMenu />} placement={vertical ? "right-start" : "bottom-start"}>
+        <PopoverFloating content={<FileMenu />} placement={vertical ? "right-start" : "bottom-start"}>
             <Button endIcon={endIconName} icon={iconName} text={text} />
-        </Popover>
+        </PopoverFloating>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Alignment, Button, Card, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
+import { Alignment, Button, Card, Menu, MenuDivider, MenuItem, PopoverFloating } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { IconNames } from "@blueprintjs/icons";
 
@@ -24,7 +24,7 @@ export const DropdownMenuExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={false} {...props}>
             <Card style={{ width: 250 }}>
-                <Popover content={<ExampleMenu />} fill={true} placement="bottom">
+                <PopoverFloating content={<ExampleMenu />} fill={true} placement="bottom">
                     <Button
                         alignText={Alignment.START}
                         endIcon={IconNames.CARET_DOWN}
@@ -32,7 +32,7 @@ export const DropdownMenuExample: React.FC<ExampleProps> = props => {
                         icon={IconNames.APPLICATION}
                         text="Open with..."
                     />
-                </Popover>
+                </PopoverFloating>
             </Card>
         </Example>
     );

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -26,7 +26,7 @@ import {
     Intent,
     Menu,
     MenuItem,
-    Popover,
+    PopoverFloating,
     type Size,
     Spinner,
     Switch,
@@ -133,7 +133,7 @@ const PopoverInputGroup: React.FC<InputGroupProps> = props => (
         {...props}
         placeholder="Add people or groups..."
         rightElement={
-            <Popover
+            <PopoverFloating
                 content={
                     <Menu>
                         <MenuItem text="can edit" />
@@ -146,7 +146,7 @@ const PopoverInputGroup: React.FC<InputGroupProps> = props => (
                 <Button disabled={props.disabled} endIcon={IconNames.CARET_DOWN} variant="minimal">
                     can edit
                 </Button>
-            </Popover>
+            </PopoverFloating>
         }
     />
 );

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -27,7 +27,7 @@ import {
     NumericInput,
     type NumericInputProps,
     type OptionProps,
-    Popover,
+    PopoverFloating,
     Position,
     type Size,
     Switch,
@@ -154,7 +154,7 @@ export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
 };
 
 const FilterMenu: React.FC = () => (
-    <Popover
+    <PopoverFloating
         position="bottom"
         content={
             <Menu>
@@ -165,7 +165,7 @@ const FilterMenu: React.FC = () => (
         }
     >
         <Button icon={IconNames.Filter} variant="minimal" />
-    </Popover>
+    </PopoverFloating>
 );
 
 interface SelectMenuProps {

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Callout, Classes, Intent, Popover, Switch } from "@blueprintjs/core";
+import { Button, Callout, Classes, Intent, PopoverFloating, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const PopoverDismissExample: React.FC<ExampleProps> = props => {
@@ -44,7 +44,7 @@ export const PopoverDismissExample: React.FC<ExampleProps> = props => {
 
     return (
         <Example options={false} {...props}>
-            <Popover
+            <PopoverFloating
                 // don't autofocus or enforce focus because it is open by default on the page,
                 // and that will make unexpectedly users scroll to this example
                 autoFocus={false}
@@ -58,7 +58,7 @@ export const PopoverDismissExample: React.FC<ExampleProps> = props => {
                                 label="Capture dismiss"
                                 onChange={handleDismissChange}
                             />
-                            <Popover
+                            <PopoverFloating
                                 autoFocus={false}
                                 captureDismiss={captureDismiss}
                                 content={POPOVER_CONTENTS}

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -21,26 +21,26 @@ import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 export const PopoverDismissExample: React.FC<ExampleProps> = props => {
     const [captureDismiss, setCaptureDismiss] = React.useState(true);
-    const [isPopoverOpen, setIsPopoverOpen] = React.useState(true);
+    const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
 
-    const timeoutId = React.useRef<number>();
+    // const timeoutId = React.useRef<number>();
 
-    React.useEffect(() => {
-        return () => {
-            if (timeoutId.current) {
-                window.clearTimeout(timeoutId.current);
-            }
-        };
-    }, []);
+    // React.useEffect(() => {
+    //     return () => {
+    //         if (timeoutId.current) {
+    //             window.clearTimeout(timeoutId.current);
+    //         }
+    //     };
+    // }, []);
 
     const handleDismissChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         setCaptureDismiss(event.target.checked);
     }, []);
 
-    const reopen = React.useCallback(() => {
-        window.clearTimeout(timeoutId.current);
-        timeoutId.current = window.setTimeout(() => setIsPopoverOpen(true), 150);
-    }, []);
+    // const reopen = React.useCallback(() => {
+    //     window.clearTimeout(timeoutId.current);
+    //     timeoutId.current = window.setTimeout(() => setIsPopoverOpen(true), 150);
+    // }, []);
 
     return (
         <Example options={false} {...props}>
@@ -75,7 +75,6 @@ export const PopoverDismissExample: React.FC<ExampleProps> = props => {
                 enforceFocus={false}
                 inheritDarkTheme={false}
                 isOpen={isPopoverOpen}
-                onClosed={reopen}
                 onInteraction={setIsPopoverOpen}
                 placement="right"
                 renderTarget={({ isOpen, ...rest }) => (

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -30,7 +30,7 @@ import {
     MenuDivider,
     MenuItem,
     type Placement,
-    Popover,
+    PopoverFloating,
     PopoverInteractionKind,
     type PopperModifierOverrides,
     PopperPlacements,
@@ -292,7 +292,7 @@ export const PopoverExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={options} {...props}>
             <div className="docs-popover-example-scroll" ref={centerScroll}>
-                <Popover
+                <PopoverFloating
                     boundary={
                         boundary === "scrollParent"
                             ? scrollParentElement.current ?? undefined
@@ -318,7 +318,7 @@ export const PopoverExample: React.FC<ExampleProps> = props => {
                     usePortal={usePortal}
                 >
                     <Button intent={Intent.PRIMARY} tabIndex={0} text={buttonText} />
-                </Popover>
+                </PopoverFloating>
                 <p>
                     Scroll around this container to experiment
                     <br />

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Intent, Popover, type PopoverInteractionKind } from "@blueprintjs/core";
+import { Button, Intent, PopoverFloating, type PopoverInteractionKind } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 import { FileMenu } from "./common/fileMenu";
@@ -31,7 +31,7 @@ export const PopoverInteractionKindExample: React.FC<ExampleProps> = props => {
                     // MenuItem's default shouldDismissPopover={true} behavior is confusing
                     // in this example, since it introduces an additional way popovers can
                     // close. set it to false here for clarity.
-                    <Popover
+                    <PopoverFloating
                         key={interactionKind}
                         content={<FileMenu shouldDismissPopover={false} />}
                         enforceFocus={false}

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -16,14 +16,14 @@
 
 import * as React from "react";
 
-import { Button, Intent, Popover } from "@blueprintjs/core";
+import { Button, Intent, PopoverFloating } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 import { FileMenu } from "../core-examples/common/fileMenu";
 
 export const PopoverMinimalExample: React.FC<ExampleProps> = props => (
     <Example options={false} {...props}>
-        <Popover
+        <PopoverFloating
             content={<FileMenu />}
             minimal={true}
             placement="bottom-end"
@@ -31,7 +31,7 @@ export const PopoverMinimalExample: React.FC<ExampleProps> = props => (
                 <Button {...rest} active={isOpen} intent={Intent.PRIMARY} text="Minimal" />
             )}
         />
-        <Popover
+        <PopoverFloating
             content={<FileMenu />}
             placement="bottom-end"
             renderTarget={({ isOpen, ...rest }) => <Button {...rest} active={isOpen} text="Default" />}

--- a/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Classes, Code, ControlGroup, type Placement, Popover } from "@blueprintjs/core";
+import { Button, Classes, Code, ControlGroup, type Placement, PopoverFloating } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 const EXAMPLE_CLASS = "docs-popover-placement-example";
@@ -103,7 +103,7 @@ const PlacementPopover: React.FC<{ placement: Placement }> = ({ placement }) => 
     );
 
     return (
-        <Popover
+        <PopoverFloating
             content={content}
             placement={placement}
             popoverClassName={CONTENT_CLASS}

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Code, H5, Popover, type PopoverProps, Switch } from "@blueprintjs/core";
+import { Button, Code, H5, PopoverFloating, type PopoverProps, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 const POPOVER_PROPS: Partial<PopoverProps> = {
@@ -90,7 +90,7 @@ export const PopoverPortalExample: React.FC<ExampleProps> = props => {
                 ref={scrollContainerLeftRef}
             >
                 <div className="docs-popover-portal-example-scroll-content">
-                    <Popover
+                    <PopoverFloating
                         {...POPOVER_PROPS}
                         content="I am in a Portal (default)."
                         isOpen={isOpen}
@@ -105,7 +105,7 @@ export const PopoverPortalExample: React.FC<ExampleProps> = props => {
                 ref={scrollContainerRightRef}
             >
                 <div className="docs-popover-portal-example-scroll-content">
-                    <Popover
+                    <PopoverFloating
                         {...POPOVER_PROPS}
                         content="I am an inline popover."
                         isOpen={isOpen}

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Popover } from "@blueprintjs/core";
+import { Button, PopoverFloating } from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 
 import { FileMenu } from "./common/fileMenu";
@@ -24,7 +24,7 @@ import { FileMenu } from "./common/fileMenu";
 export const PopoverSizingExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={false} {...props}>
-            <Popover
+            <PopoverFloating
                 content={<FileMenu className="docs-popover-sizing-example" />}
                 placement="bottom-end"
                 renderTarget={({ isOpen, ...rest }) => <Button {...rest} active={isOpen} text="Open..." />}

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, Menu, MenuItem, Popover, Text, TextArea } from "@blueprintjs/core";
+import { Button, Menu, MenuItem, PopoverFloating, Text, TextArea } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 import { type Film, TOP_100_FILMS } from "@blueprintjs/select/examples";
 
@@ -36,7 +36,7 @@ export const TextExample: React.FC<ExampleProps> = props => {
                 &nbsp;
             </Text>
             <TextArea fill={true} onChange={handleChange} value={textContent} />
-            <Popover
+            <PopoverFloating
                 content={
                     <Menu className="docs-text-example-dropdown-menu">
                         {TOP_100_FILMS.map((film: Film) => (
@@ -47,7 +47,7 @@ export const TextExample: React.FC<ExampleProps> = props => {
                 placement="bottom"
             >
                 <Button icon="media" text="Text is used in MenuItems, and is performant at scale in long lists" />
-            </Popover>
+            </PopoverFloating>
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Button, ButtonGroup, Classes, Code, H1, Popover, Switch, Tooltip } from "@blueprintjs/core";
+import { Button, ButtonGroup, Classes, Code, H1, PopoverFloating, Switch, Tooltip } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const TooltipExample: React.FC<ExampleProps> = props => {
@@ -122,7 +122,11 @@ export const TooltipExample: React.FC<ExampleProps> = props => {
                 </Tooltip>
             </div>
             <br />
-            <Popover content={<H1>Popover!</H1>} placement="right" popoverClassName={Classes.POPOVER_CONTENT_SIZING}>
+            <PopoverFloating
+                content={<H1>Popover!</H1>}
+                placement="right"
+                popoverClassName={Classes.POPOVER_CONTENT_SIZING}
+            >
                 <Tooltip
                     content={<span>This button also has a popover!</span>}
                     openOnTargetFocus={false}
@@ -131,7 +135,7 @@ export const TooltipExample: React.FC<ExampleProps> = props => {
                 >
                     <Button intent="success" text="Hover and click me" />
                 </Tooltip>
-            </Popover>
+            </PopoverFloating>
             <br />
 
             <ButtonGroup>

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -16,7 +16,7 @@
 
 import * as React from "react";
 
-import { Code, H5, Intent, MenuItem, type Popover, Switch, type TagProps } from "@blueprintjs/core";
+import { Code, H5, Intent, MenuItem, Switch, type TagProps } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { type ItemRenderer, MultiSelect } from "@blueprintjs/select";
 import {
@@ -54,8 +54,6 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
     const [resetOnSelect, setResetOnSelect] = React.useState(true);
     const [showClearButton, setShowClearButton] = React.useState(true);
     const [tagMinimal, setTagMinimal] = React.useState(false);
-
-    const popoverRef = React.useRef<Popover>(null);
 
     const selectFilms = React.useCallback(
         (filmsToSelect: Film[]) => {
@@ -268,7 +266,6 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
                 onItemsPaste={handleFilmsPaste}
                 openOnKeyDown={openOnKeyDown}
                 popoverProps={{ matchTargetWidth, minimal: popoverMinimal }}
-                popoverRef={popoverRef}
                 resetOnSelect={resetOnSelect}
                 selectedItems={films}
                 tagInputProps={{ onRemove: handleTagRemove, tagProps: getTagProps }}

--- a/packages/select/src/common/selectPopoverProps.ts
+++ b/packages/select/src/common/selectPopoverProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { PopoverFloatingRef, PopoverProps } from "@blueprintjs/core";
+import type { DefaultPopoverTargetHTMLProps, Popover, PopoverFloatingRef, PopoverProps } from "@blueprintjs/core";
 
 /**
  * Reusable collection of props for components in this package which render a `Popover`
@@ -39,12 +39,13 @@ export interface SelectPopoverProps {
     popoverProps?: Partial<Omit<PopoverProps, "content" | "defaultIsOpen" | "fill" | "renderTarget">>;
 
     /**
-     * Optional ref for the PopoverFloating component instance.
+     * Optional ref for the Popover component instance.
      * This is sometimes useful to reposition the popover.
      *
-     * Note that this is defined as a PopoverFloatingRef which provides access to the reposition() method.
+     * Note that this is defined as a specific kind of Popover instance which should be compatible with
+     * most use cases, since it uses the default target props interface.
      */
-    popoverRef?: React.RefObject<PopoverFloatingRef>;
+    popoverRef?: React.RefObject<Popover<DefaultPopoverTargetHTMLProps>> | React.RefObject<PopoverFloatingRef>;
 
     /**
      * HTML attributes to add to the popover target element.

--- a/packages/select/src/common/selectPopoverProps.ts
+++ b/packages/select/src/common/selectPopoverProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DefaultPopoverTargetHTMLProps, Popover, PopoverProps } from "@blueprintjs/core";
+import type { PopoverFloatingRef, PopoverProps } from "@blueprintjs/core";
 
 /**
  * Reusable collection of props for components in this package which render a `Popover`
@@ -39,13 +39,12 @@ export interface SelectPopoverProps {
     popoverProps?: Partial<Omit<PopoverProps, "content" | "defaultIsOpen" | "fill" | "renderTarget">>;
 
     /**
-     * Optional ref for the Popover component instance.
+     * Optional ref for the PopoverFloating component instance.
      * This is sometimes useful to reposition the popover.
      *
-     * Note that this is defined as a specific kind of Popover instance which should be compatible with
-     * most use cases, since it uses the default target props interface.
+     * Note that this is defined as a PopoverFloatingRef which provides access to the reposition() method.
      */
-    popoverRef?: React.RefObject<Popover<DefaultPopoverTargetHTMLProps>>;
+    popoverRef?: React.RefObject<PopoverFloatingRef>;
 
     /**
      * HTML attributes to add to the popover target element.

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -23,6 +23,7 @@ import {
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
     mergeRefs,
+    Popover,
     type PopoverClickTargetHandlers,
     PopoverFloating,
     type PopoverFloatingRef,
@@ -131,6 +132,13 @@ export interface MultiSelectProps<T> extends ListItemsProps<T>, SelectPopoverPro
 
     /** Custom renderer to transform an item into tag content. */
     tagRenderer: (item: T) => React.ReactNode;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 /** Exported for testing, not part of public API */
@@ -216,9 +224,11 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
         const { disabled, popoverContentProps = {}, popoverProps = {} } = this.props;
         const { handleKeyDown, handleKeyUp } = listProps;
 
+        const Component = this.props.floating ? PopoverFloating : Popover;
+
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
-            <PopoverFloating
+            <Component
                 autoFocus={false}
                 canEscapeKeyClose={true}
                 disabled={disabled}

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -136,7 +136,7 @@ export interface MultiSelectProps<T> extends ListItemsProps<T>, SelectPopoverPro
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -159,6 +159,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
     public static defaultProps = {
         disabled: false,
         fill: false,
+        floating: true,
         placeholder: "Search...",
     };
 

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -23,8 +23,9 @@ import {
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
     mergeRefs,
-    Popover,
+    type Popover,
     type PopoverClickTargetHandlers,
+    PopoverFloating,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -217,7 +218,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
 
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
-            <Popover
+            <PopoverFloating
                 autoFocus={false}
                 canEscapeKeyClose={true}
                 disabled={disabled}

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -23,9 +23,9 @@ import {
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
     mergeRefs,
-    type Popover,
     type PopoverClickTargetHandlers,
     PopoverFloating,
+    type PopoverFloatingRef,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -169,7 +169,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
 
     private refHandlers: {
         input: React.RefCallback<HTMLInputElement>;
-        popover: React.RefObject<Popover>;
+        popover: React.RefObject<PopoverFloatingRef>;
         queryList: React.RefCallback<QueryList<T>>;
     } = {
         input: refHandler(this, "input", this.props.tagInputProps?.inputRef),

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -24,8 +24,8 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     type InputGroupProps,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverFloating,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -190,7 +190,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
         // N.B. no need to set `fill` since that is unused with the `renderTarget` API
         return (
-            <Popover
+            <PopoverFloating
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -24,6 +24,7 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     type InputGroupProps,
+    Popover,
     type PopoverClickTargetHandlers,
     PopoverFloating,
     type PopoverTargetProps,
@@ -96,6 +97,13 @@ export interface SelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
      * @default false
      */
     resetOnClose?: boolean;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 /** Exported for testing, not part of public API */
@@ -170,7 +178,6 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
             placeholder = "Filter...",
             popoverContentProps = {},
             popoverProps = {},
-            popoverRef,
         } = this.props;
 
         const input = (
@@ -188,9 +195,11 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
         const { handleKeyDown, handleKeyUp } = listProps;
 
+        const Component = this.props.floating ? PopoverFloating : Popover;
+
         // N.B. no need to set `fill` since that is unused with the `renderTarget` API
         return (
-            <PopoverFloating
+            <Component
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
@@ -210,7 +219,6 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                 onOpening={this.handlePopoverOpening}
                 popoverClassName={classNames(Classes.SELECT_POPOVER, popoverProps.popoverClassName)}
                 popupKind={PopupKind.LISTBOX}
-                ref={popoverRef}
                 renderTarget={this.getPopoverTargetRenderer(listProps, this.state.isOpen)}
             />
         );

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -101,7 +101,7 @@ export interface SelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -173,6 +173,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         // not using defaultProps cuz they're hard to type with generics (can't use <T> on static members)
         const {
             filterable = true,
+            floating = true,
             disabled = false,
             inputProps = {},
             placeholder = "Filter...",
@@ -195,7 +196,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
         const { handleKeyDown, handleKeyUp } = listProps;
 
-        const Component = this.props.floating ? PopoverFloating : Popover;
+        const Component = floating ? PopoverFloating : Popover;
 
         // N.B. no need to set `fill` since that is unused with the `renderTarget` API
         return (

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -117,6 +117,7 @@ export interface SuggestProps<T> extends ListItemsProps<T>, Omit<SelectPopoverPr
 
 export interface SuggestState<T> {
     isOpen: boolean;
+    lastMouseDown: number;
     selectedItem: T | null;
 }
 
@@ -143,6 +144,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
 
     public state: SuggestState<T> = {
         isOpen: (this.props.popoverProps != null && this.props.popoverProps.isOpen) || false,
+        lastMouseDown: 0,
         selectedItem: this.getInitialSelectedItem(),
     };
 
@@ -280,6 +282,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
                     onFocus={this.handleInputFocus}
                     onKeyDown={this.getTargetKeyDownHandler(handleKeyDown)}
                     onKeyUp={this.getTargetKeyUpHandler(handleKeyUp)}
+                    onMouseDown={this.handleInputMouseDown}
                     placeholder={inputPlaceholder}
                     role="combobox"
                     value={inputValue}
@@ -297,12 +300,26 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
     private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
         this.selectText();
 
-        // TODO can we leverage Popover.openOnTargetFocus for this?
+        // Check if this focus event was caused by a recent mouse interaction
+        const isClickInducedFocus = Date.now() - this.state.lastMouseDown < 100; // 100ms threshold
+
         if (!this.props.openOnKeyDown) {
-            this.setState({ isOpen: true });
+            if (this.props.floating && isClickInducedFocus) {
+                // For PopoverFloating with click-induced focus, let PopoverFloating handle the interaction
+                // Don't set state here to avoid conflicts
+            } else {
+                // For keyboard-induced focus or non-floating popovers, handle normally
+                this.setState({ isOpen: true });
+            }
         }
 
         this.props.inputProps?.onFocus?.(event);
+    };
+
+    private handleInputMouseDown = (event: React.MouseEvent<HTMLInputElement>) => {
+        // Track when mouse down occurs to distinguish click-induced focus from keyboard focus
+        this.setState({ lastMouseDown: Date.now() });
+        this.props.inputProps?.onMouseDown?.(event);
     };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
@@ -344,15 +361,23 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
 
     // Popover interaction kind is CLICK, so this only handles click events.
     // Note that we defer to the next animation frame in order to get the latest activeElement
-    private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) =>
-        this.requestAnimationFrame(() => {
-            const isInputFocused = this.inputElement === Utils.getActiveElement(this.inputElement);
-            if (this.inputElement != null && !isInputFocused) {
-                // the input is no longer focused, we should close the popover
-                this.setState({ isOpen: false });
-            }
+    private handlePopoverInteraction = (nextOpenState: boolean, event?: React.SyntheticEvent<HTMLElement>) => {
+        if (this.props.floating) {
+            // When using PopoverFloating, trust its state management and don't interfere
+            this.setState({ isOpen: nextOpenState });
             this.props.popoverProps?.onInteraction?.(nextOpenState, event);
-        });
+        } else {
+            // Original logic for classic Popover with RAF timing
+            this.requestAnimationFrame(() => {
+                const isInputFocused = this.inputElement === Utils.getActiveElement(this.inputElement);
+                if (this.inputElement != null && !isInputFocused) {
+                    // the input is no longer focused, we should close the popover
+                    this.setState({ isOpen: false });
+                }
+                this.props.popoverProps?.onInteraction?.(nextOpenState, event);
+            });
+        }
+    };
 
     private handlePopoverOpening = (node: HTMLElement) => {
         // reset query before opening instead of when closing to prevent flash of unfiltered items.

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -110,7 +110,7 @@ export interface SuggestProps<T> extends ListItemsProps<T>, Omit<SelectPopoverPr
     /**
      * Whether to use the floating UI popover.
      *
-     * @default false
+     * @default true
      */
     floating?: boolean;
 }
@@ -131,6 +131,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
     public static defaultProps: Partial<SuggestProps<any>> = {
         closeOnSelect: true,
         fill: false,
+        floating: true,
         openOnKeyDown: false,
         resetOnClose: false,
     };

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -23,8 +23,8 @@ import {
     InputGroup,
     type InputGroupProps,
     mergeRefs,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverFloating,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -182,7 +182,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
         if (this.state.isOpen === false && prevState.isOpen === true) {
             // just closed, likely by keyboard interaction
             // wait until the transition ends so there isn't a flash of content in the popover
-            const timeout = this.props.popoverProps?.transitionDuration ?? Popover.defaultProps.transitionDuration;
+            const timeout = this.props.popoverProps?.transitionDuration ?? 300;
             setTimeout(() => this.maybeResetActiveItemToSelectedItem(), timeout);
         }
 
@@ -198,7 +198,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
 
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
-            <Popover
+            <PopoverFloating
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={isOpen}

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -23,6 +23,7 @@ import {
     InputGroup,
     type InputGroupProps,
     mergeRefs,
+    Popover,
     type PopoverClickTargetHandlers,
     PopoverFloating,
     type PopoverTargetProps,
@@ -105,6 +106,13 @@ export interface SuggestProps<T> extends ListItemsProps<T>, Omit<SelectPopoverPr
      * @default false
      */
     resetOnClose?: boolean;
+
+    /**
+     * Whether to use the floating UI popover.
+     *
+     * @default false
+     */
+    floating?: boolean;
 }
 
 export interface SuggestState<T> {
@@ -196,9 +204,11 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
         const { isOpen } = this.state;
         const { handleKeyDown, handleKeyUp } = listProps;
 
+        const Component = this.props.floating ? PopoverFloating : Popover;
+
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
-            <PopoverFloating
+            <Component
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={isOpen}

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import * as React from "react";
 
-import { DISPLAYNAME_PREFIX, Popover, type Props } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, PopoverFloating, type Props } from "@blueprintjs/core";
 import { More } from "@blueprintjs/icons";
 
 import * as Classes from "../../common/classes";
@@ -232,7 +232,7 @@ export class TruncatedFormat extends React.PureComponent<TruncatedFormatProps, T
             );
             const popoverContent = <div className={popoverClasses}>{children}</div>;
             return (
-                <Popover
+                <PopoverFloating
                     className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
                     content={popoverContent}
                     isOpen={true}
@@ -241,7 +241,7 @@ export class TruncatedFormat extends React.PureComponent<TruncatedFormatProps, T
                     rootBoundary="document"
                 >
                     <More />
-                </Popover>
+                </PopoverFloating>
             );
         } else {
             // NOTE: This structure matches what `<Popover>` does internally. If `<Popover>` changes, this must be updated.

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -23,7 +23,7 @@ import {
     Icon,
     type IconName,
     type OverlayLifecycleProps,
-    Popover,
+    PopoverFloating,
     type PopoverProps,
     type Props,
 } from "@blueprintjs/core";
@@ -224,7 +224,7 @@ export class ColumnHeaderCell extends AbstractPureComponent<ColumnHeaderCellProp
         return (
             <div className={classes}>
                 <div className={Classes.TABLE_TH_MENU_CONTAINER_BACKGROUND} />
-                <Popover
+                <PopoverFloating
                     className={classNames(Classes.TABLE_TH_MENU, menuPopoverProps?.className)}
                     content={menuRenderer(index)}
                     onClosing={this.handlePopoverClosing}
@@ -234,7 +234,7 @@ export class ColumnHeaderCell extends AbstractPureComponent<ColumnHeaderCellProp
                     {...menuPopoverProps}
                 >
                     <Icon icon={menuIcon} />
-                </Popover>
+                </PopoverFloating>
             </div>
         );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,7 @@ __metadata:
     "@blueprintjs/karma-build-scripts": "workspace:^"
     "@blueprintjs/node-build-scripts": "workspace:^"
     "@blueprintjs/test-commons": "workspace:^"
+    "@floating-ui/react": "npm:^0.27.13"
     "@popperjs/core": "npm:^2.11.8"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/react": "npm:^16.1.0"
@@ -1224,6 +1225,58 @@ __metadata:
     "@eslint/core": "npm:^0.10.0"
     levn: "npm:^0.4.1"
   checksum: ba9832b8409af618cf61791805fe201dd62f3c82c783adfcec0f5cd391e68b40beaecb47b9a3209e926dbcab65135f410cae405b69a559197795793399f61176
+  languageName: node
+  linkType: hard
+
+"@floating-ui/core@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@floating-ui/core@npm:1.7.2"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: ea5909ae1bfad6d8dd60ab893c7751fd974d96b25481d13805935a089b39881b4d69425a0a84cc74c82269d8b64ca0117c472fc83e425143bee1bb21b247de9c
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@floating-ui/dom@npm:1.7.2"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.2"
+    "@floating-ui/utils": "npm:^0.2.10"
+  checksum: 1b2ad76dc7fe245a1bb406cd5b64a1316f2ec642aebaa4d1928b56ced6fe71046f089e3fef9340bab234645b6333546211e363a630a9e7cfca6bf5031c39e0cb
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react-dom@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@floating-ui/react-dom@npm:2.1.4"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.2"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 2dade6b8e18de09c90b876249756155ab31f49b5a81d246a3dc568d0355bc9e4bc26485dfd27b9e3bf86585700f4d241e8f53e8321249ec9b012a266a86b9366
+  languageName: node
+  linkType: hard
+
+"@floating-ui/react@npm:^0.27.13":
+  version: 0.27.13
+  resolution: "@floating-ui/react@npm:0.27.13"
+  dependencies:
+    "@floating-ui/react-dom": "npm:^2.1.4"
+    "@floating-ui/utils": "npm:^0.2.10"
+    tabbable: "npm:^6.0.0"
+  peerDependencies:
+    react: ">=17.0.0"
+    react-dom: ">=17.0.0"
+  checksum: 4f5dd45829e4c62f447718d07bcf88a2388efb78dd91e38a6f34091feecfa4044ff7b43357192cdad4acbfc3898b932527c2a320913c5f492bae998f34f9f57d
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.10":
+  version: 0.2.10
+  resolution: "@floating-ui/utils@npm:0.2.10"
+  checksum: e9bc2a1730ede1ee25843937e911ab6e846a733a4488623cd353f94721b05ec2c9ec6437613a2ac9379a94c2fd40c797a2ba6fa1df2716f5ce4aa6ddb1cf9ea4
   languageName: node
   linkType: hard
 
@@ -15752,6 +15805,13 @@ __metadata:
     "@swc/core": ^1.2.147
     webpack: ">=2"
   checksum: cb3f9b116fbd292b881e804a4fe66cd6d543a7de2572f5a68e067e4780ee2d59a8da87a90736ba6e8e286e4368c98214ae3486b1b872080292814e5d3062f09c
+  languageName: node
+  linkType: hard
+
+"tabbable@npm:^6.0.0":
+  version: 6.2.0
+  resolution: "tabbable@npm:6.2.0"
+  checksum: ced8b38f05f2de62cd46836d77c2646c42b8c9713f5bd265daf0e78ff5ac73d3ba48a7ca45f348bafeef29b23da7187c72250742d37627883ef89cbd7fa76898
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **[demo] (temp) Add demo code to demo-app**
- **Attempt to migrate Popover to PopoverFloating**
- **[demo] Replace Popover with PopoverFloating in examples**
- **[demo] Replace Popover with PopoverFloating in components**
- **Allow `update()` function to be called from outside of PopoverFloating**
- **Modifiers**
- **Auto placement**

#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
