### PR TITLE
[datetime] Fix interpolated variables in RDP overrides

### DIFF
--- a/packages/datetime/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime/src/common/_react-day-picker-overrides.scss
@@ -17,10 +17,10 @@
   --rdp-background-color-dark: #{$dark-gray3};
 
   /* Outline border for focused elements */
-  --rdp-outline: ($pt-spacing * 0.5) solid var(--rdp-accent-color);
+  --rdp-outline: #{$pt-spacing * 0.5} solid var(--rdp-accent-color);
 
   /* Outline border for focused and selected elements */
-  --rdp-outline-selected: ($pt-spacing * 0.5) solid rgba(0, 0, 0, 75%);
+  --rdp-outline-selected: #{$pt-spacing * 0.5} solid rgba(0, 0, 0, 75%);
 
   margin: 0;
   min-width: auto;

--- a/packages/datetime2/src/common/_react-day-picker-overrides.scss
+++ b/packages/datetime2/src/common/_react-day-picker-overrides.scss
@@ -17,10 +17,10 @@
   --rdp-background-color-dark: #{$dark-gray3};
 
   /* Outline border for focused elements */
-  --rdp-outline: ($pt-spacing * 0.5) solid var(--rdp-accent-color);
+  --rdp-outline: #{$pt-spacing * 0.5} solid var(--rdp-accent-color);
 
   /* Outline border for focused and selected elements */
-  --rdp-outline-selected: ($pt-spacing * 0.5) solid rgba(0, 0, 0, 75%);
+  --rdp-outline-selected: #{$pt-spacing * 0.5} solid rgba(0, 0, 0, 75%);
 
   margin: 0;
   min-width: auto;


### PR DESCRIPTION
## Changes

Fixes a bug introduced in #7541 where RDP override variables were being interpolated from `$pt-spacing` incorrectly, leading to strings like `($ pt-spacing * 0.5)` being directly included in compiled CSS.

| Before | After    |
| ------  | ------  |
| <img width="666" height="396" alt="before" src="https://github.com/user-attachments/assets/f55e546f-0404-45b7-aef7-695ec8ed9958" /> | <img width="666" height="396" alt="after" src="https://github.com/user-attachments/assets/16dfff52-fcae-481c-a0bb-f1c9e2028e30" /> |