### PR TITLE
[A11y] Add bolding on hover to menu item text

### DIFF
--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -226,11 +226,13 @@ $dark-menu-item-intent-colors: (
   background-color: $menu-item-color-hover;
   color: inherit;
   cursor: pointer;
+  font-weight: bold;
   text-decoration: none;
 }
 
 @mixin dark-menu-item-hover() {
   color: inherit;
+  font-weight: bold;
 
   // need to override typography styles here
   .#{$ns}-menu-item-icon,


### PR DESCRIPTION
The menuItem states indicate hover / selection only via a background shade that is low contrast. This is bad for accessibility.

#### Changes
Bold the menu item text on the hover state. Importantly, the hover state is often used by apps to persist a menu item's selection after click.


https://github.com/user-attachments/assets/48b66835-a7a3-49e6-bedb-09be1ecd04ca


