### PR TITLE
[a11y] Add accessible hover indicator to menu items

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -249,12 +249,21 @@ $dark-menu-item-intent-colors: (
   cursor: pointer;
   text-decoration: none;
 
-  // Insert an accessible selection indicator for items with existing labels
+  // Insert an accessible selection indicator for items with text labels
   &:not(:has(.#{$ns}-submenu-icon)) {
     .#{$ns}-menu-item-label:not(.bp-menu-item-hover-indicator)::before {
       content: "• ";
       font-size: $menu-item-hover-indicator-font-size;
       line-height: 0;
+    }
+
+    // Hide bullet if label contains form controls
+    .#{$ns}-menu-item-label:has(input),
+    .#{$ns}-menu-item-label:has(textarea),
+    .#{$ns}-menu-item-label:has(select) {
+      &::before {
+        display: none;
+      }
     }
   }
 }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -228,13 +228,16 @@ $dark-menu-item-intent-colors: (
   cursor: pointer;
   text-decoration: none;
 
-  .#{$ns}-menu-item-label::before {
-    content: "• ";
-  }
+  // Insert an accessible selection indicator for non-submenu items
+  &:not(:has(.#{$ns}-submenu-icon)) {
+    .#{$ns}-menu-item-label::before {
+      content: "• ";
+    }
 
-  &:not(:has(.#{$ns}-menu-item-label))::after {
-    content: "•";
-    margin-left: auto;
+    &:not(:has(.#{$ns}-menu-item-label))::after {
+      content: "•";
+      margin-left: auto;
+    }
   }
 }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -28,6 +28,7 @@ $menu-item-padding-small: $pt-spacing !default;
 $menu-item-padding-vertical-small: $pt-spacing * 0.5 !default;
 $menu-item-selected-icon-spacing: $pt-spacing * 0.5;
 $menu-item-indent: $pt-icon-size-standard + $menu-item-selected-icon-spacing * 2;
+$menu-item-hover-indicator-font-size: 1.2em !default;
 
 $menu-background-color: $white !default;
 $dark-menu-background-color: $dark-gray3 !default;
@@ -113,17 +114,17 @@ $dark-menu-item-intent-colors: (
     align-items: center;
     color: $pt-text-color-muted;
     display: none;
-    font-size: 1.2em;
+    font-size: $menu-item-hover-indicator-font-size;
     justify-content: center;
     line-height: 1;
     position: absolute;
     right: $menu-item-padding;
     top: 50%;
     transform: translateY(-50%);
+  }
 
-    &.bp-menu-item-hover-indicator-visible {
-      display: flex;
-    }
+  &:hover .bp-menu-item-hover-indicator {
+    display: flex;
   }
 
   &::before,
@@ -252,7 +253,7 @@ $dark-menu-item-intent-colors: (
   &:not(:has(.#{$ns}-submenu-icon)) {
     .#{$ns}-menu-item-label:not(.bp-menu-item-hover-indicator)::before {
       content: "• ";
-      font-size: 1.2em;
+      font-size: $menu-item-hover-indicator-font-size;
       line-height: 0;
     }
   }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -255,6 +255,9 @@ $dark-menu-item-intent-colors: (
   &:not(:has(.#{$ns}-submenu-icon)) {
     .#{$ns}-menu-item-label:not(.bp-menu-item-hover-indicator)::before {
       content: "• ";
+      font-size: 1.2em;
+      line-height: 0;
+      vertical-align: baseline;
     }
   }
 }
@@ -364,6 +367,11 @@ $dark-menu-item-intent-colors: (
     // SVG icons remain standard size when menu is large
     margin-top: ($menu-item-line-height - $pt-icon-size-standard) * 0.5;
   }
+
+  .bp-menu-item-hover-indicator {
+    width: $pt-icon-size-standard;
+    height: $pt-icon-size-standard;
+  }
 }
 
 @mixin menu-item-small() {
@@ -373,6 +381,11 @@ $dark-menu-item-intent-colors: (
 
   .#{$ns}-menu-item-icon {
     height: $menu-item-line-height-small;
+  }
+
+  .bp-menu-item-hover-indicator {
+    width: $pt-icon-size-standard * 0.8;
+    height: $pt-icon-size-standard * 0.8;
   }
 }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -90,9 +90,11 @@ $dark-menu-item-intent-colors: (
   padding: $menu-item-padding-vertical $menu-item-padding;
   text-decoration: none;
   user-select: none;
+  position: relative;
 
   > .#{$ns}-fill {
     word-break: break-word;
+    min-width: 0;
   }
 
   .#{$ns}-menu-item-icon {
@@ -107,10 +109,24 @@ $dark-menu-item-intent-colors: (
   }
 
   .bp-menu-item-hover-indicator {
-    display: flex;
+    display: none;
     align-items: center;
     justify-content: center;
-    margin-left: auto;
+    position: absolute;
+    right: $menu-item-padding;
+    top: 50%;
+    transform: translateY(-50%);
+    width: $pt-icon-size-standard;
+    height: $pt-icon-size-standard;
+
+    svg {
+      fill: currentColor;
+      stroke: currentColor;
+    }
+
+    &.bp-menu-item-hover-indicator-visible {
+      display: flex;
+    }
   }
 
   &::before,
@@ -237,7 +253,7 @@ $dark-menu-item-intent-colors: (
 
   // Insert an accessible selection indicator for items with existing labels
   &:not(:has(.#{$ns}-submenu-icon)) {
-    .#{$ns}-menu-item-label::before {
+    .#{$ns}-menu-item-label:not(.bp-menu-item-hover-indicator)::before {
       content: "• ";
     }
   }

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -86,6 +86,7 @@ $dark-menu-item-intent-colors: (
   align-items: flex-start;
   border-radius: $menu-item-border-radius;
   color: inherit;
+  font-size: $pt-font-size;
   line-height: $menu-item-line-height;
   padding: $menu-item-padding-vertical $menu-item-padding;
   text-decoration: none;
@@ -116,13 +117,8 @@ $dark-menu-item-intent-colors: (
     right: $menu-item-padding;
     top: 50%;
     transform: translateY(-50%);
-    width: $pt-icon-size-standard;
-    height: $pt-icon-size-standard;
-
-    svg {
-      fill: currentColor;
-      stroke: currentColor;
-    }
+    font-size: 0.9em;
+    color: $pt-text-color-muted;
 
     &.bp-menu-item-hover-indicator-visible {
       display: flex;
@@ -255,9 +251,6 @@ $dark-menu-item-intent-colors: (
   &:not(:has(.#{$ns}-submenu-icon)) {
     .#{$ns}-menu-item-label:not(.bp-menu-item-hover-indicator)::before {
       content: "• ";
-      font-size: 1.2em;
-      line-height: 0;
-      vertical-align: baseline;
     }
   }
 }
@@ -368,10 +361,6 @@ $dark-menu-item-intent-colors: (
     margin-top: ($menu-item-line-height - $pt-icon-size-standard) * 0.5;
   }
 
-  .bp-menu-item-hover-indicator {
-    width: $pt-icon-size-standard;
-    height: $pt-icon-size-standard;
-  }
 }
 
 @mixin menu-item-small() {
@@ -383,10 +372,6 @@ $dark-menu-item-intent-colors: (
     height: $menu-item-line-height-small;
   }
 
-  .bp-menu-item-hover-indicator {
-    width: $pt-icon-size-standard * 0.8;
-    height: $pt-icon-size-standard * 0.8;
-  }
 }
 
 @mixin menu-divider() {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -106,6 +106,13 @@ $dark-menu-item-intent-colors: (
     color: $pt-text-color-muted;
   }
 
+  .bp-menu-item-hover-indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: auto;
+  }
+
   &::before,
   .#{$ns}-menu-item-icon,
   .#{$ns}-menu-item-selected-icon,
@@ -228,15 +235,10 @@ $dark-menu-item-intent-colors: (
   cursor: pointer;
   text-decoration: none;
 
-  // Insert an accessible selection indicator for non-submenu items
+  // Insert an accessible selection indicator for items with existing labels
   &:not(:has(.#{$ns}-submenu-icon)) {
     .#{$ns}-menu-item-label::before {
       content: "• ";
-    }
-
-    &:not(:has(.#{$ns}-menu-item-label))::after {
-      content: "•";
-      margin-left: auto;
     }
   }
 }
@@ -248,6 +250,13 @@ $dark-menu-item-intent-colors: (
   .#{$ns}-menu-item-icon,
   .#{$ns}-submenu-icon {
     color: $pt-dark-icon-color;
+  }
+
+  // Show hover indicator for non-submenu items
+  &:not(:has(.#{$ns}-submenu-icon)) {
+    .bp-menu-item-hover-indicator {
+      display: flex;
+    }
   }
 }
 

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -227,6 +227,15 @@ $dark-menu-item-intent-colors: (
   color: inherit;
   cursor: pointer;
   text-decoration: none;
+
+  .#{$ns}-menu-item-label::before {
+    content: "• ";
+  }
+
+  &:not(:has(.#{$ns}-menu-item-label))::after {
+    content: "•";
+    margin-left: auto;
+  }
 }
 
 @mixin dark-menu-item-hover() {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -117,8 +117,9 @@ $dark-menu-item-intent-colors: (
     right: $menu-item-padding;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 0.9em;
+    font-size: 1.2em;
     color: $pt-text-color-muted;
+    line-height: 1;
 
     &.bp-menu-item-hover-indicator-visible {
       display: flex;
@@ -251,6 +252,8 @@ $dark-menu-item-intent-colors: (
   &:not(:has(.#{$ns}-submenu-icon)) {
     .#{$ns}-menu-item-label:not(.bp-menu-item-hover-indicator)::before {
       content: "• ";
+      font-size: 1.2em;
+      line-height: 0;
     }
   }
 }
@@ -360,7 +363,6 @@ $dark-menu-item-intent-colors: (
     // SVG icons remain standard size when menu is large
     margin-top: ($menu-item-line-height - $pt-icon-size-standard) * 0.5;
   }
-
 }
 
 @mixin menu-item-small() {
@@ -371,7 +373,6 @@ $dark-menu-item-intent-colors: (
   .#{$ns}-menu-item-icon {
     height: $menu-item-line-height-small;
   }
-
 }
 
 @mixin menu-divider() {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -89,13 +89,13 @@ $dark-menu-item-intent-colors: (
   font-size: $pt-font-size;
   line-height: $menu-item-line-height;
   padding: $menu-item-padding-vertical $menu-item-padding;
+  position: relative;
   text-decoration: none;
   user-select: none;
-  position: relative;
 
   > .#{$ns}-fill {
-    word-break: break-word;
     min-width: 0;
+    word-break: break-word;
   }
 
   .#{$ns}-menu-item-icon {
@@ -110,16 +110,16 @@ $dark-menu-item-intent-colors: (
   }
 
   .bp-menu-item-hover-indicator {
-    display: none;
     align-items: center;
+    color: $pt-text-color-muted;
+    display: none;
+    font-size: 1.2em;
     justify-content: center;
+    line-height: 1;
     position: absolute;
     right: $menu-item-padding;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 1.2em;
-    color: $pt-text-color-muted;
-    line-height: 1;
 
     &.bp-menu-item-hover-indicator-visible {
       display: flex;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -250,10 +250,12 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             </span>
         );
 
-    // Render a hover indicator icon for items without submenu or label (only when hovered)
-    const shouldShowHoverIndicator = !hasSubmenu && props.label == null && labelElement == null && isHovered;
-    const maybeHoverIndicator = shouldShowHoverIndicator ? (
-        <span className="bp-menu-item-hover-indicator" title="Selected">
+    // Render a hover indicator icon for items without submenu or label
+    const shouldRenderHoverIndicator = !hasSubmenu && props.label == null && labelElement == null;
+    const maybeHoverIndicator = shouldRenderHoverIndicator ? (
+        <span className={classNames("bp-menu-item-hover-indicator", Classes.MENU_ITEM_LABEL, {
+            "bp-menu-item-hover-indicator-visible": isHovered,
+        })} title="Selected">
             <Dot />
         </span>
     ) : null;

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import { createElement, forwardRef, useState } from "react";
 
-import { CaretRight, Dot, SmallTick } from "@blueprintjs/icons";
+import { CaretRight, SmallTick } from "@blueprintjs/icons";
 
 import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
@@ -250,13 +250,13 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             </span>
         );
 
-    // Render a hover indicator icon for items without submenu or label
+    // Render a hover indicator for items without submenu or label
     const shouldRenderHoverIndicator = !hasSubmenu && props.label == null && labelElement == null;
     const maybeHoverIndicator = shouldRenderHoverIndicator ? (
         <span className={classNames("bp-menu-item-hover-indicator", Classes.MENU_ITEM_LABEL, {
             "bp-menu-item-hover-indicator-visible": isHovered,
         })} title="Selected">
-            <Dot />
+            •
         </span>
     ) : null;
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -15,9 +15,9 @@
  */
 
 import classNames from "classnames";
-import { createElement, forwardRef } from "react";
+import { createElement, forwardRef, useState } from "react";
 
-import { CaretRight, SmallTick } from "@blueprintjs/icons";
+import { CaretRight, Dot, SmallTick } from "@blueprintjs/icons";
 
 import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
@@ -172,6 +172,8 @@ export interface MenuItemProps
  * @see https://blueprintjs.com/docs/#core/components/menu.menu-item
  */
 export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => {
+    const [isHovered, setIsHovered] = useState(false);
+
     const {
         active = false,
         className,
@@ -248,6 +250,14 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             </span>
         );
 
+    // Render a hover indicator icon for items without submenu or label (only when hovered)
+    const shouldShowHoverIndicator = !hasSubmenu && props.label == null && labelElement == null && isHovered;
+    const maybeHoverIndicator = shouldShowHoverIndicator ? (
+        <span className="bp-menu-item-hover-indicator" title="Selected">
+            <Dot />
+        </span>
+    ) : null;
+
     const htmlPropsOnly = removeNonHTMLProps(htmlProps);
 
     const target = createElement(
@@ -255,6 +265,8 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         {
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
+            onMouseEnter: () => setIsHovered(true),
+            onMouseLeave: () => setIsHovered(false),
             ...htmlPropsOnly,
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
             role: hasSubmenu ? "none" : targetRole,
@@ -274,6 +286,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             {text}
         </Text>,
         maybeLabel,
+        maybeHoverIndicator,
         hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" /> : undefined,
     );
 

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { createElement, forwardRef, useState } from "react";
+import { createElement, forwardRef } from "react";
 
 import { CaretRight, SmallTick } from "@blueprintjs/icons";
 
@@ -172,8 +172,6 @@ export interface MenuItemProps
  * @see https://blueprintjs.com/docs/#core/components/menu.menu-item
  */
 export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuItemProps>((props, ref) => {
-    const [isHovered, setIsHovered] = useState(false);
-
     const {
         active = false,
         className,
@@ -253,9 +251,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
     // Render a hover indicator for items without submenu or label
     const shouldRenderHoverIndicator = !hasSubmenu && props.label == null && labelElement == null;
     const maybeHoverIndicator = shouldRenderHoverIndicator ? (
-        <span className={classNames("bp-menu-item-hover-indicator", Classes.MENU_ITEM_LABEL, {
-            "bp-menu-item-hover-indicator-visible": isHovered,
-        })} title="Selected">
+        <span className={classNames("bp-menu-item-hover-indicator", Classes.MENU_ITEM_LABEL)} title="Selected">
             •
         </span>
     ) : null;
@@ -267,8 +263,6 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         {
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
-            onMouseEnter: () => setIsHovered(true),
-            onMouseLeave: () => setIsHovered(false),
             ...htmlPropsOnly,
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
             role: hasSubmenu ? "none" : targetRole,


### PR DESCRIPTION
The menu item hover state is indicated by a slight darkening of the background, which is low contrast and not accessible.

#### Change

https://github.com/user-attachments/assets/4e5d5eb9-187a-415b-91de-a7cda098dff0


Add an ascii bullet point on the right side of the hover select for a secondary visual indicator.


There is some unfortunately hacky logic around excluding bullets on items that already have clear visual indicators, like submenus and input fields. Open to suggestions to improve these.

Additionally, the spacing can be awkward if the text takes up the entire menu item width.
