### PR TITLE
[core] Update elevation shadow styles

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -99,39 +99,51 @@ $pt-dark-border-shadow-opacity: $pt-border-shadow-opacity * 2 !default;
 $pt-dark-drop-shadow-opacity: $pt-drop-shadow-opacity * 2 !default;
 
 // Elevations
-$pt-elevation-shadow-0: 0 0 0 1px $pt-divider-black !default;
+$pt-elevation-shadow-0:
+  0 0 0 1px rgba($black, 15%),
+  0 0 5px 0 rgba(0, 0, 0, 2%) !default;
 $pt-elevation-shadow-1:
-  border-shadow($pt-border-shadow-opacity),
-  0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
+  0 0 0 1px rgba($black, 10%),
+  0 1px 3px 0 rgba(0, 0, 0, 10%),
+  0 1px 2px -1px rgba(0, 0, 0, 10%) !default;
 $pt-elevation-shadow-2:
-  border-shadow($pt-border-shadow-opacity),
-  0 1px 1px rgba($black, $pt-drop-shadow-opacity),
-  0 2px 6px rgba($black, $pt-drop-shadow-opacity) !default;
+  0 0 0 1px rgba($black, 10%),
+  0 4px 6px -4px rgba(0, 0, 0, 10%),
+  0 10px 15px -3px rgba(0, 0, 0, 10%) !default;
 $pt-elevation-shadow-3:
-  border-shadow($pt-border-shadow-opacity),
-  0 2px 4px rgba($black, $pt-drop-shadow-opacity),
-  0 8px 24px rgba($black, $pt-drop-shadow-opacity) !default;
+  0 0 0 1px rgba($black, 10%),
+  0 20px 25px -5px rgba(0, 0, 0, 10%),
+  0 10px 15px -3px rgba(0, 0, 0, 10%) !default;
 $pt-elevation-shadow-4:
-  border-shadow($pt-border-shadow-opacity),
-  0 4px 8px rgba($black, $pt-drop-shadow-opacity),
-  0 18px 46px 6px rgba($black, $pt-drop-shadow-opacity) !default;
+  0 0 0 1px rgba($black, 10%),
+  0 25px 50px -12px rgba(0, 0, 0, 30%) !default;
 
-$pt-dark-elevation-shadow-0: inset 0 0 0 1px rgba($white, 0.2) !default;
+$pt-dark-elevation-shadow-0:
+  inset 0 0 0 1px rgba($white, 20%),
+  0 0 10px 0 rgba(0, 0, 0, 20%) !default;
 $pt-dark-elevation-shadow-1:
-  inset 0 0 0 1px rgba($white, 0.2),
-  0 1px 1px 0 rgba($black, $pt-dark-drop-shadow-opacity) !default;
+  inset 0 0 0 1px rgba($white, 20%),
+  0 1px 10px 0 rgba(0, 0, 0, 20%),
+  inset 0 0 0.5px 0 rgba($white, 30%),
+  inset 0 0.5px 0 0 rgba($white, 8%),
+  0 1px 10px -1px rgba(0, 0, 0, 20%) !default;
 $pt-dark-elevation-shadow-2:
-  inset 0 0 0 1px rgba($white, 0.2),
-  0 1px 1px rgba($black, $pt-dark-drop-shadow-opacity),
-  0 2px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
+  inset 0 0 0 1px rgba($white, 20%),
+  0 4px 6px -4px rgba(0, 0, 0, 50%),
+  inset 0 0 0.5px 0 rgba($white, 30%),
+  inset 0 0.5px 0 0 rgba($white, 8%),
+  0 10px 30px -5px rgba(0, 0, 0, 50%) !default;
 $pt-dark-elevation-shadow-3:
-  inset 0 0 0 1px rgba($white, 0.2),
-  0 2px 4px rgba($black, $pt-dark-drop-shadow-opacity),
-  0 8px 24px rgba($black, $pt-dark-drop-shadow-opacity) !default;
+  inset 0 0 0 1px rgba($white, 20%),
+  0 20px 25px -5px rgba(0, 0, 0, 30%),
+  inset 0 0 0.5px 0 rgba($white, 30%),
+  inset 0 0.5px 0 0 rgba($white, 8%),
+  0 10px 30px -5px rgba(0, 0, 0, 30%) !default;
 $pt-dark-elevation-shadow-4:
-  inset 0 0 0 1px rgba($white, 0.2),
-  0 4px 8px rgba($black, $pt-dark-drop-shadow-opacity),
-  0 18px 46px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
+  inset 0 0 0 1px rgba($white, 20%),
+  0 25px 60px -12px rgba(0, 0, 0, 85%),
+  inset 0 0 0.5px 0 rgba($white, 30%),
+  inset 0 0.5px 0 0 rgba($white, 8%) !default;
 
 // Transitions
 $pt-transition-ease: cubic-bezier(0.4, 1, 0.75, 0.9) !default;


### PR DESCRIPTION
## Proposed Changes

Update `pt-elevation-shadow` variable styles. 

## Comparison

### Light Mode

| Stage | Image |
|--------|--------|
| Before | <img width="700" height="100" alt="before-light" src="https://github.com/user-attachments/assets/a9057e1c-75b2-4c91-b9a8-f05f8070ab75" /> |
| After | <img width="700" height="100" alt="after-light" src="https://github.com/user-attachments/assets/a70f69c4-1a76-45fd-bdbc-3223c167cce4" /> |
| Diff | <img width="700" height="100" alt="diff-light" src="https://github.com/user-attachments/assets/3ce83b58-ec85-4eae-a892-145d879bc396" /> |

### Dark Mode

| Stage | Image |
|--------|--------|
| Before | <img width="700" height="100" alt="before-dark" src="https://github.com/user-attachments/assets/02895fe1-5a35-428b-98f7-cf95c9da870e" /> |
| After | <img width="700" height="100" alt="after-dark" src="https://github.com/user-attachments/assets/24e54da7-6f49-45b5-9a00-5f9fa814783a" /> |
| Diff | <img width="700" height="100" alt="diff-dark" src="https://github.com/user-attachments/assets/5126e4a7-07a4-4613-81d7-e905ecc97f6b" /> | 

## Reviewers should focus on:

- [x] Designer review