### PR TITLE
[chore] Migrate Sass global built-in functions to module system

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
 @import "common/variables";
 @import "common/variables-extended";
 @import "common/mixins";
@@ -62,8 +63,8 @@ $headings: (
 
 @each $tag, $props in $headings {
   %#{$tag} {
-    font-size: nth($props, 1);
-    line-height: nth($props, 2);
+    font-size: list.nth($props, 1);
+    line-height: list.nth($props, 2);
   }
 
   #{$tag}.#{$ns}-heading {

--- a/packages/core/src/common/_mixins.scss
+++ b/packages/core/src/common/_mixins.scss
@@ -1,7 +1,9 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @use "sass:math";
+@use "sass:meta";
 @import "@blueprintjs/colors/lib/scss/colors";
 @import "flex";
 
@@ -34,7 +36,7 @@ $pt-dark-intent-text-colors: (
 ) !default;
 
 @mixin intent-color($intentName) {
-  color: map-get($pt-intent-colors, $intentName);
+  color: map.get($pt-intent-colors, $intentName);
 }
 
 @mixin position-all($position, $value) {
@@ -101,15 +103,15 @@ $pt-dark-intent-text-colors: (
 // returns the padding necessary to center text in a container of the given height.
 // default line-height is that of base typography, 18px assuming 14px font-size.
 
-@function centered-text($height, $line-height: floor($pt-font-size * $pt-line-height)) {
-  @return floor(($height - $line-height) * 0.5);
+@function centered-text($height, $line-height: math.floor($pt-font-size * $pt-line-height)) {
+  @return math.floor(($height - $line-height) * 0.5);
 }
 
 // Removes the unit from a Sass numeric value (if present): `strip-unit(12px) => 12`
 // @see https://css-tricks.com/snippets/sass/strip-unit-function/
 
 @function strip-unit($number) {
-  @if type-of($number) == "number" and not unitless($number) {
+  @if meta.type-of($number) == "number" and not math.is-unitless($number) {
     @return math.div($number, $number * 0 + 1);
   }
 

--- a/packages/core/src/common/_react-transition.scss
+++ b/packages/core/src/common/_react-transition.scss
@@ -1,6 +1,9 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
+@use "sass:map";
+
 /*
 A mixin to generate the classes for a React CSSTransition which animates any number of CSS
 properties at once.
@@ -93,7 +96,7 @@ If `exit` phase is given then property values are animated in reverse, from fina
     @include each-prop($properties, $end-index);
     transition-delay: $delay;
     transition-duration: $duration;
-    transition-property: map-keys($properties);
+    transition-property: map.keys($properties);
     /* stylelint-disable-next-line declaration-block-no-redundant-longhand-properties */
     transition-timing-function: $easing;
   }
@@ -107,7 +110,7 @@ Example: `each-prop((opacity: 0 1), 2)` will print "opacity: 1"
 */
 @mixin each-prop($properties, $index) {
   @each $prop, $values in $properties {
-    #{$prop}: nth($values, $index);
+    #{$prop}: list.nth($values, $index);
   }
 }
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
 @import "../../common/variables";
 @import "../forms/common";
 @import "./common";
@@ -12,7 +13,7 @@
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: index($control-group-stack, "button-default");
+    z-index: list.index($control-group-stack, "button-default");
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -20,42 +21,42 @@
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: index($control-group-stack, "button-focus");
+      z-index: list.index($control-group-stack, "button-focus");
     }
 
     &:hover {
-      z-index: index($control-group-stack, "button-hover");
+      z-index: list.index($control-group-stack, "button-hover");
     }
 
     &:active,
     &.#{$ns}-active {
-      z-index: index($control-group-stack, "button-active");
+      z-index: list.index($control-group-stack, "button-active");
     }
 
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: index($control-group-stack, "button-disabled");
+      z-index: list.index($control-group-stack, "button-disabled");
     }
 
     &[class*="#{$ns}-intent-"] {
-      z-index: index($control-group-stack, "intent-button-default");
+      z-index: list.index($control-group-stack, "intent-button-default");
 
       &:focus {
-        z-index: index($control-group-stack, "intent-button-focus");
+        z-index: list.index($control-group-stack, "intent-button-focus");
       }
 
       &:hover {
-        z-index: index($control-group-stack, "intent-button-hover");
+        z-index: list.index($control-group-stack, "intent-button-hover");
       }
 
       &:active,
       &.#{$ns}-active {
-        z-index: index($control-group-stack, "intent-button-active");
+        z-index: list.index($control-group-stack, "intent-button-active");
       }
 
       &:disabled,
       &.#{$ns}-disabled {
-        z-index: index($control-group-stack, "intent-button-disabled");
+        z-index: list.index($control-group-stack, "intent-button-disabled");
       }
     }
   }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "../../common/mixins";
 @import "../../common/variables";
 @import "../../common/variables-extended";
