### PR TITLE
[chore] Remove import cycle between Popover and Tooltip components

### DIFF
--- a/packages/core/src/common/alignment.ts
+++ b/packages/core/src/common/alignment.ts
@@ -35,5 +35,5 @@ export const TextAlignment = {
     END: "end" as const,
     START: "start" as const,
 };
-// eslint-disable-next-line @typescript-eslint/no-redeclare
+
 export type TextAlignment = (typeof TextAlignment)[keyof typeof TextAlignment];

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -38,8 +38,6 @@ import {
 import * as Errors from "../../common/errors";
 import { Overlay2 } from "../overlay2/overlay2";
 import { ResizeSensor } from "../resize-sensor/resizeSensor";
-// eslint-disable-next-line import/no-cycle
-import { Tooltip } from "../tooltip/tooltip";
 
 import { matchReferenceWidthModifier } from "./customModifiers";
 import { POPOVER_ARROW_SVG_SIZE, PopoverArrow } from "./popoverArrow";
@@ -421,7 +419,7 @@ export class Popover<
                 ...childTargetProps,
                 className: classNames(childTarget.props.className, targetModifierClasses),
                 // force disable single Tooltip child when popover is open
-                disabled: isOpen && Utils.isElementOfType(childTarget, Tooltip) ? true : childTarget.props.disabled,
+                disabled: isOpen && isElementTooltip(childTarget) ? true : childTarget.props.disabled,
                 tabIndex: childTarget.props.tabIndex ?? targetTabIndex,
             });
             const wrappedTarget = createElement(
@@ -787,6 +785,10 @@ export class Popover<
         const { content } = this.props;
         return content == null || Utils.isEmptyString(content);
     }
+}
+
+function isElementTooltip(element: any): boolean {
+    return element?.type?.displayName === `${DISPLAYNAME_PREFIX}.Tooltip`;
 }
 
 function isEscapeKeypressEvent(e?: Event) {

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,7 +19,6 @@ import { createRef } from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
-// eslint-disable-next-line import/no-cycle
 import { Popover, type PopoverInteractionKind } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";


### PR DESCRIPTION
- **Remove import cycle between Popover and Tooltip components**
- **Remove unused eslint-disable directive**

#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
