### PR TITLE
Fix toast jitter

### DIFF
--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -203,8 +203,6 @@ $toast-intent-colors: (
   /* stylelint-disable-next-line declaration-no-important */
   display: flex !important;
   flex-direction: column;
-  // Remove gap to prevent immediate spacing changes
-  // gap: $toast-margin;
   left: 0;
   // prevent container from scrolling as new toasts enter (from bottom)
   overflow: hidden;
@@ -234,11 +232,11 @@ $toast-intent-colors: (
   }
 
   &.#{$ns}-toast-container-left {
-    align-items: start;
+    align-items: flex-start;
   }
 
   &.#{$ns}-toast-container-right {
-    align-items: end;
+    align-items: flex-end;
   }
 }
 

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -80,7 +80,7 @@ $toast-intent-colors: (
 .#{$ns}-toast {
   // toast transition properties
   $enter-translate: (
-    transform: translateY(-$toast-height) translateY(0),
+    transform: translateY(calc(-100% - #{$toast-margin})) translateY(0),
   );
   $leave-blur: (
     opacity: 0 1,
@@ -117,17 +117,18 @@ $toast-intent-colors: (
   @include react-transition-phase(
     "#{$ns}-toast",
     "exit",
-    $enter-translate,
+    (transform: translateY(calc(-100% - #{$toast-margin})) translateY(0)),
     $delay: $pt-transition-duration * 0.5,
     $before: "&",
     $after: "~ &"
   );
+
   align-items: flex-start;
   background-color: $white;
   border-radius: $pt-border-radius;
   box-shadow: $pt-toast-box-shadow;
   display: flex;
-  margin: $toast-margin 0 0;
+  margin: 0 0 $toast-margin;
   max-width: min($toast-max-width, 100%);
   min-width: min($toast-min-width, 100%);
 
@@ -137,6 +138,10 @@ $toast-intent-colors: (
   // override inline styles (#367): toasts rely on relative positioning for stacking.
   /* stylelint-disable-next-line declaration-no-important */
   position: relative !important;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 
   .#{$ns}-button-group {
     flex: 0 0 auto;
@@ -193,27 +198,25 @@ $toast-intent-colors: (
 }
 
 .#{$ns}-toast-container {
-  align-items: center;
   // override inline overlay styles (#2626)
   /* stylelint-disable-next-line declaration-no-important */
-  display: flex !important;
-  flex-direction: column;
+  display: grid !important;
+  grid-template-columns: 1fr;
+  grid-auto-rows: max-content;
+  // Remove gap to prevent immediate spacing changes
+  // gap: $toast-margin;
   left: 0;
-  // toasts have margin-top so omit it on container
-
-  // prevent container from scrolling as new toasts enter (from bottom)
+  // prevent container from scrolling as new toasts enter
   overflow: hidden;
-
   // ensure there's enough space for full box-shadow
-  padding: 0 $toast-margin $toast-margin;
-
+  padding: $toast-margin $toast-margin $toast-margin;
   // container will not block clicks on elements behind it
   pointer-events: none;
-
   right: 0;
-
   // #975 ensure toasts are on top of everything (esp dialogs)
   z-index: $pt-z-index-overlay * 2;
+  // Restore centering behavior
+  justify-items: center;
 
   &.#{$ns}-toast-container-in-portal {
     position: fixed;
@@ -225,20 +228,23 @@ $toast-intent-colors: (
 
   &.#{$ns}-toast-container-top {
     top: 0;
+    grid-auto-flow: row;
   }
 
   &.#{$ns}-toast-container-bottom {
     bottom: 0;
-    flex-direction: column-reverse;
     top: auto;
+    grid-auto-flow: row;
+    // For bottom containers, align grid content to bottom
+    align-content: end;
   }
 
   &.#{$ns}-toast-container-left {
-    align-items: flex-start;
+    justify-items: start;
   }
 
   &.#{$ns}-toast-container-right {
-    align-items: flex-end;
+    justify-items: end;
   }
 }
 
@@ -250,6 +256,7 @@ $toast-intent-colors: (
   &.#{$ns}-toast-appear:not(.#{$ns}-toast-appear-active) ~ .#{$ns}-toast,
   &.#{$ns}-toast-exit-active ~ .#{$ns}-toast,
   &.#{$ns}-toast-leave-active ~ .#{$ns}-toast {
-    transform: translateY($toast-margin + $toast-height);
+    // Change from: transform: translateY(2 * $toast-margin + $toast-height);
+    transform: calc(-100% - #{$toast-margin});
   }
 }

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -198,15 +198,15 @@ $toast-intent-colors: (
 }
 
 .#{$ns}-toast-container {
+  align-items: center;
   // override inline overlay styles (#2626)
   /* stylelint-disable-next-line declaration-no-important */
-  display: grid !important;
-  grid-template-columns: 1fr;
-  grid-auto-rows: max-content;
+  display: flex !important;
+  flex-direction: column;
   // Remove gap to prevent immediate spacing changes
   // gap: $toast-margin;
   left: 0;
-  // prevent container from scrolling as new toasts enter
+  // prevent container from scrolling as new toasts enter (from bottom)
   overflow: hidden;
   // ensure there's enough space for full box-shadow
   padding: $toast-margin $toast-margin $toast-margin;
@@ -215,8 +215,6 @@ $toast-intent-colors: (
   right: 0;
   // #975 ensure toasts are on top of everything (esp dialogs)
   z-index: $pt-z-index-overlay * 2;
-  // Restore centering behavior
-  justify-items: center;
 
   &.#{$ns}-toast-container-in-portal {
     position: fixed;
@@ -228,15 +226,11 @@ $toast-intent-colors: (
 
   &.#{$ns}-toast-container-top {
     top: 0;
-    grid-auto-flow: row;
   }
 
   &.#{$ns}-toast-container-bottom {
     bottom: 0;
     top: auto;
-    grid-auto-flow: row;
-    // For bottom containers, align grid content to bottom
-    align-content: end;
   }
 
   &.#{$ns}-toast-container-left {
@@ -256,7 +250,6 @@ $toast-intent-colors: (
   &.#{$ns}-toast-appear:not(.#{$ns}-toast-appear-active) ~ .#{$ns}-toast,
   &.#{$ns}-toast-exit-active ~ .#{$ns}-toast,
   &.#{$ns}-toast-leave-active ~ .#{$ns}-toast {
-    // Change from: transform: translateY(2 * $toast-margin + $toast-height);
     transform: calc(-100% - #{$toast-margin});
   }
 }

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -234,11 +234,11 @@ $toast-intent-colors: (
   }
 
   &.#{$ns}-toast-container-left {
-    justify-items: start;
+    align-items: start;
   }
 
   &.#{$ns}-toast-container-right {
-    justify-items: end;
+    align-items: end;
   }
 }
 

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -117,7 +117,7 @@ $toast-intent-colors: (
   @include react-transition-phase(
     "#{$ns}-toast",
     "exit",
-    (transform: translateY(calc(-100% - #{$toast-margin})) translateY(0)),
+    $enter-translate,
     $delay: $pt-transition-duration * 0.5,
     $before: "&",
     $after: "~ &"


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests (N/A)
-   [ ] Update documentation (N/A)

#### Changes proposed in this pull request:

Make the toast animation a little more smooth by modifying the css to use relative height rather than absolute and have the toasts start off screen.

#### Reviewers should focus on:

The CSS file.

#### Screenshot


BEFORE
https://github.com/user-attachments/assets/b7f8a883-8893-4075-abe0-f4daed1c0e45

AFTER
https://github.com/user-attachments/assets/201e584a-5d4b-486c-a293-3014b6e82e7c