@@ -401,12 +402,12 @@ $dark-minimal-active-text-colors: (
 );
 
 @mixin pt-button-minimal-intent($intent) {
-  $intent-color: map-get($pt-intent-colors, $intent);
-  $text-color: map-get($pt-intent-text-colors, $intent);
-  $active-text-color: map-get($pt-intent-active-text-colors, $intent);
-  $dark-text-color: map-get($pt-dark-intent-text-colors, $intent);
-  $dark-active-text-color: map-get($dark-minimal-active-text-colors, $intent);
-  $dark-hover-text-color: map-get($dark-minimal-hover-text-colors, $intent);
+  $intent-color: map.get($pt-intent-colors, $intent);
+  $text-color: map.get($pt-intent-text-colors, $intent);
+  $active-text-color: map.get($pt-intent-active-text-colors, $intent);
+  $dark-text-color: map.get($pt-dark-intent-text-colors, $intent);
+  $dark-active-text-color: map.get($dark-minimal-active-text-colors, $intent);
+  $dark-hover-text-color: map.get($dark-minimal-hover-text-colors, $intent);
 
   color: $text-color;
 
@@ -499,8 +500,8 @@ $dark-minimal-active-text-colors: (
   @each $intent, $colors in $button-intents {
     &.#{$ns}-intent-#{$intent} {
       @include pt-button-outlined-intent(
-        map-get($pt-intent-text-colors, $intent),
-        map-get($pt-dark-intent-text-colors, $intent)
+        map.get($pt-intent-text-colors, $intent),
+        map.get($pt-dark-intent-text-colors, $intent)
       );
     }
   }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "../../common/variables-extended";
 
 $callout-padding: $pt-spacing * 4;
@@ -85,7 +86,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
-      color: map-get($pt-intent-text-colors, $intent);
+      color: map.get($pt-intent-text-colors, $intent);
 
       &:not(.#{$ns}-minimal) {
         background-color: rgba($color, 0.1);
@@ -98,11 +99,11 @@ $callout-padding-compact: $pt-spacing * 2;
       &[class*="#{$ns}-icon-"]::before,
       > .#{$ns}-icon:first-child,
       .#{$ns}-heading {
-        color: map-get($pt-intent-text-colors, $intent);
+        color: map.get($pt-intent-text-colors, $intent);
       }
 
       .#{$ns}-dark & {
-        color: map-get($pt-dark-intent-text-colors, $intent);
+        color: map.get($pt-dark-intent-text-colors, $intent);
 
         &:not(.#{$ns}-minimal) {
           background-color: rgba($color, 0.2);
@@ -111,7 +112,7 @@ $callout-padding-compact: $pt-spacing * 2;
         &[class*="#{$ns}-icon-"]::before,
         > .#{$ns}-icon:first-child,
         .#{$ns}-heading {
-          color: map-get($pt-dark-intent-text-colors, $intent);
+          color: map.get($pt-dark-intent-text-colors, $intent);
         }
       }
     }

