### PR TITLE
Additional 4px-based spacing component changes

### DIFF
--- a/packages/core/src/_reset.scss
+++ b/packages/core/src/_reset.scss
@@ -25,7 +25,7 @@ body {
 }
 
 p {
-  margin-bottom: $pt-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2;
   margin-top: 0;
 }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -28,7 +28,7 @@ Styleguide headings
 
 .#{$ns}-heading {
   @include heading-typography();
-  margin: 0 0 ($pt-spacing * 2);
+  margin: 0 0 ($pt-spacing * 3);
   padding: 0;
 }
 
@@ -155,7 +155,7 @@ Styleguide running-text
   }
 
   p {
-    margin: 0 0 ($pt-spacing * 2);
+    margin: 0 0 ($pt-spacing * 3);
     padding: 0;
   }
 

--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -28,7 +28,7 @@ Styleguide headings
 
 .#{$ns}-heading {
   @include heading-typography();
-  margin: 0 0 ($pt-spacing * 2.5);
+  margin: 0 0 ($pt-spacing * 2);
   padding: 0;
 }
 
@@ -155,7 +155,7 @@ Styleguide running-text
   }
 
   p {
-    margin: 0 0 ($pt-spacing * 2.5);
+    margin: 0 0 ($pt-spacing * 2);
     padding: 0;
   }
 
@@ -252,7 +252,7 @@ Styleguide preformatted
   display: block;
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
-  margin: ($pt-spacing * 2.5) 0;
+  margin: ($pt-spacing * 2) 0;
   padding: ($pt-spacing * 3) ($pt-spacing * 4);
   word-break: break-all;
   word-wrap: break-word;
