### PR TITLE
[node-build-scripts] Fix rgba hex color conversion for Less output

### DIFF
--- a/packages/node-build-scripts/src/cssVariables.mjs
+++ b/packages/node-build-scripts/src/cssVariables.mjs
@@ -174,7 +174,7 @@ export async function generateLessVariables(parsedInput) {
 }
 
 /**
- * To ensure compatibility with Less, we must converat all instances of `rgba(color, opacity)` which use a hex color
+ * To ensure compatibility with Less, we must convert all instances of `rgba(color, opacity)` which use a hex color
  * as the first argument (e.g. `rgba($black, 0.1)`) to use the more widely-compatible `rgba(r, g, b, a)` syntax.
  *
  * @param {string} variableInitializer
@@ -182,14 +182,12 @@ export async function generateLessVariables(parsedInput) {
  * @returns {string}
  */
 function evaluateRgbaInitializerColor(variableInitializer, allVariables) {
-    if (variableInitializer.match(/rgba\(([0-9]+), ([0-9]+), ([0-9]+), (.+)\)/)) {
-        // do nothing if the color is specified in full rgba(r, g, b, a) syntax, since this _is_ supported in Less
-        return variableInitializer;
-    }
-
+    // Only match rgba() calls with hex colors (e.g. rgba(#111418, 0.15))
+    // This leaves rgba(r, g, b, a) format unchanged since it's already valid Less
+    // Note: postcss-simple-vars may add whitespace around the comma, so we handle optional spaces
     return variableInitializer.replace(
-        /rgba\((.+)\, (.+)\)/g,
-        (_, colorHexCode, opacity) => `rgba(${colorHexToRgb(colorHexCode)}, ${opacity})`,
+        /rgba\((#[0-9a-fA-F]{3,8})\s*,\s*([^)]+)\)/g,
+        (_, hexColor, opacity) => `rgba(${colorHexToRgb(hexColor)}, ${opacity.trim()})`,
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug in the SCSS-to-Less variable conversion where `rgba()` calls with hex colors (e.g. `rgba(#111418, 0.15)`) were not being converted to the Less-compatible `rgba(r, g, b, a)` format.

The issue had two causes:
1. The `evaluateRgbaInitializerColor` function had an early-return check that skipped conversion for the entire value if *any* `rgba()` in it used `r, g, b, a` format. This broke for shadow variables that mix both formats (e.g. `rgba($black, 0.15), rgba(0, 0, 0, 0.02)`).
2. The regex didn't account for whitespace before the comma that `postcss-simple-vars` adds when resolving variables (producing `rgba(#111418 , 0.15)` instead of `rgba(#111418, 0.15)`).

## Context

This bug was discovered after releasing #7645, which updated elevation shadow styles. The invalid Less output caused build failures for consumers using Less, requiring a revert in #7713. This fix allows us to safely re-land those shadow style changes.

## Test plan

- [x] Run `pnpm dist:variables` in `@blueprintjs/core` and verify `lib/less/variables.less` contains valid Less with `rgba(r, g, b, a)` syntax for all elevation shadows
