### PR TITLE
Allow context menu rerendering for <Table />

### DIFF
--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -224,6 +224,7 @@ export interface MutableTableState {
     cellContent?: CellContent;
     cellTruncatedPopoverMode?: TruncatedPopoverMode;
     cellTruncationLength?: number;
+    currentTime?: string;
     enableCellEditing?: boolean;
     enableCellSelection?: boolean;
     enableCellTruncation?: boolean;
@@ -273,6 +274,7 @@ const DEFAULT_STATE: MutableTableState = {
     cellContent: CellContent.LONG_TEXT,
     cellTruncatedPopoverMode: TruncatedPopoverMode.WHEN_TRUNCATED,
     cellTruncationLength: TRUNCATION_LENGTHS[TRUNCATION_LENGTH_DEFAULT_INDEX],
+    currentTime: new Date().toLocaleTimeString(),
     enableCellEditing: false,
     enableCellSelection: true,
     enableCellTruncation: false,
@@ -333,6 +335,8 @@ export class MutableTable extends Component<{}, MutableTableState> {
 
     private previousTime: number;
 
+    private timeUpdateInterval: number;
+
     private refHandlers = {
         table: (ref: Table) => (this.tableInstance = ref),
         tableWrapperRef: (ref: HTMLDivElement) => (this.tableWrapperRef = ref),
@@ -375,6 +379,9 @@ export class MutableTable extends Component<{}, MutableTableState> {
 
     public componentDidMount() {
         this.syncFocusStyle();
+        this.timeUpdateInterval = window.setInterval(() => {
+            this.setState({ currentTime: new Date().toLocaleTimeString() });
+        }, 1000);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -392,6 +399,12 @@ export class MutableTable extends Component<{}, MutableTableState> {
         this.syncFocusStyle();
         this.syncDependentBooleanStates();
         this.stateStore.set(this.state);
+    }
+
+    public componentWillUnmount() {
+        if (this.timeUpdateInterval != null) {
+            window.clearInterval(this.timeUpdateInterval);
+        }
     }
 
     // Generators
@@ -456,6 +469,7 @@ export class MutableTable extends Component<{}, MutableTableState> {
         return (
             <Table
                 bodyContextMenuRenderer={this.renderBodyContextMenu}
+                bodyContextMenuRendererDependencies={[this.state.currentTime]}
                 enableColumnHeader={this.state.enableColumnHeader}
                 enableColumnInteractionBar={this.state.showTableInteractionBar}
                 enableColumnReordering={this.state.enableColumnReordering}
@@ -1125,7 +1139,7 @@ export class MutableTable extends Component<{}, MutableTableState> {
                 <MenuItem icon="graph-remove" text="Item 3" />
                 <MenuItem icon="group-objects" text="Item 4" />
                 <MenuDivider />
-                <MenuItem disabled={true} text="Disabled item" />
+                <MenuItem disabled={true} text={`Current time: ${this.state.currentTime}`} />
             </Menu>
         );
         return this.state.enableContextMenu ? menu : undefined;

--- a/packages/table/src/common/errors.ts
+++ b/packages/table/src/common/errors.ts
@@ -41,4 +41,6 @@ export const TABLE_UNMOUNTED_RESIZE_WARNING = `${ns} Table resize method called 
 
 export const TABLE_INVALID_CELL_RENDERER_DEPS = `${ns} cellRendererDependencies should either always be defined or undefined; this feature cannot be enabled during the component lifecycle`;
 
+export const TABLE_INVALID_BODY_CONTEXT_MENU_RENDERER_DEPS = `${ns} bodyContextMenuRendererDependencies should either always be defined or undefined; this feature cannot be enabled during the component lifecycle`;
+
 export const TABLE_COPY_FAILED = ns + ` Copy failed.`;

--- a/packages/table/src/docs/table-features.md
+++ b/packages/table/src/docs/table-features.md
@@ -40,6 +40,12 @@ callback. This "map" is referenced in the cell renderers to determine which data
 including it as a dependency in `cellRendererDependencies`, we can guarantee that cell renderers will be re-triggered
 after a sorting operation, and those renderers will reference the up-to-date `sortedIndexMap` value.
 
+Similarly, if you have a `bodyContextMenuRenderer` that needs to respond to external state changes while the menu is
+already open, you can use the `bodyContextMenuRendererDependencies` prop. When any value in this dependency list
+changes (compared using shallow equality checks), the context menu content will update, even if the menu is already
+displayed. Without this prop, the context menu will only update when it is closed and reopened. This is useful for
+scenarios like showing real-time data or user-specific options in the context menu that may change during interaction.
+
 @## Focused cell
 
 You may allow users to focus on a single cell and navigate around the table with arrow keys by setting

--- a/packages/table/src/table.tsx
+++ b/packages/table/src/table.tsx
@@ -615,6 +615,13 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
             console.error(Errors.TABLE_INVALID_CELL_RENDERER_DEPS);
         }
 
+        if (
+            this.props.bodyContextMenuRendererDependencies !== undefined &&
+            prevProps.bodyContextMenuRendererDependencies === undefined
+        ) {
+            console.error(Errors.TABLE_INVALID_BODY_CONTEXT_MENU_RENDERER_DEPS);
+        }
+
         const didCellRendererDependenciesChange =
             this.props.cellRendererDependencies !== undefined &&
             this.props.cellRendererDependencies.some(
@@ -1050,6 +1057,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
             enableGhostCells,
             loadingOptions,
             bodyContextMenuRenderer,
+            bodyContextMenuRendererDependencies,
             selectedRegionTransform,
         } = this.props;
 
@@ -1104,6 +1112,7 @@ export class Table extends AbstractComponent<TableProps, TableState, TableSnapsh
                     onFocusedRegion={this.handleFocus}
                     onSelection={this.getEnabledSelectionHandler(RegionCardinality.CELLS)}
                     bodyContextMenuRenderer={bodyContextMenuRenderer}
+                    bodyContextMenuRendererDependencies={bodyContextMenuRendererDependencies}
                     renderMode={this.getNormalizedRenderMode()}
                     selectedRegions={selectedRegions}
                     selectedRegionTransform={selectedRegionTransform}

--- a/packages/table/src/tableBody.tsx
+++ b/packages/table/src/tableBody.tsx
@@ -41,7 +41,13 @@ export interface TableBodyProps extends SelectableProps, TableBodyCellsProps {
     bodyContextMenuRenderer?: ContextMenuRenderer;
 
     /**
-     * The the type shape allowed for focus areas. Can be cell, row, or none.
+     * An optional dependency list used to trigger a re-render of the body context menu when one of its elements changes
+     * (compared using shallow equality checks).
+     */
+    bodyContextMenuRendererDependencies?: React.DependencyList;
+
+    /**
+     * The type shape allowed for focus areas. Can be cell, row, or none.
      */
     focusMode: FocusMode | undefined;
 
@@ -76,6 +82,27 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
 
     private containerRef = createRef<HTMLDivElement>();
 
+    private previousBodyContextMenuRendererDependencies: React.DependencyList | undefined = undefined;
+
+    private renderContextMenuContentWrapper = this.createRenderContextMenuWrapper();
+
+    private createRenderContextMenuWrapper() {
+        return (contentProps: ContextMenuContentProps) => this.renderContextMenu(contentProps);
+    }
+
+    private syncRenderContextMenuWrapperWithDependencies() {
+        const didBodyContextMenuRendererDependenciesChange =
+            this.props.bodyContextMenuRendererDependencies !== undefined &&
+            this.props.bodyContextMenuRendererDependencies.some(
+                (dep, index) => dep !== (this.previousBodyContextMenuRendererDependencies ?? [])[index],
+            );
+
+        if (didBodyContextMenuRendererDependenciesChange) {
+            this.previousBodyContextMenuRendererDependencies = this.props.bodyContextMenuRendererDependencies;
+            this.renderContextMenuContentWrapper = this.createRenderContextMenuWrapper();
+        }
+    }
+
     public shouldComponentUpdate(nextProps: TableBodyProps) {
         return (
             !CoreUtils.shallowCompareKeys(this.props, nextProps, { exclude: DEEP_COMPARE_KEYS }) ||
@@ -91,6 +118,8 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
             height: numFrozenRows != null ? grid.getCumulativeHeightAt(numFrozenRows - 1) : defaultStyle.height,
             width: numFrozenColumns != null ? grid.getCumulativeWidthAt(numFrozenColumns - 1) : defaultStyle.width,
         };
+
+        this.syncRenderContextMenuWrapperWithDependencies();
 
         return (
             <DragSelectable
@@ -108,7 +137,7 @@ export class TableBody extends AbstractComponent<TableBodyProps> {
             >
                 <ContextMenu
                     className={classNames(Classes.TABLE_BODY_VIRTUAL_CLIENT, Classes.TABLE_CELL_CLIENT)}
-                    content={this.renderContextMenu}
+                    content={this.renderContextMenuContentWrapper}
                     disabled={this.props.bodyContextMenuRenderer === undefined}
                     onContextMenu={this.handleContextMenu}
                     ref={this.containerRef}

--- a/packages/table/src/tableProps.ts
+++ b/packages/table/src/tableProps.ts
@@ -63,6 +63,13 @@ export interface TableProps extends Props, Partial<RowHeights>, Partial<ColumnWi
     bodyContextMenuRenderer?: ContextMenuRenderer;
 
     /**
+     * This dependency list may be used to trigger a re-render of the body context menu when one of its elements changes
+     * (compared using shallow equality checks). This is done by updating the context menu content rendering function reference,
+     * which forces ContextMenu to re-render.
+     */
+    bodyContextMenuRendererDependencies?: React.DependencyList;
+
+    /**
      * Whether the body context menu is enabled.
      *
      * @default true if bodyContextMenuRenderer is defined

--- a/packages/table/test/tableTests.tsx
+++ b/packages/table/test/tableTests.tsx
@@ -20,7 +20,7 @@ import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
-import { Utils as CoreUtils } from "@blueprintjs/core";
+import { Utils as CoreUtils, Menu } from "@blueprintjs/core";
 import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test-commons";
 
 import { Cell, Column, RegionCardinality, Table, TableLoadingOption, type TableProps } from "../src";
@@ -32,6 +32,7 @@ import { RenderMode } from "../src/common/renderMode";
 import { TableQuadrant } from "../src/quadrants/tableQuadrant";
 import { TableQuadrantStack } from "../src/quadrants/tableQuadrantStack";
 import { type Region, Regions } from "../src/regions";
+import { TableBody } from "../src/tableBody";
 import type { TableState } from "../src/tableState";
 
 import { CellType, expectCellLoading } from "./cellTestUtils";
@@ -2072,7 +2073,7 @@ describe("<Table>", function (this) {
             );
             expect(getFirstCellText()).to.equal(dependencies[0]);
 
-            // replace the single dependency with a shallow-equal value
+            // change the dependency
             dependencies[0] = "new data from external store";
             table.setProps({ cellRendererDependencies: dependencies.slice() });
             expect(getFirstCellText()).to.equal(
@@ -2086,6 +2087,82 @@ describe("<Table>", function (this) {
                     .hostNodes()
                     .text();
             }
+        });
+    });
+
+    describe("EXPERIMENTAL: bodyContextMenuRendererDependencies", () => {
+        it("Does not re-create context menu wrapper when dependencies don't change", () => {
+            const dependencies: any[] = ["stable"];
+            const bodyContextMenuRenderer = sinon.stub().returns(<Menu>Menu</Menu>);
+            const table = mount(
+                <Table
+                    numRows={1}
+                    bodyContextMenuRenderer={bodyContextMenuRenderer}
+                    bodyContextMenuRendererDependencies={dependencies}
+                >
+                    <Column name="Column0" cellRenderer={renderDummyCell} />
+                </Table>,
+            );
+
+            const tableBody = table.find(TableBody).first();
+            const originalWrapper = (tableBody.instance() as any).renderContextMenuContentWrapper;
+
+            // replace the single dependency with a shallow-equal value
+            dependencies[0] = "stable";
+            table.setProps({ bodyContextMenuRendererDependencies: dependencies });
+
+            const tableBodyAfter = table.find(TableBody).first();
+            const newWrapper = (tableBodyAfter.instance() as any).renderContextMenuContentWrapper;
+
+            expect(newWrapper).to.equal(
+                originalWrapper,
+                "renderContextMenuContentWrapper should not have been recreated when bodyContextMenuRendererDependencies are the same",
+            );
+        });
+
+        it("Does re-create context menu wrapper when dependencies change", () => {
+            const dependencies: string[] = ["some data from external store"];
+            const bodyContextMenuRenderer = sinon.stub().returns(<Menu>Menu</Menu>);
+            const table = mount(
+                <Table
+                    numRows={1}
+                    bodyContextMenuRenderer={bodyContextMenuRenderer}
+                    bodyContextMenuRendererDependencies={dependencies.slice()}
+                >
+                    <Column name="Column0" cellRenderer={renderDummyCell} />
+                </Table>,
+            );
+
+            const tableBody = table.find(TableBody).first();
+            const originalWrapper = (tableBody.instance() as any).renderContextMenuContentWrapper;
+
+            // change the dependency
+            dependencies[0] = "new data from external store";
+            table.setProps({ bodyContextMenuRendererDependencies: dependencies.slice() });
+
+            const tableBodyAfter = table.find(TableBody).first();
+            const newWrapper = (tableBodyAfter.instance() as any).renderContextMenuContentWrapper;
+
+            expect(newWrapper).to.not.equal(
+                originalWrapper,
+                "renderContextMenuContentWrapper should have been recreated when bodyContextMenuRendererDependencies changed",
+            );
+        });
+
+        it("Logs an error when bodyContextMenuRendererDependencies is enabled after mount", () => {
+            const consoleErrorSpy = sinon.stub(console, "error");
+            const bodyContextMenuRenderer = sinon.stub().returns(<Menu>Menu</Menu>);
+            const table = mount(
+                <Table numRows={1} bodyContextMenuRenderer={bodyContextMenuRenderer}>
+                    <Column name="Column0" cellRenderer={renderDummyCell} />
+                </Table>,
+            );
+
+            // Enable bodyContextMenuRendererDependencies after mount
+            table.setProps({ bodyContextMenuRendererDependencies: ["some data"] });
+
+            expect(consoleErrorSpy.calledWith(Errors.TABLE_INVALID_BODY_CONTEXT_MENU_RENDERER_DEPS)).to.be.true;
+            consoleErrorSpy.restore();
         });
     });
 


### PR DESCRIPTION
#### Checklist

-   [X] Includes tests
-   [X] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Add `bodyContextMenuRendererDependencies` as a prop to `<Table />` so that consumers can specify what dependencies will trigger a re-render of the Table's context menu content.

This is useful for cases where a menu item might be disabled until some asynchronous event has occurred and the user should see the UI update in real-time rather than having to close the context menu and re-open it again.

#### Reviewers should focus on:

`table.tsx` + `tableBody.tsx`

I tried to follow the precedent for `cellRendererDependencies` as closely as possible, but chose to implement the re-render triggering in a simpler way by changing the context menu render function reference.

#### Video

I've updated the `table-dev-app` to render the current time in the table context menu (just because it's something that updates asynchronously) to demonstrate that the context menu re-renders:

https://github.com/user-attachments/assets/1503dd40-b3df-4548-ac12-6169b7900e42