--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
 @import "./card-variables";
 
 .#{$ns}-card {
@@ -25,13 +26,13 @@
   }
 }
 
-@for $index from 1 through length($elevation-shadows) {
+@for $index from 1 through list.length($elevation-shadows) {
   .#{$ns}-elevation-#{$index - 1} {
-    box-shadow: nth($elevation-shadows, $index);
+    box-shadow: list.nth($elevation-shadows, $index);
 
     &.#{$ns}-dark,
     .#{$ns}-dark & {
-      box-shadow: nth($dark-elevation-shadows, $index);
+      box-shadow: list.nth($dark-elevation-shadows, $index);
     }
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {

--- a/packages/core/src/components/entity-title/_entity-title.scss
+++ b/packages/core/src/components/entity-title/_entity-title.scss
@@ -1,6 +1,7 @@
 // Copyright 2024 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
 @import "../../common/variables";
 @import "../../common/variables-extended";
 
@@ -72,7 +73,7 @@
       align-items: center;
       display: flex;
       // Aligning icon which has unknown dimensions on the title size
-      height: nth($props, 2);
+      height: list.nth($props, 2);
     }
   }
 

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -1,6 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
 @import "../../common/variables";
 @import "../button/common";
 @import "./common";
@@ -28,32 +29,32 @@
   }
 
   .#{$ns}-input {
-    z-index: index($control-group-stack, "input-default");
+    z-index: list.index($control-group-stack, "input-default");
 
     &:focus {
-      z-index: index($control-group-stack, "input-focus");
+      z-index: list.index($control-group-stack, "input-focus");
     }
 
     &[class*="#{$ns}-intent"] {
-      z-index: index($control-group-stack, "intent-input-default");
+      z-index: list.index($control-group-stack, "intent-input-default");
 
       &:focus {
-        z-index: index($control-group-stack, "intent-input-focus");
+        z-index: list.index($control-group-stack, "intent-input-focus");
       }
     }
 
     &[readonly],
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: index($control-group-stack, "input-disabled");
+      z-index: list.index($control-group-stack, "input-disabled");
     }
   }
 
   .#{$ns}-input-group[class*="#{$ns}-intent"] .#{$ns}-input {
-    z-index: index($control-group-stack, "intent-input-default");
+    z-index: list.index($control-group-stack, "intent-input-default");
 
     &:focus {
-      z-index: index($control-group-stack, "intent-input-focus");
+      z-index: list.index($control-group-stack, "intent-input-focus");
     }
   }
 
@@ -61,45 +62,45 @@
   .#{$ns}-html-select select,
   .#{$ns}-select select {
     @include new-render-layer();
-    z-index: index($control-group-stack, "button-default");
+    z-index: list.index($control-group-stack, "button-default");
 
     &:focus {
-      z-index: index($control-group-stack, "button-focus");
+      z-index: list.index($control-group-stack, "button-focus");
     }
 
     &:hover {
-      z-index: index($control-group-stack, "button-hover");
+      z-index: list.index($control-group-stack, "button-hover");
     }
 
     &:active {
-      z-index: index($control-group-stack, "button-active");
+      z-index: list.index($control-group-stack, "button-active");
     }
 
     &[readonly],
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: index($control-group-stack, "button-disabled");
+      z-index: list.index($control-group-stack, "button-disabled");
     }
 
     &[class*="#{$ns}-intent"] {
-      z-index: index($control-group-stack, "intent-button-default");
+      z-index: list.index($control-group-stack, "intent-button-default");
 
       &:focus {
-        z-index: index($control-group-stack, "intent-button-focus");
+        z-index: list.index($control-group-stack, "intent-button-focus");
       }
 
       &:hover {
-        z-index: index($control-group-stack, "intent-button-hover");
+        z-index: list.index($control-group-stack, "intent-button-hover");
       }
 
       &:active {
-        z-index: index($control-group-stack, "intent-button-active");
+        z-index: list.index($control-group-stack, "intent-button-active");
       }
 
       &[readonly],
       &:disabled,
       &.#{$ns}-disabled {
-        z-index: index($control-group-stack, "intent-button-disabled");
+        z-index: list.index($control-group-stack, "intent-button-disabled");
       }
     }
   }
