### PR TITLE
[chore/devx] Speed up local `lint` command

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,7 @@ module.exports = tseslint.config([
                 },
             ],
             // Run import/no-cycle only in CI because it is slow.
-            "import/no-cycle": process.env.LINT_SCRIPT ? "error" : "off",
+            "import/no-cycle": process.env.LINT_SCRIPT === "true" ? "error" : "off",
         },
     },
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,7 @@ module.exports = tseslint.config([
                 },
             ],
             // Run import/no-cycle only in CI because it is slow.
-            "import/no-cycle": process.env.LINT_SCRIPT === "true" ? "error" : "off",
+            "import/no-cycle": process.env.CI ? "error" : "off",
         },
     },
     {

--- a/packages/node-build-scripts/es-lint.mjs
+++ b/packages/node-build-scripts/es-lint.mjs
@@ -20,7 +20,9 @@ import { junitReportPath } from "./src/utils.mjs";
 await main();
 
 async function main() {
-    env.LINT_SCRIPT = "true";
+    if (process.env.CI) {
+        env.LINT_SCRIPT = "true";
+    }
 
     const FILES_GLOB = "{src,test}/**/*.{ts,tsx}";
     const absoluteFileGlob = resolve(cwd(), FILES_GLOB);

--- a/packages/node-build-scripts/es-lint.mjs
+++ b/packages/node-build-scripts/es-lint.mjs
@@ -13,17 +13,13 @@ import { ESLint } from "eslint";
 import fs from "fs-extra";
 import { globSync } from "glob";
 import { resolve } from "node:path";
-import { argv, cwd, env, exit } from "node:process";
+import { argv, cwd, exit } from "node:process";
 
 import { junitReportPath } from "./src/utils.mjs";
 
 await main();
 
 async function main() {
-    if (process.env.CI) {
-        env.LINT_SCRIPT = "true";
-    }
-
     const FILES_GLOB = "{src,test}/**/*.{ts,tsx}";
     const absoluteFileGlob = resolve(cwd(), FILES_GLOB);
 


### PR DESCRIPTION
## Description

Fixes an issue where lint commands take a very long time to execute (> 5 mins). This is due to the  `import/no-cycle` ESLint rule being enabled locally when it was originally intended to only be run on CI.

## Metrics

Executing lint on `@blueprintjs/core`

**Before:** 81s
```
time yarn lint
[node-build-scripts/es-lint] Running ESLint on /Volumes/git/blueprint/packages/core/{src,test}/**/*.{ts,tsx}
[node-build-scripts/es-lint] Done running ESLint, with no errors.
yarn lint  80.91s user 3.78s system 125% cpu 1:07.41 total
```

**After:** 20s
```
time yarn lint
[node-build-scripts/es-lint] Running ESLint on /Volumes/git/blueprint/packages/core/{src,test}/**/*.{ts,tsx}
[node-build-scripts/es-lint] Done running ESLint, with no errors.
yarn lint  19.60s user 1.45s system 206% cpu 10.193 total
```

---

Executing lint on `@blueprintjs/docs-app`

**Before:** 5min 18s
```
time yarn lint
[node-build-scripts/es-lint] Running ESLint on /Volumes/git/blueprint/packages/docs-app/{src,test}/**/*.{ts,tsx}
[node-build-scripts/es-lint] Done running ESLint, with no errors.
yarn lint  317.67s user 15.61s system 104% cpu 5:18.10 total
```

**After:** 9s
```
time yarn lint
[node-build-scripts/es-lint] Running ESLint on /Volumes/git/blueprint/packages/docs-app/{src,test}/**/*.{ts,tsx}
[node-build-scripts/es-lint] Done running ESLint, with no errors.
yarn lint  9.30s user 0.90s system 193% cpu 5.276 total
```
