### PR TITLE
Migrate `$pt-grid-size` values to `$pt-spacing`

### DIFF
--- a/packages/core/src/_reset.scss
+++ b/packages/core/src/_reset.scss
@@ -25,7 +25,7 @@ body {
 }
 
 p {
-  margin-bottom: $pt-grid-size;
+  margin-bottom: $bp-spacing * 2.5;
   margin-top: 0;
 }
 

--- a/packages/core/src/_reset.scss
+++ b/packages/core/src/_reset.scss
@@ -25,7 +25,7 @@ body {
 }
 
 p {
-  margin-bottom: $bp-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2.5;
   margin-top: 0;
 }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -308,7 +308,7 @@ Styleguide blockquote
 */
 
 %blockquote {
-  border-left: solid 4px rgba($gray4, 0.5);
+  border-left: solid $bp-spacing rgba($gray4, 0.5);
   margin: 0 0 $pt-grid-size;
   padding: 0 ($pt-grid-size * 2);
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -253,7 +253,7 @@ Styleguide preformatted
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
   margin: ($bp-spacing * 2.5) 0;
-  padding: ($bp-spacing * 3.25) ($pt-grid-size * 1.5) ($bp-spacing * 3);
+  padding: ($bp-spacing * 3.25) ($bp-spacing * 3.75) ($bp-spacing * 3);
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -253,7 +253,7 @@ Styleguide preformatted
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
   margin: ($bp-spacing * 2.5) 0;
-  padding: ($pt-grid-size * 1.3) ($pt-grid-size * 1.5) ($pt-grid-size * 1.2);
+  padding: ($pt-grid-size * 1.3) ($pt-grid-size * 1.5) ($bp-spacing * 3);
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -345,7 +345,7 @@ Styleguide lists
 
 %list {
   margin: ($bp-spacing * 2.5) 0;
-  padding-left: $pt-grid-size * 3;
+  padding-left: $bp-spacing * 7.5;
 
   li:not(:last-child) {
     margin-bottom: $pt-grid-size * 0.5;

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -28,7 +28,7 @@ Styleguide headings
 
 .#{$ns}-heading {
   @include heading-typography();
-  margin: 0 0 $pt-grid-size;
+  margin: 0 0 ($bp-spacing * 2.5);
   padding: 0;
 }
 
@@ -155,7 +155,7 @@ Styleguide running-text
   }
 
   p {
-    margin: 0 0 $pt-grid-size;
+    margin: 0 0 ($bp-spacing * 2.5);
     padding: 0;
   }
 
@@ -252,7 +252,7 @@ Styleguide preformatted
   display: block;
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
-  margin: $pt-grid-size 0;
+  margin: ($bp-spacing * 2.5) 0;
   padding: ($pt-grid-size * 1.3) ($pt-grid-size * 1.5) ($pt-grid-size * 1.2);
   word-break: break-all;
   word-wrap: break-word;
@@ -309,7 +309,7 @@ Styleguide blockquote
 
 %blockquote {
   border-left: solid $bp-spacing rgba($gray4, 0.5);
-  margin: 0 0 $pt-grid-size;
+  margin: 0 0 ($bp-spacing * 2.5);
   padding: 0 ($pt-grid-size * 2);
 
   .#{$ns}-dark & {
@@ -344,7 +344,7 @@ Styleguide lists
 */
 
 %list {
-  margin: $pt-grid-size 0;
+  margin: ($bp-spacing * 2.5) 0;
   padding-left: $pt-grid-size * 3;
 
   li:not(:last-child) {

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -144,7 +144,7 @@ Styleguide running-text
       @extend %#{$tag};
       @include heading-typography();
       margin-bottom: $bp-spacing * 5;
-      margin-top: $pt-grid-size * 4;
+      margin-top: $bp-spacing * 10;
     }
   }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -28,7 +28,7 @@ Styleguide headings
 
 .#{$ns}-heading {
   @include heading-typography();
-  margin: 0 0 ($bp-spacing * 2.5);
+  margin: 0 0 ($pt-spacing * 2.5);
   padding: 0;
 }
 
@@ -143,19 +143,19 @@ Styleguide running-text
     #{$tag} {
       @extend %#{$tag};
       @include heading-typography();
-      margin-bottom: $bp-spacing * 5;
-      margin-top: $bp-spacing * 10;
+      margin-bottom: $pt-spacing * 5;
+      margin-top: $pt-spacing * 10;
     }
   }
 
   hr {
     border: none;
     border-bottom: 1px solid $pt-divider-black;
-    margin: ($bp-spacing * 5) 0;
+    margin: ($pt-spacing * 5) 0;
   }
 
   p {
-    margin: 0 0 ($bp-spacing * 2.5);
+    margin: 0 0 ($pt-spacing * 2.5);
     padding: 0;
   }
 
@@ -242,7 +242,7 @@ Styleguide preformatted
   @include monospace-typography();
   border-radius: $pt-border-radius;
   font-size: smaller;
-  padding: ($bp-spacing * 0.5) ($bp-spacing * 1.25);
+  padding: ($pt-spacing * 0.5) ($pt-spacing * 1.25);
 }
 
 %code-block {
@@ -252,8 +252,8 @@ Styleguide preformatted
   display: block;
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
-  margin: ($bp-spacing * 2.5) 0;
-  padding: ($bp-spacing * 3.25) ($bp-spacing * 3.75) ($bp-spacing * 3);
+  margin: ($pt-spacing * 2.5) 0;
+  padding: ($pt-spacing * 3.25) ($pt-spacing * 3.75) ($pt-spacing * 3);
   word-break: break-all;
   word-wrap: break-word;
 
@@ -285,7 +285,7 @@ Styleguide preformatted
   vertical-align: middle;
 
   #{$icon-classes} {
-    margin-right: $bp-spacing * 1.25;
+    margin-right: $pt-spacing * 1.25;
   }
 }
 
@@ -308,9 +308,9 @@ Styleguide blockquote
 */
 
 %blockquote {
-  border-left: solid $bp-spacing rgba($gray4, 0.5);
-  margin: 0 0 ($bp-spacing * 2.5);
-  padding: 0 ($bp-spacing * 5);
+  border-left: solid $pt-spacing rgba($gray4, 0.5);
+  margin: 0 0 ($pt-spacing * 2.5);
+  padding: 0 ($pt-spacing * 5);
 
   .#{$ns}-dark & {
     border-color: rgba($gray2, 0.5);
@@ -344,17 +344,17 @@ Styleguide lists
 */
 
 %list {
-  margin: ($bp-spacing * 2.5) 0;
-  padding-left: $bp-spacing * 7.5;
+  margin: ($pt-spacing * 2.5) 0;
+  padding-left: $pt-spacing * 7.5;
 
   li:not(:last-child) {
-    margin-bottom: $bp-spacing * 1.25;
+    margin-bottom: $pt-spacing * 1.25;
   }
 
   // nested lists
   ol,
   ul {
-    margin-top: $bp-spacing * 1.25;
+    margin-top: $pt-spacing * 1.25;
   }
 }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -143,7 +143,7 @@ Styleguide running-text
     #{$tag} {
       @extend %#{$tag};
       @include heading-typography();
-      margin-bottom: $pt-grid-size * 2;
+      margin-bottom: $bp-spacing * 5;
       margin-top: $pt-grid-size * 4;
     }
   }
@@ -151,7 +151,7 @@ Styleguide running-text
   hr {
     border: none;
     border-bottom: 1px solid $pt-divider-black;
-    margin: ($pt-grid-size * 2) 0;
+    margin: ($bp-spacing * 5) 0;
   }
 
   p {
@@ -310,7 +310,7 @@ Styleguide blockquote
 %blockquote {
   border-left: solid $bp-spacing rgba($gray4, 0.5);
   margin: 0 0 ($bp-spacing * 2.5);
-  padding: 0 ($pt-grid-size * 2);
+  padding: 0 ($bp-spacing * 5);
 
   .#{$ns}-dark & {
     border-color: rgba($gray2, 0.5);

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -253,7 +253,7 @@ Styleguide preformatted
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
   margin: ($bp-spacing * 2.5) 0;
-  padding: ($pt-grid-size * 1.3) ($pt-grid-size * 1.5) ($bp-spacing * 3);
+  padding: ($bp-spacing * 3.25) ($pt-grid-size * 1.5) ($bp-spacing * 3);
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -242,7 +242,7 @@ Styleguide preformatted
   @include monospace-typography();
   border-radius: $pt-border-radius;
   font-size: smaller;
-  padding: ($bp-spacing * 0.5) 5px;
+  padding: ($bp-spacing * 0.5) ($bp-spacing * 1.25);
 }
 
 %code-block {
@@ -285,7 +285,7 @@ Styleguide preformatted
   vertical-align: middle;
 
   #{$icon-classes} {
-    margin-right: $pt-grid-size * 0.5;
+    margin-right: $bp-spacing * 1.25;
   }
 }
 
@@ -348,13 +348,13 @@ Styleguide lists
   padding-left: $bp-spacing * 7.5;
 
   li:not(:last-child) {
-    margin-bottom: $pt-grid-size * 0.5;
+    margin-bottom: $bp-spacing * 1.25;
   }
 
   // nested lists
   ol,
   ul {
-    margin-top: $pt-grid-size * 0.5;
+    margin-top: $bp-spacing * 1.25;
   }
 }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -242,7 +242,7 @@ Styleguide preformatted
   @include monospace-typography();
   border-radius: $pt-border-radius;
   font-size: smaller;
-  padding: 2px 5px;
+  padding: ($bp-spacing * 0.5) 5px;
 }
 
 %code-block {

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -87,7 +87,7 @@ $pt-dark-intent-text-colors: (
 @mixin focus-outline($offset: $bp-spacing * 0.5) {
   outline: $pt-focus-indicator-color solid ($bp-spacing * 0.5);
   outline-offset: $offset;
-  -moz-outline-radius: 6px;
+  -moz-outline-radius: $bp-spacing * 1.5;
 
   .#{$ns}-dark & {
     outline-color: $pt-dark-focus-indicator-color;

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -84,8 +84,8 @@ $pt-dark-intent-text-colors: (
   word-wrap: normal;
 }
 
-@mixin focus-outline($offset: 2px) {
-  outline: $pt-focus-indicator-color solid 2px;
+@mixin focus-outline($offset: $bp-spacing * 0.5) {
+  outline: $pt-focus-indicator-color solid ($bp-spacing * 0.5);
   outline-offset: $offset;
   -moz-outline-radius: 6px;
 

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -84,10 +84,10 @@ $pt-dark-intent-text-colors: (
   word-wrap: normal;
 }
 
-@mixin focus-outline($offset: $bp-spacing * 0.5) {
-  outline: $pt-focus-indicator-color solid ($bp-spacing * 0.5);
+@mixin focus-outline($offset: $pt-spacing * 0.5) {
+  outline: $pt-focus-indicator-color solid ($pt-spacing * 0.5);
   outline-offset: $offset;
-  -moz-outline-radius: $bp-spacing * 1.5;
+  -moz-outline-radius: $pt-spacing * 1.5;
 
   .#{$ns}-dark & {
     outline-color: $pt-dark-focus-indicator-color;

--- a/packages/core/src/common/_variables-extended.scss
+++ b/packages/core/src/common/_variables-extended.scss
@@ -9,7 +9,7 @@
 // exported.
 // ----------------------------------------------------------------------------
 
-$half-grid-size: $bp-spacing * 1.25 !default;
+$half-grid-size: $pt-grid-size * 0.5 !default;
 
 // Extended color palette
 $blue0: #11376b !default;

--- a/packages/core/src/common/_variables-extended.scss
+++ b/packages/core/src/common/_variables-extended.scss
@@ -9,7 +9,7 @@
 // exported.
 // ----------------------------------------------------------------------------
 
-$half-grid-size: $pt-grid-size * 0.5 !default;
+$half-grid-size: $bp-spacing * 1.25 !default;
 
 // Extended color palette
 $blue0: #11376b !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -55,7 +55,7 @@ $pt-font-family-monospace: monospace !default;
 
 $pt-font-size: $pt-grid-size * 1.4 !default;
 $pt-font-size-large: $pt-grid-size * 1.6 !default;
-$pt-font-size-small: $pt-grid-size * 1.2 !default;
+$pt-font-size-small: $bp-spacing * 3 !default;
 
 // a little bit extra to ensure the height comes out to just over 18px (and browser rounds to 18px)
 // equivalent to: math.div($pt-grid-size * 1.8, $pt-font-size) + 0.0001

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -24,6 +24,8 @@ $bp-ns: $ns;
 // (so other variables can use it to define themselves)
 $pt-grid-size: 10px !default;
 
+$bp-spacing: 4px !default;
+
 // Icon variables
 
 $icons16-family: "blueprint-icons-16" !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -66,13 +66,13 @@ $pt-line-height: 1.28581 !default;
 $pt-border-radius: $bp-spacing * 0.5 !default;
 
 // Buttons
-$pt-button-height: $pt-grid-size * 3 !default;
+$pt-button-height: $bp-spacing * 7.5 !default;
 $pt-button-height-small: $bp-spacing * 6 !default;
 $pt-button-height-smaller: $bp-spacing * 5 !default;
 $pt-button-height-large: $pt-grid-size * 4 !default;
 
 // Inputs
-$pt-input-height: $pt-grid-size * 3 !default;
+$pt-input-height: $bp-spacing * 7.5 !default;
 $pt-input-height-large: $pt-grid-size * 4 !default;
 $pt-input-height-small: $bp-spacing * 6 !default;
 

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -32,7 +32,7 @@ $icons16-family: "blueprint-icons-16" !default;
 $icons20-family: "blueprint-icons-20" !default;
 
 $pt-icon-size-standard: $bp-spacing * 4 !default;
-$pt-icon-size-large: 20px !default;
+$pt-icon-size-large: $bp-spacing * 5 !default;
 
 // Typography
 
@@ -68,7 +68,7 @@ $pt-border-radius: $bp-spacing * 0.5 !default;
 // Buttons
 $pt-button-height: $pt-grid-size * 3 !default;
 $pt-button-height-small: $pt-grid-size * 2.4 !default;
-$pt-button-height-smaller: $pt-grid-size * 2 !default;
+$pt-button-height-smaller: $bp-spacing * 5 !default;
 $pt-button-height-large: $pt-grid-size * 4 !default;
 
 // Inputs

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -24,15 +24,15 @@ $bp-ns: $ns;
 // (so other variables can use it to define themselves)
 $pt-grid-size: 10px !default;
 
-$bp-spacing: 4px !default;
+$pt-spacing: 4px !default;
 
 // Icon variables
 
 $icons16-family: "blueprint-icons-16" !default;
 $icons20-family: "blueprint-icons-20" !default;
 
-$pt-icon-size-standard: $bp-spacing * 4 !default;
-$pt-icon-size-large: $bp-spacing * 5 !default;
+$pt-icon-size-standard: $pt-spacing * 4 !default;
+$pt-icon-size-large: $pt-spacing * 5 !default;
 
 // Typography
 
@@ -53,32 +53,32 @@ $pt-font-family:
 
 $pt-font-family-monospace: monospace !default;
 
-$pt-font-size: $bp-spacing * 3.5 !default;
-$pt-font-size-large: $bp-spacing * 4 !default;
-$pt-font-size-small: $bp-spacing * 3 !default;
+$pt-font-size: $pt-spacing * 3.5 !default;
+$pt-font-size-large: $pt-spacing * 4 !default;
+$pt-font-size-small: $pt-spacing * 3 !default;
 
 // a little bit extra to ensure the height comes out to just over 18px (and browser rounds to 18px)
-// equivalent to: math.div($bp-spacing * 4.5, $pt-font-size) + 0.0001
+// equivalent to: math.div($pt-spacing * 4.5, $pt-font-size) + 0.0001
 $pt-line-height: 1.28581 !default;
 
 // Grids & dimensions
 
-// equivalent to: $bp-spacing * 0.5
+// equivalent to: $pt-spacing * 0.5
 $pt-border-radius: 2px !default;
 
 // Buttons
-$pt-button-height: $bp-spacing * 7.5 !default;
-$pt-button-height-small: $bp-spacing * 6 !default;
-$pt-button-height-smaller: $bp-spacing * 5 !default;
-$pt-button-height-large: $bp-spacing * 10 !default;
+$pt-button-height: $pt-spacing * 7.5 !default;
+$pt-button-height-small: $pt-spacing * 6 !default;
+$pt-button-height-smaller: $pt-spacing * 5 !default;
+$pt-button-height-large: $pt-spacing * 10 !default;
 
 // Inputs
-$pt-input-height: $bp-spacing * 7.5 !default;
-$pt-input-height-large: $bp-spacing * 10 !default;
-$pt-input-height-small: $bp-spacing * 6 !default;
+$pt-input-height: $pt-spacing * 7.5 !default;
+$pt-input-height-large: $pt-spacing * 10 !default;
+$pt-input-height-small: $pt-spacing * 6 !default;
 
 // Others
-$pt-navbar-height: $bp-spacing * 12.5 !default;
+$pt-navbar-height: $pt-spacing * 12.5 !default;
 
 // Z-indices
 $pt-z-index-base: 0 !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -20,10 +20,16 @@ $ns: bp6;
 // Alias for BP users outside this repo
 $bp-ns: $ns;
 
-// easily the most important variable, so it comes up top
-// (so other variables can use it to define themselves)
+// Legacy 10px-based grid size variable, kept for backward compatibility.
+// New spacing values should use $pt-spacing instead (multiply by 2.5 to convert).
+// This variable will eventually be deprecated in favor of the 4px-based system.
 $pt-grid-size: 10px !default;
 
+// Primary spacing unit for Blueprint's 4px-based spacing system.
+// This is the most important spacing variable, so it comes up early
+// (so other variables can use it to define themselves).
+// This replaces $pt-grid-size as the foundation for consistent spacing throughout components.
+// Use multiples of this value for all margins, padding, and sizing calculations.
 $pt-spacing: 4px !default;
 
 // Icon variables

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -77,7 +77,7 @@ $pt-input-height-large: $bp-spacing * 10 !default;
 $pt-input-height-small: $bp-spacing * 6 !default;
 
 // Others
-$pt-navbar-height: $pt-grid-size * 5 !default;
+$pt-navbar-height: $bp-spacing * 12.5 !default;
 
 // Z-indices
 $pt-z-index-base: 0 !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -69,11 +69,11 @@ $pt-border-radius: $bp-spacing * 0.5 !default;
 $pt-button-height: $bp-spacing * 7.5 !default;
 $pt-button-height-small: $bp-spacing * 6 !default;
 $pt-button-height-smaller: $bp-spacing * 5 !default;
-$pt-button-height-large: $pt-grid-size * 4 !default;
+$pt-button-height-large: $bp-spacing * 10 !default;
 
 // Inputs
 $pt-input-height: $bp-spacing * 7.5 !default;
-$pt-input-height-large: $pt-grid-size * 4 !default;
+$pt-input-height-large: $bp-spacing * 10 !default;
 $pt-input-height-small: $bp-spacing * 6 !default;
 
 // Others

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -58,7 +58,7 @@ $pt-font-size-large: $bp-spacing * 4 !default;
 $pt-font-size-small: $bp-spacing * 3 !default;
 
 // a little bit extra to ensure the height comes out to just over 18px (and browser rounds to 18px)
-// equivalent to: math.div($pt-grid-size * 1.8, $pt-font-size) + 0.0001
+// equivalent to: math.div($bp-spacing * 4.5, $pt-font-size) + 0.0001
 $pt-line-height: 1.28581 !default;
 
 // Grids & dimensions

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -53,7 +53,7 @@ $pt-font-family:
 
 $pt-font-family-monospace: monospace !default;
 
-$pt-font-size: $pt-grid-size * 1.4 !default;
+$pt-font-size: $bp-spacing * 3.5 !default;
 $pt-font-size-large: $pt-grid-size * 1.6 !default;
 $pt-font-size-small: $bp-spacing * 3 !default;
 

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -67,14 +67,14 @@ $pt-border-radius: $bp-spacing * 0.5 !default;
 
 // Buttons
 $pt-button-height: $pt-grid-size * 3 !default;
-$pt-button-height-small: $pt-grid-size * 2.4 !default;
+$pt-button-height-small: $bp-spacing * 6 !default;
 $pt-button-height-smaller: $bp-spacing * 5 !default;
 $pt-button-height-large: $pt-grid-size * 4 !default;
 
 // Inputs
 $pt-input-height: $pt-grid-size * 3 !default;
 $pt-input-height-large: $pt-grid-size * 4 !default;
-$pt-input-height-small: $pt-grid-size * 2.4 !default;
+$pt-input-height-small: $bp-spacing * 6 !default;
 
 // Others
 $pt-navbar-height: $pt-grid-size * 5 !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -63,7 +63,8 @@ $pt-line-height: 1.28581 !default;
 
 // Grids & dimensions
 
-$pt-border-radius: $bp-spacing * 0.5 !default;
+// equivalent to: $bp-spacing * 0.5
+$pt-border-radius: 2px !default;
 
 // Buttons
 $pt-button-height: $bp-spacing * 7.5 !default;

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -31,7 +31,7 @@ $bp-spacing: 4px !default;
 $icons16-family: "blueprint-icons-16" !default;
 $icons20-family: "blueprint-icons-20" !default;
 
-$pt-icon-size-standard: 16px !default;
+$pt-icon-size-standard: $bp-spacing * 4 !default;
 $pt-icon-size-large: 20px !default;
 
 // Typography
@@ -54,7 +54,7 @@ $pt-font-family:
 $pt-font-family-monospace: monospace !default;
 
 $pt-font-size: $bp-spacing * 3.5 !default;
-$pt-font-size-large: $pt-grid-size * 1.6 !default;
+$pt-font-size-large: $bp-spacing * 4 !default;
 $pt-font-size-small: $bp-spacing * 3 !default;
 
 // a little bit extra to ensure the height comes out to just over 18px (and browser rounds to 18px)

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -63,8 +63,7 @@ $pt-line-height: 1.28581 !default;
 
 // Grids & dimensions
 
-// equivalent to: floor(math.div($pt-grid-size, 5))
-$pt-border-radius: 2px !default;
+$pt-border-radius: $bp-spacing * 0.5 !default;
 
 // Buttons
 $pt-button-height: $pt-grid-size * 3 !default;

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -5,7 +5,7 @@
 
 .#{$ns}-alert {
   max-width: $pt-grid-size * 40;
-  padding: $pt-grid-size * 2;
+  padding: $bp-spacing * 5;
 }
 
 .#{$ns}-alert-body {
@@ -13,7 +13,7 @@
 
   .#{$ns}-icon {
     font-size: $pt-icon-size-large * 2;
-    margin-right: $pt-grid-size * 2;
+    margin-right: $bp-spacing * 5;
     margin-top: 0;
   }
 }

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -25,9 +25,9 @@
 .#{$ns}-alert-footer {
   display: flex;
   flex-direction: row-reverse;
-  margin-top: $pt-grid-size;
+  margin-top: $bp-spacing * 2.5;
 
   .#{$ns}-button {
-    margin-left: $pt-grid-size;
+    margin-left: $bp-spacing * 2.5;
   }
 }

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -4,8 +4,8 @@
 @import "../../common/variables";
 
 .#{$ns}-alert {
-  max-width: $bp-spacing * 100;
-  padding: $bp-spacing * 5;
+  max-width: $pt-spacing * 100;
+  padding: $pt-spacing * 5;
 }
 
 .#{$ns}-alert-body {
@@ -13,7 +13,7 @@
 
   .#{$ns}-icon {
     font-size: $pt-icon-size-large * 2;
-    margin-right: $bp-spacing * 5;
+    margin-right: $pt-spacing * 5;
     margin-top: 0;
   }
 }
@@ -25,9 +25,9 @@
 .#{$ns}-alert-footer {
   display: flex;
   flex-direction: row-reverse;
-  margin-top: $bp-spacing * 2.5;
+  margin-top: $pt-spacing * 2.5;
 
   .#{$ns}-button {
-    margin-left: $bp-spacing * 2.5;
+    margin-left: $pt-spacing * 2.5;
   }
 }

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables";
 
 .#{$ns}-alert {
-  max-width: $pt-grid-size * 40;
+  max-width: $bp-spacing * 100;
   padding: $bp-spacing * 5;
 }
 

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -86,7 +86,7 @@
   border: none;
   border-radius: $pt-border-radius;
   cursor: pointer;
-  margin-right: 2px;
+  margin-right: $bp-spacing * 0.5;
   padding: 1px ($pt-grid-size * 0.5);
   vertical-align: text-bottom;
 

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -32,7 +32,7 @@
       content: "";
       display: block;
       height: $pt-icon-size-standard;
-      margin: 0 ($pt-grid-size * 0.5);
+      margin: 0 ($bp-spacing * 1.25);
       width: $pt-icon-size-standard;
     }
 
@@ -66,7 +66,7 @@
   }
 
   .#{$ns}-icon {
-    margin-right: $pt-grid-size * 0.5;
+    margin-right: $bp-spacing * 1.25;
   }
 }
 
@@ -87,7 +87,7 @@
   border-radius: $pt-border-radius;
   cursor: pointer;
   margin-right: $bp-spacing * 0.5;
-  padding: 1px ($pt-grid-size * 0.5);
+  padding: 1px ($bp-spacing * 1.25);
   vertical-align: text-bottom;
 
   &::before {

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -32,7 +32,7 @@
       content: "";
       display: block;
       height: $pt-icon-size-standard;
-      margin: 0 ($bp-spacing * 1.25);
+      margin: 0 ($pt-spacing * 1.25);
       width: $pt-icon-size-standard;
     }
 
@@ -66,7 +66,7 @@
   }
 
   .#{$ns}-icon {
-    margin-right: $bp-spacing * 1.25;
+    margin-right: $pt-spacing * 1.25;
   }
 }
 
@@ -86,8 +86,8 @@
   border: none;
   border-radius: $pt-border-radius;
   cursor: pointer;
-  margin-right: $bp-spacing * 0.5;
-  padding: 1px ($bp-spacing * 1.25);
+  margin-right: $pt-spacing * 0.5;
+  padding: 1px ($pt-spacing * 1.25);
   vertical-align: text-bottom;
 
   &::before {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -9,7 +9,7 @@
 $button-border-width: 1px !default;
 $button-padding: ($bp-spacing * 1.25) ($bp-spacing * 2.5) !default;
 $button-padding-small: 0 ($bp-spacing * 1.75) !default;
-$button-padding-large: ($bp-spacing * 1.25) ($pt-grid-size * 1.5) !default;
+$button-padding-large: ($bp-spacing * 1.25) ($bp-spacing * 3.75) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -8,7 +8,7 @@
 
 $button-border-width: 1px !default;
 $button-padding: ($bp-spacing * 1.25) ($bp-spacing * 2.5) !default;
-$button-padding-small: 0 ($pt-grid-size * 0.7) !default;
+$button-padding-small: 0 ($bp-spacing * 1.75) !default;
 $button-padding-large: ($bp-spacing * 1.25) ($pt-grid-size * 1.5) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -470,7 +470,7 @@ $dark-minimal-active-text-colors: (
 }
 
 @mixin pt-button-minimal-divider() {
-  $divider-height: $pt-grid-size * 2;
+  $divider-height: $bp-spacing * 5;
   background: $pt-divider-black;
 
   margin: ($pt-button-height - $divider-height) * 0.5;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,9 +7,9 @@
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;
-$button-padding: ($bp-spacing * 1.25) ($bp-spacing * 2.5) !default;
-$button-padding-small: 0 ($bp-spacing * 1.75) !default;
-$button-padding-large: ($bp-spacing * 1.25) ($bp-spacing * 3.75) !default;
+$button-padding: ($pt-spacing * 1.25) ($pt-spacing * 2.5) !default;
+$button-padding-small: 0 ($pt-spacing * 1.75) !default;
+$button-padding-large: ($pt-spacing * 1.25) ($pt-spacing * 3.75) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 
@@ -470,7 +470,7 @@ $dark-minimal-active-text-colors: (
 }
 
 @mixin pt-button-minimal-divider() {
-  $divider-height: $bp-spacing * 5;
+  $divider-height: $pt-spacing * 5;
   background: $pt-divider-black;
 
   margin: ($pt-button-height - $divider-height) * 0.5;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,9 +7,9 @@
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;
-$button-padding: ($pt-grid-size * 0.5) ($bp-spacing * 2.5) !default;
+$button-padding: ($bp-spacing * 1.25) ($bp-spacing * 2.5) !default;
 $button-padding-small: 0 ($pt-grid-size * 0.7) !default;
-$button-padding-large: ($pt-grid-size * 0.5) ($pt-grid-size * 1.5) !default;
+$button-padding-large: ($bp-spacing * 1.25) ($pt-grid-size * 1.5) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,7 +7,7 @@
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;
-$button-padding: ($pt-grid-size * 0.5) $pt-grid-size !default;
+$button-padding: ($pt-grid-size * 0.5) ($bp-spacing * 2.5) !default;
 $button-padding-small: 0 ($pt-grid-size * 0.7) !default;
 $button-padding-large: ($pt-grid-size * 0.5) ($pt-grid-size * 1.5) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -3,9 +3,9 @@
 
 @import "../../common/variables-extended";
 
-$callout-padding: $bp-spacing * 3.75;
-$callout-header-margin-top: $bp-spacing * 0.5;
-$callout-padding-compact: $bp-spacing * 2.5;
+$callout-padding: $pt-spacing * 3.75;
+$callout-header-margin-top: $pt-spacing * 0.5;
+$callout-padding-compact: $pt-spacing * 2.5;
 
 .#{$ns}-callout {
   @include running-typography();
@@ -20,7 +20,7 @@ $callout-padding-compact: $bp-spacing * 2.5;
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($bp-spacing * 1.75);
+    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 1.75);
 
     &::before {
       @include pt-icon($pt-icon-size-standard);
@@ -37,7 +37,7 @@ $callout-padding-compact: $bp-spacing * 2.5;
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($bp-spacing * 1.75);
+    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 1.75);
 
     > .#{$ns}-icon:first-child {
       color: $pt-icon-color;
@@ -63,7 +63,7 @@ $callout-padding-compact: $bp-spacing * 2.5;
     padding: $callout-padding-compact;
 
     &.#{$ns}-callout-icon {
-      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($bp-spacing * 1.75);
+      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($pt-spacing * 1.75);
 
       > .#{$ns}-icon:first-child {
         left: $callout-padding-compact;
@@ -136,6 +136,6 @@ $callout-padding-compact: $bp-spacing * 2.5;
   }
 
   .#{$ns}-running-text & {
-    margin: ($bp-spacing * 5) 0;
+    margin: ($pt-spacing * 5) 0;
   }
 }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -20,7 +20,7 @@ $callout-padding-compact: $bp-spacing * 2.5;
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-grid-size * 0.7);
+    padding-left: $callout-padding + $pt-icon-size-standard + ($bp-spacing * 1.75);
 
     &::before {
       @include pt-icon($pt-icon-size-standard);
@@ -37,7 +37,7 @@ $callout-padding-compact: $bp-spacing * 2.5;
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-grid-size * 0.7);
+    padding-left: $callout-padding + $pt-icon-size-standard + ($bp-spacing * 1.75);
 
     > .#{$ns}-icon:first-child {
       color: $pt-icon-color;
@@ -63,7 +63,7 @@ $callout-padding-compact: $bp-spacing * 2.5;
     padding: $callout-padding-compact;
 
     &.#{$ns}-callout-icon {
-      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($pt-grid-size * 0.7);
+      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($bp-spacing * 1.75);
 
       > .#{$ns}-icon:first-child {
         left: $callout-padding-compact;

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -136,6 +136,6 @@ $callout-padding-compact: $bp-spacing * 2.5;
   }
 
   .#{$ns}-running-text & {
