### PR TITLE
[chore] Adding autorelease and configuring lerna packages

### DIFF
--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,3 +1,146 @@
-type: local
-local:
-  repositoryType: lerna
+# Autorelease configuration for Blueprint monorepo
+version: 3
+
+# Blueprint uses a PNPM workspace with Lerna for independent versioning
+# Each package in packages/* is independently versioned and released
+
+options:
+  # Repository type for proper package.json handling and versioning
+  repo_type: PNPM
+
+  # Delimiter used for npm scoped packages, e.g., @blueprintjs/core@6.3.2
+  package_delimiter: "@"
+
+  # Release only groups that have changelogs (recommended for monorepos)
+  # Also releases all groups with transitive dependencies on changed groups
+  release_recommended_groups: true
+
+  # Comment on PRs when their changes are released
+  comment_on_included_pull_requests: true
+
+  # Global branch permissions - what branches can create releases
+  allowed_branches:
+    - develop # Main development branch
+    - next # Next major version branch
+    - pattern: release/\d+\.x\.x # Major release branches (e.g., release/6.x.x)
+      type: major
+    - pattern: release/\d+\.\d+\.x # Minor release branches (e.g., release/6.3.x)
+      type: minor
+    - pattern: .* # Feature branches can create RCs
+      type: feature
+
+  # Remove [skip ci] to allow CI to run on autorelease commits
+  disable_skip_ci: true
+
+  # Enable label releases for quick releases via PR labels
+  disable_label_releases: false
+
+  # Label releases will copy the last release type (release or RC)
+  label_releases_copy_last_release_type: true
+# Note: Autorelease 3 will automatically discover all packages in packages/*
+# with package.json files and create release groups for them. Since Blueprint
+# uses independent versioning with Lerna, we don't need to explicitly define
+# each package as a release group - autorelease will infer them automatically.
+
+# If you need to explicitly configure specific packages or exclude certain ones,
+# you can add a 'groups' section here. For example:
+# groups:
+#   core:
+#     paths: ["packages/core"]
+#     tag_prefix: "@blueprintjs/core@"
+
+groups:
+  # Icons - independent versioning
+  icons:
+    paths: ["packages/icons"]
+    method: standard
+    tag_prefix: "@blueprintjs/icons@"
+
+  # Colors - independent versioning for now, to be merged with core later
+  colors:
+    paths: ["packages/colors"]
+    method: standard
+    tag_prefix: "@blueprintjs/colors@"
+
+  # Core - independent versioning, should be released with the dev apps
+  core:
+    paths: ["packages/core"]
+    method: standard
+    tag_prefix: "@blueprintjs/core@"
+
+  # Select - independent versioning
+  select:
+    paths: ["packages/select"]
+    method: standard
+    tag_prefix: "@blueprintjs/select@"
+
+  # Datetime - independent versioning
+  datetime:
+    paths: ["packages/datetime"]
+    method: standard
+    tag_prefix: "@blueprintjs/datetime@"
+
+  # Table - independent versioning
+  table:
+    paths:
+      - "packages/table"
+    method: standard
+    tag_prefix: "@blueprintjs/table@"
+
+  # Labs - independent versioning
+  labs:
+    paths: ["packages/labs"]
+    method: standard
+    tag_prefix: "@blueprintjs/labs@"
+
+  # Dev apps
+  dev-apps:
+    paths:
+      - "packages/demo-app"
+      - "packages/landing-app"
+      - "packages/table-dev-app"
+    method: standard
+    tag_prefix: "@blueprintjs/dev-apps@"
+
+  # Build Tools - Release together with same version
+  eslint-config:
+    paths: ["packages/eslint-config"]
+    method: standard
+    tag_prefix: "@blueprintjs/eslint-config@"
+
+  eslint-plugin:
+    paths: ["packages/eslint-plugin"]
+    method: standard
+    tag_prefix: "@blueprintjs/eslint-plugin@"
+
+  node-build-scripts:
+    paths: ["packages/node-build-scripts"]
+    method: standard
+    tag_prefix: "@blueprintjs/node-build-scripts@"
+
+  stylelint-plugin:
+    paths: ["packages/stylelint-plugin"]
+    method: standard
+    tag_prefix: "@blueprintjs/stylelint-plugin@"
+
+  # Documentation - independent versioning
+  docs-app:
+    paths:
+      - "packages/docs-data"
+      - "packages/docs-app"
+    method: standard
+    tag_prefix: "@blueprintjs/docs@"
+
+  docs-theme:
+    paths: ["packages/docs-theme"]
+    method: standard
+    tag_prefix: "@blueprintjs/docs-theme@"
+# Note: Packages marked as private will not be published to npm but will
+# still have their versions bumped when their release group is released.
+#
+# Deprecated packages (not in groups above, marked as private):
+# - @blueprintjs/monaco-editor-theme
+# - @blueprintjs/karma-build-scripts
+# - @blueprintjs/test-commons
+# - @blueprintjs/tslint-config
+# - @blueprintjs/webpack-build-scripts

