### PR TITLE
Fix divider compact setting

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7514.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7514.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix divider compact
+  links:
+  - https://github.com/palantir/blueprint/pull/7514

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -16,7 +16,7 @@ $divider-margin: $pt-grid-size * 0.5 !default;
     border-color: $pt-dark-divider-white;
   }
 
-  .#{$ns}-compact {
+  &.#{$ns}-compact {
     margin: 0;
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [x] Includes tests
-   [x] Update documentation (No documentation needs to be updated)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Update divider compact SCSS to target elements with both `bp6-divider` and `bp6-compact` class names.

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

https://github.com/user-attachments/assets/c64b7b9a-b876-4ecd-80f1-94ef0380cdc1