@@ -109,7 +110,7 @@
   .#{$ns}-input-group > .#{$ns}-button,
   .#{$ns}-input-group > .#{$ns}-input-left-container,
   .#{$ns}-input-group > .#{$ns}-input-action {
-    z-index: index($control-group-stack, "input-group-children");
+    z-index: list.index($control-group-stack, "input-group-children");
   }
 
   // keep the select-menu carets on top of everything always (particularly when
@@ -118,14 +119,14 @@
   .#{$ns}-html-select::after,
   .#{$ns}-select > .#{$ns}-icon,
   .#{$ns}-html-select > .#{$ns}-icon {
-    z-index: index($control-group-stack, "select-caret");
+    z-index: list.index($control-group-stack, "select-caret");
   }
 
   // select container does not get focus directly (its <select> does), and it
   // sometimes needs to compete with adjacent container elements
   .#{$ns}-html-select:focus-within,
   .#{$ns}-select:focus-within {
-    z-index: index($control-group-stack, "button-focus");
+    z-index: list.index($control-group-stack, "button-focus");
   }
 
   &:not(.#{$ns}-vertical) {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -1,6 +1,8 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
+@use "sass:map";
 @use "sass:math";
 @import "../../common/mixins";
 @import "../../common/variables";
@@ -15,9 +17,9 @@ $dark-control-background-color-hover: $minimal-button-background-color-hover !de
 $dark-control-background-color-active: $minimal-button-background-color-active !default;
 $dark-control-background-color-disabled: $minimal-button-background-color-hover !default;
 
-$control-checked-background-color: nth(map-get($button-intents, "primary"), 1) !default;
-$control-checked-background-color-hover: nth(map-get($button-intents, "primary"), 2) !default;
-$control-checked-background-color-active: nth(map-get($button-intents, "primary"), 3) !default;
+$control-checked-background-color: list.nth(map.get($button-intents, "primary"), 1) !default;
+$control-checked-background-color-hover: list.nth(map.get($button-intents, "primary"), 2) !default;
+$control-checked-background-color-active: list.nth(map.get($button-intents, "primary"), 3) !default;
 $control-checked-background-color-disabled: rgba($control-checked-background-color, 0.5) !default;
 
 $control-box-shadow: inset 0 0 0 $button-border-width $gray2 !default;

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -1,6 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "../../common/variables";
 @import "../../common/variables-extended";
 @import "../button/common";
@@ -210,15 +211,15 @@ $input-button-height-small: $pt-button-height-smaller !default;
         @include pt-input-intent($color);
 
         .#{$ns}-dark & {
-          @include pt-dark-input-intent(map-get($pt-dark-input-intent-box-shadow-colors, $intent));
+          @include pt-dark-input-intent(map.get($pt-dark-input-intent-box-shadow-colors, $intent));
         }
       }
 
       > .#{$ns}-icon {
-        color: map-get($pt-intent-text-colors, $intent);
+        color: map.get($pt-intent-text-colors, $intent);
 
         .#{$ns}-dark & {
-          color: map-get($pt-dark-intent-text-colors, $intent);
+          color: map.get($pt-dark-intent-text-colors, $intent);
         }
       }
     }

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "../../common/variables";
 
 .#{$ns}-input {
@@ -28,7 +29,7 @@
       @include pt-input-intent($color);
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent(map-get($pt-dark-input-intent-box-shadow-colors, $intent));
+        @include pt-dark-input-intent(map.get($pt-dark-input-intent-box-shadow-colors, $intent));
       }
     }
   }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -1,6 +1,8 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
