### PR TITLE
[FR] Add ensureParentOverflowVisible prop to prevent slider label clipping

### DIFF
--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -116,34 +116,34 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
         // Also include the styling that would normally come from .bp5-slider-handle .bp5-slider-label
         const style: React.CSSProperties = vertical
             ? {
-                  position: "fixed",
+                  // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
+                  background: "rgb(47, 51, 56)", // $dark-gray5
+                  borderRadius: "3px",
+                  boxShadow:
+                      "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
+                  color: "rgb(216, 219, 223)", // $light-gray5
+                  fontSize: "12px",
                   left: `${handleRect.right + labelOffset}px`,
+                  lineHeight: "1",
+                  padding: "4px 8px",
+                  position: "fixed",
                   top: `${handleRect.top + handleRect.height / 2}px`,
                   transform: "translateY(-50%)",
-                  // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
-                  background: "rgb(47, 51, 56)", // $dark-gray5
-                  borderRadius: "3px",
-                  boxShadow:
-                      "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
-                  color: "rgb(216, 219, 223)", // $light-gray5
-                  padding: "4px 8px",
-                  fontSize: "12px",
-                  lineHeight: "1",
               }
             : {
-                  position: "fixed",
-                  left: `${handleRect.left + handleRect.width / 2}px`,
-                  top: `${handleRect.top}px`,
-                  transform: `translate(-50%, ${labelOffset}px)`,
                   // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
                   background: "rgb(47, 51, 56)", // $dark-gray5
                   borderRadius: "3px",
                   boxShadow:
                       "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
                   color: "rgb(216, 219, 223)", // $light-gray5
-                  padding: "4px 8px",
                   fontSize: "12px",
+                  left: `${handleRect.left + handleRect.width / 2}px`,
                   lineHeight: "1",
+                  padding: "4px 8px",
+                  position: "fixed",
+                  top: `${handleRect.top}px`,
+                  transform: `translate(-50%, ${labelOffset}px)`,
               };
 
         return (

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -18,6 +18,7 @@ import classNames from "classnames";
 
 import { AbstractPureComponent, Classes, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
+import { Portal } from "../portal/portal";
 
 import type { HandleProps } from "./handleProps";
 import { formatPercentage } from "./sliderUtils";
@@ -34,6 +35,7 @@ export interface InternalHandleProps extends HandleProps {
     tickSize: number;
     tickSizeRatio: number;
     vertical: boolean;
+    usePortal?: boolean;
 }
 
 export interface HandleState {
@@ -65,29 +67,89 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
     }
 
     public render() {
-        const { className, disabled, label, min, max, value, vertical, htmlProps } = this.props;
+        const { className, disabled, label, min, max, value, vertical, htmlProps, usePortal } = this.props;
         const { isMoving } = this.state;
 
         return (
-            <span
-                role="slider"
-                tabIndex={0}
-                {...htmlProps}
-                className={classNames(Classes.SLIDER_HANDLE, { [Classes.ACTIVE]: isMoving }, className)}
-                onKeyDown={disabled ? undefined : this.handleKeyDown}
-                onKeyUp={disabled ? undefined : this.handleKeyUp}
-                onMouseDown={disabled ? undefined : this.beginHandleMovement}
-                onTouchStart={disabled ? undefined : this.beginHandleTouchMovement}
-                ref={this.refHandlers.handle}
-                style={this.getStyleProperties()}
-                aria-valuemin={min}
-                aria-valuemax={max}
-                aria-valuenow={value}
-                aria-disabled={disabled}
-                aria-orientation={vertical ? "vertical" : "horizontal"}
-            >
-                {label == null ? null : <span className={Classes.SLIDER_LABEL}>{label}</span>}
-            </span>
+            <>
+                <span
+                    role="slider"
+                    tabIndex={0}
+                    {...htmlProps}
+                    className={classNames(Classes.SLIDER_HANDLE, { [Classes.ACTIVE]: isMoving }, className)}
+                    onKeyDown={disabled ? undefined : this.handleKeyDown}
+                    onKeyUp={disabled ? undefined : this.handleKeyUp}
+                    onMouseDown={disabled ? undefined : this.beginHandleMovement}
+                    onTouchStart={disabled ? undefined : this.beginHandleTouchMovement}
+                    ref={this.refHandlers.handle}
+                    style={this.getStyleProperties()}
+                    aria-valuemin={min}
+                    aria-valuemax={max}
+                    aria-valuenow={value}
+                    aria-disabled={disabled}
+                    aria-orientation={vertical ? "vertical" : "horizontal"}
+                >
+                    {/* Only render label inline if not using portal */}
+                    {!usePortal && label != null && <span className={Classes.SLIDER_LABEL}>{label}</span>}
+                </span>
+                {/* Render label via portal if enabled */}
+                {usePortal && label != null && this.renderLabelPortal(label)}
+            </>
+        );
+    }
+
+    private renderLabelPortal(label: React.JSX.Element | string) {
+        if (this.handleElement == null) {
+            return null;
+        }
+
+        // Calculate the position of the label based on the handle's current position
+        const handleRect = this.handleElement.getBoundingClientRect();
+        const { vertical } = this.props;
+
+        // Position the label to match inline positioning
+        // Inline labels use: position: absolute; transform: translate(-50%, $label-offset)
+        // where $label-offset = $handle-size + $pt-spacing (16px + 4px = 20px)
+        // The transform is applied from the handle's position, so we need to calculate from handle's top
+        const labelOffset = 20; // matches $label-offset in SCSS
+
+        // Also include the styling that would normally come from .bp5-slider-handle .bp5-slider-label
+        const style: React.CSSProperties = vertical
+            ? {
+                position: "fixed",
+                left: `${handleRect.right + labelOffset}px`,
+                top: `${handleRect.top + handleRect.height / 2}px`,
+                transform: "translateY(-50%)",
+                // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
+                background: "rgb(47, 51, 56)", // $dark-gray5
+                borderRadius: "3px",
+                boxShadow: "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
+                color: "rgb(216, 219, 223)", // $light-gray5
+                padding: "4px 8px",
+                fontSize: "12px",
+                lineHeight: "1",
+            }
+            : {
+                position: "fixed",
+                left: `${handleRect.left + handleRect.width / 2}px`,
+                top: `${handleRect.top}px`,
+                transform: `translate(-50%, ${labelOffset}px)`,
+                // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
+                background: "rgb(47, 51, 56)", // $dark-gray5
+                borderRadius: "3px",
+                boxShadow: "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
+                color: "rgb(216, 219, 223)", // $light-gray5
+                padding: "4px 8px",
+                fontSize: "12px",
+                lineHeight: "1",
+            };
+
+        return (
+            <Portal>
+                <span className={Classes.SLIDER_LABEL} style={style}>
+                    {label}
+                </span>
+            </Portal>
         );
     }
 

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -18,7 +18,6 @@ import classNames from "classnames";
 
 import { AbstractPureComponent, Classes, Utils } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
-import { Portal } from "../portal/portal";
 
 import type { HandleProps } from "./handleProps";
 import { formatPercentage } from "./sliderUtils";
@@ -35,7 +34,7 @@ export interface InternalHandleProps extends HandleProps {
     tickSize: number;
     tickSizeRatio: number;
     vertical: boolean;
-    usePortal?: boolean;
+    ensureParentOverflowVisible?: boolean;
 }
 
 export interface HandleState {
@@ -55,9 +54,20 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
     };
 
     private handleElement: HTMLElement | null = null;
+    private sliderElement: HTMLElement | null = null;
+    private originalParentOverflow: string | null = null;
 
     private refHandlers = {
-        handle: (el: HTMLSpanElement) => (this.handleElement = el),
+        handle: (el: HTMLSpanElement) => {
+            this.handleElement = el;
+            // Find the slider parent when handle mounts
+            if (el && !this.sliderElement) {
+                this.sliderElement = el.closest(`.${Classes.SLIDER}`) as HTMLElement;
+                if (this.sliderElement && this.props.ensureParentOverflowVisible) {
+                    this.setParentOverflow();
+                }
+            }
+        },
     };
 
     public componentDidMount() {
@@ -67,96 +77,45 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
     }
 
     public render() {
-        const { className, disabled, label, min, max, value, vertical, htmlProps, usePortal } = this.props;
+        const { className, disabled, label, min, max, value, vertical, htmlProps } = this.props;
         const { isMoving } = this.state;
 
         return (
-            <>
-                <span
-                    role="slider"
-                    tabIndex={0}
-                    {...htmlProps}
-                    className={classNames(Classes.SLIDER_HANDLE, { [Classes.ACTIVE]: isMoving }, className)}
-                    onKeyDown={disabled ? undefined : this.handleKeyDown}
-                    onKeyUp={disabled ? undefined : this.handleKeyUp}
-                    onMouseDown={disabled ? undefined : this.beginHandleMovement}
-                    onTouchStart={disabled ? undefined : this.beginHandleTouchMovement}
-                    ref={this.refHandlers.handle}
-                    style={this.getStyleProperties()}
-                    aria-valuemin={min}
-                    aria-valuemax={max}
-                    aria-valuenow={value}
-                    aria-disabled={disabled}
-                    aria-orientation={vertical ? "vertical" : "horizontal"}
-                >
-                    {/* Only render label inline if not using portal */}
-                    {!usePortal && label != null && <span className={Classes.SLIDER_LABEL}>{label}</span>}
-                </span>
-                {/* Render label via portal if enabled */}
-                {usePortal && label != null && this.renderLabelPortal(label)}
-            </>
+            <span
+                role="slider"
+                tabIndex={0}
+                {...htmlProps}
+                className={classNames(Classes.SLIDER_HANDLE, { [Classes.ACTIVE]: isMoving }, className)}
+                onKeyDown={disabled ? undefined : this.handleKeyDown}
+                onKeyUp={disabled ? undefined : this.handleKeyUp}
+                onMouseDown={disabled ? undefined : this.beginHandleMovement}
+                onTouchStart={disabled ? undefined : this.beginHandleTouchMovement}
+                ref={this.refHandlers.handle}
+                style={this.getStyleProperties()}
+                aria-valuemin={min}
+                aria-valuemax={max}
+                aria-valuenow={value}
+                aria-disabled={disabled}
+                aria-orientation={vertical ? "vertical" : "horizontal"}
+            >
+                {label == null ? null : <span className={Classes.SLIDER_LABEL}>{label}</span>}
+            </span>
         );
     }
 
-    private renderLabelPortal(label: React.JSX.Element | string) {
-        if (this.handleElement == null) {
-            return null;
+    public componentDidUpdate(prevProps: InternalHandleProps) {
+        if (this.props.ensureParentOverflowVisible && !prevProps.ensureParentOverflowVisible) {
+            this.setParentOverflow();
+        } else if (!this.props.ensureParentOverflowVisible && prevProps.ensureParentOverflowVisible) {
+            this.restoreParentOverflow();
         }
-
-        // Calculate the position of the label based on the handle's current position
-        const handleRect = this.handleElement.getBoundingClientRect();
-        const { vertical } = this.props;
-
-        // Position the label to match inline positioning
-        // Inline labels use: position: absolute; transform: translate(-50%, $label-offset)
-        // where $label-offset = $handle-size + $pt-spacing (16px + 4px = 20px)
-        // The transform is applied from the handle's position, so we need to calculate from handle's top
-        const labelOffset = 20; // matches $label-offset in SCSS
-
-        // Also include the styling that would normally come from .bp5-slider-handle .bp5-slider-label
-        const style: React.CSSProperties = vertical
-            ? {
-                  // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
-                  background: "rgb(47, 51, 56)", // $dark-gray5
-                  borderRadius: "3px",
-                  boxShadow:
-                      "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
-                  color: "rgb(216, 219, 223)", // $light-gray5
-                  fontSize: "12px",
-                  left: `${handleRect.right + labelOffset}px`,
-                  lineHeight: "1",
-                  padding: "4px 8px",
-                  position: "fixed",
-                  top: `${handleRect.top + handleRect.height / 2}px`,
-                  transform: "translateY(-50%)",
-              }
-            : {
-                  // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
-                  background: "rgb(47, 51, 56)", // $dark-gray5
-                  borderRadius: "3px",
-                  boxShadow:
-                      "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
-                  color: "rgb(216, 219, 223)", // $light-gray5
-                  fontSize: "12px",
-                  left: `${handleRect.left + handleRect.width / 2}px`,
-                  lineHeight: "1",
-                  padding: "4px 8px",
-                  position: "fixed",
-                  top: `${handleRect.top}px`,
-                  transform: `translate(-50%, ${labelOffset}px)`,
-              };
-
-        return (
-            <Portal>
-                <span className={Classes.SLIDER_LABEL} style={style}>
-                    {label}
-                </span>
-            </Portal>
-        );
     }
 
     public componentWillUnmount() {
         this.removeDocumentEventListeners();
+        if (this.props.ensureParentOverflowVisible) {
+            this.restoreParentOverflow();
+        }
     }
 
     /** Convert client pixel to value between min and max. */
@@ -331,4 +290,40 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
         document.removeEventListener("touchend", this.endHandleTouchMovement);
         document.removeEventListener("touchcancel", this.endHandleTouchMovement);
     }
+
+    private setParentOverflow = () => {
+        if (!this.sliderElement?.parentElement) {
+            return;
+        }
+
+        const parent = this.sliderElement.parentElement;
+        const currentOverflow = window.getComputedStyle(parent).overflow;
+
+        // Only modify if parent has overflow hidden/auto/scroll
+        if (currentOverflow === "hidden" || currentOverflow === "auto" || currentOverflow === "scroll") {
+            // Store original value
+            this.originalParentOverflow = parent.style.overflow || currentOverflow;
+            // Set to visible
+            parent.style.overflow = "visible";
+        }
+    };
+
+    private restoreParentOverflow = () => {
+        if (!this.sliderElement?.parentElement || this.originalParentOverflow === null) {
+            return;
+        }
+
+        const parent = this.sliderElement.parentElement;
+        // Restore original overflow value
+        if (
+            this.originalParentOverflow === "hidden" ||
+            this.originalParentOverflow === "auto" ||
+            this.originalParentOverflow === "scroll"
+        ) {
+            parent.style.overflow = this.originalParentOverflow;
+        } else {
+            parent.style.removeProperty("overflow");
+        }
+        this.originalParentOverflow = null;
+    };
 }

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -55,7 +55,7 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
 
     private handleElement: HTMLElement | null = null;
     private sliderElement: HTMLElement | null = null;
-    private originalParentOverflow: string | null = null;
+    private modifiedElements: Array<{ element: HTMLElement; originalOverflow: string }> = [];
 
     private refHandlers = {
         handle: (el: HTMLSpanElement) => {
@@ -64,7 +64,8 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
             if (el && !this.sliderElement) {
                 this.sliderElement = el.closest(`.${Classes.SLIDER}`) as HTMLElement;
                 if (this.sliderElement && this.props.ensureParentOverflowVisible) {
-                    this.setParentOverflow();
+                    // Use setTimeout to ensure DOM is fully ready
+                    setTimeout(() => this.setParentOverflow(), 0);
                 }
             }
         },
@@ -292,38 +293,38 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
     }
 
     private setParentOverflow = () => {
-        if (!this.sliderElement?.parentElement) {
+        if (!this.sliderElement) {
             return;
         }
 
-        const parent = this.sliderElement.parentElement;
-        const currentOverflow = window.getComputedStyle(parent).overflow;
+        // Walk up the DOM tree and find all ancestors with overflow hidden/auto/scroll
+        let element: HTMLElement | null = this.sliderElement.parentElement;
+        while (element && element !== document.body) {
+            const computedStyle = window.getComputedStyle(element);
+            const currentOverflow = computedStyle.overflow;
 
-        // Only modify if parent has overflow hidden/auto/scroll
-        if (currentOverflow === "hidden" || currentOverflow === "auto" || currentOverflow === "scroll") {
-            // Store original value
-            this.originalParentOverflow = parent.style.overflow || currentOverflow;
-            // Set to visible
-            parent.style.overflow = "visible";
+            // Check if this element clips overflow
+            if (currentOverflow === "hidden" || currentOverflow === "auto" || currentOverflow === "scroll") {
+                // Store original value
+                const originalOverflow = element.style.overflow || currentOverflow;
+                this.modifiedElements.push({ element, originalOverflow });
+                // Set to visible
+                element.style.overflow = "visible";
+            }
+
+            element = element.parentElement;
         }
     };
 
     private restoreParentOverflow = () => {
-        if (!this.sliderElement?.parentElement || this.originalParentOverflow === null) {
-            return;
+        // Restore all modified elements
+        for (const { element, originalOverflow } of this.modifiedElements) {
+            if (originalOverflow === "hidden" || originalOverflow === "auto" || originalOverflow === "scroll") {
+                element.style.overflow = originalOverflow;
+            } else {
+                element.style.removeProperty("overflow");
+            }
         }
-
-        const parent = this.sliderElement.parentElement;
-        // Restore original overflow value
-        if (
-            this.originalParentOverflow === "hidden" ||
-            this.originalParentOverflow === "auto" ||
-            this.originalParentOverflow === "scroll"
-        ) {
-            parent.style.overflow = this.originalParentOverflow;
-        } else {
-            parent.style.removeProperty("overflow");
-        }
-        this.originalParentOverflow = null;
+        this.modifiedElements = [];
     };
 }

--- a/packages/core/src/components/slider/handle.tsx
+++ b/packages/core/src/components/slider/handle.tsx
@@ -116,33 +116,35 @@ export class Handle extends AbstractPureComponent<InternalHandleProps, HandleSta
         // Also include the styling that would normally come from .bp5-slider-handle .bp5-slider-label
         const style: React.CSSProperties = vertical
             ? {
-                position: "fixed",
-                left: `${handleRect.right + labelOffset}px`,
-                top: `${handleRect.top + handleRect.height / 2}px`,
-                transform: "translateY(-50%)",
-                // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
-                background: "rgb(47, 51, 56)", // $dark-gray5
-                borderRadius: "3px",
-                boxShadow: "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
-                color: "rgb(216, 219, 223)", // $light-gray5
-                padding: "4px 8px",
-                fontSize: "12px",
-                lineHeight: "1",
-            }
+                  position: "fixed",
+                  left: `${handleRect.right + labelOffset}px`,
+                  top: `${handleRect.top + handleRect.height / 2}px`,
+                  transform: "translateY(-50%)",
+                  // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
+                  background: "rgb(47, 51, 56)", // $dark-gray5
+                  borderRadius: "3px",
+                  boxShadow:
+                      "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
+                  color: "rgb(216, 219, 223)", // $light-gray5
+                  padding: "4px 8px",
+                  fontSize: "12px",
+                  lineHeight: "1",
+              }
             : {
-                position: "fixed",
-                left: `${handleRect.left + handleRect.width / 2}px`,
-                top: `${handleRect.top}px`,
-                transform: `translate(-50%, ${labelOffset}px)`,
-                // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
-                background: "rgb(47, 51, 56)", // $dark-gray5
-                borderRadius: "3px",
-                boxShadow: "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
-                color: "rgb(216, 219, 223)", // $light-gray5
-                padding: "4px 8px",
-                fontSize: "12px",
-                lineHeight: "1",
-            };
+                  position: "fixed",
+                  left: `${handleRect.left + handleRect.width / 2}px`,
+                  top: `${handleRect.top}px`,
+                  transform: `translate(-50%, ${labelOffset}px)`,
+                  // Tooltip-like styling from SCSS (lines 141-157 in _slider.scss)
+                  background: "rgb(47, 51, 56)", // $dark-gray5
+                  borderRadius: "3px",
+                  boxShadow:
+                      "0 0 0 1px rgba(17, 20, 24, 0.1), 0 2px 4px rgba(17, 20, 24, 0.2), 0 8px 24px rgba(17, 20, 24, 0.2)",
+                  color: "rgb(216, 219, 223)", // $light-gray5
+                  padding: "4px 8px",
+                  fontSize: "12px",
+                  lineHeight: "1",
+              };
 
         return (
             <Portal>

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -163,8 +163,8 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
         min: 0,
         showTrackFill: true,
         stepSize: 1,
-        vertical: false,
         useHandleLabelPortal: false,
+        vertical: false,
     };
 
     public static defaultProps: MultiSliderProps = {

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -119,6 +119,17 @@ export interface SliderBaseProps extends Props, IntentProps {
      * @default false
      */
     vertical?: boolean;
+
+    /**
+     * Whether to use a `Portal` to render the handle labels.
+     *
+     * This can be useful to prevent overflow issues in containers with `overflow: hidden`.
+     * When enabled, handle labels will render in a separate React root outside the DOM hierarchy,
+     * allowing them to break out of containers with overflow constraints.
+     *
+     * @default false
+     */
+    useHandleLabelPortal?: boolean;
 }
 
 export interface MultiSliderProps extends SliderBaseProps {
@@ -153,6 +164,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
         showTrackFill: true,
         stepSize: 1,
         vertical: false,
+        useHandleLabelPortal: false,
     };
 
     public static defaultProps: MultiSliderProps = {
@@ -320,7 +332,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
     }
 
     private renderHandles() {
-        const { disabled, max, min, stepSize, vertical } = this.props;
+        const { disabled, max, min, stepSize, vertical, useHandleLabelPortal } = this.props;
         const handleProps = getSortedInteractiveHandleProps(this.props);
 
         if (handleProps.length === 0) {
@@ -350,6 +362,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
                 tickSizeRatio={this.state.tickSizeRatio}
                 value={value}
                 vertical={vertical!}
+                usePortal={useHandleLabelPortal}
             />
         ));
     }

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -121,15 +121,12 @@ export interface SliderBaseProps extends Props, IntentProps {
     vertical?: boolean;
 
     /**
-     * Whether to use a `Portal` to render the handle labels.
-     *
-     * This can be useful to prevent overflow issues in containers with `overflow: hidden`.
-     * When enabled, handle labels will render in a separate React root outside the DOM hierarchy,
-     * allowing them to break out of containers with overflow constraints.
+     * Whether to programmatically set the slider's parent container to overflow: visible
+     * to prevent label clipping. This modifies the parent element's style directly.
      *
      * @default false
      */
-    useHandleLabelPortal?: boolean;
+    ensureParentOverflowVisible?: boolean;
 }
 
 export interface MultiSliderProps extends SliderBaseProps {
@@ -163,7 +160,6 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
         min: 0,
         showTrackFill: true,
         stepSize: 1,
-        useHandleLabelPortal: false,
         vertical: false,
     };
 
@@ -332,7 +328,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
     }
 
     private renderHandles() {
-        const { disabled, max, min, stepSize, vertical, useHandleLabelPortal } = this.props;
+        const { disabled, max, min, stepSize, vertical, ensureParentOverflowVisible } = this.props;
         const handleProps = getSortedInteractiveHandleProps(this.props);
 
         if (handleProps.length === 0) {
@@ -362,7 +358,7 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
                 tickSizeRatio={this.state.tickSizeRatio}
                 value={value}
                 vertical={vertical!}
-                usePortal={useHandleLabelPortal}
+                ensureParentOverflowVisible={ensureParentOverflowVisible}
             />
         ));
     }

