### PR TITLE
fix(Popover): Apply fill class to popover target when `fill` prop is passed

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -303,6 +303,7 @@ export class Popover<
                 [Classes.POPOVER_OPEN]: isOpen,
                 // this class is mainly useful for button targets
                 [Classes.ACTIVE]: isOpen && !isControlled && !isHoverInteractionKind,
+                [Classes.FILL]: fill,
             }),
             ref,
             ...targetEventHandlers,

--- a/packages/core/test/popover/popoverTests.tsx
+++ b/packages/core/test/popover/popoverTests.tsx
@@ -265,6 +265,30 @@ describe("<Popover>", () => {
 
             expect(container.querySelector("[aria-haspopup]")).to.be.null;
         });
+
+        it("applies fill class to target when fill={true}", () => {
+            const { container } = render(
+                <Popover content="content" fill={true}>
+                    <Button text="target" />
+                </Popover>,
+            );
+            const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+
+            expect(popoverTarget).to.exist;
+            expect(hasClass(popoverTarget!, Classes.FILL)).to.be.true;
+        });
+
+        it("does not apply FILL class to target when fill={false}", () => {
+            const { container } = render(
+                <Popover content="content" fill={false}>
+                    <Button text="target" />
+                </Popover>,
+            );
+            const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+
+            expect(popoverTarget).to.exist;
+            expect(hasClass(popoverTarget!, Classes.FILL)).to.be.false;
+        });
     });
 
     describe("basic functionality", () => {


### PR DESCRIPTION
## Problem
When the `fill` prop is passed to `Tooltip` or other `Popover`-based components, the `.bp6-fill` class was not being applied to the `.bp6-popover-target` wrapper div. This caused layout issues when using these components in flex containers, particularly when placing buttons side-by-side where one or more are wrapped in a tooltip.

When wrapping a button with `fill={true}` in a Tooltip with `fill={true}`, the button would not fill its container as expected.

Example:
```tsx
<Flex gap={2} width="100">
    <Button fill={true}>Cancel</Button>
    <Tooltip fill={true} content="Some content.">
        <Button fill={true} intent="primary">Submit</Button>
    </Tooltip>
</Flex>
```

https://codesandbox.io/p/sandbox/r93ft3

## Root Cause
The `Popover` component's target wrapper was missing the `Classes.FILL` class in its className computation, even when the `fill` prop was passed.

### Example

Given the following use case / layout pattern:

```tsx
<Flex gap={2}>
    <Button fill={true}>Cancel</Button>
    <Tooltip fill={true} content="Some content.">
        <Button fill={true} intent="primary">Submit</Button>
    </Tooltip>
</Flex>
```

---

**Before:** The popover target wrapper lacks the `.bp6-fill` class.
```html
...
<div class="bp6-popover-target">
    <button class="bp6-button bp6-fill bp6-intent-primary">Submit</button>
</div>
```

<img width="1520" height="146" alt="before" src="https://github.com/user-attachments/assets/9d74d38a-b091-4d7a-bbe6-f7b9c3bd3ec9" />


**After:** The popover target wrapper now includes `.bp6-fill`.

```html
...
<div class="bp6-popover-target bp6-fill">
    <button class="bp6-button bp6-fill bp6-intent-primary">Submit</button>
</div>
```

<img width="1520" height="146" alt="after" src="https://github.com/user-attachments/assets/8125023a-bd4e-449f-9b74-b74d7354715b" />

This results in both buttons displaying as equal width as expected.