### PR TITLE
[core] Add submenuTrapFocus prop to contain Tab navigation for nested menuItems for 508 compliance.

### DIFF
--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -19,6 +19,7 @@ import classNames from "classnames";
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
 import type { Size } from "../../common/size";
+import React from "react";
 
 export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement> {
     /** Menu items. */
@@ -47,6 +48,15 @@ export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement>
      */
     size?: Size;
 
+    /**
+     * Determines whether to trap focus within this menu.
+     * When true, pressing Tab will cycle through focusable items within the menu
+     * instead of moving focus outside.
+     * Useful for submenus to prevent focus from escaping to parent menu items.
+     * @default false
+     */
+    trapFocus?: boolean;
+
     /** Ref handler that receives the HTML `<ul>` element backing this component. */
     ulRef?: React.Ref<HTMLUListElement>;
 }
@@ -58,13 +68,46 @@ export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement>
  */
 export const Menu: React.FC<MenuProps> = props => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
-    const { className, children, large, size = "medium", small, ulRef, ...htmlProps } = props;
+    const { className, children, large, size = "medium", small, ulRef, trapFocus, ...htmlProps } = props;
+    // const { className, children, large, size = "medium", small, ulRef, ...htmlProps } = props;
+
+    const handleKeyDown = React.useCallback(
+        (e: React.KeyboardEvent<HTMLUListElement>) => {
+            if (!trapFocus) return;
+
+            if (e.key === "Tab") {
+                const menu = e.currentTarget;
+                const focusableItems = menu.querySelectorAll<HTMLElement>(
+                    '[tabindex="0"], [tabindex]:not([tabindex="-1"])',
+                );
+
+                if (focusableItems.length === 0) return;
+
+                const first = focusableItems[0];
+                const last = focusableItems[focusableItems.length - 1];
+
+                // Prevents shift+tab to go to previous focusable element
+                // if (e.shiftKey && document.activeElement === first) {
+                //     e.preventDefault();
+                //     last.focus();
+                // }
+                // Sends selector back to first element of current tabs.
+                if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
+        },
+        [trapFocus],
+    );
+
     return (
         <ul
             role="menu"
             {...htmlProps}
             className={classNames(className, Classes.MENU, Classes.sizeClass(size, { large, small }))}
             ref={ulRef}
+            onKeyDown={handleKeyDown}
         >
             {children}
         </ul>

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -15,11 +15,11 @@
  */
 
 import classNames from "classnames";
+import React from "react";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX, type Props } from "../../common/props";
 import type { Size } from "../../common/size";
-import React from "react";
 
 export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement> {
     /** Menu items. */
@@ -53,6 +53,7 @@ export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement>
      * When true, pressing Tab will cycle through focusable items within the menu
      * instead of moving focus outside.
      * Useful for submenus to prevent focus from escaping to parent menu items.
+     *
      * @default false
      */
     trapFocus?: boolean;

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -70,7 +70,6 @@ export interface MenuProps extends Props, React.HTMLAttributes<HTMLUListElement>
 export const Menu: React.FC<MenuProps> = props => {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const { className, children, large, size = "medium", small, ulRef, trapFocus, ...htmlProps } = props;
-    // const { className, children, large, size = "medium", small, ulRef, ...htmlProps } = props;
 
     /**
      * Handles keyboard navigation to trap Tab focus within this menu.

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -72,9 +72,14 @@ export const Menu: React.FC<MenuProps> = props => {
     const { className, children, large, size = "medium", small, ulRef, trapFocus, ...htmlProps } = props;
 
     /**
-     * Handles keyboard navigation to trap Tab focus within this menu.
-     * When trapFocus is enabled, pressing Tab on the last focusable item
-     * will wrap focus back to the first item instead of exiting the menu.
+     * Traps Tab key focus within this menu when trapFocus is enabled.
+     *
+     * This prevents focus from escaping to sibling menu items when tabbing
+     * through a submenu. When the user presses Tab on the last focusable item,
+     * focus wraps back to the first item instead of exiting the menu.
+     *
+     * Note: Only handles forward Tab navigation (last → first).
+     * Shift+Tab is not trapped and will exit the menu backwards.
      */
     const handleKeyDown = React.useCallback(
         (e: React.KeyboardEvent<HTMLUListElement>) => {
@@ -83,9 +88,7 @@ export const Menu: React.FC<MenuProps> = props => {
             if (e.key === "Tab") {
                 const menu = e.currentTarget;
                 // Find all focusable items within this menu
-                const focusableItems = menu.querySelectorAll<HTMLElement>(
-                    '[tabindex="0"], [tabindex]:not([tabindex="-1"])',
-                );
+                const focusableItems = menu.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
 
                 if (focusableItems.length === 0) return;
 

--- a/packages/core/src/components/menu/menu.tsx
+++ b/packages/core/src/components/menu/menu.tsx
@@ -71,12 +71,18 @@ export const Menu: React.FC<MenuProps> = props => {
     const { className, children, large, size = "medium", small, ulRef, trapFocus, ...htmlProps } = props;
     // const { className, children, large, size = "medium", small, ulRef, ...htmlProps } = props;
 
+    /**
+     * Handles keyboard navigation to trap Tab focus within this menu.
+     * When trapFocus is enabled, pressing Tab on the last focusable item
+     * will wrap focus back to the first item instead of exiting the menu.
+     */
     const handleKeyDown = React.useCallback(
         (e: React.KeyboardEvent<HTMLUListElement>) => {
             if (!trapFocus) return;
 
             if (e.key === "Tab") {
                 const menu = e.currentTarget;
+                // Find all focusable items within this menu
                 const focusableItems = menu.querySelectorAll<HTMLElement>(
                     '[tabindex="0"], [tabindex]:not([tabindex="-1"])',
                 );
@@ -86,13 +92,8 @@ export const Menu: React.FC<MenuProps> = props => {
                 const first = focusableItems[0];
                 const last = focusableItems[focusableItems.length - 1];
 
-                // Prevents shift+tab to go to previous focusable element
-                // if (e.shiftKey && document.activeElement === first) {
-                //     e.preventDefault();
-                //     last.focus();
-                // }
                 // Sends selector back to first element of current tabs.
-                if (!e.shiftKey && document.activeElement === last) {
+                if (document.activeElement === last) {
                     e.preventDefault();
                     first.focus();
                 }

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -149,6 +149,15 @@ export interface MenuItemProps
     submenuProps?: Partial<MenuProps>;
 
     /**
+     * Whether the submenu should trap tab focus within it.
+     * When true, pressing Tab within the submenu will cycle through submenu items
+     * instead of moving to other items in the parent menu.
+     *
+     * @default true
+     */
+    submenuTrapFocus?: boolean;
+
+    /**
      * Name of the HTML tag that wraps the MenuItem.
      *
      * @default "a"
@@ -187,6 +196,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         selected,
         shouldDismissPopover = true,
         submenuProps,
+        submenuTrapFocus = true,
         text = "",
         textClassName,
         tagName = "a",
@@ -256,7 +266,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
-            role: hasSubmenu ? "none" : targetRole,
+            role: hasSubmenu ? "none" : targetRole, // Causes aria-issue
             ...htmlPropsOnly,
             tabIndex: hasSubmenu ? -1 : htmlPropsOnly.tabIndex != null ? htmlPropsOnly.tabIndex : 0,
             ...(disabled ? DISABLED_PROPS : {}),
@@ -295,7 +305,12 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
                     placement="right-start"
                     usePortal={false}
                     {...popoverProps}
-                    content={<Menu {...submenuProps}>{children}</Menu>}
+                    // content={<Menu {...submenuProps}>{children}</Menu>}
+                    content={
+                        <Menu {...submenuProps} trapFocus={submenuTrapFocus}>
+                            {children}
+                        </Menu>
+                    }
                     minimal={true}
                     popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
                 >

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -305,7 +305,6 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
                     placement="right-start"
                     usePortal={false}
                     {...popoverProps}
-                    // content={<Menu {...submenuProps}>{children}</Menu>}
                     content={
                         <Menu {...submenuProps} trapFocus={submenuTrapFocus}>
                             {children}

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -153,7 +153,7 @@ export interface MenuItemProps
      * When true, pressing Tab within the submenu will cycle through submenu items
      * instead of moving to other items in the parent menu.
      *
-     * @default true
+     * @default false
      */
     submenuTrapFocus?: boolean;
 
@@ -196,7 +196,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
         selected,
         shouldDismissPopover = true,
         submenuProps,
-        submenuTrapFocus = true,
+        submenuTrapFocus = false, // Defaults to false to have old functionality (no submenu focusing when tabbing)
         text = "",
         textClassName,
         tagName = "a",
@@ -266,7 +266,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             // for menuitems, onClick when enter key pressed doesn't take effect like it does for a button-- fix this
             onKeyDown: clickElementOnKeyPress(["Enter", " "]),
             // if hasSubmenu, must apply correct role and tabIndex to the outer popover target <span> instead of this target element
-            role: hasSubmenu ? "none" : targetRole, // Causes aria-issue
+            role: hasSubmenu ? "none" : targetRole, // Causes aria-label to not be visible on inspection but voice over still catches it.
             ...htmlPropsOnly,
             tabIndex: hasSubmenu ? -1 : htmlPropsOnly.tabIndex != null ? htmlPropsOnly.tabIndex : 0,
             ...(disabled ? DISABLED_PROPS : {}),

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -72,7 +72,6 @@ describe("<Menu>", () => {
 
             const menuItems = container.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
             const lastItem = menuItems[menuItems.length - 1];
-            // const firstItem = menuItems[0];
 
             // Focus the last item
             lastItem.focus();
@@ -172,7 +171,6 @@ describe("<Menu>", () => {
             const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
             const menuItems = ul.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
             const firstItem = menuItems[0];
-            // const secondItem = menuItems[1];
 
             // Focus the first item (not the last)
             firstItem.focus();

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -16,9 +16,9 @@
 
 import { assert } from "chai";
 import { mount, shallow } from "enzyme";
+import sinon from "sinon";
 
 import { Classes, H6, Menu, MenuDivider, MenuItem } from "../../src";
-import sinon from "sinon";
 
 describe("<MenuDivider>", () => {
     it("React renders MenuDivider", () => {
@@ -79,13 +79,13 @@ describe("<Menu>", () => {
 
             // Simulate Tab keydown
             const event = new KeyboardEvent("keydown", {
-                key: "Tab",
                 bubbles: true,
                 cancelable: true,
+                key: "Tab",
             });
             const preventDefaultSpy = sinon.spy(event, "preventDefault");
 
-            wrapper.find("ul").simulate("keydown", { key: "Tab", currentTarget: wrapper.find("ul").getDOMNode() });
+            wrapper.find("ul").simulate("keydown", { currentTarget: wrapper.find("ul").getDOMNode(), key: "Tab" });
 
             // preventDefault should NOT have been called
             assert.isFalse(preventDefaultSpy.called);
@@ -110,8 +110,8 @@ describe("<Menu>", () => {
 
             const preventDefaultCalled = { value: false };
             wrapper.find("ul").simulate("keydown", {
-                key: "Tab",
                 currentTarget: ul,
+                key: "Tab",
                 preventDefault: () => {
                     preventDefaultCalled.value = true;
                 },
@@ -143,8 +143,8 @@ describe("<Menu>", () => {
 
             const preventDefaultCalled = { value: false };
             wrapper.find("ul").simulate("keydown", {
-                key: "Tab",
                 currentTarget: ul,
+                key: "Tab",
                 preventDefault: () => {
                     preventDefaultCalled.value = true;
                 },
@@ -178,8 +178,8 @@ describe("<Menu>", () => {
 
             const preventDefaultCalled = { value: false };
             wrapper.find("ul").simulate("keydown", {
-                key: "Tab",
                 currentTarget: ul,
+                key: "Tab",
                 preventDefault: () => {
                     preventDefaultCalled.value = true;
                 },
@@ -210,8 +210,8 @@ describe("<Menu>", () => {
 
             const preventDefaultCalled = { value: false };
             wrapper.find("ul").simulate("keydown", {
-                key: "Enter",
                 currentTarget: ul,
+                key: "Enter",
                 preventDefault: () => {
                     preventDefaultCalled.value = true;
                 },
@@ -220,8 +220,8 @@ describe("<Menu>", () => {
             assert.isFalse(preventDefaultCalled.value);
 
             wrapper.find("ul").simulate("keydown", {
-                key: "ArrowDown",
                 currentTarget: ul,
+                key: "ArrowDown",
                 preventDefault: () => {
                     preventDefaultCalled.value = true;
                 },
@@ -244,9 +244,8 @@ describe("<Menu>", () => {
 
             // This should not throw
             wrapper.find("ul").simulate("keydown", {
-                key: "Tab",
                 currentTarget: ul,
-                preventDefault: () => {},
+                key: "Tab",
             });
 
             wrapper.unmount();
@@ -269,8 +268,8 @@ describe("<Menu>", () => {
 
             const preventDefaultCalled = { value: false };
             wrapper.find("ul").simulate("keydown", {
-                key: "Tab",
                 currentTarget: ul,
+                key: "Tab",
                 preventDefault: () => {
                     preventDefaultCalled.value = true;
                 },

--- a/packages/core/test/menu/menuTests.tsx
+++ b/packages/core/test/menu/menuTests.tsx
@@ -15,9 +15,10 @@
  */
 
 import { assert } from "chai";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import { Classes, H6, Menu, MenuDivider, MenuItem } from "../../src";
+import sinon from "sinon";
 
 describe("<MenuDivider>", () => {
     it("React renders MenuDivider", () => {
@@ -44,5 +45,244 @@ describe("<Menu>", () => {
         );
         assert.isTrue(menu.hasClass(Classes.MENU));
         assert.lengthOf(menu.find(MenuItem), 1);
+    });
+
+    // Tests for the trapFocus tabbing functionality.
+    describe("trapFocus", () => {
+        let container: HTMLElement;
+
+        beforeEach(() => {
+            container = document.createElement("div");
+            document.body.appendChild(container);
+        });
+
+        afterEach(() => {
+            document.body.removeChild(container);
+        });
+
+        it("does not trap focus when trapFocus is false", () => {
+            const wrapper = mount(
+                <Menu trapFocus={false}>
+                    <MenuItem text="Item 1" />
+                    <MenuItem text="Item 2" />
+                    <MenuItem text="Item 3" />
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const menuItems = container.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
+            const lastItem = menuItems[menuItems.length - 1];
+            // const firstItem = menuItems[0];
+
+            // Focus the last item
+            lastItem.focus();
+            assert.strictEqual(document.activeElement, lastItem);
+
+            // Simulate Tab keydown
+            const event = new KeyboardEvent("keydown", {
+                key: "Tab",
+                bubbles: true,
+                cancelable: true,
+            });
+            const preventDefaultSpy = sinon.spy(event, "preventDefault");
+
+            wrapper.find("ul").simulate("keydown", { key: "Tab", currentTarget: wrapper.find("ul").getDOMNode() });
+
+            // preventDefault should NOT have been called
+            assert.isFalse(preventDefaultSpy.called);
+
+            wrapper.unmount();
+        });
+
+        it("does not trap focus when trapFocus is undefined", () => {
+            const wrapper = mount(
+                <Menu>
+                    <MenuItem text="Item 1" />
+                    <MenuItem text="Item 2" />
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
+            const menuItems = ul.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
+            const lastItem = menuItems[menuItems.length - 1];
+
+            lastItem.focus();
+
+            const preventDefaultCalled = { value: false };
+            wrapper.find("ul").simulate("keydown", {
+                key: "Tab",
+                currentTarget: ul,
+                preventDefault: () => {
+                    preventDefaultCalled.value = true;
+                },
+            });
+
+            assert.isFalse(preventDefaultCalled.value);
+
+            wrapper.unmount();
+        });
+
+        it("wraps focus from last to first item when trapFocus is true and Tab is pressed", () => {
+            const wrapper = mount(
+                <Menu trapFocus={true}>
+                    <MenuItem text="Item 1" />
+                    <MenuItem text="Item 2" />
+                    <MenuItem text="Item 3" />
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
+            const menuItems = ul.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
+            const firstItem = menuItems[0];
+            const lastItem = menuItems[menuItems.length - 1];
+
+            // Focus the last item
+            lastItem.focus();
+            assert.strictEqual(document.activeElement, lastItem);
+
+            const preventDefaultCalled = { value: false };
+            wrapper.find("ul").simulate("keydown", {
+                key: "Tab",
+                currentTarget: ul,
+                preventDefault: () => {
+                    preventDefaultCalled.value = true;
+                },
+            });
+
+            // preventDefault should have been called
+            assert.isTrue(preventDefaultCalled.value);
+            // Focus should now be on the first item
+            assert.strictEqual(document.activeElement, firstItem);
+
+            wrapper.unmount();
+        });
+
+        it("does not wrap focus when Tab is pressed on non-last item", () => {
+            const wrapper = mount(
+                <Menu trapFocus={true}>
+                    <MenuItem text="Item 1" />
+                    <MenuItem text="Item 2" />
+                    <MenuItem text="Item 3" />
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
+            const menuItems = ul.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
+            const firstItem = menuItems[0];
+            // const secondItem = menuItems[1];
+
+            // Focus the first item (not the last)
+            firstItem.focus();
+            assert.strictEqual(document.activeElement, firstItem);
+
+            const preventDefaultCalled = { value: false };
+            wrapper.find("ul").simulate("keydown", {
+                key: "Tab",
+                currentTarget: ul,
+                preventDefault: () => {
+                    preventDefaultCalled.value = true;
+                },
+            });
+
+            // preventDefault should NOT have been called since we're not on the last item
+            assert.isFalse(preventDefaultCalled.value);
+            // Focus should still be on the first item (browser would normally handle Tab)
+            assert.strictEqual(document.activeElement, firstItem);
+
+            wrapper.unmount();
+        });
+
+        it("does not interfere with other keys when trapFocus is true", () => {
+            const wrapper = mount(
+                <Menu trapFocus={true}>
+                    <MenuItem text="Item 1" />
+                    <MenuItem text="Item 2" />
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
+            const menuItems = ul.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
+            const lastItem = menuItems[menuItems.length - 1];
+
+            lastItem.focus();
+
+            const preventDefaultCalled = { value: false };
+            wrapper.find("ul").simulate("keydown", {
+                key: "Enter",
+                currentTarget: ul,
+                preventDefault: () => {
+                    preventDefaultCalled.value = true;
+                },
+            });
+
+            assert.isFalse(preventDefaultCalled.value);
+
+            wrapper.find("ul").simulate("keydown", {
+                key: "ArrowDown",
+                currentTarget: ul,
+                preventDefault: () => {
+                    preventDefaultCalled.value = true;
+                },
+            });
+
+            assert.isFalse(preventDefaultCalled.value);
+
+            wrapper.unmount();
+        });
+
+        it("handles menu with no focusable items gracefully", () => {
+            const wrapper = mount(
+                <Menu trapFocus={true}>
+                    <li>Non-focusable item</li>
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
+
+            // This should not throw
+            wrapper.find("ul").simulate("keydown", {
+                key: "Tab",
+                currentTarget: ul,
+                preventDefault: () => {},
+            });
+
+            wrapper.unmount();
+        });
+
+        it("handles menu with single focusable item", () => {
+            const wrapper = mount(
+                <Menu trapFocus={true}>
+                    <MenuItem text="Only Item" />
+                </Menu>,
+                { attachTo: container },
+            );
+
+            const ul = wrapper.find("ul").getDOMNode() as HTMLUListElement;
+            const menuItems = ul.querySelectorAll<HTMLElement>('[tabindex]:not([tabindex="-1"])');
+            const onlyItem = menuItems[0];
+
+            onlyItem.focus();
+            assert.strictEqual(document.activeElement, onlyItem);
+
+            const preventDefaultCalled = { value: false };
+            wrapper.find("ul").simulate("keydown", {
+                key: "Tab",
+                currentTarget: ul,
+                preventDefault: () => {
+                    preventDefaultCalled.value = true;
+                },
+            });
+
+            // When there's only one item, it's both first and last, so focus wraps to itself
+            assert.isTrue(preventDefaultCalled.value);
+            assert.strictEqual(document.activeElement, onlyItem);
+
+            wrapper.unmount();
+        });
     });
 });


### PR DESCRIPTION
#### Checklist

-   [x] Includes tests
-   [x] Update documentation

## Changes proposed in this pull request

This PR adds a new `submenuTrapFocus` prop to `MenuItem` that enables focus trapping within submenus for improved keyboard navigation and 508 accessibility compliance.

### Key changes

- Added `submenuTrapFocus` prop to `MenuItem` (defaults to `false` for backwards compatibility)
- Added `trapFocus` prop to `Menu` component to handle Tab key navigation
- Implemented keyboard handler function in `Menu` that cycles focus back to first item when Tab is pressed on the last focusable item
- Added comprehensive JSDoc comments explaining the focus trap behavior
- Updated inline comments for clarity
- Added tests to the <Menu> suite of tests in `menuTests.tsx` for the code created for tabbing - most of the new lines of code (240 new lines) are for testing this new feature.

### Behavior

- When `submenuTrapFocus` is `true`, pressing Tab on the last item in a submenu wraps focus back to the first item instead of moving outside the submenu to the next focusable element.
- When `submenuTrapFocus` is `false` (default), Tab navigation works as before where tabbing through menu items will go to the next focusable element regardless if it is in the nested menu.
- This allows users to opt-in to focus trapping for specific accessibility requirements and won't break previous menus because they will default to their current mechanism of just tabbing through all focusable elements.

## Reviewers should focus on

- **Code design:** Is `submenuTrapFocus` the right prop name? Should the default be `false` or `true`?
- **Keyboard behavior:** Does the Tab wrapping feel natural? Should Shift+Tab also be trapped (currently only forward Tab is trapped)?
- **Backwards compatibility:** Confirm that existing implementations are not affected by the `false` default
- **Documentation:** Is the JSDoc clear about when and why to use this feature?

## Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->

No visual changes - this is a keyboard navigation enhancement. Testing requires using Tab key to navigate through menu items.
