### PR TITLE
[chore] Upgrade `date-fns` to v4

### DIFF
--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -40,9 +40,9 @@
         "@blueprintjs/core": "workspace:^",
         "@blueprintjs/icons": "workspace:^",
         "@blueprintjs/select": "workspace:^",
+        "@date-fns/tz": "^1.2.0",
         "classnames": "catalog:",
-        "date-fns": "^3.6.0",
-        "date-fns-tz": "^3.2.0",
+        "date-fns": "^4.1.0",
         "react-day-picker": "^8.10.0",
         "react-innertext": "^1.1.5",
         "tslib": "catalog:"

--- a/packages/datetime/src/common/timezoneNameUtils.ts
+++ b/packages/datetime/src/common/timezoneNameUtils.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { formatInTimeZone } from "date-fns-tz";
+import { tz } from "@date-fns/tz";
+import { format } from "date-fns";
 
 import { getCurrentTimezone } from "./getTimezone";
 import { MINIMAL_TIMEZONE_ITEMS, TIMEZONE_ITEMS } from "./timezoneItems";
@@ -37,24 +38,27 @@ export function isValidTimezone(timeZone: string | undefined): boolean {
 }
 
 export function getTimezoneShortName(tzIanaCode: string, date: Date | undefined) {
-    return formatInTimeZone(date ?? CURRENT_DATE, tzIanaCode, SHORT_NAME_FORMAT_STR);
+    return format(date ?? CURRENT_DATE, SHORT_NAME_FORMAT_STR, { in: tz(tzIanaCode) });
 }
 
 /**
- * Augments a simple {@link Timezone} metadata object with long and short names formatted by `date-fns-tz`.
+ * Augments a simple {@link Timezone} metadata object with long and short names formatted by date-fns with @date-fns/tz.
  */
