### PR TITLE
Export `InteractionModeEngine`

### DIFF
--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -40,6 +40,7 @@ export {
 } from "./props";
 export { getRef, isRefCallback, isRefObject, mergeRefs, refHandler, setRef } from "./refs";
 export { Size, type NonSmallSize } from "./size";
+export { InteractionModeEngine } from "./interactionMode"
 
 import * as Classes from "./classes";
 import * as Utils from "./utils";

--- a/packages/core/src/common/index.ts
+++ b/packages/core/src/common/index.ts
@@ -23,6 +23,7 @@ export { Boundary } from "./boundary";
 export { ButtonVariant } from "./buttonVariant";
 export { Elevation } from "./elevation";
 export { Intent } from "./intent";
+export { InteractionModeEngine } from "./interactionMode"
 export { KeyCodes as Keys } from "./keyCodes";
 export { Position } from "./position";
 export {
@@ -40,7 +41,6 @@ export {
 } from "./props";
 export { getRef, isRefCallback, isRefObject, mergeRefs, refHandler, setRef } from "./refs";
 export { Size, type NonSmallSize } from "./size";
-export { InteractionModeEngine } from "./interactionMode"
 
 import * as Classes from "./classes";
 import * as Utils from "./utils";


### PR DESCRIPTION
I have a use case where I am using Blueprint from within a shadow DOM. `FocusManager` doesn't work inside the Shadow DOM since the `FOCUS_DISABLED` class doesn't get passed down through it. Exposing this would allow me to create my own handler from within the shadow dom.