### PR TITLE
fix(a11y): identify menu ID to breadcrumbs collapsed button

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 
-import { AbstractPureComponent, Boundary, Classes, type Props, removeNonHTMLProps } from "../../common";
+import { AbstractPureComponent, Boundary, Classes, type Props, removeNonHTMLProps, Utils } from "../../common";
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
@@ -92,6 +92,8 @@ export interface BreadcrumbsProps extends Props {
  * @see https://blueprintjs.com/docs/#core/components/breadcrumbs
  */
 export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
+    private collapsedBreadcrumbsMenuId = Utils.uniqueId("collapsedBreadcrumbsMenu");
+
     public static defaultProps: Partial<BreadcrumbsProps> = {
         collapseFrom: Boundary.START,
     };
@@ -129,11 +131,15 @@ export class Breadcrumbs extends AbstractPureComponent<BreadcrumbsProps> {
                 <Popover
                     placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
                     disabled={orderedItems.length === 0}
-                    content={<Menu>{orderedItems.map(this.renderOverflowBreadcrumb)}</Menu>}
+                    content={
+                        <Menu id={this.collapsedBreadcrumbsMenuId}>
+                            {orderedItems.map(this.renderOverflowBreadcrumb)}
+                        </Menu>
+                    }
                     {...popoverProps}
                 >
                     <span
-                        aria-label="collapsed breadcrumbs"
+                        aria-labelledby={this.collapsedBreadcrumbsMenuId}
                         role="button"
                         tabIndex={0}
                         {...overflowButtonProps}

--- a/packages/core/test/breadcrumbs/breadcrumbsTests.tsx
+++ b/packages/core/test/breadcrumbs/breadcrumbsTests.tsx
@@ -15,7 +15,8 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { expect } from "chai";
+import { assert, expect } from "chai";
+import { mount } from "enzyme";
 import { spy } from "sinon";
 
 import { Classes } from "../../src/common";
@@ -52,15 +53,14 @@ describe("<Breadcrumbs>", () => {
     });
 
     it("should render overflow/collapsed indicator when items don't fit", () => {
-        render(
+        const wrapper = mount(
             // 70px is just enough to show one item
             <div style={{ width: 70 }}>
                 <Breadcrumbs items={ITEMS} />
             </div>,
         );
-        const button = screen.getByRole("button", { name: /collapsed breadcrumbs/i });
 
-        expect(hasClass(button, Classes.BREADCRUMBS_COLLAPSED)).to.be.true;
+        assert.lengthOf(wrapper.find(`.${Classes.BREADCRUMBS_COLLAPSED}`), 1);
     });
 
     it("should render the correct overflow menu items", () => {


### PR DESCRIPTION
#### Changes proposed in this pull request:

<!-- Fill this out. -->

Replacing the `aria-label` attribute of the collapsed button of the breadcrumbs component to use `aria-labelledby` instead. This way the button references the popover's content as the element providing an accessible name.

The problem with the current `aria-label` is that it doesn't describe the state information of the button.
