### PR TITLE
[MenuItem] Allow `role` prop to be overwritten

### DIFF
--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -255,9 +255,9 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         {
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
-            ...htmlPropsOnly,
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
             role: hasSubmenu ? "none" : targetRole,
+            ...htmlPropsOnly,
             tabIndex: hasSubmenu ? -1 : htmlPropsOnly.tabIndex != null ? htmlPropsOnly.tabIndex : 0,
             ...(disabled ? DISABLED_PROPS : {}),
             className: anchorClasses,


### PR DESCRIPTION
## Changes

This change reverts a subtle behavior introduced in #7604 that caused the `role` prop on MenuItem to no longer be able to be overridden. This moves the passed in html props to occur after the internal assignment of `role`.

## Example

Given the following props to MenuItem:
```tsx
<MenuItem text="Test" role="option" />
```

Renders:

**Before:**
```html
<li role="none">
    <a role="menuitem" tabindex="0" class="bp6-menu-item bp6-popover-dismiss">
        <div class="bp6-text-overflow-ellipsis bp6-fill">Test</div>
    </a>
</li>
```

**After:**
```html
<li role="none">
    <a role="option" tabindex="0" class="bp6-menu-item bp6-popover-dismiss">
        <div class="bp6-text-overflow-ellipsis bp6-fill">Test</div>
    </a>
</li>
```