### PR TITLE
Remove docs banner

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -21,7 +21,6 @@ import { Component } from "react";
 import { AnchorButton, BlueprintProvider, Classes, type Intent, Tag } from "@blueprintjs/core";
 import type { DocsCompleteData } from "@blueprintjs/docs-data";
 import {
-    Banner,
     Documentation,
     type DocumentationProps,
     NavMenuItem,
@@ -74,11 +73,6 @@ export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: st
     public state = { themeName: getTheme() };
 
     public render() {
-        const banner = (
-            <Banner href="https://blueprintjs.com/docs/versions/5">
-                Blueprint v6.x is now in stable release. Still using v5.x? Click here to view the legacy docs &rarr;
-            </Banner>
-        );
         const footer = (
             <small className={classNames("docs-copyright", Classes.TEXT_MUTED)}>
                 &copy; {new Date().getFullYear()}
@@ -109,7 +103,6 @@ export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: st
                     <Documentation
                         {...this.props}
                         className={this.state.themeName}
-                        banner={banner}
                         footer={footer}
                         header={header}
                         navigatorExclude={isNavSection}


### PR DESCRIPTION
Remove the banner calling out old docs version. Standard practice is to call out when you are on a legacy version of the docs, not the other way around

ex
<img width="1286" height="158" alt="image" src="https://github.com/user-attachments/assets/bf0708f6-b7ec-4e7d-85fe-37e4d92a8c4b" />
<img width="747" height="44" alt="image" src="https://github.com/user-attachments/assets/b90d8b42-91a5-4f69-b90a-bb4d11088147" />
