### PR TITLE
[chore] Remove cyclic dependency between `karma-build-scripts` and `core`

### DIFF
--- a/packages/karma-build-scripts/createKarmaConfig.mjs
+++ b/packages/karma-build-scripts/createKarmaConfig.mjs
@@ -139,8 +139,5 @@ function getCoreStylesheetPath(dirname) {
     const localCorePath = join(dirname, "../core");
     if (existsSync(localCorePath)) {
         return join(localCorePath, coreManifest.style);
-    } else {
-        // resolves to "**/node_modules/@blueprintjs/core/lib/cjs/index.js"
-        return join(require.resolve("@blueprintjs/core"), "../../../", coreManifest.style);
     }
 }

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -23,14 +23,6 @@
         "mocha": "^10.2.0",
         "webpack": "^5.90.0"
     },
-    "peerDependencies": {
-        "@blueprintjs/core": "workspace:^"
-    },
-    "peerDependenciesMeta": {
-        "@blueprintjs/core": {
-            "optional": true
-        }
-    },
     "repository": {
         "type": "git",
         "url": "git@github.com:palantir/blueprint.git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -733,9 +733,6 @@ importers:
 
   packages/karma-build-scripts:
     dependencies:
-      '@blueprintjs/core':
-        specifier: workspace:^
-        version: link:../core
       '@blueprintjs/webpack-build-scripts':
         specifier: workspace:^
         version: link:../webpack-build-scripts


### PR DESCRIPTION
## Changes

Fixes a cyclic dependency between the `karma-build-scripts` and `core` packages that was being flagged by pnpm during install:

```
pnpm install
Scope: all 24 workspace projects
 WARN  There are cyclic workspace dependencies: /blueprint/packages/core, blueprint/packages/karma-build-scripts
...
```

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