+@use "sass:map";
 @import "../../common/mixins";
 @import "../../common/variables";
 @import "../../common/variables-extended";
@@ -250,20 +252,20 @@ $dark-menu-item-intent-colors: (
     }
   }
 
-  background-color: rgba(nth(map-get($intent-colors, "primary"), 1), $background-alpha);
-  color: nth(map-get($intent-colors, "primary"), 2);
+  background-color: rgba(list.nth(map.get($intent-colors, "primary"), 1), $background-alpha);
+  color: list.nth(map.get($intent-colors, "primary"), 2);
 
   &::before,
   .#{$ns}-menu-item-icon,
   .#{$ns}-menu-item-selected-icon,
   .#{$ns}-submenu-icon {
-    color: nth(map-get($intent-colors, "primary"), 2);
+    color: list.nth(map.get($intent-colors, "primary"), 2);
   }
 
   @each $intent in ("success", "warning", "danger") {
     &.#{$ns}-intent-#{$intent} {
-      background-color: rgba(nth(map-get($intent-colors, $intent), 1), $background-alpha);
-      color: nth(map-get($intent-colors, $intent), 2);
+      background-color: rgba(list.nth(map.get($intent-colors, $intent), 1), $background-alpha);
+      color: list.nth(map.get($intent-colors, $intent), 2);
 
       &::before,
       .#{$ns}-menu-item-icon,

--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -17,7 +17,7 @@ $pt-dark-popover-background-color: $dark-gray3 !default;
   $arrow-diagonal-half-size: math.div($arrow-square-size, 1.41421356);
   // we want the margin to be the size of the part of the arrow that is showing plus
   // a little extra space.
-  $content-margin: floor($arrow-diagonal-half-size + $arrow-target-offset);
+  $content-margin: math.floor($arrow-diagonal-half-size + $arrow-target-offset);
   // we want to move the arrow out from where it's positioned by the gap amount
   // plus the extra amount of width that is added by its 45 deg rotation.
   $arrow-position: -$arrow-square-size * 0.5 + $arrow-offset;
@@ -31,10 +31,10 @@ $pt-dark-popover-background-color: $dark-gray3 !default;
     width: $arrow-square-size;
 
     &::before {
-      height: floor($arrow-diagonal-half-size - 1);
-      margin: ceil(($arrow-square-size - $arrow-diagonal-half-size) * 0.5);
+      height: math.floor($arrow-diagonal-half-size - 1);
+      margin: math.ceil(($arrow-square-size - $arrow-diagonal-half-size) * 0.5);
       // - 1 to compenstate for transparent pixel border shadow
-      width: floor($arrow-diagonal-half-size - 1);
+      width: math.floor($arrow-diagonal-half-size - 1);
     }
   }
 }

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -1,6 +1,8 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
+@use "sass:map";
 @import "../../common/variables";
 @import "../../common/variables-extended";
 
@@ -336,7 +338,7 @@ $minimal-dark-tag-intent-colors: (
   // CSS API support
   &:empty::before {
     @include pt-icon();
-    content: map-get($blueprint-icon-codepoints, "small-cross");
+    content: map.get($blueprint-icon-codepoints, "small-cross");
   }
 
   .#{$ns}-large & {
@@ -362,32 +364,32 @@ $minimal-dark-tag-intent-colors: (
   background: none;
 
   .#{$ns}-compound-tag-left {
-    background-color: nth($left-colors, 1);
+    background-color: list.nth($left-colors, 1);
   }
 
   .#{$ns}-compound-tag-right {
-    background-color: nth($right-colors, 1);
+    background-color: list.nth($right-colors, 1);
   }
 
   &.#{$ns}-interactive {
     &:hover {
       .#{$ns}-compound-tag-left {
-        background-color: nth($left-colors, 2);
+        background-color: list.nth($left-colors, 2);
       }
 
       .#{$ns}-compound-tag-right {
