### PR TITLE
[stylelint-plugin] Add `@blueprintjs/prefer-spacing-variable` rule

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -9,6 +9,7 @@
   "rules": {
     "@blueprintjs/no-prefix-literal": [true, { "disableFix": true }],
     "@blueprintjs/no-color-literal": [true, { "disableFix": true }],
+    "@blueprintjs/prefer-spacing-variable": [true, { "disableFix": true }],
     "color-function-notation": "legacy",
     "declaration-empty-line-before": null,
     "no-invalid-position-at-import-rule": [true, {

--- a/packages/core/src/common/_variables-extended.scss
+++ b/packages/core/src/common/_variables-extended.scss
@@ -9,6 +9,7 @@
 // exported.
 // ----------------------------------------------------------------------------
 
+/* stylelint-disable-next-line @blueprintjs/prefer-spacing-variable */
 $half-grid-size: $pt-grid-size * 0.5 !default;
 
 // Extended color palette

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -27,7 +27,8 @@ Simply add this plugin in your `.stylelintrc` file and then pick the rules that 
     "plugins": ["@blueprintjs/stylelint-plugin"],
     "rules": {
         "@blueprintjs/no-color-literal": true,
-        "@blueprintjs/no-prefix-literal": true
+        "@blueprintjs/no-prefix-literal": true,
+        "@blueprintjs/prefer-spacing-variable": true
     }
 }
 ```
@@ -92,5 +93,50 @@ Optional secondary options:
 
 -   `disableFix: boolean` - if true, autofix will be disabled
 -   `variablesImportPath: { less?: string, sass?: string }` - can be used to configure a custom path for importing Blueprint variables when autofixing.
+
+### `@blueprintjs/prefer-spacing-variable` (autofixable)
+
+Enforce usage of the new `$pt-spacing` variable instead of the deprecated `$pt-grid-size` variable.
+
+Blueprint is migrating from a 10px-based grid system (`$pt-grid-size`) to a 4px-based spacing system (`$pt-spacing`) to provide more flexible spacing options and improve consistency. This rule helps automate the migration by detecting deprecated variable usage and automatically converting expressions with proper multiplier adjustments.
+
+```json
+{
+    "rules": {
+        "@blueprintjs/prefer-spacing-variable": true
+    }
+}
+```
+
+```diff
+-.my-class {
+-    padding: $pt-grid-size;
+-    margin: $pt-grid-size * 2;
+-    width: $pt-grid-size / 2;
+-}
++.my-class {
++    padding: $pt-spacing * 2.5;
++    margin: $pt-spacing * 5;
++    width: $pt-spacing / 0.8;
++}
+```
+
+The rule automatically converts mathematical expressions by applying the 2.5x conversion factor (since `$pt-grid-size` is 10px and `$pt-spacing` is 4px).
+
+**Conversion examples:**
+
+-   `$pt-grid-size` → `$pt-spacing * 2.5`
+-   `$pt-grid-size * 2` → `$pt-spacing * 5`
+-   `2 * $pt-grid-size` → `5 * $pt-spacing`
+-   `$pt-grid-size / 2` → `$pt-spacing / 0.8`
+-   `bp.$pt-grid-size * 1.5` → `bp.$pt-spacing * 3.75`
+-   `calc($pt-grid-size * 1.5)` → `calc($pt-spacing * 3.75)`
+
+Optional secondary options:
+
+-   `disableFix: boolean` - if true, autofix will be disabled
+-   `variablesImportPath: { less?: string, sass?: string }` - can be used to configure a custom path for importing Blueprint variables when autofixing.
+
+**See also:** [Spacing System Migration Guide](https://github.com/palantir/blueprint/wiki/Spacing-System-Migration:-10px-to-4px)
 
 ### [Full Documentation](http://blueprintjs.com/docs) | [Source Code](https://github.com/palantir/blueprint)

--- a/packages/stylelint-plugin/src/index.ts
+++ b/packages/stylelint-plugin/src/index.ts
@@ -15,5 +15,6 @@
 
 import noColorLiteral from "./rules/no-color-literal";
 import noPrefixLiteral from "./rules/no-prefix-literal";
+import preferSpacingVariable from "./rules/prefer-spacing-variable";
 
-export = [noColorLiteral, noPrefixLiteral];
+export = [noColorLiteral, noPrefixLiteral, preferSpacingVariable];

--- a/packages/stylelint-plugin/src/rules/prefer-spacing-variable.ts
+++ b/packages/stylelint-plugin/src/rules/prefer-spacing-variable.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Declaration, Root } from "postcss";
+import valueParser from "postcss-value-parser";
+import stylelint, { type PostcssResult, type RuleContext } from "stylelint";
+
+import { BpVariablePrefixMap, CssSyntax, getCssSyntax, isCssSyntaxToStringMap } from "../utils/cssSyntax";
+
+const ruleName = "@blueprintjs/prefer-spacing-variable";
+
+const GRID_SIZE_VARIABLE = "pt-grid-size";
+const SPACING_VARIABLE = "pt-spacing";
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+    expected: (unfixed: string, fixed: string) =>
+        `Use \`${fixed}\` instead of \`${unfixed}\` (deprecated). See: https://github.com/palantir/blueprint/wiki/Spacing-System-Migration:-10px-to-4px`,
+});
+
+interface Options {
+    disableFix?: boolean;
+    variablesImportPath?: Partial<Record<Exclude<CssSyntax, CssSyntax.OTHER>, string>>;
+}
+
+const ruleImpl =
+    (enabled: boolean, options: Options | undefined, context: RuleContext) => (root: Root, result: PostcssResult) => {
+        if (!enabled) {
+            return;
+        }
+
+        const validOptions = stylelint.utils.validateOptions(
+            result,
+            ruleName,
+            {
+                actual: enabled,
+                optional: false,
+                possible: [true, false],
+            },
+            {
+                actual: options,
+                optional: true,
+                possible: {
+                    disableFix: [true, false],
+                    variablesImportPath: [isCssSyntaxToStringMap],
+                },
+            },
+        );
+
+        if (!validOptions) {
+            return;
+        }
+
+        const disableFix = options?.disableFix ?? false;
+
+        const cssSyntax = getCssSyntax(root.source?.input.file || "");
+        if (cssSyntax === CssSyntax.OTHER) {
+            return;
+        }
+
+        const variablePrefix = BpVariablePrefixMap[cssSyntax];
+        const gridSizeVariable = `${variablePrefix}${GRID_SIZE_VARIABLE}`;
+        const spacingVariable = `${variablePrefix}${SPACING_VARIABLE}`;
+
+        root.walkDecls(decl => {
+            // Skip declarations that don't contain grid-size variables
+            if (!decl.value.includes(gridSizeVariable)) {
+                return;
+            }
+
+            if (context.fix && !disableFix) {
+                // Convert the entire value using string replacement
+                const newValue = convertGridSizeToSpacing(decl.value, gridSizeVariable, spacingVariable);
+                decl.value = newValue;
+            } else {
+                // Report warnings for each variable usage
+                const parsedValue = valueParser(decl.value);
+                parsedValue.walk(node => {
+                    if (node.type !== "word") {
+                        return;
+                    }
+
+                    const isGridSizeVariable = node.value.includes(gridSizeVariable);
+
+                    if (isGridSizeVariable) {
+                        const namespace = getVarNamespace(node.value);
+                        const isNamespaced = namespace !== undefined;
+
+                        const targetVar = isNamespaced ? `${namespace}.${spacingVariable}` : spacingVariable;
+
+                        stylelint.utils.report({
+                            index: declarationValueIndex(decl) + node.sourceIndex,
+                            message: messages.expected(node.value, targetVar),
+                            node: decl,
+                            result,
+                            ruleName,
+                        });
+                    }
+                });
+            }
+        });
+    };
+
+function getVarNamespace(value: string): string | undefined {
+    if (value.includes(".")) {
+        return value.split(".")[0];
+    }
+    return undefined;
+}
+
+/**
+ * Converts grid-size variables to spacing variables, maintains original computed value.
+ */
+function convertGridSizeToSpacing(value: string, gridVar: string, spacingVar: string): string {
+    let result = value;
+
+    // Check if there's a namespaced variable (e.g., bp.$pt-grid-size)
+    const namespacedMatch = value.match(new RegExp(`(\\w+)\\.\\$${GRID_SIZE_VARIABLE}`));
+
+    if (namespacedMatch) {
+        // Process namespaced variable
+        const namespace = namespacedMatch[1];
+        const namespacedGridVar = `${namespace}.${gridVar}`;
+        const namespacedSpacingVar = `${namespace}.${spacingVar}`;
+
+        result = processVariableConversions(result, namespacedGridVar, namespacedSpacingVar);
+    } else {
+        // Process non-namespaced variables
+        result = processVariableConversions(result, gridVar, spacingVar);
+    }
+
+    return result;
+}
+
+/**
+ * Process variable conversions for a specific variable pair
+ */
+function processVariableConversions(value: string, fromVar: string, toVar: string): string {
+    let result = value;
+    const escapedFrom = fromVar.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+    // Handle right-side multiplication: $var * N -> $var * (N * 2.5)
+    result = result.replace(new RegExp(`${escapedFrom}\\s*\\*\\s*(\\d*\\.?\\d+)`, "g"), (_match, multiplier) => {
+        const newValue = parseFloat(multiplier) * 2.5;
+        return `${toVar} * ${formatNumber(newValue)}`;
+    });
+
+    // Handle left-side multiplication: N * $var -> (N * 2.5) * $var
+    result = result.replace(new RegExp(`(\\d*\\.?\\d+)\\s*\\*\\s*${escapedFrom}`, "g"), (_match, multiplier) => {
+        const newValue = parseFloat(multiplier) * 2.5;
+        return `${formatNumber(newValue)} * ${toVar}`;
+    });
+
+    // Handle division: $var / N -> $var / (N / 2.5)
+    result = result.replace(new RegExp(`${escapedFrom}\\s*\\/\\s*(\\d*\\.?\\d+)`, "g"), (_match, divisor) => {
+        const newValue = parseFloat(divisor) / 2.5;
+        return `${toVar} / ${formatNumber(newValue)}`;
+    });
+
+    // Handle simple variable replacement (no adjacent math operations)
+    result = result.replace(new RegExp(`${escapedFrom}(?!\\s*[*/])`, "g"), `${toVar} * 2.5`);
+
+    return result;
+}
+
+function formatNumber(num: number): string {
+    return num % 1 === 0 ? num.toString() : num.toString();
+}
+
+/**
+ * Returns the index of the start of the declaration value.
+ */
+function declarationValueIndex(decl: Declaration): number {
+    const beforeColon = decl.toString().indexOf(":");
+    const afterColon = decl.raw("between").length - decl.raw("between").indexOf(":");
+    return beforeColon + afterColon;
+}
+
+ruleImpl.ruleName = ruleName;
+ruleImpl.messages = messages;
+
+export default stylelint.createPlugin(ruleName, ruleImpl);

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-calc.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-calc.scss
@@ -1,0 +1,4 @@
+.my-component {
+  height: calc($pt-grid-size * 3 + 2px);
+  margin-top: calc($pt-grid-size / 2);
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-complex.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-complex.scss
@@ -1,0 +1,10 @@
+.my-component {
+  // Multiple usages in one declaration
+  padding: $pt-grid-size $pt-grid-size * 2;
+
+  // Mixed with other values
+  margin: $pt-grid-size * 1.5 auto 10px;
+
+  // In complex calc expressions
+  height: calc(100% - $pt-grid-size * 3);
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-disabled.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-disabled.scss
@@ -1,0 +1,4 @@
+/* stylelint-disable @blueprintjs/prefer-spacing-variable */
+.my-component {
+  padding: $pt-grid-size;
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-division.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-division.scss
@@ -1,0 +1,4 @@
+.my-component {
+  padding: $pt-grid-size / 2;
+  margin: $pt-grid-size / 4;
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-less.less
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-less.less
@@ -1,0 +1,4 @@
+.my-component {
+    padding: @pt-grid-size;
+    margin: @pt-grid-size * 2;
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-multiplier.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-multiplier.scss
@@ -1,0 +1,5 @@
+.my-component {
+  margin: $pt-grid-size * 2;
+  padding: $pt-grid-size * 0.5;
+  width: $pt-grid-size * 1.5;
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-simple.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-grid-size-simple.scss
@@ -1,0 +1,3 @@
+.my-component {
+  padding: $pt-grid-size;
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-left-multipliers.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-left-multipliers.scss
@@ -1,0 +1,5 @@
+.my-component {
+  padding: 2 * $pt-grid-size;
+  margin: 0.5 * $pt-grid-size + 5px;
+  width: calc(1.5 * $pt-grid-size);
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-namespaced-grid-size.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/contains-namespaced-grid-size.scss
@@ -1,0 +1,7 @@
+@use "@blueprintjs/core/lib/scss/variables.scss" as bp;
+
+.my-component {
+  padding: bp.$pt-grid-size;
+  margin: bp.$pt-grid-size * 2;
+  width: 1.5 * bp.$pt-grid-size;
+}

--- a/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/does-not-contain-grid-size.scss
+++ b/packages/stylelint-plugin/test/fixtures/prefer-spacing-variable/does-not-contain-grid-size.scss
@@ -1,0 +1,4 @@
+.my-component {
+  padding: $pt-spacing * 2;
+  margin: 10px;
+}

--- a/packages/stylelint-plugin/test/index.mjs
+++ b/packages/stylelint-plugin/test/index.mjs
@@ -15,6 +15,7 @@
 
 import "./no-color-literal.test.mjs";
 import "./no-prefix-literal.test.mjs";
+import "./prefer-spacing-variable.test.mjs";
 import "./checkImportExists.test.mjs";
 import "./hexColor.test.mjs";
 import "./insertImport.test.mjs";

--- a/packages/stylelint-plugin/test/prefer-spacing-variable.test.mjs
+++ b/packages/stylelint-plugin/test/prefer-spacing-variable.test.mjs
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect } from "chai";
+import { copyFileSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import stylelint from "stylelint";
+
+const config = {
+    customSyntax: "postcss-scss",
+    plugins: ["@blueprintjs/stylelint-plugin"],
+    rules: {
+        "@blueprintjs/prefer-spacing-variable": true,
+    },
+};
+
+describe("prefer-spacing-variable", () => {
+    it("Warns when $pt-grid-size is used directly", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-simple.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(1);
+        expect(warnings[0].line).to.be.eq(2, "line number");
+        expect(warnings[0].text).to.include("$pt-spacing");
+        expect(warnings[0].text).to.include("deprecated");
+    });
+
+    it("Warns when $pt-grid-size is used with multipliers", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-multiplier.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(3); // Three usages in the file
+        expect(warnings[0].line).to.be.eq(2);
+        expect(warnings[1].line).to.be.eq(3);
+        expect(warnings[2].line).to.be.eq(4);
+    });
+
+    it("Warns when $pt-grid-size is used in calc() expressions", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-calc.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(2); // Two calc expressions
+        expect(warnings[0].line).to.be.eq(2);
+        expect(warnings[1].line).to.be.eq(3);
+    });
+
+    it("Warns when $pt-grid-size is used with division", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-division.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(2); // Two division expressions
+        expect(warnings[0].line).to.be.eq(2);
+        expect(warnings[1].line).to.be.eq(3);
+    });
+
+    it("Warns when $pt-grid-size is used in complex expressions", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-complex.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings.length).to.be.greaterThan(0);
+    });
+
+    it("Warns when namespaced bp.$pt-grid-size is used", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-namespaced-grid-size.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(3); // Three usages in the file
+        expect(warnings[0].line).to.be.eq(4);
+        expect(warnings[1].line).to.be.eq(5);
+        expect(warnings[2].line).to.be.eq(6);
+    });
+
+    it("Warns when left-side multipliers are used", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-left-multipliers.scss",
+        });
+        expect(result.errored).to.be.true;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(3); // Three usages in the file
+    });
+
+    it("Doesn't warn when $pt-grid-size is not present", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/does-not-contain-grid-size.scss",
+        });
+        expect(result.errored).to.be.false;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(0);
+    });
+
+    it("Doesn't warn when $pt-grid-size is present but lint rule is disabled", async () => {
+        const result = await stylelint.lint({
+            config,
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-disabled.scss",
+        });
+        expect(result.errored).to.be.false;
+        const warnings = result.results[0].warnings;
+        expect(warnings).lengthOf(0);
+    });
+
+    it("Accepts a valid secondary config", async () => {
+        const result = await stylelint.lint({
+            config: {
+                plugins: ["@blueprintjs/stylelint-plugin"],
+                rules: {
+                    "@blueprintjs/prefer-spacing-variable": [
+                        true,
+                        { disableFix: true, variablesImportPath: { sass: "some-path" } },
+                    ],
+                },
+            },
+            customSyntax: "postcss-scss",
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-simple.scss",
+        });
+        expect(result.results[0].invalidOptionWarnings).to.have.lengthOf(0);
+    });
+
+    it("Rejects an invalid secondary config", async () => {
+        const result = await stylelint.lint({
+            config: {
+                plugins: ["@blueprintjs/stylelint-plugin"],
+                rules: {
+                    "@blueprintjs/prefer-spacing-variable": [
+                        true,
+                        {
+                            disableFix: "yes",
+                            variablesImportPath: { scss: "some-path", somethingElse: "some-other-path" },
+                        },
+                    ],
+                },
+            },
+            customSyntax: "postcss-scss",
+            files: "test/fixtures/prefer-spacing-variable/contains-grid-size-simple.scss",
+        });
+        expect(result.results[0].invalidOptionWarnings.length).to.be.eq(1);
+    });
+
+    describe("auto-fixer", () => {
+        const tmpDir = join(import.meta.dirname, "tmp");
+
+        before(() => {
+            mkdirSync(tmpDir);
+        });
+        after(() => {
+            rmSync(tmpDir, { force: true, recursive: true });
+        });
+
+        it("Replaces simple $pt-grid-size with $pt-spacing", async () => {
+            const fixtureFilename = "contains-grid-size-simple.scss";
+            const fixturePath = join(import.meta.dirname, "fixtures", "prefer-spacing-variable", fixtureFilename);
+            const mutableFixturePath = join(tmpDir, fixtureFilename);
+            copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                config,
+                files: mutableFixturePath,
+                fix: true,
+            });
+
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).to.have.lengthOf(0);
+
+            const fixedSourceContents = readFileSync(mutableFixturePath, { encoding: "utf-8" });
+
+            expect(fixedSourceContents).to.contain("$pt-spacing");
+            expect(fixedSourceContents).to.not.contain("$pt-grid-size");
+        });
+
+        it("Replaces $pt-grid-size with multipliers and adjusts values", async () => {
+            const fixtureFilename = "contains-grid-size-multiplier.scss";
+            const fixturePath = join(import.meta.dirname, "fixtures", "prefer-spacing-variable", fixtureFilename);
+            const mutableFixturePath = join(tmpDir, fixtureFilename);
+            copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                config,
+                files: mutableFixturePath,
+                fix: true,
+            });
+
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).to.have.lengthOf(0);
+
+            const fixedSourceContents = readFileSync(mutableFixturePath, { encoding: "utf-8" });
+
+            expect(fixedSourceContents).to.contain("$pt-spacing * 5"); // 2 * 2.5
+            expect(fixedSourceContents).to.contain("$pt-spacing * 1.25"); // 0.5 * 2.5
+            expect(fixedSourceContents).to.contain("$pt-spacing * 3.75"); // 1.5 * 2.5
+            expect(fixedSourceContents).to.not.contain("$pt-grid-size");
+        });
+
+        it("Replaces $pt-grid-size in calc() expressions", async () => {
+            const fixtureFilename = "contains-grid-size-calc.scss";
+            const fixturePath = join(import.meta.dirname, "fixtures", "prefer-spacing-variable", fixtureFilename);
+            const mutableFixturePath = join(tmpDir, fixtureFilename);
+            copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                config,
+                files: mutableFixturePath,
+                fix: true,
+            });
+
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).to.have.lengthOf(0);
+
+            const fixedSourceContents = readFileSync(mutableFixturePath, { encoding: "utf-8" });
+
+            expect(fixedSourceContents).to.contain("$pt-spacing");
+            expect(fixedSourceContents).to.not.contain("$pt-grid-size");
+        });
+
+        it("Replaces $pt-grid-size with division and adjusts values", async () => {
+            const fixtureFilename = "contains-grid-size-division.scss";
+            const fixturePath = join(import.meta.dirname, "fixtures", "prefer-spacing-variable", fixtureFilename);
+            const mutableFixturePath = join(tmpDir, fixtureFilename);
+            copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                config,
+                files: mutableFixturePath,
+                fix: true,
+            });
+
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).to.have.lengthOf(0);
+
+            const fixedSourceContents = readFileSync(mutableFixturePath, { encoding: "utf-8" });
+
+            expect(fixedSourceContents).to.contain("$pt-spacing / 0.8"); // 2 / 2.5
+            expect(fixedSourceContents).to.contain("$pt-spacing / 1.6"); // 4 / 2.5
+            expect(fixedSourceContents).to.not.contain("$pt-grid-size");
+        });
+
+        it("Replaces namespaced bp.$pt-grid-size variables", async () => {
+            const fixtureFilename = "contains-namespaced-grid-size.scss";
+            const fixturePath = join(import.meta.dirname, "fixtures", "prefer-spacing-variable", fixtureFilename);
+            const mutableFixturePath = join(tmpDir, fixtureFilename);
+            copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                config,
+                files: mutableFixturePath,
+                fix: true,
+            });
+
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).to.have.lengthOf(0);
+
+            const fixedSourceContents = readFileSync(mutableFixturePath, { encoding: "utf-8" });
+            expect(fixedSourceContents).to.contain("bp.$pt-spacing");
+            expect(fixedSourceContents).to.not.contain("bp.$pt-grid-size");
+        });
+
+        it("Replaces left-side multipliers correctly", async () => {
+            const fixtureFilename = "contains-left-multipliers.scss";
+            const fixturePath = join(import.meta.dirname, "fixtures", "prefer-spacing-variable", fixtureFilename);
+            const mutableFixturePath = join(tmpDir, fixtureFilename);
+            copyFileSync(fixturePath, mutableFixturePath);
+
+            const result = await stylelint.lint({
+                config,
+                files: mutableFixturePath,
+                fix: true,
+            });
+
+            expect(result.errored).to.be.false;
+            const warnings = result.results[0].warnings;
+            expect(warnings).to.have.lengthOf(0);
+
+            const fixedSourceContents = readFileSync(mutableFixturePath, { encoding: "utf-8" });
+            expect(fixedSourceContents).to.contain("5 * $pt-spacing"); // 2 * 2.5
+            expect(fixedSourceContents).to.contain("1.25 * $pt-spacing"); // 0.5 * 2.5
+            expect(fixedSourceContents).to.contain("3.75 * $pt-spacing"); // 1.5 * 2.5
+            expect(fixedSourceContents).to.not.contain("$pt-grid-size");
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Introduces a new autofixable stylelint rule, `@blueprintjs/prefer-spacing-variable`, that enforces the migration from Blueprint's deprecated `$pt-grid-size` variable (10px) to the new `$pt-spacing` variable (4px).

## Features
-  Identifies use of `$pt-grid-size` in SCSS/LESS files
- Supports both namespaced and non-namespaced variable patterns
- Works with complex mathematical expressions and calc() functions
- Auto-fix: Automatically applies 2.5x scaling factor (10px ÷ 4px = 2.5)


## Conversion Examples

Before | After
-- | --
`$pt-grid-size` | `$pt-spacing * 2.5`
`$pt-grid-size * 2` | `$pt-spacing * 5`
`2 * $pt-grid-size` | `5 * $pt-spacing`
`$pt-grid-size / 2` | `$pt-spacing / 0.8`
`bp.$pt-grid-size * 1.5` | `bp.$pt-spacing * 3.75`
`calc($pt-grid-size * 1.5)` | `calc($pt-spacing * 3.75)`

## Usage

Add to `.stylelintrc`:
```json
{
    "plugins": ["@blueprintjs/stylelint-plugin"],
    "rules": {
        "@blueprintjs/prefer-spacing-variable": true
    }
}
```

**Related:** [Spacing System Migration Guide](https://github.com/palantir/blueprint/wiki/Spacing-System-Migration:-10px-to-4px)