-    margin: ($pt-grid-size * 2) 0;
+    margin: ($bp-spacing * 5) 0;
   }
 }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables-extended";
 
-$callout-padding: $pt-grid-size * 1.5;
+$callout-padding: $bp-spacing * 3.75;
 $callout-header-margin-top: $bp-spacing * 0.5;
 $callout-padding-compact: $bp-spacing * 2.5;
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables-extended";
 
 $callout-padding: $pt-grid-size * 1.5;
-$callout-header-margin-top: $pt-grid-size * 0.2;
+$callout-header-margin-top: $bp-spacing * 0.5;
 $callout-padding-compact: $pt-grid-size;
 
 .#{$ns}-callout {

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -5,7 +5,7 @@
 
 $callout-padding: $pt-grid-size * 1.5;
 $callout-header-margin-top: $bp-spacing * 0.5;
-$callout-padding-compact: $pt-grid-size;
+$callout-padding-compact: $bp-spacing * 2.5;
 
 .#{$ns}-callout {
   @include running-typography();

--- a/packages/core/src/components/card-list/card-list.scss
+++ b/packages/core/src/components/card-list/card-list.scss
@@ -65,7 +65,7 @@
 
     .#{$ns}-dark & {
       margin: 1px;
-      width: calc(100% - 2px);
+      width: calc(100% - ($bp-spacing * 0.5));
     }
   }
 }

--- a/packages/core/src/components/card-list/card-list.scss
+++ b/packages/core/src/components/card-list/card-list.scss
@@ -65,7 +65,7 @@
 
     .#{$ns}-dark & {
       margin: 1px;
-      width: calc(100% - ($bp-spacing * 0.5));
+      width: calc(100% - ($pt-spacing * 0.5));
     }
   }
 }

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -13,7 +13,7 @@ $card-list-border-width: 1px !default;
 
 // CardList Card item min-height is calculated as height of a button + vertical padding.
 // We need to add an extra pixel to account for the bottom border.
-$card-list-item-padding-vertical: $pt-grid-size !default;
+$card-list-item-padding-vertical: $bp-spacing * 2.5 !default;
 // prettier-ignore
 $card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables-extended";
 
-$card-padding: $pt-grid-size * 2 !default;
+$card-padding: $bp-spacing * 5 !default;
 $card-padding-compact: $pt-grid-size * 1.5 !default;
 
 $card-background-color: $white !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -18,7 +18,7 @@ $card-list-item-padding-vertical: $bp-spacing * 2.5 !default;
 $card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;
 
-$card-list-item-padding-vertical-compact: 7px !default;
+$card-list-item-padding-vertical-compact: $bp-spacing * 1.75 !default;
 // prettier-ignore
 $card-list-item-min-height-compact: $pt-button-height + ($card-list-item-padding-vertical-compact * 2) + $card-list-border-width !default;
 $card-list-item-padding-compact: $card-list-item-padding-vertical-compact $card-padding-compact !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -3,8 +3,8 @@
 
 @import "../../common/variables-extended";
 
-$card-padding: $bp-spacing * 5 !default;
-$card-padding-compact: $bp-spacing * 3.75 !default;
+$card-padding: $pt-spacing * 5 !default;
+$card-padding-compact: $pt-spacing * 3.75 !default;
 
 $card-background-color: $white !default;
 $dark-card-background-color: $pt-dark-app-elevated-background-color !default;
@@ -13,12 +13,12 @@ $card-list-border-width: 1px !default;
 
 // CardList Card item min-height is calculated as height of a button + vertical padding.
 // We need to add an extra pixel to account for the bottom border.
-$card-list-item-padding-vertical: $bp-spacing * 2.5 !default;
+$card-list-item-padding-vertical: $pt-spacing * 2.5 !default;
 // prettier-ignore
 $card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;
 
-$card-list-item-padding-vertical-compact: $bp-spacing * 1.75 !default;
+$card-list-item-padding-vertical-compact: $pt-spacing * 1.75 !default;
 // prettier-ignore
 $card-list-item-min-height-compact: $pt-button-height + ($card-list-item-padding-vertical-compact * 2) + $card-list-border-width !default;
 $card-list-item-padding-compact: $card-list-item-padding-vertical-compact $card-padding-compact !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables-extended";
 
 $card-padding: $bp-spacing * 5 !default;
-$card-padding-compact: $pt-grid-size * 1.5 !default;
+$card-padding-compact: $bp-spacing * 3.75 !default;
 
 $card-background-color: $white !default;
 $dark-card-background-color: $pt-dark-app-elevated-background-color !default;

--- a/packages/core/src/components/control-card/_control-card.scss
+++ b/packages/core/src/components/control-card/_control-card.scss
@@ -21,7 +21,7 @@
     // control indicators should be top-aligned
     align-items: flex-start;
     display: flex;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
     margin: 0;
     padding: $card-padding;
     width: calc(100%);

--- a/packages/core/src/components/control-card/_control-card.scss
+++ b/packages/core/src/components/control-card/_control-card.scss
@@ -21,7 +21,7 @@
     // control indicators should be top-aligned
     align-items: flex-start;
     display: flex;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
     margin: 0;
     padding: $card-padding;
     width: calc(100%);

--- a/packages/core/src/components/dialog/_dialog-footer.scss
+++ b/packages/core/src/components/dialog/_dialog-footer.scss
@@ -18,7 +18,7 @@
   gap: $dialog-padding;
   justify-content: space-between;
   margin: 0;
-  padding: ($bp-spacing * 2.5) ($bp-spacing * 2.5) ($bp-spacing * 2.5) $dialog-padding;
+  padding: ($pt-spacing * 2.5) ($pt-spacing * 2.5) ($pt-spacing * 2.5) $dialog-padding;
 
   .#{$ns}-dark & {
     background: $dark-gray4;
@@ -35,6 +35,6 @@
   justify-content: flex-end;
 
   .#{$ns}-button {
-    margin-left: $bp-spacing * 2.5;
+    margin-left: $pt-spacing * 2.5;
   }
 }

--- a/packages/core/src/components/dialog/_dialog-footer.scss
+++ b/packages/core/src/components/dialog/_dialog-footer.scss
@@ -18,7 +18,7 @@
   gap: $dialog-padding;
   justify-content: space-between;
   margin: 0;
-  padding: $pt-grid-size $pt-grid-size $pt-grid-size $dialog-padding;
+  padding: ($bp-spacing * 2.5) ($bp-spacing * 2.5) ($bp-spacing * 2.5) $dialog-padding;
 
   .#{$ns}-dark & {
     background: $dark-gray4;
@@ -35,6 +35,6 @@
   justify-content: flex-end;
 
   .#{$ns}-button {
-    margin-left: $pt-grid-size;
+    margin-left: $bp-spacing * 2.5;
   }
 }

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -85,7 +85,7 @@ $dialog-header-padding: math.div($pt-grid-size, 2);
   .#{$ns}-icon-large,
   .#{$ns}-icon {
     flex: 0 0 auto;
-    margin-left: -3px;
+    margin-left: $bp-spacing * -0.75;
     margin-right: $dialog-padding * 0.5;
 
     // only apply light color to icons that are not intent-specific

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -50,7 +50,7 @@ $dialog-padding: $pt-grid-size * 1.5 !default;
   margin: $dialog-margin;
   pointer-events: all;
   user-select: text;
-  width: $bp-spacing * 12.5;
+  width: $bp-spacing * 125;
 
   &:focus {
     outline: 0;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -9,8 +9,8 @@
 
 $dialog-background-color: $light-gray5 !default;
 $dialog-border-radius: $pt-border-radius * 2 !default;
-$dialog-margin: ($bp-spacing * 7.5) 0 !default;
-$dialog-padding: $bp-spacing * 3.75 !default;
+$dialog-margin: ($pt-spacing * 7.5) 0 !default;
+$dialog-padding: $pt-spacing * 3.75 !default;
 
 .#{$ns}-dialog-container {
   $dialog-transition-props: (
@@ -50,7 +50,7 @@ $dialog-padding: $bp-spacing * 3.75 !default;
   margin: $dialog-margin;
   pointer-events: all;
   user-select: text;
-  width: $bp-spacing * 125;
+  width: $pt-spacing * 125;
 
   &:focus {
     outline: 0;
@@ -68,7 +68,7 @@ $dialog-padding: $bp-spacing * 3.75 !default;
   }
 }
 
-$dialog-header-padding: $bp-spacing * 1.25;
+$dialog-header-padding: $pt-spacing * 1.25;
 
 .#{$ns}-dialog-header {
   align-items: center;
@@ -85,7 +85,7 @@ $dialog-header-padding: $bp-spacing * 1.25;
   .#{$ns}-icon-large,
   .#{$ns}-icon {
     flex: 0 0 auto;
-    margin-left: $bp-spacing * -0.75;
+    margin-left: $pt-spacing * -0.75;
     margin-right: $dialog-padding * 0.5;
 
     // only apply light color to icons that are not intent-specific

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -68,7 +68,7 @@ $dialog-padding: $pt-grid-size * 1.5 !default;
   }
 }
 
-$dialog-header-padding: math.div($pt-grid-size, 2);
+$dialog-header-padding: $bp-spacing * 1.25;
 
 .#{$ns}-dialog-header {
   align-items: center;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -9,7 +9,7 @@
 
 $dialog-background-color: $light-gray5 !default;
 $dialog-border-radius: $pt-border-radius * 2 !default;
-$dialog-margin: ($pt-grid-size * 3) 0 !default;
+$dialog-margin: ($bp-spacing * 7.5) 0 !default;
 $dialog-padding: $pt-grid-size * 1.5 !default;
 
 .#{$ns}-dialog-container {

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -10,7 +10,7 @@
 $dialog-background-color: $light-gray5 !default;
 $dialog-border-radius: $pt-border-radius * 2 !default;
 $dialog-margin: ($bp-spacing * 7.5) 0 !default;
-$dialog-padding: $pt-grid-size * 1.5 !default;
+$dialog-padding: $bp-spacing * 3.75 !default;
 
 .#{$ns}-dialog-container {
   $dialog-transition-props: (

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -50,7 +50,7 @@ $dialog-padding: $pt-grid-size * 1.5 !default;
   margin: $dialog-margin;
   pointer-events: all;
   user-select: text;
-  width: $pt-grid-size * 50;
+  width: $bp-spacing * 12.5;
 
   &:focus {
     outline: 0;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -205,7 +205,7 @@ $step-radius: $pt-border-radius * 2 !default;
 .#{$ns}-dialog-step-title {
   color: $pt-text-color-disabled;
   flex: 1;
-  padding-left: 10px;
+  padding-left: $bp-spacing * 2.5;
 
   .#{$ns}-dark & {
     color: $pt-dark-text-color-disabled;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -153,7 +153,7 @@ $step-radius: $pt-border-radius * 2 !default;
   border-radius: $step-radius;
   cursor: not-allowed;
   display: flex;
-  margin: 4px;
+  margin: $bp-spacing;
   padding: 6px 14px;
 
   .#{$ns}-dark & {

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -154,7 +154,7 @@ $step-radius: $pt-border-radius * 2 !default;
   cursor: not-allowed;
   display: flex;
   margin: $bp-spacing;
-  padding: ($bp-spacing * 1.5) 14px;
+  padding: ($bp-spacing * 1.5) ($bp-spacing * 3.5);
 
   .#{$ns}-dark & {
     background: $dark-gray3;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -154,7 +154,7 @@ $step-radius: $pt-border-radius * 2 !default;
   cursor: not-allowed;
   display: flex;
   margin: $bp-spacing;
-  padding: 6px 14px;
+  padding: ($bp-spacing * 1.5) 14px;
 
   .#{$ns}-dark & {
     background: $dark-gray3;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -185,9 +185,9 @@ $step-radius: $pt-border-radius * 2 !default;
   border-radius: 50%;
   color: $white;
   display: flex;
-  height: 25px;
+  height: $bp-spacing * 6.25;
   justify-content: center;
-  width: 25px;
+  width: $bp-spacing * 6.25;
 
   .#{$ns}-dark & {
     background-color: $pt-dark-icon-color-disabled;

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -153,8 +153,8 @@ $step-radius: $pt-border-radius * 2 !default;
   border-radius: $step-radius;
   cursor: not-allowed;
   display: flex;
-  margin: $bp-spacing;
-  padding: ($bp-spacing * 1.5) ($bp-spacing * 3.5);
+  margin: $pt-spacing;
+  padding: ($pt-spacing * 1.5) ($pt-spacing * 3.5);
 
   .#{$ns}-dark & {
     background: $dark-gray3;
@@ -185,9 +185,9 @@ $step-radius: $pt-border-radius * 2 !default;
   border-radius: 50%;
   color: $white;
   display: flex;
-  height: $bp-spacing * 6.25;
+  height: $pt-spacing * 6.25;
   justify-content: center;
-  width: $bp-spacing * 6.25;
+  width: $pt-spacing * 6.25;
 
   .#{$ns}-dark & {
     background-color: $pt-dark-icon-color-disabled;
@@ -205,7 +205,7 @@ $step-radius: $pt-border-radius * 2 !default;
 .#{$ns}-dialog-step-title {
   color: $pt-text-color-disabled;
   flex: 1;
-  padding-left: $bp-spacing * 2.5;
+  padding-left: $pt-spacing * 2.5;
 
   .#{$ns}-dark & {
     color: $pt-dark-text-color-disabled;

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$divider-margin: $bp-spacing * 1.25 !default;
+$divider-margin: $pt-spacing * 1.25 !default;
 
 .#{$ns}-divider {
   border-bottom: 1px solid $pt-divider-black;

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$divider-margin: $pt-grid-size * 0.5 !default;
+$divider-margin: $bp-spacing * 1.25 !default;
 
 .#{$ns}-divider {
   border-bottom: 1px solid $pt-divider-black;

--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -6,7 +6,7 @@
 @import "../../common/react-transition";
 @import "../../common/variables";
 
-$drawer-margin: ($pt-grid-size * 3) 0 !default;
+$drawer-margin: ($bp-spacing * 7.5) 0 !default;
 $drawer-padding: $bp-spacing * 5 !default;
 
 $drawer-default-size: 50%;

--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -227,7 +227,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
 
 .#{$ns}-drawer-body {
   flex: 1 1 auto;
-  line-height: $pt-grid-size * 1.8;
+  line-height: $bp-spacing * 4.5;
   overflow: auto;
 }
 

--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -7,7 +7,7 @@
 @import "../../common/variables";
 
 $drawer-margin: ($pt-grid-size * 3) 0 !default;
-$drawer-padding: $pt-grid-size * 2 !default;
+$drawer-padding: $bp-spacing * 5 !default;
 
 $drawer-default-size: 50%;
 

--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -6,8 +6,8 @@
 @import "../../common/react-transition";
 @import "../../common/variables";
 
-$drawer-margin: ($bp-spacing * 7.5) 0 !default;
-$drawer-padding: $bp-spacing * 5 !default;
+$drawer-margin: ($pt-spacing * 7.5) 0 !default;
+$drawer-padding: $pt-spacing * 5 !default;
 
 $drawer-default-size: 50%;
 
@@ -227,7 +227,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
 
 .#{$ns}-drawer-body {
   flex: 1 1 auto;
-  line-height: $bp-spacing * 4.5;
+  line-height: $pt-spacing * 4.5;
   overflow: auto;
 }
 

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -143,7 +143,7 @@
 .#{$ns}-editable-text-content {
   overflow: hidden;
   // magical number to account for slight increase in input width for cursor bar
-  padding-right: $bp-spacing * 0.5;
+  padding-right: $pt-spacing * 0.5;
   text-overflow: ellipsis;
   // preserve so trailing whitespace is included in scrollWidth
   white-space: pre;

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -143,7 +143,7 @@
 .#{$ns}-editable-text-content {
   overflow: hidden;
   // magical number to account for slight increase in input width for cursor bar
-  padding-right: 2px;
+  padding-right: $bp-spacing * 0.5;
   text-overflow: ellipsis;
   // preserve so trailing whitespace is included in scrollWidth
   white-space: pre;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -38,13 +38,13 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    gap: 0.5 * $pt-grid-size;
+    gap: $bp-spacing * 1.25;
   }
 
   &-tags-container {
     display: flex;
     gap: $bp-spacing * 0.5;
-    margin-left: 0.5 * $pt-grid-size;
+    margin-left: $bp-spacing * 1.25;
   }
 
   &-title {

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -7,7 +7,7 @@
 .#{$ns}-entity-title {
   align-items: center;
   display: flex;
-  gap: 0.7 * $pt-grid-size;
+  gap: $bp-spacing * 1.75;
   min-width: 0;
 
   &.#{$ns}-fill {

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -7,7 +7,7 @@
 .#{$ns}-entity-title {
   align-items: center;
   display: flex;
-  gap: $bp-spacing * 1.75;
+  gap: $pt-spacing * 1.75;
   min-width: 0;
 
   &.#{$ns}-fill {
@@ -38,13 +38,13 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    gap: $bp-spacing * 1.25;
+    gap: $pt-spacing * 1.25;
   }
 
   &-tags-container {
     display: flex;
-    gap: $bp-spacing * 0.5;
-    margin-left: $bp-spacing * 1.25;
+    gap: $pt-spacing * 0.5;
+    margin-left: $pt-spacing * 1.25;
   }
 
   &-title {
@@ -59,7 +59,7 @@
 
   &-subtitle {
     font-size: $pt-font-size-small;
-    margin-top: $bp-spacing * 0.5;
+    margin-top: $pt-spacing * 0.5;
   }
 
   &-ellipsize,
@@ -79,10 +79,10 @@
   &-heading-h1,
   &-heading-h2,
   &-heading-h3 {
-    gap: $bp-spacing * 3.75;
+    gap: $pt-spacing * 3.75;
 
     .#{$ns}-entity-title-status-tag {
-      margin-left: $bp-spacing * 2.5;
+      margin-left: $pt-spacing * 2.5;
     }
 
     .#{$ns}-entity-title-subtitle {
@@ -93,7 +93,7 @@
   &-heading-h4,
   &-heading-h5,
   &-heading-h6 {
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
 
     .#{$ns}-entity-title-subtitle {
       font-size: $pt-font-size-small;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -82,7 +82,7 @@
     gap: 1.5 * $pt-grid-size;
 
     .#{$ns}-entity-title-status-tag {
-      margin-left: $pt-grid-size;
+      margin-left: $bp-spacing * 2.5;
     }
 
     .#{$ns}-entity-title-subtitle {
@@ -93,7 +93,7 @@
   &-heading-h4,
   &-heading-h5,
   &-heading-h6 {
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
 
     .#{$ns}-entity-title-subtitle {
       font-size: $pt-font-size-small;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -79,7 +79,7 @@
   &-heading-h1,
   &-heading-h2,
   &-heading-h3 {
-    gap: 1.5 * $pt-grid-size;
+    gap: $bp-spacing * 3.75;
 
     .#{$ns}-entity-title-status-tag {
       margin-left: $bp-spacing * 2.5;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -43,7 +43,7 @@
 
   &-tags-container {
     display: flex;
-    gap: 0.2 * $pt-grid-size;
+    gap: $bp-spacing * 0.5;
     margin-left: 0.5 * $pt-grid-size;
   }
 
@@ -59,7 +59,7 @@
 
   &-subtitle {
     font-size: $pt-font-size-small;
-    margin-top: 0.2 * $pt-grid-size;
+    margin-top: $bp-spacing * 0.5;
   }
 
   &-ellipsize,

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -5,7 +5,7 @@
 @import "../../common/variables";
 @import "../button/common";
 
-$input-padding-horizontal: $bp-spacing * 2.5 !default;
+$input-padding-horizontal: $pt-spacing * 2.5 !default;
 $input-small-padding: $pt-input-height-small - $pt-icon-size-standard !default;
 $input-font-weight: 400 !default;
 $input-transition: box-shadow $pt-transition-duration $pt-transition-ease;
@@ -110,7 +110,7 @@ $control-group-stack: (
     border-radius: $pt-input-height;
     // override normalize.css
     box-sizing: border-box;
-    padding-left: $bp-spacing * 2.5;
+    padding-left: $pt-spacing * 2.5;
   }
 
   &[readonly] {
@@ -207,12 +207,12 @@ $control-group-stack: (
 
 @mixin pt-input-intent($color) {
   box-shadow:
-    input-transition-shadow($color, false, $bp-spacing * 0.5),
+    input-transition-shadow($color, false, $pt-spacing * 0.5),
     inset border-shadow(1, $color),
     $pt-input-box-shadow;
 
   &:focus {
-    box-shadow: input-transition-shadow($color, true, $bp-spacing * 0.5), $input-box-shadow-focus;
+    box-shadow: input-transition-shadow($color, true, $pt-spacing * 0.5), $input-box-shadow-focus;
   }
 
   &[readonly] {
@@ -227,12 +227,12 @@ $control-group-stack: (
 
 @mixin pt-dark-input-intent($color) {
   box-shadow:
-    dark-input-transition-shadow($color, false, $bp-spacing * 0.5),
+    dark-input-transition-shadow($color, false, $pt-spacing * 0.5),
     inset border-shadow(1, $color),
     $pt-dark-input-box-shadow;
 
   &:focus {
-    box-shadow: dark-input-transition-shadow($color, true, $bp-spacing * 0.5),
+    box-shadow: dark-input-transition-shadow($color, true, $pt-spacing * 0.5),
       $pt-dark-input-box-shadow;
   }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -207,12 +207,12 @@ $control-group-stack: (
 
 @mixin pt-input-intent($color) {
   box-shadow:
-    input-transition-shadow($color, false, 2px),
+    input-transition-shadow($color, false, $bp-spacing * 0.5),
     inset border-shadow(1, $color),
     $pt-input-box-shadow;
 
   &:focus {
-    box-shadow: input-transition-shadow($color, true, 2px), $input-box-shadow-focus;
+    box-shadow: input-transition-shadow($color, true, $bp-spacing * 0.5), $input-box-shadow-focus;
   }
 
   &[readonly] {
@@ -227,12 +227,13 @@ $control-group-stack: (
 
 @mixin pt-dark-input-intent($color) {
   box-shadow:
-    dark-input-transition-shadow($color, false, 2px),
+    dark-input-transition-shadow($color, false, $bp-spacing * 0.5),
     inset border-shadow(1, $color),
     $pt-dark-input-box-shadow;
 
   &:focus {
-    box-shadow: dark-input-transition-shadow($color, true, 2px), $pt-dark-input-box-shadow;
+    box-shadow: dark-input-transition-shadow($color, true, $bp-spacing * 0.5),
+      $pt-dark-input-box-shadow;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -5,7 +5,7 @@
 @import "../../common/variables";
 @import "../button/common";
 
-$input-padding-horizontal: $pt-grid-size !default;
+$input-padding-horizontal: $bp-spacing * 2.5 !default;
 $input-small-padding: $pt-input-height-small - $pt-icon-size-standard !default;
 $input-font-weight: 400 !default;
 $input-transition: box-shadow $pt-transition-duration $pt-transition-ease;
@@ -110,7 +110,7 @@ $control-group-stack: (
     border-radius: $pt-input-height;
     // override normalize.css
     box-sizing: border-box;
-    padding-left: $pt-grid-size;
+    padding-left: $bp-spacing * 2.5;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -130,7 +130,7 @@
 
   &:not(.#{$ns}-vertical) {
     > :not(:last-child) {
-      margin-right: 2px;
+      margin-right: $bp-spacing * 0.5;
     }
   }
 
@@ -156,7 +156,7 @@
     flex-direction: column;
 
     > :not(:last-child) {
-      margin-bottom: 2px;
+      margin-bottom: $bp-spacing * 0.5;
     }
   }
 }

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -130,7 +130,7 @@
 
   &:not(.#{$ns}-vertical) {
     > :not(:last-child) {
-      margin-right: $bp-spacing * 0.5;
+      margin-right: $pt-spacing * 0.5;
     }
   }
 
@@ -156,7 +156,7 @@
     flex-direction: column;
 
     > :not(:last-child) {
-      margin-bottom: $bp-spacing * 0.5;
+      margin-bottom: $pt-spacing * 0.5;
     }
   }
 }

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -27,7 +27,7 @@ $dark-control-checked-box-shadow: inset 0 0 0 $button-border-width rgba($white, 
 
 $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
-$control-indicator-spacing: $bp-spacing * 2.5 !default;
+$control-indicator-spacing: $pt-spacing * 2.5 !default;
 
 @mixin control-checked-colors($selector: ":checked") {
   input#{$selector} ~ .#{$ns}-control-indicator {
@@ -130,7 +130,7 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
   cursor: pointer;
 
   display: block;
-  margin-bottom: $bp-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2.5;
   position: relative;
   text-transform: none;
 
@@ -141,7 +141,7 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
 
   &.#{$ns}-inline {
     display: inline-block;
-    margin-inline-end: $bp-spacing * 5;
+    margin-inline-end: $pt-spacing * 5;
   }
 
   .#{$ns}-control-input {
@@ -164,7 +164,7 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
     font-size: $control-indicator-size;
     height: 1em;
     margin-inline-end: $control-indicator-spacing;
-    margin-top: $bp-spacing * -0.75;
+    margin-top: $pt-spacing * -0.75;
     position: relative;
     user-select: none;
     vertical-align: middle;
@@ -302,10 +302,10 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
         // Windows High Contrast dark theme
         background: $pt-high-contrast-mode-active-background-color;
         // Subtract border on either end, and then an extra 2px for space between the border
-        height: $control-indicator-size - $bp-spacing;
+        height: $control-indicator-size - $pt-spacing;
         margin-left: 1px;
         margin-top: 1px;
-        width: $control-indicator-size - $bp-spacing;
+        width: $control-indicator-size - $pt-spacing;
       }
     }
 
@@ -330,7 +330,7 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
 
   /* stylelint-disable-next-line order/order */
   $switch-width: 1.75em !default;
-  $switch-indicator-margin: $bp-spacing * 0.5 !default;
+  $switch-indicator-margin: $pt-spacing * 0.5 !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
 
   $switch-indicator-child-height: 1em;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -330,7 +330,7 @@ $control-indicator-spacing: $pt-grid-size !default;
 
   /* stylelint-disable-next-line order/order */
   $switch-width: 1.75em !default;
-  $switch-indicator-margin: 2px !default;
+  $switch-indicator-margin: $bp-spacing * 0.5 !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
 
   $switch-indicator-child-height: 1em;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -164,7 +164,7 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
     font-size: $control-indicator-size;
     height: 1em;
     margin-inline-end: $control-indicator-spacing;
-    margin-top: -3px;
+    margin-top: $bp-spacing * -0.75;
     position: relative;
     user-select: none;
     vertical-align: middle;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -141,7 +141,7 @@ $control-indicator-spacing: $bp-spacing * 2.5 !default;
 
   &.#{$ns}-inline {
     display: inline-block;
-    margin-inline-end: $pt-grid-size * 2;
+    margin-inline-end: $bp-spacing * 5;
   }
 
   .#{$ns}-control-input {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -302,10 +302,10 @@ $control-indicator-spacing: $pt-grid-size !default;
         // Windows High Contrast dark theme
         background: $pt-high-contrast-mode-active-background-color;
         // Subtract border on either end, and then an extra 2px for space between the border
-        height: $control-indicator-size - 4px;
+        height: $control-indicator-size - $bp-spacing;
         margin-left: 1px;
         margin-top: 1px;
-        width: $control-indicator-size - 4px;
+        width: $control-indicator-size - $bp-spacing;
       }
     }
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -27,7 +27,7 @@ $dark-control-checked-box-shadow: inset 0 0 0 $button-border-width rgba($white, 
 
 $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
-$control-indicator-spacing: $pt-grid-size !default;
+$control-indicator-spacing: $bp-spacing * 2.5 !default;
 
 @mixin control-checked-colors($selector: ":checked") {
   input#{$selector} ~ .#{$ns}-control-indicator {
@@ -130,7 +130,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   cursor: pointer;
 
   display: block;
-  margin-bottom: $pt-grid-size;
+  margin-bottom: $bp-spacing * 2.5;
   position: relative;
   text-transform: none;
 

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -5,9 +5,9 @@
 @import "../button/common";
 @import "../../common/mixins";
 
-$file-input-button-width: $bp-spacing * 17.5 !default;
-$file-input-button-width-large: $bp-spacing * 21.25 !default;
-$file-input-button-width-small: $bp-spacing * 13.75 !default;
+$file-input-button-width: $pt-spacing * 17.5 !default;
+$file-input-button-width-large: $pt-spacing * 21.25 !default;
+$file-input-button-width-small: $pt-spacing * 13.75 !default;
 $file-input-button-padding: ($pt-input-height - $pt-button-height-small) * 0.5 !default;
 $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) * 0.5 !default;
 $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-smaller) * 0.5 !default;
@@ -20,7 +20,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   input {
     margin: 0;
-    min-width: $bp-spacing * 50;
+    min-width: $pt-spacing * 50;
     opacity: 0;
 
     // unlike other form controls that directly style native elements,

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -5,7 +5,7 @@
 @import "../button/common";
 @import "../../common/mixins";
 
-$file-input-button-width: $pt-grid-size * 7 !default;
+$file-input-button-width: $bp-spacing * 17.5 !default;
 $file-input-button-width-large: $pt-grid-size * 8.5 !default;
 $file-input-button-width-small: $pt-grid-size * 5.5 !default;
 $file-input-button-padding: ($pt-input-height - $pt-button-height-small) * 0.5 !default;
@@ -20,7 +20,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   input {
     margin: 0;
-    min-width: $pt-grid-size * 20;
+    min-width: $bp-spacing * 50;
     opacity: 0;
 
     // unlike other form controls that directly style native elements,

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -6,8 +6,8 @@
 @import "../../common/mixins";
 
 $file-input-button-width: $bp-spacing * 17.5 !default;
-$file-input-button-width-large: $pt-grid-size * 8.5 !default;
-$file-input-button-width-small: $pt-grid-size * 5.5 !default;
+$file-input-button-width-large: $bp-spacing * 21.25 !default;
+$file-input-button-width-small: $bp-spacing * 13.75 !default;
 $file-input-button-padding: ($pt-input-height - $pt-button-height-small) * 0.5 !default;
 $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) * 0.5 !default;
 $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-smaller) * 0.5 !default;

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -8,7 +8,7 @@
 .#{$ns}-form-group {
   display: flex;
   flex-direction: column;
-  margin: 0 0 ($pt-grid-size * 1.5);
+  margin: 0 0 ($bp-spacing * 3.75);
 
   label.#{$ns}-label {
     margin-bottom: $bp-spacing * 1.25;

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -51,12 +51,12 @@
 
     &.#{$ns}-large label.#{$ns}-label {
       line-height: $pt-input-height-large;
-      margin: 0 $pt-grid-size 0 0;
+      margin: 0 ($bp-spacing * 2.5) 0 0;
     }
 
     label.#{$ns}-label {
       line-height: $pt-input-height;
-      margin: 0 $pt-grid-size 0 0;
+      margin: 0 ($bp-spacing * 2.5) 0 0;
     }
   }
 

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -11,7 +11,7 @@
   margin: 0 0 ($pt-grid-size * 1.5);
 
   label.#{$ns}-label {
-    margin-bottom: $pt-grid-size * 0.5;
+    margin-bottom: $bp-spacing * 1.25;
   }
 
   .#{$ns}-control {
@@ -25,11 +25,11 @@
   }
 
   .#{$ns}-form-group-sub-label {
-    margin-bottom: $pt-grid-size * 0.5;
+    margin-bottom: $bp-spacing * 1.25;
   }
 
   .#{$ns}-form-helper-text {
-    margin-top: $pt-grid-size * 0.5;
+    margin-top: $bp-spacing * 1.25;
   }
 
   /* stylelint-disable-next-line order/declaration-block-order */

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -8,10 +8,10 @@
 .#{$ns}-form-group {
   display: flex;
   flex-direction: column;
-  margin: 0 0 ($bp-spacing * 3.75);
+  margin: 0 0 ($pt-spacing * 3.75);
 
   label.#{$ns}-label {
-    margin-bottom: $bp-spacing * 1.25;
+    margin-bottom: $pt-spacing * 1.25;
   }
 
   .#{$ns}-control {
