### PR TITLE
chore(devx): add `prepack` script to `core` package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
         "lint:scss": "sass-lint",
         "lint:es": "es-lint",
         "lint-fix": "es-lint --fix && sass-lint --fix",
+        "prepack": "run-s compile dist",
         "test": "run-s test:typeCheck test:iso test:karma",
         "test:typeCheck": "tsc -p ./test",
         "test:iso": "mocha test/isotest.mjs",


### PR DESCRIPTION
#### Changes proposed in this pull request:

The output from `pnpm dist` needs to be included in the contents of `pnpm pack`, and so let's add a [lifecycle script](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts) to ensure that `dist` always runs before packing.

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->

When running `pnpm pack` locally I can indeed see that `dist` also runs:

<img width="561" height="242" alt="image" src="https://github.com/user-attachments/assets/4a4003d4-c519-40d8-926f-895fd4231b37" />
