### PR TITLE
Migrate components to use 4px-based spacing values

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -242,7 +242,7 @@ Styleguide preformatted
   @include monospace-typography();
   border-radius: $pt-border-radius;
   font-size: smaller;
-  padding: ($pt-spacing * 0.5) ($pt-spacing * 1.25);
+  padding: ($pt-spacing * 0.5) $pt-spacing;
 }
 
 %code-block {
@@ -285,7 +285,7 @@ Styleguide preformatted
   vertical-align: middle;
 
   #{$icon-classes} {
-    margin-right: $pt-spacing * 1.25;
+    margin-right: $pt-spacing;
   }
 }
 
@@ -348,13 +348,13 @@ Styleguide lists
   padding-left: $pt-spacing * 7.5;
 
   li:not(:last-child) {
-    margin-bottom: $pt-spacing * 1.25;
+    margin-bottom: $pt-spacing;
   }
 
   // nested lists
   ol,
   ul {
-    margin-top: $pt-spacing * 1.25;
+    margin-top: $pt-spacing;
   }
 }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -253,7 +253,7 @@ Styleguide preformatted
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
   margin: ($pt-spacing * 2.5) 0;
-  padding: ($pt-spacing * 3.25) ($pt-spacing * 3.75) ($pt-spacing * 3);
+  padding: ($pt-spacing * 3.25) ($pt-spacing * 4) ($pt-spacing * 3);
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -253,7 +253,7 @@ Styleguide preformatted
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
   margin: ($pt-spacing * 2.5) 0;
-  padding: ($pt-spacing * 3.25) ($pt-spacing * 4) ($pt-spacing * 3);
+  padding: ($pt-spacing * 3) ($pt-spacing * 4);
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -32,7 +32,7 @@
       content: "";
       display: block;
       height: $pt-icon-size-standard;
-      margin: 0 ($pt-spacing * 1.25);
+      margin: 0 $pt-spacing;
       width: $pt-icon-size-standard;
     }
 
@@ -66,7 +66,7 @@
   }
 
   .#{$ns}-icon {
-    margin-right: $pt-spacing * 1.25;
+    margin-right: $pt-spacing;
   }
 }
 
@@ -87,7 +87,7 @@
   border-radius: $pt-border-radius;
   cursor: pointer;
   margin-right: $pt-spacing * 0.5;