@@ -25,11 +25,11 @@
   }
 
   .#{$ns}-form-group-sub-label {
-    margin-bottom: $bp-spacing * 1.25;
+    margin-bottom: $pt-spacing * 1.25;
   }
 
   .#{$ns}-form-helper-text {
-    margin-top: $bp-spacing * 1.25;
+    margin-top: $pt-spacing * 1.25;
   }
 
   /* stylelint-disable-next-line order/declaration-block-order */
@@ -51,12 +51,12 @@
 
     &.#{$ns}-large label.#{$ns}-label {
       line-height: $pt-input-height-large;
-      margin: 0 ($bp-spacing * 2.5) 0 0;
+      margin: 0 ($pt-spacing * 2.5) 0 0;
     }
 
     label.#{$ns}-label {
       line-height: $pt-input-height;
-      margin: 0 ($bp-spacing * 2.5) 0 0;
+      margin: 0 ($pt-spacing * 2.5) 0 0;
     }
   }
 

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -84,7 +84,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
   }
 
   .#{$ns}-tag {
-    margin: $pt-grid-size * 0.5;
+    margin: $bp-spacing * 1.25;
   }
 
   // all buttons go gray in default state and assume their native colors only when hovered

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -84,7 +84,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
   }
 
   .#{$ns}-tag {
-    margin: $bp-spacing * 1.25;
+    margin: $pt-spacing * 1.25;
   }
 
   // all buttons go gray in default state and assume their native colors only when hovered

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -5,7 +5,7 @@
 
 label.#{$ns}-label {
   display: block;
-  margin-bottom: ($bp-spacing * 3.75);
+  margin-bottom: ($pt-spacing * 3.75);
   margin-top: 0;
 
   .#{$ns}-html-select,

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -5,7 +5,7 @@
 
 label.#{$ns}-label {
   display: block;
-  margin-bottom: ($pt-grid-size * 1.5);
+  margin-bottom: ($bp-spacing * 3.75);
   margin-top: 0;
 
   .#{$ns}-html-select,

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -34,7 +34,7 @@
   padding: $pt-grid-size * 3;
 
   .#{$ns}-heading {
-    margin-bottom: $pt-grid-size * 2;
+    margin-bottom: $bp-spacing * 5;
 
     &:not(:first-child) {
       margin-top: $pt-grid-size * 4;

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -17,7 +17,7 @@
 
 .#{$ns}-hotkey-dialog {
   padding-bottom: 0;
-  top: $pt-grid-size * 4;
+  top: $bp-spacing * 10;
 
   .#{$ns}-dialog-body {
     margin: 0;
@@ -37,7 +37,7 @@
     margin-bottom: $bp-spacing * 5;
 
     &:not(:first-child) {
-      margin-top: $pt-grid-size * 4;
+      margin-top: $bp-spacing * 10;
     }
   }
 }

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -31,7 +31,7 @@
 
 .#{$ns}-hotkey-column {
   margin: auto;
-  padding: $pt-grid-size * 3;
+  padding: $bp-spacing * 7.5;
 
   .#{$ns}-heading {
     margin-bottom: $bp-spacing * 5;

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -50,6 +50,6 @@
   margin-right: 0;
 
   &:not(:last-child) {
-    margin-bottom: $pt-grid-size;
+    margin-bottom: $bp-spacing * 2.5;
   }
 }

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -7,7 +7,7 @@
   align-items: center;
 
   &:not(.#{$ns}-minimal) {
-    @include pt-flex-container(row, $bp-spacing * 1.25);
+    @include pt-flex-container(row, $pt-spacing * 1.25);
   }
 
   &.#{$ns}-minimal {
@@ -17,7 +17,7 @@
 
 .#{$ns}-hotkey-dialog {
   padding-bottom: 0;
-  top: $bp-spacing * 10;
+  top: $pt-spacing * 10;
 
   .#{$ns}-dialog-body {
     margin: 0;
@@ -31,13 +31,13 @@
 
 .#{$ns}-hotkey-column {
   margin: auto;
-  padding: $bp-spacing * 7.5;
+  padding: $pt-spacing * 7.5;
 
   .#{$ns}-heading {
-    margin-bottom: $bp-spacing * 5;
+    margin-bottom: $pt-spacing * 5;
 
     &:not(:first-child) {
-      margin-top: $bp-spacing * 10;
+      margin-top: $pt-spacing * 10;
     }
   }
 }
@@ -50,6 +50,6 @@
   margin-right: 0;
 
   &:not(:last-child) {
-    margin-bottom: $bp-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2.5;
   }
 }

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -7,7 +7,7 @@
   align-items: center;
 
   &:not(.#{$ns}-minimal) {
-    @include pt-flex-container(row, $pt-grid-size * 0.5);
+    @include pt-flex-container(row, $bp-spacing * 1.25);
   }
 
   &.#{$ns}-minimal {

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -45,7 +45,7 @@
   position: absolute;
   // N.B. it's more important for the icon to vertically align with button end icons rather than
   // input right padding, see https://github.com/palantir/blueprint/issues/6184
-  right: $bp-spacing * 2.5;
+  right: $pt-spacing * 2.5;
   top: ($pt-button-height - $pt-icon-size-standard) * 0.5;
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -45,7 +45,7 @@
   position: absolute;
   // N.B. it's more important for the icon to vertically align with button end icons rather than
   // input right padding, see https://github.com/palantir/blueprint/issues/6184
-  right: $pt-grid-size;
+  right: $bp-spacing * 2.5;
   top: ($pt-button-height - $pt-icon-size-standard) * 0.5;
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -36,7 +36,7 @@
 
     &::after, // CSS support
     .#{$ns}-icon {
-      right: $bp-spacing * 3;
+      right: $pt-spacing * 3;
       top: ($pt-button-height-large - $pt-icon-size-standard) * 0.5;
     }
   }

--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -36,7 +36,7 @@
 
     &::after, // CSS support
     .#{$ns}-icon {
-      right: $pt-grid-size * 1.2;
+      right: $bp-spacing * 3;
       top: ($pt-button-height-large - $pt-icon-size-standard) * 0.5;
     }
   }

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables";
 
 $table-row-height: $pt-grid-size * 4 !default;
-$table-row-height-small: $pt-grid-size * 3 !default;
+$table-row-height-small: $bp-spacing * 7.5 !default;
 $table-border-width: 1px !default;
 $table-border-color: $pt-divider-black !default;
 $dark-table-border-color: $pt-dark-divider-white !default;

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$table-row-height: $pt-grid-size * 4 !default;
+$table-row-height: $bp-spacing * 10 !default;
 $table-row-height-small: $bp-spacing * 7.5 !default;
 $table-border-width: 1px !default;
 $table-border-color: $pt-divider-black !default;

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -3,8 +3,8 @@
 
 @import "../../common/variables";
 
-$table-row-height: $bp-spacing * 10 !default;
-$table-row-height-small: $bp-spacing * 7.5 !default;
+$table-row-height: $pt-spacing * 10 !default;
+$table-row-height-small: $pt-spacing * 7.5 !default;
 $table-border-width: 1px !default;
 $table-border-color: $pt-divider-black !default;
 $dark-table-border-color: $pt-dark-divider-white !default;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -376,7 +376,7 @@ $dark-menu-item-intent-colors: (
   #{$heading-selector} {
     font-size: $bp-spacing * 4.5;
     padding-bottom: $bp-spacing * 1.25;
-    padding-top: $pt-grid-size * 1.5;
+    padding-top: $bp-spacing * 3.75;
   }
 
   &:first-of-type #{$heading-selector} {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -16,14 +16,14 @@ $menu-item-line-height-factor: 1.4;
 $menu-item-line-height: round($pt-font-size * $menu-item-line-height-factor);
 $menu-item-line-height-large: round($pt-font-size-large * $menu-item-line-height-factor);
 
-$menu-min-width: $bp-spacing * 45 !default;
+$menu-min-width: $pt-spacing * 45 !default;
 $menu-item-padding: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $menu-item-padding-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 $menu-item-padding-vertical: ($pt-button-height - $menu-item-line-height) * 0.5 !default;
 $menu-item-padding-vertical-large: ($pt-button-height-large - $menu-item-line-height-large) * 0.5 !default;
 $menu-item-padding-small: ($pt-button-height-small - $pt-icon-size-standard) * 0.5 !default;
 $menu-item-padding-vertical-small: ($pt-button-height-small - $menu-item-line-height) * 0.5 !default;
-$menu-item-selected-icon-spacing: $bp-spacing * 0.5;
+$menu-item-selected-icon-spacing: $pt-spacing * 0.5;
 $menu-item-indent: $pt-icon-size-standard + $menu-item-selected-icon-spacing * 2;
 
 $menu-background-color: $white !default;
@@ -369,14 +369,14 @@ $dark-menu-item-intent-colors: (
   // a little extra space to avoid clipping descenders (because overflow hidden)
   line-height: $pt-icon-size-standard + 1px;
   margin: 0;
-  padding: ($bp-spacing * 2.5) $menu-item-padding 0 (1px + $half-grid-size);
+  padding: ($pt-spacing * 2.5) $menu-item-padding 0 (1px + $half-grid-size);
 }
 
 @mixin menu-header-large($heading-selector) {
   #{$heading-selector} {
-    font-size: $bp-spacing * 4.5;
-    padding-bottom: $bp-spacing * 1.25;
-    padding-top: $bp-spacing * 3.75;
+    font-size: $pt-spacing * 4.5;
+    padding-bottom: $pt-spacing * 1.25;
+    padding-top: $pt-spacing * 3.75;
   }
 
   &:first-of-type #{$heading-selector} {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -374,7 +374,7 @@ $dark-menu-item-intent-colors: (
 
 @mixin menu-header-large($heading-selector) {
   #{$heading-selector} {
-    font-size: $pt-grid-size * 1.8;
+    font-size: $bp-spacing * 4.5;
     padding-bottom: $pt-grid-size * 0.5;
     padding-top: $pt-grid-size * 1.5;
   }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -369,7 +369,7 @@ $dark-menu-item-intent-colors: (
   // a little extra space to avoid clipping descenders (because overflow hidden)
   line-height: $pt-icon-size-standard + 1px;
   margin: 0;
-  padding: $pt-grid-size $menu-item-padding 0 (1px + $half-grid-size);
+  padding: ($bp-spacing * 2.5) $menu-item-padding 0 (1px + $half-grid-size);
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -375,7 +375,7 @@ $dark-menu-item-intent-colors: (
 @mixin menu-header-large($heading-selector) {
   #{$heading-selector} {
     font-size: $bp-spacing * 4.5;
-    padding-bottom: $pt-grid-size * 0.5;
+    padding-bottom: $bp-spacing * 1.25;
     padding-top: $pt-grid-size * 1.5;
   }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -16,7 +16,7 @@ $menu-item-line-height-factor: 1.4;
 $menu-item-line-height: round($pt-font-size * $menu-item-line-height-factor);
 $menu-item-line-height-large: round($pt-font-size-large * $menu-item-line-height-factor);
 
-$menu-min-width: $pt-grid-size * 18 !default;
+$menu-min-width: $bp-spacing * 45 !default;
 $menu-item-padding: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $menu-item-padding-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 $menu-item-padding-vertical: ($pt-button-height - $menu-item-line-height) * 0.5 !default;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -23,7 +23,7 @@ $menu-item-padding-vertical: ($pt-button-height - $menu-item-line-height) * 0.5 
 $menu-item-padding-vertical-large: ($pt-button-height-large - $menu-item-line-height-large) * 0.5 !default;
 $menu-item-padding-small: ($pt-button-height-small - $pt-icon-size-standard) * 0.5 !default;
 $menu-item-padding-vertical-small: ($pt-button-height-small - $menu-item-line-height) * 0.5 !default;
-$menu-item-selected-icon-spacing: 2px;
+$menu-item-selected-icon-spacing: $bp-spacing * 0.5;
 $menu-item-indent: $pt-icon-size-standard + $menu-item-selected-icon-spacing * 2;
 
 $menu-background-color: $white !default;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -92,5 +92,5 @@ button.#{$ns}-menu-item {
 
 // #402 support menu inside label
 .#{$ns}-label .#{$ns}-menu {
-  margin-top: $bp-spacing * 1.25;
+  margin-top: $pt-spacing * 1.25;
 }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -92,5 +92,5 @@ button.#{$ns}-menu-item {
 
 // #402 support menu inside label
 .#{$ns}-label .#{$ns}-menu {
-  margin-top: $pt-grid-size * 0.5;
+  margin-top: $bp-spacing * 1.25;
 }

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -67,7 +67,7 @@ $dark-navbar-background-color: $dark-card-background-color !default;
 .#{$ns}-navbar-divider {
   border-left: 1px solid $pt-divider-black;
   height: $pt-navbar-height - $pt-grid-size * 3;
-  margin: 0 $pt-grid-size;
+  margin: 0 ($bp-spacing * 2.5);
 
   .#{$ns}-dark & {
     border-left-color: $pt-dark-divider-white;

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -66,7 +66,7 @@ $dark-navbar-background-color: $dark-card-background-color !default;
 
 .#{$ns}-navbar-divider {
   border-left: 1px solid $pt-divider-black;
-  height: $pt-navbar-height - $pt-grid-size * 3;
+  height: $pt-navbar-height - $bp-spacing * 7.5;
   margin: 0 ($bp-spacing * 2.5);
 
   .#{$ns}-dark & {

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables";
 @import "../card/card-variables";
 
-$navbar-padding: $bp-spacing * 3.75 !default;
+$navbar-padding: $pt-spacing * 3.75 !default;
 
 $navbar-background-color: $card-background-color !default;
 $dark-navbar-background-color: $dark-card-background-color !default;
@@ -66,8 +66,8 @@ $dark-navbar-background-color: $dark-card-background-color !default;
 
 .#{$ns}-navbar-divider {
   border-left: 1px solid $pt-divider-black;
-  height: $pt-navbar-height - $bp-spacing * 7.5;
-  margin: 0 ($bp-spacing * 2.5);
+  height: $pt-navbar-height - $pt-spacing * 7.5;
+  margin: 0 ($pt-spacing * 2.5);
 
   .#{$ns}-dark & {
     border-left-color: $pt-dark-divider-white;

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables";
 @import "../card/card-variables";
 
-$navbar-padding: $pt-grid-size * 1.5 !default;
+$navbar-padding: $bp-spacing * 3.75 !default;
 
 $navbar-background-color: $card-background-color !default;
 $dark-navbar-background-color: $dark-card-background-color !default;

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -5,7 +5,7 @@
 @import "../../common/mixins";
 
 .#{$ns}-non-ideal-state {
-  @include pt-flex-container(column, $bp-spacing * 5);
+  @include pt-flex-container(column, $pt-spacing * 5);
   align-items: center;
   color: $pt-text-color-muted;
   height: 100%;
@@ -14,13 +14,13 @@
   width: 100%;
 
   > * {
-    max-width: $bp-spacing * 100;
+    max-width: $pt-spacing * 100;
   }
 
   .#{$ns}-heading {
     color: $pt-text-color-muted;
-    line-height: $bp-spacing * 5;
-    margin-bottom: $bp-spacing * 2.5;
+    line-height: $pt-spacing * 5;
+    margin-bottom: $pt-spacing * 2.5;
 
     &:only-child {
       margin-bottom: 0;
@@ -28,7 +28,7 @@
   }
 
   &.#{$ns}-non-ideal-state-horizontal {
-    @include pt-flex-container(row, $bp-spacing * 5);
+    @include pt-flex-container(row, $pt-spacing * 5);
     text-align: left;
 
     // We need to override the pt-flex-container() styles on the default vertical layout of this

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -14,7 +14,7 @@
   width: 100%;
 
   > * {
-    max-width: $pt-grid-size * 40;
+    max-width: $bp-spacing * 100;
   }
 
   .#{$ns}-heading {

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -5,7 +5,7 @@
 @import "../../common/mixins";
 
 .#{$ns}-non-ideal-state {
-  @include pt-flex-container(column, $pt-grid-size * 2);
+  @include pt-flex-container(column, $bp-spacing * 5);
   align-items: center;
   color: $pt-text-color-muted;
   height: 100%;
@@ -19,7 +19,7 @@
 
   .#{$ns}-heading {
     color: $pt-text-color-muted;
-    line-height: $pt-grid-size * 2;
+    line-height: $bp-spacing * 5;
     margin-bottom: $bp-spacing * 2.5;
 
     &:only-child {
@@ -28,7 +28,7 @@
   }
 
   &.#{$ns}-non-ideal-state-horizontal {
-    @include pt-flex-container(row, $pt-grid-size * 2);
+    @include pt-flex-container(row, $bp-spacing * 5);
     text-align: left;
 
     // We need to override the pt-flex-container() styles on the default vertical layout of this

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -20,7 +20,7 @@
   .#{$ns}-heading {
     color: $pt-text-color-muted;
     line-height: $pt-grid-size * 2;
-    margin-bottom: $pt-grid-size;
+    margin-bottom: $bp-spacing * 2.5;
 
     &:only-child {
       margin-bottom: 0;

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -41,7 +41,7 @@
 
   .#{$ns}-icon {
     // reduce margins around icon so it fits better in tight header
-    margin: 0 2px;
+    margin: 0 ($bp-spacing * 0.5);
   }
 }
 

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -30,12 +30,12 @@
   }
 
   .#{$ns}-heading {
-    margin: 0 ($pt-grid-size * 0.5);
+    margin: 0 ($bp-spacing * 1.25);
   }
 }
 
 .#{$ns}-button.#{$ns}-panel-stack2-header-back {
-  margin-left: $pt-grid-size * 0.5;
+  margin-left: $bp-spacing * 1.25;
   padding-left: 0;
   white-space: nowrap;
 

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -15,7 +15,7 @@
   box-shadow: 0 1px $pt-divider-black;
   display: flex;
   flex-shrink: 0;
-  height: $pt-grid-size * 3;
+  height: $bp-spacing * 7.5;
   z-index: 1;
 
   .#{$ns}-dark & {

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -15,7 +15,7 @@
   box-shadow: 0 1px $pt-divider-black;
   display: flex;
   flex-shrink: 0;
-  height: $bp-spacing * 7.5;
+  height: $pt-spacing * 7.5;
   z-index: 1;
 
   .#{$ns}-dark & {
@@ -30,18 +30,18 @@
   }
 
   .#{$ns}-heading {
-    margin: 0 ($bp-spacing * 1.25);
+    margin: 0 ($pt-spacing * 1.25);
   }
 }
 
 .#{$ns}-button.#{$ns}-panel-stack2-header-back {
-  margin-left: $bp-spacing * 1.25;
+  margin-left: $pt-spacing * 1.25;
   padding-left: 0;
   white-space: nowrap;
 
   .#{$ns}-icon {
     // reduce margins around icon so it fits better in tight header
-    margin: 0 ($bp-spacing * 0.5);
+    margin: 0 ($pt-spacing * 0.5);
   }
 }
 

--- a/packages/core/src/components/popover/_popover-in-label.scss
+++ b/packages/core/src/components/popover/_popover-in-label.scss
@@ -6,7 +6,7 @@
 label.#{$ns}-label {
   .#{$ns}-popover-target {
     display: block;
-    margin-top: $pt-grid-size * 0.5;
+    margin-top: $bp-spacing * 1.25;
     text-transform: none;
   }
 }

--- a/packages/core/src/components/popover/_popover-in-label.scss
+++ b/packages/core/src/components/popover/_popover-in-label.scss
@@ -6,7 +6,7 @@
 label.#{$ns}-label {
   .#{$ns}-popover-target {
     display: block;
-    margin-top: $bp-spacing * 1.25;
+    margin-top: $pt-spacing * 1.25;
     text-transform: none;
   }
 }

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -20,7 +20,7 @@ $dark-popover-arrow-box-shadow:
 
 .#{$ns}-popover {
   @include popover-sizing(
-    $arrow-square-size: 30px,
+    $arrow-square-size: $bp-spacing * 7.5,
     $arrow-offset: $bp-spacing,
     $arrow-target-offset: -$bp-spacing
   );

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -9,7 +9,7 @@
 @import "./popover-in-submenu";
 @import "./popover-in-tree";
 
-$popover-width: $bp-spacing * 87.5 !default;
+$popover-width: $pt-spacing * 87.5 !default;
 $popover-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !default;
 // Extra border shadow added here to match the one in $pt-dark-popover-box-shadow.
 // We can't use a transparent color here because it is outset and will overlay other lines/borders underneath.
@@ -20,9 +20,9 @@ $dark-popover-arrow-box-shadow:
 
 .#{$ns}-popover {
   @include popover-sizing(
-    $arrow-square-size: $bp-spacing * 7.5,
-    $arrow-offset: $bp-spacing,
-    $arrow-target-offset: -$bp-spacing
+    $arrow-square-size: $pt-spacing * 7.5,
+    $arrow-offset: $pt-spacing,
+    $arrow-target-offset: -$pt-spacing
   );
   @include popover-appearance(
     $pt-popover-background-color,
@@ -44,7 +44,7 @@ $dark-popover-arrow-box-shadow:
   &.#{$ns}-popover-content-sizing {
     .#{$ns}-popover-content {
       max-width: $popover-width;
-      padding: $bp-spacing * 5;
+      padding: $pt-spacing * 5;
     }
 
     // only inline popovers get a width if this class is applied.

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -19,7 +19,11 @@ $dark-popover-arrow-box-shadow:
   1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
 .#{$ns}-popover {
-  @include popover-sizing($arrow-square-size: 30px, $arrow-offset: 4px, $arrow-target-offset: -4px);
+  @include popover-sizing(
+    $arrow-square-size: 30px,
+    $arrow-offset: $bp-spacing,
+    $arrow-target-offset: -$bp-spacing
+  );
   @include popover-appearance(
     $pt-popover-background-color,
     inherit,

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -9,7 +9,7 @@
 @import "./popover-in-submenu";
 @import "./popover-in-tree";
 
-$popover-width: $pt-grid-size * 35 !default;
+$popover-width: $bp-spacing * 87.5 !default;
 $popover-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !default;
 // Extra border shadow added here to match the one in $pt-dark-popover-box-shadow.
 // We can't use a transparent color here because it is outset and will overlay other lines/borders underneath.

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -44,7 +44,7 @@ $dark-popover-arrow-box-shadow:
   &.#{$ns}-popover-content-sizing {
     .#{$ns}-popover-content {
       max-width: $popover-width;
-      padding: $pt-grid-size * 2;
+      padding: $bp-spacing * 5;
     }
 
     // only inline popovers get a width if this class is applied.

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -6,7 +6,7 @@
 
 $progress-bar-stripes-color: rgba($white, 0.2) !default;
 
-$progress-bar-height: round($pt-grid-size * 0.8) !default;
+$progress-bar-height: $bp-spacing * 2 !default;
 $progress-bar-stripes-size: $pt-grid-size * 3 !default;
 $progress-bar-border-radius: $pt-grid-size * 4 !default;
 

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -8,7 +8,7 @@ $progress-bar-stripes-color: rgba($white, 0.2) !default;
 
 $progress-bar-height: $bp-spacing * 2 !default;
 $progress-bar-stripes-size: $bp-spacing * 7.5 !default;
-$progress-bar-border-radius: $pt-grid-size * 4 !default;
+$progress-bar-border-radius: $bp-spacing * 10 !default;
 
 $progress-bar-gradient: linear-gradient(
   -45deg,

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -6,9 +6,9 @@
 
 $progress-bar-stripes-color: rgba($white, 0.2) !default;
 
-$progress-bar-height: $bp-spacing * 2 !default;
-$progress-bar-stripes-size: $bp-spacing * 7.5 !default;
-$progress-bar-border-radius: $bp-spacing * 10 !default;
+$progress-bar-height: $pt-spacing * 2 !default;
+$progress-bar-stripes-size: $pt-spacing * 7.5 !default;
+$progress-bar-border-radius: $pt-spacing * 10 !default;
 
 $progress-bar-gradient: linear-gradient(
   -45deg,

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -7,7 +7,7 @@
 $progress-bar-stripes-color: rgba($white, 0.2) !default;
 
 $progress-bar-height: $bp-spacing * 2 !default;
-$progress-bar-stripes-size: $pt-grid-size * 3 !default;
+$progress-bar-stripes-size: $bp-spacing * 7.5 !default;
 $progress-bar-border-radius: $pt-grid-size * 4 !default;
 
 $progress-bar-gradient: linear-gradient(

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -49,7 +49,7 @@ $section-card-padding-compact: $pt-grid-size * 1.5 !default;
     }
 
     &-sub-title {
-      margin-top: 2px;
+      margin-top: $bp-spacing * 0.5;
     }
 
     &-right {

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -6,7 +6,7 @@ $section-padding-vertical: $bp-spacing * 2.5 !default;
 $section-padding-horizontal: $bp-spacing * 5 !default;
 $section-card-padding: $bp-spacing * 5 !default;
 
-$section-min-height-compact: $pt-grid-size * 4 !default;
+$section-min-height-compact: $bp-spacing * 10 !default;
 $section-padding-compact-vertical: 7px !default;
 $section-padding-compact-horizontal: 15px !default;
 $section-card-padding-compact: $pt-grid-size * 1.5 !default;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -7,7 +7,7 @@ $section-padding-horizontal: $bp-spacing * 5 !default;
 $section-card-padding: $bp-spacing * 5 !default;
 
 $section-min-height-compact: $bp-spacing * 10 !default;
-$section-padding-compact-vertical: 7px !default;
+$section-padding-compact-vertical: $bp-spacing * 1.75 !default;
 $section-padding-compact-horizontal: 15px !default;
 $section-card-padding-compact: $pt-grid-size * 1.5 !default;
 

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -3,8 +3,8 @@
 
 $section-min-height: $pt-grid-size * 5 !default;
 $section-padding-vertical: $bp-spacing * 2.5 !default;
-$section-padding-horizontal: $pt-grid-size * 2 !default;
-$section-card-padding: $pt-grid-size * 2 !default;
+$section-padding-horizontal: $bp-spacing * 5 !default;
+$section-card-padding: $bp-spacing * 5 !default;
 
 $section-min-height-compact: $pt-grid-size * 4 !default;
 $section-padding-compact-vertical: 7px !default;
@@ -25,7 +25,7 @@ $section-card-padding-compact: $pt-grid-size * 1.5 !default;
     align-items: center;
     border-bottom: 1px solid $pt-divider-black;
     display: flex;
-    gap: $pt-grid-size * 2;
+    gap: $bp-spacing * 5;
     justify-content: space-between;
     min-height: $section-min-height;
     padding: 0 $section-padding-horizontal;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -2,7 +2,7 @@
 @import "../../common/variables";
 
 $section-min-height: $pt-grid-size * 5 !default;
-$section-padding-vertical: $pt-grid-size !default;
+$section-padding-vertical: $bp-spacing * 2.5 !default;
 $section-padding-horizontal: $pt-grid-size * 2 !default;
 $section-card-padding: $pt-grid-size * 2 !default;
 
@@ -40,7 +40,7 @@ $section-card-padding-compact: $pt-grid-size * 1.5 !default;
     &-left {
       align-items: center;
       display: flex;
-      gap: $pt-grid-size;
+      gap: $bp-spacing * 2.5;
       padding: $section-padding-vertical 0;
     }
 
@@ -55,7 +55,7 @@ $section-card-padding-compact: $pt-grid-size * 1.5 !default;
     &-right {
       align-items: center;
       display: flex;
-      gap: $pt-grid-size;
+      gap: $bp-spacing * 2.5;
       margin-left: auto;
     }
 

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -8,8 +8,8 @@ $section-card-padding: $bp-spacing * 5 !default;
 
 $section-min-height-compact: $bp-spacing * 10 !default;
 $section-padding-compact-vertical: $bp-spacing * 1.75 !default;
-$section-padding-compact-horizontal: 15px !default;
-$section-card-padding-compact: $pt-grid-size * 1.5 !default;
+$section-padding-compact-horizontal: $bp-spacing * 3.75 !default;
+$section-card-padding-compact: $bp-spacing * 3.75 !default;
 
 .#{$ns}-section {
   overflow: hidden;
@@ -67,7 +67,7 @@ $section-card-padding-compact: $pt-grid-size * 1.5 !default;
 
     &-divider {
       align-self: stretch;
-      margin: $pt-grid-size * 1.5 0;
+      margin: $bp-spacing * 3.75 0;
     }
 
     &.#{$ns}-interactive {

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -1,15 +1,15 @@
 @use "sass:math";
 @import "../../common/variables";
 
-$section-min-height: $bp-spacing * 12.5 !default;
-$section-padding-vertical: $bp-spacing * 2.5 !default;
-$section-padding-horizontal: $bp-spacing * 5 !default;
-$section-card-padding: $bp-spacing * 5 !default;
+$section-min-height: $pt-spacing * 12.5 !default;
+$section-padding-vertical: $pt-spacing * 2.5 !default;
+$section-padding-horizontal: $pt-spacing * 5 !default;
+$section-card-padding: $pt-spacing * 5 !default;
 
-$section-min-height-compact: $bp-spacing * 10 !default;
-$section-padding-compact-vertical: $bp-spacing * 1.75 !default;
-$section-padding-compact-horizontal: $bp-spacing * 3.75 !default;
-$section-card-padding-compact: $bp-spacing * 3.75 !default;
+$section-min-height-compact: $pt-spacing * 10 !default;
+$section-padding-compact-vertical: $pt-spacing * 1.75 !default;
+$section-padding-compact-horizontal: $pt-spacing * 3.75 !default;
+$section-card-padding-compact: $pt-spacing * 3.75 !default;
 
 .#{$ns}-section {
   overflow: hidden;
@@ -25,7 +25,7 @@ $section-card-padding-compact: $bp-spacing * 3.75 !default;
     align-items: center;
     border-bottom: 1px solid $pt-divider-black;
     display: flex;
-    gap: $bp-spacing * 5;
+    gap: $pt-spacing * 5;
     justify-content: space-between;
     min-height: $section-min-height;
     padding: 0 $section-padding-horizontal;
@@ -40,7 +40,7 @@ $section-card-padding-compact: $bp-spacing * 3.75 !default;
     &-left {
       align-items: center;
       display: flex;
-      gap: $bp-spacing * 2.5;
+      gap: $pt-spacing * 2.5;
       padding: $section-padding-vertical 0;
     }
 
@@ -49,13 +49,13 @@ $section-card-padding-compact: $bp-spacing * 3.75 !default;
     }
 
     &-sub-title {
-      margin-top: $bp-spacing * 0.5;
+      margin-top: $pt-spacing * 0.5;
     }
 
     &-right {
       align-items: center;
       display: flex;
-      gap: $bp-spacing * 2.5;
+      gap: $pt-spacing * 2.5;
       margin-left: auto;
     }
 
@@ -67,7 +67,7 @@ $section-card-padding-compact: $bp-spacing * 3.75 !default;
 
     &-divider {
       align-self: stretch;
-      margin: $bp-spacing * 3.75 0;
+      margin: $pt-spacing * 3.75 0;
     }
 
     &.#{$ns}-interactive {

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -1,7 +1,7 @@
 @use "sass:math";
 @import "../../common/variables";
 
-$section-min-height: $pt-grid-size * 5 !default;
+$section-min-height: $bp-spacing * 12.5 !default;
 $section-padding-vertical: $bp-spacing * 2.5 !default;
 $section-padding-horizontal: $bp-spacing * 5 !default;
 $section-card-padding: $bp-spacing * 5 !default;

--- a/packages/core/src/components/segmented-control/_segmented-control.scss
+++ b/packages/core/src/components/segmented-control/_segmented-control.scss
@@ -5,8 +5,8 @@
   background-color: $light-gray5;
   border-radius: $pt-border-radius;
   display: flex;
-  gap: 3px;
-  padding: 3px;
+  gap: $bp-spacing * 0.75;
+  padding: $bp-spacing * 0.75;
 
   &.#{$ns}-inline {
     display: inline-flex;

--- a/packages/core/src/components/segmented-control/_segmented-control.scss
+++ b/packages/core/src/components/segmented-control/_segmented-control.scss
@@ -5,8 +5,8 @@
   background-color: $light-gray5;
   border-radius: $pt-border-radius;
   display: flex;
-  gap: $bp-spacing * 0.75;
-  padding: $bp-spacing * 0.75;
+  gap: $pt-spacing * 0.75;
+  padding: $pt-spacing * 0.75;
 
   &.#{$ns}-inline {
     display: inline-flex;

--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -45,7 +45,7 @@ Styleguide skeleton
   // Prevent background color from extending to the border and overlappping
   background-clip: padding-box !important;
   border-color: $skeleton-color-start !important;
-  border-radius: $bp-spacing * 0.5;
+  border-radius: $pt-spacing * 0.5;
   box-shadow: none !important;
 
   // Transparent text will occupy space but be invisible to the user

--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -45,7 +45,7 @@ Styleguide skeleton
   // Prevent background color from extending to the border and overlappping
   background-clip: padding-box !important;
   border-color: $skeleton-color-start !important;
-  border-radius: 2px;
+  border-radius: $bp-spacing * 0.5;
   box-shadow: none !important;
 
   // Transparent text will occupy space but be invisible to the user

--- a/packages/core/src/components/slider/_common.scss
+++ b/packages/core/src/components/slider/_common.scss
@@ -7,7 +7,7 @@
 @import "../button/common";
 
 @mixin slider-orientation($size, $vertical: false) {
-  $slider-min-size: $bp-spacing * 37.5;
+  $slider-min-size: $pt-spacing * 37.5;
 
   @if $vertical == false {
     height: $size;

--- a/packages/core/src/components/slider/_common.scss
+++ b/packages/core/src/components/slider/_common.scss
@@ -7,7 +7,7 @@
 @import "../button/common";
 
 @mixin slider-orientation($size, $vertical: false) {
-  $slider-min-size: $pt-grid-size * 15;
+  $slider-min-size: $bp-spacing * 37.5;
 
   @if $vertical == false {
     height: $size;

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -6,7 +6,7 @@
 
 $handle-size: $pt-icon-size-standard !default;
 $track-size: $handle-size - $pt-grid-size !default;
-$label-offset: $handle-size + 4px !default;
+$label-offset: $handle-size + $bp-spacing !default;
 
 $handle-border-shadow: 0 0 0 $button-border-width rgba($black, 0.5);
 $handle-box-shadow:

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -5,8 +5,8 @@
 @import "./common";
 
 $handle-size: $pt-icon-size-standard !default;
-$track-size: $handle-size - ($bp-spacing * 2.5) !default;
-$label-offset: $handle-size + $bp-spacing !default;
+$track-size: $handle-size - ($pt-spacing * 2.5) !default;
+$label-offset: $handle-size + $pt-spacing !default;
 
 $handle-border-shadow: 0 0 0 $button-border-width rgba($black, 0.5);
 $handle-box-shadow:
@@ -182,7 +182,7 @@ $track-height: $track-size !default;
   display: inline-block;
   font-size: $pt-font-size-small;
   line-height: 1;
-  padding: ($bp-spacing * 0.5) ($bp-spacing * 1.25);
+  padding: ($pt-spacing * 0.5) ($pt-spacing * 1.25);
   position: absolute;
   vertical-align: top;
 }

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -182,7 +182,7 @@ $track-height: $track-size !default;
   display: inline-block;
   font-size: $pt-font-size-small;
   line-height: 1;
-  padding: ($bp-spacing * 0.5) ($pt-grid-size * 0.5);
+  padding: ($bp-spacing * 0.5) ($bp-spacing * 1.25);
   position: absolute;
   vertical-align: top;
 }

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -5,7 +5,7 @@
 @import "./common";
 
 $handle-size: $pt-icon-size-standard !default;
-$track-size: $handle-size - $pt-grid-size !default;
+$track-size: $handle-size - ($bp-spacing * 2.5) !default;
 $label-offset: $handle-size + $bp-spacing !default;
 
 $handle-border-shadow: 0 0 0 $button-border-width rgba($black, 0.5);

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -182,7 +182,7 @@ $track-height: $track-size !default;
   display: inline-block;
   font-size: $pt-font-size-small;
   line-height: 1;
-  padding: ($pt-grid-size * 0.2) ($pt-grid-size * 0.5);
+  padding: ($bp-spacing * 0.5) ($pt-grid-size * 0.5);
   position: absolute;
   vertical-align: top;
 }

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -155,11 +155,11 @@ $tab-indicator-width: $bp-spacing * 0.75 !default;
 }
 
 .#{$ns}-tab-icon {
-  margin-right: 7px;
+  margin-right: $bp-spacing * 1.75;
 }
 
 .#{$ns}-tab-tag {
-  margin-left: 7px;
+  margin-left: $bp-spacing * 1.75;
 }
 
 .#{$ns}-tab-indicator-wrapper {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -31,7 +31,7 @@ $tab-indicator-width: 3px !default;
       align-items: center;
       border-radius: $pt-border-radius;
       display: flex;
