### PR TITLE
fix: ignore context menu events inside popovers in Table

### DIFF
--- a/packages/table/changelog/@unreleased/pr-7521.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-7521.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Ignore context menu events inside popovers in Table
+  links:
+  - https://github.com/palantir/blueprint/pull/7521

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -140,6 +140,13 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
             return undefined;
         }
 
+        // Check if the event originated from inside a popover - in that case we should not show the context menu
+        const eventTarget = mouseEvent.target as HTMLElement;
+        const isInsidePopover = eventTarget.closest(`.${Classes.TABLE_TRUNCATED_POPOVER}`) !== null;
+        if (isInsidePopover) {
+            return undefined;
+        }
+
         const targetRegion = this.locateClick(mouseEvent.nativeEvent as MouseEvent);
         let nextSelectedRegions: Region[] = selectedRegions;
 
@@ -162,6 +169,13 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
     // state updates cannot happen in renderContextMenu() during the render phase, so we must handle them separately
     private handleContextMenu = (e: React.MouseEvent) => {
         const { focusMode, onFocusedRegion, onSelection, selectedRegions = [] } = this.props;
+
+        // Check if the event originated from inside a popover - in that case we should not handle the context menu
+        const eventTarget = e.target as HTMLElement;
+        const isInsidePopover = eventTarget.closest(`.${Classes.TABLE_TRUNCATED_POPOVER}`) !== null;
+        if (isInsidePopover) {
+            return;
+        }
 
         const targetRegion = this.locateClick(e.nativeEvent as MouseEvent);
         let nextSelectedRegions: Region[] = selectedRegions;

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -218,7 +218,11 @@ describe("TableBody", () => {
         ) {
             return mountTableBody({
                 bodyContextMenuRenderer,
-                cellRenderer: () => <Cell>truncated…<div className={Classes.TABLE_TRUNCATED_POPOVER}>popover showing the rest</div></Cell>,
+                cellRenderer: () => (
+                    <Cell>
+                        truncated…<div className={Classes.TABLE_TRUNCATED_POPOVER}>popover showing the rest</div>
+                    </Cell>
+                ),
                 locator: {
                     convertPointToCell: sinon.stub().returns(targetCellCoords),
                 } as any,

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -200,26 +200,15 @@ describe("TableBody", () => {
 
             it("doesn't trigger context menu when right-clicking inside a popover", () => {
                 const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
-
-                // Create a fake popover element and add it to the DOM
-                const popoverElement = document.createElement("div");
-                popoverElement.className = Classes.TABLE_TRUNCATED_POPOVER;
-                containerElement!.appendChild(popoverElement);
+                const firstCellPopover = tableBody.find(Cell).find(`.${Classes.TABLE_TRUNCATED_POPOVER}`);
 
                 // Simulate right-click inside the popover
-                const event = new MouseEvent("contextmenu", {
-                    bubbles: true,
-                    cancelable: true,
-                });
-                popoverElement.dispatchEvent(event);
+                simulateAction(firstCellPopover);
 
                 // Context menu renderer should not be called
                 expect(bodyContextMenuRenderer.called).to.be.false;
                 expect(onSelection.called).to.be.false;
                 expect(onFocusedRegion.called).to.be.false;
-
-                // Clean up
-                popoverElement.remove();
             });
         }
 
@@ -229,6 +218,7 @@ describe("TableBody", () => {
         ) {
             return mountTableBody({
                 bodyContextMenuRenderer,
+                cellRenderer: () => <Cell>truncated…<div className={Classes.TABLE_TRUNCATED_POPOVER}>popover showing the rest</div></Cell>,
                 locator: {
                     convertPointToCell: sinon.stub().returns(targetCellCoords),
                 } as any,

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -197,6 +197,30 @@ describe("TableBody", () => {
                     focusSelectionIndex: 0,
                 });
             });
+
+            it("doesn't trigger context menu when right-clicking inside a popover", () => {
+                const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
+
+                // Create a fake popover element and add it to the DOM
+                const popoverElement = document.createElement("div");
+                popoverElement.className = Classes.TABLE_TRUNCATED_POPOVER;
+                containerElement!.appendChild(popoverElement);
+
+                // Simulate right-click inside the popover
+                const event = new MouseEvent("contextmenu", {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                popoverElement.dispatchEvent(event);
+
+                // Context menu renderer should not be called
+                expect(bodyContextMenuRenderer.called).to.be.false;
+                expect(onSelection.called).to.be.false;
+                expect(onFocusedRegion.called).to.be.false;
+
+                // Clean up
+                popoverElement.remove();
+            });
         }
 
         function mountTableBodyForContextMenuTests(

--- a/packages/table/test/tableBodyTests.tsx
+++ b/packages/table/test/tableBodyTests.tsx
@@ -200,7 +200,7 @@ describe("TableBody", () => {
 
             it("doesn't trigger context menu when right-clicking inside a popover", () => {
                 const tableBody = mountTableBodyForContextMenuTests(TARGET_CELL_COORDS, []);
-                const firstCellPopover = tableBody.find(Cell).find(`.${Classes.TABLE_TRUNCATED_POPOVER}`);
+                const firstCellPopover = tableBody.find(`.${Classes.TABLE_TRUNCATED_POPOVER}`).first();
 
                 // Simulate right-click inside the popover
                 simulateAction(firstCellPopover);


### PR DESCRIPTION
When using JSONFormat or TruncatedFormat with TruncatedPopoverMode.ALWAYS in a Table with bodyContextMenuRenderer, right-clicking inside the popover should show the native browser context menu instead of triggering the table's context menu.

This fix checks if context menu events originated from inside a popover element before handling them in the Table component.

#### Fixes #0000

#### Checklist

-   [x] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