-  padding: 1px ($pt-spacing * 1.25);
+  padding: 1px $pt-spacing;
   vertical-align: text-bottom;
 
   &::before {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -8,7 +8,7 @@
 
 $button-border-width: 1px !default;
 $button-padding: $pt-spacing ($pt-spacing * 2.5) !default;
-$button-padding-small: 0 ($pt-spacing * 1.75) !default;
+$button-padding-small: 0 ($pt-spacing * 2) !default;
 $button-padding-large: $pt-spacing ($pt-spacing * 4) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -9,7 +9,7 @@
 $button-border-width: 1px !default;
 $button-padding: $pt-spacing ($pt-spacing * 2.5) !default;
 $button-padding-small: 0 ($pt-spacing * 1.75) !default;
-$button-padding-large: $pt-spacing ($pt-spacing * 3.75) !default;
+$button-padding-large: $pt-spacing ($pt-spacing * 4) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -10,8 +10,8 @@ $button-border-width: 1px !default;
 $button-padding: $pt-spacing ($pt-spacing * 2.5) !default;
 $button-padding-small: 0 ($pt-spacing * 2) !default;
 $button-padding-large: $pt-spacing ($pt-spacing * 4) !default;
-$button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
-$button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
+$button-icon-spacing: $pt-spacing * 2 !default;
+$button-icon-spacing-large: $pt-spacing * 2.5 !default;
 
 /*
 CSS `border` property issues:

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,9 +7,9 @@
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;
-$button-padding: ($pt-spacing * 1.25) ($pt-spacing * 2.5) !default;
+$button-padding: $pt-spacing ($pt-spacing * 2.5) !default;
 $button-padding-small: 0 ($pt-spacing * 1.75) !default;
-$button-padding-large: ($pt-spacing * 1.25) ($pt-spacing * 3.75) !default;
+$button-padding-large: $pt-spacing ($pt-spacing * 3.75) !default;
 $button-icon-spacing: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
 $button-icon-spacing-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -55,7 +55,7 @@ $callout-padding-compact: $pt-spacing * 2.5;
 
   &.#{$ns}-callout-has-body-content {
     .#{$ns}-heading {
-      margin-bottom: $half-grid-size;
+      margin-bottom: $pt-spacing;
     }
   }
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables-extended";
 
-$callout-padding: $pt-spacing * 3.75;
+$callout-padding: $pt-spacing * 4;
 $callout-header-margin-top: $pt-spacing * 0.5;
 $callout-padding-compact: $pt-spacing * 2.5;
 

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -20,7 +20,7 @@ $callout-padding-compact: $pt-spacing * 2.5;
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 1.75);
+    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 2);
 
     &::before {
       @include pt-icon($pt-icon-size-standard);
@@ -37,7 +37,7 @@ $callout-padding-compact: $pt-spacing * 2.5;
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 1.75);
+    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 2);
 
     > .#{$ns}-icon:first-child {
       color: $pt-icon-color;
@@ -63,7 +63,7 @@ $callout-padding-compact: $pt-spacing * 2.5;
     padding: $callout-padding-compact;
 
     &.#{$ns}-callout-icon {
-      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($pt-spacing * 1.75);
+      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($pt-spacing * 2);
 
       > .#{$ns}-icon:first-child {
         left: $callout-padding-compact;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables-extended";
 
 $card-padding: $pt-spacing * 5 !default;
-$card-padding-compact: $pt-spacing * 3.75 !default;
+$card-padding-compact: $pt-spacing * 4 !default;
 
 $card-background-color: $white !default;
 $dark-card-background-color: $pt-dark-app-elevated-background-color !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -18,7 +18,7 @@ $card-list-item-padding-vertical: $pt-spacing * 2.5 !default;
 $card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;
 
-$card-list-item-padding-vertical-compact: $pt-spacing * 1.75 !default;
+$card-list-item-padding-vertical-compact: $pt-spacing * 2 !default;
 // prettier-ignore
 $card-list-item-min-height-compact: $pt-button-height + ($card-list-item-padding-vertical-compact * 2) + $card-list-border-width !default;
 $card-list-item-padding-compact: $card-list-item-padding-vertical-compact $card-padding-compact !default;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -9,8 +9,8 @@
 
 $dialog-background-color: $light-gray5 !default;
 $dialog-border-radius: $pt-border-radius * 2 !default;
-$dialog-margin: ($pt-spacing * 7.5) 0 !default;
-$dialog-padding: $pt-spacing * 3.75 !default;
+$dialog-margin: ($pt-spacing * 8) 0 !default;
+$dialog-padding: $pt-spacing * 4 !default;
 
 .#{$ns}-dialog-container {
   $dialog-transition-props: (
@@ -68,7 +68,7 @@ $dialog-padding: $pt-spacing * 3.75 !default;
   }
 }
 
-$dialog-header-padding: $pt-spacing * 1.25;
+$dialog-header-padding: $pt-spacing;
 
 .#{$ns}-dialog-header {
   align-items: center;
@@ -85,7 +85,7 @@ $dialog-header-padding: $pt-spacing * 1.25;
   .#{$ns}-icon-large,
   .#{$ns}-icon {
     flex: 0 0 auto;
-    margin-left: $pt-spacing * -0.75;
+    margin-left: -$pt-spacing;
     margin-right: $dialog-padding * 0.5;
 
     // only apply light color to icons that are not intent-specific

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -185,9 +185,9 @@ $step-radius: $pt-border-radius * 2 !default;
   border-radius: 50%;
   color: $white;
   display: flex;
-  height: $pt-spacing * 6.25;
+  height: $pt-spacing * 6;
   justify-content: center;
-  width: $pt-spacing * 6.25;
+  width: $pt-spacing * 6;
 
   .#{$ns}-dark & {
     background-color: $pt-dark-icon-color-disabled;

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$divider-margin: $pt-spacing * 1.25 !default;
+$divider-margin: $pt-spacing !default;
 
 .#{$ns}-divider {
   border-bottom: 1px solid $pt-divider-black;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -79,7 +79,7 @@
   &-heading-h1,
   &-heading-h2,
   &-heading-h3 {
-    gap: $pt-spacing * 3.75;
+    gap: $pt-spacing * 4;
 
     .#{$ns}-entity-title-status-tag {
       margin-left: $pt-spacing * 2.5;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -38,13 +38,13 @@
     align-items: center;
     display: flex;
     flex-direction: row;
-    gap: $pt-spacing * 1.25;
+    gap: $pt-spacing;
   }
 
   &-tags-container {
     display: flex;
     gap: $pt-spacing * 0.5;
-    margin-left: $pt-spacing * 1.25;
+    margin-left: $pt-spacing;
   }
 
   &-title {

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -7,7 +7,7 @@
 .#{$ns}-entity-title {
   align-items: center;
   display: flex;
-  gap: $pt-spacing * 1.75;
+  gap: $pt-spacing * 2;
   min-width: 0;
 
   &.#{$ns}-fill {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -8,7 +8,7 @@
 .#{$ns}-form-group {
   display: flex;
   flex-direction: column;
-  margin: 0 0 ($pt-spacing * 3.75);
+  margin: 0 0 ($pt-spacing * 4);
 
   label.#{$ns}-label {
     margin-bottom: $pt-spacing;

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -11,7 +11,7 @@
   margin: 0 0 ($pt-spacing * 3.75);
 
   label.#{$ns}-label {
-    margin-bottom: $pt-spacing * 1.25;
+    margin-bottom: $pt-spacing;
   }
 
   .#{$ns}-control {
@@ -25,11 +25,11 @@
   }
 
   .#{$ns}-form-group-sub-label {
-    margin-bottom: $pt-spacing * 1.25;
+    margin-bottom: $pt-spacing;
   }
 
   .#{$ns}-form-helper-text {
-    margin-top: $pt-spacing * 1.25;
+    margin-top: $pt-spacing;
   }
 
   /* stylelint-disable-next-line order/declaration-block-order */

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -15,7 +15,7 @@
   }
 
   .#{$ns}-control {
-    margin-top: ($pt-input-height - $control-indicator-size) * 0.5;
+    margin-top: $pt-spacing * 2;
   }
 
   .#{$ns}-form-group-sub-label,

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -84,7 +84,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
   }
 
   .#{$ns}-tag {
-    margin: $pt-spacing * 1.25;
+    margin: $pt-spacing;
   }
 
   // all buttons go gray in default state and assume their native colors only when hovered

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -84,7 +84,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
   }
 
   .#{$ns}-tag {
-    margin: $pt-spacing;
+    margin: $pt-spacing * 1.25;
   }
 
   // all buttons go gray in default state and assume their native colors only when hovered

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -5,7 +5,7 @@
 
 label.#{$ns}-label {
   display: block;
-  margin-bottom: ($pt-spacing * 3.75);
+  margin-bottom: $pt-spacing * 4;
   margin-top: 0;
 
   .#{$ns}-html-select,
@@ -14,12 +14,12 @@ label.#{$ns}-label {
   .#{$ns}-slider,
   .#{$ns}-popover-wrapper {
     display: block;
-    margin-top: $half-grid-size;
+    margin-top: $pt-spacing;
     text-transform: none;
   }
 
   .#{$ns}-button-group {
-    margin-top: $half-grid-size;
+    margin-top: $pt-spacing;
   }
 
   .#{$ns}-select select,
