### PR TITLE
[core] Remove default `text-decoration: none` style on anchor tags

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -198,26 +198,6 @@ Styleguide running-text
 }
 
 /*
-Links
-
-Simply use an `<a href="">` tag as you normally would. No class is necessary for Blueprint styles.
-Links are underlined only when hovered.
-
-Putting an icon inside a link will cause it to inherit the link's text color.
-
-Styleguide typography.links
-*/
-
-a {
-  text-decoration: none;
-
-  &:hover {
-    cursor: pointer;
-    text-decoration: underline;
-  }
-}
-
-/*
 Preformatted text
 
 Markup:


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

#### Reviewers should focus on:

<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