-        background-color: nth($right-colors, 2);
+        background-color: list.nth($right-colors, 2);
       }
     }
 
     &:active,
     &.#{$ns}-active {
       .#{$ns}-compound-tag-left {
-        background-color: nth($left-colors, 3);
+        background-color: list.nth($left-colors, 3);
       }
 
       .#{$ns}-compound-tag-right {
-        background-color: nth($right-colors, 3);
+        background-color: list.nth($right-colors, 3);
       }
     }
   }

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -1,6 +1,7 @@
 // Copyright 2024 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "../../common/variables";
 @import "../../common/variables-extended";
 @import "../../common/mixins";
@@ -191,7 +192,7 @@ $compound-tag-left-intent-colors: (
   // Variant: intent
   @each $intent, $left-colors in $compound-tag-left-intent-colors {
     &.#{$ns}-intent-#{$intent} {
-      $right-colors: map-get($tag-intent-colors, $intent);
+      $right-colors: map.get($tag-intent-colors, $intent);
 
       @include compound-tag-colors($left-colors, $right-colors);
     }

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "@blueprintjs/icons/lib/scss/variables";
 @import "../../common/variables";
 @import "../../common/variables-extended";
@@ -90,7 +91,7 @@ $tree-intent-icon-colors: (
 
   // CSS API support
   &.#{$ns}-icon-standard::before {
-    content: map-get($blueprint-icon-codepoints, "chevron-right");
+    content: map.get($blueprint-icon-codepoints, "chevron-right");
   }
 }
 

--- a/packages/datetime/src/components/time-picker/_time-picker.scss
+++ b/packages/datetime/src/components/time-picker/_time-picker.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "@blueprintjs/core/src/components/forms/common";
 @import "@blueprintjs/core/src/components/icon/icon-mixins";
 @import "../../common";
@@ -87,7 +88,7 @@ $timepicker-control-width: $pt-spacing * 8 !default;
         @include pt-input-intent($color);
 
         .#{$ns}-dark & {
-          @include pt-dark-input-intent(map-get($pt-dark-input-intent-box-shadow-colors, $intent));
+          @include pt-dark-input-intent(map.get($pt-dark-input-intent-box-shadow-colors, $intent));
         }
       }
     }

--- a/packages/docs-app/src/styles/_colors.scss
+++ b/packages/docs-app/src/styles/_colors.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @use "sass:math";
 @import "@blueprintjs/icons/lib/scss/variables";
 
@@ -11,7 +12,7 @@ $swatch-height: $pt-input-height-large;
 $swatch-hover-offset: -$pt-spacing;
 
 $swatch-hover-message: "Click to copy hex code";
-$swatch-copied-message: "#{map-get($blueprint-icon-codepoints, "tick")} Copied to clipboard";
+$swatch-copied-message: "#{map.get($blueprint-icon-codepoints, "tick")} Copied to clipboard";
 
 @function palette-width($columns) {
   @return math.div(102% - 2% * $columns, $columns);

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -1,6 +1,7 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "@blueprintjs/core/src/common/react-transition";
 @import "@blueprintjs/core/src/common/variables-extended";
 @import "@blueprintjs/core/src/components/icon/icon-mixins";
@@ -280,7 +281,7 @@
     &::before {
       @include pt-icon($icon-size, 16);
       color: $white;
-      content: map-get($blueprint-icon-codepoints, "envelope");
+      content: map.get($blueprint-icon-codepoints, "envelope");
       left: ($node-size - $icon-size) * 0.5 - $node-border-width;
       position: relative;
       top: ($node-size - $icon-size) * 0.5 - $node-border-width;
@@ -398,14 +399,14 @@ $docs-hotkey-piano-height: 510px;
     &:focus {
       background: rgba($blue3, 0.1);
       border: 2px solid rgba($blue3, 0.6);
-      color: map-get($pt-intent-text-colors, "primary");
+      color: map.get($pt-intent-text-colors, "primary");
       cursor: default;
       opacity: 1;
 
       .#{$ns}-dark & {
         background: rgba($blue4, 0.1);
         border: 2px solid rgba($blue4, 0.6);
-        color: map-get($pt-dark-intent-text-colors, "primary");
+        color: map.get($pt-dark-intent-text-colors, "primary");
       }
     }
   }

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -1,6 +1,9 @@
 // Copyright 2018 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