@@ -30,7 +30,7 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-control-group {
-    margin-top: $half-grid-size;
+    margin-top: $pt-spacing;
 
     > .#{$ns}-button-group,
     > .#{$ns}-html-select,
@@ -58,12 +58,12 @@ label.#{$ns}-label {
     .#{$ns}-select,
     .#{$ns}-popover-wrapper {
       display: inline-block;
-      margin: 0 0 0 $half-grid-size;
+      margin: 0 0 0 $pt-spacing;
       vertical-align: top;
     }
 
     .#{$ns}-button-group {
-      margin: 0 0 0 $half-grid-size;
+      margin: 0 0 0 $pt-spacing;
     }
 
     .#{$ns}-input-group .#{$ns}-input {
@@ -75,7 +75,7 @@ label.#{$ns}-label {
     }
 
     .#{$ns}-control-group {
-      margin: 0 0 0 $half-grid-size;
+      margin: 0 0 0 $pt-spacing;
 
       > .#{$ns}-button-group,
       > .#{$ns}-html-select,

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -7,7 +7,7 @@
   align-items: center;
 
   &:not(.#{$ns}-minimal) {
-    @include pt-flex-container(row, $pt-spacing * 1.25);
+    @include pt-flex-container(row, $pt-spacing);
   }
 
   &.#{$ns}-minimal {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -374,7 +374,7 @@ $dark-menu-item-intent-colors: (
   // a little extra space to avoid clipping descenders (because overflow hidden)
   line-height: $pt-icon-size-standard + 1px;
   margin: 0;
-  padding: ($pt-spacing * 2.5) $menu-item-padding 0 (1px + $pt-spacing);
+  padding: ($pt-spacing * 2.5) $menu-item-padding 0 ($pt-spacing * 1.5);
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -375,7 +375,7 @@ $dark-menu-item-intent-colors: (
 @mixin menu-header-large($heading-selector) {
   #{$heading-selector} {
     font-size: $pt-spacing * 4.5;
-    padding-bottom: $pt-spacing * 1.25;
+    padding-bottom: $pt-spacing;
     padding-top: $pt-spacing * 3.75;
   }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -13,16 +13,17 @@ $menu-item-border-radius: $pt-border-radius !default;
 // applied to it (#2177). Also, line-height should be an even value, or content
 // will be misaligned by one pixel (Chrome quirk).
 $menu-item-line-height-factor: 1.4;
-$menu-item-line-height: round($pt-font-size * $menu-item-line-height-factor);
-$menu-item-line-height-large: round($pt-font-size-large * $menu-item-line-height-factor);
+$menu-item-line-height-small: 20px;
+$menu-item-line-height: 22px;
+$menu-item-line-height-large: 22px;
 
 $menu-min-width: $pt-spacing * 45 !default;
-$menu-item-padding: ($pt-button-height - $pt-icon-size-standard) * 0.5 !default;
-$menu-item-padding-large: ($pt-button-height-large - $pt-icon-size-large) * 0.5 !default;
-$menu-item-padding-vertical: ($pt-button-height - $menu-item-line-height) * 0.5 !default;
-$menu-item-padding-vertical-large: ($pt-button-height-large - $menu-item-line-height-large) * 0.5 !default;
-$menu-item-padding-small: ($pt-button-height-small - $pt-icon-size-standard) * 0.5 !default;
-$menu-item-padding-vertical-small: ($pt-button-height-small - $menu-item-line-height) * 0.5 !default;
+$menu-item-padding: $pt-spacing * 2 !default;
+$menu-item-padding-large: $pt-spacing * 2.5 !default;
+$menu-item-padding-vertical: $pt-spacing !default;
+$menu-item-padding-vertical-large: $pt-spacing * 2.5 !default;
+$menu-item-padding-small: $pt-spacing !default;
+$menu-item-padding-vertical-small: $pt-spacing * 0.5 !default;
 $menu-item-selected-icon-spacing: $pt-spacing * 0.5;
 $menu-item-indent: $pt-icon-size-standard + $menu-item-selected-icon-spacing * 2;
 
@@ -312,24 +313,28 @@ $dark-menu-item-intent-colors: (
 
 @mixin menu-item-large() {
   font-size: $pt-font-size-large;
-  line-height: $menu-item-line-height-large;
   padding-bottom: $menu-item-padding-vertical-large;
   padding-top: $menu-item-padding-vertical-large;
 
   .#{$ns}-menu-item-icon {
-    height: $menu-item-line-height-large;
+    height: $menu-item-line-height;
   }
 
   &::before,
   .#{$ns}-submenu-icon {
     // SVG icons remain standard size when menu is large
-    margin-top: ($menu-item-line-height-large - $pt-icon-size-standard) * 0.5;
+    margin-top: ($menu-item-line-height - $pt-icon-size-standard) * 0.5;
   }
 }
 
 @mixin menu-item-small() {
+  line-height: $menu-item-line-height-small;
   padding-bottom: $menu-item-padding-vertical-small;
   padding-top: $menu-item-padding-vertical-small;
+
+  .#{$ns}-menu-item-icon {
+    height: $menu-item-line-height-small;
+  }
 }
 
 @mixin menu-divider() {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -336,7 +336,7 @@ $dark-menu-item-intent-colors: (
   border-top: 1px solid $pt-divider-black;
   display: block;
   // use negative margin to make dividers take up full menu width
-  margin: $half-grid-size (-$half-grid-size);
+  margin: $pt-spacing (-$pt-spacing);
 
   .#{$ns}-dark & {
     border-top-color: $pt-dark-divider-white;
@@ -346,7 +346,7 @@ $dark-menu-item-intent-colors: (
 @mixin menu-header($heading-selector: null) {
   @include menu-divider();
   cursor: default;
-  padding-left: $menu-item-padding - $half-grid-size;
+  padding-left: $menu-item-padding - $pt-spacing;
 
   @if $heading-selector != null {
     &:first-of-type {
@@ -369,7 +369,7 @@ $dark-menu-item-intent-colors: (
   // a little extra space to avoid clipping descenders (because overflow hidden)
   line-height: $pt-icon-size-standard + 1px;
   margin: 0;
-  padding: ($pt-spacing * 2.5) $menu-item-padding 0 (1px + $half-grid-size);
+  padding: ($pt-spacing * 2.5) $menu-item-padding 0 (1px + $pt-spacing);
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -376,7 +376,7 @@ $dark-menu-item-intent-colors: (
   #{$heading-selector} {
     font-size: $pt-spacing * 4.5;
     padding-bottom: $pt-spacing;
-    padding-top: $pt-spacing * 3.75;
+    padding-top: $pt-spacing * 4;
   }
 
   &:first-of-type #{$heading-selector} {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -21,7 +21,7 @@ $menu-min-width: $pt-spacing * 45 !default;
 $menu-item-padding: $pt-spacing * 2 !default;
 $menu-item-padding-large: $pt-spacing * 2.5 !default;
 $menu-item-padding-vertical: $pt-spacing !default;
-$menu-item-padding-vertical-large: $pt-spacing * 2.5 !default;
+$menu-item-padding-vertical-large: $pt-spacing * 2.25 !default;
 $menu-item-padding-small: $pt-spacing !default;
 $menu-item-padding-vertical-small: $pt-spacing * 0.5 !default;
 $menu-item-selected-icon-spacing: $pt-spacing * 0.5;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -92,5 +92,5 @@ button.#{$ns}-menu-item {
 
 // #402 support menu inside label
 .#{$ns}-label .#{$ns}-menu {
-  margin-top: $pt-spacing * 1.25;
+  margin-top: $pt-spacing;
 }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -15,7 +15,7 @@
   list-style: none;
   margin: 0;
   min-width: $menu-min-width;
-  padding: $half-grid-size;
+  padding: $pt-spacing;
   text-align: left;
 }
 

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -41,7 +41,7 @@
   &.#{$ns}-popover {
     box-shadow: none;
     // horizontal padding leaves some space from parent menu item, and extends mouse zone
-    padding: 0 $half-grid-size;
+    padding: 0 $pt-spacing;
 
     > .#{$ns}-popover-content {
       box-shadow: $pt-popover-box-shadow;

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -4,7 +4,7 @@
 @import "../../common/variables";
 @import "../card/card-variables";
 
-$navbar-padding: $pt-spacing * 3.75 !default;
+$navbar-padding: $pt-spacing * 4 !default;
 
 $navbar-background-color: $card-background-color !default;
 $dark-navbar-background-color: $dark-card-background-color !default;

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -30,12 +30,12 @@
   }
 
   .#{$ns}-heading {
-    margin: 0 ($pt-spacing * 1.25);
+    margin: 0 $pt-spacing;
   }
 }
 
 .#{$ns}-button.#{$ns}-panel-stack2-header-back {
-  margin-left: $pt-spacing * 1.25;
+  margin-left: $pt-spacing;
   padding-left: 0;
   white-space: nowrap;
 

--- a/packages/core/src/components/popover/_popover-in-label.scss
+++ b/packages/core/src/components/popover/_popover-in-label.scss
@@ -6,7 +6,7 @@
 label.#{$ns}-label {
   .#{$ns}-popover-target {
     display: block;
-    margin-top: $pt-spacing * 1.25;
+    margin-top: $pt-spacing;
     text-transform: none;
   }
 }

