### PR TITLE
[core] Fix switch control indicator alignment issues

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -457,12 +457,13 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       width: auto;
 
       &::before {
+        top: 50%;
+        transform: translateY(-50%);
         background: $white;
         border-radius: 50%;
         box-shadow: $switch-indicator-box-shadow;
         height: $switch-indicator-size;
-        left: 0;
-        margin: $switch-indicator-margin;
+        left: $switch-indicator-margin;
         position: absolute;
         transition: left $pt-transition-duration $pt-transition-ease;
         width: $switch-indicator-size;
@@ -482,7 +483,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     input:checked ~ .#{$ns}-control-indicator::before {
       // 1em is size of indicator
-      left: calc(100% - 1em);
+      left: calc($switch-indicator-margin + 100% - 1em);
     }
 
     &.#{$ns}-large {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -457,14 +457,14 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       width: auto;
 
       &::before {
-        top: 50%;
-        transform: translateY(-50%);
         background: $white;
         border-radius: 50%;
         box-shadow: $switch-indicator-box-shadow;
         height: $switch-indicator-size;
         left: $switch-indicator-margin;
         position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
         transition: left $pt-transition-duration $pt-transition-ease;
         width: $switch-indicator-size;
 


### PR DESCRIPTION
## Change
The px and margin-based vertical alignment of the switch's circular element hits rounding issues. This PR reworks it to use 50% height alignment.

## Screenshots
Before, 125% page zoom:
<img width="1458" height="418" alt="image" src="https://github.com/user-attachments/assets/d9ded2e6-2ec4-4d6e-9944-869c7ccc7150" />


After: 125% page zoom:
<img width="1260" height="367" alt="image" src="https://github.com/user-attachments/assets/cc67f949-07f8-4824-b06d-1c289f261805" />