-      padding: 0 $pt-grid-size;
+      padding: 0 ($bp-spacing * 2.5);
       width: 100%;
 
       &[aria-selected="true"] {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -58,14 +58,14 @@ $tab-indicator-width: 3px !default;
   // vertical tab component
   > .#{$ns}-tab-panel {
     margin-top: 0;
-    padding-left: $pt-grid-size * 2;
+    padding-left: $bp-spacing * 5;
   }
 }
 
 .#{$ns}-tab-list {
   align-items: flex-end;
   border: none;
-  column-gap: $pt-grid-size * 2;
+  column-gap: $bp-spacing * 5;
   display: flex;
   flex: 0 0 auto;
   list-style: none;
@@ -77,7 +77,7 @@ $tab-indicator-width: 3px !default;
     // offset column-gap from parent component above
     // since flex-expander is taking up _available_ space, we don't want to add a double gap
     // between the elements before and after the expander
-    margin-right: -$pt-grid-size * 2;
+    margin-right: $bp-spacing * -5;
   }
 }
 
@@ -147,7 +147,7 @@ $tab-indicator-width: 3px !default;
 }
 
 .#{$ns}-tab-panel {
-  margin-top: $pt-grid-size * 2;
+  margin-top: $bp-spacing * 5;
 
   &[aria-hidden="true"] {
     display: none;

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -7,7 +7,7 @@
 $tab-color-selected: $pt-link-color !default;
 $dark-tab-color-selected: $pt-dark-link-color !default;
 
-$tab-indicator-width: $bp-spacing * 0.75 !default;
+$tab-indicator-width: $pt-spacing * 0.75 !default;
 
 .#{$ns}-tabs:not(.#{$ns}-vertical).#{$ns}-fill {
   height: 100%;
@@ -31,7 +31,7 @@ $tab-indicator-width: $bp-spacing * 0.75 !default;
       align-items: center;
       border-radius: $pt-border-radius;
       display: flex;
-      padding: 0 ($bp-spacing * 2.5);
+      padding: 0 ($pt-spacing * 2.5);
       width: 100%;
 
       &[aria-selected="true"] {
@@ -58,14 +58,14 @@ $tab-indicator-width: $bp-spacing * 0.75 !default;
   // vertical tab component
   > .#{$ns}-tab-panel {
     margin-top: 0;
-    padding-left: $bp-spacing * 5;
+    padding-left: $pt-spacing * 5;
   }
 }
 
 .#{$ns}-tab-list {
   align-items: flex-end;
   border: none;
-  column-gap: $bp-spacing * 5;
+  column-gap: $pt-spacing * 5;
   display: flex;
   flex: 0 0 auto;
   list-style: none;
@@ -77,7 +77,7 @@ $tab-indicator-width: $bp-spacing * 0.75 !default;
     // offset column-gap from parent component above
     // since flex-expander is taking up _available_ space, we don't want to add a double gap
     // between the elements before and after the expander
-    margin-right: $bp-spacing * -5;
+    margin-right: $pt-spacing * -5;
   }
 }
 
@@ -147,7 +147,7 @@ $tab-indicator-width: $bp-spacing * 0.75 !default;
 }
 
 .#{$ns}-tab-panel {
-  margin-top: $bp-spacing * 5;
+  margin-top: $pt-spacing * 5;
 
   &[aria-hidden="true"] {
     display: none;
@@ -155,11 +155,11 @@ $tab-indicator-width: $bp-spacing * 0.75 !default;
 }
 
 .#{$ns}-tab-icon {
-  margin-right: $bp-spacing * 1.75;
+  margin-right: $pt-spacing * 1.75;
 }
 
 .#{$ns}-tab-tag {
-  margin-left: $bp-spacing * 1.75;
+  margin-left: $pt-spacing * 1.75;
 }
 
 .#{$ns}-tab-indicator-wrapper {

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -7,7 +7,7 @@
 $tab-color-selected: $pt-link-color !default;
 $dark-tab-color-selected: $pt-dark-link-color !default;
 
-$tab-indicator-width: 3px !default;
+$tab-indicator-width: $bp-spacing * 0.75 !default;
 
 .#{$ns}-tabs:not(.#{$ns}-vertical).#{$ns}-fill {
   height: 100%;

--- a/packages/core/src/components/tag-input/_resizable-input.scss
+++ b/packages/core/src/components/tag-input/_resizable-input.scss
@@ -4,7 +4,7 @@
 .#{$ns}-resizable-input-span {
   max-height: 0;
   max-width: 100%;
-  min-width: $bp-spacing * 20;
+  min-width: $pt-spacing * 20;
   opacity: 0;
   overflow: hidden;
   position: absolute;

--- a/packages/core/src/components/tag-input/_resizable-input.scss
+++ b/packages/core/src/components/tag-input/_resizable-input.scss
@@ -4,7 +4,7 @@
 .#{$ns}-resizable-input-span {
   max-height: 0;
   max-width: 100%;
-  min-width: $pt-grid-size * 8;
+  min-width: $bp-spacing * 20;
   opacity: 0;
   overflow: hidden;
   position: absolute;

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -73,7 +73,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     flex: 1 1 auto;
     line-height: $tag-height;
     // essentially a min-width, cuz flex allows it to grow or shrink:
-    width: $pt-grid-size * 8;
+    width: $bp-spacing * 20;
 
     &:disabled,
     &.#{$ns}-disabled {

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -73,7 +73,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     flex: 1 1 auto;
     line-height: $tag-height;
     // essentially a min-width, cuz flex allows it to grow or shrink:
-    width: $bp-spacing * 20;
+    width: $pt-spacing * 20;
 
     &:disabled,
     &.#{$ns}-disabled {

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -9,20 +9,20 @@
 
 $tag-default-color: $gray1 !default;
 
-$tag-height: $bp-spacing * 5 !default;
+$tag-height: $pt-spacing * 5 !default;
 $tag-line-height: $pt-icon-size-standard !default;
 $tag-padding-top: ($tag-height - $tag-line-height) * 0.5 !default;
 $tag-padding: $tag-padding-top * 3 !default;
 $tag-margin: ($pt-input-height - $tag-height) * 0.5 !default;
 
-$tag-height-large: $bp-spacing * 7.5 !default;
+$tag-height-large: $pt-spacing * 7.5 !default;
 $tag-line-height-large: $pt-icon-size-large !default;
 $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 
-$tag-icon-spacing: ($tag-height - ($bp-spacing * 3)) * 0.5 !default;
+$tag-icon-spacing: ($tag-height - ($pt-spacing * 3)) * 0.5 !default;
 $tag-icon-spacing-large: ($tag-height-large - $pt-icon-size-standard) * 0.5 !default;
 
-$tag-round-adjustment: $bp-spacing * 0.5 !default;
+$tag-round-adjustment: $pt-spacing * 0.5 !default;
 
 $tag-intent-colors: (
   "primary": (

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -15,7 +15,7 @@ $tag-padding-top: ($tag-height - $tag-line-height) * 0.5 !default;
 $tag-padding: $tag-padding-top * 3 !default;
 $tag-margin: ($pt-input-height - $tag-height) * 0.5 !default;
 
-$tag-height-large: $pt-grid-size * 3 !default;
+$tag-height-large: $bp-spacing * 7.5 !default;
 $tag-line-height-large: $pt-icon-size-large !default;
 $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -9,7 +9,7 @@
 
 $tag-default-color: $gray1 !default;
 
-$tag-height: $pt-grid-size * 2 !default;
+$tag-height: $bp-spacing * 5 !default;
 $tag-line-height: $pt-icon-size-standard !default;
 $tag-padding-top: ($tag-height - $tag-line-height) * 0.5 !default;
 $tag-padding: $tag-padding-top * 3 !default;

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -22,7 +22,7 @@ $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 $tag-icon-spacing: ($tag-height - 12px) * 0.5 !default;
 $tag-icon-spacing-large: ($tag-height-large - $pt-icon-size-standard) * 0.5 !default;
 
-$tag-round-adjustment: 2px !default;
+$tag-round-adjustment: $bp-spacing * 0.5 !default;
 
 $tag-intent-colors: (
   "primary": (

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -19,7 +19,7 @@ $tag-height-large: $pt-grid-size * 3 !default;
 $tag-line-height-large: $pt-icon-size-large !default;
 $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 
-$tag-icon-spacing: ($tag-height - 12px) * 0.5 !default;
+$tag-icon-spacing: ($tag-height - ($bp-spacing * 3)) * 0.5 !default;
 $tag-icon-spacing-large: ($tag-height-large - $pt-icon-size-standard) * 0.5 !default;
 
 $tag-round-adjustment: $bp-spacing * 0.5 !default;

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -110,7 +110,7 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left,
     .#{$ns}-compound-tag-right {
-      padding: 5px ($bp-spacing * 2);
+      padding: ($bp-spacing * 1.25) ($bp-spacing * 2);
     }
 
     .#{$ns}-compound-tag-left {

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -110,7 +110,7 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left,
     .#{$ns}-compound-tag-right {
-      padding: 5px 8px;
+      padding: 5px ($bp-spacing * 2);
     }
 
     .#{$ns}-compound-tag-left {

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -129,7 +129,7 @@ $compound-tag-left-intent-colors: (
       margin-left: 7px;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
-      margin-right: -10px !important;
+      margin-right: $bp-spacing * -2.5 !important;
     }
 
     // Variant: large & round

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -115,18 +115,18 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left {
       > #{$icon-classes} {
-        margin-right: 7px;
+        margin-right: $bp-spacing * 1.75;
       }
     }
 
     .#{$ns}-compound-tag-right {
       > #{$icon-classes} {
-        margin-left: 7px;
+        margin-left: $bp-spacing * 1.75;
       }
     }
 
     .#{$ns}-tag-remove {
-      margin-left: 7px;
+      margin-left: $bp-spacing * 1.75;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
       margin-right: $bp-spacing * -2.5 !important;

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -51,7 +51,7 @@ $compound-tag-left-intent-colors: (
   .#{$ns}-compound-tag-right {
     align-items: center;
     display: inline-flex;
-    padding: 2px 4px;
+    padding: ($bp-spacing * 0.5) 4px;
   }
 
   .#{$ns}-compound-tag-left {
@@ -68,7 +68,7 @@ $compound-tag-left-intent-colors: (
     border-bottom-right-radius: $pt-border-radius;
     border-top-right-radius: $pt-border-radius;
     flex-grow: 1;
-    padding: 2px 4px;
+    padding: ($bp-spacing * 0.5) 4px;
 
     > #{$icon-classes} {
       margin-left: 4px;
@@ -79,7 +79,7 @@ $compound-tag-left-intent-colors: (
     }
 
     .#{$ns}-tag-remove {
-      margin-left: 2px;
+      margin-left: $bp-spacing * 0.5;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
       margin-right: -4px !important;

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -51,7 +51,7 @@ $compound-tag-left-intent-colors: (
   .#{$ns}-compound-tag-right {
     align-items: center;
     display: inline-flex;
-    padding: ($bp-spacing * 0.5) 4px;
+    padding: ($bp-spacing * 0.5) $bp-spacing;
   }
 
   .#{$ns}-compound-tag-left {
@@ -60,7 +60,7 @@ $compound-tag-left-intent-colors: (
     margin-right: 0; // override pt-tag() pt-flex-container() style
 
     > #{$icon-classes} {
-      margin-right: 4px;
+      margin-right: $bp-spacing;
     }
   }
 
@@ -68,10 +68,10 @@ $compound-tag-left-intent-colors: (
     border-bottom-right-radius: $pt-border-radius;
     border-top-right-radius: $pt-border-radius;
     flex-grow: 1;
-    padding: ($bp-spacing * 0.5) 4px;
+    padding: ($bp-spacing * 0.5) $bp-spacing;
 
     > #{$icon-classes} {
-      margin-left: 4px;
+      margin-left: $bp-spacing;
     }
 
     .#{$ns}-compound-tag-right-content {
@@ -82,7 +82,7 @@ $compound-tag-left-intent-colors: (
       margin-left: $bp-spacing * 0.5;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
-      margin-right: -4px !important;
+      margin-right: -$bp-spacing !important;
     }
   }
 

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -51,7 +51,7 @@ $compound-tag-left-intent-colors: (
   .#{$ns}-compound-tag-right {
     align-items: center;
     display: inline-flex;
-    padding: ($bp-spacing * 0.5) $bp-spacing;
+    padding: ($pt-spacing * 0.5) $pt-spacing;
   }
 
   .#{$ns}-compound-tag-left {
@@ -60,7 +60,7 @@ $compound-tag-left-intent-colors: (
     margin-right: 0; // override pt-tag() pt-flex-container() style
 
     > #{$icon-classes} {
-      margin-right: $bp-spacing;
+      margin-right: $pt-spacing;
     }
   }
 
@@ -68,10 +68,10 @@ $compound-tag-left-intent-colors: (
     border-bottom-right-radius: $pt-border-radius;
     border-top-right-radius: $pt-border-radius;
     flex-grow: 1;
-    padding: ($bp-spacing * 0.5) $bp-spacing;
+    padding: ($pt-spacing * 0.5) $pt-spacing;
 
     > #{$icon-classes} {
-      margin-left: $bp-spacing;
+      margin-left: $pt-spacing;
     }
 
     .#{$ns}-compound-tag-right-content {
@@ -79,10 +79,10 @@ $compound-tag-left-intent-colors: (
     }
 
     .#{$ns}-tag-remove {
-      margin-left: $bp-spacing * 0.5;
+      margin-left: $pt-spacing * 0.5;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
-      margin-right: -$bp-spacing !important;
+      margin-right: -$pt-spacing !important;
     }
   }
 
@@ -110,26 +110,26 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left,
     .#{$ns}-compound-tag-right {
-      padding: ($bp-spacing * 1.25) ($bp-spacing * 2);
+      padding: ($pt-spacing * 1.25) ($pt-spacing * 2);
     }
 
     .#{$ns}-compound-tag-left {
       > #{$icon-classes} {
-        margin-right: $bp-spacing * 1.75;
+        margin-right: $pt-spacing * 1.75;
       }
     }
 
     .#{$ns}-compound-tag-right {
       > #{$icon-classes} {
-        margin-left: $bp-spacing * 1.75;
+        margin-left: $pt-spacing * 1.75;
       }
     }
 
     .#{$ns}-tag-remove {
-      margin-left: $bp-spacing * 1.75;
+      margin-left: $pt-spacing * 1.75;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
-      margin-right: $bp-spacing * -2.5 !important;
+      margin-right: $pt-spacing * -2.5 !important;
     }
 
     // Variant: large & round

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -5,9 +5,9 @@
 @import "../../common/react-transition";
 
 $toast-height: $pt-button-height-large !default;
-$toast-min-width: $bp-spacing * 75 !default;
-$toast-max-width: $bp-spacing * 125 !default;
-$toast-margin: $bp-spacing * 5 !default;
+$toast-min-width: $pt-spacing * 75 !default;
+$toast-max-width: $pt-spacing * 125 !default;
+$toast-margin: $pt-spacing * 5 !default;
 
 $toast-intent-colors: (
   "primary": (
@@ -84,7 +84,7 @@ $toast-intent-colors: (
   );
   $leave-blur: (
     opacity: 0 1,
-    filter: blur($bp-spacing * 2.5) blur(0),
+    filter: blur($pt-spacing * 2.5) blur(0),
   );
 
   // new toasts slide in from the top

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -84,7 +84,7 @@ $toast-intent-colors: (
   );
   $leave-blur: (
     opacity: 0 1,
-    filter: blur($pt-grid-size) blur(0),
+    filter: blur($bp-spacing * 2.5) blur(0),
   );
 
   // new toasts slide in from the top

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -5,8 +5,8 @@
 @import "../../common/react-transition";
 
 $toast-height: $pt-button-height-large !default;
-$toast-min-width: $pt-grid-size * 30 !default;
-$toast-max-width: $pt-grid-size * 50 !default;
+$toast-min-width: $bp-spacing * 75 !default;
+$toast-max-width: $bp-spacing * 125 !default;
 $toast-margin: $bp-spacing * 5 !default;
 
 $toast-intent-colors: (

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -7,7 +7,7 @@
 $toast-height: $pt-button-height-large !default;
 $toast-min-width: $pt-grid-size * 30 !default;
 $toast-max-width: $pt-grid-size * 50 !default;
-$toast-margin: $pt-grid-size * 2 !default;
+$toast-margin: $bp-spacing * 5 !default;
 
 $toast-intent-colors: (
   "primary": (

--- a/packages/core/src/components/tooltip/_common.scss
+++ b/packages/core/src/components/tooltip/_common.scss
@@ -7,5 +7,5 @@ $tooltip-text-color: $light-gray5 !default;
 $dark-tooltip-background-color: $light-gray3 !default;
 $dark-tooltip-text-color: $dark-gray5 !default;
 
-$tooltip-padding-vertical: $pt-grid-size !default;
+$tooltip-padding-vertical: $bp-spacing * 2.5 !default;
 $tooltip-padding-horizontal: 1.2 * $pt-grid-size !default;

--- a/packages/core/src/components/tooltip/_common.scss
+++ b/packages/core/src/components/tooltip/_common.scss
@@ -8,4 +8,4 @@ $dark-tooltip-background-color: $light-gray3 !default;
 $dark-tooltip-text-color: $dark-gray5 !default;
 
 $tooltip-padding-vertical: $bp-spacing * 2.5 !default;
-$tooltip-padding-horizontal: 1.2 * $pt-grid-size !default;
+$tooltip-padding-horizontal: $bp-spacing * 3 !default;

--- a/packages/core/src/components/tooltip/_common.scss
+++ b/packages/core/src/components/tooltip/_common.scss
@@ -7,5 +7,5 @@ $tooltip-text-color: $light-gray5 !default;
 $dark-tooltip-background-color: $light-gray3 !default;
 $dark-tooltip-text-color: $dark-gray5 !default;
 
-$tooltip-padding-vertical: $bp-spacing * 2.5 !default;
-$tooltip-padding-horizontal: $bp-spacing * 3 !default;
+$tooltip-padding-vertical: $pt-spacing * 2.5 !default;
+$tooltip-padding-horizontal: $pt-spacing * 3 !default;

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -15,7 +15,7 @@ $tooltip-padding-compact-horizontal: 0.7 * $pt-grid-size !default;
 .#{$ns}-tooltip {
   @include popover-sizing(
     $arrow-square-size: $bp-spacing * 5.5,
-    $arrow-offset: 3px,
+    $arrow-offset: $bp-spacing * 0.75,
     $arrow-target-offset: -$bp-spacing
   );
   @include popover-appearance(
@@ -58,16 +58,16 @@ $tooltip-padding-compact-horizontal: 0.7 * $pt-grid-size !default;
 
   // need to adjust arrow placement a little bit for tooltips
   &.#{$ns}-popover-placement-top .#{$ns}-popover-arrow {
-    transform: translateY(-3px);
+    transform: translateY($bp-spacing * -0.75);
   }
   &.#{$ns}-popover-placement-left .#{$ns}-popover-arrow {
-    transform: translateX(-3px);
+    transform: translateX($bp-spacing * -0.75);
   }
   &.#{$ns}-popover-placement-bottom .#{$ns}-popover-arrow {
-    transform: translateY(3px);
+    transform: translateY($bp-spacing * 0.75);
   }
   &.#{$ns}-popover-placement-right .#{$ns}-popover-arrow {
-    transform: translateX(3px);
+    transform: translateX($bp-spacing * 0.75);
   }
 
   &.#{$ns}-dark,

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -9,7 +9,7 @@
 $tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !default;
 $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
-$tooltip-padding-compact-vertical: 0.5 * $pt-grid-size !default;
+$tooltip-padding-compact-vertical: $bp-spacing * 1.25 !default;
 $tooltip-padding-compact-horizontal: 0.7 * $pt-grid-size !default;
 
 .#{$ns}-tooltip {

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -14,7 +14,7 @@ $tooltip-padding-compact-horizontal: 0.7 * $pt-grid-size !default;
 
 .#{$ns}-tooltip {
   @include popover-sizing(
-    $arrow-square-size: 22px,
+    $arrow-square-size: $bp-spacing * 5.5,
     $arrow-offset: 3px,
     $arrow-target-offset: -$bp-spacing
   );

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -13,7 +13,11 @@ $tooltip-padding-compact-vertical: 0.5 * $pt-grid-size !default;
 $tooltip-padding-compact-horizontal: 0.7 * $pt-grid-size !default;
 
 .#{$ns}-tooltip {
-  @include popover-sizing($arrow-square-size: 22px, $arrow-offset: 3px, $arrow-target-offset: -4px);
+  @include popover-sizing(
+    $arrow-square-size: 22px,
+    $arrow-offset: 3px,
+    $arrow-target-offset: -$bp-spacing
+  );
   @include popover-appearance(
     $tooltip-background-color,
     $tooltip-text-color,

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -9,14 +9,14 @@
 $tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !default;
 $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
-$tooltip-padding-compact-vertical: $bp-spacing * 1.25 !default;
-$tooltip-padding-compact-horizontal: $bp-spacing * 1.75 !default;
+$tooltip-padding-compact-vertical: $pt-spacing * 1.25 !default;
+$tooltip-padding-compact-horizontal: $pt-spacing * 1.75 !default;
 
 .#{$ns}-tooltip {
   @include popover-sizing(
-    $arrow-square-size: $bp-spacing * 5.5,
-    $arrow-offset: $bp-spacing * 0.75,
-    $arrow-target-offset: -$bp-spacing
+    $arrow-square-size: $pt-spacing * 5.5,
+    $arrow-offset: $pt-spacing * 0.75,
+    $arrow-target-offset: -$pt-spacing
   );
   @include popover-appearance(
     $tooltip-background-color,
@@ -58,16 +58,16 @@ $tooltip-padding-compact-horizontal: $bp-spacing * 1.75 !default;
 
   // need to adjust arrow placement a little bit for tooltips
   &.#{$ns}-popover-placement-top .#{$ns}-popover-arrow {
-    transform: translateY($bp-spacing * -0.75);
+    transform: translateY($pt-spacing * -0.75);
   }
   &.#{$ns}-popover-placement-left .#{$ns}-popover-arrow {
-    transform: translateX($bp-spacing * -0.75);
+    transform: translateX($pt-spacing * -0.75);
   }
   &.#{$ns}-popover-placement-bottom .#{$ns}-popover-arrow {
-    transform: translateY($bp-spacing * 0.75);
+    transform: translateY($pt-spacing * 0.75);
   }
   &.#{$ns}-popover-placement-right .#{$ns}-popover-arrow {
-    transform: translateX($bp-spacing * 0.75);
+    transform: translateX($pt-spacing * 0.75);
   }
 
   &.#{$ns}-dark,

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -10,7 +10,7 @@ $tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !de
 $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
 $tooltip-padding-compact-vertical: $bp-spacing * 1.25 !default;
-$tooltip-padding-compact-horizontal: 0.7 * $pt-grid-size !default;
+$tooltip-padding-compact-horizontal: $bp-spacing * 1.75 !default;
 
 .#{$ns}-tooltip {
   @include popover-sizing(

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -162,7 +162,7 @@ $tree-intent-icon-colors: (
   }
 
   .#{$ns}-tree-node-caret {
-    margin-right: 3px;
+    margin-right: $bp-spacing * 0.75;
     min-width: $tree-row-height-compact;
     padding: $tree-icon-spacing-compact;
   }

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -9,7 +9,7 @@
 $tree-row-height: $pt-grid-size * 3 !default;
 $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) * 0.5 !default;
 