--- a/packages/core/src/components/popover/_popover-in-submenu.scss
+++ b/packages/core/src/components/popover/_popover-in-submenu.scss
@@ -12,7 +12,7 @@
   &.#{$ns}-popover {
     box-shadow: none;
     // horizontal padding leaves some space from parent menu item, and extends mouse zone
-    padding: 0 $half-grid-size;
+    padding: 0 $pt-spacing;
 
     > .#{$ns}-popover-content {
       box-shadow: $pt-popover-box-shadow;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -7,7 +7,7 @@ $section-padding-horizontal: $pt-spacing * 5 !default;
 $section-card-padding: $pt-spacing * 5 !default;
 
 $section-min-height-compact: $pt-spacing * 10 !default;
-$section-padding-compact-vertical: $pt-spacing * 1.75 !default;
+$section-padding-compact-vertical: $pt-spacing * 2 !default;
 $section-padding-compact-horizontal: $pt-spacing * 4 !default;
 $section-card-padding-compact: $pt-spacing * 4 !default;
 

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -8,8 +8,8 @@ $section-card-padding: $pt-spacing * 5 !default;
 
 $section-min-height-compact: $pt-spacing * 10 !default;
 $section-padding-compact-vertical: $pt-spacing * 1.75 !default;
-$section-padding-compact-horizontal: $pt-spacing * 3.75 !default;
-$section-card-padding-compact: $pt-spacing * 3.75 !default;
+$section-padding-compact-horizontal: $pt-spacing * 4 !default;
+$section-card-padding-compact: $pt-spacing * 4 !default;
 
 .#{$ns}-section {
   overflow: hidden;
@@ -67,7 +67,7 @@ $section-card-padding-compact: $pt-spacing * 3.75 !default;
 
     &-divider {
       align-self: stretch;
-      margin: $pt-spacing * 3.75 0;
+      margin: $pt-spacing * 4 0;
     }
 
     &.#{$ns}-interactive {

--- a/packages/core/src/components/segmented-control/_segmented-control.scss
+++ b/packages/core/src/components/segmented-control/_segmented-control.scss
@@ -5,8 +5,8 @@
   background-color: $light-gray5;
   border-radius: $pt-border-radius;
   display: flex;
