### PR TITLE
fix(node-build-scripts): Update `variables.less` test fixture

### DIFF
--- a/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
+++ b/packages/node-build-scripts/src/__tests__/__fixtures__/expected/variables.less
@@ -4,8 +4,8 @@
 
 @ns: bp4;
 @icons16-family: "blueprint-icons-16";
-@pt-font-family: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans",
-    "Helvetica Neue", "blueprint-icons-16", sans-serif;
+@pt-font-family: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+    "Open Sans", "Helvetica Neue", "blueprint-icons-16", sans-serif;
 @pt-border-radius: 2px;
 @black: #111418;
 @gray1: #5f6b7c;


### PR DESCRIPTION
## Summary

Fixes the following local failures in the `node-build-scripts` package:

<img width="1832" height="1100" alt="Screenshot 2025-11-12 at 13 19 36@2x" src="https://github.com/user-attachments/assets/e1aeedb8-e758-41ee-bbb8-abe68d4f00e8" />

## Problem

The `cssVariables.test.ts` was failing locally due to formatting differences in the `variables.less` fixture file. The test expected a different line break position in the `@pt-font-family` declaration than what Prettier now produces after upgrading. (see: #7602, #7616)

Related to #7522
