### PR TITLE
fix(a11y): prop for `H2` heading in dialog title

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -97,6 +97,7 @@ $dialog-header-padding: $pt-spacing;
   .#{$ns}-heading {
     @include overflow-ellipsis;
     flex: 1 1 auto;
+    font-size: 14px;
     line-height: inherit;
     margin: 0;
 

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -30,7 +30,7 @@ import {
 import * as Errors from "../../common/errors";
 import { uniqueId } from "../../common/utils";
 import { Button } from "../button/buttons";
-import { H6 } from "../html/html";
+import { H2 } from "../html/html";
 import { Icon } from "../icon/icon";
 import type { BackdropProps, OverlayableProps } from "../overlay/overlayProps";
 import { Overlay2 } from "../overlay2/overlay2";
@@ -84,6 +84,13 @@ export interface DialogProps extends OverlayableProps, BackdropProps, Props {
     title?: React.ReactNode;
 
     /**
+     * HTML heading component to use for the dialog title.
+     *
+     * @default H2
+     */
+    titleTagName?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
+
+    /**
      * Name of the transition for internal `CSSTransition`. Providing your own
      * name here will require defining new CSS transition properties.
      */
@@ -117,6 +124,7 @@ export class Dialog extends AbstractPureComponent<DialogProps> {
     public static defaultProps: DialogProps = {
         canOutsideClickClose: true,
         isOpen: false,
+        titleTagName: H2,
     };
 
     private childRef = createRef<HTMLDivElement>();
@@ -189,14 +197,14 @@ export class Dialog extends AbstractPureComponent<DialogProps> {
     }
 
     private maybeRenderHeader() {
-        const { icon, title } = this.props;
+        const { icon, title, titleTagName: TitleTagName = H2 } = this.props;
         if (title == null) {
             return undefined;
         }
         return (
             <div className={Classes.DIALOG_HEADER}>
                 <Icon icon={icon} size={IconSize.STANDARD} aria-hidden={true} tabIndex={-1} />
-                <H6 id={this.titleId}>{title}</H6>
+                <TitleTagName id={this.titleId}>{title}</TitleTagName>
                 {this.maybeRenderCloseButton()}
             </div>
         );


### PR DESCRIPTION
#### Changes proposed in this pull request:

Headings should reflect their visual level on the page. `<h6>` isn't appropriate for a dialog title.

#### Screenshot

I changed the font size to preserve the current appearance of the title.

Today:
<img width="1276" height="258" alt="Screenshot 2025-11-26 at 11 21 54 AM" src="https://github.com/user-attachments/assets/7ab19da0-4c83-415c-99a8-3f0f98b686ad" />

With this change:
<img width="1328" height="250" alt="Screenshot 2025-11-26 at 11 38 28 AM" src="https://github.com/user-attachments/assets/be1e139c-2d82-49e6-b6c0-6b8278869789" />