-  gap: $pt-spacing * 0.75;
-  padding: $pt-spacing * 0.75;
+  gap: $pt-spacing * 0.5;
+  padding: $pt-spacing * 0.5;
 
   &.#{$ns}-inline {
     display: inline-flex;

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -182,7 +182,7 @@ $track-height: $track-size !default;
   display: inline-block;
   font-size: $pt-font-size-small;
   line-height: 1;
-  padding: ($pt-spacing * 0.5) ($pt-spacing * 1.25);
+  padding: ($pt-spacing * 0.5) $pt-spacing;
   position: absolute;
   vertical-align: top;
 }

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -155,11 +155,11 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 }
 
 .#{$ns}-tab-icon {
-  margin-right: $pt-spacing * 1.75;
+  margin-right: $pt-spacing * 2;
 }
 
 .#{$ns}-tab-tag {
-  margin-left: $pt-spacing * 1.75;
+  margin-left: $pt-spacing * 2;
 }
 
 .#{$ns}-tab-indicator-wrapper {

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -5,7 +5,7 @@
 @import "../forms/common";
 @import "../tag/common";
 
-$tag-input-padding: ($pt-input-height - $tag-height) * 0.5 !default;
+$tag-input-padding: $pt-spacing !default;
 
 $tag-input-icon-padding: ($pt-input-height - $pt-icon-size-standard) * 0.5 !default;
 $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 0.5 !default;
@@ -17,7 +17,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   height: auto;
   line-height: inherit;
   min-height: $pt-input-height;
-  padding-left: $tag-input-padding;
+  padding-left: $pt-spacing * 1.5;
   padding-right: 0;
 
   .#{$ns}-tag-input-icon {
@@ -34,8 +34,8 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     // fill vertical height
     align-self: stretch;
     flex-wrap: wrap;
-    margin-right: $tag-input-icon-padding;
-    margin-top: $tag-input-padding;
+    margin-right: $pt-spacing;
+    margin-top: $pt-spacing;
     // allow tags to ellipse and not overflow the container
     min-width: 0;
     position: relative;
@@ -54,7 +54,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     > * {
-      margin-bottom: $tag-input-padding;
+      margin-bottom: $pt-spacing;
     }
   }
 

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -19,8 +19,8 @@ $tag-height-large: $pt-spacing * 7.5 !default;
 $tag-line-height-large: $pt-spacing * 4.5 !default;
 $tag-padding-large: $pt-spacing * 2.5 !default;
 
-$tag-icon-spacing: ($tag-height - ($pt-spacing * 3)) * 0.5 !default;
-$tag-icon-spacing-large: ($tag-height-large - $pt-icon-size-standard) * 0.5 !default;
+$tag-icon-spacing: $pt-spacing !default;
+$tag-icon-spacing-large: $pt-spacing * 2 !default;
 
 $tag-round-adjustment: $pt-spacing * 0.5 !default;
 

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -16,8 +16,8 @@ $tag-padding: $tag-padding-top * 3 !default;
 $tag-margin: ($pt-input-height - $tag-height) * 0.5 !default;
 
 $tag-height-large: $pt-spacing * 7.5 !default;
-$tag-line-height-large: $pt-icon-size-large !default;
-$tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
+$tag-line-height-large: $pt-spacing * 4.5 !default;
+$tag-padding-large: $pt-spacing * 2.5 !default;
 
 $tag-icon-spacing: ($tag-height - ($pt-spacing * 3)) * 0.5 !default;
 $tag-icon-spacing-large: ($tag-height-large - $pt-icon-size-standard) * 0.5 !default;
@@ -156,7 +156,7 @@ $minimal-dark-tag-intent-colors: (
   line-height: $tag-line-height-large;
   min-height: $tag-height-large;
   min-width: $tag-height-large;
-  padding: ($tag-padding-large * 0.5) $tag-padding-large;
+  padding: ($tag-padding-large * 0.6) $tag-padding-large;
 
   &.#{$ns}-round {
     padding-left: $tag-padding-large + $tag-round-adjustment;

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -110,7 +110,7 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left,
     .#{$ns}-compound-tag-right {
-      padding: $pt-spacing ($pt-spacing * 2);
+      padding: ($pt-spacing * 1.5) ($pt-spacing * 2);
     }
 
     .#{$ns}-compound-tag-left {

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -115,18 +115,18 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left {
       > #{$icon-classes} {
-        margin-right: $pt-spacing * 1.75;
+        margin-right: $pt-spacing * 2;
       }
     }
 
     .#{$ns}-compound-tag-right {
       > #{$icon-classes} {
-        margin-left: $pt-spacing * 1.75;
+        margin-left: $pt-spacing * 2;
       }
     }
 
     .#{$ns}-tag-remove {
-      margin-left: $pt-spacing * 1.75;
+      margin-left: $pt-spacing * 2;
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
       margin-right: $pt-spacing * -2.5 !important;

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -110,7 +110,7 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left,
     .#{$ns}-compound-tag-right {
-      padding: ($pt-spacing * 1.25) ($pt-spacing * 2);
+      padding: $pt-spacing ($pt-spacing * 2);
     }
 
     .#{$ns}-compound-tag-left {

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -10,7 +10,7 @@ $tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !de
 $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
 $tooltip-padding-compact-vertical: $pt-spacing !default;
-$tooltip-padding-compact-horizontal: $pt-spacing * 1.75 !default;
+$tooltip-padding-compact-horizontal: $pt-spacing * 2 !default;
 
 .#{$ns}-tooltip {
   @include popover-sizing(

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -9,7 +9,7 @@
 $tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-drop-shadow-opacity) !default;
 $dark-tooltip-arrow-box-shadow: 1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
