### PR TITLE
[a11y] Read only input has visual indicator on focus

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -115,6 +115,10 @@ $control-group-stack: (
 
   &[readonly] {
     box-shadow: inset 0 0 0 1px $pt-divider-black;
+
+    &:focus {
+      box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+    }
   }
 
   &:disabled,
@@ -197,6 +201,12 @@ $control-group-stack: (
 
   &[readonly] {
     box-shadow: inset 0 0 0 1px $pt-dark-divider-black;
+
+    &:focus {
+      box-shadow:
+        dark-input-transition-shadow($dark-input-shadow-color-focus, true),
+        inset 0 0 0 1px $pt-dark-divider-black;
+    }
   }
 
   &:disabled,

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -203,10 +203,7 @@ $control-group-stack: (
     box-shadow: inset 0 0 0 1px $pt-dark-divider-black;
 
     &:focus {
-      box-shadow:
-        dark-input-transition-shadow($dark-input-shadow-color-focus, true),
-        inset 0 0 0 1px $pt-dark-divider-black;
-    }
+      box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);
   }
 
   &:disabled,

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -204,6 +204,7 @@ $control-group-stack: (
 
     &:focus {
       box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);
+    }
   }
 
   &:disabled,


### PR DESCRIPTION
#### Fixes N/A 

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

N/A for the above.

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

A "read-only" input is technically focusable, but there is no visual indicator when it is focused for accessibility purposes. The change proposed here is to add a "focus" state to a read-only input. We should answer the design question of what a "focused" state for a "read-only" input looks like (for eg: it could be a gray outline?)

#### Reviewers should focus on:

Design

#### Screenshot

| Before | After |
|--------|-------|
| <img width="812" height="464" alt="Screenshot 2025-11-25 at 12 50 32" src="https://github.com/user-attachments/assets/43a31a39-c55f-4b59-a62e-e5673f462d18" /> | <img width="848" height="471" alt="Screenshot 2025-11-25 at 12 50 52" src="https://github.com/user-attachments/assets/183da170-4a88-4cf6-8912-ea946552c7ca" /> |
