### PR TITLE
Fix Select components items becoming unclickable

### DIFF
--- a/packages/select/src/common/itemListRenderer.ts
+++ b/packages/select/src/common/itemListRenderer.ts
@@ -57,7 +57,7 @@ export interface ItemListRendererProps<T> {
     /**
      * Props to apply to the `Menu` created within the `itemListRenderer`
      */
-    menuProps?: React.HTMLAttributes<HTMLUListElement> & { inert?: string };
+    menuProps?: React.HTMLAttributes<HTMLUListElement>;
 
     /**
      * Call this function to render an item.

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -185,7 +185,6 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                 role="combobox"
                 {...inputProps}
                 inputRef={this.handleInputRef}
-                onBlur={listProps.handleInputBlur}
                 onChange={listProps.handleQueryChange}
                 value={listProps.query}
             />


### PR DESCRIPTION
## Fixes

Regression introduced in #7543

## Problem

After #7543 was merged, items in Select-type components (components based on QueryList) became unselectable via mouse clicks. Keyboard navigation with arrow keys continued to work.

## Root Cause

The `inert` attribute was added to conditionally hide the listbox from screen readers when users were typing. The intent was to prevent screen readers from announcing fragmented updates during typing. However, the inert attribute ends up making elements completely non-interactive.

## Solution

Removes the `listboxHasVisualFocus` state and related conditional hiding logic. All other core accessibility improvements from #7543 remain.

## Testing

- Verify Select items are clickable
- Arrow key navigation in Select should still work correctly
- Screen reader accessibility improvements should remain in place
- No browser console warnings