### PR TITLE
[chore] Upgrade `date-fns` to v3

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -41,8 +41,8 @@
         "@blueprintjs/icons": "workspace:^",
         "@blueprintjs/select": "workspace:^",
         "classnames": "catalog:",
-        "date-fns": "^2.28.0",
-        "date-fns-tz": "^2.0.0",
+        "date-fns": "^3.6.0",
+        "date-fns-tz": "^3.2.0",
         "react-day-picker": "^8.10.0",
         "react-innertext": "^1.1.5",
         "tslib": "catalog:"

--- a/packages/datetime/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime/src/common/dateFnsLocaleUtils.ts
@@ -23,14 +23,20 @@ import type { DateFnsLocaleLoader } from "./dateFnsLocaleProps";
 
 /**
  * Lazy-loads a date-fns locale for use in a datetime class component.
+ *
+ * Note: date-fns v3+ uses named exports instead of default exports.
+ * The locale code (e.g., "en-US") must be converted to camelCase (e.g., "enUS")
+ * to access the correct export.
  */
 export async function loadDateFnsLocale(localeCode: string): Promise<Locale | undefined> {
     try {
         const localeModule = await import(
             /* webpackChunkName: "date-fns-locale-[request]" */
-            `date-fns/locale/${localeCode}/index.js`
+            `date-fns/locale/${localeCode}.mjs`
         );
-        return localeModule.default;
+        // Convert locale code to camelCase for named export access (e.g., "en-US" -> "enUS")
+        const camelCaseCode = localeCode.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+        return localeModule[camelCaseCode];
     } catch {
         if (!Utils.isNodeEnv("production")) {
             console.error(

--- a/packages/datetime/src/common/timezoneUtils.ts
+++ b/packages/datetime/src/common/timezoneUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { formatInTimeZone, utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
+import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
 
 import { getCurrentTimezone } from "./getTimezone";
 import { TimePrecision } from "./timePrecision";
@@ -91,8 +91,8 @@ export function getDateObjectFromIsoString(
  * @returns The date converted to match the new timezone
  */
 export function convertLocalDateToTimezoneTime(date: Date, newTimezone: string) {
-    const nowUtc = zonedTimeToUtc(date, getCurrentTimezone());
-    return utcToZonedTime(nowUtc, newTimezone);
+    const nowUtc = fromZonedTime(date, getCurrentTimezone());
+    return toZonedTime(nowUtc, newTimezone);
 }
 
 /**
@@ -105,6 +105,6 @@ export function convertLocalDateToTimezoneTime(date: Date, newTimezone: string) 
  * @returns The date converted to match the new timezone
  */
 export function convertDateToLocalEquivalentOfTimezoneTime(date: Date, newTimezone: string) {
-    const nowUtc = zonedTimeToUtc(date, newTimezone);
-    return utcToZonedTime(nowUtc, getCurrentTimezone());
+    const nowUtc = fromZonedTime(date, newTimezone);
+    return toZonedTime(nowUtc, getCurrentTimezone());
 }

--- a/packages/datetime/src/components/date-picker/date-picker.md
+++ b/packages/datetime/src/components/date-picker/date-picker.md
@@ -118,7 +118,7 @@ Use the `locale: Locale` type if you wish to statically load date-fns locale mod
 
 ```ts
 import { DatePicker } from "@blueprintjs/datetime";
-import enUS from "date-fns/locale/en-US";
+import { enUS } from "date-fns/locale/en-US";
 
 function Example() {
     return <DatePicker locale={enUS} />;

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { isSameDay, isValid } from "date-fns";
+import { isSameDay, isValid, type Locale } from "date-fns";
 import { createElement } from "react";
 
 import {

--- a/packages/datetime/test/common/loadDateFnsLocaleFake.ts
+++ b/packages/datetime/test/common/loadDateFnsLocaleFake.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Locale } from "date-fns";
 import * as Locales from "date-fns/locale";
 
 export async function loadDateFnsLocaleFake(localeOrCode: Locale | string | undefined) {

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -16,8 +16,8 @@
 
 import { assert } from "chai";
 import { intlFormat, isEqual, parseISO } from "date-fns";
-import enUSLocale from "date-fns/locale/en-US";
-import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
+import { enUS as enUSLocale } from "date-fns/locale/en-US";
+import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef } from "react";
 import * as sinon from "sinon";
@@ -970,7 +970,7 @@ describe("<DateInput>", () => {
  * Use this helper function to reset the date's timezone to UTC instead.
  */
 function localDateToUtcDate(date: Date) {
-    return zonedTimeToUtc(date, TimezoneUtils.getCurrentTimezone());
+    return fromZonedTime(date, TimezoneUtils.getCurrentTimezone());
 }
 
 function dateToIsoString(date: Date) {

--- a/packages/datetime/test/components/datePickerTests.tsx
+++ b/packages/datetime/test/components/datePickerTests.tsx
@@ -15,7 +15,7 @@
  */
 
 import { assert } from "chai";
-import enUSLocale from "date-fns/locale/en-US";
+import { enUS as enUSLocale } from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
 import { Day } from "react-day-picker";
 import sinon from "sinon";

--- a/packages/datetime/test/components/dateRangeInputTests.tsx
+++ b/packages/datetime/test/components/dateRangeInputTests.tsx
@@ -15,9 +15,9 @@
  */
 
 import { expect } from "chai";
-import { format, parse } from "date-fns";
+import { format, type Locale, parse } from "date-fns";
 import * as Locales from "date-fns/locale";
-import esLocale from "date-fns/locale/es";
+import { es as esLocale } from "date-fns/locale/es";
 import { mount, type ReactWrapper } from "enzyme";
 import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";

--- a/packages/datetime/test/components/dateRangePickerTests.tsx
+++ b/packages/datetime/test/components/dateRangePickerTests.tsx
@@ -16,7 +16,7 @@
 
 import { assert } from "chai";
 import { addDays, format, parse } from "date-fns";
-import enUSLocale from "date-fns/locale/en-US";
+import { enUS as enUSLocale } from "date-fns/locale/en-US";
 import { mount, type ReactWrapper } from "enzyme";
 import { type DayModifiers, DayPicker, type ModifiersClassNames } from "react-day-picker";
 import sinon from "sinon";

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -37,7 +37,7 @@
         "@blueprintjs/core": "workspace:^",
         "@blueprintjs/datetime": "workspace:^",
         "@blueprintjs/icons": "workspace:^",
-        "date-fns": "^2.28.0",
+        "date-fns": "^3.6.0",
         "react-day-picker": "^8.10.0",
         "tslib": "catalog:"
     },

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -30,7 +30,7 @@
         "@documentalist/client": "^5.0.0",
         "chroma-js": "^2.4.2",
         "classnames": "catalog:",
-        "date-fns": "^2.28.0",
+        "date-fns": "^3.6.0",
         "dedent": "^1.5.1",
         "downloadjs": "^1.4.7",
         "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,14 +228,14 @@ importers:
         specifier: 'catalog:'
         version: 2.5.1
       date-fns:
-        specifier: ^2.28.0
-        version: 2.30.0
+        specifier: ^3.6.0
+        version: 3.6.0
       date-fns-tz:
-        specifier: ^2.0.0
-        version: 2.0.1(date-fns@2.30.0)
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@3.6.0)
       react-day-picker:
         specifier: ^8.10.0
-        version: 8.10.1(date-fns@2.30.0)(react@18.3.1)
+        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
       react-innertext:
         specifier: ^1.1.5
         version: 1.1.5(@types/react@18.3.12)(react@18.3.1)
@@ -304,11 +304,11 @@ importers:
         specifier: 18.3.12
         version: 18.3.12
       date-fns:
-        specifier: ^2.28.0
-        version: 2.30.0
+        specifier: ^3.6.0
+        version: 3.6.0
       react-day-picker:
         specifier: ^8.10.0
-        version: 8.10.1(date-fns@2.30.0)(react@18.3.1)
+        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
       tslib:
         specifier: 'catalog:'
         version: 2.6.3
@@ -444,8 +444,8 @@ importers:
         specifier: 'catalog:'
         version: 2.5.1
       date-fns:
-        specifier: ^2.28.0
-        version: 2.30.0
+        specifier: ^3.6.0
+        version: 3.6.0
       dedent:
         specifier: ^1.5.1
         version: 1.7.0
@@ -4291,14 +4291,13 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns-tz@2.0.1:
-    resolution: {integrity: sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==}
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
     peerDependencies:
-      date-fns: 2.x
+      date-fns: ^3.0.0 || ^4.0.0
 
-  date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
@@ -12456,13 +12455,11 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns-tz@2.0.1(date-fns@2.30.0):
+  date-fns-tz@3.2.0(date-fns@3.6.0):
     dependencies:
-      date-fns: 2.30.0
+      date-fns: 3.6.0
 
-  date-fns@2.30.0:
-    dependencies:
-      '@babel/runtime': 7.28.4
+  date-fns@3.6.0: {}
 
   date-format@4.0.14: {}
 
@@ -16211,9 +16208,9 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
 
-  react-day-picker@8.10.1(date-fns@2.30.0)(react@18.3.1):
+  react-day-picker@8.10.1(date-fns@3.6.0)(react@18.3.1):
     dependencies:
-      date-fns: 2.30.0
+      date-fns: 3.6.0
       react: 18.3.1
 
   react-dom@18.3.1(react@18.3.1):


### PR DESCRIPTION
Fixes #6744

## Summary
Upgrades `date-fns` from v2.28.0 to v3.6.0 and `date-fns-tz` from v2.0.0 to v3.2.0 across all Blueprint packages that use these dependencies.

## Changes

### Package Updates

- **@blueprintjs/datetime:** `date-fns` ^2.28.0 → ^3.6.0, `date-fns-tz` ^2.0.0 → ^3.2.0
- **@blueprintjs/datetime2:** `date-fns` ^2.28.0 → ^3.6.0
- **@blueprintjs/docs-app:** `date-fns` ^2.28.0 → ^3.6.0

### Code Changes

**1. Locale Imports**

date-fns v3 uses named exports instead of default exports:
```diff
- import enUSLocale from "date-fns/locale/en-US";
+ import { enUS as enUSLocale } from "date-fns/locale/en-US";
```

**2. Dynamic Locale Loading**

Updated the dynamic locale loader for v3's flat package structure:
```diff
- `date-fns/locale/${localeCode}/index.js`
+ `date-fns/locale/${localeCode}.mjs`
```

Also added logic to convert locale codes to camelCase for named export access (e.g., "en-US" → "enUS"). File: `src/common/dateFnsLocaleUtils.ts`

**3. date-fns-tz v3 API Changes**

Function names were updated to match the new API:

```diff
- import { zonedTimeToUtc, utcToZonedTime } from "date-fns-tz";
+ import { fromZonedTime, toZonedTime } from "date-fns-tz";
```

**4. Missing Type Imports**

Added missing Locale type imports in files where the type was used but not imported.

## Breaking Changes
None for consumers. All changes are internal to Blueprint. The public API of `@blueprintjs/datetime` remains unchanged.

## References

- [date-fns v3 release blog post](https://blog.date-fns.org/v3-is-out/)
- [date-fns v3.0.0 changelog](https://date-fns.org/v3.0.0/docs/Change-Log#3.0.0-2023-12-18)
- [date-fns-tz v3 README](https://github.com/marnusw/date-fns-tz#readme)

## Future Work
Phase 2 (#7633): Upgrade to date-fns v4 and migrate from third-party `date-fns-tz` to the official `@date-fns/tz` package with first-class timezone support via `TZDate`.