--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -76,7 +76,7 @@ groups:
 
   # Datetime - independent versioning
   datetime:
-    paths: ["packages/datetime"]
+    paths: ["packages/datetime, packages/datetime2"]
     method: standard
     tag_prefix: "@blueprintjs/datetime@"
 

--- a/.palantir/autorelease.yml
+++ b/.palantir/autorelease.yml
@@ -1,5 +1,7 @@
 # Autorelease configuration for Blueprint monorepo
-version: 3
+version:
+
+disabled: false
 
 # Blueprint uses a PNPM workspace with Lerna for independent versioning
 # Each package in packages/* is independently versioned and released
@@ -37,6 +39,10 @@ options:
 
   # Label releases will copy the last release type (release or RC)
   label_releases_copy_last_release_type: true
+
+  permissions:
+    # Allow only maintainers to create releases
+    - role: maintainer
 # Note: Autorelease 3 will automatically discover all packages in packages/*
 # with package.json files and create release groups for them. Since Blueprint
 # uses independent versioning with Lerna, we don't need to explicitly define
@@ -76,14 +82,14 @@ groups:
 
   # Datetime - independent versioning
   datetime:
-    paths: ["packages/datetime, packages/datetime2"]
+    paths:
+      - "packages/datetime"
     method: standard
     tag_prefix: "@blueprintjs/datetime@"
 
   # Table - independent versioning
   table:
-    paths:
-      - "packages/table"
+    paths: ["packages/table"]
     method: standard
     tag_prefix: "@blueprintjs/table@"
 
@@ -97,10 +103,15 @@ groups:
   dev-apps:
     paths:
       - "packages/demo-app"
-      - "packages/landing-app"
       - "packages/table-dev-app"
     method: standard
     tag_prefix: "@blueprintjs/dev-apps@"
+
+  # Landing app
+  landing-app:
+    paths: ["packages/landing-app"]
+    method: standard
+    tag_prefix: "@blueprintjs/landing-app@"
 
   # Build Tools - Release together with same version
   eslint-config:

--- a/lerna.json
+++ b/lerna.json
@@ -2,14 +2,5 @@
     "npmClient": "pnpm",
     "version": "independent",
     "useWorkspaces": true,
-    "packages": ["packages/*"],
-    "command": {
-        "version": {
-            "ignoreChanges": ["**/*.md", "**/*.spec.ts", "**/*.spec.tsx"],
-            "message": "chore(release): publish %s",
-            "allowBranch": ["develop", "next", "release/*"],
-            "private": false
-        }
-    },
-    "ignorePatterns": ["**/node_modules/**", "**/dist/**"]
+    "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,6 @@
 {
     "npmClient": "pnpm",
-    "version": "independent"
+    "version": "independent",
+    "useWorkspaces": true,
+    "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,14 @@
     "npmClient": "pnpm",
     "version": "independent",
     "useWorkspaces": true,
-    "packages": ["packages/*"]
+    "packages": ["packages/*"],
+    "command": {
+        "version": {
+            "ignoreChanges": ["**/*.md", "**/*.spec.ts", "**/*.spec.tsx"],
+            "message": "chore(release): publish %s",
+            "allowBranch": ["develop", "next", "release/*"],
+            "private": false
+        }
+    },
+    "ignorePatterns": ["**/node_modules/**", "**/dist/**"]
 }

--- a/packages/karma-build-scripts/package.json
+++ b/packages/karma-build-scripts/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@blueprintjs/karma-build-scripts",
     "version": "6.0.10",
+    "private": true,
     "description": "Karma build scripts for @blueprintjs packages",
     "type": "module",
     "main": "index.mjs",

--- a/packages/monaco-editor-theme/package.json
+++ b/packages/monaco-editor-theme/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@blueprintjs/monaco-editor-theme",
     "version": "1.0.24",
