### PR TITLE
[2/2 Docs hackweek re-skin] feat: Docs TOC

### DIFF
--- a/packages/docs-app/src/components/welcome.tsx
+++ b/packages/docs-app/src/components/welcome.tsx
@@ -47,7 +47,7 @@ const WelcomeCard: React.FC<{
     sameTab?: boolean;
 }> = props => (
     <a className="blueprint-welcome-card" href={props.href} target={props.sameTab ? "" : "_blank"}>
-        <Card interactive={true}>
+        <Card interactive={true} compact={true} className="blueprint-welcome-card">
             <Icon icon={props.icon} size={40} />
             <H4>{props.title}</H4>
             {props.children}

--- a/packages/docs-app/src/styles/_welcome.scss
+++ b/packages/docs-app/src/styles/_welcome.scss
@@ -2,11 +2,11 @@
 
 .blueprint-welcome {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: $pt-spacing * 2;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  justify-content: center;
   margin: ($content-padding * 2) 0;
   text-align: center;
-  justify-content: center;
 
   .blueprint-welcome-card {
     flex-grow: 1;

--- a/packages/docs-app/src/styles/_welcome.scss
+++ b/packages/docs-app/src/styles/_welcome.scss
@@ -1,10 +1,12 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 
 .blueprint-welcome {
-  @include pt-flex-container(row, $content-padding);
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: $pt-spacing * 2;
   margin: ($content-padding * 2) 0;
   text-align: center;
+  justify-content: center;
 
   .blueprint-welcome-card {
     flex-grow: 1;

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -371,7 +371,9 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
             if (this.state.activePageId === activePageId) {
                 scrollToHeading("smooth");
             } else {
-                this.setState({ activePageId, activeSectionId, isNavigatorOpen: false }, () => scrollToHeading("instant"));
+                this.setState({ activePageId, activeSectionId, isNavigatorOpen: false }, () =>
+                    scrollToHeading("instant"),
+                );
             }
         }
     };

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -352,7 +352,7 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
         // only update state if this section reference is valid
         const activePageId = this.routeToPage[activeSectionId];
         if (activeSectionId !== undefined && activePageId !== undefined) {
-            this.setState({ activePageId, activeSectionId, isNavigatorOpen: false }, () => {
+            const scrollToHeading = (behavior: "smooth" | "instant") => {
                 // Scroll to the heading after React finishes rendering
                 requestAnimationFrame(() => {
                     const headingElement = document.getElementById(activeSectionId);
@@ -360,11 +360,19 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
                         const scrollParent = this.props.scrollParent ?? document.documentElement;
                         const offsetPosition = headingElement.offsetTop - HEADING_IN_VIEW_THRESHOLD;
                         scrollParent.scrollTo({
+                            behavior,
                             top: offsetPosition,
                         });
                     }
                 });
-            });
+            };
+
+            // If we're on the same page, just scroll. Otherwise update state first.
+            if (this.state.activePageId === activePageId) {
+                scrollToHeading("smooth");
+            } else {
+                this.setState({ activePageId, activeSectionId, isNavigatorOpen: false }, () => scrollToHeading("instant"));
+            }
         }
     };
 

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -44,6 +44,8 @@ import { NavMenu } from "./navMenu";
 import type { NavMenuItemProps } from "./navMenuItem";
 import { Page } from "./page";
 import { addScrollbarStyle } from "./scrollbar";
+import { HEADING_IN_VIEW_THRESHOLD, HeadingRegistryProvider } from "./toc/headingRegistry";
+import { TOCContainer, TOCContent, TOCItems } from "./toc/TOC";
 import { ApiLink } from "./typescript/apiLink";
 
 export interface DocumentationProps extends Props {
@@ -139,15 +141,6 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
     /** Map of section route to containing page reference. */
     private routeToPage: { [route: string]: string };
 
-    private contentElement: HTMLElement | null = null;
-
-    private navElement: HTMLElement | null = null;
-
-    private refHandlers = {
-        content: (ref: HTMLElement | null) => (this.contentElement = ref),
-        nav: (ref: HTMLElement | null) => (this.navElement = ref),
-    };
-
     public constructor(props: DocumentationProps) {
         super(props);
         this.state = {
@@ -187,89 +180,100 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
 
         return (
             <DocumentationContext.Provider value={this.getDocumentationContextApi()}>
-                <HotkeysTarget
-                    hotkeys={[
-                        {
-                            combo: "shift+s",
-                            global: true,
-                            group: "Navigation (global)",
-                            label: "Open navigator",
-                            onKeyDown: this.handleOpenNavigator,
-                            preventDefault: true,
-                        },
-                        {
-                            combo: "[",
-                            global: true,
-                            group: "Navigation (global)",
-                            label: "Previous section",
-                            onKeyDown: this.handlePreviousSection,
-                        },
-                        {
-                            combo: "]",
-                            global: true,
-                            group: "Navigation (global)",
-                            label: "Next section",
-                            onKeyDown: this.handleNextSection,
-                        },
-                    ]}
-                >
-                    <div className={rootClasses}>
-                        {this.props.banner}
-                        <div className="docs-app">
-                            <Header>
-                                <HeaderLeft>{this.props.header}</HeaderLeft>
-                                <HeaderCenter>
-                                    <HeaderSearch onClick={this.handleOpenNavigator} />
-                                </HeaderCenter>
-                                <HeaderRight>
-                                    <HeaderThemeToggle
-                                        isDarkThemeEnabled={isDarkTheme}
-                                        onToggle={this.props.onThemeToggle}
-                                    />
-                                    <HeaderGitHubLink />
-                                </HeaderRight>
-                            </Header>
-                            <div className="docs-nav-wrapper" role="navigation">
-                                <div className="docs-nav" ref={this.refHandlers.nav}>
-                                    <NavMenu
-                                        activePageId={activePageId}
-                                        activeSectionId={activeSectionId}
-                                        items={nav}
-                                        level={0}
-                                        onItemClick={this.handleNavigation}
-                                        renderNavMenuItem={this.props.renderNavMenuItem}
-                                    />
-                                    {this.props.footer}
+                <HeadingRegistryProvider>
+                    <HotkeysTarget
+                        hotkeys={[
+                            {
+                                combo: "shift+s",
+                                global: true,
+                                group: "Navigation (global)",
+                                label: "Open navigator",
+                                onKeyDown: this.handleOpenNavigator,
+                                preventDefault: true,
+                            },
+                            {
+                                combo: "[",
+                                global: true,
+                                group: "Navigation (global)",
+                                label: "Previous section",
+                                onKeyDown: this.handlePreviousSection,
+                            },
+                            {
+                                combo: "]",
+                                global: true,
+                                group: "Navigation (global)",
+                                label: "Next section",
+                                onKeyDown: this.handleNextSection,
+                            },
+                        ]}
+                    >
+                        <div className={rootClasses}>
+                            {this.props.banner}
+                            <div className="docs-app">
+                                <Header>
+                                    <HeaderLeft>{this.props.header}</HeaderLeft>
+                                    <HeaderCenter>
+                                        <HeaderSearch onClick={this.handleOpenNavigator} />
+                                    </HeaderCenter>
+                                    <HeaderRight>
+                                        <HeaderThemeToggle
+                                            isDarkThemeEnabled={isDarkTheme}
+                                            onToggle={this.props.onThemeToggle}
+                                        />
+                                        <HeaderGitHubLink />
+                                    </HeaderRight>
+                                </Header>
+                                <div className="docs-nav-wrapper" role="navigation">
+                                    <div className="docs-nav">
+                                        <NavMenu
+                                            activePageId={activePageId}
+                                            activeSectionId={activeSectionId}
+                                            items={nav}
+                                            level={0}
+                                            onItemClick={this.handleNavigation}
+                                            renderNavMenuItem={this.props.renderNavMenuItem}
+                                        />
+                                        {this.props.footer}
+                                    </div>
                                 </div>
-                            </div>
-                            <main
-                                className={classNames("docs-content-wrapper", Classes.FILL)}
-                                ref={this.refHandlers.content}
-                                role="main"
-                            >
-                                <Page
-                                    page={pages[activePageId]!}
-                                    renderActions={this.props.renderPageActions}
-                                    tagRenderers={this.props.tagRenderers}
+                                <main className="docs-content-wrapper" role="main">
+                                    <div className="docs-page-scroll-gradient docs-page-scroll-gradient-top" />
+                                    <div className="docs-page-scroll-gradient docs-page-scroll-gradient-bottom" />
+                                    <div className="docs-content-with-toc">
+                                        <Page
+                                            page={pages[activePageId]!}
+                                            renderActions={this.props.renderPageActions}
+                                            tagRenderers={this.props.tagRenderers}
+                                            className={classNames({ banner: !!this.props.banner })}
+                                        />
+                                        <TOCContainer
+                                            className={classNames({ banner: !!this.props.banner })}
+                                            isDarkThemeEnabled={isDarkTheme}
+                                        >
+                                            <TOCContent>
+                                                <TOCItems key={activePageId} />
+                                            </TOCContent>
+                                        </TOCContainer>
+                                    </div>
+                                </main>
+                                <Drawer
+                                    className={apiClasses}
+                                    isOpen={isApiBrowserOpen}
+                                    onClose={this.handleApiBrowserClose}
+                                >
+                                    <TypescriptExample tag="typescript" value={activeApiMember} />
+                                </Drawer>
+                                <Navigator
+                                    isOpen={this.state.isNavigatorOpen}
+                                    items={nav}
+                                    itemExclude={this.props.navigatorExclude}
+                                    onClose={this.handleCloseNavigator}
+                                    useDarkTheme={isDarkTheme}
                                 />
-                            </main>
-                            <Drawer
-                                className={apiClasses}
-                                isOpen={isApiBrowserOpen}
-                                onClose={this.handleApiBrowserClose}
-                            >
-                                <TypescriptExample tag="typescript" value={activeApiMember} />
-                            </Drawer>
-                            <Navigator
-                                isOpen={this.state.isNavigatorOpen}
-                                items={nav}
-                                itemExclude={this.props.navigatorExclude}
-                                onClose={this.handleCloseNavigator}
-                                useDarkTheme={isDarkTheme}
-                            />
+                            </div>
                         </div>
-                    </div>
-                </HotkeysTarget>
+                    </HotkeysTarget>
+                </HeadingRegistryProvider>
             </DocumentationContext.Provider>
         );
     }
@@ -278,28 +282,35 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
         addScrollbarStyle();
         this.updateHash();
         FocusStyleManager.onlyShowFocusOnTabs();
-        this.scrollToActiveSection();
         this.props.onComponentUpdate?.(this.state.activePageId);
+
+        // Apply dark theme class to HTML element if needed
+        this.updateHtmlThemeClass();
+
         // whoa handling future history...
         window.addEventListener("hashchange", this.handleHashChange);
-        document.addEventListener("scroll", this.handleScroll);
-        requestAnimationFrame(() => this.maybeScrollToActivePageMenuItem());
+    }
+
+    private updateHtmlThemeClass() {
+        // Check if dark theme is applied to the root element
+        const isDarkTheme = document.body.classList.contains(Classes.DARK);
+
+        // Apply or remove the dark theme class from the HTML element
+        if (isDarkTheme) {
+            document.documentElement.classList.add(Classes.DARK);
+        } else {
+            document.documentElement.classList.remove(Classes.DARK);
+        }
     }
 
     public componentWillUnmount() {
         window.removeEventListener("hashchange", this.handleHashChange);
-        document.removeEventListener("scroll", this.handleScroll);
     }
 
-    public componentDidUpdate(_prevProps: DocumentationProps, prevState: DocumentationState) {
+    public componentDidUpdate(_prevProps: DocumentationProps) {
         const { activePageId } = this.state;
-
-        // only scroll to heading when switching pages, but always check if nav item needs scrolling.
-        if (prevState.activePageId !== activePageId) {
-            this.scrollToActiveSection();
-            this.maybeScrollToActivePageMenuItem();
-        }
-
+        // Update HTML theme class in case it changed
+        this.updateHtmlThemeClass();
         this.props.onComponentUpdate?.(activePageId);
     }
 
@@ -343,49 +354,25 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
         // only update state if this section reference is valid
         const activePageId = this.routeToPage[activeSectionId];
         if (activeSectionId !== undefined && activePageId !== undefined) {
-            this.setState({ activePageId, activeSectionId, isNavigatorOpen: false });
-            this.scrollToActiveSection();
+            this.setState({ activePageId, activeSectionId, isNavigatorOpen: false }, () => {
+                // Scroll to the heading after React finishes rendering
+                requestAnimationFrame(() => {
+                    const headingElement = document.getElementById(activeSectionId);
+                    if (headingElement != null) {
+                        const scrollParent = this.props.scrollParent ?? document.documentElement;
+                        const offsetPosition = headingElement.offsetTop - HEADING_IN_VIEW_THRESHOLD;
+                        scrollParent.scrollTo({
+                            top: offsetPosition,
+                        });
+                    }
+                });
+            });
         }
     };
 
     private handleNextSection = () => this.shiftSection(1);
 
     private handlePreviousSection = () => this.shiftSection(-1);
-
-    private handleScroll = () => {
-        const activeSectionId = getScrolledReference(100, this.props.scrollParent);
-        if (activeSectionId == null) {
-            return;
-        }
-        // use the longer (deeper) name to avoid jumping up between sections
-        this.setState({ activeSectionId });
-    };
-
-    private maybeScrollToActivePageMenuItem() {
-        if (this.navElement == null) {
-            return;
-        }
-
-        const { activeSectionId } = this.state;
-        // only scroll nav menu if active item is not visible in viewport.
-        // using activeSectionId so you can see the page title in nav (may not be visible in document).
-        const navItemElement = this.navElement.querySelector<HTMLElement>(`a[href="#${activeSectionId}"]`);
-        if (navItemElement == null) {
-            return;
-        }
-
-        const scrollOffset = navItemElement.offsetTop - this.navElement.scrollTop;
-        if (scrollOffset < 0 || scrollOffset > this.navElement.offsetHeight) {
-            // reveal two items above this item in list
-            this.navElement.scrollTop = navItemElement.offsetTop - navItemElement.offsetHeight * 2;
-        }
-    }
-
-    private scrollToActiveSection() {
-        if (this.contentElement != null) {
-            scrollToReference(this.state.activeSectionId, this.props.scrollParent);
-        }
-    }
 
     private shiftSection(direction: 1 | -1) {
         // use the current hash instead of `this.state.activeSectionId` to avoid cases where the
@@ -403,43 +390,6 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
         this.setState({ activeApiMember, isApiBrowserOpen: true });
 
     private handleApiBrowserClose = () => this.setState({ isApiBrowserOpen: false });
-}
-
-/** Shorthand for element.querySelector() + cast to HTMLElement */
-function queryHTMLElement(parent: Element, selector: string) {
-    return parent.querySelector<HTMLElement>(selector);
-}
-
-/**
- * Returns the reference of the closest section within `offset` pixels of the top of the viewport.
- */
-function getScrolledReference(offset: number, scrollContainer: HTMLElement = document.documentElement) {
-    const headings = Array.from(scrollContainer.querySelectorAll<HTMLElement>(".docs-title"));
-    while (headings.length > 0) {
-        // iterating in reverse order (popping from end / bottom of page)
-        // so the first element below the threshold is the one we want.
-        const element = headings.pop();
-        if (element && element.offsetTop < scrollContainer.scrollTop + offset) {
-            // relying on DOM structure to get reference
-            return element.querySelector("[data-route]")?.getAttribute("data-route");
-        }
-    }
-    return undefined;
-}
-
-/**
- * Scroll the scroll container such that the reference heading appears at the top of the viewport.
- */
-function scrollToReference(reference: string, scrollContainer: HTMLElement = document.documentElement) {
-    // without rAF, on initial load this would scroll to the bottom because the CSS had not been applied.
-    // with rAF, CSS is applied before updating scroll positions so all elements are in their correct places.
-    requestAnimationFrame(() => {
-        const headingAnchor = queryHTMLElement(scrollContainer, `a[data-route="${reference}"]`);
-        if (headingAnchor != null && headingAnchor.parentElement != null) {
-            const scrollOffset = headingAnchor.parentElement!.offsetTop + headingAnchor.offsetTop;
-            scrollContainer.scrollTop = scrollOffset;
-        }
-    });
 }
 
 type TypeRenderer = (type: string) => React.ReactNode;

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -237,8 +237,6 @@ export class Documentation extends PureComponent<DocumentationProps, Documentati
                                     </div>
                                 </div>
                                 <main className="docs-content-wrapper" role="main">
-                                    <div className="docs-page-scroll-gradient docs-page-scroll-gradient-top" />
-                                    <div className="docs-page-scroll-gradient docs-page-scroll-gradient-bottom" />
                                     <div className="docs-content-with-toc">
                                         <Page
                                             page={pages[activePageId]!}

--- a/packages/docs-theme/src/components/headerActions.tsx
+++ b/packages/docs-theme/src/components/headerActions.tsx
@@ -60,8 +60,9 @@ export const HeaderThemeToggle: React.FC<{
             <Button
                 icon={isDarkThemeEnabled ? "flash" : "moon"}
                 onClick={handleToggle}
+                variant="minimal"
                 title={`Switch to ${isDarkThemeEnabled ? "light" : "dark"} theme (Shift+D)`}
-                text={<span className={Classes.TEXT_MUTED}>⇧D</span>}
+                text={<span className={Classes.TEXT_DISABLED}>⇧D</span>}
             />
         </HotkeysTarget>
     );

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -34,29 +34,31 @@ export interface NavMenuProps extends Props {
 
 export const NavMenu: React.FC<NavMenuProps> = props => {
     const { renderNavMenuItem = NavMenuItem } = props;
-    const menu = props.items.map(section => {
-        const isActive = props.activeSectionId === section.route;
-        const isExpanded = isActive || isParentOfRoute(section.route, props.activeSectionId);
-        // active section gets selected styles, expanded section shows its children
-        const itemClasses = classNames(`depth-${section.level - props.level - 1}`, {
-            "docs-nav-expanded": isExpanded,
-            [Classes.ACTIVE]: isActive,
+    const menu = props.items
+        .filter(section => isPageNode(section))
+        .map(section => {
+            const isActive = props.activeSectionId === section.route;
+            const isExpanded = isActive || isParentOfRoute(section.route, props.activeSectionId);
+            // active section gets selected styles, expanded section shows its children
+            const itemClasses = classNames(`depth-${section.level - props.level - 1}`, {
+                "docs-nav-expanded": isExpanded,
+                [Classes.ACTIVE]: isActive,
+            });
+            const item = renderNavMenuItem({
+                className: itemClasses,
+                href: "#" + section.route,
+                isActive,
+                isExpanded,
+                onClick: () => props.onItemClick(section.route),
+                section,
+            });
+            return (
+                <li key={section.route}>
+                    {item}
+                    {isPageNode(section) ? <NavMenu {...props} level={section.level} items={section.children} /> : null}
+                </li>
+            );
         });
-        const item = renderNavMenuItem({
-            className: itemClasses,
-            href: "#" + section.route,
-            isActive,
-            isExpanded,
-            onClick: () => props.onItemClick(section.route),
-            section,
-        });
-        return (
-            <li key={section.route}>
-                {item}
-                {isPageNode(section) ? <NavMenu {...props} level={section.level} items={section.children} /> : null}
-            </li>
-        );
-    });
     const classes = classNames("docs-nav-menu", Classes.LIST_UNSTYLED, props.className);
     return <ul className={classes}>{menu}</ul>;
 };

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -34,10 +34,10 @@ export interface NavMenuProps extends Props {
 
 export const NavMenu: React.FC<NavMenuProps> = props => {
     const { renderNavMenuItem = NavMenuItem } = props;
-    
+
     // Filter out heading nodes - only include page nodes
     const filteredItems = props.items.filter(item => isPageNode(item));
-    
+
     const menu = filteredItems.map(section => {
         const isActive = props.activeSectionId === section.route;
         const isExpanded = isActive || isParentOfRoute(section.route, props.activeSectionId);

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -15,9 +15,12 @@
  */
 
 import type { PageData } from "@documentalist/client";
+import classNames from "classnames";
+import { forwardRef } from "react";
 
 import { Classes } from "@blueprintjs/core";
 
+import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 import type { TagRendererMap } from "../tags";
 
 import { renderBlock } from "./block";
@@ -26,15 +29,18 @@ export interface PageProps {
     page: PageData;
     renderActions?: (page: PageData) => React.ReactNode;
     tagRenderers: TagRendererMap;
+    className?: string;
 }
 
-export const Page: React.FC<PageProps> = ({ page, renderActions, tagRenderers }) => {
-    // apply running text styles to blocks in pages (but not on blocks in examples)
+export const Page = forwardRef<HTMLDivElement, PageProps>(({ page, renderActions, tagRenderers, className }, ref) => {
     const pageContents = renderBlock(page, tagRenderers, Classes.TEXT_LARGE);
     return (
-        <div className="docs-page" data-page-id={page.route}>
-            {renderActions && <div className="docs-page-actions">{renderActions(page)}</div>}
+        <div className="docs-page" data-page-id={page.route} ref={ref}>
+            {renderActions != null && (
+                <div className={classNames("docs-page-actions", className)}>{renderActions(page)}</div>
+            )}
             {pageContents}
         </div>
     );
-};
+});
+Page.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.Page`;

--- a/packages/docs-theme/src/components/toc/TOC.tsx
+++ b/packages/docs-theme/src/components/toc/TOC.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import classNames from "classnames";
+import { forwardRef, type PropsWithChildren, useCallback, useMemo } from "react";
+
+import { Classes } from "@blueprintjs/core";
+
+import { type HeadingData, useHeadingRegistry } from "./headingRegistry";
+import { useTOCActiveItem } from "./useTOCActiveItem";
+
+export const TOCContainer = forwardRef<
+    HTMLDivElement,
+    PropsWithChildren<{
+        className?: string;
+        title?: React.ReactNode;
+        isDarkThemeEnabled?: boolean;
+    }>
+>(({ title = "On this page", children, isDarkThemeEnabled, className }, ref) => {
+    return (
+        <aside
+            ref={ref}
+            className={classNames("docs-toc-container", { [Classes.DARK]: isDarkThemeEnabled, className })}
+            aria-label="Table of contents"
+            role="navigation"
+        >
+            <div className="docs-toc">
+                {title && (
+                    <div className="docs-toc-header" aria-hidden="true">
+                        {title}
+                    </div>
+                )}
+                {children}
+            </div>
+        </aside>
+    );
+});
+
+TOCContainer.displayName = "TOCContainer";
+
+export const TOCContent = forwardRef<HTMLDivElement, PropsWithChildren>(({ children }, ref) => {
+    return (
+        <div ref={ref} className={"docs-toc-scroll-area"}>
+            {children}
+        </div>
+    );
+});
+
+TOCContent.displayName = "TOCContent";
+
+// TOC Items Component
+
+export const TOCItems = () => {
+    const { headings } = useHeadingRegistry();
+
+    const sortedHeadings = useMemo(() => {
+        return [...headings].sort((a, b) => {
+            const position = a.element.compareDocumentPosition(b.element);
+            // eslint-disable-next-line no-bitwise
+            if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+                return -1;
+            }
+            // eslint-disable-next-line no-bitwise
+            if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+                return 1;
+            }
+            return 0;
+        });
+    }, [headings]);
+
+    const routes = useMemo(() => sortedHeadings.map(h => h.route), [sortedHeadings]);
+    const { activeAnchor, handleTocItemClick } = useTOCActiveItem(routes);
+
+    if (sortedHeadings.length === 0) {
+        return (
+            <div className={classNames("docs-toc-empty", Classes.TEXT_MUTED)} role="status">
+                No headings
+            </div>
+        );
+    }
+
+    return (
+        <nav className="docs-toc-items" aria-label="Page sections">
+            {sortedHeadings.map((heading, index) => (
+                <TOCItem
+                    key={heading.route}
+                    heading={heading}
+                    isActive={activeAnchor == null ? index === 0 : activeAnchor === heading.route}
+                    onItemClick={handleTocItemClick}
+                />
+            ))}
+        </nav>
+    );
+};
+
+TOCItems.displayName = "TOCItems";
+
+const TOCItem: React.FC<{
+    heading: HeadingData;
+    isActive: boolean;
+    onItemClick: (route: string) => void;
+}> = ({ heading, isActive, onItemClick }) => {
+    const handleClick = useCallback(
+        (e: React.MouseEvent<HTMLAnchorElement>) => {
+            e.preventDefault();
+            onItemClick(heading.route);
+        },
+        [heading.route, onItemClick],
+    );
+
+    return (
+        <a
+            href={heading.url}
+            className={classNames("docs-toc-item", {
+                "docs-toc-active": isActive,
+                "docs-toc-level-1": heading.depth <= 1,
+                "docs-toc-level-2": heading.depth === 2,
+                "docs-toc-level-3": heading.depth === 3,
+                "docs-toc-level-4": heading.depth >= 4,
+            })}
+            aria-current={isActive ? "location" : undefined}
+            aria-level={heading.depth}
+            data-active={isActive}
+            data-route={heading.route}
+            onClick={handleClick}
+        >
+            {heading.title}
+        </a>
+    );
+};

--- a/packages/docs-theme/src/components/toc/headingRegistry.tsx
+++ b/packages/docs-theme/src/components/toc/headingRegistry.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, type RefObject, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+/** Threshold for detecting scroll at top of page */
+export const SCROLL_TOP_THRESHOLD = 10;
+
+/** Threshold for considering a heading "in view" (scroll offset + buffer) */
+export const HEADING_IN_VIEW_THRESHOLD = 50;
+
+export interface HeadingData {
+    depth: number;
+    element: HTMLElement;
+    route: string;
+    title: string;
+    url: string;
+}
+
+interface HeadingRegistryContextValue {
+    getHeadingElement: (route: string) => HTMLElement | undefined;
+    headings: HeadingData[];
+    registerHeading: (route: string, element: HTMLElement, data: Omit<HeadingData, "element">) => void;
+    scrollToHeading: (route: string) => void;
+    unregisterHeading: (route: string) => void;
+}
+
+const HeadingRegistryContext = createContext<HeadingRegistryContextValue | undefined>(undefined);
+
+export const HeadingRegistryProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [headingsMap, setHeadingsMap] = useState<Map<string, HeadingData>>(new Map());
+
+    const registerHeading = useCallback((route: string, element: HTMLElement, data: Omit<HeadingData, "element">) => {
+        setHeadingsMap(prev => {
+            const next = new Map(prev);
+            next.set(route, { ...data, element });
+            return next;
+        });
+    }, []);
+
+    const unregisterHeading = useCallback((route: string) => {
+        setHeadingsMap(prev => {
+            const next = new Map(prev);
+            next.delete(route);
+            return next;
+        });
+    }, []);
+
+    const scrollToHeading = useCallback(
+        (route: string) => {
+            const headingData = headingsMap.get(route);
+
+            if (headingData == null) {
+                return;
+            }
+
+            requestAnimationFrame(() => {
+                const scrollContainer = document.documentElement;
+                const offsetPosition = headingData.element.offsetTop - HEADING_IN_VIEW_THRESHOLD;
+
+                scrollContainer.scrollTo({
+                    behavior: "smooth",
+                    top: offsetPosition,
+                });
+            });
+        },
+        [headingsMap],
+    );
+
+    const getHeadingElement = useCallback(
+        (route: string): HTMLElement | undefined => {
+            return headingsMap.get(route)?.element;
+        },
+        [headingsMap],
+    );
+
+    const headings = useMemo(() => Array.from(headingsMap.values()), [headingsMap]);
+
+    const value = useMemo(
+        () => ({
+            getHeadingElement,
+            headings,
+            registerHeading,
+            scrollToHeading,
+            unregisterHeading,
+        }),
+        [getHeadingElement, headings, registerHeading, scrollToHeading, unregisterHeading],
+    );
+
+    return <HeadingRegistryContext.Provider value={value}>{children}</HeadingRegistryContext.Provider>;
+};
+
+export const useHeadingRegistry = () => {
+    const context = useContext(HeadingRegistryContext);
+    if (context == null) {
+        throw new Error("useHeadingRegistry must be used within HeadingRegistryProvider");
+    }
+    return context;
+};
+
+export const useRegisterHeading = (
+    route: string,
+    ref: RefObject<HTMLHeadingElement>,
+    { depth, title, url }: Omit<HeadingData, "element" | "route">,
+) => {
+    const { registerHeading, unregisterHeading } = useHeadingRegistry();
+
+    useEffect(() => {
+        if (ref.current != null) {
+            registerHeading(route, ref.current, { depth, route, title, url });
+        }
+
+        return () => {
+            unregisterHeading(route);
+        };
+    }, [route, ref, registerHeading, unregisterHeading, depth, title, url]);
+};

--- a/packages/docs-theme/src/components/toc/useTOCActiveItem.ts
+++ b/packages/docs-theme/src/components/toc/useTOCActiveItem.ts
@@ -47,10 +47,18 @@ export function useTOCActiveItem(routes: string[]) {
                     // Check if the clicked heading is now in a good position
                     const rect = clickedEntry.target.getBoundingClientRect();
                     if (rect.top >= 0 && rect.top <= HEADING_IN_VIEW_THRESHOLD) {
+                        // Clicked heading reached optimal position, clear lock and continue
                         lastClickedRef.current = null;
+                    } else {
+                        // Stay locked to clicked item while it's scrolling into position
+                        return;
                     }
                 }
-                return;
+                // If clickedEntry doesn't exist or is not intersecting, clear lock and continue
+                // This allows TOC to update when user scrolls away from clicked item
+                if (clickedEntry == null || !clickedEntry.isIntersecting) {
+                    lastClickedRef.current = null;
+                }
             }
 
             // Special case: Top of page → first heading
@@ -113,6 +121,7 @@ export function useTOCActiveItem(routes: string[]) {
     const handleTocItemClick = useCallback((route: string) => {
         lastClickedRef.current = route;
         setActiveAnchor(route);
+        // Set hash to trigger navigation - this will be handled by documentation.tsx
         window.location.hash = route;
     }, []);
 

--- a/packages/docs-theme/src/components/toc/useTOCActiveItem.ts
+++ b/packages/docs-theme/src/components/toc/useTOCActiveItem.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { HEADING_IN_VIEW_THRESHOLD, SCROLL_TOP_THRESHOLD, useHeadingRegistry } from "./headingRegistry";
+
+export function useTOCActiveItem(routes: string[]) {
+    const { headings } = useHeadingRegistry();
+    const [activeAnchor, setActiveAnchor] = useState<string | null>(null);
+
+    // Store the last clicked anchor to give it priority during scroll animation
+    const lastClickedRef = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (routes.length === 0) {
+            return;
+        }
+
+        const relevantHeadings = headings.filter(h => routes.includes(h.route));
+
+        if (relevantHeadings.length === 0) {
+            return;
+        }
+
+        // Track which headings are currently intersecting
+        const intersectingHeadings = new Map<string, IntersectionObserverEntry>();
+
+        const updateActiveAnchor = () => {
+            // If user recently clicked, keep that one active during scroll animation
+            if (lastClickedRef.current != null) {
+                const clickedEntry = intersectingHeadings.get(lastClickedRef.current);
+                if (clickedEntry?.isIntersecting) {
+                    // Check if the clicked heading is now in a good position
+                    const rect = clickedEntry.target.getBoundingClientRect();
+                    if (rect.top >= 0 && rect.top <= HEADING_IN_VIEW_THRESHOLD) {
+                        lastClickedRef.current = null;
+                    }
+                }
+                return;
+            }
+
+            // Special case: Top of page → first heading
+            if (window.scrollY <= SCROLL_TOP_THRESHOLD) {
+                setActiveAnchor(routes[0] ?? null);
+                return;
+            }
+
+            // Find the topmost intersecting heading
+            let topmostEntry: IntersectionObserverEntry | undefined;
+            let topmostTop = Infinity;
+
+            for (const entry of intersectingHeadings.values()) {
+                if (entry.isIntersecting && entry.boundingClientRect.top < topmostTop) {
+                    topmostTop = entry.boundingClientRect.top;
+                    topmostEntry = entry;
+                }
+            }
+
+            if (topmostEntry != null) {
+                const route = topmostEntry.target.getAttribute("id");
+                if (route != null) {
+                    setActiveAnchor(route);
+                }
+            }
+        };
+
+        const observer = new IntersectionObserver(
+            entries => {
+                // Update the map of intersecting headings
+                for (const entry of entries) {
+                    const route = entry.target.getAttribute("id");
+                    if (route != null) {
+                        intersectingHeadings.set(route, entry);
+                    }
+                }
+
+                updateActiveAnchor();
+            },
+            {
+                // Root margin creates a detection zone near the top of viewport
+                rootMargin: `-${HEADING_IN_VIEW_THRESHOLD}px 0px -70% 0px`,
+                threshold: [0, 0.5, 1],
+            },
+        );
+
+        // Observe all relevant headings
+        for (const heading of relevantHeadings) {
+            observer.observe(heading.element);
+        }
+
+        // Set initial active anchor
+        updateActiveAnchor();
+
+        return () => {
+            observer.disconnect();
+        };
+    }, [routes, headings]);
+
+    const handleTocItemClick = useCallback((route: string) => {
+        lastClickedRef.current = route;
+        setActiveAnchor(route);
+        window.location.hash = route;
+    }, []);
+
+    return {
+        activeAnchor,
+        handleTocItemClick,
+    };
+}

--- a/packages/docs-theme/src/docs-theme.scss
+++ b/packages/docs-theme/src/docs-theme.scss
@@ -17,3 +17,4 @@ Licensed under the Apache License, Version 2.0.
 @import "styles/navigator";
 @import "styles/overrides";
 @import "styles/props";
+@import "styles/toc";

--- a/packages/docs-theme/src/docs-theme.scss
+++ b/packages/docs-theme/src/docs-theme.scss
@@ -17,4 +17,3 @@ Licensed under the Apache License, Version 2.0.
 @import "styles/navigator";
 @import "styles/overrides";
 @import "styles/props";
-@import "styles/toc";

--- a/packages/docs-theme/src/styles/_content.scss
+++ b/packages/docs-theme/src/styles/_content.scss
@@ -18,6 +18,22 @@ $attribute-modifier-color: $violet5;
   word-wrap: break-word;
   position: relative;
 
+  &.level-2 {
+    margin: ($heading-margin * 0.8) 0 ($heading-margin * 0.3);
+  }
+
+  &.level-3 {
+    margin: ($heading-margin * 0.6) 0 ($heading-margin * 0.2);
+  }
+
+  &.level-4 {
+    margin: ($heading-margin * 0.5) 0 ($heading-margin * 0.15);
+  }
+
+  &.level-5 {
+    margin: ($heading-margin * 0.4) 0 ($heading-margin * 0.1);
+  }
+
   // first heading (the h1 at the top) needs smaller top margin to avoid extra scrolling
   .depth-1 > & {
     margin-top: $content-padding;

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -88,7 +88,7 @@ Page layout elements
   position: fixed;
   right: auto;
   top: $header-height;
-  width: $pt-spacing * 80;
+  width: $sidebar-width;
 
   .#{$ns}-dark & {
     border-right: 1px solid $dark-gray3;
@@ -156,9 +156,11 @@ Page layout elements
 }
 
 .docs-content-with-toc {
+  padding-top: $pt-spacing * 15;
   display: flex;
   gap: $pt-spacing * 12;
   min-width: 0;
+  width: calc(100vw - #{$sidebar-width} - #{$container-padding} * 2 - #{$pt-spacing} * 4);
   padding-left: $pt-spacing * 12;
   position: relative;
 }
@@ -170,7 +172,6 @@ Page layout elements
   max-width: $pt-spacing * 188;
   min-width: 0;
   overflow-wrap: break-word;
-  padding-left: $pt-spacing * 12;
   position: relative;
   width: 100%;
   word-wrap: break-word;

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -54,7 +54,6 @@ Page layout elements
   margin-right: auto;
   max-width: $container-width;
   min-height: 100vh;
-  overflow-x: hidden;
   padding-left: $pt-spacing * 6;
   padding-right: $pt-spacing * 6;
   padding-top: $header-height;
@@ -102,7 +101,7 @@ Page layout elements
   }
 
   > * {
-    padding: 0 $sidebar-padding * 3;
+    padding: 0 $sidebar-padding;
     padding-left: 0;
     padding-top: $top-content-offset;
   }
@@ -128,17 +127,16 @@ Page layout elements
   display: flex;
   gap: $pt-spacing * 12;
   min-width: 0;
-  padding-left: $pt-spacing * 12;
+  padding-left: $pt-spacing * 8;
   padding-top: $pt-spacing * 15;
   position: relative;
-  width: calc(100vw - #{$sidebar-width} - #{$container-padding} * 2 - #{$pt-spacing} * 4);
 }
 
 .docs-page {
   display: flex;
   flex-direction: column;
   gap: $pt-spacing * 12;
-  max-width: $pt-spacing * 188;
+  max-width: $pt-spacing * 320;
   min-width: 0;
   overflow-wrap: break-word;
   position: relative;

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -156,13 +156,13 @@ Page layout elements
 }
 
 .docs-content-with-toc {
-  padding-top: $pt-spacing * 15;
   display: flex;
   gap: $pt-spacing * 12;
   min-width: 0;
-  width: calc(100vw - #{$sidebar-width} - #{$container-padding} * 2 - #{$pt-spacing} * 4);
   padding-left: $pt-spacing * 12;
+  padding-top: $pt-spacing * 15;
   position: relative;
+  width: calc(100vw - #{$sidebar-width} - #{$container-padding} * 2 - #{$pt-spacing} * 4);
 }
 
 .docs-page {

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -60,6 +60,7 @@ Page layout elements
   position: relative;
   text-rendering: optimizelegibility;
   width: 100%;
+  overflow-x: hidden;
 
   &.banner {
     min-height: calc(100vh - $banner-height);
@@ -120,38 +121,6 @@ Page layout elements
 
   .#{$ns}-dark & {
     box-shadow: 1px 0 0 $pt-dark-divider-black;
-  }
-}
-
-.docs-page-scroll-gradient {
-  height: calc($top-content-offset - 5px);
-  left: 0;
-  pointer-events: none; // Allow clicking through
-  position: fixed;
-  right: 0;
-  z-index: 2;
-
-  &.docs-page-scroll-gradient-top {
-    background-image: linear-gradient(
-      to top,
-      transparent,
-      color-mix(in srgb, var(--bp-docs-background-color) 60%, transparent) 80%
-    );
-    top: $header-height;
-
-    // Adjust position when banner is present
-    .docs-banner + .docs-app & {
-      top: calc(#{$banner-height} + #{$header-height});
-    }
-  }
-
-  &.docs-page-scroll-gradient-bottom {
-    background-image: linear-gradient(
-      to bottom,
-      transparent,
-      color-mix(in srgb, var(--bp-docs-background-color) 60%, transparent) 80%
-    );
-    bottom: 0;
   }
 }
 

--- a/packages/docs-theme/src/styles/_layout.scss
+++ b/packages/docs-theme/src/styles/_layout.scss
@@ -54,13 +54,13 @@ Page layout elements
   margin-right: auto;
   max-width: $container-width;
   min-height: 100vh;
+  overflow-x: hidden;
   padding-left: $pt-spacing * 6;
   padding-right: $pt-spacing * 6;
   padding-top: $header-height;
   position: relative;
   text-rendering: optimizelegibility;
   width: 100%;
-  overflow-x: hidden;
 
   &.banner {
     min-height: calc(100vh - $banner-height);

--- a/packages/docs-theme/src/styles/_toc.scss
+++ b/packages/docs-theme/src/styles/_toc.scss
@@ -1,0 +1,133 @@
+// Copyright 2023 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+@import "banner";
+@import "variables";
+
+.docs-toc-container {
+  $base-top: $header-height + $top-content-offset;
+
+  &.banner {
+    top: calc($banner-height + $base-top);
+  }
+
+  top: $base-top;
+  position: sticky;
+  display: flex;
+  flex-direction: column;
+  gap: $pt-spacing * 3;
+  height: fit-content;
+  flex-shrink: 0;
+  width: calc($pt-spacing * 62);
+  padding: $pt-spacing * 3;
+}
+
+.docs-toc {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding-top: 40px;
+}
+
+.docs-toc-header {
+  font-weight: 600;
+  margin-bottom: $pt-spacing * 3;
+  font-size: $pt-font-size-small;
+}
+
+.docs-toc-scroll-area {
+  position: relative;
+  min-height: 0;
+  font-size: $pt-font-size-small;
+  margin-left: 1px;
+  overflow: auto;
+  scrollbar-width: none;
+  padding: $pt-spacing * 3 0;
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    white $pt-spacing * 3,
+    white calc(100% - #{$pt-spacing * 3}),
+    transparent
+  );
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.docs-toc-items {
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid rgba($pt-text-color, 0.1);
+}
+
+.docs-toc-item {
+  padding: calc($pt-spacing * 1) 0;
+  font-size: $pt-font-size-small;
+  color: $pt-text-color-muted;
+  transition: color 0.15s ease;
+  overflow-wrap: anywhere;
+
+  &:first-child {
+    padding-top: 0;
+  }
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+
+  &:hover {
+    color: $pt-text-color;
+    text-decoration: none;
+  }
+
+  &.docs-toc-active {
+    color: $pt-intent-primary;
+  }
+}
+
+.docs-toc-level-1 {
+  padding-left: $pt-spacing * 3;
+}
+
+.docs-toc-level-2 {
+  padding-left: $pt-spacing * 5;
+}
+
+.docs-toc-level-3 {
+  padding-left: $pt-spacing * 8;
+}
+
+.docs-toc-level-4 {
+  padding-left: $pt-spacing * 10;
+}
+
+.docs-toc-empty {
+  padding: $pt-spacing * 3;
+  font-size: $pt-font-size-small;
+  border-radius: $pt-border-radius;
+  background-color: rgba($gray5, 0.1);
+}
+
+// Dark theme styles
+.docs-toc-container.#{$ns}-dark {
+  .docs-toc-items {
+    border-left-color: rgba($pt-dark-text-color, 0.1);
+  }
+
+  .docs-toc-item {
+    color: $pt-dark-text-color-muted;
+
+    &:hover {
+      color: $pt-dark-text-color;
+    }
+
+    &.docs-toc-active {
+      color: $blue5;
+    }
+  }
+
+  .docs-toc-empty {
+    background-color: rgba($gray1, 0.1);
+  }
+}

--- a/packages/docs-theme/src/styles/_toc.scss
+++ b/packages/docs-theme/src/styles/_toc.scss
@@ -5,20 +5,20 @@
 
 .docs-toc-container {
   $base-top: $header-height + $top-content-offset;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: $pt-spacing * 3;
+  height: fit-content;
+  padding: $pt-spacing * 3;
+  position: sticky;
+
+  top: $base-top;
+  width: calc($pt-spacing * 62);
 
   &.banner {
     top: calc($banner-height + $base-top);
   }
-
-  top: $base-top;
-  position: sticky;
-  display: flex;
-  flex-direction: column;
-  gap: $pt-spacing * 3;
-  height: fit-content;
-  flex-shrink: 0;
-  width: calc($pt-spacing * 62);
-  padding: $pt-spacing * 3;
 }
 
 .docs-toc {
@@ -29,26 +29,26 @@
 }
 
 .docs-toc-header {
+  font-size: $pt-font-size-small;
   font-weight: 600;
   margin-bottom: $pt-spacing * 3;
-  font-size: $pt-font-size-small;
 }
 
 .docs-toc-scroll-area {
-  position: relative;
-  min-height: 0;
   font-size: $pt-font-size-small;
   margin-left: 1px;
-  overflow: auto;
-  scrollbar-width: none;
-  padding: $pt-spacing * 3 0;
   mask-image: linear-gradient(
     to bottom,
     transparent,
-    white $pt-spacing * 3,
-    white calc(100% - #{$pt-spacing * 3}),
+    $white $pt-spacing * 3,
+    $white calc(100% - #{$pt-spacing * 3}),
     transparent
   );
+  min-height: 0;
+  overflow: auto;
+  padding: $pt-spacing * 3 0;
+  position: relative;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
     display: none;
@@ -56,17 +56,17 @@
 }
 
 .docs-toc-items {
+  border-left: 1px solid rgba($pt-text-color, 0.1);
   display: flex;
   flex-direction: column;
-  border-left: 1px solid rgba($pt-text-color, 0.1);
 }
 
 .docs-toc-item {
-  padding: calc($pt-spacing * 1) 0;
-  font-size: $pt-font-size-small;
   color: $pt-text-color-muted;
-  transition: color 0.15s ease;
+  font-size: $pt-font-size-small;
   overflow-wrap: anywhere;
+  padding: calc($pt-spacing * 1) 0;
+  transition: color 0.15s ease;
 
   &:first-child {
     padding-top: 0;
@@ -103,10 +103,10 @@
 }
 
 .docs-toc-empty {
-  padding: $pt-spacing * 3;
-  font-size: $pt-font-size-small;
-  border-radius: $pt-border-radius;
   background-color: rgba($gray5, 0.1);
+  border-radius: $pt-border-radius;
+  font-size: $pt-font-size-small;
+  padding: $pt-spacing * 3;
 }
 
 // Dark theme styles

--- a/packages/docs-theme/src/styles/_variables.scss
+++ b/packages/docs-theme/src/styles/_variables.scss
@@ -9,7 +9,7 @@ $container-width: $pt-spacing * 320;
 $container-padding: $pt-spacing;
 $top-content-offset: $pt-spacing * 10;
 
-$sidebar-width: $pt-spacing * 80;
+$sidebar-width: $pt-spacing * 60;
 $sidebar-padding: $pt-spacing * 6;
 $sidebar-background-color: $white;
 $header-height: $pt-spacing * 15;

--- a/packages/docs-theme/src/tags/heading.tsx
+++ b/packages/docs-theme/src/tags/heading.tsx
@@ -16,29 +16,40 @@
 
 import { isHeadingTag, type Tag } from "@documentalist/client";
 import classNames from "classnames";
-import { createElement } from "react";
+import { createElement, useRef } from "react";
 
-import { Classes } from "@blueprintjs/core";
-import { Link } from "@blueprintjs/icons";
+import { Classes, Icon } from "@blueprintjs/core";
 
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
+import { useRegisterHeading } from "../components/toc/headingRegistry";
 
 export const Heading: React.FC<Tag> = props => {
-    if (!isHeadingTag(props)) {
+    const isHeading = isHeadingTag(props);
+    const route = isHeading ? props.route : "";
+    const level = isHeading ? props.level : 1;
+    const value = isHeading ? props.value : "";
+
+    const headingRef = useRef<HTMLHeadingElement>(null);
+
+    useRegisterHeading(route, headingRef, {
+        depth: level,
+        title: value,
+        url: `#${route}`,
+    });
+
+    if (!isHeading) {
         return null;
     }
 
-    const { level, route, value } = props;
-    const className = classNames(Classes.HEADING, "docs-title");
+    const className = classNames(Classes.HEADING, "docs-title", `level-${level}`);
     const children = [
         <a className="docs-anchor" data-route={route} key="anchor" aria-hidden={true} tabIndex={-1} />,
-        <a className="docs-anchor-link" href={"#" + route} key="link" aria-hidden={true} tabIndex={-1}>
-            <Link />
+        <a className="docs-anchor-link" href={"#" + route} key="link" aria-label={`Direct link to ${value}`}>
+            <Icon icon={"link"} />
         </a>,
         value,
     ];
 
-    // use createElement so we can dynamically choose tag based on depth
-    return createElement(`h${level}`, { className }, children);
+    return createElement(`h${level}`, { className, id: route, ref: headingRef }, children);
 };
 Heading.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.Heading`;


### PR DESCRIPTION
Add a complete TOC system using React context and heading registry for reliable scroll behavior without DOM queries. The TOC displays page sections and auto-highlights the active section as user scrolls.

Key changes:
- Create HeadingRegistryProvider context to manage heading refs and metadata
- Implement useRegisterHeading hook for headings to register themselves
- Add TOC components: TOCContainer, TOCContent, TOCItems with composition API
- Create useTOCActiveItem hook with IntersectionObserver for scroll spy
- Add heading.tsx integration to register headings with context
- Update Page component to use HeadingRegistryProvider
- Add scroll gradients to content wrapper for visual polish
- Integrate TOC into documentation.tsx layout with proper positioning
- Add comprehensive TOC styling with active states and level indentation
- Support heading depth levels 1-4 with visual hierarchy
- Add smooth scrolling to headings on TOC item click
- Remove fragile querySelector-based approach

#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
