### PR TITLE
Fix flaky tests in Popover, Overlay2, and Table components

### DIFF
--- a/packages/core/test/overlay2/overlay2Tests.tsx
+++ b/packages/core/test/overlay2/overlay2Tests.tsx
@@ -31,7 +31,7 @@ import {
     Portal,
     Utils,
 } from "../../src";
-import { findInPortal, sleep } from "../utils";
+import { findInPortal } from "../utils";
 
 import "./overlay2-test-debugging.scss";
 
@@ -723,7 +723,13 @@ describe("<Overlay2>", () => {
         assert.isTrue(onOpening.calledOnce, "onOpening");
         assert.isFalse(onOpened.calledOnce, "onOpened not called yet");
 
-        await sleep(10);
+        // Wait for transition to complete and onOpened to be called
+        await waitFor(
+            () => {
+                assert.isTrue(onOpened.calledOnce, "onOpened");
+            },
+            { timeout: 100 },
+        );
 
         // on*ed called after transition completes
         assert.isTrue(onOpened.calledOnce, "onOpened");
@@ -733,9 +739,15 @@ describe("<Overlay2>", () => {
         assert.isTrue(onClosing.calledOnce, "onClosing");
         assert.isFalse(onClosed.calledOnce, "onClosed not called yet");
 
-        await sleep(10);
+        // Wait for transition to complete and onClosed to be called
+        await waitFor(
+            () => {
+                assert.isTrue(onClosed.calledOnce, "onClosed");
+            },
+            { timeout: 100 },
+        );
 
-        assert.isTrue(onClosed.calledOnce, "onOpened");
+        assert.isTrue(onClosed.calledOnce, "onClosed");
     });
 
     let index = 0;

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -345,7 +345,7 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            userEvent.click(targetButton);
+            await userEvent.click(targetButton);
 
             const overlay = container.querySelector(`.${Classes.OVERLAY}`);
 
@@ -357,7 +357,7 @@ describe("<Popover>", () => {
 
             const closeButton = screen.getByRole("button", { name: "close" });
 
-            userEvent.click(closeButton);
+            await userEvent.click(closeButton);
 
             await waitFor(() => {
                 expect(hasClass(overlay!, Classes.OVERLAY_OPEN)).to.be.false;

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -16,6 +16,7 @@
 
 import { expect } from "chai";
 import { mount } from "enzyme";
+import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
@@ -577,7 +578,7 @@ describe("TableQuadrantStack", () => {
             });
 
             it("invokes onScroll on TOP quadrant wheel", () => {
-                TestUtils.act(() => {
+                act(() => {
                     TestUtils.Simulate.wheel(topScrollContainer);
                 });
                 expect(onScroll.calledOnce).to.be.true;

--- a/packages/table/test/quadrants/tableQuadrantStackTests.tsx
+++ b/packages/table/test/quadrants/tableQuadrantStackTests.tsx
@@ -577,7 +577,9 @@ describe("TableQuadrantStack", () => {
             });
 
             it("invokes onScroll on TOP quadrant wheel", () => {
-                TestUtils.Simulate.wheel(topScrollContainer);
+                TestUtils.act(() => {
+                    TestUtils.Simulate.wheel(topScrollContainer);
+                });
                 expect(onScroll.calledOnce).to.be.true;
             });
 


### PR DESCRIPTION
Resolves intermittent test failures on CircleCI by addressing timing issues:

#### Fixes #7528

#### Checklist

-   [na] Includes tests
-   [na] Update documentation

#### Changes proposed in this pull request:
- [Popover] Await userEvent.click() calls to eliminate race conditions in focus management test
- [Overlay2] Replace hard-coded sleep(10) with waitFor() polling to handle variable CI timing in lifecycle test
- [Table] Wrap event simulation in act() to ensure React updates are flushed before assertions in scroll syncing test (https://react.dev/reference/react/act)

#### Reviewers should focus on:

Run on CircleCI, potentially many times, to verify this fixes the flakiness.