+@use "sass:map";
+
 $pkg-icon-width: $pt-spacing * 6;
 
 $package-colors: (
@@ -127,11 +130,11 @@ $dark-package-colors: (
     text-transform: uppercase;
   }
 
-  @each $package-name in map-keys($package-colors) {
-    $color: nth(map-get($package-colors, $package-name), 1);
-    $dark-color: nth(map-get($dark-package-colors, $package-name), 1);
-    $text-color: nth(map-get($package-colors, $package-name), 2);
-    $dark-text-color: nth(map-get($dark-package-colors, $package-name), 2);
+  @each $package-name in map.keys($package-colors) {
+    $color: list.nth(map.get($package-colors, $package-name), 1);
+    $dark-color: list.nth(map.get($dark-package-colors, $package-name), 1);
+    $text-color: list.nth(map.get($package-colors, $package-name), 2);
+    $dark-text-color: list.nth(map.get($dark-package-colors, $package-name), 2);
 
     &[data-route="#{$package-name}"] {
       .docs-nav-package-icon {

--- a/packages/docs-theme/src/styles/_banner.scss
+++ b/packages/docs-theme/src/styles/_banner.scss
@@ -1,6 +1,8 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:list";
+
 @import "@blueprintjs/core/src/common/variables";
 @import "@blueprintjs/core/src/components/button/common";
 
@@ -35,14 +37,14 @@ $banner-height: $pt-spacing * 10;
 
   @each $intent, $colors in $button-intents {
     &.#{$ns}-intent-#{$intent} {
-      background: nth($colors, 1);
+      background: list.nth($colors, 1);
 
       &:hover {
-        background: nth($colors, 2);
+        background: list.nth($colors, 2);
       }
 
       &:active {
-        background: nth($colors, 3);
+        background: list.nth($colors, 3);
       }
     }
   }

--- a/packages/docs-theme/src/styles/_props.scss
+++ b/packages/docs-theme/src/styles/_props.scss
@@ -1,6 +1,8 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
+
 .docs-prop-details code {
   /* stylelint-disable declaration-no-important */
   background: none !important;
@@ -57,7 +59,7 @@
   color: $red3;
 
   &::after {
-    content: map-get($blueprint-icon-codepoints, "small-cross");
+    content: map.get($blueprint-icon-codepoints, "small-cross");
   }
 }
 
@@ -69,7 +71,7 @@
   }
 
   &::after {
-    content: map-get($blueprint-icon-codepoints, "small-tick");
+    content: map.get($blueprint-icon-codepoints, "small-tick");
   }
 }
 

--- a/packages/table/src/cell/_cell.scss
+++ b/packages/table/src/cell/_cell.scss
@@ -1,5 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
+@use "sass:color";
 @import "../common/loading";
 @import "../common/variables";
 @import "./common";
@@ -38,7 +39,7 @@
   }
 
   .#{$ns}-table-cell-ledger-odd {
-    background-color: mix($table-background-color, $cell-background-color, 50%);
+    background-color: color.mix($table-background-color, $cell-background-color, 50%);
   }
 
   .#{$ns}-dark & {
@@ -47,7 +48,7 @@
     }
 
     .#{$ns}-table-cell-ledger-odd {
-      background-color: mix($dark-table-background-color, $dark-cell-background-color, 50%);
+      background-color: color.mix($dark-table-background-color, $dark-cell-background-color, 50%);
     }
   }
 }

