### PR TITLE
[1/3 Docs hackweek re-skin] feat: Docs layout

### DIFF
--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -6,6 +6,10 @@
 
 $banner-height: $pt-spacing * 10;
 
+export {
+  $banner-height: $banner-height;
+}
+
 // banner along top of screen linking to v2 docs
 .docs-banner {
   @include pt-flex-container(row);
@@ -16,7 +20,7 @@ $banner-height: $pt-spacing * 10;
   justify-content: center;
   left: 0;
   min-height: $banner-height;
-  padding: ($pt-spacing * 2.5) ($pt-spacing * 5);
+  padding: $pt-spacing * 3 $pt-spacing * 5;
 
   position: fixed;
   right: 0;

--- a/packages/docs-theme/src/styles/_code-example.scss
+++ b/packages/docs-theme/src/styles/_code-example.scss
@@ -8,20 +8,16 @@
 
 .docs-code-example {
   align-items: center;
-  background: $pt-app-secondary-background-color;
+  background-color: rgba($pt-app-elevated-background-color, 0.5);
+  border-radius: $pt-border-radius * 2;
+  border: 1px solid $light-gray3;
   border-radius: $pt-border-radius * 2;
   display: flex;
   justify-content: center;
   padding: $pt-spacing * 5;
 
   .#{$ns}-dark & {
-    background: $pt-dark-app-secondary-background-color;
+    background-color: rgba($pt-dark-app-background-color, 0.5);
+    border: 1px solid $dark-gray3;
   }
-}
-
-.docs-code-example-toolbar {
-  display: flex;
-  gap: 5px;
-  justify-content: flex-end;
-  padding-top: 10px;
 }

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -6,7 +6,7 @@
 @import "variables";
 
 $heading-margin: $pt-spacing * 10;
-$link-icon-padding: $pt-spacing * 2.5;
+$link-icon-padding: $pt-spacing * 3;
 
 $class-modifier-color: $rose4;
 $attribute-modifier-color: $violet5;