--- a/packages/docs-app/src/examples/core-examples/sliderExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sliderExample.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from "react";
 
-import { Card, H5, Slider, Switch } from "@blueprintjs/core";
+import { Card, H3, H5, Slider, Switch } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 export const SliderExample: React.FC<ExampleProps> = props => {
@@ -73,6 +73,63 @@ export const SliderExample: React.FC<ExampleProps> = props => {
                     vertical={vertical}
                 />
             </Card>
+
+            {/* TODO: Remove this test section before merging PR - temporary demonstration of ensureParentOverflowVisible */}
+            <div style={{ marginTop: "40px" }}>
+                <H3 style={{ marginBottom: "10px" }}>Test: Slider in overflow container</H3>
+                <p style={{ color: "#666", fontSize: "14px", marginBottom: "20px" }}>
+                    Red box has overflow:hidden. Toggle "Ensure parent overflow visible" to test if
+                    labels escape.
+                </p>
+
+                <div
+                    style={{
+                        border: "2px solid red",
+                        height: "100px",
+                        marginBottom: "20px",
+                        overflow: "hidden",
+                        padding: "40px 20px",
+                    }}
+                >
+                    <p style={{ fontSize: "12px", marginBottom: "10px" }}>
+                        Without ensureParentOverflowVisible (label will clip):
+                    </p>
+                    <Slider
+                        handleHtmlProps={{ "aria-label": "overflow test without fix" }}
+                        labelStepSize={2500}
+                        max={10000}
+                        min={0}
+                        onChange={setValue1}
+                        stepSize={100}
+                        value={value1}
+                        vertical={vertical}
+                    />
+                </div>
+
+                <div
+                    style={{
+                        border: "2px solid green",
+                        height: "100px",
+                        overflow: "hidden",
+                        padding: "40px 20px",
+                    }}
+                >
+                    <p style={{ fontSize: "12px", marginBottom: "10px" }}>
+                        With ensureParentOverflowVisible (label escapes):
+                    </p>
+                    <Slider
+                        handleHtmlProps={{ "aria-label": "overflow test with fix" }}
+                        labelStepSize={2500}
+                        max={10000}
+                        min={0}
+                        onChange={setValue1}
+                        stepSize={100}
+                        value={value1}
+                        vertical={vertical}
+                        ensureParentOverflowVisible={true}
+                    />
+                </div>
+            </div>
         </Example>
     );
 };