-$tooltip-padding-compact-vertical: $pt-spacing * 1.25 !default;
+$tooltip-padding-compact-vertical: $pt-spacing !default;
 $tooltip-padding-compact-horizontal: $pt-spacing * 1.75 !default;
 
 .#{$ns}-tooltip {

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -56,7 +56,7 @@ $tree-intent-icon-colors: (
   background: none;
   display: flex;
   height: $tree-row-height;
-  padding-right: $pt-spacing * 1.25;
+  padding-right: $pt-spacing;
   width: 100%;
 
   &:hover {
@@ -112,7 +112,7 @@ $tree-intent-icon-colors: (
 }
 
 .#{$ns}-tree-node-secondary-label {
-  padding: 0 ($pt-spacing * 1.25);
+  padding: 0 $pt-spacing;
   user-select: none;
 
   .#{$ns}-popover-wrapper,

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -7,7 +7,7 @@
 @import "../../common/mixins";
 
 $tree-row-height: $pt-spacing * 7.5 !default;
-$tree-icon-spacing: ($tree-row-height - $pt-icon-size-standard) * 0.5 !default;
+$tree-icon-spacing: $pt-spacing * 2 !default;
 
 $tree-row-height-compact: $pt-spacing * 6 !default;
 $tree-icon-spacing-compact: ($tree-row-height-compact - $pt-icon-size-standard) * 0.5 !default;

--- a/packages/datetime/src/_common.scss
+++ b/packages/datetime/src/_common.scss
@@ -5,7 +5,7 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/icons/lib/scss/variables";
 
-$datepicker-padding: $pt-spacing * 1.25 !default;
+$datepicker-padding: $pt-spacing !default;
 
 $datepicker-min-width: $pt-spacing * 52.5 !default;
 $datepicker-day-size: $pt-spacing * 7.5 !default;

--- a/packages/datetime/src/components/date-picker/_date-picker.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker.scss
@@ -124,7 +124,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: $pt-spacing * 1.25;
+  gap: $pt-spacing;
 
   > .#{$ns}-divider {
     margin: 0; // margin is already applied via flex gap

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -98,7 +98,7 @@ $timepicker-control-width: $pt-spacing * 8.25 !default;
   }
 
   .#{$ns}-timepicker-ampm-select {
-    margin-left: $pt-spacing * 1.25;
+    margin-left: $pt-spacing;
   }
 
   &.#{$ns}-disabled {

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -10,8 +10,8 @@ $timepicker-input-row-height: $pt-spacing * 7.5 !default;
 $timepicker-input-row-inner-height: $timepicker-input-row-height - 2 !default;
 // helps focus states of inputs line up correctly
 $timepicker-row-padding: 0 1px !default;
-$timepicker-divider-width: $pt-spacing * 2.75 !default;
-$timepicker-control-width: $pt-spacing * 8.25 !default;
+$timepicker-divider-width: $pt-spacing * 2 !default;
+$timepicker-control-width: $pt-spacing * 8 !default;
 
 .#{$ns}-timepicker {
   white-space: nowrap;

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -117,7 +117,7 @@
   align-items: center;
   display: flex;
   flex-direction: column;
-  gap: $pt-spacing * 1.25;
+  gap: $pt-spacing;
 
   > .#{$ns}-divider {
     margin: 0; // margin is already applied via flex gap

--- a/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagInputExample.tsx
@@ -27,7 +27,7 @@ const VALUES = [
     // supports single JSX elements
     <strong key="al">Albert</strong>,
     // supports JSX "fragments" (don't forget `key` on elements in arrays!)
-    ["Bar", <em key="thol">thol</em>, "omew"],
+    ["Br", <em key="thol">and</em>, "on"],
     // and supports simple strings
     "Casper",
     // falsy values are not rendered and ignored by the keyboard

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -332,11 +332,11 @@ $docs-hotkey-piano-height: 510px;
 
     > div {
       background-color: $white;
-      border-bottom-left-radius: $pt-spacing * 1.25;
-      border-bottom-right-radius: $pt-spacing * 1.25;
+      border-bottom-left-radius: $pt-spacing;
+      border-bottom-right-radius: $pt-spacing;
       color: $black;
       height: $pt-spacing * 60;
-      margin-right: $pt-spacing * 1.25;
+      margin-right: $pt-spacing;
       width: $pt-spacing * 20;
     }
   }
@@ -363,7 +363,7 @@ $docs-hotkey-piano-height: 510px;
   }
 
   .piano-key-text {
-    bottom: $pt-spacing * 1.25;
+    bottom: $pt-spacing;
     left: 0;
     position: absolute;
     right: 0;
@@ -695,7 +695,7 @@ $docs-hotkey-piano-height: 510px;
 
 .#{$ns}-progress-bar.docs-toast-progress {
   margin-bottom: 0;
-  margin-top: $pt-spacing * 1.25;
+  margin-top: $pt-spacing;
 }
 
 #{example("Tooltip")} {
@@ -703,7 +703,7 @@ $docs-hotkey-piano-height: 510px;
     flex-direction: column;
 
     > * {
-      margin: $pt-spacing * 1.25;
+      margin: $pt-spacing;
     }
   }
 }
@@ -762,7 +762,7 @@ $docs-hotkey-piano-height: 510px;
 }
 
 .docs-date-range {
-  @include pt-flex-container(row, $pt-spacing * 1.25);
+  @include pt-flex-container(row, $pt-spacing);
   align-items: center;
 }
 

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -94,7 +94,7 @@ $dark-package-colors: (
   margin-right: $pt-spacing * 2.5;
 
   .#{$ns}-tag {
-    margin-left: $pt-spacing * 1.25;
+    margin-left: $pt-spacing;
     padding-left: $pt-spacing * 2.5;
     vertical-align: middle;
   }
