### PR TITLE
[Docs] change references and install examples from `yarn` to `pnpm`

### DIFF
--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -19,10 +19,10 @@ Check out the [migration guides to upgrade from v5.x &rarr;](https://github.com/
 
 [**@blueprintjs/core**](https://www.npmjs.com/package/@blueprintjs/core) is the primary Blueprint library package,
 home to over 40 UI components.
-Install it with your Node.js package manager of choice ([Yarn](https://yarnpkg.com/) is used in this example):
+Install it with your Node.js package manager of choice ([pnpm](https://github.com/pnpm/pnpm) is used in this example):
 
 ```sh
-yarn add @blueprintjs/core react react-dom
+pnpm add @blueprintjs/core react react-dom
 ```
 
 Additional UI components and APIs are available in:

--- a/packages/docs-app/src/blueprint.md
+++ b/packages/docs-app/src/blueprint.md
@@ -19,7 +19,7 @@ Check out the [migration guides to upgrade from v5.x &rarr;](https://github.com/
 
 [**@blueprintjs/core**](https://www.npmjs.com/package/@blueprintjs/core) is the primary Blueprint library package,
 home to over 40 UI components.
-Install it with your Node.js package manager of choice ([pnpm](https://github.com/pnpm/pnpm) is used in this example):
+Install it with your Node.js package manager of choice:
 
 ```sh
 pnpm add @blueprintjs/core react react-dom

--- a/packages/docs-app/src/getting-started.md
+++ b/packages/docs-app/src/getting-started.md
@@ -9,11 +9,11 @@ Each package contains a CSS file and a collection of ES modules exposing React c
 also available, for backwards-compatibility). The `main` module exports all symbols that are considered public API.
 The JavaScript components are stable and their APIs adhere to [semantic versioning](http://semver.org/).
 
-1.  Install the core package and its peer dependencies with an NPM client like `npm` or `yarn`,
+1.  Install the core package and its peer dependencies with an NPM client like `npm` or `pnpm`,
     pulling in all relevant dependencies:
 
     ```sh
-    yarn add @blueprintjs/core react react-dom
+    pnpm add @blueprintjs/core react react-dom
     ```
 
 2.  After installation, you'll be able to import the React components in your application:

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,8 +9,7 @@ This package contains the [ESLint](https://eslint.org/) configuration for Bluepr
 ## Installation
 
 ```
-yarn add @blueprintjs/eslint-config
-```
+pnpm add @blueprintjs/eslint-config```
 
 ## Usage
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,7 +9,8 @@ This package contains the [ESLint](https://eslint.org/) configuration for Bluepr
 ## Installation
 
 ```
-pnpm add @blueprintjs/eslint-config```
+pnpm add @blueprintjs/eslint-config
+```
 
 ## Usage
 

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -9,7 +9,7 @@ This package contains the [ESLint](https://eslint.org/) configuration for Bluepr
 ## Installation
 
 ```
-pnpm add @blueprintjs/eslint-config
+pnpm add --save-dev @blueprintjs/eslint-config
 ```
 
 ## Usage

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -13,7 +13,7 @@ This package contains the [ESLint](https://eslint.org/) plugin for Blueprint. It
 ## Installation
 
 ```
-yarn add --dev @blueprintjs/eslint-plugin
+pnpm add --save-dev @blueprintjs/eslint-plugin
 ```
 
 ## Usage

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -13,7 +13,7 @@ This package contains the [stylelint](https://stylelint.io/) plugin for Blueprin
 ## Installation
 
 ```
-yarn add --dev @blueprintjs/stylelint-plugin
+pnpm add --save-dev @blueprintjs/stylelint-plugin
 ```
 
 ## Usage

--- a/packages/tslint-config/README.md
+++ b/packages/tslint-config/README.md
@@ -19,7 +19,7 @@ This package contains configuration for [TSLint](https://palantir.github.io/tsli
 ## Installation
 
 ```
-yarn add @blueprintjs/tslint-config tslint
+pnpm add @blueprintjs/tslint-config tslint
 ```
 
 ## Usage

--- a/packages/tslint-config/README.md
+++ b/packages/tslint-config/README.md
@@ -19,7 +19,7 @@ This package contains configuration for [TSLint](https://palantir.github.io/tsli
 ## Installation
 
 ```
-pnpm add @blueprintjs/tslint-config tslint
+pnpm add --save-dev @blueprintjs/tslint-config tslint
 ```
 
 ## Usage


### PR DESCRIPTION
#### Fixes #7683

As of https://github.com/palantir/blueprint/pull/7598, we have now switched package managers to pnpm from yarn. However, our documentation does not yet reference that switch.

#### Checklist

-   [x] Update documentation


#### Changes proposed in this pull request:
Provide developers with `pnpm` examples instead of original `yarn` usage

#### Reviewers should focus on:
Whether or not its proper to link to `pnpm's` Github vs. official `.io` website.