### PR TITLE
[chore] Add Claude directory to pretterignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ dist/
 /site/
 pnpm-lock.yaml
 changelog/
+.claude/


### PR DESCRIPTION
## Changes

Add `.claude/` directory to `.prettierignore` to prevent Prettier from checking formatting on any local development files (such as `.claude/settings.local.json`). This helps prevent scripts like `pnpm verify` from failing if a developer is using Cluade.