@@ -178,7 +178,7 @@ $dark-package-colors: (
   }
 
   + .docs-nav-menu {
-    margin-bottom: $pt-spacing * 1.25;
+    margin-bottom: $pt-spacing;
     margin-left: $pkg-icon-width + ($pt-spacing * 2.5);
 
     &:empty {
@@ -206,7 +206,7 @@ $dark-package-colors: (
 
   svg {
     height: 1.2em;
-    padding: 0 ($pt-spacing * 1.25);
+    padding: 0 $pt-spacing;
   }
 
   a:not(:hover) {

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -23,12 +23,12 @@
   &::before {
     content: "=";
     display: inline-block;
-    margin: 0 ($pt-spacing * 1.25);
+    margin: 0 $pt-spacing;
   }
 }
 
 .docs-prop-description {
-  margin-top: $pt-spacing * 1.25;
+  margin-top: $pt-spacing;
 
   p:last-child {
     margin: 0;
@@ -42,14 +42,14 @@
 
   .#{$ns}-tag {
     margin-right: $pt-spacing * 2.5;
-    margin-top: $pt-spacing * 1.25;
+    margin-top: $pt-spacing;
   }
 }
 
 .docs-prop-name code::after {
   @include pt-icon();
   line-height: small;
-  margin-left: $pt-spacing * 1.25;
+  margin-left: $pt-spacing;
   vertical-align: middle;
 }
 

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -9,7 +9,7 @@ $container-width: $pt-spacing * 275;
 $container-padding: $pt-spacing;
 
 $sidebar-width: $pt-spacing * 75;
-$sidebar-padding: $pt-spacing * 3.75;
+$sidebar-padding: $pt-spacing * 4;
 $sidebar-background-color: $white;
 $dark-sidebar-background-color: $dark-gray3;
 

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -6,7 +6,7 @@
 @import "@blueprintjs/core/src/common/mixins";
 
 $container-width: $pt-spacing * 275;
-$container-padding: $pt-spacing * 1.25;
+$container-padding: $pt-spacing;
 
 $sidebar-width: $pt-spacing * 75;
 $sidebar-padding: $pt-spacing * 3.75;

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -158,7 +158,7 @@ footer {
 
     h3 {
       font-size: $pt-spacing * 4.5;
-      margin-bottom: $pt-spacing * 6.25;
+      margin-bottom: $pt-spacing * 6;
     }
 
     .#{$ns}-icon-dot {

--- a/packages/landing-app/src/index.scss
+++ b/packages/landing-app/src/index.scss
@@ -86,7 +86,7 @@ header {
 
   .#{$ns}-icon-dot {
     color: rgba($white, 0.5);
-    margin: $pt-spacing * 1.25;
+    margin: $pt-spacing;
   }
 
   canvas {
@@ -144,7 +144,7 @@ footer {
     display: flex;
     justify-content: space-between;
     min-height: $pt-navbar-height;
-    padding: $pt-spacing * 1.25;
+    padding: $pt-spacing;
   }
 }
 
@@ -174,7 +174,7 @@ footer {
     }
 
     .landing-button {
-      margin: $pt-spacing * 1.25;
+      margin: $pt-spacing;
     }
   }
 }

--- a/packages/select/src/components/multi-select/_multi-select.scss
+++ b/packages/select/src/components/multi-select/_multi-select.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$select-padding: $pt-spacing * 1.25;
+$select-padding: $pt-spacing;
 
 .#{$ns}-multi-select {
   min-width: $pt-spacing * 37.5;

--- a/packages/select/src/components/select/_select.scss
+++ b/packages/select/src/components/select/_select.scss
@@ -3,7 +3,7 @@
 
 @import "../../common/variables";
 
-$select-padding: $pt-spacing * 1.25;
+$select-padding: $pt-spacing;
 
 .#{$ns}-select-popover {
   .#{$ns}-popover-content {

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -99,7 +99,7 @@ body {
   }
 
   .tbl-select-label {
-    margin-bottom: $pt-spacing * 1.75;
+    margin-bottom: $pt-spacing * 2;
     margin-top: $pt-spacing * -0.75;
 
     .#{$ns}-html-select {
@@ -155,7 +155,7 @@ body {
 
 .tbl-custom-column-header {
   line-height: 1;
-  padding: ($pt-spacing * 1.75) 0;
+  padding: ($pt-spacing * 2) 0;
 }
 
 .tbl-custom-column-header-name {

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -90,7 +90,7 @@ body {
   }
 
   .#{$ns}-divider {
-    margin: ($pt-spacing * 3.75) ($pt-spacing * 1.25);
+    margin: ($pt-spacing * 3.75) $pt-spacing;
   }
 
   .#{$ns}-label,

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -73,7 +73,7 @@ body {
   height: 100%;
   order: 1;
   overflow-y: auto;
-  padding: $pt-spacing * 3.75;
+  padding: $pt-spacing * 4;
   z-index: 3;
 
   h4.#{$ns}-heading {
@@ -90,7 +90,7 @@ body {
   }
 
   .#{$ns}-divider {
-    margin: ($pt-spacing * 3.75) $pt-spacing;
+    margin: ($pt-spacing * 4) $pt-spacing;
   }
 
   .#{$ns}-label,

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -38,9 +38,9 @@
 
   opacity: 0.3;
 
-  padding: 0 $pt-spacing * 1.25;
+  padding: 0 $pt-spacing;
   position: absolute;
-  right: $pt-spacing * 1.25;
+  right: $pt-spacing;
   text-align: center;
   top: 0;
 

--- a/packages/table/src/common/_loading.scss
+++ b/packages/table/src/common/_loading.scss
@@ -20,7 +20,7 @@
       $cell-transition-duration linear forwards skeleton-fade-in,
       $skeleton-animation;
     animation-delay: 0s, $cell-transition-duration;
-    height: $pt-spacing * 1.25;
+    height: $pt-spacing;
     opacity: 0;
   }
 }

--- a/packages/table/src/headers/_common.scss
+++ b/packages/table/src/headers/_common.scss
@@ -2,7 +2,7 @@
 
 $column-header-min-height: $pt-spacing * 7.5 !default;
 $row-header-min-width: $column-header-min-height !default;
-$row-header-padding: 0 ($pt-spacing * 1.25) !default;
+$row-header-padding: 0 $pt-spacing !default;
 
 $header-background-color: $table-background-color !default;
 $header-hover-background-color: $light-gray3 !default;

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -351,7 +351,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
 .#{$ns}-table-row-name {
   display: block;
   font-size: $pt-font-size-small;
-  padding: 0 $pt-spacing * 1.25;
+  padding: 0 $pt-spacing;
   text-align: right;
 }
 

--- a/packages/table/src/interactions/_interactions.scss
+++ b/packages/table/src/interactions/_interactions.scss
@@ -2,7 +2,7 @@
 
 @import "../common/variables";
 
-$resize-handle-target-width: $pt-spacing * 1.25 !default;
+$resize-handle-target-width: $pt-spacing !default;
 $resize-handle-width: $pt-spacing * 0.75 !default;
 $resize-handle-position-correction: $pt-spacing * -0.75 !default;
 $resize-handle-padding: $pt-spacing * 0.5 !default;


### PR DESCRIPTION
## Changes

FLUP to #7541

Functional changes to Blueprint components to align values to a 4px grid. Broadly the changes are as follows (not exhaustive):

| px | `$bp-spacing` |
|--------|--------|
| 5px → 4px | `$pt-spacing * 1.25` → `$pt-spacing` |
| 7px → 8px | `$pt-spacing * 1.75` →  `$pt-spacing * 2` |
| 15px → 16px | `$pt-spacing * 3.75` → `$pt-spacing * 4` | 
| 25px → 24px | `$pt-spacing * 6.25` → `$pt-spacing * 6` | 

#### Reviewers should focus on:

Review documentation [before](https://blueprintjs.com/docs/) and [after](https://output.circle-artifacts.com/output/job/68a7f2c9-31b9-4592-8abd-273d6dfebd7e/artifacts/0/packages/docs-app/dist/index.html) based on proposed component changes.

<!-- Include an image of the most relevant user-facing change, if any. -->

## Component Changelog - Spacing Adjustments

### Typography
- **Inline code (`.bp6-code`)**: Horizontal padding reduced from 5px to 4px
- **Code block (`.bp6-code-block`)**:
  - Top padding reduced from 13px to 12px
  - Horizontal padding increased from 15px to 16px
- **List (`.bp6-list`)**: Item and sublist spacing reduced from 5px to 4px

### Components

#### Breadcrumbs
- Separator (">") horizontal margin reduced from 5px to 4px
- Collapsed breadcrumbs ("...") horizontal padding reduced from 5px to 4px

#### Buttons
- **Small**: Horizontal padding and icon spacing increased to 8px (from 7px)
- **Medium**: Vertical padding reduced to 4px (from 5px), icon spacing increased to 8px
- **Large**: Horizontal padding increased to 16px (from 15px), vertical padding reduced to 4px

#### Callout
- Default padding increased from 15px to 16px
- Heading bottom margin reduced from 5px to 4px
- Icon-to-text spacing increased from 3px to 4px

#### Card
- Compact card padding increased from 15px to 16px

#### Divider
- Margin reduced from 5px to 4px

#### Entity Title
- Icon-to-text gap increased from 7px to 8px
- Text-to-tag gap decreased from 10px to 8px

#### Menu
- Menu padding reduced from 5px to 4px
- **Menu Item**: 
  - Horizontal padding and icon margin increased to 8px (from 7px)
  - Medium size vertical padding reduced to 4px (from 5px)
- **Menu Divider**: 
  - Margin reduced to 4px, heading padding increased to 8px

#### Navbar
- Horizontal padding increased from 15px to 16px

#### Section
- Compact section padding increased from 15px to 16px
- Compact section header vertical padding increased from 7px to 8px

#### Tabs
- Tab icon and tag spacing increased from 7px to 8px

#### Tag / Compound Tag
- **Large Tag**: 
  - Line-height decreased from 20px to 18px
  - Vertical padding increased from 5px to 6px
  - Icon spacing increased from 7px to 8px

### Form Controls

#### Form Group
- Bottom margin increased from 15px to 16px
- Label/sub-label bottom margin decreased from 5px to 4px
- Helper text top margin decreased from 5px to 4px

#### Label
- Default bottom margin increased from 15px to 16px

#### Controls (Checkbox/Radio/Switch)
- Label bottom margin reduced from 5px to 4px
- Control top margin increased from 7px to 8px

#### Segmented Control
- Padding decreased from 3px to 2px
- Button gap decreased from 3px to 2px

#### Slider
- Label horizontal padding decreased from 5px to 4px

### Form Inputs

#### Tag Input
- Tag gap decreased from 5px to 4px
- Vertical padding decreased from 5px to 4px
- Left padding increased from 5px to 6px

### Overlays

#### Dialog
- Padding increased from 15px to 16px
- Header vertical padding decreased from 5px to 4px
- Top/bottom margin increased from 30px to 32px
- MultiStepDialog step icon size reduced from 25px to 24px

#### Tooltip
- **Compact**: Horizontal padding increased to 8px (from 7px), vertical padding decreased to 4px (from 5px)

### Other Components

#### Tree
- Icon spacing increased from 7px to 8px
- Node content left padding decreased from 23px to 22px
- Node content right padding decreased from 5px to 4px

#### Date Picker
- Outer padding reduced from 5px to 4px
- Content gap reduced from 5px to 4px

#### Time Picker
- Colon divider width reduced from 11px to 8px
- Control width reduced from 33px to 32px
- AM/PM select spacing reduced from 5px to 4px

#### Select / MultiSelect
- Popover content padding reduced from 5px to 4px

#### Table
- Row name horizontal padding decreased from 5px to 4px
- Skeleton loading bar height reduced from 5px to 4px

#### Key Combo
- Modifier key spacing decreased from 5px to 4px
- Icon-to-text spacing in modifier keys decreased from 5px to 4px
