### PR TITLE
[core] Change `$pt-link-color` from `$blue2` to `$blue3`

### DIFF
--- a/packages/core/src/common/_color-aliases.scss
+++ b/packages/core/src/common/_color-aliases.scss
@@ -41,7 +41,7 @@ $pt-text-color: $dark-gray1 !default;
 $pt-text-color-muted: $gray1 !default;
 $pt-text-color-disabled: rgba($gray1, 0.6) !default;
 $pt-heading-color: $pt-text-color !default;
-$pt-link-color: $blue2 !default;
+$pt-link-color: $blue3 !default;
 $pt-dark-text-color: $light-gray5 !default;
 $pt-dark-text-color-muted: $gray4 !default;
 $pt-dark-text-color-disabled: rgba($gray4, 0.6) !default;


### PR DESCRIPTION
## Changes

Adjust the color of links in Blueprint from `$blue2` (`#215DB0`) to `$blue3` (`#2D72D2`)

<img width="2666" height="1470" alt="diff" src="https://github.com/user-attachments/assets/e76e2d9f-8ff1-4355-9561-2f0d6c8aa6f4" />

## Context

The style of links in Blueprint currently defaults to blue text that gets an underline on hover. This runs up against the recommendations in [WCAG 1.4.1](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html) around the use of color to distinguish links from a body of surrounding text. WCAG provides a compliant approach with [Technique G183](https://www.w3.org/WAI/WCAG21/Techniques/general/G183) that has the following three requirements:
> Use of Color a [relative luminance](https://www.w3.org/TR/WCAG21/#dfn-relative-luminance) (lightness) difference of 3:1 or greater with the text around can be used. This technique goes beyond the success criterion and asks for visual highlights when the user hovers over each link, such as an underline, a change in font style such as bold or italics, or an increase in font size. Such a hover effect provides confirmation to pointer users that the text is a link, similar to how the link alters its appearance for keyboard users when it receives focus, in order to meet [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible).

We meet the later two criteria (underline on hover, outline on focus), but do not currently have a contrast of "3:1 or greater" with regards to our default body text and link text:

https://webaim.org/resources/linkcontrastchecker/?fcolor=1C2127&bcolor=FFFFFF&lcolor=215DB0

This change proposes increasing the luminance of links so that they meet his criteria:

https://webaim.org/resources/linkcontrastchecker/?fcolor=1C2127&bcolor=FFFFFF&lcolor=2D72D2