@@ -14,6 +14,8 @@ $attribute-modifier-color: $violet5;
 // title of a section
 .docs-title {
   margin: $heading-margin 0 ($heading-margin * 0.5);
+  overflow-wrap: break-word;
+  word-wrap: break-word;
   position: relative;
 
   // first heading (the h1 at the top) needs smaller top margin to avoid extra scrolling

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -3,7 +3,7 @@
 
 // Base styles for all examples
 
-$example-frame-spacing: $pt-spacing * 2.5;
+$example-frame-spacing: $pt-spacing * 3;
 $example-frame-border-radius: $pt-border-radius * 2;
 $example-spacing: $pt-spacing * 10;
 
@@ -16,18 +16,18 @@ $example-spacing: $pt-spacing * 10;
 
 // options to the right of example in same row
 .docs-example-frame-row {
-  @include pt-flex-container(row, $pt-spacing * 2.5, $fill: ".docs-example");
+  @include pt-flex-container(row, $pt-spacing * 3, $fill: ".docs-example");
 
   // option elements arranged vertically. use headings for grouping.
   .docs-example-options {
-    @include pt-flex-container(column, $pt-spacing * 2.5);
+    @include pt-flex-container(column, $pt-spacing * 3);
     max-width: $pt-spacing * 75;
   }
 }
 
 // options below example in its own row.
 .docs-example-frame-column {
-  @include pt-flex-container(column, $pt-spacing * 2.5, $fill: ".docs-example");
+  @include pt-flex-container(column, $pt-spacing * 3, $fill: ".docs-example");
 
   // option elements arranged horizontally. group controls into columns.
   .docs-example-options {
@@ -44,7 +44,7 @@ $example-spacing: $pt-spacing * 10;
 
 .docs-example {
   align-items: center;
-  background: $pt-app-secondary-background-color;
+  background-color: rgba($pt-app-elevated-background-color, 0.5);
   border-radius: $example-frame-border-radius;
   display: flex;
   flex: 1 1 auto;
@@ -54,9 +54,11 @@ $example-spacing: $pt-spacing * 10;
   // https://css-tricks.com/flexbox-truncated-text/#article-header-id-3
   min-width: 0;
   padding: $example-spacing * 0.5;
+  border: 1px solid $light-gray3;
 
   .#{$ns}-dark & {
-    background: $pt-dark-app-secondary-background-color;
+    background-color: rgba($pt-dark-app-background-color, 0.5);
+    border: 1px solid $dark-gray3;
   }
 
   > * {
@@ -72,7 +74,7 @@ $example-spacing: $pt-spacing * 10;
   text-align: left;
 
   .#{$ns}-heading:not(:first-child) {
-    margin-top: $pt-spacing * 2.5;
+    margin-top: $pt-spacing * 3;
   }
 
   .docs-prop-description {

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -12,9 +12,15 @@ $nav-item-color-active: $minimal-button-background-color-active;
 $dark-nav-item-color-hover: $dark-minimal-button-background-color-hover;
 $dark-nav-item-color-active: $dark-minimal-button-background-color-active;
 
+html {
+  // Single CSS variable for background color
+  background-color: var(--bp-docs-background-color);
+}
+
 body {
   // vertical scrollbar is always visible for the `.#{$ns}-overlay-open` padding (from `scrollbar.ts`)
   overflow-y: scroll;
+  background-color: inherit; // Inherit from html
 }
 
 /*
@@ -34,18 +40,32 @@ Page layout elements
 */
 
 .docs-root {
-  background-color: $pt-app-background-color;
-
-  &.#{$ns}-dark {
-    background-color: $pt-dark-app-background-color;
-  }
+  background-color: inherit; // Inherit from html
 }
 
 .docs-app {
   @include pt-flex-container(row);
-  margin: auto;
   max-width: $container-width;
+  width: 100%;
   min-height: 100vh;
+  position: relative;
+  display: grid;
+  grid-template-columns: $sidebar-width 1fr;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  column-gap: calc($pt-spacing * 4);
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: calc($pt-spacing * 16);
+  padding-top: $header-height;
+
+  &.banner {
+    min-height: calc(100vh - $banner-height);
+  }
+
+  .docs-banner + & {
+    padding-top: calc(#{$banner-height} + #{$header-height});
+  }
 }
 
 .docs-nav-wrapper {
@@ -56,56 +76,112 @@ Page layout elements
 
 .docs-nav {
   $background-shift: 999px;
-  background-color: $sidebar-background-color;
-  box-shadow: 1px 0 0 $pt-divider-black;
-  height: 100vh;
+  border-right: 1px solid $light-gray3;
 
   // these rules allow the nav background-color to cover all area to the left
   /* stylelint-disable-next-line order/properties-order */
   margin-left: -$background-shift;
   overflow: hidden auto;
-  padding-bottom: $sidebar-padding * 2;
   padding-left: $background-shift + $container-padding;
 
   position: fixed;
   width: $sidebar-width + $background-shift;
+  background-color: inherit; // Inherit from html
+
+  height: calc(100vh - #{$header-height});
+  top: $header-height;
 
   .#{$ns}-dark & {
-    background-color: $dark-sidebar-background-color;
-    box-shadow: 1px 0 0 $pt-dark-divider-black;
+    border-right: 1px solid $dark-gray3;
+  }
+
+  // Account for banner if present
+  .docs-banner + .docs-app & {
+    height: calc(100vh - #{$banner-height} - #{$header-height});
+    top: calc(#{$banner-height} + #{$header-height});
   }
 
   > * {
-    padding: $sidebar-padding;
+    padding: 0 $sidebar-padding * 3;
+    padding-top: $top-content-offset;
     padding-left: 0;
   }
 }
 
 .docs-content-wrapper {
-  align-items: flex-start;
-  background-color: $pt-app-background-color;
   flex-basis: $content-width;
   outline: none;
+  position: relative;
+  display: block;
+  min-height: 100%;
+  min-width: 0;
+  flex: 1;
+  overflow: visible;
+  background-color: inherit;
 
   .#{$ns}-dark & {
-    background-color: $pt-dark-app-background-color;
+    box-shadow: 1px 0 0 $pt-dark-divider-black;
   }
 }
 
-.docs-page {
-  max-width: $content-width;
-  padding-bottom: $content-padding * 2;
-  padding-left: $content-padding * 2;
-  padding-right: $container-padding;
-  /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
-  padding-top: 0;
+.docs-page-scroll-gradient {
+  position: fixed;
+  left: 0;
+  right: 0;
+  height: calc($top-content-offset - 5px);
+  z-index: 2;
+  pointer-events: none; // Allow clicking through
+
+  &.docs-page-scroll-gradient-top {
+    top: $header-height;
+    background-image: linear-gradient(
+      to top,
+      transparent,
+      color-mix(in srgb, var(--bp-docs-background-color) 60%, transparent) 80%
+    );
+
+    // Adjust position when banner is present
+    .docs-banner + .docs-app & {
+      top: calc(#{$banner-height} + #{$header-height});
+    }
+  }
+
+  &.docs-page-scroll-gradient-bottom {
+    bottom: 0;
+    background-image: linear-gradient(
+      to bottom,
+      transparent,
+      color-mix(in srgb, var(--bp-docs-background-color) 60%, transparent) 80%
+    );
+  }
+}
+
+.docs-content-with-toc {
+  gap: $pt-spacing * 12;
+  display: flex;
   position: relative;
+  min-width: 0;
+  padding-left: $pt-spacing * 12;
+}
+
+.docs-page {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  max-width: calc($pt-spacing * 188);
+  margin-top: $header-height;
+  padding-left: $pt-spacing * 12;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  gap: calc($pt-spacing * 12);
 }
 
 .docs-page-actions {
   position: absolute;
   right: 0;
-  top: $container-padding;
+  top: $top-content-offset + $container-padding;
   // above h1 heading
   z-index: 1;
 }
@@ -118,7 +194,7 @@ Lefthand navigation menu
   .#{$ns}-menu-item {
     align-items: center;
     padding-left: 0;
-    padding-right: $pt-spacing * 2.5;
+    padding-right: $pt-spacing * 3;
     white-space: initial;
 
     &:hover,

--- a/packages/docs-theme/src/styles/_navbar.scss
+++ b/packages/docs-theme/src/styles/_navbar.scss
@@ -4,7 +4,7 @@
 @import "variables";
 @import "../../../core/src/components/button/common";
 
-$nav-divider-offset: $pt-spacing * 12.5;
+$nav-divider-offset: $pt-spacing * 12;
 
 @mixin divider-gradient($color, $dark-color) {
   background-image: linear-gradient(to right, rgba($color, 0) 0%, $color 40%);
@@ -15,13 +15,13 @@ $nav-divider-offset: $pt-spacing * 12.5;
 }
 
 .docs-nav-button {
-  @include pt-flex-container(row, ($pt-spacing * 2.5) + $pt-spacing);
+  @include pt-flex-container(row, $pt-spacing * 4);
   align-items: center;
   cursor: pointer;
 
   margin-left: -$nav-divider-offset;
-  padding: ($pt-spacing * 2.5) $sidebar-padding;
-  padding-left: $nav-divider-offset + $pt-spacing;
+  padding: $pt-spacing * 3 $sidebar-padding;
+  padding-left: $nav-divider-offset + 4px;
 
   &:hover {
     @include divider-gradient($pt-app-background-color, $pt-dark-app-background-color);

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -5,13 +5,20 @@
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/core/src/common/mixins";
 
-$container-width: $pt-spacing * 275;
-$container-padding: $pt-spacing;
+$container-width: $pt-spacing * 320;
+$container-padding: $pt-spacing * 1;
+$top-content-offset: $pt-spacing * 10;
 
-$sidebar-width: $pt-spacing * 75;
-$sidebar-padding: $pt-spacing * 4;
+$sidebar-width: $pt-spacing * 62;
+$sidebar-padding: $pt-spacing * 6;
 $sidebar-background-color: $white;
+$header-height: $pt-spacing * 15;
 $dark-sidebar-background-color: $dark-gray3;
 
-$content-width: $container-width - $sidebar-width;
+$content-width: $container-width - ($sidebar-width * 2);
 $content-padding: $pt-spacing * 5;
+
+html {
+  --bp-docs-background-color: #{$pt-app-secondary-background-color};
+  --bp-docs-divider-color: #{$light-gray2};
+}


### PR DESCRIPTION
Refactor docs layout.

Key changes:
- Add CSS variable for consistent background color across html/body
- Convert .docs-app to CSS Grid with fixed sidebar width
- Add proper min-width: 0 constraints to allow content wrapping
- Add overflow-wrap: break-word to titles and content
- Position sidebar and nav with fixed positioning relative to header
- Add proper spacing variables and remove old sidebar padding
- Update content area to use flexbox with proper constraints
- Add border styling for light/dark theme consistency

#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
