### PR TITLE
Add generically typed options to <SegmentedControl />

### DIFF
--- a/packages/core/src/components/segmented-control/segmentedControl.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.tsx
@@ -31,16 +31,16 @@ import { Button } from "../button/buttons";
 
 export type SegmentedControlIntent = typeof Intent.NONE | typeof Intent.PRIMARY;
 
-interface SegmentedControlOptionProps extends OptionProps<string> {
+interface SegmentedControlOptionProps<T extends string | number = string> extends OptionProps<T> {
     icon?: ButtonProps["icon"];
 }
 
 /**
  * SegmentedControl component props.
  */
-export interface SegmentedControlProps
+export interface SegmentedControlProps<T extends string | number = string>
     extends Props,
-        ControlledValueProps<string>,
+        ControlledValueProps<T>,
         React.RefAttributes<HTMLDivElement> {
     /**
      * Whether this control should be disabled.
@@ -75,7 +75,7 @@ export interface SegmentedControlProps
     /**
      * List of available options.
      */
-    options: SegmentedControlOptionProps[];
+    options: Array<SegmentedControlOptionProps<T>>;
 
     /**
      * Aria role for the overall component (container).
@@ -112,7 +112,10 @@ export interface SegmentedControlProps
  *
  * @see https://blueprintjs.com/docs/#core/components/segmented-control
  */
-export const SegmentedControl: React.FC<SegmentedControlProps> = forwardRef((props, ref) => {
+function SegmentedControlInner<T extends string | number = string>(
+    props: SegmentedControlProps<T>,
+    ref: React.Ref<HTMLDivElement>,
+) {
     const {
         className,
         defaultValue,
@@ -132,13 +135,13 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = forwardRef((pro
         ...htmlProps
     } = props;
 
-    const [localValue, setLocalValue] = useState<string | undefined>(defaultValue);
+    const [localValue, setLocalValue] = useState<T | undefined>(defaultValue);
     const selectedValue = controlledValue ?? localValue;
 
     const outerRef = useRef<HTMLDivElement>(null);
 
     const handleOptionClick = useCallback(
-        (newSelectedValue: string, targetElement: HTMLElement) => {
+        (newSelectedValue: T, targetElement: HTMLElement) => {
             setLocalValue(newSelectedValue);
             onValueChange?.(newSelectedValue, targetElement);
         },
@@ -233,25 +236,31 @@ export const SegmentedControl: React.FC<SegmentedControlProps> = forwardRef((pro
             })}
         </div>
     );
-});
-SegmentedControl.displayName = `${DISPLAYNAME_PREFIX}.SegmentedControl`;
+}
 
-interface SegmentedControlOptionComponentProps
-    extends OptionProps<string>,
-        Pick<SegmentedControlProps, "intent" | "small" | "large" | "size">,
+const SegmentedControlImpl = forwardRef(SegmentedControlInner);
+SegmentedControlImpl.displayName = `${DISPLAYNAME_PREFIX}.SegmentedControl`;
+export const SegmentedControl = SegmentedControlImpl as <T extends string | number = string>(
+    props: SegmentedControlProps<T>,
+    ref: React.Ref<HTMLDivElement>,
+) => React.ReactNode;
+
+interface SegmentedControlOptionComponentProps<T extends string | number = string>
+    extends OptionProps<T>,
+        Pick<SegmentedControlProps<T>, "intent" | "small" | "large" | "size">,
         Pick<ButtonProps, "role" | "tabIndex" | "icon">,
         React.AriaAttributes {
     isSelected: boolean;
-    onClick: (value: string, targetElement: HTMLElement) => void;
+    onClick: (value: T, targetElement: HTMLElement) => void;
 }
 
-function SegmentedControlOption({
+function SegmentedControlOption<T extends string | number = string>({
     isSelected,
     label,
     onClick,
     value,
     ...buttonProps
-}: SegmentedControlOptionComponentProps) {
+}: SegmentedControlOptionComponentProps<T>) {
     const handleClick = useCallback(
         (event: React.MouseEvent<HTMLElement>) => onClick?.(value, event.currentTarget),
         [onClick, value],

--- a/packages/core/src/components/segmented-control/segmentedControl.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.tsx
@@ -238,6 +238,7 @@ function SegmentedControlInner<T extends string | number = string>(
     );
 }
 
+// TODO: React 19 makes it easier to pass refs, makeing wrapping unnecessary (https://react.dev/reference/react/forwardRef).
 const SegmentedControlImpl = forwardRef(SegmentedControlInner);
 SegmentedControlImpl.displayName = `${DISPLAYNAME_PREFIX}.SegmentedControl`;
 export const SegmentedControl = SegmentedControlImpl as <T extends string | number = string>(

--- a/packages/core/test/segmented-control/segmentedControlTests.tsx
+++ b/packages/core/test/segmented-control/segmentedControlTests.tsx
@@ -40,6 +40,27 @@ const OPTIONS: Array<OptionProps<string>> = [
     },
 ];
 
+enum ViewMode {
+    List = "list",
+    Grid = "grid",
+    Gallery = "gallery",
+}
+
+const ENUM_OPTIONS: Array<OptionProps<ViewMode>> = [
+    {
+        label: "List",
+        value: ViewMode.List,
+    },
+    {
+        label: "Grid",
+        value: ViewMode.Grid,
+    },
+    {
+        label: "Gallery",
+        value: ViewMode.Gallery,
+    },
+];
+
 describe("<SegmentedControl>", () => {
     let containerElement: HTMLElement;
 
@@ -149,25 +170,14 @@ describe("<SegmentedControl>", () => {
     });
 
     it("should support enum values", () => {
-        enum TestEnum {
-            List = "list",
-            Grid = "grid",
-            Gallery = "gallery",
-        }
-
         const onValueChange = sinon.spy();
-        render(
-            <SegmentedControl<TestEnum>
-                onValueChange={onValueChange}
-                options={[{ value: TestEnum.List }, { value: TestEnum.Grid }, { value: TestEnum.Gallery }]}
-            />,
-        );
+        render(<SegmentedControl<ViewMode> onValueChange={onValueChange} options={ENUM_OPTIONS} />);
         const listButton = screen.getByRole("radio", { name: /list/i });
 
         userEvent.click(listButton);
 
         expect(onValueChange.called).to.be.true;
-        expect(onValueChange.args[0][0]).to.equal(TestEnum.List);
+        expect(onValueChange.args[0][0]).to.equal(ViewMode.List);
         expect(listButton.getAttribute("aria-checked")).to.equal("true");
     });
 });

--- a/packages/core/test/segmented-control/segmentedControlTests.tsx
+++ b/packages/core/test/segmented-control/segmentedControlTests.tsx
@@ -147,4 +147,24 @@ describe("<SegmentedControl>", () => {
         expect(listButton.getAttribute("aria-checked")).to.equal("false");
         expect(gridButton.getAttribute("aria-checked")).to.equal("false");
     });
+
+    it("should support enum values", () => {
+        enum TestEnum {
+            List = "list",
+            Grid = "grid",
+            Gallery = "gallery",
+        }
+
+        render(
+            <SegmentedControl
+                options={[{ value: TestEnum.List }, { value: TestEnum.Grid }, { value: TestEnum.Gallery }]}
+            />,
+        );
+        const listButton = screen.getByRole("radio", { name: /list/i });
+        const gridButton = screen.getByRole("radio", { name: /grid/i });
+        const galleryButton = screen.getByRole("radio", { name: /gallery/i });
+        expect(listButton.getAttribute("aria-checked")).to.equal("true");
+        expect(gridButton.getAttribute("aria-checked")).to.equal("false");
+        expect(galleryButton.getAttribute("aria-checked")).to.equal("false");
+    });
 });

--- a/packages/core/test/segmented-control/segmentedControlTests.tsx
+++ b/packages/core/test/segmented-control/segmentedControlTests.tsx
@@ -155,16 +155,19 @@ describe("<SegmentedControl>", () => {
             Gallery = "gallery",
         }
 
+        const onValueChange = sinon.spy();
         render(
-            <SegmentedControl
+            <SegmentedControl<TestEnum>
+                onValueChange={onValueChange}
                 options={[{ value: TestEnum.List }, { value: TestEnum.Grid }, { value: TestEnum.Gallery }]}
             />,
         );
         const listButton = screen.getByRole("radio", { name: /list/i });
-        const gridButton = screen.getByRole("radio", { name: /grid/i });
-        const galleryButton = screen.getByRole("radio", { name: /gallery/i });
+
+        userEvent.click(listButton);
+
+        expect(onValueChange.called).to.be.true;
+        expect(onValueChange.args[0][0]).to.equal(TestEnum.List);
         expect(listButton.getAttribute("aria-checked")).to.equal("true");
-        expect(gridButton.getAttribute("aria-checked")).to.equal("false");
-        expect(galleryButton.getAttribute("aria-checked")).to.equal("false");
     });
 });


### PR DESCRIPTION
#### Fixes #6695

#### Checklist

-   [x] Includes tests
-   [x] Update documentation 

#### Changes proposed in this pull request:
Instead of having the value of the option typed as a string, it should be a generic so that one could pass a enum for example.

#### Reviewers should focus on:
I did not change the documentation as the documentation still holds for this change. Maybe it should include this, i was not sure?
I would like focus on the wrapping around the forwardRef as it was a bit annoying to get the generic types to work there, the way i ended up doing it seemed to me the cleanest, but maybe there is a better way. Furthermore i added a comment that when/if this repo gets updated to React 19 then it should make it way easier as forwardRef is deprecated there.