@@ -309,7 +309,7 @@ Styleguide blockquote
 
 %blockquote {
   border-left: solid $pt-spacing rgba($gray4, 0.5);
-  margin: 0 0 ($pt-spacing * 2.5);
+  margin: 0 0 ($pt-spacing * 2);
   padding: 0 ($pt-spacing * 5);
 
   .#{$ns}-dark & {
@@ -344,7 +344,7 @@ Styleguide lists
 */
 
 %list {
-  margin: ($pt-spacing * 2.5) 0;
+  margin: ($pt-spacing * 2) 0;
   padding-left: $pt-spacing * 7.5;
 
   li:not(:last-child) {

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -25,9 +25,9 @@
 .#{$ns}-alert-footer {
   display: flex;
   flex-direction: row-reverse;
-  margin-top: $pt-spacing * 2.5;
+  margin-top: $pt-spacing * 2;
 
   .#{$ns}-button {
-    margin-left: $pt-spacing * 2.5;
+    margin-left: $pt-spacing * 2;
   }
 }

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -25,7 +25,7 @@
 .#{$ns}-alert-footer {
   display: flex;
   flex-direction: row-reverse;
-  margin-top: $pt-spacing * 2;
+  margin-top: $pt-spacing * 3;
 
   .#{$ns}-button {
     margin-left: $pt-spacing * 2;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,11 +7,11 @@
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;
-$button-padding: $pt-spacing ($pt-spacing * 2.5) !default;
+$button-padding: $pt-spacing ($pt-spacing * 2) !default;
 $button-padding-small: 0 ($pt-spacing * 2) !default;
 $button-padding-large: $pt-spacing ($pt-spacing * 4) !default;
 $button-icon-spacing: $pt-spacing * 2 !default;
-$button-icon-spacing-large: $pt-spacing * 2.5 !default;
+$button-icon-spacing-large: $pt-spacing * 2 !default;
 
 /*
 CSS `border` property issues:

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -5,7 +5,7 @@
 
 $callout-padding: $pt-spacing * 4;
 $callout-header-margin-top: $pt-spacing * 0.5;
-$callout-padding-compact: $pt-spacing * 2.5;
+$callout-padding-compact: $pt-spacing * 2;
 
 .#{$ns}-callout {
   @include running-typography();

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -13,7 +13,7 @@ $card-list-border-width: 1px !default;
 
 // CardList Card item min-height is calculated as height of a button + vertical padding.
 // We need to add an extra pixel to account for the bottom border.
-$card-list-item-padding-vertical: $pt-spacing * 2.5 !default;
+$card-list-item-padding-vertical: $pt-spacing * 2 !default;
 // prettier-ignore
 $card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -15,10 +15,10 @@ $card-list-border-width: 1px !default;
 // We need to add an extra pixel to account for the bottom border.
 $card-list-item-padding-vertical: $pt-spacing * 2 !default;
 // prettier-ignore
-$card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
+$card-list-item-min-height: $pt-spacing * 12 !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;
 
 $card-list-item-padding-vertical-compact: $pt-spacing * 2 !default;
 // prettier-ignore
-$card-list-item-min-height-compact: $pt-button-height + ($card-list-item-padding-vertical-compact * 2) + $card-list-border-width !default;
+$card-list-item-min-height-compact: $pt-spacing * 10 !default;
 $card-list-item-padding-compact: $card-list-item-padding-vertical-compact $card-padding-compact !default;

--- a/packages/core/src/components/card/_card-variables.scss
+++ b/packages/core/src/components/card/_card-variables.scss
@@ -15,10 +15,10 @@ $card-list-border-width: 1px !default;
 // We need to add an extra pixel to account for the bottom border.
 $card-list-item-padding-vertical: $pt-spacing * 2 !default;
 // prettier-ignore
-$card-list-item-min-height: $pt-spacing * 12 !default;
+$card-list-item-min-height: $pt-button-height + ($card-list-item-padding-vertical * 2) + $card-list-border-width !default;
 $card-list-item-padding: $card-list-item-padding-vertical $card-padding !default;
 
 $card-list-item-padding-vertical-compact: $pt-spacing * 2 !default;
 // prettier-ignore
-$card-list-item-min-height-compact: $pt-spacing * 10 !default;
+$card-list-item-min-height-compact: $pt-button-height + ($card-list-item-padding-vertical-compact * 2) + $card-list-border-width !default;
 $card-list-item-padding-compact: $card-list-item-padding-vertical-compact $card-padding-compact !default;

--- a/packages/core/src/components/control-card/_control-card.scss
+++ b/packages/core/src/components/control-card/_control-card.scss
@@ -21,7 +21,7 @@
     // control indicators should be top-aligned
     align-items: flex-start;
     display: flex;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
     margin: 0;
     padding: $card-padding;
     width: calc(100%);

--- a/packages/core/src/components/dialog/_dialog-footer.scss
+++ b/packages/core/src/components/dialog/_dialog-footer.scss
@@ -18,7 +18,7 @@
   gap: $dialog-padding;
   justify-content: space-between;
   margin: 0;
-  padding: ($pt-spacing * 2.5) ($pt-spacing * 2.5) ($pt-spacing * 2.5) $dialog-padding;
+  padding: ($pt-spacing * 2) ($pt-spacing * 2) ($pt-spacing * 2) $dialog-padding;
 
   .#{$ns}-dark & {
     background: $dark-gray4;
@@ -35,6 +35,6 @@
   justify-content: flex-end;
 
   .#{$ns}-button {
-    margin-left: $pt-spacing * 2.5;
+    margin-left: $pt-spacing * 2;
   }
 }

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -205,7 +205,7 @@ $step-radius: $pt-border-radius * 2 !default;
 .#{$ns}-dialog-step-title {
   color: $pt-text-color-disabled;
   flex: 1;
-  padding-left: $pt-spacing * 2.5;
+  padding-left: $pt-spacing * 2;
 
   .#{$ns}-dark & {
     color: $pt-dark-text-color-disabled;

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -81,10 +81,6 @@
   &-heading-h3 {
     gap: $pt-spacing * 4;
 
-    .#{$ns}-entity-title-status-tag {
-      margin-left: $pt-spacing * 2;
-    }
-
     .#{$ns}-entity-title-subtitle {
       font-size: $pt-font-size;
     }

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -82,7 +82,7 @@
     gap: $pt-spacing * 4;
 
     .#{$ns}-entity-title-status-tag {
-      margin-left: $pt-spacing * 2.5;
+      margin-left: $pt-spacing * 2;
     }
 
     .#{$ns}-entity-title-subtitle {
@@ -93,7 +93,7 @@
   &-heading-h4,
   &-heading-h5,
   &-heading-h6 {
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
 
     .#{$ns}-entity-title-subtitle {
       font-size: $pt-font-size-small;

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -5,7 +5,7 @@
 @import "../../common/variables";
 @import "../button/common";
 
-$input-padding-horizontal: $pt-spacing * 2.5 !default;
+$input-padding-horizontal: $pt-spacing * 2 !default;
 $input-small-padding: $pt-input-height-small - $pt-icon-size-standard !default;
 $input-font-weight: 400 !default;
 $input-transition: box-shadow $pt-transition-duration $pt-transition-ease;
@@ -110,7 +110,7 @@ $control-group-stack: (
     border-radius: $pt-input-height;
     // override normalize.css
     box-sizing: border-box;
-    padding-left: $pt-spacing * 2.5;
+    padding-left: $pt-spacing * 2;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -27,7 +27,7 @@ $dark-control-checked-box-shadow: inset 0 0 0 $button-border-width rgba($white, 
 
 $control-indicator-size: $pt-icon-size-standard !default;
 $control-indicator-size-large: $pt-icon-size-large !default;
-$control-indicator-spacing: $pt-spacing * 2.5 !default;
+$control-indicator-spacing: $pt-spacing * 2 !default;
 
 @mixin control-checked-colors($selector: ":checked") {
   input#{$selector} ~ .#{$ns}-control-indicator {
@@ -130,7 +130,7 @@ $control-indicator-spacing: $pt-spacing * 2.5 !default;
   cursor: pointer;
 
   display: block;
-  margin-bottom: $pt-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2;
   position: relative;
   text-transform: none;
 

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -51,12 +51,12 @@
 
     &.#{$ns}-large label.#{$ns}-label {
       line-height: $pt-input-height-large;
-      margin: 0 ($pt-spacing * 2.5) 0 0;
+      margin: 0 ($pt-spacing * 2) 0 0;
     }
 
     label.#{$ns}-label {
       line-height: $pt-input-height;
-      margin: 0 ($pt-spacing * 2.5) 0 0;
+      margin: 0 ($pt-spacing * 2) 0 0;
     }
   }
 

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -51,12 +51,12 @@
 
     &.#{$ns}-large label.#{$ns}-label {
       line-height: $pt-input-height-large;
-      margin: 0 ($pt-spacing * 2) 0 0;
+      margin: 0 ($pt-spacing * 3) 0 0;
     }
 
     label.#{$ns}-label {
       line-height: $pt-input-height;
-      margin: 0 ($pt-spacing * 2) 0 0;
+      margin: 0 ($pt-spacing * 3) 0 0;
     }
   }
 

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -50,6 +50,6 @@
   margin-right: 0;
 
   &:not(:last-child) {
-    margin-bottom: $pt-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2;
   }
 }

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -45,7 +45,7 @@
   position: absolute;
   // N.B. it's more important for the icon to vertically align with button end icons rather than
   // input right padding, see https://github.com/palantir/blueprint/issues/6184
-  right: $pt-spacing * 2.5;
+  right: $pt-spacing * 2;
   top: ($pt-button-height - $pt-icon-size-standard) * 0.5;
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -45,7 +45,7 @@
   position: absolute;
   // N.B. it's more important for the icon to vertically align with button end icons rather than
   // input right padding, see https://github.com/palantir/blueprint/issues/6184
-  right: $pt-spacing * 2;
+  right: $pt-spacing * 1.5;
   top: ($pt-button-height - $pt-icon-size-standard) * 0.5;
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -45,7 +45,7 @@
   position: absolute;
   // N.B. it's more important for the icon to vertically align with button end icons rather than
   // input right padding, see https://github.com/palantir/blueprint/issues/6184
-  right: $pt-spacing * 1.5;
+  right: $pt-spacing * 2;
   top: ($pt-button-height - $pt-icon-size-standard) * 0.5;
 
   &.#{$ns}-disabled {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -19,7 +19,7 @@ $menu-item-line-height-large: 22px;
 
 $menu-min-width: $pt-spacing * 45 !default;
 $menu-item-padding: $pt-spacing * 2 !default;
-$menu-item-padding-large: $pt-spacing * 2.5 !default;
+$menu-item-padding-large: $pt-spacing * 2 !default;
 $menu-item-padding-vertical: $pt-spacing !default;
 $menu-item-padding-vertical-large: $pt-spacing * 2.25 !default;
 $menu-item-padding-small: $pt-spacing !default;
@@ -374,7 +374,7 @@ $dark-menu-item-intent-colors: (
   // a little extra space to avoid clipping descenders (because overflow hidden)
   line-height: $pt-icon-size-standard + 1px;
   margin: 0;
-  padding: ($pt-spacing * 2.5) $menu-item-padding 0 ($pt-spacing * 1.5);
+  padding: ($pt-spacing * 2) $menu-item-padding 0 ($pt-spacing * 1.5);
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -374,7 +374,7 @@ $dark-menu-item-intent-colors: (
   // a little extra space to avoid clipping descenders (because overflow hidden)
   line-height: $pt-icon-size-standard + 1px;
   margin: 0;
-  padding: ($pt-spacing * 2) $menu-item-padding 0 ($pt-spacing * 1.5);
+  padding: ($pt-spacing * 2) $menu-item-padding 0 ($pt-spacing * 2);
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -67,7 +67,7 @@ $dark-navbar-background-color: $dark-card-background-color !default;
 .#{$ns}-navbar-divider {
   border-left: 1px solid $pt-divider-black;
   height: $pt-navbar-height - $pt-spacing * 7.5;
-  margin: 0 ($pt-spacing * 2.5);
+  margin: 0 ($pt-spacing * 2);
 
   .#{$ns}-dark & {
     border-left-color: $pt-dark-divider-white;

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -20,7 +20,7 @@
   .#{$ns}-heading {
     color: $pt-text-color-muted;
     line-height: $pt-spacing * 5;
-    margin-bottom: $pt-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2;
 
     &:only-child {
       margin-bottom: 0;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -2,7 +2,7 @@
 @import "../../common/variables";
 
 $section-min-height: $pt-spacing * 12.5 !default;
-$section-padding-vertical: $pt-spacing * 2.5 !default;
+$section-padding-vertical: $pt-spacing * 2 !default;
 $section-padding-horizontal: $pt-spacing * 5 !default;
 $section-card-padding: $pt-spacing * 5 !default;
 
@@ -40,7 +40,7 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
     &-left {
       align-items: center;
       display: flex;
-      gap: $pt-spacing * 2.5;
+      gap: $pt-spacing * 2;
       padding: $section-padding-vertical 0;
     }
 
@@ -55,7 +55,7 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
     &-right {
       align-items: center;
       display: flex;
-      gap: $pt-spacing * 2.5;
+      gap: $pt-spacing * 2;
       margin-left: auto;
     }
 

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -5,7 +5,7 @@
 @import "./common";
 
 $handle-size: $pt-icon-size-standard !default;
-$track-size: $handle-size - ($pt-spacing * 2.5) !default;
+$track-size: $handle-size - ($pt-spacing * 2) !default;
 $label-offset: $handle-size + $pt-spacing !default;
 
 $handle-border-shadow: 0 0 0 $button-border-width rgba($black, 0.5);

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -5,7 +5,7 @@
 @import "./common";
 
 $handle-size: $pt-icon-size-standard !default;
-$track-size: $handle-size - ($pt-spacing * 2) !default;
+$track-size: $handle-size - ($pt-spacing * 2.5) !default;
 $label-offset: $handle-size + $pt-spacing !default;
 
 $handle-border-shadow: 0 0 0 $button-border-width rgba($black, 0.5);

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -31,7 +31,7 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
       align-items: center;
       border-radius: $pt-border-radius;
       display: flex;
-      padding: 0 ($pt-spacing * 2.5);
+      padding: 0 ($pt-spacing * 2);
       width: 100%;
 
       &[aria-selected="true"] {

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -17,7 +17,7 @@ $tag-margin: ($pt-input-height - $tag-height) * 0.5 !default;
 
 $tag-height-large: $pt-spacing * 7.5 !default;
 $tag-line-height-large: $pt-spacing * 4.5 !default;
-$tag-padding-large: $pt-spacing * 2.5 !default;
+$tag-padding-large: $pt-spacing * 2 !default;
 
 $tag-icon-spacing: $pt-spacing !default;
 $tag-icon-spacing-large: $pt-spacing * 2 !default;

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -156,7 +156,7 @@ $minimal-dark-tag-intent-colors: (
   line-height: $tag-line-height-large;
   min-height: $tag-height-large;
   min-width: $tag-height-large;
-  padding: ($tag-padding-large * 0.6) $tag-padding-large;
+  padding: ($tag-padding-large * 0.75) $tag-padding-large;
 
   &.#{$ns}-round {
     padding-left: $tag-padding-large + $tag-round-adjustment;

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -84,7 +84,7 @@ $toast-intent-colors: (
   );
   $leave-blur: (
     opacity: 0 1,
-    filter: blur($pt-spacing * 2.5) blur(0),
+    filter: blur($pt-spacing * 2) blur(0),
   );
 
   // new toasts slide in from the top

--- a/packages/core/src/components/tooltip/_common.scss
+++ b/packages/core/src/components/tooltip/_common.scss
@@ -7,5 +7,5 @@ $tooltip-text-color: $light-gray5 !default;
 $dark-tooltip-background-color: $light-gray3 !default;
 $dark-tooltip-text-color: $dark-gray5 !default;
 
-$tooltip-padding-vertical: $pt-spacing * 2.5 !default;
+$tooltip-padding-vertical: $pt-spacing * 2 !default;
 $tooltip-padding-horizontal: $pt-spacing * 3 !default;

--- a/packages/datetime/src/components/date-picker/_date-picker.scss
+++ b/packages/datetime/src/components/date-picker/_date-picker.scss
@@ -35,7 +35,7 @@
 
     // create space between months (selector matches all but first month)
     & + & {
-      margin-left: $pt-spacing * 2.5;
+      margin-left: $pt-spacing * 2;
     }
   }
 

--- a/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
+++ b/packages/datetime/src/components/date-range-picker/_date-range-picker.scss
@@ -15,7 +15,7 @@
 
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
-    min-width: $datepicker-min-width + ($pt-spacing * 2.5);
+    min-width: $datepicker-min-width + ($pt-spacing * 2);
   }
 
   &.#{$ns}-daterangepicker-single-month .rdp {

--- a/packages/datetime2/src/components/date-picker3/_date-picker3.scss
+++ b/packages/datetime2/src/components/date-picker3/_date-picker3.scss
@@ -28,7 +28,7 @@
 
     // create space between months (selector matches all but first month)
     & + & {
-      margin-left: $pt-spacing * 2.5;
+      margin-left: $pt-spacing * 2;
     }
   }
 

--- a/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
+++ b/packages/datetime2/src/components/date-range-picker3/_date-range-picker3.scss
@@ -13,7 +13,7 @@
 .#{$ns}-daterangepicker {
   // ensure min-widths are set correctly for variants of contiguous months, single month, and shortcuts
   &.#{$ns}-daterangepicker-contiguous .rdp {
-    min-width: $datepicker-min-width + ($pt-spacing * 2.5);
+    min-width: $datepicker-min-width + ($pt-spacing * 2);
   }
 
   &.#{$ns}-daterangepicker-single-month .rdp {

--- a/packages/demo-app/src/styles/_examples.scss
+++ b/packages/demo-app/src/styles/_examples.scss
@@ -20,7 +20,7 @@ $dark-intent-danger-text: $red5;
   background-color: $light-gray2;
   display: flex;
   flex-direction: column;
-  padding: $pt-spacing * 2.5;
+  padding: $pt-spacing * 2;
   width: 100%;
 
   &.#{$ns}-dark {
@@ -33,7 +33,7 @@ $dark-intent-danger-text: $red5;
   justify-content: space-evenly;
 
   > :not(:last-child) {
-    margin-right: $pt-spacing * 2.5;
+    margin-right: $pt-spacing * 2;
   }
 }
 
@@ -48,10 +48,10 @@ $dark-intent-danger-text: $red5;
   background-color: $light-gray4;
   display: flex;
   flex-direction: column;
-  margin-bottom: $pt-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2;
 
   > :not(:last-child) {
-    margin-bottom: $pt-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2;
   }
 
   &.horizontal {
@@ -60,7 +60,7 @@ $dark-intent-danger-text: $red5;
 
     > :not(:last-child) {
       margin-bottom: 0;
-      margin-right: $pt-spacing * 2.5;
+      margin-right: $pt-spacing * 2;
     }
   }
 }
@@ -70,7 +70,7 @@ $dark-intent-danger-text: $red5;
   flex-direction: column;
 
   > :not(:last-child) {
-    margin-bottom: $pt-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2;
   }
 }
 
@@ -79,7 +79,7 @@ $dark-intent-danger-text: $red5;
   flex-direction: column;
 
   > :not(:last-child) {
-    margin-bottom: $pt-spacing * 2.5;
+    margin-bottom: $pt-spacing * 2;
   }
 }
 
@@ -144,5 +144,5 @@ $dark-intent-danger-text: $red5;
 }
 
 .#{$ns}-toast {
-  margin: ($pt-spacing * 2.5) 0;
+  margin: ($pt-spacing * 2) 0;
 }

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -106,7 +106,7 @@ label.docs-color-scheme-label {
 }
 
 .docs-color-scheme-radios {
-  margin-bottom: $pt-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2;
 }
 
 .docs-color-bar-hexes {
@@ -141,7 +141,7 @@ label.docs-color-scheme-label {
 
   .docs-color-scheme & {
     flex: 1 1 auto;
-    margin: 0 ($pt-spacing * 2.5);
+    margin: 0 ($pt-spacing * 2);
   }
 }
 
@@ -212,7 +212,7 @@ label.docs-color-scheme-label {
   font-size: $pt-font-size-small;
   justify-content: space-between;
   line-height: 1;
-  padding: 0 ($pt-spacing * 2.5);
+  padding: 0 ($pt-spacing * 2);
   transition: all $pt-transition-duration $pt-transition-ease;
   white-space: nowrap;
 

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -25,7 +25,7 @@
 }
 
 .docs-prop-code-tooltip {
-  margin-bottom: $pt-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2;
 }
 
 .docs-example .#{$ns}-form-group:last-child {
@@ -92,13 +92,13 @@
 .docs-code-example {
   .group {
     display: flex;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
   }
 
   .stack {
     display: flex;
     flex-direction: column;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
   }
 
   .center {
@@ -172,7 +172,7 @@
 
 #{example("ControlCardList")} {
   .#{$ns}-control-card-label .#{$ns}-icon {
-    margin-right: $pt-spacing * 2.5;
+    margin-right: $pt-spacing * 2;
   }
 }
 
@@ -199,7 +199,7 @@
   .docs-example .#{$ns}-card {
     display: flex;
     flex-direction: column;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
   }
 
   // this example has a "fill" prop option, which doesn't work nicely with the default margin
@@ -241,7 +241,7 @@
 }
 
 #{example("DividerVertical")} .docs-code-example > :first-child {
-  gap: $pt-spacing * 2.5;
+  gap: $pt-spacing * 2;
   max-width: 500px;
   text-align: center;
   width: 100%;
@@ -253,7 +253,7 @@
     flex-direction: column;
 
     > * {
-      margin: $pt-spacing * 2.5;
+      margin: $pt-spacing * 2;
     }
   }
 }
@@ -377,7 +377,7 @@ $docs-hotkey-piano-height: 510px;
 
 #{example("HotkeyTester")} {
   .docs-hotkey-tester {
-    @include pt-flex-container(column, $pt-spacing * 2.5);
+    @include pt-flex-container(column, $pt-spacing * 2);
     align-items: center;
     background: rgba($gray3, 0.2);
     border: 2px solid rgba($gray3, 0.8);
@@ -495,7 +495,7 @@ $docs-hotkey-piano-height: 510px;
     width: 1600px;
 
     > p {
-      margin-top: $pt-spacing * 2.5;
+      margin-top: $pt-spacing * 2;
     }
   }
 }
@@ -513,11 +513,11 @@ $docs-hotkey-piano-height: 510px;
     padding: $pt-spacing * 5;
 
     .#{$ns}-button:not(:first-child) {
-      margin-left: $pt-spacing * 2.5;
+      margin-left: $pt-spacing * 2;
     }
 
     .#{$ns}-callout {
-      margin: ($pt-spacing * 2.5) 0;
+      margin: ($pt-spacing * 2) 0;
     }
   }
 }
@@ -539,7 +539,7 @@ $docs-hotkey-piano-height: 510px;
     flex: 1 0 auto;
     flex-direction: column;
     justify-content: space-around;
-    padding: $pt-spacing * 2.5;
+    padding: $pt-spacing * 2;
   }
 
   ul {
@@ -551,7 +551,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example {
   .docs-example-grid {
     display: grid;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
     grid-template-columns: 1fr 2fr 1fr;
     grid-template-rows: 1fr 2fr 1fr;
     justify-content: stretch;
@@ -606,7 +606,7 @@ $docs-hotkey-piano-height: 510px;
 .docs-popover-placement-example-content {
   .#{$ns}-popover-content {
     line-height: 2;
-    padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
+    padding: ($pt-spacing * 2) ($pt-spacing * 5);
     text-align: center;
   }
 
@@ -639,14 +639,14 @@ $docs-hotkey-piano-height: 510px;
 
 .docs-popover-minimal-example {
   .#{$ns}-button:first-child {
-    margin-right: $pt-spacing * 2.5;
+    margin-right: $pt-spacing * 2;
   }
 }
 
 .docs-popover-interaction-kind-example {
   .#{$ns}-button {
     font-family: $pt-font-family-monospace;
-    margin-right: $pt-spacing * 2.5;
+    margin-right: $pt-spacing * 2;
   }
 }
 
@@ -688,7 +688,7 @@ $docs-hotkey-piano-height: 510px;
 
 .docs-popover-portal-example-popover {
   .#{$ns}-popover-content {
-    padding: $pt-spacing * 2.5;
+    padding: $pt-spacing * 2;
     white-space: nowrap;
   }
 }
@@ -727,7 +727,7 @@ $docs-hotkey-piano-height: 510px;
   .docs-example .#{$ns}-card {
     display: flex;
     flex-direction: column;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
   }
 }
 
@@ -739,7 +739,7 @@ $docs-hotkey-piano-height: 510px;
   .metadata-panel {
     display: flex;
     flex-direction: column;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
 
     > div {
       display: flex;
@@ -756,7 +756,7 @@ $docs-hotkey-piano-height: 510px;
 #{page("datetime", "^=")} {
   .docs-example {
     flex-direction: column;
-    gap: $pt-spacing * 2.5;
+    gap: $pt-spacing * 2;
     justify-content: center;
   }
 }

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -91,11 +91,11 @@ $dark-package-colors: (
 .docs-heading {
   font-size: $pt-spacing * 5;
   font-weight: 600;
-  margin-right: $pt-spacing * 2.5;
+  margin-right: $pt-spacing * 2;
 
   .#{$ns}-tag {
     margin-left: $pt-spacing;
-    padding-left: $pt-spacing * 2.5;
+    padding-left: $pt-spacing * 2;
     vertical-align: middle;
   }
 }
@@ -113,7 +113,7 @@ $dark-package-colors: (
 
 .docs-nav-package-icon {
   border-radius: $pt-border-radius * 3;
-  margin-right: $pt-spacing * 2.5;
+  margin-right: $pt-spacing * 2;
 }
 
 .docs-nav-package {
@@ -179,7 +179,7 @@ $dark-package-colors: (
 
   + .docs-nav-menu {
     margin-bottom: $pt-spacing;
-    margin-left: $pkg-icon-width + ($pt-spacing * 2.5);
+    margin-left: $pkg-icon-width + ($pt-spacing * 2);
 
     &:empty {
       display: none;
@@ -190,7 +190,7 @@ $dark-package-colors: (
 .docs-nav-section {
   font-size: small;
   font-weight: 700;
-  margin-bottom: $pt-spacing * 2.5;
+  margin-bottom: $pt-spacing * 2;
   margin-top: $pt-spacing * 5;
   text-transform: uppercase;
 

--- a/packages/docs-theme/src/common/sandbox.ts
+++ b/packages/docs-theme/src/common/sandbox.ts
@@ -229,13 +229,13 @@ export const getStyles = () => {
 
 .group {
   display: flex;
-  gap: 10px;
+  gap: 8px;
 }
 
 .stack {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .center {

--- a/packages/docs-theme/src/styles/_api.scss
+++ b/packages/docs-theme/src/styles/_api.scss
@@ -14,7 +14,7 @@
 
   .docs-interface-header {
     flex: 0 0 auto;
-    padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
+    padding: ($pt-spacing * 2) ($pt-spacing * 5);
 
     + .docs-section {
       flex-shrink: 0;

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -16,7 +16,7 @@ $banner-height: $pt-spacing * 10;
   justify-content: center;
   left: 0;
   min-height: $banner-height;
-  padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
+  padding: ($pt-spacing * 2) ($pt-spacing * 5);
 
   position: fixed;
   right: 0;

--- a/packages/docs-theme/src/styles/_code-example.scss
+++ b/packages/docs-theme/src/styles/_code-example.scss
@@ -23,5 +23,5 @@
   display: flex;
   gap: 5px;
   justify-content: flex-end;
-  padding-top: 10px;
+  padding-top: 8px;
 }

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -6,7 +6,7 @@
 @import "variables";
 
 $heading-margin: $pt-spacing * 10;
-$link-icon-padding: $pt-spacing * 2.5;
+$link-icon-padding: $pt-spacing * 2;
 
 $class-modifier-color: $rose4;
 $attribute-modifier-color: $violet5;

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -3,7 +3,7 @@
 
 // Base styles for all examples
 
-$example-frame-spacing: $pt-spacing * 2.5;
+$example-frame-spacing: $pt-spacing * 2;
 $example-frame-border-radius: $pt-border-radius * 2;
 $example-spacing: $pt-spacing * 10;
 
@@ -16,18 +16,18 @@ $example-spacing: $pt-spacing * 10;
 
 // options to the right of example in same row
 .docs-example-frame-row {
-  @include pt-flex-container(row, $pt-spacing * 2.5, $fill: ".docs-example");
+  @include pt-flex-container(row, $pt-spacing * 2, $fill: ".docs-example");
 
   // option elements arranged vertically. use headings for grouping.
   .docs-example-options {
-    @include pt-flex-container(column, $pt-spacing * 2.5);
+    @include pt-flex-container(column, $pt-spacing * 2);
     max-width: $pt-spacing * 75;
   }
 }
 
 // options below example in its own row.
 .docs-example-frame-column {
-  @include pt-flex-container(column, $pt-spacing * 2.5, $fill: ".docs-example");
+  @include pt-flex-container(column, $pt-spacing * 2, $fill: ".docs-example");
 
   // option elements arranged horizontally. group controls into columns.
   .docs-example-options {
@@ -72,7 +72,7 @@ $example-spacing: $pt-spacing * 10;
   text-align: left;
 
   .#{$ns}-heading:not(:first-child) {
-    margin-top: $pt-spacing * 2.5;
+    margin-top: $pt-spacing * 2;
   }
 
   .docs-prop-description {

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -118,7 +118,7 @@ Lefthand navigation menu
   .#{$ns}-menu-item {
     align-items: center;
     padding-left: 0;
-    padding-right: $pt-spacing * 2.5;
+    padding-right: $pt-spacing * 2;
     white-space: initial;
 
     &:hover,

--- a/packages/docs-theme/src/styles/_navbar.scss
+++ b/packages/docs-theme/src/styles/_navbar.scss
@@ -15,12 +15,12 @@ $nav-divider-offset: $pt-spacing * 12.5;
 }
 
 .docs-nav-button {
-  @include pt-flex-container(row, ($pt-spacing * 2.5) + $pt-spacing);
+  @include pt-flex-container(row, ($pt-spacing * 2) + $pt-spacing);
   align-items: center;
   cursor: pointer;
 
   margin-left: -$nav-divider-offset;
-  padding: ($pt-spacing * 2.5) $sidebar-padding;
+  padding: ($pt-spacing * 2) $sidebar-padding;
   padding-left: $nav-divider-offset + $pt-spacing;
 
   &:hover {

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -41,7 +41,7 @@
   }
 
   .#{$ns}-tag {
-    margin-right: $pt-spacing * 2.5;
+    margin-right: $pt-spacing * 2;
     margin-top: $pt-spacing;
   }
 }
@@ -81,7 +81,7 @@
   font-size: $pt-font-size-large;
   font-weight: 600;
   justify-content: space-between;
-  padding: ($pt-spacing * 2.5) 0;
+  padding: ($pt-spacing * 2) 0;
   position: relative;
 
   // optional interface description
@@ -89,7 +89,7 @@
     box-shadow: 0 1px 0 $pt-divider-black;
     display: flex;
     flex-direction: column;
-    margin-top: $pt-spacing * 2.5;
+    margin-top: $pt-spacing * 2;
   }
 
   .#{$ns}-dark & {
@@ -108,12 +108,12 @@
 
 .docs-type-alias {
   overflow: auto;
-  padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
+  padding: ($pt-spacing * 2) ($pt-spacing * 5);
 }
 
 .docs-modifiers-table {
   .docs-section & .#{$ns}-html-table {
-    margin-top: $pt-spacing * 2.5;
+    margin-top: $pt-spacing * 2;
   }
 
   th:first-child,

--- a/packages/table-dev-app/src/index.scss
+++ b/packages/table-dev-app/src/index.scss
@@ -86,7 +86,7 @@ body {
 
   h6.#{$ns}-heading {
     color: $pt-text-color-muted;
-    padding: ($pt-spacing * 2.5) 0 ($pt-spacing * 0.75);
+    padding: ($pt-spacing * 2) 0 ($pt-spacing * 0.75);
   }
 
   .#{$ns}-divider {
@@ -95,7 +95,7 @@ body {
 
   .#{$ns}-label,
   .#{$ns}-control {
-    padding-left: $pt-spacing * 2.5;
+    padding-left: $pt-spacing * 2;
   }
 
   .tbl-select-label {
@@ -127,7 +127,7 @@ body {
 }
 
 .sidebar-indented-group {
-  margin-left: $pt-spacing * 2.5;
+  margin-left: $pt-spacing * 2;
 }
 
 .tbl-zebra-stripe {

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -5,7 +5,7 @@
 $cell-border-width: 1px !default;
 $frozen-cell-border-width: $pt-spacing * 0.75 !default;
 
-$cell-padding-horizontal: $pt-spacing * 2.5 !default;
+$cell-padding-horizontal: $pt-spacing * 2 !default;
 $cell-padding-vertical: 0 !default;
 $cell-padding: $cell-padding-vertical $cell-padding-horizontal !default;
 $cell-height: $pt-spacing * 5 !default;

--- a/packages/table/src/cell/formats/_formats.scss
+++ b/packages/table/src/cell/formats/_formats.scss
@@ -8,7 +8,7 @@
 }
 
 .#{$ns}-table-truncated-value {
-  left: $pt-spacing * 2.5;
+  left: $pt-spacing * 2;
   max-height: 100%;
 
   overflow: hidden;
@@ -20,7 +20,7 @@
 }
 
 .#{$ns}-table-truncated-format-text {
-  left: $pt-spacing * 2.5;
+  left: $pt-spacing * 2;
   max-height: 100%;
 
   overflow: hidden;
@@ -67,7 +67,7 @@
   max-width: $pt-spacing * 150;
   min-width: $pt-spacing * 50;
   overflow: auto;
-  padding: $pt-spacing * 2.5;
+  padding: $pt-spacing * 2;
 }
 
 .#{$ns}-table-popover-whitespace-pre {

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -397,7 +397,7 @@ $dark-selectable-header-menu-selected-hover-background: menu-background(
 
   .#{$ns}-table-column-name-text {
     @include cell-content-align-vertical();
-    padding: $pt-spacing * 2.5;
+    padding: $pt-spacing * 2;
 
     .#{$ns}-skeleton {
       height: $column-name-text-skeleton-height;


### PR DESCRIPTION
## Changes proposed in this pull request

This PR continues the migration to 4px-based spacing by modifying various component spacings away from `10px` (`$pt-spacing * 2.5`) towards other values (`8px` or `12px`)

### `@blueprintjs/core`

**Typography**
- Increased bottom margin on paragraphs from 10px to 12px
- Increased bottom margin on headings (`.bp6-heading`) from 10px to 12px
- Reduced top and bottom margin on code blocks (`.bp6-code`) from 10px to 8px
- Reduced bottom margin on block quotes (`.bp6-blockquote`) from 10px to 8px
- Reduced top and bottom margin on lists (`.bp6-list`) from 10px to 8px

**Components**
- **Alert**: Increased footer top margin from 10px to 12px and decreased button spacing from 10px to 8px
- **Button**: Reduced horizontal padding on medium buttons and icon-text margin on large buttons from 10px to 8px
- **Callout**: Reduced `compact` variant padding from 10px to 8px
- **SwitchCard/CheckboxCard/RadioCard**: Reduced gap between label and control indicator from 10px to 8px
- **Checkbox/Radio/Switch**: Reduced margin between controls and effective space between indicator and label from 10px to 8px
- **Dialog**: Reduced footer padding (top, right, bottom) and action gap from 10px to 8px
- **MultistepDialog**: Reduced gap between step icon and title from 10px to 8px
- **EntityTitle**: Reduced gap between icon and text in H4/H5/H6 heading variants from 10px to 8px
- **FormGroup**: Reduced margin between label and content in `inline` variant from 10px to 12px
- **Hotkey**: Reduced margin between hotkeys from 10px to 8px
- **HTMLSelect**: Reduced horizontal padding from 10px to 8px
- **InputGroup/FileInput/NumericInput/SearchInput**: Reduced default horizontal padding from 10px to 8px
- **Menu**: Heading: reduced top padding from 10px to 8px, increased left padding from 6px to 8px
- **Navbar**: Reduced divider horizontal margin from 10px to 8px
- **NonIdealState**: Reduced heading bottom margin from 10px to 8px
- **Section**: Reduced gap between section icon and title from 10px to 8px
- **Tabs**: Reduced horizontal padding on `vertical` variant Tabs from 10px to 8px
- **Tag/CompoundTag**: Reduced large tag horizontal padding from 10px to 8px
- **TextArea**: Reduced padding from 10px to 8px
- **Tooltip**: Reduced vertical padding from 10px to 8px

### `@blueprintjs/table`

- **Table**: Reduced cell horizontal padding from 10px to 8px
- **Column header cell**: Reduced horizontal padding from 10px to 8px

## Reviewers should focus on

- Visual spacing consistency across affected components
- Ensuring the 4px grid alignment is maintained throughout
- Any unintended layout shifts