### PR TITLE
chore(devx): remove `changelog` configuration

### DIFF
--- a/.palantir/changelog.yml
+++ b/.palantir/changelog.yml
@@ -1,3 +1,0 @@
-# Excavator auto-updates this file. Please contribute improvements to the central template.
-
-# This file is intentionally empty. The file's existence enables changelog-app and is empty to use the default configuration.


### PR DESCRIPTION
#### Changes proposed in this pull request:

As mentioned in the comment this repo isn't using changelogs for now so to make the dev experience a bit smoother let's disable the bot for now.