-$tree-row-height-compact: 24px !default;
+$tree-row-height-compact: $bp-spacing * 6 !default;
 $tree-icon-spacing-compact: ($tree-row-height-compact - $pt-icon-size-standard) * 0.5 !default;
 
 $tree-intent-icon-colors: (

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -56,7 +56,7 @@ $tree-intent-icon-colors: (
   background: none;
   display: flex;
   height: $tree-row-height;
-  padding-right: $pt-grid-size * 0.5;
+  padding-right: $bp-spacing * 1.25;
   width: 100%;
 
   &:hover {
@@ -112,7 +112,7 @@ $tree-intent-icon-colors: (
 }
 
 .#{$ns}-tree-node-secondary-label {
-  padding: 0 ($pt-grid-size * 0.5);
+  padding: 0 ($bp-spacing * 1.25);
   user-select: none;
 
   .#{$ns}-popover-wrapper,

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -6,7 +6,7 @@
 @import "../../common/variables-extended";
 @import "../../common/mixins";
 
-$tree-row-height: $pt-grid-size * 3 !default;
+$tree-row-height: $bp-spacing * 7.5 !default;
 $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) * 0.5 !default;
 
 $tree-row-height-compact: $bp-spacing * 6 !default;

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -6,10 +6,10 @@
 @import "../../common/variables-extended";
 @import "../../common/mixins";
 
-$tree-row-height: $bp-spacing * 7.5 !default;
+$tree-row-height: $pt-spacing * 7.5 !default;
 $tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) * 0.5 !default;
 
-$tree-row-height-compact: $bp-spacing * 6 !default;
+$tree-row-height-compact: $pt-spacing * 6 !default;
 $tree-icon-spacing-compact: ($tree-row-height-compact - $pt-icon-size-standard) * 0.5 !default;
 
 $tree-intent-icon-colors: (
@@ -56,7 +56,7 @@ $tree-intent-icon-colors: (
   background: none;
   display: flex;
   height: $tree-row-height;
-  padding-right: $bp-spacing * 1.25;
+  padding-right: $pt-spacing * 1.25;
   width: 100%;
 
   &:hover {
@@ -112,7 +112,7 @@ $tree-intent-icon-colors: (
 }
 
 .#{$ns}-tree-node-secondary-label {
-  padding: 0 ($bp-spacing * 1.25);
+  padding: 0 ($pt-spacing * 1.25);
   user-select: none;
 
   .#{$ns}-popover-wrapper,
@@ -162,7 +162,7 @@ $tree-intent-icon-colors: (
   }
 
   .#{$ns}-tree-node-caret {
-    margin-right: $bp-spacing * 0.75;
+    margin-right: $pt-spacing * 0.75;
     min-width: $tree-row-height-compact;
     padding: $tree-icon-spacing-compact;
   }

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -7,7 +7,7 @@
 
 $datepicker-padding: $pt-grid-size * 0.5 !default;
 
-$datepicker-min-width: $pt-grid-size * 21 !default;
+$datepicker-min-width: $bp-spacing * 52.5 !default;
 $datepicker-day-size: $bp-spacing * 7.5 !default;
 $datepicker-header-height: $bp-spacing * 10 !default;
 $datepicker-header-margin: ($datepicker-header-height - $pt-input-height) * 0.5 !default;

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -5,11 +5,11 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/icons/lib/scss/variables";
 
-$datepicker-padding: $bp-spacing * 1.25 !default;
+$datepicker-padding: $pt-spacing * 1.25 !default;
 
-$datepicker-min-width: $bp-spacing * 52.5 !default;
-$datepicker-day-size: $bp-spacing * 7.5 !default;
-$datepicker-header-height: $bp-spacing * 10 !default;
+$datepicker-min-width: $pt-spacing * 52.5 !default;
+$datepicker-day-size: $pt-spacing * 7.5 !default;
+$datepicker-header-height: $pt-spacing * 10 !default;
 $datepicker-header-margin: ($datepicker-header-height - $pt-input-height) * 0.5 !default;
 
 $datepicker-background-color: $white !default;

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -9,7 +9,7 @@ $datepicker-padding: $pt-grid-size * 0.5 !default;
 
 $datepicker-min-width: $pt-grid-size * 21 !default;
 $datepicker-day-size: $bp-spacing * 7.5 !default;
-$datepicker-header-height: $pt-grid-size * 4 !default;
+$datepicker-header-height: $bp-spacing * 10 !default;
 $datepicker-header-margin: ($datepicker-header-height - $pt-input-height) * 0.5 !default;
 
 $datepicker-background-color: $white !default;

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -5,7 +5,7 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/icons/lib/scss/variables";
 
-$datepicker-padding: $pt-grid-size * 0.5 !default;
+$datepicker-padding: $bp-spacing * 1.25 !default;
 
 $datepicker-min-width: $bp-spacing * 52.5 !default;
 $datepicker-day-size: $bp-spacing * 7.5 !default;

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -8,7 +8,7 @@
 $datepicker-padding: $pt-grid-size * 0.5 !default;
 
 $datepicker-min-width: $pt-grid-size * 21 !default;
-$datepicker-day-size: $pt-grid-size * 3 !default;
+$datepicker-day-size: $bp-spacing * 7.5 !default;
 $datepicker-header-height: $pt-grid-size * 4 !default;
 $datepicker-header-margin: ($datepicker-header-height - $pt-input-height) * 0.5 !default;
 

--- a/packages/datetime/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime/src/common/_react-day-picker-overrides.scss
@@ -8,7 +8,7 @@
 @import "react-day-picker/dist/style";
 
 .#{$ns}-datepicker-content .rdp {
-  --rdp-cell-size: #{$pt-grid-size * 3};
+  --rdp-cell-size: #{$bp-spacing * 7.5};
   --rdp-accent-color: #{$blue3};
   --rdp-background-color: #{$white};
 

--- a/packages/datetime/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime/src/common/_react-day-picker-overrides.scss
@@ -17,10 +17,10 @@
   --rdp-background-color-dark: #{$dark-gray3};
 
   /* Outline border for focused elements */
-  --rdp-outline: 2px solid var(--rdp-accent-color);
+  --rdp-outline: ($bp-spacing * 0.5) solid var(--rdp-accent-color);
 
   /* Outline border for focused and selected elements */
-  --rdp-outline-selected: 2px solid rgba(0, 0, 0, 75%);
+  --rdp-outline-selected: ($bp-spacing * 0.5) solid rgba(0, 0, 0, 75%);
 
   margin: 0;
   min-width: auto;

--- a/packages/datetime/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime/src/common/_react-day-picker-overrides.scss
@@ -8,7 +8,7 @@
 @import "react-day-picker/dist/style";
 
 .#{$ns}-datepicker-content .rdp {
-  --rdp-cell-size: #{$bp-spacing * 7.5};
+  --rdp-cell-size: #{$pt-spacing * 7.5};
   --rdp-accent-color: #{$blue3};
   --rdp-background-color: #{$white};
 
@@ -17,10 +17,10 @@
   --rdp-background-color-dark: #{$dark-gray3};
 
   /* Outline border for focused elements */
-  --rdp-outline: ($bp-spacing * 0.5) solid var(--rdp-accent-color);
+  --rdp-outline: ($pt-spacing * 0.5) solid var(--rdp-accent-color);
 
   /* Outline border for focused and selected elements */
-  --rdp-outline-selected: ($bp-spacing * 0.5) solid rgba(0, 0, 0, 75%);
+  --rdp-outline-selected: ($pt-spacing * 0.5) solid rgba(0, 0, 0, 75%);
 
   margin: 0;
   min-width: auto;

--- a/packages/datetime/src/components/date-picker/_date-picker-caption.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker-caption.scss
@@ -17,7 +17,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: $bp-spacing * 0.5;
+      right: $pt-spacing * 0.5;
     }
   }
 
@@ -39,7 +39,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: $bp-spacing * 0.5;
+      right: $pt-spacing * 0.5;
     }
   }
 
@@ -58,7 +58,7 @@
 
 .#{$ns}-datepicker-year-select {
   flex-shrink: 1;
-  min-width: $bp-spacing * 15;
+  min-width: $pt-spacing * 15;
 }
 
 .#{$ns}-datepicker-caption-measure {

--- a/packages/datetime/src/components/date-picker/_date-picker-caption.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker-caption.scss
@@ -17,7 +17,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: 2px;
+      right: $bp-spacing * 0.5;
     }
   }
 
@@ -39,7 +39,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: 2px;
+      right: $bp-spacing * 0.5;
     }
   }
 

--- a/packages/datetime/src/components/date-picker/_date-picker-caption.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker-caption.scss
@@ -58,7 +58,7 @@
 
 .#{$ns}-datepicker-year-select {
   flex-shrink: 1;
-  min-width: 60px;
+  min-width: $bp-spacing * 15;
 }
 
 .#{$ns}-datepicker-caption-measure {

--- a/packages/datetime/src/components/date-picker/_date-picker.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker.scss
@@ -35,7 +35,7 @@
 
     // create space between months (selector matches all but first month)
     & + & {
-      margin-left: $pt-grid-size;
+      margin-left: $bp-spacing * 2.5;
     }
   }
 

--- a/packages/datetime/src/components/date-picker/_date-picker.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker.scss
@@ -35,7 +35,7 @@
 
     // create space between months (selector matches all but first month)
     & + & {
-      margin-left: $bp-spacing * 2.5;
+      margin-left: $pt-spacing * 2.5;
     }
   }
 
@@ -124,7 +124,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: $bp-spacing * 1.25;
+  gap: $pt-spacing * 1.25;
 
   > .#{$ns}-divider {
     margin: 0; // margin is already applied via flex gap
@@ -140,7 +140,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: $bp-spacing * 0.5;
+      right: $pt-spacing * 0.5;
     }
   }
 }

--- a/packages/datetime/src/components/date-picker/_date-picker.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker.scss
@@ -140,7 +140,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: 2px;
+      right: $bp-spacing * 0.5;
     }
   }
 }

--- a/packages/datetime/src/components/date-picker/_date-picker.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker.scss
@@ -124,7 +124,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: $bp-spacing * 1.25;
 
   > .#{$ns}-divider {
     margin: 0; // margin is already applied via flex gap

--- a/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
+++ b/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
@@ -15,7 +15,7 @@
 
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
-    min-width: $datepicker-min-width + ($bp-spacing * 2.5);
+    min-width: $datepicker-min-width + ($pt-spacing * 2.5);
   }
 
   &.#{$ns}-daterangepicker-single-month .rdp {
@@ -173,6 +173,6 @@
 }
 
 .#{$ns}-menu.#{$ns}-daterangepicker-shortcuts {
-  min-width: $bp-spacing * 30;
+  min-width: $pt-spacing * 30;
   padding: 0;
 }

--- a/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
+++ b/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
@@ -15,7 +15,7 @@
 
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
-    min-width: $datepicker-min-width + $pt-grid-size;
+    min-width: $datepicker-min-width + ($bp-spacing * 2.5);
   }
 
   &.#{$ns}-daterangepicker-single-month .rdp {

--- a/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
+++ b/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
@@ -173,6 +173,6 @@
 }
 
 .#{$ns}-menu.#{$ns}-daterangepicker-shortcuts {
-  min-width: $pt-grid-size * 12;
+  min-width: $bp-spacing * 30;
   padding: 0;
 }

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -98,7 +98,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
   }
 
   .#{$ns}-timepicker-ampm-select {
-    margin-left: $pt-grid-size * 0.5;
+    margin-left: $bp-spacing * 1.25;
   }
 
   &.#{$ns}-disabled {

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -5,7 +5,7 @@
 @import "@blueprintjs/core/src/components/icon/icon-mixins";
 @import "../../common";
 
-$timepicker-input-row-height: $pt-grid-size * 3 !default;
+$timepicker-input-row-height: $bp-spacing * 7.5 !default;
 // subtract two because of inset shadow
 $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -5,13 +5,13 @@
 @import "@blueprintjs/core/src/components/icon/icon-mixins";
 @import "../../common";
 
-$timepicker-input-row-height: $bp-spacing * 7.5 !default;
+$timepicker-input-row-height: $pt-spacing * 7.5 !default;
 // subtract two because of inset shadow
 $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly
 $timepicker-row-padding: 0 1px !default;
-$timepicker-divider-width: $bp-spacing * 2.75 !default;
-$timepicker-control-width: $bp-spacing * 8.25 !default;
+$timepicker-divider-width: $pt-spacing * 2.75 !default;
+$timepicker-control-width: $pt-spacing * 8.25 !default;
 
 .#{$ns}-timepicker {
   white-space: nowrap;
@@ -23,7 +23,7 @@ $timepicker-control-width: $bp-spacing * 8.25 !default;
   .#{$ns}-timepicker-arrow-button {
     @include pt-icon-colors();
     display: inline-block;
-    padding: $bp-spacing 0;
+    padding: $pt-spacing 0;
     text-align: center;
     width: $timepicker-control-width;
 
@@ -98,7 +98,7 @@ $timepicker-control-width: $bp-spacing * 8.25 !default;
   }
 
   .#{$ns}-timepicker-ampm-select {
-    margin-left: $bp-spacing * 1.25;
+    margin-left: $pt-spacing * 1.25;
   }
 
   &.#{$ns}-disabled {

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -23,7 +23,7 @@ $timepicker-control-width: $pt-grid-size * 3.3 !default;
   .#{$ns}-timepicker-arrow-button {
     @include pt-icon-colors();
     display: inline-block;
-    padding: ($pt-grid-size * 0.4) 0;
+    padding: $bp-spacing 0;
     text-align: center;
     width: $timepicker-control-width;
 

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -11,7 +11,7 @@ $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly
 $timepicker-row-padding: 0 1px !default;
 $timepicker-divider-width: $bp-spacing * 2.75 !default;
-$timepicker-control-width: $pt-grid-size * 3.3 !default;
+$timepicker-control-width: $bp-spacing * 8.25 !default;
 
 .#{$ns}-timepicker {
   white-space: nowrap;

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -10,7 +10,7 @@ $timepicker-input-row-height: $bp-spacing * 7.5 !default;
 $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly
 $timepicker-row-padding: 0 1px !default;
-$timepicker-divider-width: $pt-grid-size * 1.1 !default;
+$timepicker-divider-width: $bp-spacing * 2.75 !default;
 $timepicker-control-width: $pt-grid-size * 3.3 !default;
 
 .#{$ns}-timepicker {

--- a/packages/datetime2/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime2/src/common/_react-day-picker-overrides.scss
@@ -8,7 +8,7 @@
 @import "react-day-picker/dist/style";
 
 .#{$ns}-datepicker-content .rdp {
-  --rdp-cell-size: #{$pt-grid-size * 3};
+  --rdp-cell-size: #{$bp-spacing * 7.5};
   --rdp-accent-color: #{$blue3};
   --rdp-background-color: #{$white};
 

--- a/packages/datetime2/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime2/src/common/_react-day-picker-overrides.scss
@@ -17,10 +17,10 @@
   --rdp-background-color-dark: #{$dark-gray3};
 
   /* Outline border for focused elements */
-  --rdp-outline: 2px solid var(--rdp-accent-color);
+  --rdp-outline: ($bp-spacing * 0.5) solid var(--rdp-accent-color);
 
   /* Outline border for focused and selected elements */
-  --rdp-outline-selected: 2px solid rgba(0, 0, 0, 75%);
+  --rdp-outline-selected: ($bp-spacing * 0.5) solid rgba(0, 0, 0, 75%);
 
   margin: 0;
   min-width: auto;

--- a/packages/datetime2/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime2/src/common/_react-day-picker-overrides.scss
@@ -8,7 +8,7 @@
 @import "react-day-picker/dist/style";
 
 .#{$ns}-datepicker-content .rdp {
-  --rdp-cell-size: #{$bp-spacing * 7.5};
+  --rdp-cell-size: #{$pt-spacing * 7.5};
   --rdp-accent-color: #{$blue3};
   --rdp-background-color: #{$white};
 
@@ -17,10 +17,10 @@
   --rdp-background-color-dark: #{$dark-gray3};
 
   /* Outline border for focused elements */
-  --rdp-outline: ($bp-spacing * 0.5) solid var(--rdp-accent-color);
+  --rdp-outline: ($pt-spacing * 0.5) solid var(--rdp-accent-color);
 
   /* Outline border for focused and selected elements */
-  --rdp-outline-selected: ($bp-spacing * 0.5) solid rgba(0, 0, 0, 75%);
+  --rdp-outline-selected: ($pt-spacing * 0.5) solid rgba(0, 0, 0, 75%);
 
   margin: 0;
   min-width: auto;

--- a/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
@@ -21,7 +21,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: $bp-spacing * 0.5;
+      right: $pt-spacing * 0.5;
     }
   }
 
@@ -40,7 +40,7 @@
 
 .#{$ns}-datepicker-year-select {
   flex-shrink: 1;
-  min-width: $bp-spacing * 15;
+  min-width: $pt-spacing * 15;
 }
 
 .#{$ns}-datepicker-caption-measure {

--- a/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
@@ -40,7 +40,7 @@
 
 .#{$ns}-datepicker-year-select {
   flex-shrink: 1;
-  min-width: 60px;
+  min-width: $bp-spacing * 15;
 }
 
 .#{$ns}-datepicker-caption-measure {

--- a/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3-caption.scss
@@ -21,7 +21,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: 2px;
+      right: $bp-spacing * 0.5;
     }
   }
 

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -133,7 +133,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: 2px;
+      right: $bp-spacing * 0.5;
     }
   }
 }

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -28,7 +28,7 @@
 
     // create space between months (selector matches all but first month)
     & + & {
-      margin-left: $pt-grid-size;
+      margin-left: $bp-spacing * 2.5;
     }
   }
 

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -117,7 +117,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: $bp-spacing * 1.25;
 
   > .#{$ns}-divider {
     margin: 0; // margin is already applied via flex gap

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -28,7 +28,7 @@
 
     // create space between months (selector matches all but first month)
     & + & {
-      margin-left: $bp-spacing * 2.5;
+      margin-left: $pt-spacing * 2.5;
     }
   }
 
@@ -117,7 +117,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: $bp-spacing * 1.25;
+  gap: $pt-spacing * 1.25;
 
   > .#{$ns}-divider {
     margin: 0; // margin is already applied via flex gap
@@ -133,7 +133,7 @@
     padding-right: $pt-icon-size-standard;
 
     + .#{$ns}-icon {
-      right: $bp-spacing * 0.5;
+      right: $pt-spacing * 0.5;
     }
   }
 }

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -13,7 +13,7 @@
 .#{$ns}-daterangepicker {
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
-    min-width: $datepicker-min-width + $pt-grid-size;
+    min-width: $datepicker-min-width + ($bp-spacing * 2.5);
   }
 
   &.#{$ns}-daterangepicker-single-month .rdp {

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -13,7 +13,7 @@
 .#{$ns}-daterangepicker {
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
-    min-width: $datepicker-min-width + ($bp-spacing * 2.5);
+    min-width: $datepicker-min-width + ($pt-spacing * 2.5);
   }
 
   &.#{$ns}-daterangepicker-single-month .rdp {

--- a/packages/demo-app/src/styles/_examples.scss
+++ b/packages/demo-app/src/styles/_examples.scss
@@ -41,7 +41,7 @@ $dark-intent-danger-text: $red5;
   align-items: center;
   display: flex;
   flex-direction: column;
-  margin-bottom: 30px;
+  margin-bottom: $bp-spacing * 7.5;
 }
 
 .example-card {

--- a/packages/demo-app/src/styles/_examples.scss
+++ b/packages/demo-app/src/styles/_examples.scss
@@ -20,7 +20,7 @@ $dark-intent-danger-text: $red5;
   background-color: $light-gray2;
   display: flex;
   flex-direction: column;
-  padding: $bp-spacing * 2.5;
+  padding: $pt-spacing * 2.5;
   width: 100%;
 
   &.#{$ns}-dark {
@@ -33,7 +33,7 @@ $dark-intent-danger-text: $red5;
   justify-content: space-evenly;
 
   > :not(:last-child) {
-    margin-right: $bp-spacing * 2.5;
+    margin-right: $pt-spacing * 2.5;
   }
 }
 
@@ -41,17 +41,17 @@ $dark-intent-danger-text: $red5;
   align-items: center;
   display: flex;
   flex-direction: column;
-  margin-bottom: $bp-spacing * 7.5;
+  margin-bottom: $pt-spacing * 7.5;
 }
 
 .example-card {
   background-color: $light-gray4;
   display: flex;
   flex-direction: column;
-  margin-bottom: $bp-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2.5;
 
   > :not(:last-child) {
-    margin-bottom: $bp-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2.5;
   }
 
   &.horizontal {
@@ -60,7 +60,7 @@ $dark-intent-danger-text: $red5;
 
     > :not(:last-child) {
       margin-bottom: 0;
-      margin-right: $bp-spacing * 2.5;
+      margin-right: $pt-spacing * 2.5;
     }
   }
 }
@@ -70,7 +70,7 @@ $dark-intent-danger-text: $red5;
   flex-direction: column;
 
   > :not(:last-child) {
-    margin-bottom: $bp-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2.5;
   }
 }
 
@@ -79,7 +79,7 @@ $dark-intent-danger-text: $red5;
   flex-direction: column;
 
   > :not(:last-child) {
-    margin-bottom: $bp-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2.5;
   }
 }
 
@@ -144,5 +144,5 @@ $dark-intent-danger-text: $red5;
 }
 
 .#{$ns}-toast {
-  margin: ($bp-spacing * 2.5) 0;
+  margin: ($pt-spacing * 2.5) 0;
 }

--- a/packages/demo-app/src/styles/_examples.scss
+++ b/packages/demo-app/src/styles/_examples.scss
@@ -20,7 +20,7 @@ $dark-intent-danger-text: $red5;
   background-color: $light-gray2;
   display: flex;
   flex-direction: column;
-  padding: 10px;
+  padding: $bp-spacing * 2.5;
   width: 100%;
 
   &.#{$ns}-dark {
@@ -33,7 +33,7 @@ $dark-intent-danger-text: $red5;
   justify-content: space-evenly;
 
   > :not(:last-child) {
-    margin-right: 10px;
+    margin-right: $bp-spacing * 2.5;
   }
 }
 
@@ -48,10 +48,10 @@ $dark-intent-danger-text: $red5;
   background-color: $light-gray4;
   display: flex;
   flex-direction: column;
-  margin-bottom: 10px;
+  margin-bottom: $bp-spacing * 2.5;
 
   > :not(:last-child) {
-    margin-bottom: 10px;
+    margin-bottom: $bp-spacing * 2.5;
   }
 
   &.horizontal {
@@ -60,7 +60,7 @@ $dark-intent-danger-text: $red5;
 
     > :not(:last-child) {
       margin-bottom: 0;
-      margin-right: 10px;
+      margin-right: $bp-spacing * 2.5;
     }
   }
 }
@@ -70,7 +70,7 @@ $dark-intent-danger-text: $red5;
   flex-direction: column;
 
   > :not(:last-child) {
-    margin-bottom: 10px;
+    margin-bottom: $bp-spacing * 2.5;
   }
 }
 
@@ -79,7 +79,7 @@ $dark-intent-danger-text: $red5;
   flex-direction: column;
 
   > :not(:last-child) {
-    margin-bottom: 10px;
+    margin-bottom: $bp-spacing * 2.5;
   }
 }
 
@@ -144,5 +144,5 @@ $dark-intent-danger-text: $red5;
 }
 
 .#{$ns}-toast {
-  margin: 10px 0;
+  margin: ($bp-spacing * 2.5) 0;
 }

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -5,10 +5,10 @@
 @import "@blueprintjs/icons/lib/scss/variables";
 
 $palette-spacing: $pt-grid-size * 2;
-$palette-border-radius: 4px;
+$palette-border-radius: $bp-spacing;
 
 $swatch-height: $pt-input-height-large;
-$swatch-hover-offset: -4px;
+$swatch-hover-offset: -$bp-spacing;
 
 $swatch-hover-message: "Click to copy hex code";
 $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied to clipboard";

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -136,7 +136,7 @@ label.docs-color-scheme-label {
   }
 
   &.selected::before {
-    box-shadow: border-shadow(1, $pt-intent-primary, 2px);
+    box-shadow: border-shadow(1, $pt-intent-primary, $bp-spacing * 0.5);
   }
 
   .docs-color-scheme & {
@@ -227,7 +227,7 @@ label.docs-color-scheme-label {
   margin-left: -1px;
   position: relative;
   top: -1px;
-  width: calc(100% + 2px);
+  width: calc(100% + $bp-spacing * 0.5);
 
   &::before {
     @include position-all(absolute, 0);

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -57,8 +57,8 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
   justify-content: space-between;
 
   .docs-color-scheme & {
-    margin-left: (-$pt-grid-size);
-    margin-right: (-$pt-grid-size);
+    margin-left: $bp-spacing * -2.5;
+    margin-right: $bp-spacing * -2.5;
   }
 }
 
@@ -106,7 +106,7 @@ label.docs-color-scheme-label {
 }
 
 .docs-color-scheme-radios {
-  margin-bottom: $pt-grid-size;
+  margin-bottom: $bp-spacing * 2.5;
 }
 
 .docs-color-bar-hexes {
@@ -141,7 +141,7 @@ label.docs-color-scheme-label {
 
   .docs-color-scheme & {
     flex: 1 1 auto;
-    margin: 0 $pt-grid-size;
+    margin: 0 ($bp-spacing * 2.5);
   }
 }
 
@@ -212,7 +212,7 @@ label.docs-color-scheme-label {
   font-size: $pt-font-size-small;
   justify-content: space-between;
   line-height: 1;
-  padding: 0 $pt-grid-size;
+  padding: 0 ($bp-spacing * 2.5);
   transition: all $pt-transition-duration $pt-transition-ease;
   white-space: nowrap;
 

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -4,11 +4,11 @@
 @use "sass:math";
 @import "@blueprintjs/icons/lib/scss/variables";
 
-$palette-spacing: $bp-spacing * 5;
-$palette-border-radius: $bp-spacing;
+$palette-spacing: $pt-spacing * 5;
+$palette-border-radius: $pt-spacing;
 
 $swatch-height: $pt-input-height-large;
-$swatch-hover-offset: -$bp-spacing;
+$swatch-hover-offset: -$pt-spacing;
 
 $swatch-hover-message: "Click to copy hex code";
 $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied to clipboard";
@@ -57,8 +57,8 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
   justify-content: space-between;
 
   .docs-color-scheme & {
-    margin-left: $bp-spacing * -2.5;
-    margin-right: $bp-spacing * -2.5;
+    margin-left: $pt-spacing * -2.5;
+    margin-right: $pt-spacing * -2.5;
   }
 }
 
@@ -102,11 +102,11 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
 }
 
 label.docs-color-scheme-label {
-  margin: ($bp-spacing * 5) 0;
+  margin: ($pt-spacing * 5) 0;
 }
 
 .docs-color-scheme-radios {
-  margin-bottom: $bp-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2.5;
 }
 
 .docs-color-bar-hexes {
@@ -136,12 +136,12 @@ label.docs-color-scheme-label {
   }
 
   &.selected::before {
-    box-shadow: border-shadow(1, $pt-intent-primary, $bp-spacing * 0.5);
+    box-shadow: border-shadow(1, $pt-intent-primary, $pt-spacing * 0.5);
   }
 
   .docs-color-scheme & {
     flex: 1 1 auto;
-    margin: 0 ($bp-spacing * 2.5);
+    margin: 0 ($pt-spacing * 2.5);
   }
 }
 
@@ -212,7 +212,7 @@ label.docs-color-scheme-label {
   font-size: $pt-font-size-small;
   justify-content: space-between;
   line-height: 1;
-  padding: 0 ($bp-spacing * 2.5);
+  padding: 0 ($pt-spacing * 2.5);
   transition: all $pt-transition-duration $pt-transition-ease;
   white-space: nowrap;
 
@@ -227,7 +227,7 @@ label.docs-color-scheme-label {
   margin-left: -1px;
   position: relative;
   top: -1px;
-  width: calc(100% + $bp-spacing * 0.5);
+  width: calc(100% + $pt-spacing * 0.5);
 
   &::before {
     @include position-all(absolute, 0);
@@ -301,7 +301,7 @@ $aliases: (
   }
 }
 
-$bubble-size: $bp-spacing * 5;
+$bubble-size: $pt-spacing * 5;
 
 .docs-color-bubble {
   border-radius: $pt-border-radius;

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -4,7 +4,7 @@
 @use "sass:math";
 @import "@blueprintjs/icons/lib/scss/variables";
 
-$palette-spacing: $pt-grid-size * 2;
+$palette-spacing: $bp-spacing * 5;
 $palette-border-radius: $bp-spacing;
 
 $swatch-height: $pt-input-height-large;
@@ -102,7 +102,7 @@ $swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied t
 }
 
 label.docs-color-scheme-label {
-  margin: ($pt-grid-size * 2) 0;
+  margin: ($bp-spacing * 5) 0;
 }
 
 .docs-color-scheme-radios {
@@ -301,7 +301,7 @@ $aliases: (
   }
 }
 
-$bubble-size: $pt-grid-size * 2;
+$bubble-size: $bp-spacing * 5;
 
 .docs-color-bubble {
   border-radius: $pt-border-radius;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -699,7 +699,7 @@ $docs-hotkey-piano-height: 510px;
 
   em {
     display: inline-block;
-    max-width: 25 * $pt-grid-size;
+    max-width: $bp-spacing * 62.5;
 
     .#{$ns}-dark & {
       color: $pt-dark-text-color-muted;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -371,7 +371,7 @@
   .docs-context-menu-node {
     $node-size: $pt-grid-size * 8;
     $icon-size: $pt-icon-size-standard * 2;
-    $node-border-width: 4px;
+    $node-border-width: $bp-spacing;
     background-color: $blue5;
 
     border: $node-border-width solid $white;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -168,7 +168,7 @@
 
 #{example("CardElevation")} {
   .docs-code-example {
-    gap: $pt-grid-size * 4;
+    gap: $bp-spacing * 10;
 
     // lighten the example background in dark mode to make elevation shadows visible
     .#{$ns}-dark & {
@@ -321,7 +321,7 @@
   .docs-example .#{$ns}-card {
     display: flex;
     justify-content: space-around;
-    padding-inline: $pt-grid-size * 4;
+    padding-inline: $bp-spacing * 10;
     width: 100%;
   }
 }
@@ -455,7 +455,7 @@ $docs-hotkey-piano-height: 510px;
       background-color: $black;
       color: $white;
       height: $pt-grid-size * 16;
-      left: $pt-grid-size * -4;
+      left: $bp-spacing * -10;
       position: absolute;
       top: 0;
     }
@@ -910,7 +910,7 @@ $docs-hotkey-piano-height: 510px;
 
 #{example("DateRangeInput")} {
   .docs-example {
-    padding: ($pt-grid-size * 4) ($bp-spacing * 5);
+    padding: ($bp-spacing * 10) ($bp-spacing * 5);
   }
 
   .#{$ns}-input-group {

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -25,7 +25,7 @@
 }
 
 .docs-prop-code-tooltip {
-  margin-bottom: $bp-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2.5;
 }
 
 .docs-example .#{$ns}-form-group:last-child {
@@ -57,7 +57,7 @@
 }
 
 #{page("tree")} .#{$ns}-tree {
-  width: $bp-spacing * 87.5;
+  width: $pt-spacing * 87.5;
 }
 
 #{example("BreadcrumbsOverflow")} {
@@ -69,7 +69,7 @@
 #{example("ButtonPlayground")} {
   .docs-example {
     flex-direction: column;
-    gap: $bp-spacing * 7.5;
+    gap: $pt-spacing * 7.5;
 
     > * {
       margin: 0;
@@ -97,14 +97,14 @@
 #{example("ButtonIcon")},
 #{example("ButtonStates")} {
   .docs-code-example {
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 }
 
 #{example("ButtonAlignText")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 
   .#{$ns}-button {
@@ -125,7 +125,7 @@
 #{example("ButtonGroupFlex")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 }
 
@@ -135,7 +135,7 @@
 
 #{example("ButtonGroupVertical")} {
   .docs-code-example {
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 
   .#{$ns}-button-group {
@@ -148,7 +148,7 @@
 #{example("CalloutCompact")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 }
 
@@ -156,7 +156,7 @@
 #{example("CardCompact")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 
   .#{$ns}-card {
@@ -168,7 +168,7 @@
 
 #{example("CardElevation")} {
   .docs-code-example {
-    gap: $bp-spacing * 10;
+    gap: $pt-spacing * 10;
 
     // lighten the example background in dark mode to make elevation shadows visible
     .#{$ns}-dark & {
@@ -179,9 +179,9 @@
   .#{$ns}-card {
     align-items: center;
     display: flex;
-    height: $bp-spacing * 15;
+    height: $pt-spacing * 15;
     justify-content: center;
-    width: $bp-spacing * 15;
+    width: $pt-spacing * 15;
   }
 }
 
@@ -195,7 +195,7 @@
 #{example("CardListCompact")} {
   .docs-code-example {
     align-items: flex-start;
-    gap: $bp-spacing * 5;
+    gap: $pt-spacing * 5;
   }
 
   .#{$ns}-card-list {
@@ -252,14 +252,14 @@
 
 .docs-control-card-group-row {
   display: grid;
-  gap: $bp-spacing * 5;
-  grid-template-columns: repeat(auto-fit, minmax($bp-spacing * 25, 1fr));
+  gap: $pt-spacing * 5;
+  grid-template-columns: repeat(auto-fit, minmax($pt-spacing * 25, 1fr));
   width: 100%;
 }
 
 #{example("ControlCardList")} {
   .#{$ns}-control-card-label .#{$ns}-icon {
-    margin-right: $bp-spacing * 2.5;
+    margin-right: $pt-spacing * 2.5;
   }
 }
 
@@ -268,7 +268,7 @@
   .docs-code-example {
     align-items: flex-start;
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 }
 
@@ -285,7 +285,7 @@
 #{example("EditableTextIntent")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 }
 
@@ -295,7 +295,7 @@
   }
 
   h1 {
-    margin-bottom: $bp-spacing * 7.5;
+    margin-bottom: $pt-spacing * 7.5;
   }
 }
 
@@ -303,7 +303,7 @@
   .docs-example .#{$ns}-card {
     display: flex;
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 
   // this example has a "fill" prop option, which doesn't work nicely with the default margin
@@ -313,7 +313,7 @@
   }
 
   .#{$ns}-form-content {
-    min-width: $bp-spacing * 50;
+    min-width: $pt-spacing * 50;
   }
 }
 
@@ -321,7 +321,7 @@
   .docs-example .#{$ns}-card {
     display: flex;
     justify-content: space-around;
-    padding-inline: $bp-spacing * 10;
+    padding-inline: $pt-spacing * 10;
     width: 100%;
   }
 }
