### PR TITLE
[chore] Configure publishBranch in `pnpm-workspace.yaml`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,6 @@ packages:
 catalog:
   classnames: ^2.3.1
   tslib: ~2.6.2
+
+# CI: Only publish from develop, next, or release/* branches
+publishBranch: "^(develop|next|release/.*)$"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,4 @@ catalog:
   classnames: ^2.3.1
   tslib: ~2.6.2
 
-# CI: Only publish from develop, next, or release/* branches
-publishBranch: "^(develop|next|release/.*)$"
+publishBranch: develop

--- a/scripts/circle-publish-npm
+++ b/scripts/circle-publish-npm
@@ -23,7 +23,7 @@ fi
 if [[ "$branch" == "next" ]]; then
     echo "Publishing with next tag because branch name is next"
     # must set public access for scoped packages
-    pnpm publish --publish-branch "$branch" --tag next --access public
+    pnpm publish --tag next --access public
 else
-    pnpm publish --publish-branch "$branch" --access public
+    pnpm publish --access public
 fi

--- a/scripts/circle-publish-npm
+++ b/scripts/circle-publish-npm
@@ -23,7 +23,7 @@ fi
 if [[ "$branch" == "next" ]]; then
     echo "Publishing with next tag because branch name is next"
     # must set public access for scoped packages
-    pnpm publish --tag next --access public
+    pnpm publish --publish-branch next --tag next --access public
 else
     pnpm publish --access public
 fi


### PR DESCRIPTION
## Changes

Follow-up to #7619 to move `publishBranch` configuration from command-line arguments to `pnpm-workspace.yaml`.

Addresses https://github.com/palantir/blueprint/pull/7619#discussion_r2491231723

## Context

As noted in the [PR comment](https://github.com/palantir/blueprint/pull/7619#discussion_r2491231723), pnpm provides multiple ways to configure the `publishBranch` option. Dynamically passing the branch via `--publish-branch "$branch"` reduces protection against accidental publishing from feature branches. By centralizing this configuration in `pnpm-workspace.yaml`, we maintain stronger safety guarantees.

See [pnpm publish configuration documentation](https://pnpm.io/cli/publish#configuration) for details on workspace-level configuration.

## Testing

CI should continue to work correctly for publishing from `develop`, `next`, and `release/*` branches, while preventing accidental publishes from feature branches.

- [x] Verify with `pnpm publish --dry-run` after this PR merges and is on `develop`.