### PR TITLE
Hide custom MenuItem icons from screen readers

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -265,9 +265,9 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         isSelected ? <SmallTick className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
         hasIcon ? (
             // wrap icon in a <span> in case `icon` is a custom element rather than a built-in icon identifier,
-            // so that we always render this class
-            <span className={Classes.MENU_ITEM_ICON}>
-                <Icon icon={icon} aria-hidden={true} tabIndex={-1} />
+            // so that we always render this class and hide it from a screen reader
+            <span className={Classes.MENU_ITEM_ICON} aria-hidden={true}>
+                <Icon icon={icon} tabIndex={-1} />
             </span>
         ) : undefined,
         <Text className={classNames(Classes.FILL, textClassName)} ellipsize={!multiline} title={htmlTitle}>

--- a/packages/core/test/menu/menuItemTests.tsx
+++ b/packages/core/test/menu/menuItemTests.tsx
@@ -199,6 +199,19 @@ describe("MenuItem", () => {
         assert.strictEqual(label.find("article").text(), "label element");
     });
 
+    it("renders icon with aria-hidden attribute on wrapper span", () => {
+        const wrapper = mount(<MenuItem icon="graph" text="Graph" />);
+        const iconWrapper = wrapper.find(`.${Classes.MENU_ITEM_ICON}`);
+        assert.strictEqual(iconWrapper.prop("aria-hidden"), true);
+    });
+
+    it("renders custom icon element with aria-hidden attribute on wrapper span", () => {
+        const customIcon = <span className="custom-icon">Custom</span>;
+        const wrapper = mount(<MenuItem icon={customIcon} text="Custom" />);
+        const iconWrapper = wrapper.find(`.${Classes.MENU_ITEM_ICON}`);
+        assert.strictEqual(iconWrapper.prop("aria-hidden"), true);
+    });
+
     describe("tabIndex behavior", () => {
         it("MenuItem without submenu has tabIndex={0} when enabled", () => {
             const { container } = render(<MenuItem text="Item" />);


### PR DESCRIPTION
This PR updates our rendering of icons in the `MenuItem` component to ensure that it is always hidden from a screen reader.

Previously, we set `aria-hidden` on the `Icon` element itself, which worked when a consumer passed in a Blueprint icon string. However, if a consumer passed in a custom icon element instead, the `aria-hidden` was swallowed and the icon name would be read by a screen reader. The `MenuItem` also includes a title string, so the icon is decorative and reading it aloud is duplicative.

I think this could _technically_ be a break if a consumer were passing in a complicated component as the icon here with `tabIndex={0}`, and expected it to still receive focus + be read aloud. I can't think of any good use-cases for that, though, and it seems like an abuse of the Menu API to me.

## Screenshot
The effect of this is visible on the `Menu` documentation page if you edit the Palantir icon to include a `title` attribute. Previously, this `title` attribute was read aloud even though it is decorative. Now, it is not.

### Before
<img width="2606" height="648" alt="image" src="https://github.com/user-attachments/assets/74c9f0b8-dbf6-44e5-9ec6-96fb124a11e4" />

### After
<img width="2622" height="704" alt="image" src="https://github.com/user-attachments/assets/76104d95-34ef-4236-ac5a-949c1c945144" />