-export function getTimezoneNames(tz: Timezone, date: Date | number | undefined = CURRENT_DATE): TimezoneWithNames {
+export function getTimezoneNames(
+    timezone: Timezone,
+    date: Date | number | undefined = CURRENT_DATE,
+): TimezoneWithNames {
     return {
-        ...tz,
-        longName: formatInTimeZone(date, tz.ianaCode, LONG_NAME_FORMAT_STR),
-        shortName: formatInTimeZone(date, tz.ianaCode, SHORT_NAME_FORMAT_STR),
+        ...timezone,
+        longName: format(date, LONG_NAME_FORMAT_STR, { in: tz(timezone.ianaCode) }),
+        shortName: format(date, SHORT_NAME_FORMAT_STR, { in: tz(timezone.ianaCode) }),
     };
 }
 
 export const mapTimezonesWithNames = (
     date: Date | undefined,
     timezones: Timezone[] | TimezoneWithNames[],
-): TimezoneWithNames[] => timezones.map(tz => getTimezoneNames(tz, date));
+): TimezoneWithNames[] => timezones.map(timezone => getTimezoneNames(timezone, date));
 
 export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezone: boolean): TimezoneWithNames[] {
     const systemTimezone = getCurrentTimezone();
@@ -66,11 +70,11 @@ export function getInitialTimezoneItems(date: Date | undefined, showLocalTimezon
             ? {
                   ...localTimezone,
                   longName: "Current timezone",
-                  shortName: formatInTimeZone(date ?? CURRENT_DATE, localTimezone.ianaCode, SHORT_NAME_FORMAT_STR),
+                  shortName: format(date ?? CURRENT_DATE, SHORT_NAME_FORMAT_STR, { in: tz(localTimezone.ianaCode) }),
               }
             : undefined;
     const minimalTimezoneItemsWithNames = mapTimezonesWithNames(date, MINIMAL_TIMEZONE_ITEMS).filter(
-        tz => tz.ianaCode !== localTimezoneItem?.ianaCode,
+        timezone => timezone.ianaCode !== localTimezoneItem?.ianaCode,
     );
     return localTimezoneItem === undefined
         ? minimalTimezoneItemsWithNames

--- a/packages/datetime/src/common/timezoneOffsetUtils.ts
+++ b/packages/datetime/src/common/timezoneOffsetUtils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getTimezoneOffset } from "date-fns-tz";
+import { tzOffset } from "@date-fns/tz";
 
 import type { Timezone, TimezoneWithoutOffset } from "./timezoneTypes";
 
@@ -22,16 +22,18 @@ import type { Timezone, TimezoneWithoutOffset } from "./timezoneTypes";
  * Augment hard-coded timezone information stored in this package with its current offset relative to UTC,
  * adjusted for daylight saving using the current date.
  *
- * @see https://github.com/marnusw/date-fns-tz#gettimezoneoffset
+ * @see https://github.com/date-fns/tz
  */
 export function lookupTimezoneOffset(tz: TimezoneWithoutOffset, date?: Date): Timezone {
-    const offsetInMs = getTimezoneOffset(tz.ianaCode, date);
+    // tzOffset returns offset in minutes directly
+    const offsetInMinutesFromTzOffset = tzOffset(tz.ianaCode, date ?? new Date());
+    const offsetInMs = offsetInMinutesFromTzOffset * 60 * 1000;
     if (isNaN(offsetInMs)) {
         throw new Error(`Unable to lookup offset for invalid timezone '${tz.ianaCode}'`);
     }
 
     const isPositiveOffset = offsetInMs >= 0;
-    const offsetInMinutes = Math.abs(offsetInMs) / 1000 / 60;
+    const offsetInMinutes = Math.abs(offsetInMinutesFromTzOffset);
     const offsetHours = Math.trunc(offsetInMinutes / 60)
         .toString()
         .padStart(2, "0");

--- a/packages/datetime/src/common/timezoneUtils.ts
+++ b/packages/datetime/src/common/timezoneUtils.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
+import { tz, tzOffset } from "@date-fns/tz";
+import { format } from "date-fns";
 
 import { getCurrentTimezone } from "./getTimezone";
 import { TimePrecision } from "./timePrecision";
@@ -32,8 +33,7 @@ const TIME_FORMAT_TO_ISO_FORMAT: Record<TimePrecision | "date", string> = {
 };
 
 /**
- * @see https://github.com/marnusw/date-fns-tz#formatintimezone
- * @returns a string of tokens which tell date-fns-tz's formatInTimeZone how to render a datetime
+ * @returns a string of tokens which tell date-fns how to render a datetime
  */
 function getFormatStr(timePrecision: TimePrecision | undefined): string {
     return TIME_FORMAT_TO_ISO_FORMAT[timePrecision ?? NO_TIME_PRECISION];
@@ -45,7 +45,8 @@ export function getIsoEquivalentWithUpdatedTimezone(
     timePrecision: TimePrecision | undefined,
 ): string {
     const convertedDate = convertDateToLocalEquivalentOfTimezoneTime(date, timezone);
-    return formatInTimeZone(convertedDate, timezone, getFormatStr(timePrecision));
+    // Format the date in the specified timezone using date-fns v4 with @date-fns/tz
+    return format(convertedDate, getFormatStr(timePrecision), { in: tz(timezone) });
 }
 
 /**
@@ -91,8 +92,12 @@ export function getDateObjectFromIsoString(
  * @returns The date converted to match the new timezone
  */
 export function convertLocalDateToTimezoneTime(date: Date, newTimezone: string) {
-    const nowUtc = fromZonedTime(date, getCurrentTimezone());
-    return toZonedTime(nowUtc, newTimezone);
+    // Equivalent to the old toZonedTime function
+    // Takes a date and returns it adjusted to show the same moment in the new timezone
+    const currentOffset = tzOffset(getCurrentTimezone(), date);
+    const newOffset = tzOffset(newTimezone, date);
+    const offsetDiff = newOffset - currentOffset;
+    return new Date(date.getTime() + offsetDiff * 60 * 1000);
 }
 
 /**
@@ -105,6 +110,10 @@ export function convertLocalDateToTimezoneTime(date: Date, newTimezone: string) 
  * @returns The date converted to match the new timezone
  */
 export function convertDateToLocalEquivalentOfTimezoneTime(date: Date, newTimezone: string) {
-    const nowUtc = fromZonedTime(date, newTimezone);
-    return toZonedTime(nowUtc, getCurrentTimezone());
+    // Equivalent to the old fromZonedTime function
+    // Treats the date's values as if they were in newTimezone, converts to current timezone
+    const currentOffset = tzOffset(getCurrentTimezone(), date);
+    const newOffset = tzOffset(newTimezone, date);
+    const offsetDiff = newOffset - currentOffset;
+    return new Date(date.getTime() - offsetDiff * 60 * 1000);
 }

--- a/packages/datetime/test/common/timezoneUtilsTest.ts
+++ b/packages/datetime/test/common/timezoneUtilsTest.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import { tzOffset } from "@date-fns/tz";
 import { expect } from "chai";
-import { getTimezoneOffset } from "date-fns-tz";
 
 import { getCurrentTimezone } from "../../src/common/getTimezone";
 import {
@@ -33,8 +33,9 @@ const MOCK_WINTER_DATE = new Date(2022, 0, 1, 12);
 
 // warning: this doesn't work for 1/2 hour offsets
 function getTimzoneOffsetRelativeToCurrentInHours(tz: string, date: Date): number {
-    const currentOffsetInMinutes = getTimezoneOffset(CURRENT_TZ, date) / 1000 / 60;
-    const tzOffsetInMinutes = getTimezoneOffset(tz, date) / 1000 / 60;
+    // tzOffset returns offset in minutes directly (not milliseconds like the old getTimezoneOffset)
+    const currentOffsetInMinutes = tzOffset(CURRENT_TZ, date);
+    const tzOffsetInMinutes = tzOffset(tz, date);
     return (tzOffsetInMinutes - currentOffsetInMinutes) / 60;
 }
 

--- a/packages/datetime/test/components/dateInputTests.tsx
+++ b/packages/datetime/test/components/dateInputTests.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import { tz, TZDate } from "@date-fns/tz";
 import { assert } from "chai";
-import { intlFormat, isEqual, parseISO } from "date-fns";
+import { format, intlFormat, isEqual, parseISO } from "date-fns";
 import { enUS as enUSLocale } from "date-fns/locale/en-US";
-import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef } from "react";
 import * as sinon from "sinon";
@@ -602,7 +602,7 @@ describe("<DateInput>", () => {
             assert.isTrue(onChange.calledTwice, "onChange called twice");
             assert.strictEqual(
                 onChange.args[1][0],
-                formatInTimeZone(parseISO(DATE2_VALUE), TimezoneUtils.UTC_TIME.ianaCode, "yyyy-MM-dd'T'HH:mm:ssxxx"),
+                format(parseISO(DATE2_VALUE), "yyyy-MM-dd'T'HH:mm:ssxxx", { in: tz(TimezoneUtils.UTC_TIME.ianaCode) }),
             );
             assert.isTrue(onKeyDown.calledOnce, "onKeyDown called once");
             assert.strictEqual(
@@ -827,14 +827,14 @@ describe("<DateInput>", () => {
         describe("with formatDate & parseDate undefined", () => {
             describe("with dateFnsFormat defined", () => {
                 it("uses the specified format", () => {
-                    const format = "Pp";
+                    const formatStr = "Pp";
                     const wrapper = mount(
-                        <DateInput {...LOCALE_LOADER} dateFnsFormat={format} value={todayIsoString} />,
+                        <DateInput {...LOCALE_LOADER} dateFnsFormat={formatStr} value={todayIsoString} />,
                         {
                             attachTo: containerElement,
                         },
                     );
-                    const formatter = getDateFnsFormatter(format, enUSLocale);
+                    const formatter = getDateFnsFormatter(formatStr, enUSLocale);
                     assert.strictEqual(wrapper.find("input").prop("value"), formatter(today));
                 });
             });
@@ -970,7 +970,8 @@ describe("<DateInput>", () => {
  * Use this helper function to reset the date's timezone to UTC instead.
  */
 function localDateToUtcDate(date: Date) {
-    return fromZonedTime(date, TimezoneUtils.getCurrentTimezone());
+    // Interpret the date as being in the current timezone and return as Date
+    return new TZDate(date, TimezoneUtils.getCurrentTimezone());
 }
 
 function dateToIsoString(date: Date) {

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -37,7 +37,7 @@
         "@blueprintjs/core": "workspace:^",
         "@blueprintjs/datetime": "workspace:^",
         "@blueprintjs/icons": "workspace:^",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.1.0",
         "react-day-picker": "^8.10.0",
         "tslib": "catalog:"
     },

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -30,7 +30,7 @@
         "@documentalist/client": "^5.0.0",
         "chroma-js": "^2.4.2",
         "classnames": "catalog:",
-        "date-fns": "^3.6.0",
+        "date-fns": "^4.1.0",
         "dedent": "^1.5.1",
         "downloadjs": "^1.4.7",
         "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       '@blueprintjs/select':
         specifier: workspace:^
         version: link:../select
+      '@date-fns/tz':
+        specifier: ^1.2.0
+        version: 1.4.1
       '@types/react':
         specifier: 18.3.12
         version: 18.3.12
@@ -228,14 +231,11 @@ importers:
         specifier: 'catalog:'
         version: 2.5.1
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
-      date-fns-tz:
-        specifier: ^3.2.0
-        version: 3.2.0(date-fns@3.6.0)
+        specifier: ^4.1.0
+        version: 4.1.0
       react-day-picker:
         specifier: ^8.10.0
-        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
+        version: 8.10.1(date-fns@4.1.0)(react@18.3.1)
       react-innertext:
         specifier: ^1.1.5
         version: 1.1.5(@types/react@18.3.12)(react@18.3.1)
@@ -304,11 +304,11 @@ importers:
         specifier: 18.3.12
         version: 18.3.12
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^4.1.0
+        version: 4.1.0
       react-day-picker:
         specifier: ^8.10.0
-        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
+        version: 8.10.1(date-fns@4.1.0)(react@18.3.1)
       tslib:
         specifier: 'catalog:'
         version: 2.6.3
@@ -444,8 +444,8 @@ importers:
         specifier: 'catalog:'
         version: 2.5.1
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^4.1.0
+        version: 4.1.0
       dedent:
         specifier: ^1.5.1
         version: 1.7.0
@@ -1646,6 +1646,9 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -4291,13 +4294,8 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
-  date-fns-tz@3.2.0:
-    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
-    peerDependencies:
-      date-fns: ^3.0.0 || ^4.0.0
-
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
@@ -9422,6 +9420,8 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
+  '@date-fns/tz@1.4.1': {}
+
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@documentalist/client@5.0.0': {}
@@ -12455,11 +12455,7 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns-tz@3.2.0(date-fns@3.6.0):
-    dependencies:
-      date-fns: 3.6.0
-
-  date-fns@3.6.0: {}
+  date-fns@4.1.0: {}
 
   date-format@4.0.14: {}
 
@@ -16208,9 +16204,9 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
 
-  react-day-picker@8.10.1(date-fns@3.6.0)(react@18.3.1):
+  react-day-picker@8.10.1(date-fns@4.1.0)(react@18.3.1):
     dependencies:
-      date-fns: 3.6.0
+      date-fns: 4.1.0
       react: 18.3.1
 
   react-dom@18.3.1(react@18.3.1):


### PR DESCRIPTION
Builds on #7632 (upgrade to date-fns v3), related to #6744

## Summary

Upgrades `date-fns` from v3.6.0 to v4.1.0 and migrates from the third-party `date-fns-tz` package to the official `@date-fns/tz` package with first-class timezone support.

## Changes

### Package Updates

- **@blueprintjs/datetime:** `date-fns` ^3.6.0 → ^4.1.0, removed `date-fns-tz`, added `@date-fns/tz` ^1.2.0
- **@blueprintjs/datetime2:** `date-fns` ^3.6.0 → ^4.1.0
- **@blueprintjs/docs-app:** `date-fns` ^3.6.0 → ^4.1.0

### Migration to `@date-fns/tz`

Replaced the third-party `date-fns-tz` package with the official `@date-fns/tz` package, which provides first-class timezone support in date-fns v4.

**1. Timezone Formatting**

```diff
- import { formatInTimeZone } from "date-fns-tz";
+ import { tz } from "@date-fns/tz";
+ import { format } from "date-fns";

- formatInTimeZone(date, timezone, formatStr)
+ format(date, formatStr, { in: tz(timezone) })
```

**2. Timezone Offset Calculation**

The API changed from returning milliseconds to returning minutes:

```diff
- import { getTimezoneOffset } from "date-fns-tz";
+ import { tzOffset } from "@date-fns/tz";

- const offsetInMs = getTimezoneOffset(timezone, date);
- const offsetInMinutes = offsetInMs / 1000 / 60;
+ const offsetInMinutes = tzOffset(timezone, date);
+ const offsetInMs = offsetInMinutes * 60 * 1000;
```

**3. Timezone Conversion Functions**

Reimplemented `convertLocalDateToTimezoneTime` and `convertDateToLocalEquivalentOfTimezoneTime` using `tzOffset` instead of `toZonedTime`/`fromZonedTime`:

```ts
// Equivalent to the old toZonedTime
export function convertLocalDateToTimezoneTime(date: Date, newTimezone: string) {
    const currentOffset = tzOffset(getCurrentTimezone(), date);
    const newOffset = tzOffset(newTimezone, date);
    const offsetDiff = newOffset - currentOffset;
    return new Date(date.getTime() + offsetDiff * 60 * 1000);
}

// Equivalent to the old fromZonedTime
export function convertDateToLocalEquivalentOfTimezoneTime(date: Date, newTimezone: string) {
    const currentOffset = tzOffset(getCurrentTimezone(), date);
    const newOffset = tzOffset(newTimezone, date);
    const offsetDiff = newOffset - currentOffset;
    return new Date(date.getTime() - offsetDiff * 60 * 1000);
}
```

## Breaking Changes
None for consumers of `@blueprintjs/datetime`. All changes are internal implementation details. The public API remains unchanged.

## Documentation
- [date-fns v4 changelog](https://github.com/date-fns/date-fns/releases/tag/v4.0.0)
- [date-fns v4.0 blog post](https://blog.date-fns.org/v4-0-is-out/)
- [@date-fns/tz documentation](https://github.com/date-fns/tz)