+    "private": true,
     "description": "Blueprint theme for monaco-editor",
     "main": "lib/cjs/index.js",
     "module": "lib/esm/index.js",

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@blueprintjs/test-commons",
     "version": "4.0.3",
+    "private": true,
     "description": "Common utilities for tests in @blueprintjs packages",
     "type": "module",
     "types": "./lib/index.d.ts",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@blueprintjs/tslint-config",
     "version": "4.1.8",
+    "private": true,
     "description": "TSLint configuration for @blueprintjs packages",
     "scripts": {
         "compile": "tsc -p ./src",

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@blueprintjs/webpack-build-scripts",
     "version": "6.2.15",
+    "private": true,
     "description": "Webpack build scripts for @blueprintjs packages",
     "type": "module",
     "main": "index.mjs",

--- a/scripts/test-autorelease.sh
+++ b/scripts/test-autorelease.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Script to test autorelease configuration
+# This creates a test branch and shows what autorelease would do
+
+set -e
+
+echo "Testing autorelease configuration..."
+echo ""
+
+# Save current branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Create test branch
+TEST_BRANCH="test/autorelease-$(date +%s)"
+echo "Creating test branch: $TEST_BRANCH"
+git checkout -b "$TEST_BRANCH"
+
+# Create a sample changelog entry for testing
+TEST_FILE="packages/core/CHANGELOG.md"
+if [ -f "$TEST_FILE" ]; then
+    echo "" >> "$TEST_FILE"
+    echo "## Test" >> "$TEST_FILE"
+    echo "- Test change for autorelease validation" >> "$TEST_FILE"
+    git add "$TEST_FILE"
+    git commit -m "test: validate autorelease configuration"
+fi
+
+echo ""
+echo "Test branch created. To test autorelease:"
+echo "1. Push this branch: git push origin $TEST_BRANCH"
+echo "2. Check CI/CD pipeline to see autorelease analysis"
+echo "3. Autorelease will create a PR or comment showing what it would release"
+echo ""
+echo "To cleanup:"
+echo "  git checkout $CURRENT_BRANCH"
+echo "  git branch -D $TEST_BRANCH"
+echo "  git push origin --delete $TEST_BRANCH"

--- a/scripts/validate-autorelease.js
+++ b/scripts/validate-autorelease.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Validate autorelease configuration and show what would be released
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+const { execSync } = require('child_process');
+
+console.log('=== Autorelease Configuration Validator ===\n');
+
+// Read and parse autorelease.yml
+const configPath = path.join(__dirname, '../.palantir/autorelease.yml');
+let config;
+try {
+  config = yaml.parse(fs.readFileSync(configPath, 'utf8'));
+  console.log('✓ YAML syntax is valid\n');
+} catch (e) {
+  console.error('✗ YAML syntax error:', e.message);
+  process.exit(1);
+}
+
+// Validate groups
+console.log(`Found ${Object.keys(config.groups).length} release groups:\n`);
+
+const issues = [];
+for (const [groupName, groupConfig] of Object.entries(config.groups)) {
+  console.log(`📦 ${groupName}`);
+  console.log(`   Tag prefix: ${groupConfig.tag_prefix}`);
+  console.log(`   Method: ${groupConfig.method}`);
+  console.log(`   Paths:`);
+
+  const packages = [];
+  for (const pkgPath of groupConfig.paths) {
+    const fullPath = path.join(__dirname, '..', pkgPath);
+    const pkgJsonPath = path.join(fullPath, 'package.json');
+
+    if (fs.existsSync(pkgJsonPath)) {
+      const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+      const isPrivate = pkgJson.private ? ' (private)' : '';
+      console.log(`     - ${pkgPath} → ${pkgJson.name}@${pkgJson.version}${isPrivate}`);
+      packages.push({ name: pkgJson.name, path: pkgPath, version: pkgJson.version, private: pkgJson.private });
+    } else {
+      console.log(`     - ${pkgPath} → ⚠️  package.json not found`);
+      issues.push(`Group '${groupName}' references non-existent path: ${pkgPath}`);
+    }
+  }
+
+  // Check for version consistency in multi-package groups
+  if (packages.length > 1) {
+    const versions = [...new Set(packages.map(p => p.version))];
+    if (versions.length > 1) {
+      console.log(`     ⚠️  Multiple versions in group: ${versions.join(', ')}`);
+      issues.push(`Group '${groupName}' has packages with different versions`);
+    }
+  }
+
+  console.log('');
+}
+
+// Check for packages not in any group
+const allPackages = fs.readdirSync(path.join(__dirname, '../packages'))
+  .filter(dir => {
+    const pkgPath = path.join(__dirname, '../packages', dir, 'package.json');
+    return fs.existsSync(pkgPath);
+  });
+
+const coveredPackages = new Set();
+for (const groupConfig of Object.values(config.groups)) {
+  for (const pkgPath of groupConfig.paths) {
+    const dirName = pkgPath.replace('packages/', '');
+    coveredPackages.add(dirName);
+  }
+}
+
+const uncoveredPackages = allPackages.filter(pkg => !coveredPackages.has(pkg));
+if (uncoveredPackages.length > 0) {
+  console.log('⚠️  Packages not in any autorelease group:');
+  for (const pkg of uncoveredPackages) {
+    const pkgJson = JSON.parse(fs.readFileSync(
+      path.join(__dirname, '../packages', pkg, 'package.json'),
+      'utf8'
+    ));
+    const isPrivate = pkgJson.private ? ' (private - OK)' : ' (⚠️  will not be released)';
+    console.log(`   - ${pkg}${isPrivate}`);
+  }
+  console.log('');
+}
+
+// Summary
+if (issues.length > 0) {
+  console.log('❌ Issues found:');
+  issues.forEach(issue => console.log(`   - ${issue}`));
+  process.exit(1);
+} else {
+  console.log('✅ Configuration looks good!');
+  console.log('\nTo test on a real branch:');
+  console.log('  1. Create a test branch');
+  console.log('  2. Add a changelog entry to any package');
+  console.log('  3. Push to GitHub and check the CI pipeline');
+  console.log('  4. Autorelease will comment on the PR showing what it would release');
+}


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

#### Changes proposed in this pull request:

Adding autorelease, with the following groups:
  * Icons - independent versioning
  icons:
    paths: ["packages/icons"]
    method: standard
    tag_prefix: "@blueprintjs/icons@"

  * Colors - independent versioning for now, to be merged with core later
  colors:
    paths: ["packages/colors"]
    method: standard
    tag_prefix: "@blueprintjs/colors@"

  * Core - independent versioning, should be released with the dev apps
  core:
    paths: ["packages/core"]
    method: standard
    tag_prefix: "@blueprintjs/core@"

  * Select - independent versioning
  select:
    paths: ["packages/select"]
    method: standard
    tag_prefix: "@blueprintjs/select@"

  * Datetime - independent versioning
  datetime:
    paths: ["packages/datetime"]
    method: standard
    tag_prefix: "@blueprintjs/datetime@"

  * Table - independent versioning
  table:
    paths:
      - "packages/table"
    method: standard
    tag_prefix: "@blueprintjs/table@"

  * Labs - independent versioning
  labs:
    paths: ["packages/labs"]
    method: standard
    tag_prefix: "@blueprintjs/labs@"

  * Dev apps
  dev-apps:
    paths:
      - "packages/demo-app"
      - "packages/landing-app"
      - "packages/table-dev-app"
    method: standard
    tag_prefix: "@blueprintjs/dev-apps@"

  * Build Tools - Release together with same version
    - eslint-config:
      - paths: ["packages/eslint-config"]
      - method: standard
      - tag_prefix: "@blueprintjs/eslint-config@"
    - eslint-plugin:
      - paths: ["packages/eslint-plugin"]
      - method: standard
      - tag_prefix: "@blueprintjs/eslint-plugin@"
    - node-build-scripts:
      - paths: ["packages/node-build-scripts"]
      - method: standard
      - tag_prefix: "@blueprintjs/node-build-scripts@"
    - stylelint-plugin:
      - paths: ["packages/stylelint-plugin"]
      - method: standard
      - tag_prefix: "@blueprintjs/stylelint-plugin@" 

  * Documentation - independent versioning
  docs-app:
    paths:
      - "packages/docs-data"
      - "packages/docs-app"
    method: standard
    tag_prefix: "@blueprintjs/docs@"

  docs-theme:
    paths: ["packages/docs-theme"]
    method: standard
    tag_prefix: "@blueprintjs/docs-theme@"

Making these packages private:

- packages/karma-build-scripts/package.json
- packages/test-commons/package.json
- packages/tslint-config/package.json
- packages/webpack-build-scripts/package.json
- packages/monaco-editor-theme/package.json

#### Reviewers should focus on:

Checking the autorelease configuration. Note that lerna will recommend similar groups of packages, and we'd like to version the build tools and documentation together, as well as core and the documentation groups.

#### Screenshot

N/A