### PR TITLE
chore: update pinned version of Chrome used by CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
       - browser-tools/install_chrome:
-          chrome_version: "144.0.7559.31"
+          chrome_version: "143.0.7499.192"
       - browser-tools/install_chrome
       - browser-tools/install_chromedriver
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
       - browser-tools/install_chrome:
-          chrome_version: "137.0.7151.68"
+          chrome_version: "144.0.7559.31"
       - browser-tools/install_chrome
       - browser-tools/install_chromedriver
       - run:


### PR DESCRIPTION
FLUP to https://github.com/palantir/blueprint/pull/7469
Unblocks https://github.com/palantir/blueprint/commit/e6242a3ebda9037ab88702f0addd732a54e14df0 which is currently failing CI checks for `ci/circleci: test-react-18`

#### Error
```
Google Chrome is not currently installed; installing it
Preparing Chrome installation for Debian-based systems
Hit:1 https://download.docker.com/linux/ubuntu noble InRelease
Hit:2 http://security.ubuntu.com/ubuntu noble-security InRelease               
Hit:3 http://archive.ubuntu.com/ubuntu noble InRelease                         
Hit:4 http://archive.ubuntu.com/ubuntu noble-updates InRelease                 
Hit:6 http://archive.ubuntu.com/ubuntu noble-backports InRelease               
Hit:5 https://packagecloud.io/github/git-lfs/ubuntu noble InRelease            
Hit:7 https://ppa.launchpadcontent.net/git-core/ppa/ubuntu noble InRelease
Reading package lists... Done
```

#### Changes proposed in this pull request:
Attempting to update the pinned version of Chrome used by tests in CI.
