### PR TITLE
[Button] Allow Icons with `intent` to be displayed inside default Buttons

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -90,11 +90,13 @@
   }
 
   #{$icon-classes} {
-    color: $pt-icon-color;
-
     &.#{$ns}-align-right {
       margin-left: $button-icon-spacing;
     }
+  }
+
+  .#{$ns}-icon:not([class*="#{$ns}-intent-"]) {
+    color: $pt-icon-color;
   }
 
   // button with SVG icon only (no text or children)


### PR DESCRIPTION
#### Fixes #7550

### Changes

This PR modifies the Button component CSS to preserve Icon intent colors when an Icon with an explicit `intent` prop is placed inside a default (non-intent) Button.

### Problem

Previously, all icons inside buttons would have their color overridden to `$pt-icon-color`, regardless of whether the icon had its own intent styling. This made it impossible to display semantic icon colors within neutral buttons.

### Solution

Changed the CSS selector from applying color to all icons (`#{$icon-classes}`) to only applying the default button icon color to icons that don't have an intent class (`.#{$ns}-icon:not([class*="#{$ns}-intent-"])`).

### Before / After
| Before | After    |
| ------  | ------  |
| <img width="246" height="320" alt="before" src="https://github.com/user-attachments/assets/68417bd4-eb97-4f80-9bff-a610a52eeb80" /> | <img width="246" height="320" alt="after" src="https://github.com/user-attachments/assets/249cfb58-a238-4053-8979-f8ea45ffc9cf" /> |

```tsx
<div>
    <Button icon={<Icon intent="primary" icon="info-sign" />} text="Primary" />
    <Button icon={<Icon intent="success" icon="tick" />} text="Success" />
    <Button icon={<Icon intent="warning" icon="warning-sign" />} text="Warning" />
    <Button icon={<Icon intent="danger" icon="cross" />} text="Danger" />
</div>
```

### Extended Example
<img width="642" height="316" alt="Screenshot 2025-08-21 at 11 38 07@2x" src="https://github.com/user-attachments/assets/67ebd3a1-0dc1-4b9b-bae2-feaec63f4ab6" />

```tsx
<div className="app">
    <div className="example">
        <Button icon={<Icon icon="info-sign" />} text="Primary" />
        <Button icon={<Icon icon="tick" />} text="Success" />
        <Button icon={<Icon icon="warning-sign" />} text="Warning" />
        <Button icon={<Icon icon="cross" />} text="Danger" />
    </div>
    <div className="example">
        <Button icon={<Icon intent="primary" icon="info-sign" />} text="Primary" />
        <Button icon={<Icon intent="success" icon="tick" />} text="Success" />
        <Button icon={<Icon intent="warning" icon="warning-sign" />} text="Warning" />
        <Button icon={<Icon intent="danger" icon="cross" />} text="Danger" />
    </div>
    <div className="example">
        <Button intent="primary" icon={<Icon intent="primary" icon="info-sign" />} text="Primary" />
        <Button intent="success" icon={<Icon intent="success" icon="tick" />} text="Success" />
        <Button intent="warning" icon={<Icon intent="warning" icon="warning-sign" />} text="Warning" />
        <Button intent="danger" icon={<Icon intent="danger" icon="cross" />} text="Danger" />
    </div>
</div>
```

This example demonstrates the fix across three scenarios:

- **Column 1:** Default buttons with no icon intent - all icons appear gray (baseline behavior)
- **Column 2:** Default buttons with intent-specific icons (icons showing their semantic colors).
  - **This is the fix previously these would appear gray.**
- **Column 3:** Intent buttons with matching intent icons, both button and icon styled with the same color (already worked before)