### PR TITLE
[fix] Overlay Focus Stacking for 508/a11y

### DIFF
--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -18,7 +18,6 @@
 import classNames from "classnames";
 import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
-import { useUID } from "react-uid";
 
 import { Classes, mergeRefs } from "../../common";
 import {
@@ -689,8 +688,7 @@ function useOverlay2Validation({ childRef, childRefs, children }: Overlay2Props)
  * Generates a unique ID for a given Overlay which persists across the component's lifecycle.
  */
 function useOverlay2ID(): string {
-    // TODO: migrate to React.useId() in React 18
-    const id = useUID();
+    const id = React.useId();
     return `${Overlay2.displayName}-${id}`;
 }
 

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
  *
@@ -704,4 +703,3 @@ function getLifecycleCallbackWithChildRef(
         }
     };
 }
-

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
  *
@@ -17,6 +18,7 @@
 import classNames from "classnames";
 import * as React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
+import { useUID } from "react-uid";
 
 import { Classes, mergeRefs } from "../../common";
 import {
@@ -328,6 +330,14 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
             return;
         }
 
+        // Only add listener if this overlay is the most recent one
+        const lastOpened = getLastOpened();
+        const isTopOverlay = lastOpened?.id === id;
+
+        if (!isTopOverlay) {
+            return;
+        }
+
         // Focus events do not bubble, but setting useCapture allows us to listen in and execute
         // our handler before all others
         document.addEventListener("focus", handleDocumentFocus, /* useCapture */ true);
@@ -335,7 +345,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         return () => {
             document.removeEventListener("focus", handleDocumentFocus, /* useCapture */ true);
         };
-    }, [handleDocumentFocus, enforceFocus, isOpen]);
+    }, [handleDocumentFocus, enforceFocus, isOpen, getLastOpened, id]);
 
     const overlayWillCloseRef = React.useRef(overlayWillClose);
     overlayWillCloseRef.current = overlayWillClose;
@@ -679,7 +689,8 @@ function useOverlay2Validation({ childRef, childRefs, children }: Overlay2Props)
  * Generates a unique ID for a given Overlay which persists across the component's lifecycle.
  */
 function useOverlay2ID(): string {
-    const id = React.useId();
+    // TODO: migrate to React.useId() in React 18
+    const id = useUID();
     return `${Overlay2.displayName}-${id}`;
 }
 
@@ -695,3 +706,4 @@ function getLifecycleCallbackWithChildRef(
         }
     };
 }
+


### PR DESCRIPTION
#### Fixes

Fixes case where portal containers/multiple React roots creates a race condition that doesn't properly update focus stacking listeners

#### Changes proposed in this pull request:

Ensures only the most recent overlay has a focus listener