### PR TITLE
fix(a11y): wrap breadcrumbs in `nav` element

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -103,6 +103,8 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
                 collapseFrom={collapseFrom}
                 minVisibleItems={minVisibleItems}
                 tagName="ol"
+                navigable={true}
+                navigationAriaLabel="Breadcrumb"
                 {...overflowListProps}
                 className={classNames(Classes.BREADCRUMBS, overflowListProps.className, className)}
                 items={items}

--- a/packages/core/src/components/overflow-list/overflowList.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.tsx
@@ -100,6 +100,20 @@ export interface OverflowListProps<T> extends Props {
      * Remember to set a `key` on the rendered element!
      */
     visibleItemRenderer: (item: T, index: number) => React.ReactNode;
+
+    /**
+     * If true, the overflow list will be wrapped with a `nav` element.
+     *
+     * @default false
+     */
+    navigable?: boolean;
+
+    /**
+     * ARIA label to apply to the `nav` element. Only used if `navigable` is true.
+     *
+     * @default ""
+     */
+    navigationAriaLabel?: string;
 }
 
 export interface OverflowListState<T> {
@@ -198,9 +212,18 @@ export class OverflowList<T> extends Component<OverflowListProps<T>, OverflowLis
     }
 
     public render() {
-        const { className, collapseFrom, observeParents, style, tagName = "div", visibleItemRenderer } = this.props;
+        const {
+            className,
+            collapseFrom,
+            observeParents,
+            style,
+            tagName = "div",
+            visibleItemRenderer,
+            navigable = false,
+            navigationAriaLabel = "",
+        } = this.props;
         const overflow = this.maybeRenderOverflow();
-        const list = createElement(
+        let list = createElement(
             tagName,
             {
                 className: classNames(Classes.OVERFLOW_LIST, className),
@@ -211,6 +234,10 @@ export class OverflowList<T> extends Component<OverflowListProps<T>, OverflowLis
             collapseFrom === Boundary.END ? overflow : null,
             <div className={Classes.OVERFLOW_LIST_SPACER} ref={ref => (this.spacer = ref)} />,
         );
+
+        if (navigable) {
+            list = <nav aria-label={navigationAriaLabel}>{list}</nav>;
+        }
 
         return (
             <ResizeSensor onResize={this.resize} observeParents={observeParents}>


### PR DESCRIPTION
#### Changes proposed in this pull request:

Following the guidelines from https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/ that recommend wrapping breadcrumb components with a `nav` element.

#### Screenshot

Testing this in `docs-app` shows that the breadcrumb display isn't affected and that the list is indeed wrapped with the `nav` element:
<img width="831" height="284" alt="image" src="https://github.com/user-attachments/assets/21396dac-a205-4919-a80f-16e08665bd86" />
