### PR TITLE
[docs-app] Wrap docs in ThemeProvider and expose `isDarkTheme` through context

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -26,6 +26,7 @@ import {
     type DocumentationProps,
     NavMenuItem,
     type NavMenuItemProps,
+    ThemeProvider,
 } from "@blueprintjs/docs-theme";
 
 import { highlightCodeBlocks } from "../styles/syntaxHighlighting";
@@ -97,20 +98,27 @@ export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: st
                 packageInfo={this.getNpmPackage("@blueprintjs/core")}
             />
         );
+        const themeContextValue = {
+            isDarkTheme: this.state.themeName === DARK_THEME,
+            toggleTheme: this.handleToggleDark,
+        };
+
         return (
             <BlueprintProvider>
-                <Documentation
-                    {...this.props}
-                    className={this.state.themeName}
-                    banner={banner}
-                    footer={footer}
-                    header={header}
-                    navigatorExclude={isNavSection}
-                    onComponentUpdate={this.handleComponentUpdate}
-                    renderNavMenuItem={this.renderNavMenuItem}
-                    renderPageActions={this.renderPageActions}
-                    renderViewSourceLinkText={this.renderViewSourceLinkText}
-                />
+                <ThemeProvider value={themeContextValue}>
+                    <Documentation
+                        {...this.props}
+                        className={this.state.themeName}
+                        banner={banner}
+                        footer={footer}
+                        header={header}
+                        navigatorExclude={isNavSection}
+                        onComponentUpdate={this.handleComponentUpdate}
+                        renderNavMenuItem={this.renderNavMenuItem}
+                        renderPageActions={this.renderPageActions}
+                        renderViewSourceLinkText={this.renderViewSourceLinkText}
+                    />
+                </ThemeProvider>
             </BlueprintProvider>
         );
     }

--- a/packages/docs-theme/src/common/index.ts
+++ b/packages/docs-theme/src/common/index.ts
@@ -21,3 +21,4 @@ export * from "./constants";
 export * from "./documentalistUtils";
 export * from "./eventHandlerUtils";
 export * from "./stringUtils";
+export * from "./themeContext";

--- a/packages/docs-theme/src/common/themeContext.tsx
+++ b/packages/docs-theme/src/common/themeContext.tsx
@@ -1,0 +1,18 @@
+/* !
+ * (c) Copyright 2025 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { createContext, useContext } from "react";
+
+export interface ThemeContextValue {
+    isDarkTheme: boolean;
+    toggleTheme?: (useDark: boolean) => void;
+}
+
+export const ThemeContext = createContext<ThemeContextValue>({
+    isDarkTheme: false,
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const ThemeProvider = ThemeContext.Provider;


### PR DESCRIPTION
#### Changes

Cherry-picked from #7536

Expose docs theme name value through context to make it easier to access in downstream example components.