@@ -345,7 +345,7 @@
 }
 
 #{example("DividerVertical")} .docs-code-example > :first-child {
-  gap: $bp-spacing * 2.5;
+  gap: $pt-spacing * 2.5;
   max-width: 500px;
   text-align: center;
   width: 100%;
@@ -357,7 +357,7 @@
     flex-direction: column;
 
     > * {
-      margin: $bp-spacing * 2.5;
+      margin: $pt-spacing * 2.5;
     }
   }
 }
@@ -365,13 +365,13 @@
 .docs-context-menu-example {
   .docs-example {
     flex-direction: column;
-    height: $bp-spacing * 62.5;
+    height: $pt-spacing * 62.5;
   }
 
   .docs-context-menu-node {
-    $node-size: $bp-spacing * 20;
+    $node-size: $pt-spacing * 20;
     $icon-size: $pt-icon-size-standard * 2;
-    $node-border-width: $bp-spacing;
+    $node-border-width: $pt-spacing;
     background-color: $blue5;
 
     border: $node-border-width solid $white;
@@ -421,12 +421,12 @@ $docs-hotkey-piano-height: 510px;
 
   .#{$ns}-non-ideal-state {
     margin: 0;
-    min-height: $docs-hotkey-piano-height - ($bp-spacing * 5);
-    padding: $bp-spacing * 5;
+    min-height: $docs-hotkey-piano-height - ($pt-spacing * 5);
+    padding: $pt-spacing * 5;
   }
 
   > :first-child {
-    margin-bottom: $bp-spacing * 5;
+    margin-bottom: $pt-spacing * 5;
   }
 
   .piano-key {
@@ -436,12 +436,12 @@ $docs-hotkey-piano-height: 510px;
 
     > div {
       background-color: $white;
-      border-bottom-left-radius: $bp-spacing * 1.25;
-      border-bottom-right-radius: $bp-spacing * 1.25;
+      border-bottom-left-radius: $pt-spacing * 1.25;
+      border-bottom-right-radius: $pt-spacing * 1.25;
       color: $black;
-      height: $bp-spacing * 60;
-      margin-right: $bp-spacing * 1.25;
-      width: $bp-spacing * 20;
+      height: $pt-spacing * 60;
+      margin-right: $pt-spacing * 1.25;
+      width: $pt-spacing * 20;
     }
   }
 
@@ -454,8 +454,8 @@ $docs-hotkey-piano-height: 510px;
     > div {
       background-color: $black;
       color: $white;
-      height: $bp-spacing * 40;
-      left: $bp-spacing * -10;
+      height: $pt-spacing * 40;
+      left: $pt-spacing * -10;
       position: absolute;
       top: 0;
     }
@@ -467,7 +467,7 @@ $docs-hotkey-piano-height: 510px;
   }
 
   .piano-key-text {
-    bottom: $bp-spacing * 1.25;
+    bottom: $pt-spacing * 1.25;
     left: 0;
     position: absolute;
     right: 0;
@@ -481,7 +481,7 @@ $docs-hotkey-piano-height: 510px;
 
 #{example("HotkeyTester")} {
   .docs-hotkey-tester {
-    @include pt-flex-container(column, $bp-spacing * 2.5);
+    @include pt-flex-container(column, $pt-spacing * 2.5);
     align-items: center;
     background: rgba($gray3, 0.2);
     border: 2px solid rgba($gray3, 0.8);
@@ -489,9 +489,9 @@ $docs-hotkey-piano-height: 510px;
     flex: 1 1;
     justify-content: space-around;
     max-width: 70%;
-    min-height: $bp-spacing * 30;
+    min-height: $pt-spacing * 30;
     opacity: 0.4;
-    padding: $bp-spacing * 5;
+    padding: $pt-spacing * 5;
     transition: all $pt-transition-duration $pt-transition-ease;
 
     &:hover {
@@ -524,7 +524,7 @@ $docs-hotkey-piano-height: 510px;
 #{example("OverflowList")} {
   .#{$ns}-card {
     margin: 0;
-    min-width: $bp-spacing * 17.5;
+    min-width: $pt-spacing * 17.5;
   }
 
   .#{$ns}-overflow-list {
@@ -541,7 +541,7 @@ $docs-hotkey-piano-height: 510px;
 
 // prettier-ignore
 .docs-overlay-example-transition {
-  $overlay-example-width: $bp-spacing * 100;
+  $overlay-example-width: $pt-spacing * 100;
   $enter: (
     transform: (translateY(-50vh) rotate(-10deg), translateY(0) rotate(0deg))
   );
@@ -572,7 +572,7 @@ $docs-hotkey-piano-height: 510px;
 
   .#{$ns}-overlay-inline & {
     left: calc(50% - #{$overlay-example-width * 0.5});
-    margin: ($bp-spacing * 5) 0;
+    margin: ($pt-spacing * 5) 0;
   }
 }
 
@@ -599,7 +599,7 @@ $docs-hotkey-piano-height: 510px;
     width: 1600px;
 
     > p {
-      margin-top: $bp-spacing * 2.5;
+      margin-top: $pt-spacing * 2.5;
     }
   }
 }
@@ -614,14 +614,14 @@ $docs-hotkey-piano-height: 510px;
 
   .#{$ns}-popover-content {
     min-width: 300px;
-    padding: $bp-spacing * 5;
+    padding: $pt-spacing * 5;
 
     .#{$ns}-button:not(:first-child) {
-      margin-left: $bp-spacing * 2.5;
+      margin-left: $pt-spacing * 2.5;
     }
 
     .#{$ns}-callout {
-      margin: ($bp-spacing * 2.5) 0;
+      margin: ($pt-spacing * 2.5) 0;
     }
   }
 }
@@ -643,7 +643,7 @@ $docs-hotkey-piano-height: 510px;
     flex: 1 0 auto;
     flex-direction: column;
     justify-content: space-around;
-    padding: $bp-spacing * 2.5;
+    padding: $pt-spacing * 2.5;
   }
 
   ul {
@@ -655,7 +655,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example {
   .docs-example-grid {
     display: grid;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
     grid-template-columns: 1fr 2fr 1fr;
     grid-template-rows: 1fr 2fr 1fr;
     justify-content: stretch;
@@ -699,7 +699,7 @@ $docs-hotkey-piano-height: 510px;
 
   em {
     display: inline-block;
-    max-width: $bp-spacing * 62.5;
+    max-width: $pt-spacing * 62.5;
 
     .#{$ns}-dark & {
       color: $pt-dark-text-color-muted;
@@ -710,7 +710,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example-content {
   .#{$ns}-popover-content {
     line-height: 2;
-    padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
+    padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
     text-align: center;
   }
 
@@ -743,19 +743,19 @@ $docs-hotkey-piano-height: 510px;
 
 .docs-popover-minimal-example {
   .#{$ns}-button:first-child {
-    margin-right: $bp-spacing * 2.5;
+    margin-right: $pt-spacing * 2.5;
   }
 }
 
 .docs-popover-interaction-kind-example {
   .#{$ns}-button {
     font-family: $pt-font-family-monospace;
-    margin-right: $bp-spacing * 2.5;
+    margin-right: $pt-spacing * 2.5;
   }
 }
 
 .docs-popover-sizing-example {
-  max-height: $bp-spacing * 37.5;
+  max-height: $pt-spacing * 37.5;
   overflow-y: auto;
 }
 
@@ -776,8 +776,8 @@ $docs-hotkey-piano-height: 510px;
     // can't compute this height easily using SCSS variables. instead of using
     // JS to measure, just hardcode it since we have full control of all the
     // example code.
-    $assumed-height-of-target-plus-popover: $bp-spacing * 21.25;
-    $vertical-padding: $bp-spacing * 5;
+    $assumed-height-of-target-plus-popover: $pt-spacing * 21.25;
+    $vertical-padding: $pt-spacing * 5;
     align-items: flex-start;
 
     display: flex;
@@ -792,14 +792,14 @@ $docs-hotkey-piano-height: 510px;
 
 .docs-popover-portal-example-popover {
   .#{$ns}-popover-content {
-    padding: $bp-spacing * 2.5;
+    padding: $pt-spacing * 2.5;
     white-space: nowrap;
   }
 }
 
 .#{$ns}-progress-bar.docs-toast-progress {
   margin-bottom: 0;
-  margin-top: $bp-spacing * 1.25;
+  margin-top: $pt-spacing * 1.25;
 }
 
 #{example("Tooltip")} {
@@ -807,7 +807,7 @@ $docs-hotkey-piano-height: 510px;
     flex-direction: column;
 
     > * {
-      margin: $bp-spacing * 1.25;
+      margin: $pt-spacing * 1.25;
     }
   }
 }
@@ -831,7 +831,7 @@ $docs-hotkey-piano-height: 510px;
   .docs-example .#{$ns}-card {
     display: flex;
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
   }
 }
 
@@ -843,7 +843,7 @@ $docs-hotkey-piano-height: 510px;
   .metadata-panel {
     display: flex;
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
 
     > div {
       display: flex;
@@ -860,13 +860,13 @@ $docs-hotkey-piano-height: 510px;
 #{page("datetime", "^=")} {
   .docs-example {
     flex-direction: column;
-    gap: $bp-spacing * 2.5;
+    gap: $pt-spacing * 2.5;
     justify-content: center;
   }
 }
 
 .docs-date-range {
-  @include pt-flex-container(row, $bp-spacing * 1.25);
+  @include pt-flex-container(row, $pt-spacing * 1.25);
   align-items: center;
 }
 
@@ -910,7 +910,7 @@ $docs-hotkey-piano-height: 510px;
 
 #{example("DateRangeInput")} {
   .docs-example {
-    padding: ($bp-spacing * 10) ($bp-spacing * 5);
+    padding: ($pt-spacing * 10) ($pt-spacing * 5);
   }
 
   .#{$ns}-input-group {
@@ -944,7 +944,7 @@ $docs-hotkey-piano-height: 510px;
 #{page("table", "^=")} {
   // make all tables the same width & height
   .#{$ns}-table-container {
-    height: $bp-spacing * 90;
+    height: $pt-spacing * 90;
     width: 100%;
   }
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -195,7 +195,7 @@
 #{example("CardListCompact")} {
   .docs-code-example {
     align-items: flex-start;
-    gap: $pt-grid-size * 2;
+    gap: $bp-spacing * 5;
   }
 
   .#{$ns}-card-list {
@@ -252,7 +252,7 @@
 
 .docs-control-card-group-row {
   display: grid;
-  gap: $pt-grid-size * 2;
+  gap: $bp-spacing * 5;
   grid-template-columns: repeat(auto-fit, minmax($pt-grid-size * 10, 1fr));
   width: 100%;
 }
@@ -421,12 +421,12 @@ $docs-hotkey-piano-height: 510px;
 
   .#{$ns}-non-ideal-state {
     margin: 0;
-    min-height: $docs-hotkey-piano-height - ($pt-grid-size * 2);
-    padding: $pt-grid-size * 2;
+    min-height: $docs-hotkey-piano-height - ($bp-spacing * 5);
+    padding: $bp-spacing * 5;
   }
 
   > :first-child {
-    margin-bottom: $pt-grid-size * 2;
+    margin-bottom: $bp-spacing * 5;
   }
 
   .piano-key {
@@ -491,7 +491,7 @@ $docs-hotkey-piano-height: 510px;
     max-width: 70%;
     min-height: $pt-grid-size * 12;
     opacity: 0.4;
-    padding: $pt-grid-size * 2;
+    padding: $bp-spacing * 5;
     transition: all $pt-transition-duration $pt-transition-ease;
 
     &:hover {
@@ -572,7 +572,7 @@ $docs-hotkey-piano-height: 510px;
 
   .#{$ns}-overlay-inline & {
     left: calc(50% - #{$overlay-example-width * 0.5});
-    margin: 20px 0;
+    margin: ($bp-spacing * 5) 0;
   }
 }
 
@@ -614,7 +614,7 @@ $docs-hotkey-piano-height: 510px;
 
   .#{$ns}-popover-content {
     min-width: 300px;
-    padding: $pt-grid-size * 2;
+    padding: $bp-spacing * 5;
 
     .#{$ns}-button:not(:first-child) {
       margin-left: $bp-spacing * 2.5;
@@ -710,7 +710,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example-content {
   .#{$ns}-popover-content {
     line-height: 2;
-    padding: ($bp-spacing * 2.5) ($pt-grid-size * 2);
+    padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
     text-align: center;
   }
 
@@ -777,7 +777,7 @@ $docs-hotkey-piano-height: 510px;
     // JS to measure, just hardcode it since we have full control of all the
     // example code.
     $assumed-height-of-target-plus-popover: $pt-grid-size * 8.5;
-    $vertical-padding: $pt-grid-size * 2;
+    $vertical-padding: $bp-spacing * 5;
     align-items: flex-start;
 
     display: flex;
@@ -910,7 +910,7 @@ $docs-hotkey-piano-height: 510px;
 
 #{example("DateRangeInput")} {
   .docs-example {
-    padding: ($pt-grid-size * 4) ($pt-grid-size * 2);
+    padding: ($pt-grid-size * 4) ($bp-spacing * 5);
   }
 
   .#{$ns}-input-group {

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -436,11 +436,11 @@ $docs-hotkey-piano-height: 510px;
 
     > div {
       background-color: $white;
-      border-bottom-left-radius: 5px;
-      border-bottom-right-radius: 5px;
+      border-bottom-left-radius: $bp-spacing * 1.25;
+      border-bottom-right-radius: $bp-spacing * 1.25;
       color: $black;
       height: $bp-spacing * 60;
-      margin-right: $pt-grid-size * 0.5;
+      margin-right: $bp-spacing * 1.25;
       width: $bp-spacing * 20;
     }
   }
@@ -467,7 +467,7 @@ $docs-hotkey-piano-height: 510px;
   }
 
   .piano-key-text {
-    bottom: 5px;
+    bottom: $bp-spacing * 1.25;
     left: 0;
     position: absolute;
     right: 0;
@@ -799,7 +799,7 @@ $docs-hotkey-piano-height: 510px;
 
 .#{$ns}-progress-bar.docs-toast-progress {
   margin-bottom: 0;
-  margin-top: $pt-grid-size * 0.5;
+  margin-top: $bp-spacing * 1.25;
 }
 
 #{example("Tooltip")} {
@@ -807,7 +807,7 @@ $docs-hotkey-piano-height: 510px;
     flex-direction: column;
 
     > * {
-      margin: $pt-grid-size * 0.5;
+      margin: $bp-spacing * 1.25;
     }
   }
 }
@@ -866,7 +866,7 @@ $docs-hotkey-piano-height: 510px;
 }
 
 .docs-date-range {
-  @include pt-flex-container(row, $pt-grid-size * 0.5);
+  @include pt-flex-container(row, $bp-spacing * 1.25);
   align-items: center;
 }
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -57,7 +57,7 @@
 }
 
 #{page("tree")} .#{$ns}-tree {
-  width: $pt-grid-size * 35;
+  width: $bp-spacing * 87.5;
 }
 
 #{example("BreadcrumbsOverflow")} {
@@ -179,9 +179,9 @@
   .#{$ns}-card {
     align-items: center;
     display: flex;
-    height: 60px;
+    height: $bp-spacing * 15;
     justify-content: center;
-    width: 60px;
+    width: $bp-spacing * 15;
   }
 }
 
@@ -253,7 +253,7 @@
 .docs-control-card-group-row {
   display: grid;
   gap: $bp-spacing * 5;
-  grid-template-columns: repeat(auto-fit, minmax($pt-grid-size * 10, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax($bp-spacing * 25, 1fr));
   width: 100%;
 }
 
@@ -313,7 +313,7 @@
   }
 
   .#{$ns}-form-content {
-    min-width: $pt-grid-size * 20;
+    min-width: $bp-spacing * 50;
   }
 }
 
@@ -365,11 +365,11 @@
 .docs-context-menu-example {
   .docs-example {
     flex-direction: column;
-    height: $pt-grid-size * 25;
+    height: $bp-spacing * 62.5;
   }
 
   .docs-context-menu-node {
-    $node-size: $pt-grid-size * 8;
+    $node-size: $bp-spacing * 20;
     $icon-size: $pt-icon-size-standard * 2;
     $node-border-width: $bp-spacing;
     background-color: $blue5;
@@ -439,9 +439,9 @@ $docs-hotkey-piano-height: 510px;
       border-bottom-left-radius: 5px;
       border-bottom-right-radius: 5px;
       color: $black;
-      height: $pt-grid-size * 24;
+      height: $bp-spacing * 60;
       margin-right: $pt-grid-size * 0.5;
-      width: $pt-grid-size * 8;
+      width: $bp-spacing * 20;
     }
   }
 
@@ -454,7 +454,7 @@ $docs-hotkey-piano-height: 510px;
     > div {
       background-color: $black;
       color: $white;
-      height: $pt-grid-size * 16;
+      height: $bp-spacing * 40;
       left: $bp-spacing * -10;
       position: absolute;
       top: 0;
@@ -489,7 +489,7 @@ $docs-hotkey-piano-height: 510px;
     flex: 1 1;
     justify-content: space-around;
     max-width: 70%;
-    min-height: $pt-grid-size * 12;
+    min-height: $bp-spacing * 30;
     opacity: 0.4;
     padding: $bp-spacing * 5;
     transition: all $pt-transition-duration $pt-transition-ease;
@@ -524,7 +524,7 @@ $docs-hotkey-piano-height: 510px;
 #{example("OverflowList")} {
   .#{$ns}-card {
     margin: 0;
-    min-width: $pt-grid-size * 7;
+    min-width: $bp-spacing * 17.5;
   }
 
   .#{$ns}-overflow-list {
@@ -541,7 +541,7 @@ $docs-hotkey-piano-height: 510px;
 
 // prettier-ignore
 .docs-overlay-example-transition {
-  $overlay-example-width: $pt-grid-size * 40;
+  $overlay-example-width: $bp-spacing * 100;
   $enter: (
     transform: (translateY(-50vh) rotate(-10deg), translateY(0) rotate(0deg))
   );
@@ -755,7 +755,7 @@ $docs-hotkey-piano-height: 510px;
 }
 
 .docs-popover-sizing-example {
-  max-height: $pt-grid-size * 15;
+  max-height: $bp-spacing * 37.5;
   overflow-y: auto;
 }
 
@@ -944,7 +944,7 @@ $docs-hotkey-piano-height: 510px;
 #{page("table", "^=")} {
   // make all tables the same width & height
   .#{$ns}-table-container {
-    height: $pt-grid-size * 36;
+    height: $bp-spacing * 90;
     width: 100%;
   }
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -776,7 +776,7 @@ $docs-hotkey-piano-height: 510px;
     // can't compute this height easily using SCSS variables. instead of using
     // JS to measure, just hardcode it since we have full control of all the
     // example code.
-    $assumed-height-of-target-plus-popover: $pt-grid-size * 8.5;
+    $assumed-height-of-target-plus-popover: $bp-spacing * 21.25;
     $vertical-padding: $bp-spacing * 5;
     align-items: flex-start;
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -25,7 +25,7 @@
 }
 
 .docs-prop-code-tooltip {
-  margin-bottom: $pt-grid-size;
+  margin-bottom: $bp-spacing * 2.5;
 }
 
 .docs-example .#{$ns}-form-group:last-child {
@@ -97,14 +97,14 @@
 #{example("ButtonIcon")},
 #{example("ButtonStates")} {
   .docs-code-example {
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 }
 
 #{example("ButtonAlignText")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 
   .#{$ns}-button {
@@ -125,7 +125,7 @@
 #{example("ButtonGroupFlex")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 }
 
@@ -135,7 +135,7 @@
 
 #{example("ButtonGroupVertical")} {
   .docs-code-example {
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 
   .#{$ns}-button-group {
@@ -148,7 +148,7 @@
 #{example("CalloutCompact")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 }
 
@@ -156,7 +156,7 @@
 #{example("CardCompact")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 
   .#{$ns}-card {
@@ -259,7 +259,7 @@
 
 #{example("ControlCardList")} {
   .#{$ns}-control-card-label .#{$ns}-icon {
-    margin-right: $pt-grid-size;
+    margin-right: $bp-spacing * 2.5;
   }
 }
 
@@ -268,7 +268,7 @@
   .docs-code-example {
     align-items: flex-start;
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 }
 
@@ -285,7 +285,7 @@
 #{example("EditableTextIntent")} {
   .docs-code-example {
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 }
 
@@ -303,7 +303,7 @@
   .docs-example .#{$ns}-card {
     display: flex;
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 
   // this example has a "fill" prop option, which doesn't work nicely with the default margin
@@ -345,7 +345,7 @@
 }
 
 #{example("DividerVertical")} .docs-code-example > :first-child {
-  gap: 10px;
+  gap: $bp-spacing * 2.5;
   max-width: 500px;
   text-align: center;
   width: 100%;
@@ -357,7 +357,7 @@
     flex-direction: column;
 
     > * {
-      margin: 10px;
+      margin: $bp-spacing * 2.5;
     }
   }
 }
@@ -481,7 +481,7 @@ $docs-hotkey-piano-height: 510px;
 
 #{example("HotkeyTester")} {
   .docs-hotkey-tester {
-    @include pt-flex-container(column, $pt-grid-size);
+    @include pt-flex-container(column, $bp-spacing * 2.5);
     align-items: center;
     background: rgba($gray3, 0.2);
     border: 2px solid rgba($gray3, 0.8);
@@ -599,7 +599,7 @@ $docs-hotkey-piano-height: 510px;
     width: 1600px;
 
     > p {
-      margin-top: $pt-grid-size;
+      margin-top: $bp-spacing * 2.5;
     }
   }
 }
@@ -617,11 +617,11 @@ $docs-hotkey-piano-height: 510px;
     padding: $pt-grid-size * 2;
 
     .#{$ns}-button:not(:first-child) {
-      margin-left: $pt-grid-size;
+      margin-left: $bp-spacing * 2.5;
     }
 
     .#{$ns}-callout {
-      margin: $pt-grid-size 0;
+      margin: ($bp-spacing * 2.5) 0;
     }
   }
 }
@@ -643,7 +643,7 @@ $docs-hotkey-piano-height: 510px;
     flex: 1 0 auto;
     flex-direction: column;
     justify-content: space-around;
-    padding: 10px;
+    padding: $bp-spacing * 2.5;
   }
 
   ul {
@@ -655,7 +655,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example {
   .docs-example-grid {
     display: grid;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
     grid-template-columns: 1fr 2fr 1fr;
     grid-template-rows: 1fr 2fr 1fr;
     justify-content: stretch;
@@ -710,7 +710,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example-content {
   .#{$ns}-popover-content {
     line-height: 2;
-    padding: $pt-grid-size ($pt-grid-size * 2);
+    padding: ($bp-spacing * 2.5) ($pt-grid-size * 2);
     text-align: center;
   }
 
@@ -743,14 +743,14 @@ $docs-hotkey-piano-height: 510px;
 
 .docs-popover-minimal-example {
   .#{$ns}-button:first-child {
-    margin-right: $pt-grid-size;
+    margin-right: $bp-spacing * 2.5;
   }
 }
 
 .docs-popover-interaction-kind-example {
   .#{$ns}-button {
     font-family: $pt-font-family-monospace;
-    margin-right: $pt-grid-size;
+    margin-right: $bp-spacing * 2.5;
   }
 }
 
@@ -792,7 +792,7 @@ $docs-hotkey-piano-height: 510px;
 
 .docs-popover-portal-example-popover {
   .#{$ns}-popover-content {
-    padding: $pt-grid-size;
+    padding: $bp-spacing * 2.5;
     white-space: nowrap;
   }
 }
@@ -831,7 +831,7 @@ $docs-hotkey-piano-height: 510px;
   .docs-example .#{$ns}-card {
     display: flex;
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
   }
 }
 
