### PR TITLE
[chore] Fix publishing to npm with `pnpm publish`

### DIFF
--- a/scripts/circle-publish-npm
+++ b/scripts/circle-publish-npm
@@ -23,7 +23,7 @@ fi
 if [[ "$branch" == "next" ]]; then
     echo "Publishing with next tag because branch name is next"
     # must set public access for scoped packages
-    pnpm publish --tag next --access public
+    pnpm publish --publish-branch "$branch" --tag next --access public
 else
-    pnpm publish --access public
+    pnpm publish --publish-branch "$branch" --access public
 fi


### PR DESCRIPTION
## Changes

Fixes deploying packages to npm post yarn-to-pnpm migration.

#7598 changed the package manager from yarn to pnpm. The `deploy-npm` job currently fails on the `publish-npm-semver-tagged` call to `circle-publish-npm` with the following output:

```
~/project/packages/colors ~/project
Attempting to publish package at path 'packages/colors'
? You're on branch "develop" but your "publish-branch" is set to "master|main". Do you want to continue? (y/N) ‣ false
Too long with no output (exceeded 10m0s): context deadline exceeded
```
> https://app.circleci.com/pipelines/github/palantir/blueprint/9174/workflows/ae492397-1f21-4313-8e75-29ab40733453/jobs/116230

Add the `--publish-branch` to specify the correct branch for publishing (usually "develop").

See: https://pnpm.io/cli/publish