### PR TITLE
[FIX] Inner Label in OFF State appears in ON State when ON State is Empty

### DIFF
--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -114,7 +114,7 @@ export const Switch: React.FC<SwitchProps> = forwardRef((props, ref) => {
             ? [
                   <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
                       <div className={Classes.SWITCH_INNER_TEXT}>
-                          {innerLabelChecked ? innerLabelChecked : innerLabel}
+                          {innerLabelChecked ?? innerLabel}
                       </div>
                   </div>,
                   <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>

--- a/packages/core/src/components/forms/controls.tsx
+++ b/packages/core/src/components/forms/controls.tsx
@@ -113,9 +113,7 @@ export const Switch: React.FC<SwitchProps> = forwardRef((props, ref) => {
         innerLabel || innerLabelChecked
             ? [
                   <div key="checked" className={Classes.CONTROL_INDICATOR_CHILD}>
-                      <div className={Classes.SWITCH_INNER_TEXT}>
-                          {innerLabelChecked ?? innerLabel}
-                      </div>
+                      <div className={Classes.SWITCH_INNER_TEXT}>{innerLabelChecked ?? innerLabel}</div>
                   </div>,
                   <div key="unchecked" className={Classes.CONTROL_INDICATOR_CHILD}>
                       <div className={Classes.SWITCH_INNER_TEXT}>{innerLabel}</div>

--- a/packages/core/test/controls/controlsTests.tsx
+++ b/packages/core/test/controls/controlsTests.tsx
@@ -140,11 +140,62 @@ describe("Controls", () => {
             expect(labels).to.have.length(1);
         });
 
-        it("should render two innerLabels when innerLabel is defined and innerLabelChecked is not", () => {
+        it("should use innerLabel for both states when only innerLabel is defined", () => {
             render(<Switch innerLabel="test" />);
-            const labels = screen.getAllByText("test");
+            const switchContainer = screen.getByRole("checkbox").closest(`.${Classes.SWITCH}`);
+            const labelTexts = switchContainer!.querySelectorAll(`.${Classes.SWITCH_INNER_TEXT}`);
 
-            expect(labels).to.have.length(2);
+            // Should render 2 containers and both should have "test" text (by design)
+            expect(labelTexts).to.have.length(2);
+            expect(labelTexts[0].textContent).to.equal("test"); // checked state
+            expect(labelTexts[1].textContent).to.equal("test"); // unchecked state
+        });
+
+        it("should show innerLabelChecked only when innerLabel is explicitly empty string", () => {
+            render(<Switch innerLabelChecked="on" innerLabel="" />);
+            const switchContainer = screen.getByRole("checkbox").closest(`.${Classes.SWITCH}`);
+            const labelTexts = switchContainer!.querySelectorAll(`.${Classes.SWITCH_INNER_TEXT}`);
+
+            // Checked label should have "on", unchecked label should be empty (bug fix verification)
+            expect(labelTexts[0].textContent).to.equal("on");
+            expect(labelTexts[1].textContent).to.equal("");
+        });
+
+        it("should show innerLabel only when innerLabelChecked is explicitly empty string", () => {
+            render(<Switch innerLabelChecked="" innerLabel="off" />);
+            const switchContainer = screen.getByRole("checkbox").closest(`.${Classes.SWITCH}`);
+            const labelTexts = switchContainer!.querySelectorAll(`.${Classes.SWITCH_INNER_TEXT}`);
+
+            // Checked label should be empty, unchecked label should have "off" (bug fix verification)
+            expect(labelTexts[0].textContent).to.equal("");
+            expect(labelTexts[1].textContent).to.equal("off");
+        });
+
+        it("should toggle between innerLabelChecked and innerLabel when both are defined", () => {
+            const { rerender } = render(<Switch innerLabelChecked="on" innerLabel="off" checked={false} />);
+            let switchContainer = screen.getByRole("checkbox").closest(`.${Classes.SWITCH}`);
+            let labelTexts = switchContainer!.querySelectorAll(`.${Classes.SWITCH_INNER_TEXT}`);
+
+            // When unchecked, checked label should have "on" and unchecked label should have "off"
+            expect(labelTexts[0].textContent).to.equal("on");
+            expect(labelTexts[1].textContent).to.equal("off");
+
+            // When checked, same labels exist (CSS controls visibility)
+            rerender(<Switch innerLabelChecked="on" innerLabel="off" checked={true} />);
+            switchContainer = screen.getByRole("checkbox").closest(`.${Classes.SWITCH}`);
+            labelTexts = switchContainer!.querySelectorAll(`.${Classes.SWITCH_INNER_TEXT}`);
+            expect(labelTexts[0].textContent).to.equal("on");
+            expect(labelTexts[1].textContent).to.equal("off");
+        });
+
+        it("should show innerLabelChecked in checked label and empty in unchecked label when only innerLabelChecked is defined", () => {
+            render(<Switch innerLabelChecked="on" />);
+            const switchContainer = screen.getByRole("checkbox").closest(`.${Classes.SWITCH}`);
+            const labelTexts = switchContainer!.querySelectorAll(`.${Classes.SWITCH_INNER_TEXT}`);
+
+            // Checked label should have "on", unchecked label should be empty
+            expect(labelTexts[0].textContent).to.equal("on");
+            expect(labelTexts[1].textContent).to.equal("");
         });
     });
 });


### PR DESCRIPTION
#### Fixes #7617

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

#### Changes proposed in this pull request:

- Simple recalculation of inner label when one is not specified

#### Reviewers should focus on:

The switch component, specifically when the off label is specified only, and compare to the functionality of when the on label is specified only.

#### Screenshot

<img width="224" height="55" alt="Screenshot 2025-11-03 at 11 03 22 PM" src="https://github.com/user-attachments/assets/0e662b88-2cd1-40dd-8654-daf61901ad75" />

<img width="220" height="51" alt="Screenshot 2025-11-03 at 11 03 36 PM" src="https://github.com/user-attachments/assets/549827e8-2919-4654-b73f-ef1eca9bc8bf" />

#### Testing

Put this block of code in the switch example to test this out

```
<Switch
    {...switchProps}
    labelElement={"Bug Test: Only ON label"}
    innerLabelChecked="on"
    innerLabel=""
/>
<Switch
    {...switchProps}
    labelElement={"Bug Test: Only OFF label"}
    innerLabelChecked=""
    innerLabel="off"
/>
```