### PR TITLE
[core] Fix Less compatibility for elevation shadow variables

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -99,51 +99,53 @@ $pt-dark-border-shadow-opacity: $pt-border-shadow-opacity * 2 !default;
 $pt-dark-drop-shadow-opacity: $pt-drop-shadow-opacity * 2 !default;
 
 // Elevations
+// N.B. we use decimal opacity values (e.g. 0.15) instead of percentage syntax (e.g. 15%)
+// for compatibility with Less, which does not support percentage syntax in rgba().
 $pt-elevation-shadow-0:
-  0 0 0 1px rgba($black, 15%),
-  0 0 5px 0 rgba(0, 0, 0, 2%) !default;
+  0 0 0 1px rgba($black, 0.15),
+  0 0 5px 0 rgba(0, 0, 0, 0.02) !default;
 $pt-elevation-shadow-1:
-  0 0 0 1px rgba($black, 10%),
-  0 1px 3px 0 rgba(0, 0, 0, 10%),
-  0 1px 2px -1px rgba(0, 0, 0, 10%) !default;
+  0 0 0 1px rgba($black, 0.1),
+  0 1px 3px 0 rgba(0, 0, 0, 0.1),
+  0 1px 2px -1px rgba(0, 0, 0, 0.1) !default;
 $pt-elevation-shadow-2:
-  0 0 0 1px rgba($black, 10%),
-  0 4px 6px -4px rgba(0, 0, 0, 10%),
-  0 10px 15px -3px rgba(0, 0, 0, 10%) !default;
+  0 0 0 1px rgba($black, 0.1),
+  0 4px 6px -4px rgba(0, 0, 0, 0.1),
+  0 10px 15px -3px rgba(0, 0, 0, 0.1) !default;
 $pt-elevation-shadow-3:
-  0 0 0 1px rgba($black, 10%),
-  0 20px 25px -5px rgba(0, 0, 0, 10%),
-  0 10px 15px -3px rgba(0, 0, 0, 10%) !default;
+  0 0 0 1px rgba($black, 0.1),
+  0 20px 25px -5px rgba(0, 0, 0, 0.1),
+  0 10px 15px -3px rgba(0, 0, 0, 0.1) !default;
 $pt-elevation-shadow-4:
-  0 0 0 1px rgba($black, 10%),
-  0 25px 50px -12px rgba(0, 0, 0, 30%) !default;
+  0 0 0 1px rgba($black, 0.1),
+  0 25px 50px -12px rgba(0, 0, 0, 0.3) !default;
 
 $pt-dark-elevation-shadow-0:
-  inset 0 0 0 1px rgba($white, 20%),
-  0 0 10px 0 rgba(0, 0, 0, 20%) !default;
+  inset 0 0 0 1px rgba($white, 0.2),
+  0 0 10px 0 rgba(0, 0, 0, 0.2) !default;
 $pt-dark-elevation-shadow-1:
-  inset 0 0 0 1px rgba($white, 20%),
-  0 1px 10px 0 rgba(0, 0, 0, 20%),
-  inset 0 0 0.5px 0 rgba($white, 30%),
-  inset 0 0.5px 0 0 rgba($white, 8%),
-  0 1px 10px -1px rgba(0, 0, 0, 20%) !default;
+  inset 0 0 0 1px rgba($white, 0.2),
+  0 1px 10px 0 rgba(0, 0, 0, 0.2),
+  inset 0 0 0.5px 0 rgba($white, 0.3),
+  inset 0 0.5px 0 0 rgba($white, 0.08),
+  0 1px 10px -1px rgba(0, 0, 0, 0.2) !default;
 $pt-dark-elevation-shadow-2:
-  inset 0 0 0 1px rgba($white, 20%),
-  0 4px 6px -4px rgba(0, 0, 0, 50%),
-  inset 0 0 0.5px 0 rgba($white, 30%),
-  inset 0 0.5px 0 0 rgba($white, 8%),
-  0 10px 30px -5px rgba(0, 0, 0, 50%) !default;
+  inset 0 0 0 1px rgba($white, 0.2),
+  0 4px 6px -4px rgba(0, 0, 0, 0.5),
+  inset 0 0 0.5px 0 rgba($white, 0.3),
+  inset 0 0.5px 0 0 rgba($white, 0.08),
+  0 10px 30px -5px rgba(0, 0, 0, 0.5) !default;
 $pt-dark-elevation-shadow-3:
-  inset 0 0 0 1px rgba($white, 20%),
-  0 20px 25px -5px rgba(0, 0, 0, 30%),
-  inset 0 0 0.5px 0 rgba($white, 30%),
-  inset 0 0.5px 0 0 rgba($white, 8%),
-  0 10px 30px -5px rgba(0, 0, 0, 30%) !default;
+  inset 0 0 0 1px rgba($white, 0.2),
+  0 20px 25px -5px rgba(0, 0, 0, 0.3),
+  inset 0 0 0.5px 0 rgba($white, 0.3),
+  inset 0 0.5px 0 0 rgba($white, 0.08),
+  0 10px 30px -5px rgba(0, 0, 0, 0.3) !default;
 $pt-dark-elevation-shadow-4:
-  inset 0 0 0 1px rgba($white, 20%),
-  0 25px 60px -12px rgba(0, 0, 0, 85%),
-  inset 0 0 0.5px 0 rgba($white, 30%),
-  inset 0 0.5px 0 0 rgba($white, 8%) !default;
+  inset 0 0 0 1px rgba($white, 0.2),
+  0 25px 60px -12px rgba(0, 0, 0, 0.85),
+  inset 0 0 0.5px 0 rgba($white, 0.3),
+  inset 0 0.5px 0 0 rgba($white, 0.08) !default;
 
 // Transitions
 $pt-transition-ease: cubic-bezier(0.4, 1, 0.75, 0.9) !default;


### PR DESCRIPTION
## Summary

Fixes a breaking change introduced in #7645 where elevation shadow variables were updated to use percentage syntax in `rgba()` (e.g., `rgba($black, 15%)`). While valid in Sass, this syntax is not supported by Less's `rgba()` function, causing build failures for downstream consumers who compile Blueprint's Less variables.

**Error seen by consumers:**
```
Less error: error evaluating function rgba: color functions take numbers as parameters
```

## Changes
- Reverts `rgba()` opacity values from percentage syntax (`15%`) to decimal syntax (`0.15`)

## Test plan

- [x] Verify `pnpm dist:variables` generates valid Less output
- [ ] Verify Less consumers can compile `variables.less` without errors