### PR TITLE
Create outline around switches

### DIFF
--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -457,12 +457,13 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       width: auto;
 
       &::before {
+        top: 50%;
+        transform: translateY(-50%);
         background: $white;
         border-radius: 50%;
         box-shadow: $switch-indicator-box-shadow;
         height: $switch-indicator-size;
-        left: 0;
-        margin: $switch-indicator-margin;
+        left: $switch-indicator-margin;
         position: absolute;
         transition: left $pt-transition-duration $pt-transition-ease;
         width: $switch-indicator-size;
@@ -482,7 +483,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     input:checked ~ .#{$ns}-control-indicator::before {
       // 1em is size of indicator
-      left: calc(100% - 1em);
+      left: calc($switch-indicator-margin + 100% - 1em);
     }
 
     &.#{$ns}-large {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -333,7 +333,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   /* stylelint-disable-next-line order/order */
   $switch-width: 1.75em !default;
   $switch-indicator-margin: $pt-spacing * 0.5 !default;
-  $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
+  $switch-indicator-size: calc(1em - #{$switch-indicator-margin});
 
   $switch-indicator-child-height: 1em;
   $switch-indicator-child-outside-margin: 0.5em;
@@ -360,7 +360,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   $dark-switch-checked-text-color-disabled: $pt-dark-text-color-disabled !default;
 
   $switch-indicator-background-color: rgba($gray3, 0.3) !default;
-  $switch-indicator-box-shadow: 0 0 0 $button-border-width rgba($black, 0.5) !default;
+  $switch-indicator-box-shadow: 0 0 0 $button-border-width $gray1 !default;
   $switch-indicator-background-color-disabled: rgba($white, 0.8) !default;
   $switch-checked-indicator-background-color-disabled: rgba($white, 0.5) !default;
 
@@ -447,11 +447,11 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     }
 
     .#{$ns}-control-indicator {
-      border: 1px solid $gray2;
+      // border: 1px solid $gray2;
       border-radius: $switch-width;
       // override default button styles, never have a box-shadow here.
       /* stylelint-disable-next-line declaration-no-important */
-      box-shadow: none !important;
+      box-shadow: 1px solid $gray2; //none;
       min-width: $switch-width;
       transition: background-color $pt-transition-duration $pt-transition-ease;
       width: auto;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -341,14 +341,14 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
   $switch-indicator-text-font-size: 0.7em;
 
-  $switch-text-color: $pt-text-color !default;
+  $switch-text-color: $white !default;
   $switch-text-color-disabled: $pt-text-color-disabled !default;
   $switch-checked-text-color: $white !default;
   $switch-checked-text-color-disabled: rgba($white, 0.6) !default;
-  $switch-background-color: rgba($gray3, 0.3) !default;
-  $switch-background-color-hover: rgba($gray3, 0.4) !default;
-  $switch-background-color-active: rgba($gray3, 0.5) !default;
-  $switch-background-color-disabled: rgba($gray3, 0.15) !default;
+  $switch-background-color: rgba($gray1, 0.7) !default;
+  $switch-background-color-hover: rgba($gray1, 0.8) !default;
+  $switch-background-color-active: rgba($gray1, 1) !default;
+  $switch-background-color-disabled: rgba($gray1, 0.15) !default;
   $switch-checked-background-color: $control-checked-background-color !default;
   $switch-checked-background-color-hover: $control-checked-background-color-hover !default;
   $switch-checked-background-color-active: $control-checked-background-color-active !default;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -341,14 +341,14 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
   $switch-indicator-text-font-size: 0.7em;
 
-  $switch-text-color: $white !default;
+  $switch-text-color: $pt-text-color !default;
   $switch-text-color-disabled: $pt-text-color-disabled !default;
   $switch-checked-text-color: $white !default;
   $switch-checked-text-color-disabled: rgba($white, 0.6) !default;
-  $switch-background-color: rgba($gray1, 0.7) !default;
-  $switch-background-color-hover: rgba($gray1, 0.8) !default;
-  $switch-background-color-active: rgba($gray1, 1) !default;
-  $switch-background-color-disabled: rgba($gray1, 0.15) !default;
+  $switch-background-color: rgba($gray3, 0.3) !default;
+  $switch-background-color-hover: rgba($gray3, 0.4) !default;
+  $switch-background-color-active: rgba($gray3, 0.5) !default;
+  $switch-background-color-disabled: rgba($gray3, 0.15) !default;
   $switch-checked-background-color: $control-checked-background-color !default;
   $switch-checked-background-color-hover: $control-checked-background-color-hover !default;
   $switch-checked-background-color-active: $control-checked-background-color-active !default;

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -447,7 +447,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     }
 
     .#{$ns}-control-indicator {
-      border: none;
+      border: 1px solid $gray2;
       border-radius: $switch-width;
       // override default button styles, never have a box-shadow here.
       /* stylelint-disable-next-line declaration-no-important */

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -457,14 +457,14 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       width: auto;
 
       &::before {
-        top: 50%;
-        transform: translateY(-50%);
         background: $white;
         border-radius: 50%;
         box-shadow: $switch-indicator-box-shadow;
         height: $switch-indicator-size;
         left: $switch-indicator-margin;
         position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
         transition: left $pt-transition-duration $pt-transition-ease;
         width: $switch-indicator-size;
 

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -332,8 +332,8 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
   /* stylelint-disable-next-line order/order */
   $switch-width: 1.75em !default;
-  $switch-indicator-margin: $pt-spacing * 0.5 !default;
-  $switch-indicator-size: calc(1em - #{$switch-indicator-margin});
+  $switch-indicator-margin: $pt-spacing * 0.25 !default;
+  $switch-indicator-size: calc(1em - $switch-indicator-margin * 2);
 
   $switch-indicator-child-height: 1em;
   $switch-indicator-child-outside-margin: 0.5em;
@@ -483,7 +483,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     input:checked ~ .#{$ns}-control-indicator::before {
       // 1em is size of indicator
-      left: calc($switch-indicator-margin + 100% - 1em);
+      left: calc(100% - $switch-indicator-size - $switch-indicator-margin);
     }
 
     &.#{$ns}-large {


### PR DESCRIPTION
The current switches fail accessibility requirements since the entire object has < 3.0 contrast ratio. One possible fix is to introduce an outline around the backing. Having 2 outlines close by looks bad, so this PR experiments with making them flush.

#### Screenshot
<img width="997" height="628" alt="image" src="https://github.com/user-attachments/assets/d2ec37ec-2485-4bb6-8773-5b8f286bfd5c" />

<!-- Include an image of the most relevant user-facing change, if any. -->
