### PR TITLE
[core] Update border-radius styles

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -249,7 +249,6 @@ Styleguide preformatted
 %code-block {
   @include monospace-typography;
   border-radius: $pt-border-radius;
-
   display: block;
   font-size: $pt-font-size - 1px;
   line-height: 1.4;
@@ -282,7 +281,7 @@ Styleguide preformatted
   justify-content: center;
   line-height: $pt-button-height-small;
   min-width: $pt-button-height-small;
-  padding: $pt-border-radius ($pt-border-radius * 2);
+  padding: ($pt-spacing * 0.5) $pt-spacing;
   vertical-align: middle;
 
   #{$icon-classes} {

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -69,8 +69,8 @@ $pt-line-height: 1.28581 !default;
 
 // Grids & dimensions
 
-// equivalent to: $pt-spacing * 0.5
-$pt-border-radius: 2px !default;
+// equivalent to: $pt-spacing
+$pt-border-radius: 4px !default;
 
 // Buttons
 $pt-button-height: $pt-spacing * 7.5 !default;

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -8,7 +8,7 @@
 @import "../../common/variables";
 
 $dialog-background-color: $light-gray5 !default;
-$dialog-border-radius: $pt-border-radius * 2 !default;
+$dialog-border-radius: $pt-border-radius !default;
 $dialog-margin: ($pt-spacing * 8) 0 !default;
 $dialog-padding: $pt-spacing * 4 !default;
 

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -6,8 +6,8 @@
 @import "../../common/react-transition";
 @import "../../common/variables";
 
-$dialog-border-radius: $pt-border-radius * 2 !default;
-$step-radius: $pt-border-radius * 2 !default;
+$dialog-border-radius: $pt-border-radius !default;
+$step-radius: $pt-border-radius !default;
 
 .#{$ns}-multistep-dialog-panels {
   display: flex;

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -14,7 +14,7 @@
 
   // input styles on the ::before
   &::before {
-    @include position-all(absolute, -$pt-border-radius);
+    @include position-all(absolute, $pt-spacing * -0.5);
     border-radius: $pt-border-radius;
     content: "";
     transition:

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -102,7 +102,7 @@ $dark-popover-arrow-box-shadow:
 
 // the box-shadow under the arrow SVG paths
 .#{$ns}-popover-arrow::before {
-  border-radius: $pt-border-radius - 1;
+  border-radius: 1px;
   content: "";
   display: block;
   position: absolute;

--- a/packages/docs-app/src/styles/_examples.scss
+++ b/packages/docs-app/src/styles/_examples.scss
@@ -382,7 +382,7 @@ $docs-hotkey-piano-height: 510px;
     align-items: center;
     background: rgba($gray3, 0.2);
     border: 2px solid rgba($gray3, 0.8);
-    border-radius: $pt-border-radius * 2;
+    border-radius: $pt-border-radius;
     flex: 1 1;
     justify-content: space-around;
     max-width: 70%;

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -47,7 +47,7 @@ $icons-per-row: 5;
   &::before {
     @include position-all(absolute, 0);
     background: $light-gray4;
-    border-radius: $pt-border-radius * 2;
+    border-radius: $pt-border-radius;
     content: "";
     opacity: 0;
     // must set this to avoid capturing hover events which should be sent to ClickToCopy element(s) instead

--- a/packages/docs-app/src/styles/_nav.scss
+++ b/packages/docs-app/src/styles/_nav.scss
@@ -123,7 +123,7 @@ $dark-package-colors: (
 }
 
 .docs-nav-package-icon {
-  border-radius: $pt-border-radius * 3;
+  border-radius: 6px;
   margin-right: $pt-spacing * 2;
 }
 

--- a/packages/docs-theme/src/styles/_code-example.scss
+++ b/packages/docs-theme/src/styles/_code-example.scss
@@ -9,7 +9,7 @@
 .docs-code-example {
   align-items: center;
   background: $pt-app-secondary-background-color;
-  border-radius: $pt-border-radius * 2;
+  border-radius: $pt-border-radius;
   display: flex;
   justify-content: center;
   padding: $pt-spacing * 5;

--- a/packages/docs-theme/src/styles/_examples.scss
+++ b/packages/docs-theme/src/styles/_examples.scss
@@ -4,7 +4,7 @@
 // Base styles for all examples
 
 $example-frame-spacing: $pt-spacing * 2;
-$example-frame-border-radius: $pt-border-radius * 2;
+$example-frame-border-radius: $pt-border-radius;
 $example-spacing: $pt-spacing * 10;
 
 // full-bleed wrapper for example


### PR DESCRIPTION
## Proposed Changes

Changes the value of `$pt-border-radius` from 2px → 4px.

## Component Changes _(* not exhaustive)_

### Button

| Before | After | Diff |
|--------|--------|--------|
| <img width="100" height="60" alt="before-button" src="https://github.com/user-attachments/assets/3d3ee38e-3416-4336-8871-7eb483616ca9" /> | <img width="100" height="60" alt="after-button" src="https://github.com/user-attachments/assets/cf9d5a72-39b3-45fd-9304-7ab2a62422dd" /> | <img width="100" height="60" alt="diff-button" src="https://github.com/user-attachments/assets/abc5e0a5-44b2-4ecf-8835-3848f7b693f1" /> | 

### Callout

| Before | After | Diff |
|--------|--------|--------|
| <img width="750" height="270" alt="before-callout" src="https://github.com/user-attachments/assets/ca9f519e-c4cb-40af-a96a-01e276c73d9f" /> | <img width="750" height="270" alt="after-callout" src="https://github.com/user-attachments/assets/d39249e4-0571-479f-a25f-340a02b55595" /> | <img width="750" height="270" alt="diff-callout" src="https://github.com/user-attachments/assets/9339653d-ee9b-4678-9de2-20308b6f235e" /> | 

### Card

| Before | After | Diff |
|--------|--------|--------|
| <img width="756" height="164" alt="before-card" src="https://github.com/user-attachments/assets/4cc8d140-9a8f-48d2-baab-59d8cf6fbe7c" /> | <img width="756" height="164" alt="after-card" src="https://github.com/user-attachments/assets/046ec92d-1e09-4aee-86d4-9bc47d951d99" /> | <img width="756" height="164" alt="diff-card" src="https://github.com/user-attachments/assets/5a3c49e7-3ccc-48a3-b5df-5d7a74361905" /> | 

### Input

| Before | After | Diff |
|--------|--------|--------|
| <img width="528" height="250" alt="before-input" src="https://github.com/user-attachments/assets/7088ee70-de0f-4591-8d6f-fb744b066ffc" /> | <img width="528" height="250" alt="after-input" src="https://github.com/user-attachments/assets/b45421d0-ed34-46a0-908d-6826406613bb" /> | <img width="528" height="250" alt="untitled" src="https://github.com/user-attachments/assets/d1e0b69c-170f-4817-ac4f-a68f57b1420c" /> | 

### Menu

| Before | After | Diff |
|--------|--------|--------|
| <img width="524" height="324" alt="before-menu" src="https://github.com/user-attachments/assets/324b3855-4d0d-4664-b8c9-f26bc2de60ee" /> | <img width="524" height="324" alt="after-menu" src="https://github.com/user-attachments/assets/f03110fc-ac67-44e6-b850-d495e0838289" /> | <img width="524" height="324" alt="diff-menu" src="https://github.com/user-attachments/assets/0255e08c-1bb9-4a10-8239-0bd00ed5fbed" /> | 

## Reviewers should focus on:

- [x] Designer review