### PR TITLE
[a11y] Add jsxA11yPlugin to Select on pnpm lint

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -73,7 +73,7 @@ module.exports = tseslint.config(
         // Gradually rolling out jsx-a11y rules package-by-package.
         // To enable for another package, add it to this glob pattern, e.g.:
         // files: ["**/packages/{core,select}/**/*.{ts,tsx}"],
-        files: ["**/packages/core/**/*.{ts,tsx}"],
+        files: ["**/packages/{core,select}/**/*.{ts,tsx}"],
         ignores: ["**/test/**/*.{ts,tsx}", "**/test/*.{ts,tsx}"],
     },
     {


### PR DESCRIPTION
FLUP to [[a11y] Add jsx-eslint eslint-plugin-jsx-a11y to repo](https://github.com/palantir/blueprint/pull/7692/files#top)

#### Changes proposed in this pull request:
Adding `jsxA11yPlugin` to `Select` s.t. running `pnpm lint` will notify us of WCAG/a11y issues within this package