### PR TITLE
[Fix] Allow focus on items wrapped in disabled tooltips

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -253,10 +253,10 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         {
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
+            ...removeNonHTMLProps(htmlProps),
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
             role: hasSubmenu ? "none" : targetRole,
             tabIndex: hasSubmenu ? -1 : 0,
-            ...removeNonHTMLProps(htmlProps),
             ...(disabled ? DISABLED_PROPS : {}),
             className: anchorClasses,
         },

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -248,15 +248,17 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             </span>
         );
 
+    const htmlPropsOnly = removeNonHTMLProps(htmlProps);
+
     const target = createElement(
         tagName,
         {
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
-            ...removeNonHTMLProps(htmlProps),
+            ...htmlPropsOnly,
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
             role: hasSubmenu ? "none" : targetRole,
-            tabIndex: hasSubmenu ? -1 : 0,
+            tabIndex: hasSubmenu ? -1 : htmlPropsOnly.tabIndex != null ? htmlPropsOnly.tabIndex : 0,
             ...(disabled ? DISABLED_PROPS : {}),
             className: anchorClasses,
         },


### PR DESCRIPTION
#### Fixes #7046

#### Checklist

-   [x] Includes tests
-   [ ] Update documentation

#### Changes proposed in this pull request:

The issue that came up was that `targetTabIndex` was `undefined` if the popover is disabled. There seems to have been work to not set `tabIndex` here (https://github.com/palantir/blueprint/pull/6851) as well when content is empty. However, this didn't allow for `menuItem` to set its `tabIndex`.

The fix is to have a fallback for `MenuItem` to set `tabIndex` even if the `htmlProps` come through with a `tabIndex` of `undefined`, since it was being overwritten by `...removeNonHTMLProps`.

#### Reviewers should focus on:

- https://github.com/palantir/blueprint/pull/6851 might now be an issue, need to check.
- Are the a11y responsibilities satisfied with this?

#### Screenshot

<img width="1265" height="1150" alt="demo-app-popover-tab-index" src="https://github.com/user-attachments/assets/250483d1-c711-4ebf-920a-0923d3ebb07c" />