--- a/packages/table/src/cell/_common.scss
+++ b/packages/table/src/cell/_common.scss
@@ -1,5 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
+@use "sass:map";
 @import "../common/variables";
 
 $cell-border-width: 1px !default;
@@ -38,12 +39,12 @@ $cell-transition-duration: $pt-transition-duration * 3;
   @each $intent, $color in $pt-intent-colors {
     &.#{$ns}-intent-#{$intent} {
       background-color: rgba($color, $cell-background-color-opacity);
-      color: map-get($pt-intent-text-colors, $intent);
+      color: map.get($pt-intent-text-colors, $intent);
     }
 
     .#{$ns}-dark &.#{$ns}-intent-#{$intent} {
       background: rgba($color, $cell-background-color-opacity);
-      color: map-get($pt-dark-intent-text-colors, $intent);
+      color: map.get($pt-dark-intent-text-colors, $intent);
     }
   }
 }

--- a/packages/table/src/headers/_headers.scss
+++ b/packages/table/src/headers/_headers.scss
@@ -1,5 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 
+@use "sass:color";
 @import "../common/loading";
 @import "../common/variables";
 @import "../cell/common";
@@ -16,17 +17,17 @@ $dark-header-menu-hover-background: menu-background($dark-header-background-colo
 // when selection is enabled, background color changes on hover; need to match that.
 $selectable-header-menu-hover-background: menu-background($header-hover-background-color);
 $selectable-header-menu-selected-background: menu-background(
-  mix($pt-intent-primary, $header-background-color, 10%)
+  color.mix($pt-intent-primary, $header-background-color, 10%)
 );
 $selectable-header-menu-selected-hover-background: menu-background(
-  mix($pt-intent-primary, $header-hover-background-color, 10%)
+  color.mix($pt-intent-primary, $header-hover-background-color, 10%)
 );
 $dark-selectable-header-menu-hover-background: menu-background($dark-header-hover-background-color);
 $dark-selectable-header-menu-selected-background: menu-background(
-  mix($pt-intent-primary, $dark-header-background-color, 10%)
+  color.mix($pt-intent-primary, $dark-header-background-color, 10%)
 );
 $dark-selectable-header-menu-selected-hover-background: menu-background(
-  mix($pt-intent-primary, $dark-header-hover-background-color, 10%)
+  color.mix($pt-intent-primary, $dark-header-hover-background-color, 10%)
 );
 
 .#{$ns}-table-header {


### PR DESCRIPTION
## Description

This change migrates Sass global built-in functions to use the module system using the [sass-migrator](https://sass-lang.com/documentation/cli/migrator) tool. Specifically, we want to **_only_** migrate global built-in functions first since we have encountered trouble in the past when trying to migrate other `@import` rules to use `@use` (e.g. #7157).

This prevents the following warnings from being shown when compiling Sass:
```
DEPRECATION WARNING [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
```

The following command was run to generate this PR:
```
sass-migrator \
  --load-path node_modules \
  module \
  --migrate-deps \
  --built-in-only \
  packages/colors/src/_colors.scss \
  packages/core/src/blueprint.scss \
  packages/datetime/src/blueprint-datetime.scss \
  packages/datetime2/src/blueprint-datetime2.scss \
  packages/demo-app/src/index.scss \
  packages/docs-app/src/index.scss \
  packages/docs-theme/src/docs-theme.scss \
  packages/landing-app/src/index.scss \
  packages/select/src/blueprint-select.scss \
  packages/table-dev-app/src/index.scss \
  packages/table/src/table.scss
```

https://sass-lang.com/documentation/breaking-changes/import/#automatic-migration

> If you want to migrate away from global built-in functions, but aren’t yet ready to fully migrate your `@import` rules, you can pass the `--built-in-only` flag to migrate the functions while leaving `@import` rules as-is.