### PR TITLE
[Overlay2]: Remove `defaultProps` from component

### DIFF
--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -33,7 +33,7 @@ import { Button } from "../button/buttons";
 import { H6 } from "../html/html";
 import { Icon } from "../icon/icon";
 import type { BackdropProps, OverlayableProps } from "../overlay/overlayProps";
-import { Overlay2, OVERLAY2_DEFAULT_PROPS } from "../overlay2/overlay2";
+import { Overlay2 } from "../overlay2/overlay2";
 
 export interface DialogProps extends OverlayableProps, BackdropProps, Props {
     /** Dialog contents. */
@@ -146,7 +146,7 @@ export class Dialog extends AbstractPureComponent<DialogProps> {
                     <div
                         className={classNames(Classes.DIALOG, className)}
                         role={role}
-                        aria-modal={overlayProps.enforceFocus ?? OVERLAY2_DEFAULT_PROPS.enforceFocus}
+                        aria-modal={overlayProps.enforceFocus ?? true}
                         aria-labelledby={this.props["aria-labelledby"] || (title ? this.titleId : undefined)}
                         aria-describedby={this.props["aria-describedby"]}
                         style={style}

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -63,21 +63,6 @@ export interface Overlay2Props extends OverlayProps, React.RefAttributes<Overlay
     childRefs?: Record<string, React.RefObject<HTMLElement>>;
 }
 
-export const OVERLAY2_DEFAULT_PROPS = {
-    autoFocus: true,
-    backdropProps: {},
-    canEscapeKeyClose: true,
-    canOutsideClickClose: true,
-    enforceFocus: true,
-    hasBackdrop: true,
-    isOpen: false,
-    lazy: hasDOMEnvironment(),
-    shouldReturnFocusOnClose: true,
-    transitionDuration: 300,
-    transitionName: Classes.OVERLAY,
-    usePortal: true,
-};
-
 /**
  * Overlay2 component.
  *
@@ -85,19 +70,19 @@ export const OVERLAY2_DEFAULT_PROPS = {
  */
 export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props, forwardedRef) => {
     const {
-        autoFocus,
+        autoFocus = true,
         backdropClassName,
-        backdropProps,
-        canEscapeKeyClose,
-        canOutsideClickClose,
+        backdropProps = {},
+        canEscapeKeyClose = true,
+        canOutsideClickClose = true,
         childRef,
         childRefs,
         children,
         className,
-        enforceFocus,
-        hasBackdrop,
-        isOpen,
-        lazy,
+        enforceFocus = true,
+        hasBackdrop = true,
+        isOpen = false,
+        lazy = hasDOMEnvironment(),
         onClose,
         onClosed,
         onClosing,
@@ -105,10 +90,10 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         onOpening,
         portalClassName,
         portalContainer,
-        shouldReturnFocusOnClose,
-        transitionDuration,
-        transitionName,
-        usePortal,
+        shouldReturnFocusOnClose = true,
+        transitionDuration = 300,
+        transitionName = Classes.OVERLAY,
+        usePortal = true,
     } = props;
 
     useOverlay2Validation(props);
@@ -654,8 +639,7 @@ export const Overlay2 = React.forwardRef<OverlayInstance, Overlay2Props>((props,
         return transitionGroup;
     }
 });
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-Overlay2.defaultProps = OVERLAY2_DEFAULT_PROPS;
+
 Overlay2.displayName = `${DISPLAYNAME_PREFIX}.Overlay2`;
 
 function useOverlay2Validation({ childRef, childRefs, children }: Overlay2Props) {


### PR DESCRIPTION
#### Part of #7518

Replaces `defaultProps` on Overlay2 in favor of ES6 default parameters.