### PR DESCRIPTION
#### Fixes [#6765](https://github.com/palantir/blueprint/issues/6765)

### Changes proposed in this pull request:

Added a new optional `useHandleLabelPortal` prop to `SliderBaseProps` that fixes an issue where slider handle labels (tooltips showing current values) get clipped when the slider is placed inside containers with `overflow: hidden`. This is particularly problematic with sliders that have large min/max ranges (e.g., -1,000,000 to 1,000,000) where the label text is wide.

### Technical implementation:
  - Added `ensureParentOverflowVisible?: boolean` prop to `SliderBaseProps` interface (defaults to `false` for backward
  compatibility)
  - Modified Handle component to programmatically set parent container's overflow style to visible when the prop is enabled
  - Walks up the DOM tree from the slider element to find all ancestor elements with `overflow: hidden/auto/scroll` and
  temporarily modifies them
  - Stores original overflow values and restores them when the prop is disabled or component unmounts
  - Works with all slider variants (`Slider`, `RangeSlider`, `MultiSlider`) and both orientations (horizontal, vertical)

### Files modified:
- `packages/core/src/components/slider/multiSlider.tsx` - Added prop definition and default value
- `packages/core/src/components/slider/handle.tsx` - Added DOM traversal logic to modify parent overflow styles

#### Screenshot

<img width="546" height="333" alt="Screenshot 2025-10-09 at 8 47 32 PM" src="https://github.com/user-attachments/assets/fe5e81de-4453-488d-a7da-9fa05bc26115" />