@@ -843,7 +843,7 @@ $docs-hotkey-piano-height: 510px;
   .metadata-panel {
     display: flex;
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
 
     > div {
       display: flex;
@@ -860,7 +860,7 @@ $docs-hotkey-piano-height: 510px;
 #{page("datetime", "^=")} {
   .docs-example {
     flex-direction: column;
-    gap: $pt-grid-size;
+    gap: $bp-spacing * 2.5;
     justify-content: center;
   }
 }

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -69,7 +69,7 @@
 #{example("ButtonPlayground")} {
   .docs-example {
     flex-direction: column;
-    gap: $pt-grid-size * 3;
+    gap: $bp-spacing * 7.5;
 
     > * {
       margin: 0;
@@ -295,7 +295,7 @@
   }
 
   h1 {
-    margin-bottom: $pt-grid-size * 3;
+    margin-bottom: $bp-spacing * 7.5;
   }
 }
 

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -139,7 +139,7 @@ $icons-per-row: 5;
 .docs-icon-name {
   opacity: 1;
   position: absolute;
-  top: $pt-grid-size * 4;
+  top: $bp-spacing * 10;
 }
 
 .docs-icon-detail {

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -12,14 +12,14 @@ $icons-per-row: 5;
 
 .docs-icons {
   .#{$ns}-input-group {
-    margin: ($pt-grid-size * 5) 0;
+    margin: ($bp-spacing * 12.5) 0;
   }
 
   .docs-icon-group {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    margin-bottom: $pt-grid-size * 5;
+    margin-bottom: $bp-spacing * 12.5;
 
     .#{$ns}-heading {
       flex: 1 1 100%;

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -31,7 +31,7 @@ $icons-per-row: 5;
 
 .docs-icon-container,
 .docs-icon-spacer {
-  height: $pt-grid-size * 12;
+  height: $bp-spacing * 30;
   width: math.div(100%, $icons-per-row);
 
   // remove margin on last row of icons

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -4,7 +4,7 @@
 @use "sass:math";
 @import "@blueprintjs/core/src/common/variables";
 
-$svg-icon-size: $bp-spacing * 9;
+$svg-icon-size: $pt-spacing * 9;
 
 $hover-transition: $pt-transition-duration $pt-transition-ease;
 
@@ -12,18 +12,18 @@ $icons-per-row: 5;
 
 .docs-icons {
   .#{$ns}-input-group {
-    margin: ($bp-spacing * 12.5) 0;
+    margin: ($pt-spacing * 12.5) 0;
   }
 
   .docs-icon-group {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    margin-bottom: $bp-spacing * 12.5;
+    margin-bottom: $pt-spacing * 12.5;
 
     .#{$ns}-heading {
       flex: 1 1 100%;
-      margin: 0 0 $bp-spacing * 5;
+      margin: 0 0 $pt-spacing * 5;
       text-transform: capitalize;
     }
   }
@@ -31,7 +31,7 @@ $icons-per-row: 5;
 
 .docs-icon-container,
 .docs-icon-spacer {
-  height: $bp-spacing * 30;
+  height: $pt-spacing * 30;
   width: math.div(100%, $icons-per-row);
 
   // remove margin on last row of icons
@@ -99,7 +99,7 @@ $icons-per-row: 5;
   border-radius: $pt-border-radius;
   display: flex;
   flex-direction: column;
-  padding: ($bp-spacing * 5) 0;
+  padding: ($pt-spacing * 5) 0;
   transition: background-color $hover-transition;
 
   .docs-icon-svg {
@@ -127,7 +127,7 @@ $icons-per-row: 5;
 .docs-icon-name,
 .docs-icon-detail {
   font-size: $pt-font-size-small;
-  margin-top: $bp-spacing * 5;
+  margin-top: $pt-spacing * 5;
   text-align: center;
   transform: translateY(0);
   transition:
@@ -139,7 +139,7 @@ $icons-per-row: 5;
 .docs-icon-name {
   opacity: 1;
   position: absolute;
-  top: $bp-spacing * 10;
+  top: $pt-spacing * 10;
 }
 
 .docs-icon-detail {

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -23,7 +23,7 @@ $icons-per-row: 5;
 
     .#{$ns}-heading {
       flex: 1 1 100%;
-      margin: 0 0 $pt-grid-size * 2;
+      margin: 0 0 $bp-spacing * 5;
       text-transform: capitalize;
     }
   }
@@ -99,7 +99,7 @@ $icons-per-row: 5;
   border-radius: $pt-border-radius;
   display: flex;
   flex-direction: column;
-  padding: ($pt-grid-size * 2) 0;
+  padding: ($bp-spacing * 5) 0;
   transition: background-color $hover-transition;
 
   .docs-icon-svg {
@@ -127,7 +127,7 @@ $icons-per-row: 5;
 .docs-icon-name,
 .docs-icon-detail {
   font-size: $pt-font-size-small;
-  margin-top: $pt-grid-size * 2;
+  margin-top: $bp-spacing * 5;
   text-align: center;
   transform: translateY(0);
   transition:

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -4,7 +4,7 @@
 @use "sass:math";
 @import "@blueprintjs/core/src/common/variables";
 
-$svg-icon-size: 36px;
+$svg-icon-size: $bp-spacing * 9;
 
 $hover-transition: $pt-transition-duration $pt-transition-ease;
 

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -89,7 +89,7 @@ $dark-package-colors: (
 }
 
 .docs-heading {
-  font-size: $pt-grid-size * 2;
+  font-size: $bp-spacing * 5;
   font-weight: 600;
   margin-right: $bp-spacing * 2.5;
 
@@ -191,7 +191,7 @@ $dark-package-colors: (
   font-size: small;
   font-weight: 700;
   margin-bottom: $bp-spacing * 2.5;
-  margin-top: $pt-grid-size * 2;
+  margin-top: $bp-spacing * 5;
   text-transform: uppercase;
 
   // dedent menu under a section title

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -1,7 +1,7 @@
 // Copyright 2018 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-$pkg-icon-width: 24px;
+$pkg-icon-width: $bp-spacing * 6;
 
 $package-colors: (
   "blueprint": (

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -1,7 +1,7 @@
 // Copyright 2018 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-$pkg-icon-width: $bp-spacing * 6;
+$pkg-icon-width: $pt-spacing * 6;
 
 $package-colors: (
   "blueprint": (
@@ -89,20 +89,20 @@ $dark-package-colors: (
 }
 
 .docs-heading {
-  font-size: $bp-spacing * 5;
+  font-size: $pt-spacing * 5;
   font-weight: 600;
-  margin-right: $bp-spacing * 2.5;
+  margin-right: $pt-spacing * 2.5;
 
   .#{$ns}-tag {
-    margin-left: $bp-spacing * 1.25;
-    padding-left: $bp-spacing * 2.5;
+    margin-left: $pt-spacing * 1.25;
+    padding-left: $pt-spacing * 2.5;
     vertical-align: middle;
   }
 }
 
 .docs-version-list {
-  max-height: $bp-spacing * 50;
-  min-width: $bp-spacing * 30;
+  max-height: $pt-spacing * 50;
+  min-width: $pt-spacing * 30;
   overflow: auto;
 }
 
@@ -113,7 +113,7 @@ $dark-package-colors: (
 
 .docs-nav-package-icon {
   border-radius: $pt-border-radius * 3;
-  margin-right: $bp-spacing * 2.5;
+  margin-right: $pt-spacing * 2.5;
 }
 
 .docs-nav-package {
@@ -178,8 +178,8 @@ $dark-package-colors: (
   }
 
   + .docs-nav-menu {
-    margin-bottom: $bp-spacing * 1.25;
-    margin-left: $pkg-icon-width + ($bp-spacing * 2.5);
+    margin-bottom: $pt-spacing * 1.25;
+    margin-left: $pkg-icon-width + ($pt-spacing * 2.5);
 
     &:empty {
       display: none;
@@ -190,8 +190,8 @@ $dark-package-colors: (
 .docs-nav-section {
   font-size: small;
   font-weight: 700;
-  margin-bottom: $bp-spacing * 2.5;
-  margin-top: $bp-spacing * 5;
+  margin-bottom: $pt-spacing * 2.5;
+  margin-top: $pt-spacing * 5;
   text-transform: uppercase;
 
   // dedent menu under a section title
@@ -206,7 +206,7 @@ $dark-package-colors: (
 
   svg {
     height: 1.2em;
-    padding: 0 ($bp-spacing * 1.25);
+    padding: 0 ($pt-spacing * 1.25);
   }
 
   a:not(:hover) {

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -91,11 +91,11 @@ $dark-package-colors: (
 .docs-heading {
   font-size: $pt-grid-size * 2;
   font-weight: 600;
-  margin-right: $pt-grid-size;
+  margin-right: $bp-spacing * 2.5;
 
   .#{$ns}-tag {
     margin-left: $pt-grid-size * 0.5;
-    padding-left: $pt-grid-size;
+    padding-left: $bp-spacing * 2.5;
     vertical-align: middle;
   }
 }
@@ -113,7 +113,7 @@ $dark-package-colors: (
 
 .docs-nav-package-icon {
   border-radius: $pt-border-radius * 3;
-  margin-right: $pt-grid-size;
+  margin-right: $bp-spacing * 2.5;
 }
 
 .docs-nav-package {
@@ -179,7 +179,7 @@ $dark-package-colors: (
 
   + .docs-nav-menu {
     margin-bottom: $pt-grid-size * 0.5;
-    margin-left: $pkg-icon-width + $pt-grid-size;
+    margin-left: $pkg-icon-width + ($bp-spacing * 2.5);
 
     &:empty {
       display: none;
@@ -190,7 +190,7 @@ $dark-package-colors: (
 .docs-nav-section {
   font-size: small;
   font-weight: 700;
-  margin-bottom: $pt-grid-size;
+  margin-bottom: $bp-spacing * 2.5;
   margin-top: $pt-grid-size * 2;
   text-transform: uppercase;
 

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -94,7 +94,7 @@ $dark-package-colors: (
   margin-right: $bp-spacing * 2.5;
 
   .#{$ns}-tag {
-    margin-left: $pt-grid-size * 0.5;
+    margin-left: $bp-spacing * 1.25;
     padding-left: $bp-spacing * 2.5;
     vertical-align: middle;
   }
@@ -178,7 +178,7 @@ $dark-package-colors: (
   }
 
   + .docs-nav-menu {
-    margin-bottom: $pt-grid-size * 0.5;
+    margin-bottom: $bp-spacing * 1.25;
     margin-left: $pkg-icon-width + ($bp-spacing * 2.5);
 
     &:empty {
@@ -206,7 +206,7 @@ $dark-package-colors: (
 
   svg {
     height: 1.2em;
-    padding: 0 ($pt-grid-size * 0.5);
+    padding: 0 ($bp-spacing * 1.25);
   }
 
   a:not(:hover) {

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -101,8 +101,8 @@ $dark-package-colors: (
 }
 
 .docs-version-list {
-  max-height: $pt-grid-size * 20;
-  min-width: $pt-grid-size * 12;
+  max-height: $bp-spacing * 50;
+  min-width: $bp-spacing * 30;
   overflow: auto;
 }
 

--- a/packages/docs-theme/src/styles/_api.scss
+++ b/packages/docs-theme/src/styles/_api.scss
@@ -14,26 +14,26 @@
 
   .docs-interface-header {
     flex: 0 0 auto;
-    padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
+    padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
 
     + .docs-section {
       flex-shrink: 0;
-      padding-left: $bp-spacing * 5;
-      padding-right: $bp-spacing * 5;
+      padding-left: $pt-spacing * 5;
+      padding-right: $pt-spacing * 5;
     }
   }
 
   .docs-modifiers-table {
     overflow: auto;
-    padding-bottom: $bp-spacing * 5;
+    padding-bottom: $pt-spacing * 5;
 
     th:first-child,
     td:first-child {
-      padding-left: $bp-spacing * 5;
+      padding-left: $pt-spacing * 5;
     }
 
     td:last-child {
-      padding-right: $bp-spacing * 5;
+      padding-right: $pt-spacing * 5;
     }
   }
 }

--- a/packages/docs-theme/src/styles/_api.scss
+++ b/packages/docs-theme/src/styles/_api.scss
@@ -14,7 +14,7 @@
 
   .docs-interface-header {
     flex: 0 0 auto;
-    padding: $pt-grid-size ($pt-grid-size * 2);
+    padding: ($bp-spacing * 2.5) ($pt-grid-size * 2);
 
     + .docs-section {
       flex-shrink: 0;

--- a/packages/docs-theme/src/styles/_api.scss
+++ b/packages/docs-theme/src/styles/_api.scss
@@ -14,26 +14,26 @@
 
   .docs-interface-header {
     flex: 0 0 auto;
-    padding: ($bp-spacing * 2.5) ($pt-grid-size * 2);
+    padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
 
     + .docs-section {
       flex-shrink: 0;
-      padding-left: $pt-grid-size * 2;
-      padding-right: $pt-grid-size * 2;
+      padding-left: $bp-spacing * 5;
+      padding-right: $bp-spacing * 5;
     }
   }
 
   .docs-modifiers-table {
     overflow: auto;
-    padding-bottom: $pt-grid-size * 2;
+    padding-bottom: $bp-spacing * 5;
 
     th:first-child,
     td:first-child {
-      padding-left: $pt-grid-size * 2;
+      padding-left: $bp-spacing * 5;
     }
 
     td:last-child {
-      padding-right: $pt-grid-size * 2;
+      padding-right: $bp-spacing * 5;
     }
   }
 }

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -4,7 +4,7 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/core/src/components/button/common";
 
-$banner-height: $bp-spacing * 10;
+$banner-height: $pt-spacing * 10;
 
 // banner along top of screen linking to v2 docs
 .docs-banner {
@@ -16,7 +16,7 @@ $banner-height: $bp-spacing * 10;
   justify-content: center;
   left: 0;
   min-height: $banner-height;
-  padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
+  padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
 
   position: fixed;
   right: 0;

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -4,7 +4,7 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/core/src/components/button/common";
 
-$banner-height: $pt-grid-size * 4;
+$banner-height: $bp-spacing * 10;
 
 // banner along top of screen linking to v2 docs
 .docs-banner {

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -16,7 +16,7 @@ $banner-height: $pt-grid-size * 4;
   justify-content: center;
   left: 0;
   min-height: $banner-height;
-  padding: $pt-grid-size $pt-grid-size * 2;
+  padding: ($bp-spacing * 2.5) $pt-grid-size * 2;
 
   position: fixed;
   right: 0;

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -16,7 +16,7 @@ $banner-height: $pt-grid-size * 4;
   justify-content: center;
   left: 0;
   min-height: $banner-height;
-  padding: ($bp-spacing * 2.5) $pt-grid-size * 2;
+  padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
 
   position: fixed;
   right: 0;

--- a/packages/docs-theme/src/styles/_code-example.scss
+++ b/packages/docs-theme/src/styles/_code-example.scss
@@ -1,7 +1,7 @@
 .docs-code-example-frame {
   display: flex;
   flex-direction: column;
-  margin-top: $pt-grid-size * 2;
+  margin-top: $bp-spacing * 5;
   position: relative;
   width: 100%;
 }
@@ -12,7 +12,7 @@
   border-radius: $pt-border-radius * 2;
   display: flex;
   justify-content: center;
-  padding: $pt-grid-size * 2;
+  padding: $bp-spacing * 5;
 
   .#{$ns}-dark & {
     background: $pt-dark-app-secondary-background-color;

--- a/packages/docs-theme/src/styles/_code-example.scss
+++ b/packages/docs-theme/src/styles/_code-example.scss
@@ -1,7 +1,7 @@
 .docs-code-example-frame {
   display: flex;
   flex-direction: column;
-  margin-top: $bp-spacing * 5;
+  margin-top: $pt-spacing * 5;
   position: relative;
   width: 100%;
 }
@@ -12,7 +12,7 @@
   border-radius: $pt-border-radius * 2;
   display: flex;
   justify-content: center;
-  padding: $bp-spacing * 5;
+  padding: $pt-spacing * 5;
 
   .#{$ns}-dark & {
     background: $pt-dark-app-secondary-background-color;

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -6,7 +6,7 @@
 @import "variables";
 
 $heading-margin: $pt-grid-size * 4;
-$link-icon-padding: $pt-grid-size;
+$link-icon-padding: $bp-spacing * 2.5;
 
 $class-modifier-color: $rose4;
 $attribute-modifier-color: $violet5;

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -5,8 +5,8 @@
 @import "@blueprintjs/icons/lib/scss/variables";
 @import "variables";
 
-$heading-margin: $bp-spacing * 10;
-$link-icon-padding: $bp-spacing * 2.5;
+$heading-margin: $pt-spacing * 10;
+$link-icon-padding: $pt-spacing * 2.5;
 
 $class-modifier-color: $rose4;
 $attribute-modifier-color: $violet5;

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -5,7 +5,7 @@
 @import "@blueprintjs/icons/lib/scss/variables";
 @import "variables";
 
-$heading-margin: $pt-grid-size * 4;
+$heading-margin: $bp-spacing * 10;
 $link-icon-padding: $bp-spacing * 2.5;
 
 $class-modifier-color: $rose4;

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -3,9 +3,9 @@
 
 // Base styles for all examples
 
-$example-frame-spacing: $bp-spacing * 2.5;
+$example-frame-spacing: $pt-spacing * 2.5;
 $example-frame-border-radius: $pt-border-radius * 2;
-$example-spacing: $bp-spacing * 10;
+$example-spacing: $pt-spacing * 10;
 
 // full-bleed wrapper for example
 .docs-example-frame {
@@ -16,22 +16,22 @@ $example-spacing: $bp-spacing * 10;
 
 // options to the right of example in same row
 .docs-example-frame-row {
-  @include pt-flex-container(row, $bp-spacing * 2.5, $fill: ".docs-example");
+  @include pt-flex-container(row, $pt-spacing * 2.5, $fill: ".docs-example");
 
   // option elements arranged vertically. use headings for grouping.
   .docs-example-options {
-    @include pt-flex-container(column, $bp-spacing * 2.5);
-    max-width: $bp-spacing * 75;
+    @include pt-flex-container(column, $pt-spacing * 2.5);
+    max-width: $pt-spacing * 75;
   }
 }
 
 // options below example in its own row.
 .docs-example-frame-column {
-  @include pt-flex-container(column, $bp-spacing * 2.5, $fill: ".docs-example");
+  @include pt-flex-container(column, $pt-spacing * 2.5, $fill: ".docs-example");
 
   // option elements arranged horizontally. group controls into columns.
   .docs-example-options {
-    @include pt-flex-container(row, $bp-spacing * 10);
+    @include pt-flex-container(row, $pt-spacing * 10);
     justify-content: center;
     max-width: unset;
 
@@ -68,11 +68,11 @@ $example-spacing: $bp-spacing * 10;
   background-color: $pt-app-elevated-background-color;
   border-radius: $example-frame-border-radius;
   flex: 0 0 auto;
-  padding: $bp-spacing * 5;
+  padding: $pt-spacing * 5;
   text-align: left;
 
   .#{$ns}-heading:not(:first-child) {
-    margin-top: $bp-spacing * 2.5;
+    margin-top: $pt-spacing * 2.5;
   }
 
   .docs-prop-description {
@@ -115,7 +115,7 @@ $example-spacing: $bp-spacing * 10;
 .docs-example-view-source {
   border-radius: $example-frame-border-radius;
   display: block;
-  margin-bottom: $bp-spacing * 10;
+  margin-bottom: $pt-spacing * 10;
   margin-top: $example-frame-spacing;
 
   &.#{$ns}-button {

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -5,7 +5,7 @@
 
 $example-frame-spacing: $bp-spacing * 2.5;
 $example-frame-border-radius: $pt-border-radius * 2;
-$example-spacing: $pt-grid-size * 4;
+$example-spacing: $bp-spacing * 10;
 
 // full-bleed wrapper for example
 .docs-example-frame {
@@ -31,7 +31,7 @@ $example-spacing: $pt-grid-size * 4;
 
   // option elements arranged horizontally. group controls into columns.
   .docs-example-options {
-    @include pt-flex-container(row, $pt-grid-size * 4);
+    @include pt-flex-container(row, $bp-spacing * 10);
     justify-content: center;
     max-width: unset;
 
@@ -115,7 +115,7 @@ $example-spacing: $pt-grid-size * 4;
 .docs-example-view-source {
   border-radius: $example-frame-border-radius;
   display: block;
-  margin-bottom: $pt-grid-size * 4;
+  margin-bottom: $bp-spacing * 10;
   margin-top: $example-frame-spacing;
 
   &.#{$ns}-button {

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -3,7 +3,7 @@
 
 // Base styles for all examples
 
-$example-frame-spacing: $pt-grid-size;
+$example-frame-spacing: $bp-spacing * 2.5;
 $example-frame-border-radius: $pt-border-radius * 2;
 $example-spacing: $pt-grid-size * 4;
 
@@ -16,18 +16,18 @@ $example-spacing: $pt-grid-size * 4;
 
 // options to the right of example in same row
 .docs-example-frame-row {
-  @include pt-flex-container(row, $pt-grid-size, $fill: ".docs-example");
+  @include pt-flex-container(row, $bp-spacing * 2.5, $fill: ".docs-example");
 
   // option elements arranged vertically. use headings for grouping.
   .docs-example-options {
-    @include pt-flex-container(column, $pt-grid-size);
+    @include pt-flex-container(column, $bp-spacing * 2.5);
     max-width: $pt-grid-size * 30;
   }
 }
 
 // options below example in its own row.
 .docs-example-frame-column {
-  @include pt-flex-container(column, $pt-grid-size, $fill: ".docs-example");
+  @include pt-flex-container(column, $bp-spacing * 2.5, $fill: ".docs-example");
 
   // option elements arranged horizontally. group controls into columns.
   .docs-example-options {
@@ -72,7 +72,7 @@ $example-spacing: $pt-grid-size * 4;
   text-align: left;
 
   .#{$ns}-heading:not(:first-child) {
-    margin-top: $pt-grid-size;
+    margin-top: $bp-spacing * 2.5;
   }
 
   .docs-prop-description {

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -21,7 +21,7 @@ $example-spacing: $bp-spacing * 10;
   // option elements arranged vertically. use headings for grouping.
   .docs-example-options {
     @include pt-flex-container(column, $bp-spacing * 2.5);
-    max-width: $pt-grid-size * 30;
+    max-width: $bp-spacing * 75;
   }
 }
 

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -68,7 +68,7 @@ $example-spacing: $pt-grid-size * 4;
   background-color: $pt-app-elevated-background-color;
   border-radius: $example-frame-border-radius;
   flex: 0 0 auto;
-  padding: $pt-grid-size * 2;
+  padding: $bp-spacing * 5;
   text-align: left;
 
   .#{$ns}-heading:not(:first-child) {

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -118,7 +118,7 @@ Lefthand navigation menu
   .#{$ns}-menu-item {
     align-items: center;
     padding-left: 0;
-    padding-right: $pt-grid-size;
+    padding-right: $bp-spacing * 2.5;
     white-space: initial;
 
     &:hover,

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -5,7 +5,7 @@
 @import "@blueprintjs/core/src/components/forms/common";
 @import "variables";
 
-$nav-item-indent: $pt-grid-size * 2;
+$nav-item-indent: $bp-spacing * 5;
 
 $nav-item-color-hover: $minimal-button-background-color-hover;
 $nav-item-color-active: $minimal-button-background-color-active;

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -5,7 +5,7 @@
 @import "@blueprintjs/core/src/components/forms/common";
 @import "variables";
 
-$nav-item-indent: $bp-spacing * 5;
+$nav-item-indent: $pt-spacing * 5;
 
 $nav-item-color-hover: $minimal-button-background-color-hover;
 $nav-item-color-active: $minimal-button-background-color-active;
@@ -118,7 +118,7 @@ Lefthand navigation menu
   .#{$ns}-menu-item {
     align-items: center;
     padding-left: 0;
-    padding-right: $bp-spacing * 2.5;
+    padding-right: $pt-spacing * 2.5;
     white-space: initial;
 
     &:hover,

--- a/packages/docs-theme/src/styles/_navbar.scss
+++ b/packages/docs-theme/src/styles/_navbar.scss
@@ -4,7 +4,7 @@
 @import "variables";
 @import "../../../core/src/components/button/common";
 
-$nav-divider-offset: $pt-grid-size * 5;
+$nav-divider-offset: $bp-spacing * 12.5;
 
 @mixin divider-gradient($color, $dark-color) {
   background-image: linear-gradient(to right, rgba($color, 0) 0%, $color 40%);

--- a/packages/docs-theme/src/styles/_navbar.scss
+++ b/packages/docs-theme/src/styles/_navbar.scss
@@ -15,13 +15,13 @@ $nav-divider-offset: $pt-grid-size * 5;
 }
 
 .docs-nav-button {
-  @include pt-flex-container(row, $pt-grid-size + 4px);
+  @include pt-flex-container(row, $pt-grid-size + $bp-spacing);
   align-items: center;
   cursor: pointer;
 
   margin-left: -$nav-divider-offset;
   padding: $pt-grid-size $sidebar-padding;
-  padding-left: $nav-divider-offset + 4px;
+  padding-left: $nav-divider-offset + $bp-spacing;
 
   &:hover {
     @include divider-gradient($pt-app-background-color, $pt-dark-app-background-color);

--- a/packages/docs-theme/src/styles/_navbar.scss
+++ b/packages/docs-theme/src/styles/_navbar.scss
@@ -4,7 +4,7 @@
 @import "variables";
 @import "../../../core/src/components/button/common";
 
-$nav-divider-offset: $bp-spacing * 12.5;
+$nav-divider-offset: $pt-spacing * 12.5;
 
 @mixin divider-gradient($color, $dark-color) {
   background-image: linear-gradient(to right, rgba($color, 0) 0%, $color 40%);
@@ -15,13 +15,13 @@ $nav-divider-offset: $bp-spacing * 12.5;
 }
 
 .docs-nav-button {
-  @include pt-flex-container(row, ($bp-spacing * 2.5) + $bp-spacing);
+  @include pt-flex-container(row, ($pt-spacing * 2.5) + $pt-spacing);
   align-items: center;
   cursor: pointer;
 
   margin-left: -$nav-divider-offset;
-  padding: ($bp-spacing * 2.5) $sidebar-padding;
-  padding-left: $nav-divider-offset + $bp-spacing;
+  padding: ($pt-spacing * 2.5) $sidebar-padding;
+  padding-left: $nav-divider-offset + $pt-spacing;
 
   &:hover {
     @include divider-gradient($pt-app-background-color, $pt-dark-app-background-color);

--- a/packages/docs-theme/src/styles/_navbar.scss
+++ b/packages/docs-theme/src/styles/_navbar.scss
@@ -15,12 +15,12 @@ $nav-divider-offset: $pt-grid-size * 5;
 }
 
 .docs-nav-button {
-  @include pt-flex-container(row, $pt-grid-size + $bp-spacing);
+  @include pt-flex-container(row, ($bp-spacing * 2.5) + $bp-spacing);
   align-items: center;
   cursor: pointer;
 
   margin-left: -$nav-divider-offset;
-  padding: $pt-grid-size $sidebar-padding;
+  padding: ($bp-spacing * 2.5) $sidebar-padding;
   padding-left: $nav-divider-offset + $bp-spacing;
 
   &:hover {

--- a/packages/docs-theme/src/styles/_navigator.scss
+++ b/packages/docs-theme/src/styles/_navigator.scss
@@ -1,7 +1,7 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-$navigator-width: $bp-spacing * 100;
+$navigator-width: $pt-spacing * 100;
 
 .docs-navigator-menu {
   left: calc(50% - #{$navigator-width * 0.5});

--- a/packages/docs-theme/src/styles/_navigator.scss
+++ b/packages/docs-theme/src/styles/_navigator.scss
@@ -1,7 +1,7 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-$navigator-width: $pt-grid-size * 40;
+$navigator-width: $bp-spacing * 100;
 
 .docs-navigator-menu {
   left: calc(50% - #{$navigator-width * 0.5});

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -23,12 +23,12 @@
   &::before {
     content: "=";
     display: inline-block;
-    margin: 0 ($bp-spacing * 1.25);
+    margin: 0 ($pt-spacing * 1.25);
   }
 }
 
 .docs-prop-description {
-  margin-top: $bp-spacing * 1.25;
+  margin-top: $pt-spacing * 1.25;
 
   p:last-child {
     margin: 0;
@@ -41,15 +41,15 @@
   }
 
   .#{$ns}-tag {
-    margin-right: $bp-spacing * 2.5;
-    margin-top: $bp-spacing * 1.25;
+    margin-right: $pt-spacing * 2.5;
+    margin-top: $pt-spacing * 1.25;
   }
 }
 
 .docs-prop-name code::after {
   @include pt-icon();
   line-height: small;
-  margin-left: $bp-spacing * 1.25;
+  margin-left: $pt-spacing * 1.25;
   vertical-align: middle;
 }
 
@@ -81,7 +81,7 @@
   font-size: $pt-font-size-large;
   font-weight: 600;
   justify-content: space-between;
-  padding: ($bp-spacing * 2.5) 0;
+  padding: ($pt-spacing * 2.5) 0;
   position: relative;
 
   // optional interface description
@@ -89,7 +89,7 @@
     box-shadow: 0 1px 0 $pt-divider-black;
     display: flex;
     flex-direction: column;
-    margin-top: $bp-spacing * 2.5;
+    margin-top: $pt-spacing * 2.5;
   }
 
   .#{$ns}-dark & {
@@ -108,12 +108,12 @@
 
 .docs-type-alias {
   overflow: auto;
-  padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
+  padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
 }
 
 .docs-modifiers-table {
   .docs-section & .#{$ns}-html-table {
-    margin-top: $bp-spacing * 2.5;
+    margin-top: $pt-spacing * 2.5;
   }
 
   th:first-child,

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -108,7 +108,7 @@
 
 .docs-type-alias {
   overflow: auto;
-  padding: ($bp-spacing * 2.5) ($pt-grid-size * 2);
+  padding: ($bp-spacing * 2.5) ($bp-spacing * 5);
 }
 
 .docs-modifiers-table {

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -23,12 +23,12 @@
   &::before {
     content: "=";
     display: inline-block;
-    margin: 0 ($pt-grid-size * 0.5);
+    margin: 0 ($bp-spacing * 1.25);
   }
 }
 
 .docs-prop-description {
-  margin-top: $pt-grid-size * 0.5;
+  margin-top: $bp-spacing * 1.25;
 
   p:last-child {
     margin: 0;
@@ -42,14 +42,14 @@
 
   .#{$ns}-tag {
     margin-right: $bp-spacing * 2.5;
-    margin-top: $pt-grid-size * 0.5;
+    margin-top: $bp-spacing * 1.25;
   }
 }
 
 .docs-prop-name code::after {
   @include pt-icon();
   line-height: small;
-  margin-left: $pt-grid-size * 0.5;
+  margin-left: $bp-spacing * 1.25;
   vertical-align: middle;
 }
 

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -41,7 +41,7 @@
   }
 
   .#{$ns}-tag {
-    margin-right: $pt-grid-size;
+    margin-right: $bp-spacing * 2.5;
     margin-top: $pt-grid-size * 0.5;
   }
 }
@@ -81,7 +81,7 @@
   font-size: $pt-font-size-large;
   font-weight: 600;
   justify-content: space-between;
-  padding: $pt-grid-size 0;
+  padding: ($bp-spacing * 2.5) 0;
   position: relative;
 
   // optional interface description
@@ -89,7 +89,7 @@
     box-shadow: 0 1px 0 $pt-divider-black;
     display: flex;
     flex-direction: column;
-    margin-top: $pt-grid-size;
+    margin-top: $bp-spacing * 2.5;
   }
 
   .#{$ns}-dark & {
@@ -108,12 +108,12 @@
 
 .docs-type-alias {
   overflow: auto;
-  padding: $pt-grid-size ($pt-grid-size * 2);
+  padding: ($bp-spacing * 2.5) ($pt-grid-size * 2);
 }
 
 .docs-modifiers-table {
   .docs-section & .#{$ns}-html-table {
-    margin-top: $pt-grid-size;
+    margin-top: $bp-spacing * 2.5;
   }
 
   th:first-child,

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -6,7 +6,7 @@
 @import "@blueprintjs/core/src/common/mixins";
 
 $container-width: $bp-spacing * 275;
-$container-padding: $pt-grid-size * 0.5;
+$container-padding: $bp-spacing * 1.25;
 
 $sidebar-width: $bp-spacing * 75;
 $sidebar-padding: $pt-grid-size * 1.5;

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -5,10 +5,10 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/core/src/common/mixins";
 
-$container-width: $pt-grid-size * 110;
+$container-width: $bp-spacing * 275;
 $container-padding: $pt-grid-size * 0.5;
 
-$sidebar-width: $pt-grid-size * 30;
+$sidebar-width: $bp-spacing * 75;
 $sidebar-padding: $pt-grid-size * 1.5;
 $sidebar-background-color: $white;
 $dark-sidebar-background-color: $dark-gray3;

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -14,4 +14,4 @@ $sidebar-background-color: $white;
 $dark-sidebar-background-color: $dark-gray3;
 
 $content-width: $container-width - $sidebar-width;
-$content-padding: $pt-grid-size * 2;
+$content-padding: $bp-spacing * 5;

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -5,13 +5,13 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/core/src/common/mixins";
 
-$container-width: $bp-spacing * 275;
-$container-padding: $bp-spacing * 1.25;
+$container-width: $pt-spacing * 275;
+$container-padding: $pt-spacing * 1.25;
 
-$sidebar-width: $bp-spacing * 75;
-$sidebar-padding: $bp-spacing * 3.75;
+$sidebar-width: $pt-spacing * 75;
+$sidebar-padding: $pt-spacing * 3.75;
 $sidebar-background-color: $white;
 $dark-sidebar-background-color: $dark-gray3;
 
 $content-width: $container-width - $sidebar-width;
-$content-padding: $bp-spacing * 5;
+$content-padding: $pt-spacing * 5;

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -9,7 +9,7 @@ $container-width: $bp-spacing * 275;
 $container-padding: $bp-spacing * 1.25;
 
 $sidebar-width: $bp-spacing * 75;
-$sidebar-padding: $pt-grid-size * 1.5;
+$sidebar-padding: $bp-spacing * 3.75;
 $sidebar-background-color: $white;
 $dark-sidebar-background-color: $dark-gray3;
 

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -33,7 +33,7 @@ body {
 .landing-container {
   margin: 0 auto;
   max-width: $container-width;
-  padding: 0 $pt-grid-size * 2;
+  padding: 0 $bp-spacing * 5;
 }
 
 header {

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -158,7 +158,7 @@ footer {
 
     h3 {
       font-size: $bp-spacing * 4.5;
-      margin-bottom: $pt-grid-size * 2.5;
+      margin-bottom: $bp-spacing * 6.25;
     }
 
     .#{$ns}-icon-dot {

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -33,7 +33,7 @@ body {
 .landing-container {
   margin: 0 auto;
   max-width: $container-width;
-  padding: 0 $bp-spacing * 5;
+  padding: 0 $pt-spacing * 5;
 }
 
 header {
@@ -57,14 +57,14 @@ header {
     font-weight: 400;
     line-height: 1.2;
     margin: 0 auto;
-    margin-top: $bp-spacing * 82.5;
+    margin-top: $pt-spacing * 82.5;
   }
 
   h3 {
     color: $white;
     font-weight: 400;
-    margin-bottom: $bp-spacing * 7.5;
-    margin-top: $bp-spacing * 7.5;
+    margin-bottom: $pt-spacing * 7.5;
+    margin-top: $pt-spacing * 7.5;
     opacity: 0.8;
   }
 
@@ -86,7 +86,7 @@ header {
 
   .#{$ns}-icon-dot {
     color: rgba($white, 0.5);
-    margin: $bp-spacing * 1.25;
+    margin: $pt-spacing * 1.25;
   }
 
   canvas {
@@ -100,15 +100,15 @@ footer {
 
 .landing-about {
   .landing-container {
-    @include pt-flex-container(column, $bp-spacing * 7.5);
+    @include pt-flex-container(column, $pt-spacing * 7.5);
     align-items: center;
-    padding-bottom: $bp-spacing * 15;
-    padding-top: $bp-spacing * 15;
+    padding-bottom: $pt-spacing * 15;
+    padding-top: $pt-spacing * 15;
     text-align: center;
   }
 
   img {
-    width: $bp-spacing * 15;
+    width: $pt-spacing * 15;
   }
 
   p:first-of-type {
@@ -121,8 +121,8 @@ footer {
 
   .landing-separator {
     background-color: $dark-gray5;
-    height: $bp-spacing * 0.5;
-    width: $bp-spacing * 10;
+    height: $pt-spacing * 0.5;
+    width: $pt-spacing * 10;
   }
 }
 
@@ -144,21 +144,21 @@ footer {
     display: flex;
     justify-content: space-between;
     min-height: $pt-navbar-height;
-    padding: $bp-spacing * 1.25;
+    padding: $pt-spacing * 1.25;
   }
 }
 
 @media (max-width: $mobile-breakpoint) {
   header {
-    height: $bp-spacing * 200;
+    height: $pt-spacing * 200;
 
     h1 {
-      font-size: $bp-spacing * 9;
+      font-size: $pt-spacing * 9;
     }
 
     h3 {
-      font-size: $bp-spacing * 4.5;
-      margin-bottom: $bp-spacing * 6.25;
+      font-size: $pt-spacing * 4.5;
+      margin-bottom: $pt-spacing * 6.25;
     }
 
     .#{$ns}-icon-dot {
@@ -174,7 +174,7 @@ footer {
     }
 
     .landing-button {
-      margin: $bp-spacing * 1.25;
+      margin: $pt-spacing * 1.25;
     }
   }
 }

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -86,7 +86,7 @@ header {
 
   .#{$ns}-icon-dot {
     color: rgba($white, 0.5);
-    margin: $pt-grid-size * 0.5;
+    margin: $bp-spacing * 1.25;
   }
 
   canvas {
@@ -144,7 +144,7 @@ footer {
     display: flex;
     justify-content: space-between;
     min-height: $pt-navbar-height;
-    padding: $pt-grid-size * 0.5;
+    padding: $bp-spacing * 1.25;
   }
 }
 
@@ -174,7 +174,7 @@ footer {
     }
 
     .landing-button {
-      margin: $pt-grid-size * 0.5;
+      margin: $bp-spacing * 1.25;
     }
   }
 }

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -63,8 +63,8 @@ header {
   h3 {
     color: $white;
     font-weight: 400;
-    margin-bottom: $pt-grid-size * 3;
-    margin-top: $pt-grid-size * 3;
+    margin-bottom: $bp-spacing * 7.5;
+    margin-top: $bp-spacing * 7.5;
     opacity: 0.8;
   }
 
@@ -100,7 +100,7 @@ footer {
 
 .landing-about {
   .landing-container {
-    @include pt-flex-container(column, $pt-grid-size * 3);
+    @include pt-flex-container(column, $bp-spacing * 7.5);
     align-items: center;
     padding-bottom: $pt-grid-size * 6;
     padding-top: $pt-grid-size * 6;

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -57,7 +57,7 @@ header {
     font-weight: 400;
     line-height: 1.2;
     margin: 0 auto;
-    margin-top: $pt-grid-size * 33;
+    margin-top: $bp-spacing * 82.5;
   }
 
   h3 {
@@ -102,13 +102,13 @@ footer {
   .landing-container {
     @include pt-flex-container(column, $bp-spacing * 7.5);
     align-items: center;
-    padding-bottom: $pt-grid-size * 6;
-    padding-top: $pt-grid-size * 6;
+    padding-bottom: $bp-spacing * 15;
+    padding-top: $bp-spacing * 15;
     text-align: center;
   }
 
   img {
-    width: $pt-grid-size * 6;
+    width: $bp-spacing * 15;
   }
 
   p:first-of-type {
@@ -150,7 +150,7 @@ footer {
 
 @media (max-width: $mobile-breakpoint) {
   header {
-    height: $pt-grid-size * 80;
+    height: $bp-spacing * 200;
 
     h1 {
       font-size: $bp-spacing * 9;

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -157,7 +157,7 @@ footer {
     }
 
     h3 {
-      font-size: $pt-grid-size * 1.8;
+      font-size: $bp-spacing * 4.5;
       margin-bottom: $pt-grid-size * 2.5;
     }
 

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -122,7 +122,7 @@ footer {
   .landing-separator {
     background-color: $dark-gray5;
     height: $bp-spacing * 0.5;
-    width: $pt-grid-size * 4;
+    width: $bp-spacing * 10;
   }
 }
 

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -121,7 +121,7 @@ footer {
 
   .landing-separator {
     background-color: $dark-gray5;
-    height: 2px;
+    height: $bp-spacing * 0.5;
     width: $pt-grid-size * 4;
   }
 }

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -153,7 +153,7 @@ footer {
     height: $pt-grid-size * 80;
 
     h1 {
-      font-size: $pt-grid-size * 3.6;
+      font-size: $bp-spacing * 9;
     }
 
     h3 {

--- a/packages/select/src/common/_variables.scss
+++ b/packages/select/src/common/_variables.scss
@@ -7,5 +7,5 @@
 @import "@blueprintjs/colors/lib/scss/colors";
 @import "@blueprintjs/core/src/common/variables";
 
-$select-popover-max-height: $bp-spacing * 75 !default;
-$select-popover-max-width: $bp-spacing * 100 !default;
+$select-popover-max-height: $pt-spacing * 75 !default;
+$select-popover-max-width: $pt-spacing * 100 !default;

--- a/packages/select/src/common/_variables.scss
+++ b/packages/select/src/common/_variables.scss
@@ -7,5 +7,5 @@
 @import "@blueprintjs/colors/lib/scss/colors";
 @import "@blueprintjs/core/src/common/variables";
 
-$select-popover-max-height: $pt-grid-size * 30 !default;
-$select-popover-max-width: $pt-grid-size * 40 !default;
+$select-popover-max-height: $bp-spacing * 75 !default;
+$select-popover-max-width: $bp-spacing * 100 !default;

--- a/packages/select/src/components/multi-select/_multi-select.scss
+++ b/packages/select/src/components/multi-select/_multi-select.scss
@@ -3,10 +3,10 @@
 
 @import "../../common/variables";
 
-$select-padding: $bp-spacing * 1.25;
+$select-padding: $pt-spacing * 1.25;
 
 .#{$ns}-multi-select {
-  min-width: $bp-spacing * 37.5;
+  min-width: $pt-spacing * 37.5;
 }
 
 .#{$ns}-multi-select-popover {

--- a/packages/select/src/components/multi-select/_multi-select.scss
+++ b/packages/select/src/components/multi-select/_multi-select.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$select-padding: $pt-grid-size * 0.5;
+$select-padding: $bp-spacing * 1.25;
 
 .#{$ns}-multi-select {
   min-width: $bp-spacing * 37.5;

--- a/packages/select/src/components/multi-select/_multi-select.scss
+++ b/packages/select/src/components/multi-select/_multi-select.scss
@@ -6,7 +6,7 @@
 $select-padding: $pt-grid-size * 0.5;
 
 .#{$ns}-multi-select {
-  min-width: $pt-grid-size * 15;
+  min-width: $bp-spacing * 37.5;
 }
 
 .#{$ns}-multi-select-popover {

--- a/packages/select/src/components/omnibar/_omnibar.scss
+++ b/packages/select/src/components/omnibar/_omnibar.scss
@@ -15,7 +15,7 @@ $omnibar-input-height: $pt-grid-size * 4 !default;
 .#{$ns}-omnibar {
   $omnibar-transition-props: (
     filter: (
-      blur($pt-grid-size * 2),
+      blur($bp-spacing * 5),
       blur(0),
     ),
     opacity: (

--- a/packages/select/src/components/omnibar/_omnibar.scss
+++ b/packages/select/src/components/omnibar/_omnibar.scss
@@ -9,13 +9,13 @@
 @import "@blueprintjs/core/src/common/react-transition";
 
 $omnibar-height: 60vh !default;
-$omnibar-width: $bp-spacing * 125 !default;
-$omnibar-input-height: $bp-spacing * 10 !default;
+$omnibar-width: $pt-spacing * 125 !default;
+$omnibar-input-height: $pt-spacing * 10 !default;
 
 .#{$ns}-omnibar {
   $omnibar-transition-props: (
     filter: (
-      blur($bp-spacing * 5),
+      blur($pt-spacing * 5),
       blur(0),
     ),
     opacity: (

--- a/packages/select/src/components/omnibar/_omnibar.scss
+++ b/packages/select/src/components/omnibar/_omnibar.scss
@@ -10,7 +10,7 @@
 
 $omnibar-height: 60vh !default;
 $omnibar-width: $pt-grid-size * 50 !default;
-$omnibar-input-height: $pt-grid-size * 4 !default;
+$omnibar-input-height: $bp-spacing * 10 !default;
 
 .#{$ns}-omnibar {
   $omnibar-transition-props: (

--- a/packages/select/src/components/omnibar/_omnibar.scss
+++ b/packages/select/src/components/omnibar/_omnibar.scss
@@ -9,7 +9,7 @@
 @import "@blueprintjs/core/src/common/react-transition";
 
 $omnibar-height: 60vh !default;
-$omnibar-width: $pt-grid-size * 50 !default;
+$omnibar-width: $bp-spacing * 125 !default;
 $omnibar-input-height: $bp-spacing * 10 !default;
 
 .#{$ns}-omnibar {

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$select-padding: $pt-grid-size * 0.5;
+$select-padding: $bp-spacing * 1.25;
 
 .#{$ns}-select-popover {
   .#{$ns}-popover-content {

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$select-padding: $bp-spacing * 1.25;
+$select-padding: $pt-spacing * 1.25;
 
 .#{$ns}-select-popover {
   .#{$ns}-popover-content {

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -77,7 +77,7 @@ body {
   z-index: 3;
 
   h4.#{$ns}-heading {
-    margin-top: $pt-grid-size * 2;
+    margin-top: $bp-spacing * 5;
 
     &:first-child {
       margin-top: 0;

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -86,7 +86,7 @@ body {
 
   h6.#{$ns}-heading {
     color: $pt-text-color-muted;
-    padding: ($bp-spacing * 2.5) 0 3px;
+    padding: ($bp-spacing * 2.5) 0 ($bp-spacing * 0.75);
   }
 
   .#{$ns}-divider {
@@ -100,7 +100,7 @@ body {
 
   .tbl-select-label {
     margin-bottom: 7px;
-    margin-top: -3px;
+    margin-top: $bp-spacing * -0.75;
 
     .#{$ns}-html-select {
       float: right;
@@ -112,7 +112,7 @@ body {
   }
 
   > .#{$ns}-button + .#{$ns}-button {
-    margin-top: 3px;
+    margin-top: $bp-spacing * 0.75;
   }
 
   .#{$ns}-dark & {
@@ -166,7 +166,7 @@ body {
   color: $gray1;
   font-family: "Courier", monospace;
   font-size: 12px;
-  margin-top: 3px;
+  margin-top: $bp-spacing * 0.75;
 
   .#{$ns}-dark & {
     color: $gray5;

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -73,7 +73,7 @@ body {
   height: 100%;
   order: 1;
   overflow-y: auto;
-  padding: 15px;
+  padding: $bp-spacing * 3.75;
   z-index: 3;
 
   h4.#{$ns}-heading {
@@ -90,7 +90,7 @@ body {
   }
 
   .#{$ns}-divider {
-    margin: 15px ($bp-spacing * 1.25);
+    margin: ($bp-spacing * 3.75) ($bp-spacing * 1.25);
   }
 
   .#{$ns}-label,

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -73,11 +73,11 @@ body {
   height: 100%;
   order: 1;
   overflow-y: auto;
-  padding: $bp-spacing * 3.75;
+  padding: $pt-spacing * 3.75;
   z-index: 3;
 
   h4.#{$ns}-heading {
-    margin-top: $bp-spacing * 5;
+    margin-top: $pt-spacing * 5;
 
     &:first-child {
       margin-top: 0;
@@ -86,21 +86,21 @@ body {
 
   h6.#{$ns}-heading {
     color: $pt-text-color-muted;
-    padding: ($bp-spacing * 2.5) 0 ($bp-spacing * 0.75);
+    padding: ($pt-spacing * 2.5) 0 ($pt-spacing * 0.75);
   }
 
   .#{$ns}-divider {
-    margin: ($bp-spacing * 3.75) ($bp-spacing * 1.25);
+    margin: ($pt-spacing * 3.75) ($pt-spacing * 1.25);
   }
 
   .#{$ns}-label,
   .#{$ns}-control {
-    padding-left: $bp-spacing * 2.5;
+    padding-left: $pt-spacing * 2.5;
   }
 
   .tbl-select-label {
-    margin-bottom: $bp-spacing * 1.75;
-    margin-top: $bp-spacing * -0.75;
+    margin-bottom: $pt-spacing * 1.75;
+    margin-top: $pt-spacing * -0.75;
 
     .#{$ns}-html-select {
       float: right;
@@ -112,7 +112,7 @@ body {
   }
 
   > .#{$ns}-button + .#{$ns}-button {
-    margin-top: $bp-spacing * 0.75;
+    margin-top: $pt-spacing * 0.75;
   }
 
   .#{$ns}-dark & {
@@ -127,7 +127,7 @@ body {
 }
 
 .sidebar-indented-group {
-  margin-left: $bp-spacing * 2.5;
+  margin-left: $pt-spacing * 2.5;
 }
 
 .tbl-zebra-stripe {
@@ -155,7 +155,7 @@ body {
 
 .tbl-custom-column-header {
   line-height: 1;
-  padding: ($bp-spacing * 1.75) 0;
+  padding: ($pt-spacing * 1.75) 0;
 }
 
 .tbl-custom-column-header-name {
@@ -166,7 +166,7 @@ body {
   color: $gray1;
   font-family: "Courier", monospace;
   font-size: 12px;
-  margin-top: $bp-spacing * 0.75;
+  margin-top: $pt-spacing * 0.75;
 
   .#{$ns}-dark & {
     color: $gray5;

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -90,7 +90,7 @@ body {
   }
 
   .#{$ns}-divider {
-    margin: 15px 5px;
+    margin: 15px ($bp-spacing * 1.25);
   }
 
   .#{$ns}-label,

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -99,7 +99,7 @@ body {
   }
 
   .tbl-select-label {
-    margin-bottom: 7px;
+    margin-bottom: $bp-spacing * 1.75;
     margin-top: $bp-spacing * -0.75;
 
     .#{$ns}-html-select {
@@ -155,7 +155,7 @@ body {
 
 .tbl-custom-column-header {
   line-height: 1;
-  padding: 7px 0;
+  padding: ($bp-spacing * 1.75) 0;
 }
 
 .tbl-custom-column-header-name {

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -86,7 +86,7 @@ body {
 
   h6.#{$ns}-heading {
     color: $pt-text-color-muted;
-    padding: 10px 0 3px;
+    padding: ($bp-spacing * 2.5) 0 3px;
   }
 
   .#{$ns}-divider {
@@ -95,7 +95,7 @@ body {
 
   .#{$ns}-label,
   .#{$ns}-control {
-    padding-left: $pt-grid-size;
+    padding-left: $bp-spacing * 2.5;
   }
 
   .tbl-select-label {
@@ -127,7 +127,7 @@ body {
 }
 
 .sidebar-indented-group {
-  margin-left: $pt-grid-size;
+  margin-left: $bp-spacing * 2.5;
 }
 
 .tbl-zebra-stripe {

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -3,7 +3,7 @@
 @import "../common/variables";
 
 $cell-border-width: 1px !default;
-$frozen-cell-border-width: 3px !default;
+$frozen-cell-border-width: $bp-spacing * 0.75 !default;
 
 $cell-padding-horizontal: $bp-spacing * 2.5 !default;
 $cell-padding-vertical: 0 !default;

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -5,7 +5,7 @@
 $cell-border-width: 1px !default;
 $frozen-cell-border-width: 3px !default;
 
-$cell-padding-horizontal: $pt-grid-size !default;
+$cell-padding-horizontal: $bp-spacing * 2.5 !default;
 $cell-padding-vertical: 0 !default;
 $cell-padding: $cell-padding-vertical $cell-padding-horizontal !default;
 $cell-height: $pt-grid-size * 2 !default;

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -9,7 +9,7 @@ $cell-padding-horizontal: $bp-spacing * 2.5 !default;
 $cell-padding-vertical: 0 !default;
 $cell-padding: $cell-padding-vertical $cell-padding-horizontal !default;
 $cell-height: $bp-spacing * 5 !default;
-$large-cell-height: $pt-grid-size * 3 !default;
+$large-cell-height: $bp-spacing * 7.5 !default;
 
 $cell-background-color: $white !default;
 $cell-background-color-opacity: 0.1 !default;

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -8,7 +8,7 @@ $frozen-cell-border-width: 3px !default;
 $cell-padding-horizontal: $bp-spacing * 2.5 !default;
 $cell-padding-vertical: 0 !default;
 $cell-padding: $cell-padding-vertical $cell-padding-horizontal !default;
-$cell-height: $pt-grid-size * 2 !default;
+$cell-height: $bp-spacing * 5 !default;
 $large-cell-height: $pt-grid-size * 3 !default;
 
 $cell-background-color: $white !default;

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -3,13 +3,13 @@
 @import "../common/variables";
 
 $cell-border-width: 1px !default;
-$frozen-cell-border-width: $bp-spacing * 0.75 !default;
+$frozen-cell-border-width: $pt-spacing * 0.75 !default;
 
-$cell-padding-horizontal: $bp-spacing * 2.5 !default;
+$cell-padding-horizontal: $pt-spacing * 2.5 !default;
 $cell-padding-vertical: 0 !default;
 $cell-padding: $cell-padding-vertical $cell-padding-horizontal !default;
-$cell-height: $bp-spacing * 5 !default;
-$large-cell-height: $bp-spacing * 7.5 !default;
+$cell-height: $pt-spacing * 5 !default;
+$large-cell-height: $pt-spacing * 7.5 !default;
 
 $cell-background-color: $white !default;
 $cell-background-color-opacity: 0.1 !default;

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -38,9 +38,9 @@
 
   opacity: 0.3;
 
-  padding: 0 $pt-grid-size * 0.5;
+  padding: 0 $bp-spacing * 1.25;
   position: absolute;
-  right: $pt-grid-size * 0.5;
+  right: $bp-spacing * 1.25;
   text-align: center;
   top: 0;
 

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -8,25 +8,25 @@
 }
 
 .#{$ns}-table-truncated-value {
-  left: $bp-spacing * 2.5;
+  left: $pt-spacing * 2.5;
   max-height: 100%;
 
   overflow: hidden;
   position: absolute;
   // note: changing this value can throw off the width calculation in truncated popover
-  right: $bp-spacing * 8.75;
+  right: $pt-spacing * 8.75;
   text-overflow: ellipsis;
   top: 0;
 }
 
 .#{$ns}-table-truncated-format-text {
-  left: $bp-spacing * 2.5;
+  left: $pt-spacing * 2.5;
   max-height: 100%;
 
   overflow: hidden;
   position: absolute;
   // note: changing this value can throw off the width calculation in truncated popover
-  right: $bp-spacing * 2.5;
+  right: $pt-spacing * 2.5;
   text-overflow: ellipsis;
   top: 0;
 }
@@ -38,9 +38,9 @@
 
   opacity: 0.3;
 
-  padding: 0 $bp-spacing * 1.25;
+  padding: 0 $pt-spacing * 1.25;
   position: absolute;
-  right: $bp-spacing * 1.25;
+  right: $pt-spacing * 1.25;
   text-align: center;
   top: 0;
 
@@ -63,11 +63,11 @@
 
 .#{$ns}-table-truncated-popover {
   font-family: $pt-font-family-monospace;
-  max-height: $bp-spacing * 75;
-  max-width: $bp-spacing * 150;
-  min-width: $bp-spacing * 50;
+  max-height: $pt-spacing * 75;
+  max-width: $pt-spacing * 150;
+  min-width: $pt-spacing * 50;
   overflow: auto;
-  padding: $bp-spacing * 2.5;
+  padding: $pt-spacing * 2.5;
 }
 
 .#{$ns}-table-popover-whitespace-pre {

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -8,7 +8,7 @@
 }
 
 .#{$ns}-table-truncated-value {
-  left: $pt-grid-size;
+  left: $bp-spacing * 2.5;
   max-height: 100%;
 
   overflow: hidden;
@@ -20,13 +20,13 @@
 }
 
 .#{$ns}-table-truncated-format-text {
-  left: $pt-grid-size;
+  left: $bp-spacing * 2.5;
   max-height: 100%;
 
   overflow: hidden;
   position: absolute;
   // note: changing this value can throw off the width calculation in truncated popover
-  right: $pt-grid-size;
+  right: $bp-spacing * 2.5;
   text-overflow: ellipsis;
   top: 0;
 }
@@ -67,7 +67,7 @@
   max-width: 60 * $pt-grid-size;
   min-width: 20 * $pt-grid-size;
   overflow: auto;
-  padding: $pt-grid-size $pt-grid-size;
+  padding: $bp-spacing * 2.5;
 }
 
 .#{$ns}-table-popover-whitespace-pre {

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -14,7 +14,7 @@
   overflow: hidden;
   position: absolute;
   // note: changing this value can throw off the width calculation in truncated popover
-  right: $pt-grid-size * 3.5;
+  right: $bp-spacing * 8.75;
   text-overflow: ellipsis;
   top: 0;
 }

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -63,9 +63,9 @@
 
 .#{$ns}-table-truncated-popover {
   font-family: $pt-font-family-monospace;
-  max-height: 30 * $pt-grid-size;
-  max-width: 60 * $pt-grid-size;
-  min-width: 20 * $pt-grid-size;
+  max-height: $bp-spacing * 75;
+  max-width: $bp-spacing * 150;
+  min-width: $bp-spacing * 50;
   overflow: auto;
   padding: $bp-spacing * 2.5;
 }

--- a/packages/table/src/common/_loading.scss
+++ b/packages/table/src/common/_loading.scss
@@ -20,7 +20,7 @@
       $cell-transition-duration linear forwards skeleton-fade-in,
       $skeleton-animation;
     animation-delay: 0s, $cell-transition-duration;
-    height: $pt-grid-size * 0.5;
+    height: $bp-spacing * 1.25;
     opacity: 0;
   }
 }

--- a/packages/table/src/common/_loading.scss
+++ b/packages/table/src/common/_loading.scss
@@ -20,7 +20,7 @@
       $cell-transition-duration linear forwards skeleton-fade-in,
       $skeleton-animation;
     animation-delay: 0s, $cell-transition-duration;
-    height: $bp-spacing * 1.25;
+    height: $pt-spacing * 1.25;
     opacity: 0;
   }
 }

--- a/packages/table/src/headers/_common.scss
+++ b/packages/table/src/headers/_common.scss
@@ -17,4 +17,4 @@ $dark-row-header-text-color: $pt-dark-text-color-muted !default;
 
 $header-selected-background-color: $pt-intent-primary !default;
 
-$interaction-bar-height: $pt-grid-size * 2 !default;
+$interaction-bar-height: $bp-spacing * 5 !default;

--- a/packages/table/src/headers/_common.scss
+++ b/packages/table/src/headers/_common.scss
@@ -2,7 +2,7 @@
 
 $column-header-min-height: $bp-spacing * 7.5 !default;
 $row-header-min-width: $column-header-min-height !default;
-$row-header-padding: 0 $pt-grid-size * 0.5 !default;
+$row-header-padding: 0 ($bp-spacing * 1.25) !default;
 
 $header-background-color: $table-background-color !default;
 $header-hover-background-color: $light-gray3 !default;

--- a/packages/table/src/headers/_common.scss
+++ b/packages/table/src/headers/_common.scss
@@ -7,7 +7,7 @@ $row-header-padding: 0 $pt-grid-size * 0.5 !default;
 $header-background-color: $table-background-color !default;
 $header-hover-background-color: $light-gray3 !default;
 $column-header-text-color: $pt-text-color !default;
-$column-name-text-skeleton-height: $pt-grid-size * 0.8;
+$column-name-text-skeleton-height: $bp-spacing * 2;
 $row-header-text-color: $pt-text-color-muted !default;
 
 $dark-header-background-color: $dark-table-background-color !default;

--- a/packages/table/src/headers/_common.scss
+++ b/packages/table/src/headers/_common.scss
@@ -1,13 +1,13 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
-$column-header-min-height: $bp-spacing * 7.5 !default;
+$column-header-min-height: $pt-spacing * 7.5 !default;
 $row-header-min-width: $column-header-min-height !default;
-$row-header-padding: 0 ($bp-spacing * 1.25) !default;
+$row-header-padding: 0 ($pt-spacing * 1.25) !default;
 
 $header-background-color: $table-background-color !default;
 $header-hover-background-color: $light-gray3 !default;
 $column-header-text-color: $pt-text-color !default;
-$column-name-text-skeleton-height: $bp-spacing * 2;
+$column-name-text-skeleton-height: $pt-spacing * 2;
 $row-header-text-color: $pt-text-color-muted !default;
 
 $dark-header-background-color: $dark-table-background-color !default;
@@ -17,4 +17,4 @@ $dark-row-header-text-color: $pt-dark-text-color-muted !default;
 
 $header-selected-background-color: $pt-intent-primary !default;
 
-$interaction-bar-height: $bp-spacing * 5 !default;
+$interaction-bar-height: $pt-spacing * 5 !default;

--- a/packages/table/src/headers/_common.scss
+++ b/packages/table/src/headers/_common.scss
@@ -1,6 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
-$column-header-min-height: $pt-grid-size * 3 !default;
+$column-header-min-height: $bp-spacing * 7.5 !default;
 $row-header-min-width: $column-header-min-height !default;
 $row-header-padding: 0 $pt-grid-size * 0.5 !default;
 

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -99,7 +99,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
   position: absolute;
   right: 0;
   top: 0;
-  width: $column-header-min-height + $pt-grid-size * 2;
+  width: $column-header-min-height + $bp-spacing * 5;
 
   .#{$ns}-table-interaction-bar & {
     height: $interaction-bar-height;

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -99,7 +99,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
   position: absolute;
   right: 0;
   top: 0;
-  width: $column-header-min-height + $bp-spacing * 5;
+  width: $column-header-min-height + $pt-spacing * 5;
 
   .#{$ns}-table-interaction-bar & {
     height: $interaction-bar-height;
@@ -351,7 +351,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
 .#{$ns}-table-row-name {
   display: block;
   font-size: $pt-font-size-small;
-  padding: 0 $bp-spacing * 1.25;
+  padding: 0 $pt-spacing * 1.25;
   text-align: right;
 }
 
@@ -397,7 +397,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
 
   .#{$ns}-table-column-name-text {
     @include cell-content-align-vertical();
-    padding: $bp-spacing * 2.5;
+    padding: $pt-spacing * 2.5;
 
     .#{$ns}-skeleton {
       height: $column-name-text-skeleton-height;

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -351,7 +351,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
 .#{$ns}-table-row-name {
   display: block;
   font-size: $pt-font-size-small;
-  padding: 0 $pt-grid-size * 0.5;
+  padding: 0 $bp-spacing * 1.25;
   text-align: right;
 }
 

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -397,7 +397,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
 
   .#{$ns}-table-column-name-text {
     @include cell-content-align-vertical();
-    padding: $pt-grid-size;
+    padding: $bp-spacing * 2.5;
 
     .#{$ns}-skeleton {
       height: $column-name-text-skeleton-height;

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -11,7 +11,7 @@ $resize-handle-dragging-color: $pt-intent-primary !default;
 
 // we want to square off the margin around the handle
 // so we need a special value based on the handle icon shape
-$reorder-handle-width: 22px !default;
+$reorder-handle-width: $bp-spacing * 5.5 !default;
 
 @mixin grabbable() {
   cursor: grab;

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -2,16 +2,16 @@
 
 @import "../common/variables";
 
-$resize-handle-target-width: $bp-spacing * 1.25 !default;
-$resize-handle-width: $bp-spacing * 0.75 !default;
-$resize-handle-position-correction: $bp-spacing * -0.75 !default;
-$resize-handle-padding: $bp-spacing * 0.5 !default;
+$resize-handle-target-width: $pt-spacing * 1.25 !default;
+$resize-handle-width: $pt-spacing * 0.75 !default;
+$resize-handle-position-correction: $pt-spacing * -0.75 !default;
+$resize-handle-padding: $pt-spacing * 0.5 !default;
 $resize-handle-color: $pt-intent-primary !default;
 $resize-handle-dragging-color: $pt-intent-primary !default;
 
 // we want to square off the margin around the handle
 // so we need a special value based on the handle icon shape
-$reorder-handle-width: $bp-spacing * 5.5 !default;
+$reorder-handle-width: $pt-spacing * 5.5 !default;
 
 @mixin grabbable() {
   cursor: grab;

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -2,7 +2,7 @@
 
 @import "../common/variables";
 
-$resize-handle-target-width: 5px !default;
+$resize-handle-target-width: $bp-spacing * 1.25 !default;
 $resize-handle-width: $bp-spacing * 0.75 !default;
 $resize-handle-position-correction: $bp-spacing * -0.75 !default;
 $resize-handle-padding: $bp-spacing * 0.5 !default;

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -3,8 +3,8 @@
 @import "../common/variables";
 
 $resize-handle-target-width: 5px !default;
-$resize-handle-width: 3px !default;
-$resize-handle-position-correction: -3px !default;
+$resize-handle-width: $bp-spacing * 0.75 !default;
+$resize-handle-position-correction: $bp-spacing * -0.75 !default;
 $resize-handle-padding: $bp-spacing * 0.5 !default;
 $resize-handle-color: $pt-intent-primary !default;
 $resize-handle-dragging-color: $pt-intent-primary !default;

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -5,7 +5,7 @@
 $resize-handle-target-width: 5px !default;
 $resize-handle-width: 3px !default;
 $resize-handle-position-correction: -3px !default;
-$resize-handle-padding: 2px !default;
+$resize-handle-padding: $bp-spacing * 0.5 !default;
 $resize-handle-color: $pt-intent-primary !default;
 $resize-handle-dragging-color: $pt-intent-primary !default;
 

--- a/packages/table/src/layers/_layers.scss
+++ b/packages/table/src/layers/_layers.scss
@@ -44,7 +44,7 @@ $region-selected-color: $pt-intent-primary !default;
 }
 
 .#{$ns}-table-focus-region {
-  border: ($bp-spacing * 0.5) solid $blue3;
+  border: ($pt-spacing * 0.5) solid $blue3;
 }
 
 .#{$ns}-table-column-headers .#{$ns}-table-region {

--- a/packages/table/src/layers/_layers.scss
+++ b/packages/table/src/layers/_layers.scss
@@ -44,7 +44,7 @@ $region-selected-color: $pt-intent-primary !default;
 }
 
 .#{$ns}-table-focus-region {
-  border: 2px solid $blue3;
+  border: ($bp-spacing * 0.5) solid $blue3;
 }
 
 .#{$ns}-table-column-headers .#{$ns}-table-region {

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -30,7 +30,7 @@ $menu-z-index: $row-z-index + 1 !default;
   height: 100%; // IE 11
   max-height: 100%;
   max-width: 100%;
-  min-height: $pt-grid-size * 6; // For unit tests, we make sure at least one row is visible
+  min-height: $bp-spacing * 15; // For unit tests, we make sure at least one row is visible
   overflow: hidden;
   will-change: transform; // forces hardware acceleration for smoother animations
 

--- a/packages/table/src/table.scss
+++ b/packages/table/src/table.scss
@@ -30,7 +30,7 @@ $menu-z-index: $row-z-index + 1 !default;
   height: 100%; // IE 11
   max-height: 100%;
   max-width: 100%;
-  min-height: $bp-spacing * 15; // For unit tests, we make sure at least one row is visible
+  min-height: $pt-spacing * 15; // For unit tests, we make sure at least one row is visible
   overflow: hidden;
   will-change: transform; // forces hardware acceleration for smoother animations
 


### PR DESCRIPTION
## Changes

This PR migrates Blueprint's spacing system from the 10px-based `$pt-grid-size` to a new 4px-based `$pt-spacing` variable. All existing spacing values have been converted to equivalent `$pt-spacing` calculations, ensuring no visual changes. The legacy `$pt-grid-size` and `$half-grid-size` both remain for backward compatibility. Raw pixel values were also migrated for consistency, making it easier to identify and update inconsistent spacing in future work.

Component spacing updates will follow in #7542.

https://github.com/palantir/blueprint/blob/c036e394b174273c3f5346bd093dbdc7b7205209/packages/core/src/common/_variables.scss#L23-L33

### Conversion Table

The following table roughly describes the new format of the changes. The conversion from `$pt-grid-size` to `$pt-spacing` is achieved by multiplying by `2.5` (10px/4px).

| px Value | `$pt-grid-size` (10px base) | `$pt-spacing` (4px base) |
| -------- | ------------------------- | ---------------------- |
| `2px`      | `$pt-grid-size * 0.2`       | `$pt-spacing * 0.5`     |
| `3px`      | `$pt-grid-size * 0.3`       | `$pt-spacing * 0.75`     |
| **`4px`**      | **`$pt-grid-size * 0.4`**       | **`$pt-spacing`**     |
| `5px`      | `$pt-grid-size * 0.5`       | `$pt-spacing * 1.25`     |
| `6px`      | `$pt-grid-size * 0.6`       | `$pt-spacing * 1.5`     |
| `7px`      | `$pt-grid-size * 0.7`       | `$pt-spacing * 1.75`     |
| `8px`      | `$pt-grid-size * 0.8`       | `$pt-spacing * 2`     |
| **`10px`**     | **`$pt-grid-size`**             | **`$pt-spacing * 2.5`**     |
| `11px`     | `$pt-grid-size * 1.1`       | `$pt-spacing * 2.75`     |
| `12px`     | `$pt-grid-size * 1.2`       | `$pt-spacing * 3`     |
| `13px`     | `$pt-grid-size * 1.3`       | `$pt-spacing * 3.25`     |
| `14px`     | `$pt-grid-size * 1.4`       | `$pt-spacing * 3.5`     |
| `15px`     | `$pt-grid-size * 1.5`       | `$pt-spacing * 3.75`     |
| `16px`     | `$pt-grid-size * 1.6`       | `$pt-spacing * 4`     |
| `18px`     | `$pt-grid-size * 1.8`       | `$pt-spacing * 4.5`     |
| `20px`     | `$pt-grid-size * 2`       | `$pt-spacing * 5`     |
| `22px`     | `$pt-grid-size * 2.2`       | `$pt-spacing * 5.5`     |
| `24px`     | `$pt-grid-size * 2.4`       | `$pt-spacing * 6`     |
| `25px`     | `$pt-grid-size * 2.5`       | `$pt-spacing * 6.25`     |
| `30px`     | `$pt-grid-size * 3`       | `$pt-spacing * 7.5`     |
| `36px`     | `$pt-grid-size * 3.6`       | `$pt-spacing * 9`     |
| `40px`     | `$pt-grid-size * 4`       | `$pt-spacing * 10`     |
| `50px`     | `$pt-grid-size * 5`       | `$pt-spacing * 12.5`     |

etc.

#### Reviewers should focus on:

- ~~Does the naming of this new variable (`$bp-spacing`) make sense? Are there alternatives we want to consider?~~
  - Renamed to `$pt-spacing`
- Regression testing to ensure no errors were introduced while converting values