### PR TITLE
[core] Integrating design tokens into core for buttons

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -1,10 +1,23 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@use "sass:list";
 @import "../../common/variables";
 @import "../forms/common";
 @import "./common";
+
+// z-index values for button stacking order (derived from $control-group-stack in forms/_common.scss)
+$button-group-z-index: (
+  "button-disabled": 3,
+  "button-default": 4,
+  "button-focus": 5,
+  "button-hover": 6,
+  "button-active": 7,
+  "intent-button-disabled": 8,
+  "intent-button-default": 9,
+  "intent-button-focus": 10,
+  "intent-button-hover": 11,
+  "intent-button-active": 12,
+);
 
 .#{$ns}-button-group {
   display: inline-flex;
@@ -13,7 +26,7 @@
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: list.index($control-group-stack, "button-default");
+    z-index: map-get($button-group-z-index, "button-default");
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -21,42 +34,42 @@
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: list.index($control-group-stack, "button-focus");
+      z-index: map-get($button-group-z-index, "button-focus");
     }
 
     &:hover {
-      z-index: list.index($control-group-stack, "button-hover");
+      z-index: map-get($button-group-z-index, "button-hover");
     }
 
     &:active,
     &.#{$ns}-active {
-      z-index: list.index($control-group-stack, "button-active");
+      z-index: map-get($button-group-z-index, "button-active");
     }
 
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: list.index($control-group-stack, "button-disabled");
+      z-index: map-get($button-group-z-index, "button-disabled");
     }
 
     &[class*="#{$ns}-intent-"] {
-      z-index: list.index($control-group-stack, "intent-button-default");
+      z-index: map-get($button-group-z-index, "intent-button-default");
 
       &:focus {
-        z-index: list.index($control-group-stack, "intent-button-focus");
+        z-index: map-get($button-group-z-index, "intent-button-focus");
       }
 
       &:hover {
-        z-index: list.index($control-group-stack, "intent-button-hover");
+        z-index: map-get($button-group-z-index, "intent-button-hover");
       }
 
       &:active,
       &.#{$ns}-active {
-        z-index: list.index($control-group-stack, "intent-button-active");
+        z-index: map-get($button-group-z-index, "intent-button-active");
       }
 
       &:disabled,
       &.#{$ns}-disabled {
-        z-index: list.index($control-group-stack, "intent-button-disabled");
+        z-index: map-get($button-group-z-index, "intent-button-disabled");
       }
     }
   }
@@ -80,7 +93,7 @@
   &:not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
     > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
     > .#{$ns}-button:not(:last-child) {
-      margin-right: -$button-border-width;
+      margin-right: calc(-1 * var(--bp-surface-border-width));
     }
   }
 
@@ -103,7 +116,7 @@
       &:not(:last-child) {
         border-bottom-right-radius: 0;
         border-top-right-radius: 0;
-        margin-right: -$button-border-width;
+        margin-right: calc(-1 * var(--bp-surface-border-width));
       }
     }
   }
@@ -157,19 +170,19 @@
     &.#{$ns}-outlined {
       > .#{$ns}-popover-wrapper:first-child .#{$ns}-button,
       > .#{$ns}-button:first-child {
-        border-radius: $pt-border-radius $pt-border-radius 0 0;
+        border-radius: var(--bp-surface-border-radius) var(--bp-surface-border-radius) 0 0;
       }
 
       > .#{$ns}-popover-wrapper:last-child .#{$ns}-button,
       > .#{$ns}-button:last-child {
-        border-radius: 0 0 $pt-border-radius $pt-border-radius;
+        border-radius: 0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius);
       }
     }
 
     &:not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
       > .#{$ns}-button:not(:last-child) {
-        margin-bottom: -$button-border-width;
+        margin-bottom: calc(-1 * var(--bp-surface-border-width));
       }
     }
 

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+@use "sass:map";
 @import "../../common/variables";
 @import "../forms/common";
 @import "./common";
@@ -26,7 +27,7 @@ $button-group-z-index: (
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: map-get($button-group-z-index, "button-default");
+    z-index: map.get($button-group-z-index, "button-default");
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -34,42 +35,42 @@ $button-group-z-index: (
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: map-get($button-group-z-index, "button-focus");
+      z-index: map.get($button-group-z-index, "button-focus");
     }
 
     &:hover {
-      z-index: map-get($button-group-z-index, "button-hover");
+      z-index: map.get($button-group-z-index, "button-hover");
     }
 
     &:active,
     &.#{$ns}-active {
-      z-index: map-get($button-group-z-index, "button-active");
+      z-index: map.get($button-group-z-index, "button-active");
     }
 
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: map-get($button-group-z-index, "button-disabled");
+      z-index: map.get($button-group-z-index, "button-disabled");
     }
 
     &[class*="#{$ns}-intent-"] {
-      z-index: map-get($button-group-z-index, "intent-button-default");
+      z-index: map.get($button-group-z-index, "intent-button-default");
 
       &:focus {
-        z-index: map-get($button-group-z-index, "intent-button-focus");
+        z-index: map.get($button-group-z-index, "intent-button-focus");
       }
 
       &:hover {
-        z-index: map-get($button-group-z-index, "intent-button-hover");
+        z-index: map.get($button-group-z-index, "intent-button-hover");
       }
 
       &:active,
       &.#{$ns}-active {
-        z-index: map-get($button-group-z-index, "intent-button-active");
+        z-index: map.get($button-group-z-index, "intent-button-active");
       }
 
       &:disabled,
       &.#{$ns}-disabled {
-        z-index: map-get($button-group-z-index, "intent-button-disabled");
+        z-index: map.get($button-group-z-index, "intent-button-disabled");
       }
     }
   }

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -7,7 +7,8 @@
 
 .#{$ns}-button {
   @include pt-button-layout;
-  @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
 
   &:empty {
     // override padding from other modifiers (for CSS icon support)
@@ -54,15 +55,18 @@
   // size modifiers
   &.#{$ns}-large,
   .#{$ns}-large & {
-    @include pt-button-height(calc(var(--bp-surface-spacing) * 10));
     @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+    min-height: calc(var(--bp-surface-spacing) * 10);
+    min-width: calc(var(--bp-surface-spacing) * 10);
     font-size: var(--bp-typography-size-body-large);
     padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4);
   }
 
   &.#{$ns}-small,
   .#{$ns}-small & {
-    @include pt-button-height-small;
+    min-height: calc(var(--bp-surface-spacing) * 6);
+    min-width: calc(var(--bp-surface-spacing) * 6);
+    padding: 0 calc(var(--bp-surface-spacing) * 2);
   }
 
   // loading state

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -131,15 +131,24 @@
     }
 
     &[class*="#{$ns}-intent-"] {
-      box-shadow: $dark-button-box-shadow;
+      box-shadow:
+        inset 0 0 0 var(--bp-surface-border-width)
+          color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+        0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 
       &:hover {
-        box-shadow: $dark-button-box-shadow;
+        box-shadow:
+          inset 0 0 0 var(--bp-surface-border-width)
+            color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+          0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
       }
 
       &:active,
       &.#{$ns}-active {
-        box-shadow: $dark-button-box-shadow-active;
+        box-shadow:
+          inset 0 0 0 var(--bp-surface-border-width)
+            color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+          0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent);
       }
 
       &:disabled,
@@ -179,17 +188,25 @@
   // special case override: use dark text for warning intent
   &.#{$ns}-intent-warning {
     &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-      fill: rgba($dark-gray1, 0.7);
+      fill: color-mix(in oklch, var(--bp-intent-warning-foreground) 70%, transparent);
     }
 
     &:not(.#{$ns}-disabled):not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       &:hover {
-        background: var(--bp-intent-warning-hover);
+        background: color-mix(
+          in oklch,
+          var(--bp6-button-warning-rest) 77%,
+          var(--bp-intent-warning-hover)
+        );
       }
 
       &:active,
       &.#{$ns}-active {
-        background: var(--bp-intent-warning-active);
+        background: color-mix(
+          in oklch,
+          var(--bp6-button-warning-rest) 46%,
+          var(--bp-intent-warning-active)
+        );
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           // Windows High Contrast dark theme

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -56,9 +56,9 @@
   &.#{$ns}-large,
   .#{$ns}-large & {
     @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+    font-size: var(--bp-typography-size-body-large);
     min-height: calc(var(--bp-surface-spacing) * 10);
     min-width: calc(var(--bp-surface-spacing) * 10);
-    font-size: var(--bp-typography-size-body-large);
     padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4);
   }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -104,7 +104,7 @@
   // if loading, then it contains exactly [spinner, icon]
   .#{$ns}-spinner + .#{$ns}-icon:last-child {
     // center icon horizontally. this works for large buttons too.
-    margin: 0 (-($pt-button-height - $pt-icon-size-standard) * 0.5);
+    margin: 0 calc((#{$pt-button-height} - #{$pt-icon-size-standard}) * -0.5);
   }
 
   // dark theme

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -200,14 +200,7 @@
 
     &:disabled,
     &.#{$ns}-disabled {
-      background:
-        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
-        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
-        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
-        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
-        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
-        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
-        var(--bp-surface-layer-warning), var(--bp-intent-warning-disabled);
+      background-color: color-mix(in oklch, var(--bp-intent-warning-rest) 50%, transparent);
 
       .#{$ns}-dark &,
       [data-bp-color-scheme="dark"] & {

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -54,7 +54,10 @@
   // size modifiers
   &.#{$ns}-large,
   .#{$ns}-large & {
-    @include pt-button-height-large;
+    @include pt-button-height(calc(var(--bp-surface-spacing) * 10));
+    @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+    font-size: var(--bp-typography-size-body-large);
+    padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4);
   }
 
   &.#{$ns}-small,
@@ -125,7 +128,22 @@
     }
 
     &[class*="#{$ns}-intent-"] {
-      @include pt-dark-button-intent;
+      box-shadow: $dark-button-box-shadow;
+
+      &:hover {
+        box-shadow: $dark-button-box-shadow;
+      }
+
+      &:active,
+      &.#{$ns}-active {
+        box-shadow: $dark-button-box-shadow-active;
+      }
+
+      &:disabled,
+      &.#{$ns}-disabled {
+        box-shadow: none;
+        color: color-mix(in oklch, var(--bp-intent-default-foreground) 30%, transparent);
+      }
 
       .#{$ns}-button-spinner .#{$ns}-spinner-head {
         stroke: var(--bp-typography-color-default-hover);

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -7,9 +7,7 @@
 
 .#{$ns}-button {
   @include pt-button-layout;
-  @include pt-button-height(
-    $button-height
-  ); // TODO: $pt-button-height replaced here for now, replace in variables
+  @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
 
   &:empty {
     // override padding from other modifiers (for CSS icon support)
@@ -87,18 +85,18 @@
   &[class*="#{$ns}-icon-"] {
     &::before {
       @include pt-icon;
-      color: var(--bp-typography-colorMuted);
+      color: var(--bp-typography-color-muted);
     }
   }
 
   #{$icon-classes} {
     &.#{$ns}-align-right {
-      margin-left: $button-icon-spacing;
+      margin-left: calc(var(--bp-surface-spacing) * 2);
     }
   }
 
   .#{$ns}-icon:not([class*="#{$ns}-intent-"]) {
-    color: var(--bp-typography-colorMuted);
+    color: var(--bp-typography-color-muted);
   }
 
   // button with SVG icon only (no text or children)
@@ -106,7 +104,8 @@
   // if loading, then it contains exactly [spinner, icon]
   .#{$ns}-spinner + .#{$ns}-icon:last-child {
     // center icon horizontally. this works for large buttons too.
-    margin: 0 calc((#{$pt-button-height} - #{$pt-icon-size-standard}) * -0.5);
+    margin: 0
+      calc(calc(var(--bp-surface-spacing) * 7.5) - calc(var(--bp-surface-spacing) * 4) * -0.5);
   }
 
   // dark theme
@@ -115,12 +114,12 @@
       @include pt-dark-button;
 
       &[class*="#{$ns}-icon-"]::before {
-        color: $pt-dark-icon-color;
+        color: var(--bp-typography-color-default-active);
       }
 
       #{$icon-classes} {
         &:not([class*="#{$ns}-intent-"]) {
-          color: $pt-dark-icon-color;
+          color: var(--bp-typography-color-default-active);
         }
       }
     }
@@ -129,7 +128,7 @@
       @include pt-dark-button-intent;
 
       .#{$ns}-button-spinner .#{$ns}-spinner-head {
-        stroke: $dark-progress-head-color;
+        stroke: var(--bp-typography-color-default-hover);
       }
     }
   }
@@ -159,26 +158,26 @@
   // special case override: use dark text for warning intent
   &.#{$ns}-intent-warning {
     background: var(--bp-intent-warning-rest);
-    color: var(--bp-typography-colorRest-default);
+    color: var(--bp-typography-color-default-rest);
 
     &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-      fill: var(--bp-typography-colorMuted);
+      fill: var(--bp-typography-color-muted);
     }
 
     &:not(.#{$ns}-disabled):not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       &:hover {
         background: var(--bp-intent-warning-hover);
-        color: var(--bp-typography-colorRest-default);
+        color: var(--bp-typography-color-default-rest);
       }
 
       &:active,
       &.#{$ns}-active {
         background: var(--bp-intent-warning-active);
-        color: var(--bp-typography-colorRest-default);
+        color: var(--bp-typography-color-default-rest);
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           // Windows High Contrast dark theme
-          background: $pt-high-contrast-mode-active-background-color;
+          background: highlight;
         }
       }
     }
@@ -186,10 +185,10 @@
     &:disabled,
     &.#{$ns}-disabled {
       background: var(--bp-intent-warning-disabled);
-      color: var(--bp-typography-colorDisabled-default);
+      color: var(--bp-typography-color-default-disabled);
 
       .#{$ns}-dark & {
-        color: var(--bp-typography-colorDisabled-default);
+        color: var(--bp-typography-color-default-disabled);
       }
     }
 
@@ -215,11 +214,11 @@ a.#{$ns}-button {
   &:hover,
   &:active {
     // override global 'a' styles
-    color: var(--bp-typography-colorRest-default);
+    color: var(--bp-typography-color-default-rest);
   }
 
   &.#{$ns}-disabled {
-    color: var(--bp-typography-colorRest-default);
+    color: var(--bp-typography-color-default-rest);
   }
 }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -218,10 +218,11 @@
     &:disabled,
     &.#{$ns}-disabled {
       background-color: color-mix(in oklch, var(--bp-intent-warning-rest) 50%, transparent);
+      color: color-mix(in oklch, var(--bp-intent-warning-foreground), 38%, transparent);
 
       .#{$ns}-dark &,
       [data-bp-color-scheme="dark"] & {
-        color: var(--bp-typography-color-default-disabled);
+        color: color-mix(in oklch, var(--bp-intent-warning-foreground) 50%, transparent);
       }
     }
 
@@ -232,7 +233,7 @@
       .#{$ns}-dark &,
       [data-bp-color-scheme="dark"] & {
         &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-          fill: var(--bp-intent-warning-rest);
+          fill: var(--bp6-button-warning-rest);
         }
       }
     }

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -115,7 +115,7 @@
 
   // dark theme
   .#{$ns}-dark &,
-  [data-bp-color-scheme=\"dark\"] & {
+  [data-bp-color-scheme="dark"] & {
     &:not([class*="#{$ns}-intent-"]) {
       @include pt-dark-button;
 
@@ -210,7 +210,7 @@
         var(--bp-surface-layer-warning), var(--bp-intent-warning-disabled);
 
       .#{$ns}-dark &,
-      [data-bp-color-scheme=\"dark\"] & {
+      [data-bp-color-scheme="dark"] & {
         color: var(--bp-typography-color-default-disabled);
       }
     }
@@ -220,7 +220,7 @@
       background: none;
 
       .#{$ns}-dark &,
-      [data-bp-color-scheme=\"dark\"] & {
+      [data-bp-color-scheme="dark"] & {
         &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
           fill: var(--bp-intent-warning-rest);
         }

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -252,7 +252,7 @@ a.#{$ns}-button {
   }
 
   &.#{$ns}-disabled {
-    color: var(--bp-typography-color-default-rest);
+    color: var(--bp-typography-color-default-disabled);
   }
 }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -114,17 +114,18 @@
   }
 
   // dark theme
-  .#{$ns}-dark & {
+  .#{$ns}-dark &,
+  [data-bp-color-scheme=\"dark\"] & {
     &:not([class*="#{$ns}-intent-"]) {
       @include pt-dark-button;
 
       &[class*="#{$ns}-icon-"]::before {
-        color: var(--bp-typography-color-default-active);
+        color: var(--bp-typography-color-default-rest);
       }
 
       #{$icon-classes} {
         &:not([class*="#{$ns}-intent-"]) {
-          color: var(--bp-typography-color-default-active);
+          color: var(--bp-typography-color-default-rest);
         }
       }
     }
@@ -177,23 +178,18 @@
 
   // special case override: use dark text for warning intent
   &.#{$ns}-intent-warning {
-    background: var(--bp-intent-warning-rest);
-    color: var(--bp-typography-color-default-rest);
-
     &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-      fill: var(--bp-typography-color-muted);
+      fill: rgba($dark-gray1, 0.7);
     }
 
     &:not(.#{$ns}-disabled):not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       &:hover {
         background: var(--bp-intent-warning-hover);
-        color: var(--bp-typography-color-default-rest);
       }
 
       &:active,
       &.#{$ns}-active {
         background: var(--bp-intent-warning-active);
-        color: var(--bp-typography-color-default-rest);
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           // Windows High Contrast dark theme
@@ -204,10 +200,17 @@
 
     &:disabled,
     &.#{$ns}-disabled {
-      background: var(--bp-intent-warning-disabled);
-      color: var(--bp-typography-color-default-disabled);
+      background:
+        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
+        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
+        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
+        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
+        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
+        var(--bp-surface-layer-warning), var(--bp-surface-layer-warning),
+        var(--bp-surface-layer-warning), var(--bp-intent-warning-disabled);
 
-      .#{$ns}-dark & {
+      .#{$ns}-dark &,
+      [data-bp-color-scheme=\"dark\"] & {
         color: var(--bp-typography-color-default-disabled);
       }
     }
@@ -216,7 +219,8 @@
     &.#{$ns}-outlined {
       background: none;
 
-      .#{$ns}-dark & {
+      .#{$ns}-dark &,
+      [data-bp-color-scheme=\"dark\"] & {
         &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
           fill: var(--bp-intent-warning-rest);
         }

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -7,7 +7,9 @@
 
 .#{$ns}-button {
   @include pt-button-layout;
-  @include pt-button-height($pt-button-height);
+  @include pt-button-height(
+    $button-height
+  ); // TODO: $pt-button-height replaced here for now, replace in variables
 
   &:empty {
     // override padding from other modifiers (for CSS icon support)
@@ -48,7 +50,7 @@
   }
 
   &[class*="#{$ns}-intent-"] .#{$ns}-button-spinner .#{$ns}-spinner-head {
-    stroke: $white;
+    stroke: var(--bp-intent-primary-foreground);
   }
 
   // size modifiers
@@ -85,7 +87,7 @@
   &[class*="#{$ns}-icon-"] {
     &::before {
       @include pt-icon;
-      color: $pt-icon-color;
+      color: var(--bp-typography-colorMuted);
     }
   }
 
@@ -96,7 +98,7 @@
   }
 
   .#{$ns}-icon:not([class*="#{$ns}-intent-"]) {
-    color: $pt-icon-color;
+    color: var(--bp-typography-colorMuted);
   }
 
   // button with SVG icon only (no text or children)
@@ -156,23 +158,23 @@
 
   // special case override: use dark text for warning intent
   &.#{$ns}-intent-warning {
-    background: $orange5;
-    color: $pt-text-color;
+    background: var(--bp-intent-warning-rest);
+    color: var(--bp-typography-colorRest-default);
 
     &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-      fill: rgba($dark-gray1, 0.7);
+      fill: var(--bp-typography-colorMuted);
     }
 
     &:not(.#{$ns}-disabled):not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
       &:hover {
-        background: $orange4;
-        color: $pt-text-color;
+        background: var(--bp-intent-warning-hover);
+        color: var(--bp-typography-colorRest-default);
       }
 
       &:active,
       &.#{$ns}-active {
-        background: $orange3;
-        color: $pt-text-color;
+        background: var(--bp-intent-warning-active);
+        color: var(--bp-typography-colorRest-default);
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           // Windows High Contrast dark theme
@@ -183,11 +185,11 @@
 
     &:disabled,
     &.#{$ns}-disabled {
-      background: rgba($orange3, 0.5);
-      color: rgba($dark-gray1, 0.35);
+      background: var(--bp-intent-warning-disabled);
+      color: var(--bp-typography-colorDisabled-default);
 
       .#{$ns}-dark & {
-        color: rgba($dark-gray1, 0.6);
+        color: var(--bp-typography-colorDisabled-default);
       }
     }
 
@@ -197,7 +199,7 @@
 
       .#{$ns}-dark & {
         &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-          fill: $orange5;
+          fill: var(--bp-intent-warning-rest);
         }
       }
     }
@@ -213,11 +215,11 @@ a.#{$ns}-button {
   &:hover,
   &:active {
     // override global 'a' styles
-    color: $pt-text-color;
+    color: var(--bp-typography-colorRest-default);
   }
 
   &.#{$ns}-disabled {
-    color: $button-color-disabled;
+    color: var(--bp-typography-colorRest-default);
   }
 }
 

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -217,7 +217,7 @@
 
     &:disabled,
     &.#{$ns}-disabled {
-      background-color: color-mix(in oklch, var(--bp-intent-warning-rest) 50%, transparent);
+      background-color: color-mix(in oklch, var(--bp-intent-warning-rest) 40%, transparent);
       color: color-mix(in oklch, var(--bp-intent-warning-foreground), 38%, transparent);
 
       .#{$ns}-dark &,
@@ -230,10 +230,22 @@
     &.#{$ns}-outlined {
       background: none;
 
+      // Mute disabled text — orange is perceptually brighter than other intents
+      &:disabled,
+      &.#{$ns}-disabled {
+        color: color-mix(in oklch, var(--bp-intent-warning-hover) 40%, transparent);
+      }
+
       .#{$ns}-dark &,
       [data-bp-color-scheme="dark"] & {
         &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-          fill: var(--bp6-button-warning-rest);
+          fill: color-mix(in oklch, var(--bp-intent-warning-rest) 50%, transparent);
+        }
+
+        // Use rest color at lower opacity instead of the pre-lightened dark text color
+        &:disabled,
+        &.#{$ns}-disabled {
+          color: color-mix(in oklch, var(--bp-intent-warning-rest) 35%, transparent);
         }
       }
     }

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -108,7 +108,9 @@
   .#{$ns}-spinner + .#{$ns}-icon:last-child {
     // center icon horizontally. this works for large buttons too.
     margin: 0
-      calc(calc(var(--bp-surface-spacing) * 7.5) - calc(var(--bp-surface-spacing) * 4) * -0.5);
+      calc(
+        -1 * calc(calc(var(--bp-surface-spacing) * 7.5) - calc(var(--bp-surface-spacing) * 4)) * 0.5
+      );
   }
 
   // dark theme

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -218,7 +218,6 @@
     &:disabled,
     &.#{$ns}-disabled {
       background-color: color-mix(in oklch, var(--bp-intent-warning-rest) 40%, transparent);
-      color: color-mix(in oklch, var(--bp-intent-warning-foreground), 38%, transparent);
 
       .#{$ns}-dark &,
       [data-bp-color-scheme="dark"] & {
@@ -239,13 +238,7 @@
       .#{$ns}-dark &,
       [data-bp-color-scheme="dark"] & {
         &:not(.#{$ns}-disabled).#{$ns}-icon > svg {
-          fill: color-mix(in oklch, var(--bp-intent-warning-rest) 50%, transparent);
-        }
-
-        // Use rest color at lower opacity instead of the pre-lightened dark text color
-        &:disabled,
-        &.#{$ns}-disabled {
-          color: color-mix(in oklch, var(--bp-intent-warning-rest) 35%, transparent);
+          fill: color-mix(in oklch, var(--bp-intent-warning-rest) 35%, transparent);
         }
       }
     }

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -133,13 +133,13 @@
     &[class*="#{$ns}-intent-"] {
       box-shadow:
         inset 0 0 0 var(--bp-surface-border-width)
-          color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+          color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
         0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 
       &:hover {
         box-shadow:
           inset 0 0 0 var(--bp-surface-border-width)
-            color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+            color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
           0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
       }
 
@@ -147,7 +147,7 @@
       &.#{$ns}-active {
         box-shadow:
           inset 0 0 0 var(--bp-surface-border-width)
-            color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+            color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
           0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent);
       }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -285,6 +285,7 @@ $button-dark-intent-text-colors: (
   &:hover,
   &:active,
   &.#{$ns}-active {
+    /* stylelint-disable-next-line color-named */
     color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
   }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -498,22 +498,26 @@ $button-dark-intent-text-colors: (
     $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
 
     &.#{$ns}-intent-#{$intent} {
-      border-color: color-mix(in oklch, $text-color 60%, transparent);
+      @include pt-button-outlined-intent($text-color, $dark-text-color);
+    }
+  }
+}
 
-      &:disabled,
-      &.#{$ns}-disabled {
-        border-color: color-mix(in oklch, $text-color 20%, transparent);
-      }
+@mixin pt-button-outlined-intent($text-color, $dark-text-color) {
+  border-color: color-mix(in oklch, $text-color 60%, transparent);
 
-      .#{$ns}-dark &,
-      [data-bp-color-scheme="dark"] & {
-        border-color: color-mix(in oklch, $dark-text-color 60%, transparent);
+  &:disabled,
+  &.#{$ns}-disabled {
+    border-color: color-mix(in oklch, $text-color 20%, transparent);
+  }
 
-        &:disabled,
-        &.#{$ns}-disabled {
-          border-color: color-mix(in oklch, $dark-text-color 20%, transparent);
-        }
-      }
+  .#{$ns}-dark &,
+  [data-bp-color-scheme="dark"] & {
+    border-color: color-mix(in oklch, $dark-text-color 60%, transparent);
+
+    &:disabled,
+    &.#{$ns}-disabled {
+      border-color: color-mix(in oklch, $dark-text-color 20%, transparent);
     }
   }
 }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,83 +7,45 @@
 @import "../../common/variables-extended";
 @import "../progress-bar/common";
 
-$button-border-width: var(--bp-surface-borderWidth) !default;
-$button-padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2) !default;
+// These variables are exported for use by other components (slider, forms, html-select, etc.)
+$button-border-width: var(--bp-surface-border-width) !default;
+
+// Exported for forms/_input-group.scss
 $button-padding-small: 0 calc(var(--bp-surface-spacing) * 2) !default;
-$button-padding-large: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4) !default;
-$button-icon-spacing: calc(var(--bp-surface-spacing) * 2) !default;
-$button-icon-spacing-large: calc(var(--bp-surface-spacing) * 2) !default;
 
-// TODO: These height variables are temporary, but since `$pt-button-height-...` are used to define other components,
-// this is scoping the variables here
-$button-height: calc(var(--bp-surface-spacing) * 7.5) !default;
-$button-height-small: calc(var(--bp-surface-spacing) * 6) !default;
-$button-height-smaller: calc(var(--bp-surface-spacing) * 5) !default;
-$button-height-large: calc(var(--bp-surface-spacing) * 10) !default;
+// Exported for forms and html-select
+$button-color-disabled: var(--bp-typography-color-default-disabled) !default;
 
-/*
-CSS `border` property issues:
-- An element can only have one border.
-- Borders can't stack with shadows.
-- Borders modify the size of the element they're applied to.
-- Border positioning requires the extra `box-sizing` property.
+// Exported for slider, html-select, forms
+$button-background-color-disabled: color-mix(
+  in oklch,
+  var(--bp-surface-background-color-default-disabled) 50%,
+  transparent
+) !default;
+$dark-button-background-color: var(--bp-surface-background-color-default-active) !default;
+$dark-button-background-color-hover: var(--bp-surface-background-color-default-hover) !default;
+$dark-button-background-color-active: var(--bp-surface-background-color-default-rest) !default;
+$dark-button-background-color-disabled: color-mix(
+  in oklch,
+  var(--bp-surface-background-color-default-active) 15%,
+  transparent
+) !default;
+$dark-button-color-disabled: var(--bp-typography-color-default-disabled) !default;
 
-`box-shadow` doesn't have these issues, we're using it instead of `border`.
-*/
+// Exported for forms/_controls.scss (rgba fallback for Firefox < 128)
+$minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
+$minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+
+// Exported for slider
 $button-box-shadow:
-  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-1000) l c h / 0.2),
-  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.1) !default;
-$button-box-shadow-active:
-  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-1000) l c h / 0.2),
-  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.2) !default;
-
+  inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+  0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent) !default;
 $dark-button-box-shadow:
-  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-100) l c h / 0.1),
-  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.2) !default;
+  inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+  0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent) !default;
 $dark-button-box-shadow-active:
-  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-100) l c h / 0.1),
-  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.4) !default;
-
-$button-color-disabled: var(
-  --bp-typography-colorDisabled-default
-) !default; //TODO: Used in forms and html-select, should remove
-$button-background-color: var(--bp-surface-colorRest-default) !default;
-$button-background-color-hover: var(--bp-surface-colorHover-default) !default;
-$button-background-color-active: var(--bp-surface-colorActive-default) !default;
-$button-background-color-disabled: oklch(
-  from var(--bp-surface-colorDisabled-default) l c h / 0.5
-) !default;
-$button-background-color-active-disabled: oklch(
-  from var(--bp-surface-colorDisabled-default) l c h / 0.7
-) !default;
-$button-intent-color-disabled: oklch(from var(--bp-intent-default-foreground) l c h / 0.6);
-$dark-button-color-disabled: var(--bp-typography-colorDisabled-default) !default;
-$dark-button-background-color: var(--bp-surface-colorActive-default) !default;
-$dark-button-background-color-hover: var(--bp-surface-colorHover-default) !default;
-$dark-button-background-color-active: var(--bp-surface-colorRest-default) !default;
-$dark-button-background-color-disabled: oklch(
-  from var(--bp-surface-colorActive-default) l c h / 0.15
-) !default;
-$dark-button-background-color-active-disabled: oklch(
-  from var(--bp-surface-colorActive-default) l c h / 0.7
-) !default;
-$dark-button-intent-color-disabled: oklch(from var(--bp-intent-default-foreground) l c h / 0.3);
-
-$minimal-button-divider-width: var(--bp-surface-borderWidth) !default;
-$minimal-button-background-color: none !default;
-$minimal-button-background-color-hover: var(--bp-surface-depthLayer-default) !default;
-$minimal-button-background-color-active: oklch(
-  from var(--bp-intent-default-rest) l c h / 0.15
-) !default;
-$dark-minimal-button-background-color: none !default;
-$dark-minimal-button-background-color-hover: var(--bp-surface-depthLayer-default) !default;
-$dark-minimal-button-background-color-active: oklch(
-  from var(--bp-intent-default-rest) l c h / 0.15
-) !default;
-
-$button-outlined-width: var(--bp-surface-borderWidth) !default;
-$button-outlined-border-intent-opacity: 0.6 !default;
-$button-outlined-border-disabled-intent-opacity: 0.2 !default;
+  inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+  0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent) !default;
 
 // "intent": (default, hover, active colors)
 $button-intents: (
@@ -110,15 +72,14 @@ $button-intents: (
 ) !default;
 
 @mixin pt-button-layout() {
-  @include pt-flex-container(row, $button-icon-spacing, $inline: inline);
+  @include pt-flex-container(row, calc(var(--bp-surface-spacing) * 2), $inline: inline);
   align-items: center;
-
   border: none;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   cursor: pointer;
-  font-size: $pt-font-size;
+  font-size: var(--bp-typography-size-body-medium);
   justify-content: center;
-  padding: $button-padding;
+  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
   text-align: left;
   vertical-align: middle;
 }
@@ -129,20 +90,20 @@ $button-intents: (
 }
 
 @mixin pt-button-height-large() {
-  @include pt-button-height($button-height-large);
-  @include pt-flex-margin(row, $button-icon-spacing-large);
-  font-size: $pt-font-size-large;
-  padding: $button-padding-large;
+  @include pt-button-height(calc(var(--bp-surface-spacing) * 10));
+  @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+  font-size: var(--bp-typography-size-body-large);
+  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4);
 }
 
 @mixin pt-button-height-default() {
-  @include pt-button-height($button-height);
-  padding: $button-padding;
+  @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
+  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
 }
 
 @mixin pt-button-height-small() {
-  @include pt-button-height($button-height-small);
-  padding: $button-padding-small;
+  @include pt-button-height(calc(var(--bp-surface-spacing) * 6));
+  padding: 0 calc(var(--bp-surface-spacing) * 2);
 }
 
 // N.B. this mixin cannot be used on pseudo element selectors because it will produce invalid CSS
@@ -164,42 +125,46 @@ $button-intents: (
 
     &.#{$ns}-active,
     &.#{$ns}-active:hover {
-      background: $button-background-color-active-disabled;
+      background: color-mix(in oklch, var(--bp-surface-background-color-default-disabled) 70%, transparent);
     }
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
   }
 }
 
 @mixin pt-button-default-colors() {
-  background-color: $button-background-color;
+  background-color: var(--bp-surface-background-color-default-rest);
   box-shadow: $button-box-shadow;
-  color: $pt-text-color;
+  color: var(--bp-typography-color-default-rest);
 }
 
 @mixin pt-button-hover() {
   background-clip: padding-box;
-  background-color: $button-background-color-hover;
-  box-shadow: $button-box-shadow-active;
+  background-color: var(--bp-surface-background-color-default-hover);
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 }
 
 @mixin pt-button-active() {
-  background-color: $button-background-color-active;
-  box-shadow: $button-box-shadow-active;
+  background-color: var(--bp-surface-background-color-default-active);
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
-    background: $pt-high-contrast-mode-active-background-color;
+    background: highlight;
   }
 }
 
 @mixin pt-button-disabled() {
-  background-color: $button-background-color-disabled;
+  background-color: var(--bp-surface-background-color-default-disabled);
   box-shadow: none;
-  color: var(--bp-typography-colorDisabled-default);
+  color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
   outline: none;
 }
@@ -217,13 +182,17 @@ $button-intents: (
 
   &:hover {
     background-color: $hover-color;
-    box-shadow: $button-box-shadow-active;
+    box-shadow:
+      inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   }
 
   &:active,
   &.#{$ns}-active {
     background-color: $active-color;
-    box-shadow: $button-box-shadow-active;
+    box-shadow:
+      inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   }
 
   &:disabled,
@@ -233,7 +202,7 @@ $button-intents: (
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
     box-shadow: none;
   }
 }
@@ -242,12 +211,12 @@ $button-intents: (
   background-color: rgba($default-color, 0.5);
   border-color: transparent;
   box-shadow: none;
-  color: $button-intent-color-disabled;
+  color: color-mix(in oklch, var(--bp-intent-default-foreground) 60%, transparent);
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
-    border-color: $pt-high-contrast-mode-disabled-border-color;
-    color: $pt-high-contrast-mode-disabled-border-color;
+    border-color: graytext;
+    color: graytext;
   }
 }
 
@@ -258,7 +227,7 @@ $button-intents: (
   &:hover,
   &:active,
   &.#{$ns}-active {
-    color: $pt-dark-text-color;
+    color: var(--bp-typography-color-default-rest);
   }
 
   &:hover {
@@ -275,7 +244,7 @@ $button-intents: (
     @include pt-dark-button-disabled;
 
     &.#{$ns}-active {
-      background: $dark-button-background-color-active-disabled;
+      background: color-mix(in oklch, var(--bp-surface-background-color-default-active) 70%, transparent);
     }
   }
 
@@ -288,7 +257,7 @@ $button-intents: (
 @mixin pt-dark-button-default-colors() {
   background-color: $dark-button-background-color;
   box-shadow: $dark-button-box-shadow;
-  color: $pt-dark-text-color;
+  color: var(--bp-typography-color-default-rest);
 }
 
 @mixin pt-dark-button-hover() {
@@ -304,7 +273,7 @@ $button-intents: (
 @mixin pt-dark-button-disabled() {
   background-color: $dark-button-background-color-disabled;
   box-shadow: none;
-  color: $dark-button-color-disabled;
+  color: var(--bp-typography-color-default-disabled);
 }
 
 @mixin pt-dark-button-intent() {
@@ -327,25 +296,33 @@ $button-intents: (
 
 @mixin pt-dark-button-intent-disabled() {
   box-shadow: none;
-  color: $dark-button-intent-color-disabled;
+  color: color-mix(in oklch, var(--bp-intent-default-foreground) 30%, transparent);
 }
 
 @mixin pt-button-minimal() {
-  background: $minimal-button-background-color;
+  background: none;
   box-shadow: none;
 
   &:hover {
     background: $minimal-button-background-color-hover;
     box-shadow: none;
-    color: $pt-text-color;
+    color: var(--bp-typography-color-default-rest);
     text-decoration: none;
+
+    @supports (background: color-mix(in oklch, red, transparent)) {
+      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 15%, transparent);
+    }
   }
 
   &:active,
   &.#{$ns}-active {
     background: $minimal-button-background-color-active;
     box-shadow: none;
-    color: $pt-text-color;
+    color: var(--bp-typography-color-default-rest);
+
+    @supports (background: color-mix(in oklch, red, transparent)) {
+      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+    }
   }
 
   &:disabled,
@@ -353,11 +330,15 @@ $button-intents: (
   &.#{$ns}-disabled,
   &.#{$ns}-disabled:hover {
     background: none;
-    color: $pt-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
 
     &.#{$ns}-active {
       background: $minimal-button-background-color-active;
+
+      @supports (background: color-mix(in oklch, red, transparent)) {
+        background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+      }
     }
   }
 
@@ -373,7 +354,7 @@ $button-intents: (
 }
 
 @mixin pt-dark-button-minimal() {
-  background: $dark-minimal-button-background-color;
+  background: none;
   box-shadow: none;
   color: var(--bp-intent-default-foreground);
 
@@ -386,12 +367,20 @@ $button-intents: (
   }
 
   &:hover {
-    background: $dark-minimal-button-background-color-hover;
+    background: $minimal-button-background-color-hover;
+
+    @supports (background: color-mix(in oklch, red, transparent)) {
+      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 15%, transparent);
+    }
   }
 
   &:active,
   &.#{$ns}-active {
-    background: $dark-minimal-button-background-color-active;
+    background: $minimal-button-background-color-active;
+
+    @supports (background: color-mix(in oklch, red, transparent)) {
+      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+    }
   }
 
   &:disabled,
@@ -399,11 +388,15 @@ $button-intents: (
   &.#{$ns}-disabled,
   &.#{$ns}-disabled:hover {
     background: none;
-    color: $pt-dark-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
 
     &.#{$ns}-active {
-      background: $dark-minimal-button-background-color-active;
+      background: $minimal-button-background-color-active;
+
+      @supports (background: color-mix(in oklch, red, transparent)) {
+        background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+      }
     }
   }
 }
@@ -492,22 +485,20 @@ $dark-minimal-active-text-colors: (
 }
 
 @mixin pt-button-minimal-divider() {
-  $divider-height: calc(var(--bp-surface-spacing) * 5);
-  background: var(--bp-surface-borderColor-default);
-
-  margin: calc((#{$button-height} - #{$divider-height}) * 0.5);
-  width: $minimal-button-divider-width;
+  background: var(--bp-surface-border-color-default);
+  margin: calc((calc(var(--bp-surface-spacing) * 7.5) - calc(var(--bp-surface-spacing) * 5)) * 0.5);
+  width: var(--bp-surface-border-width);
 }
 
 @mixin pt-button-outlined() {
-  border: $button-outlined-width solid var(--bp-surface-borderColor-default);
+  border: var(--bp-surface-border-width) solid var(--bp-surface-border-color-default);
   box-sizing: border-box;
 
   &:disabled,
   &.#{$ns}-disabled,
   &:disabled:hover,
   &.#{$ns}-disabled:hover {
-    border-color: var(--bp-surface-borderColor-default);
+    border-color: var(--bp-surface-border-color-default);
   }
 
   .#{$ns}-dark & {
@@ -525,30 +516,30 @@ $dark-minimal-active-text-colors: (
 }
 
 @mixin pt-dark-button-outlined() {
-  border-color: var(--bp-surface-borderColor-strong);
+  border-color: var(--bp-surface-border-color-strong);
 
   &:disabled,
   &:disabled:hover,
   &.#{$ns}-disabled,
   &.#{$ns}-disabled:hover {
-    border-color: var(--bp-surface-borderColor-default);
+    border-color: var(--bp-surface-border-color-default);
   }
 }
 
 @mixin pt-button-outlined-intent($text-color, $dark-text-color) {
-  border-color: rgba($text-color, $button-outlined-border-intent-opacity);
+  border-color: rgba($text-color, 0.6);
 
   &:disabled,
   &.#{$ns}-disabled {
-    border-color: rgba($text-color, $button-outlined-border-disabled-intent-opacity);
+    border-color: rgba($text-color, 0.2);
   }
 
   .#{$ns}-dark & {
-    border-color: rgba($dark-text-color, $button-outlined-border-intent-opacity);
+    border-color: rgba($dark-text-color, 0.6);
 
     &:disabled,
     &.#{$ns}-disabled {
-      border-color: rgba($dark-text-color, $button-outlined-border-disabled-intent-opacity);
+      border-color: rgba($dark-text-color, 0.2);
     }
   }
 }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -114,11 +114,30 @@ $button-intent-active-text-colors: (
 ) !default;
 
 $button-dark-intent-text-colors: (
-  "primary": color-mix(in oklch, var(--bp-intent-primary-rest) 51%, white),
-  "success": color-mix(in oklch, var(--bp-intent-success-rest) 54%, white),
-  "warning": color-mix(in oklch, var(--bp-intent-warning-rest) 53%, white),
-  "danger": color-mix(in oklch, var(--bp-intent-danger-rest) 53%, white),
-  "default": color-mix(in oklch, var(--bp-intent-default-rest) 53%, white),
+  "primary": color-mix(in oklch, var(--bp-intent-primary-rest) 51%, var(--bp-palette-white)),
+  "success": color-mix(in oklch, var(--bp-intent-success-rest) 54%, var(--bp-palette-white)),
+  "warning": color-mix(in oklch, var(--bp-intent-warning-rest) 53%, var(--bp-palette-white)),
+  "danger": color-mix(in oklch, var(--bp-intent-danger-rest) 53%, var(--bp-palette-white)),
+  // Use srgb for default intent to avoid hue shift with near-neutral gray
+  "default": color-mix(in srgb, var(--bp-intent-default-rest) 46%, var(--bp-palette-white)),
+) !default;
+
+$button-dark-minimal-hover-text-colors: (
+  "primary": color-mix(in oklch, var(--bp-intent-primary-hover) 51%, var(--bp-palette-white)),
+  "success": color-mix(in oklch, var(--bp-intent-success-hover) 54%, var(--bp-palette-white)),
+  "warning": color-mix(in oklch, var(--bp-intent-warning-hover) 53%, var(--bp-palette-white)),
+  "danger": color-mix(in oklch, var(--bp-intent-danger-hover) 53%, var(--bp-palette-white)),
+  // Use srgb for default intent to avoid hue shift with near-neutral gray
+  "default": color-mix(in srgb, var(--bp-intent-default-hover) 46%, var(--bp-palette-white)),
+) !default;
+
+$button-dark-minimal-active-text-colors: (
+  "primary": color-mix(in oklch, var(--bp-intent-primary-active) 51%, var(--bp-palette-white)),
+  "success": color-mix(in oklch, var(--bp-intent-success-active) 54%, var(--bp-palette-white)),
+  "warning": color-mix(in oklch, var(--bp-intent-warning-active) 53%, var(--bp-palette-white)),
+  "danger": color-mix(in oklch, var(--bp-intent-danger-active) 53%, var(--bp-palette-white)),
+  // Use srgb for default intent to avoid hue shift with near-neutral gray
+  "default": color-mix(in srgb, var(--bp-intent-default-active) 46%, var(--bp-palette-white)),
 ) !default;
 
 @mixin pt-button-layout() {
@@ -168,7 +187,8 @@ $button-dark-intent-text-colors: (
 
     &.#{$ns}-active,
     &.#{$ns}-active:hover {
-      background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 28%, transparent);
+      // Use srgb for consistency (avoids hue shift with near-neutral gray)
+      background-color: color-mix(in srgb, var(--bp-intent-default-disabled) 28%, transparent);
     }
   }
 
@@ -179,8 +199,9 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-default-colors() {
+  // Use srgb for consistency with dark theme (avoids hue shift with near-neutral gray)
   /* stylelint-disable-next-line color-named */
-  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
+  background-color: color-mix(in srgb, var(--bp-intent-default-rest) 5%, var(--bp-palette-white));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
@@ -190,8 +211,9 @@ $button-dark-intent-text-colors: (
 
 @mixin pt-button-hover() {
   background-clip: padding-box;
+  // Use srgb for consistency with dark theme (avoids hue shift with near-neutral gray)
   /* stylelint-disable-next-line color-named */
-  background-color: color-mix(in oklch, var(--bp-intent-default-hover) 8%, white);
+  background-color: color-mix(in srgb, var(--bp-intent-default-hover) 8%, var(--bp-palette-white));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
@@ -201,7 +223,11 @@ $button-dark-intent-text-colors: (
 @mixin pt-button-active() {
   // TODO: Consider changing color channels for color mix
   /* stylelint-disable-next-line color-named */
-  background-color: color-mix(in srgb, var(--bp-intent-default-active) 15%, white);
+  background-color: color-mix(
+    in srgb,
+    var(--bp-intent-default-active) 16%,
+    var(--bp-palette-white)
+  );
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
@@ -214,7 +240,8 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-disabled() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
+  // Use srgb for consistency with dark theme (avoids hue shift with near-neutral gray)
+  background-color: color-mix(in srgb, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -262,7 +289,7 @@ $button-dark-intent-text-colors: (
     background-color: color-mix(in oklch, $default-color 50%, transparent);
     border-color: transparent;
     box-shadow: none;
-    color: color-mix(in oklch, var(--bp-intent-default-foreground) 60%, transparent);
+    color: color-mix(in oklch, $text-color 60%, transparent);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
@@ -285,8 +312,9 @@ $button-dark-intent-text-colors: (
   &:hover,
   &:active,
   &.#{$ns}-active {
+    // Use srgb to avoid hue shift with near-neutral gray
     /* stylelint-disable-next-line color-named */
-    color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
+    color: color-mix(in srgb, var(--bp-intent-default-hover) 7%, var(--bp-palette-white));
   }
 
   &:hover {
@@ -303,18 +331,20 @@ $button-dark-intent-text-colors: (
     @include pt-dark-button-disabled;
 
     &.#{$ns}-active {
-      background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 7%, transparent);
+      // Use srgb to avoid hue shift with near-neutral gray
+      background-color: color-mix(in srgb, var(--bp-intent-default-disabled) 7%, transparent);
     }
   }
 
   .#{$ns}-button-spinner .#{$ns}-spinner-head {
+    // Use srgb to avoid hue shift with near-neutral gray
     background: color-mix(
-      in oklch,
+      in srgb,
       var(--bp-intent-default-rest) 20%,
       var(--bp-palette-black)
     ); //$dark-progress-track-color;
     stroke: color-mix(
-      in oklch,
+      in srgb,
       var(--bp-intent-default-rest) 55%,
       var(--bp-palette-white)
     ); //$dark-progress-head-color;
@@ -322,7 +352,8 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-default-colors() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 40%, var(--bp-palette-black));
+  // Use srgb to avoid hue shift with near-neutral gray
+  background-color: color-mix(in srgb, var(--bp-intent-default-rest) 40%, var(--bp-palette-black));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
@@ -331,7 +362,8 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-hover() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 29%, var(--bp-palette-black));
+  // Use srgb instead of oklch to avoid hue shift with near-neutral dark colors
+  background-color: color-mix(in srgb, var(--bp-intent-default-hover) 53%, var(--bp-palette-black));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
@@ -339,7 +371,12 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-active() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 19%, var(--bp-palette-black));
+  // Use srgb instead of oklch to avoid hue shift with near-neutral dark colors
+  background-color: color-mix(
+    in srgb,
+    var(--bp-intent-default-active) 44%,
+    var(--bp-palette-black)
+  );
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
@@ -347,7 +384,8 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-disabled() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, transparent);
+  // Use srgb to avoid hue shift with near-neutral gray
+  background-color: color-mix(in srgb, var(--bp-intent-default-disabled) 4%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
 }
@@ -357,7 +395,8 @@ $button-dark-intent-text-colors: (
   box-shadow: none;
 
   &:hover {
-    background-color: color-mix(in oklch, var(--bp-intent-default-rest) 15%, transparent);
+    // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+    background-color: color-mix(in srgb, var(--bp-intent-default-hover) 21%, transparent);
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
     text-decoration: none;
@@ -365,7 +404,8 @@ $button-dark-intent-text-colors: (
 
   &:active,
   &.#{$ns}-active {
-    background-color: color-mix(in oklch, var(--bp-intent-default-rest) 30%, transparent);
+    // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+    background-color: color-mix(in srgb, var(--bp-intent-default-active) 47%, transparent);
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
   }
@@ -379,7 +419,7 @@ $button-dark-intent-text-colors: (
     cursor: not-allowed;
 
     &.#{$ns}-active {
-      background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 30%, transparent);
+      background-color: color-mix(in srgb, var(--bp-intent-default-disabled) 30%, transparent);
     }
   }
 
@@ -398,12 +438,14 @@ $button-dark-intent-text-colors: (
     }
 
     &:hover {
-      background-color: color-mix(in oklch, var(--bp-intent-default-rest) 15%, transparent);
+      // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+      background-color: color-mix(in srgb, var(--bp-intent-default-hover) 21%, transparent);
     }
 
     &:active,
     &.#{$ns}-active {
-      background-color: color-mix(in oklch, var(--bp-intent-default-rest) 30%, transparent);
+      // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+      background-color: color-mix(in srgb, var(--bp-intent-default-active) 47%, transparent);
     }
 
     &:disabled,
@@ -415,7 +457,7 @@ $button-dark-intent-text-colors: (
       cursor: not-allowed;
 
       &.#{$ns}-active {
-        background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 30%, transparent);
+        background-color: color-mix(in srgb, var(--bp-intent-default-disabled) 30%, transparent);
       }
     }
   }
@@ -432,8 +474,8 @@ $button-dark-intent-text-colors: (
   $text-color: map.get($button-minimal-intent-text-colors, $intent);
   $active-text-color: map.get($button-intent-active-text-colors, $intent);
   $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
-  $dark-active-text-color: var(--bp-intent-#{$intent}-active);
-  $dark-hover-text-color: var(--bp-intent-#{$intent}-hover);
+  $dark-hover-text-color: map.get($button-dark-minimal-hover-text-colors, $intent);
+  $dark-active-text-color: map.get($button-dark-minimal-active-text-colors, $intent);
 
   color: $text-color;
 
@@ -521,7 +563,7 @@ $button-dark-intent-text-colors: (
   }
 
   @each $intent, $colors in $button-intents {
-    $text-color: map.get($pt-intent-text-colors, $intent);
+    $text-color: map.get($button-minimal-intent-text-colors, $intent);
     $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
 
     &.#{$ns}-intent-#{$intent} {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -35,6 +35,9 @@ $dark-button-color-disabled: var(--bp-typography-color-default-disabled) !defaul
 // Exported for forms/_controls.scss (rgba fallback for Firefox < 128)
 $minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
 $minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+$dark-minimal-button-background-color: none !default;
+$dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
+$dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
 
 // Exported for slider
 $button-box-shadow:
@@ -143,6 +146,7 @@ $button-intents: (
 }
 
 @mixin pt-button-default-colors() {
+  background-color: $light-gray5; // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-rest);
   box-shadow: $button-box-shadow;
   color: var(--bp-typography-color-default-rest);
@@ -150,6 +154,7 @@ $button-intents: (
 
 @mixin pt-button-hover() {
   background-clip: padding-box;
+  background-color: $light-gray4; // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-hover);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -158,6 +163,7 @@ $button-intents: (
 }
 
 @mixin pt-button-active() {
+  background-color: $light-gray2; // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-active);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -171,6 +177,10 @@ $button-intents: (
 }
 
 @mixin pt-button-disabled() {
+  background-color: rgba(
+    $light-gray1,
+    0.5
+  ); // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-disabled);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
@@ -320,32 +330,26 @@ $button-intents: (
 
   &:hover {
     background: $minimal-button-background-color-hover;
+    background: color-mix(
+      in oklch,
+      var(--bp-surface-background-color-default-rest) 15%,
+      transparent
+    );
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
     text-decoration: none;
-
-    @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-rest) 15%,
-        transparent
-      );
-    }
   }
 
   &:active,
   &.#{$ns}-active {
     background: $minimal-button-background-color-active;
+    background: color-mix(
+      in oklch,
+      var(--bp-surface-background-color-default-rest) 30%,
+      transparent
+    );
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
-
-    @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-rest) 30%,
-        transparent
-      );
-    }
   }
 
   &:disabled,
@@ -358,14 +362,11 @@ $button-intents: (
 
     &.#{$ns}-active {
       background: $minimal-button-background-color-active;
-
-      @supports (background: color-mix(in oklch, red, transparent)) {
-        background: color-mix(
-          in oklch,
-          var(--bp-surface-background-color-default-rest) 30%,
-          transparent
-        );
-      }
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 30%,
+        transparent
+      );
     }
   }
 
@@ -395,27 +396,21 @@ $button-intents: (
 
   &:hover {
     background: $minimal-button-background-color-hover;
-
-    @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-rest) 15%,
-        transparent
-      );
-    }
+    background: color-mix(
+      in oklch,
+      var(--bp-surface-background-color-default-rest) 15%,
+      transparent
+    );
   }
 
   &:active,
   &.#{$ns}-active {
     background: $minimal-button-background-color-active;
-
-    @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-rest) 30%,
-        transparent
-      );
-    }
+    background: color-mix(
+      in oklch,
+      var(--bp-surface-background-color-default-rest) 30%,
+      transparent
+    );
   }
 
   &:disabled,
@@ -428,14 +423,11 @@ $button-intents: (
 
     &.#{$ns}-active {
       background: $minimal-button-background-color-active;
-
-      @supports (background: color-mix(in oklch, red, transparent)) {
-        background: color-mix(
-          in oklch,
-          var(--bp-surface-background-color-default-rest) 30%,
-          transparent
-        );
-      }
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 30%,
+        transparent
+      );
     }
   }
 }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -14,16 +14,11 @@ $button-border-width: var(--bp-surface-border-width) !default;
 $button-padding-small: 0 calc(var(--bp-surface-spacing) * 2) !default;
 
 // Exported for forms and html-select
-$button-color-disabled: var(--bp-typography-color-default-disabled) !default;
+$button-color-disabled: rgba(var(--bp-palette-gray-1), 0.6) !default;
 
 // Exported for slider, html-select, forms
-$button-background-color-disabled: color-mix(
-  in oklch,
-  var(--bp-surface-background-color-default-disabled) 50%,
-  transparent
-) !default;
-$dark-button-background-color: var(--bp-surface-background-color-default-active) !default;
-$dark-button-color-disabled: var(--bp-typography-color-default-disabled) !default;
+$button-background-color-disabled: rgba(var(--bp-palette-light-gray-1), 0.5) !default;
+$dark-button-color-disabled: rgba(var(--bp-palette-gray-4), 0.6) !default;
 
 // Exported for forms/_controls.scss (rgba fallback for Firefox < 128)
 $minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
@@ -51,26 +46,36 @@ $button-intents: (
     var(--bp-intent-primary-rest),
     var(--bp-intent-primary-hover),
     var(--bp-intent-primary-active),
+    var(--bp-intent-primary-foreground),
+    var(--bp-intent-primary-disabled),
   ),
   "success": (
     var(--bp-intent-success-rest),
     var(--bp-intent-success-hover),
     var(--bp-intent-success-active),
+    var(--bp-intent-success-foreground),
+    var(--bp-intent-success-disabled),
   ),
   "warning": (
-    var(--bp-intent-warning-rest),
+    (oklch(from var(--bp-intent-warning-rest) calc(l + 0.215) calc(c - 0.01) calc(h + 7))),
     var(--bp-intent-warning-hover),
     var(--bp-intent-warning-active),
+    var(--bp-intent-warning-foreground),
+    var(--bp-intent-warning-disabled),
   ),
   "danger": (
     var(--bp-intent-danger-rest),
     var(--bp-intent-danger-hover),
     var(--bp-intent-danger-active),
+    var(--bp-intent-danger-foreground),
+    var(--bp-intent-danger-disabled),
   ),
   "default": (
     var(--bp-intent-default-rest),
     var(--bp-intent-default-hover),
     var(--bp-intent-default-active),
+    var(--bp-intent-default-foreground),
+    var(--bp-intent-default-disabled),
   ),
 ) !default;
 
@@ -78,12 +83,14 @@ $button-intents: (
 $button-intent-colors: (
   "primary": var(--bp-intent-primary-rest),
   "success": var(--bp-intent-success-rest),
-  "warning": var(--bp-intent-warning-rest),
+  "warning": (
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.215) calc(c - 0.01) calc(h + 7)),
+  ),
   "danger": var(--bp-intent-danger-rest),
   "default": var(--bp-intent-default-rest),
 ) !default;
 
-$button-intent-text-colors: (
+$button-minimal-intent-text-colors: (
   "primary": var(--bp-intent-primary-hover),
   "success": var(--bp-intent-success-hover),
   "warning": var(--bp-intent-warning-hover),
@@ -169,15 +176,19 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-default-colors() {
-  background-color: $light-gray5; // fallback for browsers without oklch relative color support
-  background-color: var(--bp-surface-background-color-default-rest);
+  background-color: var(
+    --bp-palette-light-gray-5
+  ); // fallback for browsers without oklch relative color support
+  background: var(--bp-surface-layer-default), var(--bp-surface-background-color-default-rest);
   box-shadow: $button-box-shadow;
   color: var(--bp-typography-color-default-rest);
 }
 
 @mixin pt-button-hover() {
   background-clip: padding-box;
-  background-color: $light-gray4; // fallback for browsers without oklch relative color support
+  background-color: var(
+    --bp-palette-light-gray-4
+  ); // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-hover);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -204,22 +215,22 @@ $button-dark-intent-text-colors: (
     $light-gray1,
     0.5
   ); // fallback for browsers without oklch relative color support
-  background-color: var(--bp-surface-background-color-default-disabled);
+  background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
   outline: none;
 }
 
-@mixin pt-button-intent($default-color, $hover-color, $active-color) {
+@mixin pt-button-intent($default-color, $hover-color, $active-color, $text-color, $disabled-color) {
   background-color: $default-color;
   box-shadow: $button-box-shadow;
-  color: var(--bp-intent-primary-foreground);
+  color: $text-color;
 
   &:hover,
   &:active,
   &.#{$ns}-active {
-    color: var(--bp-intent-primary-foreground);
+    color: $text-color;
   }
 
   &:hover {
@@ -241,7 +252,7 @@ $button-dark-intent-text-colors: (
 
   &:disabled,
   &.#{$ns}-disabled {
-    background-color: rgba($default-color, 0.5);
+    background-color: color-mix(in oklch, $default-color 50%, transparent);
     border-color: transparent;
     box-shadow: none;
     color: color-mix(in oklch, var(--bp-intent-default-foreground) 60%, transparent);
@@ -264,11 +275,11 @@ $button-dark-intent-text-colors: (
 @mixin pt-dark-button() {
   @include pt-dark-button-default-colors;
 
-  &:hover,
-  &:active,
-  &.#{$ns}-active {
-    color: var(--bp-typography-color-default-rest);
-  }
+  // &:hover,
+  // &:active,
+  // &.#{$ns}-active {
+  //   color: var(--bp-typography-color-default-rest);
+  // }
 
   &:hover {
     @include pt-dark-button-hover;
@@ -299,33 +310,53 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-default-colors() {
-  background-color: $dark-button-background-color;
+  background-color: var(
+    --bp-palette-dark-gray-3
+  ); // TODO: Remove fallback for places where background-color is specified
+  background:
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-background-color-default-rest); // 	~#2b323d
   box-shadow: $dark-button-box-shadow;
-  color: var(--bp-typography-color-default-rest);
+  color: var(--bp-intent-default-foreground);
 }
 
 @mixin pt-dark-button-hover() {
-  background-color: $dark-gray2; // fallback for browsers without CSS custom property support
-  background-color: var(--bp-surface-background-color-default-hover);
+  background-color: var(
+    --bp-palette-dark-gray-2
+  ); // TODO: Remove fallback for places where background-color is specified
+  background:
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-background-color-default-hover);
   box-shadow: $dark-button-box-shadow-active;
 }
 
 @mixin pt-dark-button-active() {
-  background-color: $dark-gray1; // fallback for browsers without CSS custom property support
-  background-color: var(--bp-surface-background-color-default-rest);
+  background-color: var(
+    --bp-palette-dark-gray-1
+  ); // TODO: Remove fallback for places where background-color is specified
+  background:
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
+    var(--bp-surface-background-color-default-active);
+
   box-shadow: $dark-button-box-shadow-active;
 }
 
 @mixin pt-dark-button-disabled() {
   background-color: rgba(
-    $dark-gray3,
+    var(--bp-palette-dark-gray-3),
     0.15
   ); // fallback for browsers without oklch relative color support
-  background-color: color-mix(
-    in oklch,
-    var(--bp-surface-background-color-default-disabled) 15%,
-    transparent
-  );
+  background: var(--bp-surface-background-color-default-disabled);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
 }
@@ -376,7 +407,8 @@ $button-dark-intent-text-colors: (
     }
   }
 
-  .#{$ns}-dark & {
+  .#{$ns}-dark &,
+  [data-bp-color-scheme=\"dark\"] & {
     background: none;
     box-shadow: none;
     color: var(--bp-intent-default-foreground);
@@ -436,7 +468,7 @@ $button-dark-intent-text-colors: (
 
 @mixin pt-button-minimal-intent($intent) {
   $intent-color: map.get($button-intent-colors, $intent);
-  $text-color: map.get($button-intent-text-colors, $intent);
+  $text-color: map.get($button-minimal-intent-text-colors, $intent);
   $active-text-color: map.get($button-intent-active-text-colors, $intent);
   $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
   $dark-active-text-color: var(--bp-intent-#{$intent}-active);
@@ -477,7 +509,8 @@ $button-dark-intent-text-colors: (
     stroke: $text-color;
   }
 
-  .#{$ns}-dark & {
+  .#{$ns}-dark &,
+  [data-bp-color-scheme=\"dark\"] & {
     color: $dark-text-color;
 
     &:hover {
@@ -514,7 +547,8 @@ $button-dark-intent-text-colors: (
     border-color: var(--bp-surface-border-color-default);
   }
 
-  .#{$ns}-dark & {
+  .#{$ns}-dark &,
+  [data-bp-color-scheme=\"dark\"] & {
     border-color: var(--bp-surface-border-color-strong);
 
     &:disabled,
@@ -537,7 +571,8 @@ $button-dark-intent-text-colors: (
         border-color: color-mix(in oklch, $text-color 20%, transparent);
       }
 
-      .#{$ns}-dark & {
+      .#{$ns}-dark &,
+      [data-bp-color-scheme=\"dark\"] & {
         border-color: color-mix(in oklch, $dark-text-color 60%, transparent);
 
         &:disabled,

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -40,6 +40,20 @@ $dark-button-box-shadow-active:
     color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
   0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent) !default;
 
+// Temporary: warning button rest color needs a pre-computed fallback
+// for browsers that don't support relative color syntax.
+:root {
+  --bp-button-warning-rest: #fbb360;
+}
+
+@supports (color: oklch(from var(--any-color) l c h)) {
+  :root {
+    --bp-button-warning-rest: oklch(
+      from var(--bp-intent-warning-rest) calc(l + 0.177) calc(c - 0.01) calc(h + 6.26)
+    );
+  }
+}
+
 // "intent": (default, hover, active colors)
 $button-intents: (
   "primary": (
@@ -57,7 +71,7 @@ $button-intents: (
     var(--bp-intent-success-disabled),
   ),
   "warning": (
-    (oklch(from var(--bp-intent-warning-rest) calc(l + 0.215) calc(c - 0.01) calc(h + 7))),
+    var(--bp-button-warning-rest),
     var(--bp-intent-warning-hover),
     var(--bp-intent-warning-active),
     var(--bp-intent-warning-foreground),
@@ -83,9 +97,7 @@ $button-intents: (
 $button-intent-colors: (
   "primary": var(--bp-intent-primary-rest),
   "success": var(--bp-intent-success-rest),
-  "warning": (
-    oklch(from var(--bp-intent-warning-rest) calc(l + 0.215) calc(c - 0.01) calc(h + 7)),
-  ),
+  "warning": var(--bp-button-warning-rest),
   "danger": var(--bp-intent-danger-rest),
   "default": var(--bp-intent-default-rest),
 ) !default;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -26,7 +26,7 @@ $minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !de
 $dark-minimal-button-background-color-hover: rgba(var(--bp-palette-gray-3), 0.15) !default;
 $dark-minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !default;
 
-// Exported for slider
+// Exported for slider, replaced below
 $button-box-shadow:
   inset 0 0 0 var(--bp-surface-border-width)
     color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -181,7 +181,10 @@ $button-dark-intent-text-colors: (
 @mixin pt-button-default-colors() {
   /* stylelint-disable-next-line color-named */
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
-  box-shadow: $button-box-shadow;
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
   color: var(--bp-typography-color-default-rest);
 }
 
@@ -225,7 +228,10 @@ $button-dark-intent-text-colors: (
   $text-color: var(--bp-palette-white)
 ) {
   background-color: $default-color;
-  box-shadow: $button-box-shadow;
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
   color: $text-color;
 
   &:hover,
@@ -301,25 +307,42 @@ $button-dark-intent-text-colors: (
   }
 
   .#{$ns}-button-spinner .#{$ns}-spinner-head {
-    background: $dark-progress-track-color;
-    stroke: $dark-progress-head-color;
+    background: color-mix(
+      in oklch,
+      var(--bp-intent-default-rest) 20%,
+      var(--bp-palette-black)
+    ); //$dark-progress-track-color;
+    stroke: color-mix(
+      in oklch,
+      var(--bp-intent-default-rest) 55%,
+      var(--bp-palette-white)
+    ); //$dark-progress-head-color;
   }
 }
 
 @mixin pt-dark-button-default-colors() {
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 40%, var(--bp-palette-black));
-  box-shadow: $dark-button-box-shadow;
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   color: var(--bp-intent-default-foreground);
 }
 
 @mixin pt-dark-button-hover() {
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 29%, var(--bp-palette-black));
-  box-shadow: $dark-button-box-shadow-active;
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent);
 }
 
 @mixin pt-dark-button-active() {
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 19%, var(--bp-palette-black));
-  box-shadow: $dark-button-box-shadow-active;
+  box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent);
 }
 
 @mixin pt-dark-button-disabled() {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -408,7 +408,7 @@ $button-dark-intent-text-colors: (
   }
 
   .#{$ns}-dark &,
-  [data-bp-color-scheme=\"dark\"] & {
+  [data-bp-color-scheme="dark"] & {
     background: none;
     box-shadow: none;
     color: var(--bp-intent-default-foreground);
@@ -510,7 +510,7 @@ $button-dark-intent-text-colors: (
   }
 
   .#{$ns}-dark &,
-  [data-bp-color-scheme=\"dark\"] & {
+  [data-bp-color-scheme="dark"] & {
     color: $dark-text-color;
 
     &:hover {
@@ -548,7 +548,7 @@ $button-dark-intent-text-colors: (
   }
 
   .#{$ns}-dark &,
-  [data-bp-color-scheme=\"dark\"] & {
+  [data-bp-color-scheme="dark"] & {
     border-color: var(--bp-surface-border-color-strong);
 
     &:disabled,
@@ -572,7 +572,7 @@ $button-dark-intent-text-colors: (
       }
 
       .#{$ns}-dark &,
-      [data-bp-color-scheme=\"dark\"] & {
+      [data-bp-color-scheme="dark"] & {
         border-color: color-mix(in oklch, $dark-text-color 60%, transparent);
 
         &:disabled,

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -187,12 +187,14 @@ $button-dark-minimal-active-text-colors: (
 }
 
 @mixin pt-button-height-default() {
-  @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
   padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
 }
 
 @mixin pt-button-height-small() {
-  @include pt-button-height(calc(var(--bp-surface-spacing) * 6));
+  min-height: calc(var(--bp-surface-spacing) * 6);
+  min-width: calc(var(--bp-surface-spacing) * 6);
   padding: 0 calc(var(--bp-surface-spacing) * 2);
 }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -8,11 +8,11 @@
 @import "../progress-bar/common";
 
 $button-border-width: 1px !default;
-$button-padding: $pt-spacing ($pt-spacing * 2) !default;
-$button-padding-small: 0 ($pt-spacing * 2) !default;
-$button-padding-large: $pt-spacing ($pt-spacing * 4) !default;
-$button-icon-spacing: $pt-spacing * 2 !default;
-$button-icon-spacing-large: $pt-spacing * 2 !default;
+$button-padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2) !default;
+$button-padding-small: 0 calc(var(--bp-surface-spacing) * 2) !default;
+$button-padding-large: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4) !default;
+$button-icon-spacing: calc(var(--bp-surface-spacing) * 2) !default;
+$button-icon-spacing-large: calc(var(--bp-surface-spacing) * 2) !default;
 
 /*
 CSS `border` property issues:
@@ -24,67 +24,67 @@ CSS `border` property issues:
 `box-shadow` doesn't have these issues, we're using it instead of `border`.
 */
 $button-box-shadow:
-  inset 0 0 0 $button-border-width rgba($black, 0.2),
-  0 1px 2px rgba($black, 0.1) !default;
+  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-1000) l c h / 0.2),
+  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.1) !default;
 $button-box-shadow-active:
-  inset 0 0 0 $button-border-width rgba($black, 0.2),
-  0 1px 2px rgba($black, 0.2) !default;
+  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-1000) l c h / 0.2),
+  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.2) !default;
 
 $dark-button-box-shadow:
-  inset 0 0 0 $button-border-width rgba($white, 0.1),
-  0 1px 2px rgba($black, 0.2) !default;
+  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-100) l c h / 0.1),
+  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.2) !default;
 $dark-button-box-shadow-active:
-  inset 0 0 0 $button-border-width rgba($white, 0.1),
-  0 1px 2px rgba($black, 0.4) !default;
+  inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-100) l c h / 0.1),
+  0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.4) !default;
 
-$button-color-disabled: $pt-text-color-disabled !default;
-$button-background-color: $light-gray5 !default;
-$button-background-color-hover: $light-gray4 !default;
-$button-background-color-active: $light-gray2 !default;
+$button-color-disabled: var(--bp-typography-colorDisabled-default) !default;
+$button-background-color: var(--bp-surface-colorRest-default) !default;
+$button-background-color-hover: var(--bp-surface-colorHover-default) !default;
+$button-background-color-active: var(--bp-surface-colorActive-default) !default;
 $button-background-color-disabled: rgba($light-gray1, 0.5) !default;
 $button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
-$button-intent-color-disabled: rgba($white, 0.6);
-$dark-button-color-disabled: $pt-dark-text-color-disabled !default;
-$dark-button-background-color: $dark-gray3 !default;
-$dark-button-background-color-hover: $dark-gray2 !default;
-$dark-button-background-color-active: $dark-gray1 !default;
+$button-intent-color-disabled: oklch(from var(--bp-palette-gray-100) l c h / 0.6);
+$dark-button-color-disabled: var(--bp-typography-colorDisabled-default) !default;
+$dark-button-background-color: var(--bp-palette-gray-700) !default;
+$dark-button-background-color-hover: var(--bp-palette-gray-600) !default;
+$dark-button-background-color-active: var(--bp-palette-gray-800) !default;
 $dark-button-background-color-disabled: rgba($dark-gray3, 0.15) !default;
 $dark-button-background-color-active-disabled: rgba($dark-gray3, 0.7) !default;
-$dark-button-intent-color-disabled: rgba($white, 0.3);
+$dark-button-intent-color-disabled: oklch(from var(--bp-palette-gray-100) l c h / 0.3);
 
-$minimal-button-divider-width: 1px !default;
+$minimal-button-divider-width: var(--bp-surface-borderWidth) !default;
 $minimal-button-background-color: none !default;
-$minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
-$minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+$minimal-button-background-color-hover: var(--bp-surface-depthLayer-default) !default;
+$minimal-button-background-color-active: oklch(from var(--bp-intent-default-rest) l c h / 0.15) !default;
 $dark-minimal-button-background-color: none !default;
-$dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
-$dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+$dark-minimal-button-background-color-hover: var(--bp-surface-depthLayer-default) !default;
+$dark-minimal-button-background-color-active: oklch(from var(--bp-intent-default-rest) l c h / 0.15) !default;
 
-$button-outlined-width: 1px !default;
+$button-outlined-width: var(--bp-surface-borderWidth) !default;
 $button-outlined-border-intent-opacity: 0.6 !default;
 $button-outlined-border-disabled-intent-opacity: 0.2 !default;
 
 // "intent": (default, hover, active colors)
 $button-intents: (
   "primary": (
-    $blue3,
-    $blue2,
-    $blue1,
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
   ),
   "success": (
-    $green3,
-    $green2,
-    $green1,
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
   ),
   "warning": (
-    $orange3,
-    $orange2,
-    $orange1,
+    var(--bp-intent-warning-rest),
+    var(--bp-intent-warning-hover),
+    var(--bp-intent-warning-active),
   ),
   "danger": (
-    $red3,
-    $red2,
-    $red1,
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
   ),
 ) !default;
 
@@ -471,10 +471,10 @@ $dark-minimal-active-text-colors: (
 }
 
 @mixin pt-button-minimal-divider() {
-  $divider-height: $pt-spacing * 5;
+  $divider-height: calc(var(--bp-surface-spacing) * 5);
   background: $pt-divider-black;
 
-  margin: ($pt-button-height - $divider-height) * 0.5;
+  margin: calc((#{$pt-button-height} - #{$divider-height}) * 0.5);
   width: $minimal-button-divider-width;
 
   .#{$ns}-dark & {

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -21,10 +21,10 @@ $button-background-color-disabled: rgba(var(--bp-palette-light-gray-1), 0.5) !de
 $dark-button-color-disabled: rgba(var(--bp-palette-gray-4), 0.6) !default;
 
 // Exported for forms/_controls.scss (rgba fallback for Firefox < 128)
-$minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
-$minimal-button-background-color-active: rgba($gray3, 0.3) !default;
-$dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
-$dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+$minimal-button-background-color-hover: rgba(var(--bp-palette-gray-3), 0.15) !default;
+$minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !default;
+$dark-minimal-button-background-color-hover: rgba(var(--bp-palette-gray-3), 0.15) !default;
+$dark-minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !default;
 
 // Exported for slider
 $button-box-shadow:
@@ -43,7 +43,7 @@ $dark-button-box-shadow-active:
 // Temporary: warning button rest color needs a pre-computed fallback
 // for browsers that don't support relative color syntax.
 :root {
-  --bp6-button-warning-rest: var(--bp-palete-orange-5); //#fbb360;
+  --bp6-button-warning-rest: var(--bp-palette-orange-5); //#fbb360;
 }
 
 @supports (color: oklch(from var(--any-color) l c h)) {
@@ -179,6 +179,7 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-default-colors() {
+  /* stylelint-disable-next-line color-named */
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
   box-shadow: $button-box-shadow;
   color: var(--bp-typography-color-default-rest);
@@ -210,7 +211,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-disabled() {
-  /* stylelint-disable-next-line color-named */
   background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,38 +7,66 @@
 @import "../../common/variables-extended";
 @import "../progress-bar/common";
 
-// These variables are exported for use by other components (slider, forms, html-select, etc.)
-$button-border-width: 1px !default; //TODO: Update to var(--bp-surface-border-width) !default; when all instances use calc
+// N.B. Keeping existing SCSS variables for backward-compatibility.
+// These are **not used** in button, and should be removed in
+// the major version change.
 
-// Exported for forms/_input-group.scss
-$button-padding-small: 0 calc(var(--bp-surface-spacing) * 2) !default;
+$button-border-width: 1px !default;
+$button-padding: $pt-spacing ($pt-spacing * 2) !default;
+$button-padding-small: 0 ($pt-spacing * 2) !default;
+$button-padding-large: $pt-spacing ($pt-spacing * 4) !default;
+$button-icon-spacing: $pt-spacing * 2 !default;
+$button-icon-spacing-large: $pt-spacing * 2 !default;
 
-// Exported for forms and html-select
-$button-color-disabled: rgba(var(--bp-palette-gray-1), 0.6) !default;
+/*
+CSS `border` property issues:
+- An element can only have one border.
+- Borders can't stack with shadows.
+- Borders modify the size of the element they're applied to.
+- Border positioning requires the extra `box-sizing` property.
 
-// Exported for slider, html-select, forms
-$button-background-color-disabled: rgba(var(--bp-palette-light-gray-1), 0.5) !default;
-$dark-button-color-disabled: rgba(var(--bp-palette-gray-4), 0.6) !default;
-
-// Exported for forms/_controls.scss (rgba fallback for Firefox < 128)
-$minimal-button-background-color-hover: rgba(var(--bp-palette-gray-3), 0.15) !default;
-$minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !default;
-$dark-minimal-button-background-color-hover: rgba(var(--bp-palette-gray-3), 0.15) !default;
-$dark-minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !default;
-
-// Exported for slider, kept original, replaced with surface tokens below
+`box-shadow` doesn't have these issues, we're using it instead of `border`.
+*/
 $button-box-shadow:
-  inset 0 0 0 var(--bp-surface-border-width)
-    color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
-  0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent) !default;
+  inset 0 0 0 $button-border-width rgba($black, 0.2),
+  0 1px 2px rgba($black, 0.1) !default;
+$button-box-shadow-active:
+  inset 0 0 0 $button-border-width rgba($black, 0.2),
+  0 1px 2px rgba($black, 0.2) !default;
+
 $dark-button-box-shadow:
-  inset 0 0 0 var(--bp-surface-border-width)
-    color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
-  0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent) !default;
+  inset 0 0 0 $button-border-width rgba($white, 0.1),
+  0 1px 2px rgba($black, 0.2) !default;
 $dark-button-box-shadow-active:
-  inset 0 0 0 var(--bp-surface-border-width)
-    color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
-  0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent) !default;
+  inset 0 0 0 $button-border-width rgba($white, 0.1),
+  0 1px 2px rgba($black, 0.4) !default;
+
+$button-color-disabled: $pt-text-color-disabled !default;
+$button-background-color: $light-gray5 !default;
+$button-background-color-hover: $light-gray4 !default;
+$button-background-color-active: $light-gray2 !default;
+$button-background-color-disabled: rgba($light-gray1, 0.5) !default;
+$button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
+$button-intent-color-disabled: rgba($white, 0.6);
+$dark-button-color-disabled: $pt-dark-text-color-disabled !default;
+$dark-button-background-color: $dark-gray3 !default;
+$dark-button-background-color-hover: $dark-gray2 !default;
+$dark-button-background-color-active: $dark-gray1 !default;
+$dark-button-background-color-disabled: rgba($dark-gray3, 0.15) !default;
+$dark-button-background-color-active-disabled: rgba($dark-gray3, 0.7) !default;
+$dark-button-intent-color-disabled: rgba($white, 0.3);
+
+$minimal-button-divider-width: 1px !default;
+$minimal-button-background-color: none !default;
+$minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
+$minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+$dark-minimal-button-background-color: none !default;
+$dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
+$dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
+
+$button-outlined-width: 1px !default;
+$button-outlined-border-intent-opacity: 0.6 !default;
+$button-outlined-border-disabled-intent-opacity: 0.2 !default;
 
 // Temporary: warning button rest color needs a pre-computed fallback
 // for browsers that don't support relative color syntax.

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -176,9 +176,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-default-colors() {
-  background-color: var(
-    --bp-palette-light-gray-5
-  ); // fallback for browsers without oklch relative color support
   background: var(--bp-surface-layer-default), var(--bp-surface-background-color-default-rest);
   box-shadow: $button-box-shadow;
   color: var(--bp-typography-color-default-rest);
@@ -186,9 +183,6 @@ $button-dark-intent-text-colors: (
 
 @mixin pt-button-hover() {
   background-clip: padding-box;
-  background-color: var(
-    --bp-palette-light-gray-4
-  ); // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-hover);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -197,7 +191,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-active() {
-  background-color: $light-gray2; // fallback for browsers without oklch relative color support
   background-color: var(--bp-surface-background-color-default-active);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -211,10 +204,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-disabled() {
-  background-color: rgba(
-    $light-gray1,
-    0.5
-  ); // fallback for browsers without oklch relative color support
   background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
@@ -310,9 +299,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-default-colors() {
-  background-color: var(
-    --bp-palette-dark-gray-3
-  ); // TODO: Remove fallback for places where background-color is specified
   background:
     var(--bp-surface-layer-default), var(--bp-surface-layer-default),
     var(--bp-surface-layer-default), var(--bp-surface-layer-default),
@@ -325,9 +311,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-hover() {
-  background-color: var(
-    --bp-palette-dark-gray-2
-  ); // TODO: Remove fallback for places where background-color is specified
   background:
     var(--bp-surface-layer-default), var(--bp-surface-layer-default),
     var(--bp-surface-layer-default), var(--bp-surface-layer-default),
@@ -339,9 +322,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-active() {
-  background-color: var(
-    --bp-palette-dark-gray-1
-  ); // TODO: Remove fallback for places where background-color is specified
   background:
     var(--bp-surface-layer-default), var(--bp-surface-layer-default),
     var(--bp-surface-layer-default), var(--bp-surface-layer-default),
@@ -352,10 +332,6 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-disabled() {
-  background-color: rgba(
-    var(--bp-palette-dark-gray-3),
-    0.15
-  ); // fallback for browsers without oklch relative color support
   background: var(--bp-surface-background-color-default-disabled);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
@@ -366,7 +342,6 @@ $button-dark-intent-text-colors: (
   box-shadow: none;
 
   &:hover {
-    background: $minimal-button-background-color-hover;
     background: color-mix(
       in oklch,
       var(--bp-surface-background-color-default-hover) 15%,
@@ -379,7 +354,6 @@ $button-dark-intent-text-colors: (
 
   &:active,
   &.#{$ns}-active {
-    background: $minimal-button-background-color-active;
     background: color-mix(
       in oklch,
       var(--bp-surface-background-color-default-active) 30%,
@@ -398,7 +372,6 @@ $button-dark-intent-text-colors: (
     cursor: not-allowed;
 
     &.#{$ns}-active {
-      background: $minimal-button-background-color-active;
       background: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-disabled) 30%,
@@ -422,7 +395,6 @@ $button-dark-intent-text-colors: (
     }
 
     &:hover {
-      background: $dark-minimal-button-background-color-hover;
       background: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-hover) 15%,
@@ -432,7 +404,6 @@ $button-dark-intent-text-colors: (
 
     &:active,
     &.#{$ns}-active {
-      background: $dark-minimal-button-background-color-active;
       background: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-active) 30%,
@@ -449,7 +420,6 @@ $button-dark-intent-text-colors: (
       cursor: not-allowed;
 
       &.#{$ns}-active {
-        background: $dark-minimal-button-background-color-active;
         background: color-mix(
           in oklch,
           var(--bp-surface-background-color-default-disabled) 30%,

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -23,19 +23,11 @@ $button-background-color-disabled: color-mix(
   transparent
 ) !default;
 $dark-button-background-color: var(--bp-surface-background-color-default-active) !default;
-$dark-button-background-color-hover: var(--bp-surface-background-color-default-hover) !default;
-$dark-button-background-color-active: var(--bp-surface-background-color-default-rest) !default;
-$dark-button-background-color-disabled: color-mix(
-  in oklch,
-  var(--bp-surface-background-color-default-active) 15%,
-  transparent
-) !default;
 $dark-button-color-disabled: var(--bp-typography-color-default-disabled) !default;
 
 // Exported for forms/_controls.scss (rgba fallback for Firefox < 128)
 $minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
 $minimal-button-background-color-active: rgba($gray3, 0.3) !default;
-$dark-minimal-button-background-color: none !default;
 $dark-minimal-button-background-color-hover: rgba($gray3, 0.15) !default;
 $dark-minimal-button-background-color-active: rgba($gray3, 0.3) !default;
 
@@ -93,13 +85,6 @@ $button-intents: (
 @mixin pt-button-height($height) {
   min-height: $height;
   min-width: $height;
-}
-
-@mixin pt-button-height-large() {
-  @include pt-button-height(calc(var(--bp-surface-spacing) * 10));
-  @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
-  font-size: var(--bp-typography-size-body-large);
-  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4);
 }
 
 @mixin pt-button-height-default() {
@@ -218,26 +203,22 @@ $button-intents: (
 
   &:disabled,
   &.#{$ns}-disabled {
-    @include pt-button-intent-disabled($default-color);
+    background-color: rgba($default-color, 0.5);
+    border-color: transparent;
+    box-shadow: none;
+    color: color-mix(in oklch, var(--bp-intent-default-foreground) 60%, transparent);
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+      // Windows High Contrast dark theme
+      border-color: graytext;
+      color: graytext;
+    }
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
     border: 1px solid buttonborder;
     box-shadow: none;
-  }
-}
-
-@mixin pt-button-intent-disabled($default-color) {
-  background-color: rgba($default-color, 0.5);
-  border-color: transparent;
-  box-shadow: none;
-  color: color-mix(in oklch, var(--bp-intent-default-foreground) 60%, transparent);
-
-  @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    // Windows High Contrast dark theme
-    border-color: graytext;
-    color: graytext;
   }
 }
 
@@ -286,42 +267,29 @@ $button-intents: (
 }
 
 @mixin pt-dark-button-hover() {
-  background-color: $dark-button-background-color-hover;
+  background-color: $dark-gray2; // fallback for browsers without CSS custom property support
+  background-color: var(--bp-surface-background-color-default-hover);
   box-shadow: $dark-button-box-shadow-active;
 }
 
 @mixin pt-dark-button-active() {
-  background-color: $dark-button-background-color-active;
+  background-color: $dark-gray1; // fallback for browsers without CSS custom property support
+  background-color: var(--bp-surface-background-color-default-rest);
   box-shadow: $dark-button-box-shadow-active;
 }
 
 @mixin pt-dark-button-disabled() {
-  background-color: $dark-button-background-color-disabled;
+  background-color: rgba(
+    $dark-gray3,
+    0.15
+  ); // fallback for browsers without oklch relative color support
+  background-color: color-mix(
+    in oklch,
+    var(--bp-surface-background-color-default-active) 15%,
+    transparent
+  );
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
-}
-
-@mixin pt-dark-button-intent() {
-  box-shadow: $dark-button-box-shadow;
-
-  &:hover {
-    box-shadow: $dark-button-box-shadow;
-  }
-
-  &:active,
-  &.#{$ns}-active {
-    box-shadow: $dark-button-box-shadow-active;
-  }
-
-  &:disabled,
-  &.#{$ns}-disabled {
-    @include pt-dark-button-intent-disabled;
-  }
-}
-
-@mixin pt-dark-button-intent-disabled() {
-  box-shadow: none;
-  color: color-mix(in oklch, var(--bp-intent-default-foreground) 30%, transparent);
 }
 
 @mixin pt-button-minimal() {
@@ -371,7 +339,54 @@ $button-intents: (
   }
 
   .#{$ns}-dark & {
-    @include pt-dark-button-minimal;
+    background: none;
+    box-shadow: none;
+    color: var(--bp-intent-default-foreground);
+
+    &:hover,
+    &:active,
+    &.#{$ns}-active {
+      background: none;
+      box-shadow: none;
+      color: var(--bp-intent-default-foreground);
+    }
+
+    &:hover {
+      background: $minimal-button-background-color-hover;
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 15%,
+        transparent
+      );
+    }
+
+    &:active,
+    &.#{$ns}-active {
+      background: $minimal-button-background-color-active;
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 30%,
+        transparent
+      );
+    }
+
+    &:disabled,
+    &:disabled:hover,
+    &.#{$ns}-disabled,
+    &.#{$ns}-disabled:hover {
+      background: none;
+      color: var(--bp-typography-color-default-disabled);
+      cursor: not-allowed;
+
+      &.#{$ns}-active {
+        background: $minimal-button-background-color-active;
+        background: color-mix(
+          in oklch,
+          var(--bp-surface-background-color-default-rest) 30%,
+          transparent
+        );
+      }
+    }
   }
 
   @each $intent, $colors in $button-intents {
@@ -381,78 +396,13 @@ $button-intents: (
   }
 }
 
-@mixin pt-dark-button-minimal() {
-  background: none;
-  box-shadow: none;
-  color: var(--bp-intent-default-foreground);
-
-  &:hover,
-  &:active,
-  &.#{$ns}-active {
-    background: none;
-    box-shadow: none;
-    color: var(--bp-intent-default-foreground);
-  }
-
-  &:hover {
-    background: $minimal-button-background-color-hover;
-    background: color-mix(
-      in oklch,
-      var(--bp-surface-background-color-default-rest) 15%,
-      transparent
-    );
-  }
-
-  &:active,
-  &.#{$ns}-active {
-    background: $minimal-button-background-color-active;
-    background: color-mix(
-      in oklch,
-      var(--bp-surface-background-color-default-rest) 30%,
-      transparent
-    );
-  }
-
-  &:disabled,
-  &:disabled:hover,
-  &.#{$ns}-disabled,
-  &.#{$ns}-disabled:hover {
-    background: none;
-    color: var(--bp-typography-color-default-disabled);
-    cursor: not-allowed;
-
-    &.#{$ns}-active {
-      background: $minimal-button-background-color-active;
-      background: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-rest) 30%,
-        transparent
-      );
-    }
-  }
-}
-
-$dark-minimal-hover-text-colors: (
-  "primary": var(--bp-intent-primary-hover),
-  "success": var(--bp-intent-success-hover),
-  "warning": var(--bp-intent-warning-hover),
-  "danger": var(--bp-intent-danger-hover),
-);
-
-$dark-minimal-active-text-colors: (
-  "primary": var(--bp-intent-primary-active),
-  "success": var(--bp-intent-success-active),
-  "warning": var(--bp-intent-warning-active),
-  "danger": var(--bp-intent-danger-active),
-);
-
 @mixin pt-button-minimal-intent($intent) {
   $intent-color: map.get($pt-intent-colors, $intent);
   $text-color: map.get($pt-intent-text-colors, $intent);
   $active-text-color: map.get($pt-intent-active-text-colors, $intent);
   $dark-text-color: map.get($pt-dark-intent-text-colors, $intent);
-  $dark-active-text-color: map.get($dark-minimal-active-text-colors, $intent);
-  $dark-hover-text-color: map.get($dark-minimal-hover-text-colors, $intent);
+  $dark-active-text-color: var(--bp-intent-#{$intent}-active);
+  $dark-hover-text-color: var(--bp-intent-#{$intent}-hover);
 
   color: $text-color;
 
@@ -515,62 +465,48 @@ $dark-minimal-active-text-colors: (
   }
 }
 
-@mixin pt-button-minimal-divider() {
-  background: var(--bp-surface-border-color-default);
-  margin: calc((calc(var(--bp-surface-spacing) * 7.5) - calc(var(--bp-surface-spacing) * 5)) * 0.5);
-  width: var(--bp-surface-border-width);
-}
-
 @mixin pt-button-outlined() {
   border: var(--bp-surface-border-width) solid var(--bp-surface-border-color-default);
   box-sizing: border-box;
 
   &:disabled,
-  &.#{$ns}-disabled,
   &:disabled:hover,
+  &.#{$ns}-disabled,
   &.#{$ns}-disabled:hover {
     border-color: var(--bp-surface-border-color-default);
   }
 
   .#{$ns}-dark & {
-    @include pt-dark-button-outlined;
+    border-color: var(--bp-surface-border-color-strong);
+
+    &:disabled,
+    &:disabled:hover,
+    &.#{$ns}-disabled,
+    &.#{$ns}-disabled:hover {
+      border-color: var(--bp-surface-border-color-default);
+    }
   }
 
   @each $intent, $colors in $button-intents {
+    $text-color: map.get($pt-intent-text-colors, $intent);
+    $dark-text-color: map.get($pt-dark-intent-text-colors, $intent);
+
     &.#{$ns}-intent-#{$intent} {
-      @include pt-button-outlined-intent(
-        map.get($pt-intent-text-colors, $intent),
-        map.get($pt-dark-intent-text-colors, $intent)
-      );
-    }
-  }
-}
+      border-color: rgba($text-color, 0.6);
 
-@mixin pt-dark-button-outlined() {
-  border-color: var(--bp-surface-border-color-strong);
+      &:disabled,
+      &.#{$ns}-disabled {
+        border-color: rgba($text-color, 0.2);
+      }
 
-  &:disabled,
-  &:disabled:hover,
-  &.#{$ns}-disabled,
-  &.#{$ns}-disabled:hover {
-    border-color: var(--bp-surface-border-color-default);
-  }
-}
+      .#{$ns}-dark & {
+        border-color: rgba($dark-text-color, 0.6);
 
-@mixin pt-button-outlined-intent($text-color, $dark-text-color) {
-  border-color: rgba($text-color, 0.6);
-
-  &:disabled,
-  &.#{$ns}-disabled {
-    border-color: rgba($text-color, 0.2);
-  }
-
-  .#{$ns}-dark & {
-    border-color: rgba($dark-text-color, 0.6);
-
-    &:disabled,
-    &.#{$ns}-disabled {
-      border-color: rgba($dark-text-color, 0.2);
+        &:disabled,
+        &.#{$ns}-disabled {
+          border-color: rgba($dark-text-color, 0.2);
+        }
+      }
     }
   }
 }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -43,12 +43,12 @@ $dark-button-box-shadow-active:
 // Temporary: warning button rest color needs a pre-computed fallback
 // for browsers that don't support relative color syntax.
 :root {
-  --bp-button-warning-rest: #fbb360;
+  --bp6-button-warning-rest: var(--bp-palete-orange-5); //#fbb360;
 }
 
 @supports (color: oklch(from var(--any-color) l c h)) {
   :root {
-    --bp-button-warning-rest: oklch(
+    --bp6-button-warning-rest: oklch(
       from var(--bp-intent-warning-rest) calc(l + 0.177) calc(c - 0.01) calc(h + 6.26)
     );
   }
@@ -69,7 +69,7 @@ $button-intents: (
     var(--bp-intent-success-foreground),
   ),
   "warning": (
-    var(--bp-button-warning-rest),
+    var(--bp6-button-warning-rest),
     var(--bp-intent-warning-hover),
     var(--bp-intent-warning-active),
     var(--bp-intent-warning-foreground),
@@ -92,7 +92,7 @@ $button-intents: (
 $button-intent-colors: (
   "primary": var(--bp-intent-primary-rest),
   "success": var(--bp-intent-success-rest),
-  "warning": var(--bp-button-warning-rest),
+  "warning": var(--bp6-button-warning-rest),
   "danger": var(--bp-intent-danger-rest),
   "default": var(--bp-intent-default-rest),
 ) !default;
@@ -168,9 +168,9 @@ $button-dark-intent-text-colors: (
 
     &.#{$ns}-active,
     &.#{$ns}-active:hover {
-      background: color-mix(
+      background-color: color-mix(
         in oklch,
-        var(--bp-surface-background-color-default-disabled) 70%,
+        var(--bp-intent-default-disabled) 70%,
         transparent
       );
     }
@@ -183,14 +183,14 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-default-colors() {
-  background: var(--bp-surface-layer-default), var(--bp-surface-background-color-default-rest);
+  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
   box-shadow: $button-box-shadow;
   color: var(--bp-typography-color-default-rest);
 }
 
 @mixin pt-button-hover() {
+  background-color: color-mix(in oklch, var(--bp-intent-default-hover) 8%, white);
   background-clip: padding-box;
-  background: var(--bp-surface-background-color-default-hover);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -198,7 +198,7 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-active() {
-  background: var(--bp-surface-background-color-default-active);
+  background-color: color-mix(in oklch, var(--bp-intent-default-active) 15%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -211,7 +211,7 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-disabled() {
-  background: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
+  background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -296,7 +296,7 @@ $button-dark-intent-text-colors: (
     @include pt-dark-button-disabled;
 
     &.#{$ns}-active {
-      background: color-mix(
+      background-color: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-active) 70%,
         transparent
@@ -311,40 +311,23 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-dark-button-default-colors() {
-  background:
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-background-color-default-rest); // 	~#2b323d
+  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 40%, var(--bp-palette-black));
   box-shadow: $dark-button-box-shadow;
   color: var(--bp-intent-default-foreground);
 }
 
 @mixin pt-dark-button-hover() {
-  background:
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-background-color-default-hover);
+  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 29%, var(--bp-palette-black));
   box-shadow: $dark-button-box-shadow-active;
 }
 
 @mixin pt-dark-button-active() {
-  background:
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-layer-default), var(--bp-surface-layer-default),
-    var(--bp-surface-background-color-default-active);
-
+  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 19%, var(--bp-palette-black));
   box-shadow: $dark-button-box-shadow-active;
 }
 
 @mixin pt-dark-button-disabled() {
-  background: var(--bp-surface-background-color-default-disabled);
+  background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
 }
@@ -354,7 +337,7 @@ $button-dark-intent-text-colors: (
   box-shadow: none;
 
   &:hover {
-    background: color-mix(
+    background-color: color-mix(
       in oklch,
       var(--bp-surface-background-color-default-hover) 15%,
       transparent
@@ -366,7 +349,7 @@ $button-dark-intent-text-colors: (
 
   &:active,
   &.#{$ns}-active {
-    background: color-mix(
+    background-color: color-mix(
       in oklch,
       var(--bp-surface-background-color-default-active) 30%,
       transparent
@@ -384,7 +367,7 @@ $button-dark-intent-text-colors: (
     cursor: not-allowed;
 
     &.#{$ns}-active {
-      background: color-mix(
+      background-color: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-disabled) 30%,
         transparent
@@ -407,7 +390,7 @@ $button-dark-intent-text-colors: (
     }
 
     &:hover {
-      background: color-mix(
+      background-color: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-hover) 15%,
         transparent
@@ -416,7 +399,7 @@ $button-dark-intent-text-colors: (
 
     &:active,
     &.#{$ns}-active {
-      background: color-mix(
+      background-color: color-mix(
         in oklch,
         var(--bp-surface-background-color-default-active) 30%,
         transparent
@@ -432,7 +415,7 @@ $button-dark-intent-text-colors: (
       cursor: not-allowed;
 
       &.#{$ns}-active {
-        background: color-mix(
+        background-color: color-mix(
           in oklch,
           var(--bp-surface-background-color-default-disabled) 30%,
           transparent
@@ -467,13 +450,13 @@ $button-dark-intent-text-colors: (
   }
 
   &:hover {
-    background: color-mix(in oklch, $intent-color 15%, transparent);
+    background-color: color-mix(in oklch, $intent-color 15%, transparent);
     color: $text-color;
   }
 
   &:active,
   &.#{$ns}-active {
-    background: color-mix(in oklch, $intent-color 30%, transparent);
+    background-color: color-mix(in oklch, $intent-color 30%, transparent);
     color: $active-text-color;
   }
 
@@ -483,7 +466,7 @@ $button-dark-intent-text-colors: (
     color: color-mix(in oklch, $text-color 50%, transparent);
 
     &.#{$ns}-active {
-      background: color-mix(in oklch, $intent-color 30%, transparent);
+      background-color: color-mix(in oklch, $intent-color 30%, transparent);
     }
   }
 
@@ -496,13 +479,13 @@ $button-dark-intent-text-colors: (
     color: $dark-text-color;
 
     &:hover {
-      background: color-mix(in oklch, $intent-color 20%, transparent);
+      background-color: color-mix(in oklch, $intent-color 20%, transparent);
       color: $dark-hover-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
-      background: color-mix(in oklch, $intent-color 30%, transparent);
+      background-color: color-mix(in oklch, $intent-color 30%, transparent);
       color: $dark-active-text-color;
     }
 
@@ -512,7 +495,7 @@ $button-dark-intent-text-colors: (
       color: color-mix(in oklch, $dark-text-color 50%, transparent);
 
       &.#{$ns}-active {
-        background: color-mix(in oklch, $intent-color 30%, transparent);
+        background-color: color-mix(in oklch, $intent-color 30%, transparent);
       }
     }
   }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -168,11 +168,7 @@ $button-dark-intent-text-colors: (
 
     &.#{$ns}-active,
     &.#{$ns}-active:hover {
-      background-color: color-mix(
-        in oklch,
-        var(--bp-intent-default-disabled) 70%,
-        transparent
-      );
+      background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 28%, transparent);
     }
   }
 
@@ -296,11 +292,7 @@ $button-dark-intent-text-colors: (
     @include pt-dark-button-disabled;
 
     &.#{$ns}-active {
-      background-color: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-active) 70%,
-        transparent
-      );
+      background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 7%, transparent);
     }
   }
 
@@ -337,11 +329,7 @@ $button-dark-intent-text-colors: (
   box-shadow: none;
 
   &:hover {
-    background-color: color-mix(
-      in oklch,
-      var(--bp-surface-background-color-default-hover) 15%,
-      transparent
-    );
+    background-color: color-mix(in oklch, var(--bp-intent-default-rest) 15%, transparent);
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
     text-decoration: none;
@@ -349,11 +337,7 @@ $button-dark-intent-text-colors: (
 
   &:active,
   &.#{$ns}-active {
-    background-color: color-mix(
-      in oklch,
-      var(--bp-surface-background-color-default-active) 30%,
-      transparent
-    );
+    background-color: color-mix(in oklch, var(--bp-intent-default-rest) 30%, transparent);
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
   }
@@ -367,11 +351,7 @@ $button-dark-intent-text-colors: (
     cursor: not-allowed;
 
     &.#{$ns}-active {
-      background-color: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-disabled) 30%,
-        transparent
-      );
+      background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 30%, transparent);
     }
   }
 
@@ -390,20 +370,12 @@ $button-dark-intent-text-colors: (
     }
 
     &:hover {
-      background-color: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-hover) 15%,
-        transparent
-      );
+      background-color: color-mix(in oklch, var(--bp-intent-default-rest) 15%, transparent);
     }
 
     &:active,
     &.#{$ns}-active {
-      background-color: color-mix(
-        in oklch,
-        var(--bp-surface-background-color-default-active) 30%,
-        transparent
-      );
+      background-color: color-mix(in oklch, var(--bp-intent-default-rest) 30%, transparent);
     }
 
     &:disabled,
@@ -415,11 +387,7 @@ $button-dark-intent-text-colors: (
       cursor: not-allowed;
 
       &.#{$ns}-active {
-        background-color: color-mix(
-          in oklch,
-          var(--bp-surface-background-color-default-disabled) 30%,
-          transparent
-        );
+        background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 30%, transparent);
       }
     }
   }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -241,7 +241,7 @@ $button-dark-minimal-active-text-colors: (
   background-clip: padding-box;
   // Use srgb for consistency with dark theme (avoids hue shift with near-neutral gray)
   /* stylelint-disable-next-line color-named */
-  background-color: color-mix(in srgb, var(--bp-intent-default-hover) 8%, var(--bp-palette-white));
+  background-color: color-mix(in srgb, var(--bp-intent-default-hover) 9%, var(--bp-palette-white));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
@@ -342,7 +342,7 @@ $button-dark-minimal-active-text-colors: (
   &.#{$ns}-active {
     // Use srgb to avoid hue shift with near-neutral gray
     /* stylelint-disable-next-line color-named */
-    color: color-mix(in srgb, var(--bp-intent-default-hover) 7%, var(--bp-palette-white));
+    color: color-mix(in srgb, var(--bp-intent-default-hover) 4%, var(--bp-palette-white));
   }
 
   &:hover {
@@ -373,7 +373,7 @@ $button-dark-minimal-active-text-colors: (
     ); //$dark-progress-track-color;
     stroke: color-mix(
       in srgb,
-      var(--bp-intent-default-rest) 55%,
+      var(--bp-intent-default-rest) 68%,
       var(--bp-palette-white)
     ); //$dark-progress-head-color;
   }
@@ -391,7 +391,7 @@ $button-dark-minimal-active-text-colors: (
 
 @mixin pt-dark-button-hover() {
   // Use srgb instead of oklch to avoid hue shift with near-neutral dark colors
-  background-color: color-mix(in srgb, var(--bp-intent-default-hover) 53%, var(--bp-palette-black));
+  background-color: color-mix(in srgb, var(--bp-intent-default-hover) 42%, var(--bp-palette-black));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
@@ -402,7 +402,7 @@ $button-dark-minimal-active-text-colors: (
   // Use srgb instead of oklch to avoid hue shift with near-neutral dark colors
   background-color: color-mix(
     in srgb,
-    var(--bp-intent-default-active) 44%,
+    var(--bp-intent-default-active) 30%,
     var(--bp-palette-black)
   );
   box-shadow:
@@ -424,7 +424,7 @@ $button-dark-minimal-active-text-colors: (
 
   &:hover {
     // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-    background-color: color-mix(in srgb, var(--bp-intent-default-hover) 21%, transparent);
+    background-color: color-mix(in srgb, var(--bp-intent-default-hover) 8%, transparent);
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
     text-decoration: none;
@@ -433,7 +433,7 @@ $button-dark-minimal-active-text-colors: (
   &:active,
   &.#{$ns}-active {
     // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-    background-color: color-mix(in srgb, var(--bp-intent-default-active) 47%, transparent);
+    background-color: color-mix(in srgb, var(--bp-intent-default-active) 16%, transparent);
     box-shadow: none;
     color: var(--bp-typography-color-default-rest);
   }
@@ -467,13 +467,15 @@ $button-dark-minimal-active-text-colors: (
 
     &:hover {
       // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-      background-color: color-mix(in srgb, var(--bp-intent-default-hover) 21%, transparent);
+      // Higher % than light theme because base color is close to dark backgrounds
+      background-color: color-mix(in srgb, var(--bp-intent-default-hover) 15%, transparent);
     }
 
     &:active,
     &.#{$ns}-active {
       // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-      background-color: color-mix(in srgb, var(--bp-intent-default-active) 47%, transparent);
+      // Higher % than light theme because base color is close to dark backgrounds
+      background-color: color-mix(in srgb, var(--bp-intent-default-active) 30%, transparent);
     }
 
     &:disabled,

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -228,7 +228,6 @@ $button-dark-minimal-active-text-colors: (
 
 @mixin pt-button-default-colors() {
   // Use srgb for consistency with dark theme (avoids hue shift with near-neutral gray)
-  /* stylelint-disable-next-line color-named */
   background-color: color-mix(in srgb, var(--bp-intent-default-rest) 5%, var(--bp-palette-white));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -240,7 +239,6 @@ $button-dark-minimal-active-text-colors: (
 @mixin pt-button-hover() {
   background-clip: padding-box;
   // Use srgb for consistency with dark theme (avoids hue shift with near-neutral gray)
-  /* stylelint-disable-next-line color-named */
   background-color: color-mix(in srgb, var(--bp-intent-default-hover) 9%, var(--bp-palette-white));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -249,8 +247,7 @@ $button-dark-minimal-active-text-colors: (
 }
 
 @mixin pt-button-active() {
-  // TODO: Consider changing color channels for color mix
-  /* stylelint-disable-next-line color-named */
+  // Use srgb to avoid hue shift with near-neutral gray
   background-color: color-mix(
     in srgb,
     var(--bp-intent-default-active) 16%,
@@ -341,7 +338,6 @@ $button-dark-minimal-active-text-colors: (
   &:active,
   &.#{$ns}-active {
     // Use srgb to avoid hue shift with near-neutral gray
-    /* stylelint-disable-next-line color-named */
     color: color-mix(in srgb, var(--bp-intent-default-hover) 4%, var(--bp-palette-white));
   }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -38,13 +38,16 @@ $minimal-button-background-color-active: rgba($gray3, 0.3) !default;
 
 // Exported for slider
 $button-box-shadow:
-  inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+  inset 0 0 0 var(--bp-surface-border-width)
+    color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
   0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent) !default;
 $dark-button-box-shadow:
-  inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+  inset 0 0 0 var(--bp-surface-border-width)
+    color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
   0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent) !default;
 $dark-button-box-shadow-active:
-  inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+  inset 0 0 0 var(--bp-surface-border-width)
+    color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
   0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent) !default;
 
 // "intent": (default, hover, active colors)
@@ -125,7 +128,11 @@ $button-intents: (
 
     &.#{$ns}-active,
     &.#{$ns}-active:hover {
-      background: color-mix(in oklch, var(--bp-surface-background-color-default-disabled) 70%, transparent);
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-disabled) 70%,
+        transparent
+      );
     }
   }
 
@@ -145,14 +152,16 @@ $button-intents: (
   background-clip: padding-box;
   background-color: var(--bp-surface-background-color-default-hover);
   box-shadow:
-    inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 }
 
 @mixin pt-button-active() {
   background-color: var(--bp-surface-background-color-default-active);
   box-shadow:
-    inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    inset 0 0 0 var(--bp-surface-border-width)
+      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -183,7 +192,8 @@ $button-intents: (
   &:hover {
     background-color: $hover-color;
     box-shadow:
-      inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      inset 0 0 0 var(--bp-surface-border-width)
+        color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
       0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   }
 
@@ -191,7 +201,8 @@ $button-intents: (
   &.#{$ns}-active {
     background-color: $active-color;
     box-shadow:
-      inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      inset 0 0 0 var(--bp-surface-border-width)
+        color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
       0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   }
 
@@ -244,7 +255,11 @@ $button-intents: (
     @include pt-dark-button-disabled;
 
     &.#{$ns}-active {
-      background: color-mix(in oklch, var(--bp-surface-background-color-default-active) 70%, transparent);
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-active) 70%,
+        transparent
+      );
     }
   }
 
@@ -310,7 +325,11 @@ $button-intents: (
     text-decoration: none;
 
     @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 15%, transparent);
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 15%,
+        transparent
+      );
     }
   }
 
@@ -321,7 +340,11 @@ $button-intents: (
     color: var(--bp-typography-color-default-rest);
 
     @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 30%,
+        transparent
+      );
     }
   }
 
@@ -337,7 +360,11 @@ $button-intents: (
       background: $minimal-button-background-color-active;
 
       @supports (background: color-mix(in oklch, red, transparent)) {
-        background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+        background: color-mix(
+          in oklch,
+          var(--bp-surface-background-color-default-rest) 30%,
+          transparent
+        );
       }
     }
   }
@@ -370,7 +397,11 @@ $button-intents: (
     background: $minimal-button-background-color-hover;
 
     @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 15%, transparent);
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 15%,
+        transparent
+      );
     }
   }
 
@@ -379,7 +410,11 @@ $button-intents: (
     background: $minimal-button-background-color-active;
 
     @supports (background: color-mix(in oklch, red, transparent)) {
-      background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+      background: color-mix(
+        in oklch,
+        var(--bp-surface-background-color-default-rest) 30%,
+        transparent
+      );
     }
   }
 
@@ -395,7 +430,11 @@ $button-intents: (
       background: $minimal-button-background-color-active;
 
       @supports (background: color-mix(in oklch, red, transparent)) {
-        background: color-mix(in oklch, var(--bp-surface-background-color-default-rest) 30%, transparent);
+        background: color-mix(
+          in oklch,
+          var(--bp-surface-background-color-default-rest) 30%,
+          transparent
+        );
       }
     }
   }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -67,6 +67,44 @@ $button-intents: (
     var(--bp-intent-danger-hover),
     var(--bp-intent-danger-active),
   ),
+  "default": (
+    var(--bp-intent-default-rest),
+    var(--bp-intent-default-hover),
+    var(--bp-intent-default-active),
+  ),
+) !default;
+
+// Based off of `$pt-` variables in common/_mixins.scss
+$button-intent-colors: (
+  "primary": var(--bp-intent-primary-rest),
+  "success": var(--bp-intent-success-rest),
+  "warning": var(--bp-intent-warning-rest),
+  "danger": var(--bp-intent-danger-rest),
+  "default": var(--bp-intent-default-rest),
+) !default;
+
+$button-intent-text-colors: (
+  "primary": var(--bp-intent-primary-hover),
+  "success": var(--bp-intent-success-hover),
+  "warning": var(--bp-intent-warning-hover),
+  "danger": var(--bp-intent-danger-hover),
+  "default": var(--bp-intent-default-hover),
+) !default;
+
+$button-intent-active-text-colors: (
+  "primary": var(--bp-intent-primary-active),
+  "success": var(--bp-intent-success-active),
+  "warning": var(--bp-intent-warning-active),
+  "danger": var(--bp-intent-danger-active),
+  "default": var(--bp-intent-default-active),
+) !default;
+
+$button-dark-intent-text-colors: (
+  "primary": color-mix(in oklch, var(--bp-intent-primary-rest) 51%, white),
+  "success": color-mix(in oklch, var(--bp-intent-success-rest) 54%, white),
+  "warning": color-mix(in oklch, var(--bp-intent-warning-rest) 53%, white),
+  "danger": color-mix(in oklch, var(--bp-intent-danger-rest) 53%, white),
+  "default": color-mix(in oklch, var(--bp-intent-default-rest) 53%, white),
 ) !default;
 
 @mixin pt-button-layout() {
@@ -285,7 +323,7 @@ $button-intents: (
   ); // fallback for browsers without oklch relative color support
   background-color: color-mix(
     in oklch,
-    var(--bp-surface-background-color-default-active) 15%,
+    var(--bp-surface-background-color-default-disabled) 15%,
     transparent
   );
   box-shadow: none;
@@ -300,7 +338,7 @@ $button-intents: (
     background: $minimal-button-background-color-hover;
     background: color-mix(
       in oklch,
-      var(--bp-surface-background-color-default-rest) 15%,
+      var(--bp-surface-background-color-default-hover) 15%,
       transparent
     );
     box-shadow: none;
@@ -313,7 +351,7 @@ $button-intents: (
     background: $minimal-button-background-color-active;
     background: color-mix(
       in oklch,
-      var(--bp-surface-background-color-default-rest) 30%,
+      var(--bp-surface-background-color-default-active) 30%,
       transparent
     );
     box-shadow: none;
@@ -332,7 +370,7 @@ $button-intents: (
       background: $minimal-button-background-color-active;
       background: color-mix(
         in oklch,
-        var(--bp-surface-background-color-default-rest) 30%,
+        var(--bp-surface-background-color-default-disabled) 30%,
         transparent
       );
     }
@@ -352,20 +390,20 @@ $button-intents: (
     }
 
     &:hover {
-      background: $minimal-button-background-color-hover;
+      background: $dark-minimal-button-background-color-hover;
       background: color-mix(
         in oklch,
-        var(--bp-surface-background-color-default-rest) 15%,
+        var(--bp-surface-background-color-default-hover) 15%,
         transparent
       );
     }
 
     &:active,
     &.#{$ns}-active {
-      background: $minimal-button-background-color-active;
+      background: $dark-minimal-button-background-color-active;
       background: color-mix(
         in oklch,
-        var(--bp-surface-background-color-default-rest) 30%,
+        var(--bp-surface-background-color-default-active) 30%,
         transparent
       );
     }
@@ -379,10 +417,10 @@ $button-intents: (
       cursor: not-allowed;
 
       &.#{$ns}-active {
-        background: $minimal-button-background-color-active;
+        background: $dark-minimal-button-background-color-active;
         background: color-mix(
           in oklch,
-          var(--bp-surface-background-color-default-rest) 30%,
+          var(--bp-surface-background-color-default-disabled) 30%,
           transparent
         );
       }
@@ -397,10 +435,10 @@ $button-intents: (
 }
 
 @mixin pt-button-minimal-intent($intent) {
-  $intent-color: map.get($pt-intent-colors, $intent);
-  $text-color: map.get($pt-intent-text-colors, $intent);
-  $active-text-color: map.get($pt-intent-active-text-colors, $intent);
-  $dark-text-color: map.get($pt-dark-intent-text-colors, $intent);
+  $intent-color: map.get($button-intent-colors, $intent);
+  $text-color: map.get($button-intent-text-colors, $intent);
+  $active-text-color: map.get($button-intent-active-text-colors, $intent);
+  $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
   $dark-active-text-color: var(--bp-intent-#{$intent}-active);
   $dark-hover-text-color: var(--bp-intent-#{$intent}-hover);
 
@@ -415,23 +453,23 @@ $button-intents: (
   }
 
   &:hover {
-    background: rgba($intent-color, 0.15);
+    background: color-mix(in oklch, $intent-color 15%, transparent);
     color: $text-color;
   }
 
   &:active,
   &.#{$ns}-active {
-    background: rgba($intent-color, 0.3);
+    background: color-mix(in oklch, $intent-color 30%, transparent);
     color: $active-text-color;
   }
 
   &:disabled,
   &.#{$ns}-disabled {
     background: none;
-    color: rgba($text-color, 0.5);
+    color: color-mix(in oklch, $text-color 50%, transparent);
 
     &.#{$ns}-active {
-      background: rgba($intent-color, 0.3);
+      background: color-mix(in oklch, $intent-color 30%, transparent);
     }
   }
 
@@ -443,23 +481,23 @@ $button-intents: (
     color: $dark-text-color;
 
     &:hover {
-      background: rgba($intent-color, 0.2);
+      background: color-mix(in oklch, $intent-color 20%, transparent);
       color: $dark-hover-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
-      background: rgba($intent-color, 0.3);
+      background: color-mix(in oklch, $intent-color 30%, transparent);
       color: $dark-active-text-color;
     }
 
     &:disabled,
     &.#{$ns}-disabled {
       background: none;
-      color: rgba($dark-text-color, 0.5);
+      color: color-mix(in oklch, $dark-text-color 50%, transparent);
 
       &.#{$ns}-active {
-        background: rgba($intent-color, 0.3);
+        background: color-mix(in oklch, $intent-color 30%, transparent);
       }
     }
   }
@@ -489,22 +527,22 @@ $button-intents: (
 
   @each $intent, $colors in $button-intents {
     $text-color: map.get($pt-intent-text-colors, $intent);
-    $dark-text-color: map.get($pt-dark-intent-text-colors, $intent);
+    $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
 
     &.#{$ns}-intent-#{$intent} {
-      border-color: rgba($text-color, 0.6);
+      border-color: color-mix(in oklch, $text-color 60%, transparent);
 
       &:disabled,
       &.#{$ns}-disabled {
-        border-color: rgba($text-color, 0.2);
+        border-color: color-mix(in oklch, $text-color 20%, transparent);
       }
 
       .#{$ns}-dark & {
-        border-color: rgba($dark-text-color, 0.6);
+        border-color: color-mix(in oklch, $dark-text-color 60%, transparent);
 
         &:disabled,
         &.#{$ns}-disabled {
-          border-color: rgba($dark-text-color, 0.2);
+          border-color: color-mix(in oklch, $dark-text-color 20%, transparent);
         }
       }
     }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -26,7 +26,7 @@ $minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !de
 $dark-minimal-button-background-color-hover: rgba(var(--bp-palette-gray-3), 0.15) !default;
 $dark-minimal-button-background-color-active: rgba(var(--bp-palette-gray-3), 0.3) !default;
 
-// Exported for slider, replaced below
+// Exported for slider, kept original, replaced with surface tokens below
 $button-box-shadow:
   inset 0 0 0 var(--bp-surface-border-width)
     color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -183,7 +183,7 @@ $button-dark-intent-text-colors: (
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
   color: var(--bp-typography-color-default-rest);
 }
@@ -194,7 +194,7 @@ $button-dark-intent-text-colors: (
   background-color: color-mix(in oklch, var(--bp-intent-default-hover) 8%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 }
 
@@ -204,7 +204,7 @@ $button-dark-intent-text-colors: (
   background-color: color-mix(in srgb, var(--bp-intent-default-active) 15%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -230,7 +230,7 @@ $button-dark-intent-text-colors: (
   background-color: $default-color;
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
   color: $text-color;
 
@@ -244,7 +244,7 @@ $button-dark-intent-text-colors: (
     background-color: $hover-color;
     box-shadow:
       inset 0 0 0 var(--bp-surface-border-width)
-        color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+        color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
       0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   }
 
@@ -253,7 +253,7 @@ $button-dark-intent-text-colors: (
     background-color: $active-color;
     box-shadow:
       inset 0 0 0 var(--bp-surface-border-width)
-        color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+        color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
       0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   }
 
@@ -325,7 +325,7 @@ $button-dark-intent-text-colors: (
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 40%, var(--bp-palette-black));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 20%, transparent);
   color: var(--bp-intent-default-foreground);
 }
@@ -334,7 +334,7 @@ $button-dark-intent-text-colors: (
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 29%, var(--bp-palette-black));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent);
 }
 
@@ -342,7 +342,7 @@ $button-dark-intent-text-colors: (
   background-color: color-mix(in oklch, var(--bp-intent-default-rest) 19%, var(--bp-palette-black));
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
-      color-mix(in oklch, var(--bp-palette-white) 10%, transparent),
+      color-mix(in oklch, var(--bp-surface-border-color-default) 50%, transparent),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 40%, transparent);
 }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -61,35 +61,30 @@ $button-intents: (
     var(--bp-intent-primary-hover),
     var(--bp-intent-primary-active),
     var(--bp-intent-primary-foreground),
-    var(--bp-intent-primary-disabled),
   ),
   "success": (
     var(--bp-intent-success-rest),
     var(--bp-intent-success-hover),
     var(--bp-intent-success-active),
     var(--bp-intent-success-foreground),
-    var(--bp-intent-success-disabled),
   ),
   "warning": (
     var(--bp-button-warning-rest),
     var(--bp-intent-warning-hover),
     var(--bp-intent-warning-active),
     var(--bp-intent-warning-foreground),
-    var(--bp-intent-warning-disabled),
   ),
   "danger": (
     var(--bp-intent-danger-rest),
     var(--bp-intent-danger-hover),
     var(--bp-intent-danger-active),
     var(--bp-intent-danger-foreground),
-    var(--bp-intent-danger-disabled),
   ),
   "default": (
     var(--bp-intent-default-rest),
     var(--bp-intent-default-hover),
     var(--bp-intent-default-active),
     var(--bp-intent-default-foreground),
-    var(--bp-intent-default-disabled),
   ),
 ) !default;
 
@@ -195,7 +190,7 @@ $button-dark-intent-text-colors: (
 
 @mixin pt-button-hover() {
   background-clip: padding-box;
-  background-color: var(--bp-surface-background-color-default-hover);
+  background: var(--bp-surface-background-color-default-hover);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -203,7 +198,7 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-active() {
-  background-color: var(--bp-surface-background-color-default-active);
+  background: var(--bp-surface-background-color-default-active);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -216,14 +211,19 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-disabled() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
+  background: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
   outline: none;
 }
 
-@mixin pt-button-intent($default-color, $hover-color, $active-color, $text-color, $disabled-color) {
+@mixin pt-button-intent(
+  $default-color,
+  $hover-color,
+  $active-color,
+  $text-color: var(--bp-palette-white)
+) {
   background-color: $default-color;
   box-shadow: $button-box-shadow;
   color: $text-color;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -194,7 +194,8 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-active() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-active) 15%, white);
+  // TODO: Consider changing color channels for color mix
+  background-color: color-mix(in srgb, var(--bp-intent-default-active) 15%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -470,7 +471,7 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-outlined() {
-  border: var(--bp-surface-border-width) solid var(--bp-surface-border-color-default);
+  border: var(--bp-surface-border-width) solid var(--bp-surface-border-color-strong);
   box-sizing: border-box;
 
   &:disabled,

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -276,11 +276,11 @@ $button-dark-intent-text-colors: (
 @mixin pt-dark-button() {
   @include pt-dark-button-default-colors;
 
-  // &:hover,
-  // &:active,
-  // &.#{$ns}-active {
-  //   color: var(--bp-typography-color-default-rest);
-  // }
+  &:hover,
+  &:active,
+  &.#{$ns}-active {
+    color: color-mix(in oklch, var(--bp-intent-default-rest) 5%, white);
+  }
 
   &:hover {
     @include pt-dark-button-hover;

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -7,12 +7,19 @@
 @import "../../common/variables-extended";
 @import "../progress-bar/common";
 
-$button-border-width: 1px !default;
+$button-border-width: var(--bp-surface-borderWidth) !default;
 $button-padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2) !default;
 $button-padding-small: 0 calc(var(--bp-surface-spacing) * 2) !default;
 $button-padding-large: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 4) !default;
 $button-icon-spacing: calc(var(--bp-surface-spacing) * 2) !default;
 $button-icon-spacing-large: calc(var(--bp-surface-spacing) * 2) !default;
+
+// TODO: These height variables are temporary, but since `$pt-button-height-...` are used to define other components,
+// this is scoping the variables here
+$button-height: calc(var(--bp-surface-spacing) * 7.5) !default;
+$button-height-small: calc(var(--bp-surface-spacing) * 6) !default;
+$button-height-smaller: calc(var(--bp-surface-spacing) * 5) !default;
+$button-height-large: calc(var(--bp-surface-spacing) * 10) !default;
 
 /*
 CSS `border` property issues:
@@ -37,28 +44,42 @@ $dark-button-box-shadow-active:
   inset 0 0 0 $button-border-width oklch(from var(--bp-palette-gray-100) l c h / 0.1),
   0 1px 2px oklch(from var(--bp-palette-gray-1000) l c h / 0.4) !default;
 
-$button-color-disabled: var(--bp-typography-colorDisabled-default) !default;
+$button-color-disabled: var(
+  --bp-typography-colorDisabled-default
+) !default; //TODO: Used in forms and html-select, should remove
 $button-background-color: var(--bp-surface-colorRest-default) !default;
 $button-background-color-hover: var(--bp-surface-colorHover-default) !default;
 $button-background-color-active: var(--bp-surface-colorActive-default) !default;
-$button-background-color-disabled: rgba($light-gray1, 0.5) !default;
-$button-background-color-active-disabled: rgba($light-gray1, 0.7) !default;
-$button-intent-color-disabled: oklch(from var(--bp-palette-gray-100) l c h / 0.6);
+$button-background-color-disabled: oklch(
+  from var(--bp-surface-colorDisabled-default) l c h / 0.5
+) !default;
+$button-background-color-active-disabled: oklch(
+  from var(--bp-surface-colorDisabled-default) l c h / 0.7
+) !default;
+$button-intent-color-disabled: oklch(from var(--bp-intent-default-foreground) l c h / 0.6);
 $dark-button-color-disabled: var(--bp-typography-colorDisabled-default) !default;
-$dark-button-background-color: var(--bp-palette-gray-700) !default;
-$dark-button-background-color-hover: var(--bp-palette-gray-600) !default;
-$dark-button-background-color-active: var(--bp-palette-gray-800) !default;
-$dark-button-background-color-disabled: rgba($dark-gray3, 0.15) !default;
-$dark-button-background-color-active-disabled: rgba($dark-gray3, 0.7) !default;
-$dark-button-intent-color-disabled: oklch(from var(--bp-palette-gray-100) l c h / 0.3);
+$dark-button-background-color: var(--bp-surface-colorActive-default) !default;
+$dark-button-background-color-hover: var(--bp-surface-colorHover-default) !default;
+$dark-button-background-color-active: var(--bp-surface-colorRest-default) !default;
+$dark-button-background-color-disabled: oklch(
+  from var(--bp-surface-colorActive-default) l c h / 0.15
+) !default;
+$dark-button-background-color-active-disabled: oklch(
+  from var(--bp-surface-colorActive-default) l c h / 0.7
+) !default;
+$dark-button-intent-color-disabled: oklch(from var(--bp-intent-default-foreground) l c h / 0.3);
 
 $minimal-button-divider-width: var(--bp-surface-borderWidth) !default;
 $minimal-button-background-color: none !default;
 $minimal-button-background-color-hover: var(--bp-surface-depthLayer-default) !default;
-$minimal-button-background-color-active: oklch(from var(--bp-intent-default-rest) l c h / 0.15) !default;
+$minimal-button-background-color-active: oklch(
+  from var(--bp-intent-default-rest) l c h / 0.15
+) !default;
 $dark-minimal-button-background-color: none !default;
 $dark-minimal-button-background-color-hover: var(--bp-surface-depthLayer-default) !default;
-$dark-minimal-button-background-color-active: oklch(from var(--bp-intent-default-rest) l c h / 0.15) !default;
+$dark-minimal-button-background-color-active: oklch(
+  from var(--bp-intent-default-rest) l c h / 0.15
+) !default;
 
 $button-outlined-width: var(--bp-surface-borderWidth) !default;
 $button-outlined-border-intent-opacity: 0.6 !default;
@@ -108,19 +129,19 @@ $button-intents: (
 }
 
 @mixin pt-button-height-large() {
-  @include pt-button-height($pt-button-height-large);
+  @include pt-button-height($button-height-large);
   @include pt-flex-margin(row, $button-icon-spacing-large);
   font-size: $pt-font-size-large;
   padding: $button-padding-large;
 }
 
 @mixin pt-button-height-default() {
-  @include pt-button-height($pt-button-height);
+  @include pt-button-height($button-height);
   padding: $button-padding;
 }
 
 @mixin pt-button-height-small() {
-  @include pt-button-height($pt-button-height-small);
+  @include pt-button-height($button-height-small);
   padding: $button-padding-small;
 }
 
@@ -178,7 +199,7 @@ $button-intents: (
 @mixin pt-button-disabled() {
   background-color: $button-background-color-disabled;
   box-shadow: none;
-  color: $button-color-disabled;
+  color: var(--bp-typography-colorDisabled-default);
   cursor: not-allowed;
   outline: none;
 }
@@ -186,12 +207,12 @@ $button-intents: (
 @mixin pt-button-intent($default-color, $hover-color, $active-color) {
   background-color: $default-color;
   box-shadow: $button-box-shadow;
-  color: $white;
+  color: var(--bp-intent-primary-foreground);
 
   &:hover,
   &:active,
   &.#{$ns}-active {
-    color: $white;
+    color: var(--bp-intent-primary-foreground);
   }
 
   &:hover {
@@ -354,14 +375,14 @@ $button-intents: (
 @mixin pt-dark-button-minimal() {
   background: $dark-minimal-button-background-color;
   box-shadow: none;
-  color: $white;
+  color: var(--bp-intent-default-foreground);
 
   &:hover,
   &:active,
   &.#{$ns}-active {
     background: none;
     box-shadow: none;
-    color: $white;
+    color: var(--bp-intent-default-foreground);
   }
 
   &:hover {
@@ -388,17 +409,17 @@ $button-intents: (
 }
 
 $dark-minimal-hover-text-colors: (
-  "primary": $blue5,
-  "success": $green5,
-  "warning": $orange5,
-  "danger": $red5,
+  "primary": var(--bp-intent-primary-hover),
+  "success": var(--bp-intent-success-hover),
+  "warning": var(--bp-intent-warning-hover),
+  "danger": var(--bp-intent-danger-hover),
 );
 
 $dark-minimal-active-text-colors: (
-  "primary": $blue6,
-  "success": $green6,
-  "warning": $orange6,
-  "danger": $red6,
+  "primary": var(--bp-intent-primary-active),
+  "success": var(--bp-intent-success-active),
+  "warning": var(--bp-intent-warning-active),
+  "danger": var(--bp-intent-danger-active),
 );
 
 @mixin pt-button-minimal-intent($intent) {
@@ -472,25 +493,21 @@ $dark-minimal-active-text-colors: (
 
 @mixin pt-button-minimal-divider() {
   $divider-height: calc(var(--bp-surface-spacing) * 5);
-  background: $pt-divider-black;
+  background: var(--bp-surface-borderColor-default);
 
-  margin: calc((#{$pt-button-height} - #{$divider-height}) * 0.5);
+  margin: calc((#{$button-height} - #{$divider-height}) * 0.5);
   width: $minimal-button-divider-width;
-
-  .#{$ns}-dark & {
-    background: $pt-dark-divider-white;
-  }
 }
 
 @mixin pt-button-outlined() {
-  border: $button-outlined-width solid rgba($pt-text-color, 0.2);
+  border: $button-outlined-width solid var(--bp-surface-borderColor-default);
   box-sizing: border-box;
 
   &:disabled,
   &.#{$ns}-disabled,
   &:disabled:hover,
   &.#{$ns}-disabled:hover {
-    border-color: rgba($pt-text-color-disabled, 0.1);
+    border-color: var(--bp-surface-borderColor-default);
   }
 
   .#{$ns}-dark & {
@@ -508,13 +525,13 @@ $dark-minimal-active-text-colors: (
 }
 
 @mixin pt-dark-button-outlined() {
-  border-color: rgba($white, 0.4);
+  border-color: var(--bp-surface-borderColor-strong);
 
   &:disabled,
   &:disabled:hover,
   &.#{$ns}-disabled,
   &.#{$ns}-disabled:hover {
-    border-color: rgba($white, 0.2);
+    border-color: var(--bp-surface-borderColor-default);
   }
 }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -8,7 +8,7 @@
 @import "../progress-bar/common";
 
 // These variables are exported for use by other components (slider, forms, html-select, etc.)
-$button-border-width: var(--bp-surface-border-width) !default;
+$button-border-width: 1px !default; //TODO: Update to var(--bp-surface-border-width) !default; when all instances use calc
 
 // Exported for forms/_input-group.scss
 $button-padding-small: 0 calc(var(--bp-surface-spacing) * 2) !default;
@@ -185,8 +185,9 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-hover() {
-  background-color: color-mix(in oklch, var(--bp-intent-default-hover) 8%, white);
   background-clip: padding-box;
+  /* stylelint-disable-next-line color-named */
+  background-color: color-mix(in oklch, var(--bp-intent-default-hover) 8%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
       color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
@@ -195,6 +196,7 @@ $button-dark-intent-text-colors: (
 
 @mixin pt-button-active() {
   // TODO: Consider changing color channels for color mix
+  /* stylelint-disable-next-line color-named */
   background-color: color-mix(in srgb, var(--bp-intent-default-active) 15%, white);
   box-shadow:
     inset 0 0 0 var(--bp-surface-border-width)
@@ -208,6 +210,7 @@ $button-dark-intent-text-colors: (
 }
 
 @mixin pt-button-disabled() {
+  /* stylelint-disable-next-line color-named */
   background-color: color-mix(in oklch, var(--bp-intent-default-disabled) 20%, transparent);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);

--- a/packages/core/src/design-tokens/README.md
+++ b/packages/core/src/design-tokens/README.md
@@ -34,15 +34,55 @@ pnpm run build:tokens  # Generate tokens
 
 ## Additional Notes
 
-### Distribution
+### Token Structure
 
-The output is named with an underscore prefix (`_tokens.scss`) to follow the SCSS partial convention. This ensures the token definitions are **inlined** during SCSS compilation rather than left as a CSS `@import` statement (which would cause path resolution issues in the compiled output).
+Tokens follow the [DTCG](https://tr.designtokens.org/format/) specification. Source files live in `tokens/base/` (5 files: palette, intent, surface, typography, emphasis) with theme overrides in `tokens/themes/` (which currently includes only dark tokens).
 
-**Source:** `src/design-tokens/tokens/*.json`
+Each token uses these standard DTCG properties:
+
+| Property       | Purpose                                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| `$type`        | Data type: `color`, `dimension`, `shadow`, `fontFamily`, `fontWeight`, `number`, `duration`, `cubicBezier` |
+| `$value`       | The token value — a literal, a reference like `"{palette.blue.3}"`, or a complex object                    |
+| `$description` | Human-readable explanation                                                                                 |
+| `$extensions`  | Custom Blueprint metadata                                                                                  |
+
+#### Custom extensions
+
+**`com.blueprint.derive`** — derives a new color from the referenced `$value` using OKLCH color space transforms:
+
+```json
+{
+    "$value": "{intent.default.rest}",
+    "$extensions": {
+        "com.blueprint.derive": {
+            "alpha": 0.25
+        }
+    }
+}
+```
+
+Available derivation properties: `alpha`, `lightnessScale`, `chromaScale`, `lightnessOffset`, `chromaOffset`, `hueOffset`. These are applied during build to produce both a static hex fallback and a relative color syntax expression (`oklch(from ...)`).
+
+**`com.blueprint.role`** — assigns special build handling to a token. Currently one role exists:
+
+- `"stackable-layer"` — wraps the compiled color in `linear-gradient(color 0 0)` so it can be composited as a `background-image` layer.
+
+#### Theme overrides
+
+Dark mode files in `tokens/themes/dark/` override base tokens by redefining `$value` and/or `$extensions`. For example, `surface.border-color.strong` changes from gray-based in light mode to white-based in dark mode:
+
+```json
+// base/surface.tokens.json
+"strong": { "$value": "{intent.default.rest}", "$extensions": { "com.blueprint.derive": { "alpha": 0.25 } } }
+
+// themes/dark/surface.tokens.json
+"strong": { "$value": "{palette.white}", "$extensions": { "com.blueprint.derive": { "alpha": 0.3 } } }
+```
 
 ### Browser Compatibility
 
-Some tokens use the CSS [relative color syntax(https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) (`oklch(from ...)`) for deriving hover, active, and alpha-modified colors. This requires:
+Some tokens use the CSS [relative color syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) (`oklch(from ...)`) for deriving hover, active, and alpha-modified colors. This requires:
 
 | Browser | Minimum Version |
 | ------- | --------------- |

--- a/packages/core/src/design-tokens/README.md
+++ b/packages/core/src/design-tokens/README.md
@@ -2,11 +2,7 @@
 
 Blueprint design tokens generated with [Style Dictionary](https://styledictionary.com/).
 
-## Output
-
-The tokens are compiled to `dist/_tokens.scss`, a SCSS partial that gets inlined into `blueprint.css` during compilation.
-
-## Usage
+## Configuration
 
 Tokens are available as CSS custom properties on `:root`:
 

--- a/packages/core/src/design-tokens/README.md
+++ b/packages/core/src/design-tokens/README.md
@@ -56,9 +56,3 @@ Some tokens use the CSS [relative color syntax(https://developer.mozilla.org/en-
 | Edge    | 122+            |
 
 Older browsers will ignore these property values. Within Blueprint components, there will be fallback values provided. Outside of Blueprint, you may need to provide your own fallbacks.
-
-### Migration Notes
-
-#### Button
-
-- Dark background colors are currently using a combination of `var(--bp-surface-layer-default)` and `var(--bp-surface-background-color-default-rest)` to achieve a similar effect to the previous single token. This is due to the fact that the new tokens are designed to be more atomic and composable, rather than providing pre-combined values. The exact combination may need to be adjusted based on the desired visual outcome.

--- a/packages/core/src/design-tokens/README.md
+++ b/packages/core/src/design-tokens/README.md
@@ -12,23 +12,23 @@ Tokens are available as CSS custom properties on `:root`:
 
 ```css
 .element {
-  color: var(--bp-typography-color-default-rest);
-  background: var(--bp-surface-background-color-default-rest);
-  border-radius: var(--bp-surface-border-radius);
-  padding: calc(var(--bp-surface-spacing) * 2);
+    color: var(--bp-typography-color-default-rest);
+    background: var(--bp-surface-background-color-default-rest);
+    border-radius: var(--bp-surface-border-radius);
+    padding: calc(var(--bp-surface-spacing) * 2);
 }
 ```
 
 ## Token Categories
 
-| Category | Prefix | Description |
-|----------|--------|-------------|
-| Palette | `--bp-palette-*` | Raw color values (gray, blue, green, etc.) |
-| Intent | `--bp-intent-*` | Semantic colors (primary, success, warning, danger) |
-| Surface | `--bp-surface-*` | Backgrounds, borders, shadows, spacing, z-index |
-| Typography | `--bp-typography-*` | Font families, sizes, weights, line heights, colors |
-| Iconography | `--bp-iconography-*` | Icon sizes and colors |
-| Emphasis | `--bp-emphasis-*` | Focus rings, transitions, easing |
+| Category    | Prefix               | Description                                         |
+| ----------- | -------------------- | --------------------------------------------------- |
+| Palette     | `--bp-palette-*`     | Raw color values (gray, blue, green, etc.)          |
+| Intent      | `--bp-intent-*`      | Semantic colors (primary, success, warning, danger) |
+| Surface     | `--bp-surface-*`     | Backgrounds, borders, shadows, spacing, z-index     |
+| Typography  | `--bp-typography-*`  | Font families, sizes, weights, line heights, colors |
+| Iconography | `--bp-iconography-*` | Icon sizes and colors                               |
+| Emphasis    | `--bp-emphasis-*`    | Focus rings, transitions, easing                    |
 
 ## Development
 
@@ -49,10 +49,16 @@ The output is named with an underscore prefix (`_tokens.scss`) to follow the SCS
 Some tokens use the CSS [relative color syntax(https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Relative_colors) (`oklch(from ...)`) for deriving hover, active, and alpha-modified colors. This requires:
 
 | Browser | Minimum Version |
-|---------|-----------------|
-| Chrome  | 122+ |
-| Safari  | 18+ |
-| Firefox | 128+ |
-| Edge    | 122+ |
+| ------- | --------------- |
+| Chrome  | 122+            |
+| Safari  | 18+             |
+| Firefox | 128+            |
+| Edge    | 122+            |
 
 Older browsers will ignore these property values. Within Blueprint components, there will be fallback values provided. Outside of Blueprint, you may need to provide your own fallbacks.
+
+### Migration Notes
+
+#### Button
+
+- Dark background colors are currently using a combination of `var(--bp-surface-layer-default)` and `var(--bp-surface-background-color-default-rest)` to achieve a similar effect to the previous single token. This is due to the fact that the new tokens are designed to be more atomic and composable, rather than providing pre-combined values. The exact combination may need to be adjusted based on the desired visual outcome.

--- a/packages/core/src/design-tokens/USAGE.md
+++ b/packages/core/src/design-tokens/USAGE.md
@@ -109,7 +109,7 @@ Surface tokens control the button's dimensions and structural properties:
 
 ```scss
 // Layout — spacing token used as a multiplier base
-@include pt-button-height(calc(var(--bp-surface-spacing) * 7.5)); // 30px default height
+height: calc(var(--bp-surface-spacing) * 7.5); // 30px default height
 padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2); // 4px 8px
 border-radius: var(--bp-surface-border-radius); // 4px
 

--- a/packages/core/src/design-tokens/USAGE.md
+++ b/packages/core/src/design-tokens/USAGE.md
@@ -1,0 +1,143 @@
+# Design Tokens Usage
+
+Design tokens are a single source of truth for Blueprint's visual language. They are defined as JSON in `tokens/base/` and compiled to CSS custom properties (prefixed `--bp-`), enabling consistent theming across different color schemes without duplicating style logic in each component.
+
+## Intent tokens
+
+Intent tokens map semantic meaning to colors. Rather than referencing a raw palette value like `--bp-palette-blue-3`, components use `--bp-intent-primary-rest`, which can be remapped per theme or brand.
+
+Five intent types are defined in `tokens/base/intent.tokens.json`, each with interaction states:
+
+| Token pattern           | States                                | Example resolution          |
+| ----------------------- | ------------------------------------- | --------------------------- |
+| `--bp-intent-default-*` | `rest`, `hover`, `active`, `disabled` | `rest` → `palette.gray.1`   |
+| `--bp-intent-primary-*` | same                                  | `rest` → `palette.blue.3`   |
+| `--bp-intent-success-*` | same                                  | `rest` → `palette.green.3`  |
+| `--bp-intent-warning-*` | same                                  | `rest` → `palette.orange.3` |
+| `--bp-intent-danger-*`  | same                                  | `rest` → `palette.red.3`    |
+
+Intent tokens do not change between light and dark themes — the same blue is used for `primary` in both modes. Theme-specific adjustments happen at the surface layer (e.g. `--bp-surface-background-color-primary-rest`) which derives from intent tokens but applies lightness/chroma scaling per theme.
+
+## Surface tokens
+
+Surface tokens control the structural and spatial properties shared across components: borders, border-radius, shadows, spacing, and background colors. They are defined in `tokens/base/surface.tokens.json` with dark-mode overrides in `tokens/themes/dark/surface.tokens.json`.
+
+Key surface tokens used throughout components:
+
+| Token                                                   | Value                              | Purpose                                                                                                   |
+| ------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `--bp-surface-spacing`                                  | `4px`                              | Base spacing unit. Components multiply this (e.g. `calc(var(--bp-surface-spacing) * 2)` for 8px padding). |
+| `--bp-surface-border-width`                             | `1px`                              | Consistent border width for all bordered elements.                                                        |
+| `--bp-surface-border-radius`                            | `4px`                              | Shared corner radius.                                                                                     |
+| `--bp-surface-border-color-default`                     | `intent.default.rest` at 12% alpha | Subtle border for default states.                                                                         |
+| `--bp-surface-border-color-strong`                      | `intent.default.rest` at 25% alpha | More prominent border for outlined elements.                                                              |
+| `--bp-surface-shadow-0` through `--bp-surface-shadow-4` | Multi-layer box shadows            | Five elevation levels, from flat (0) to maximum depth (4).                                                |
+
+Surface tokens adapt automatically by theme. In light mode, borders derive from the default intent color with low opacity over a light background. In dark mode, the same tokens switch to white-based borders with inset highlights and deeper black shadows — without any component code changing.
+
+### Surface background colors, layers, and layer overrides
+
+Beyond structural properties, surface tokens provide a three-tier system for background color and compositing. Each tier builds on the one below it.
+
+#### Background colors
+
+`--bp-surface-background-color-{intent}-{state}`
+
+These are fully resolved, ready-to-use background colors for each intent and interaction state. For the **default** intent, they are derived from intent colors with lightness/chroma scaling — `default-rest` compiles to white in light mode despite deriving from gray, because the token applies `lightnessScale: 1.909`:
+
+| Token | Light mode | Dark mode |
+| ----- | ---------- | --------- |
+| `--bp-surface-background-color-default-rest` | `#ffffff` | Derived with `lightnessScale: 0.248` |
+| `--bp-surface-background-color-default-hover` | `#f6f7f9` | Darker gray |
+| `--bp-surface-background-color-default-active` | `#edeff2` | Darker gray |
+| `--bp-surface-background-color-default-disabled` | `#ffffff` | Derived with `lightnessScale: 0.319` |
+
+For **non-default** intents (primary, success, warning, danger), background colors pass through directly from the intent tokens with no derivation — the same blue works in both themes.
+
+Dark mode overrides in `tokens/themes/dark/surface.tokens.json` only redefine the `default` background colors with different scaling factors. Non-default intents need no dark override.
+
+#### Layer colors
+
+`--bp-surface-layer-color-{intent}`
+
+These are semi-transparent tints of each intent color, controlled by a shared opacity token:
+
+| Token | Value |
+| ----- | ----- |
+| `--bp-surface-layer-opacity` | `0.05` (5%) |
+| `--bp-surface-layer-color-default` | `intent.default.rest` at 5% alpha |
+| `--bp-surface-layer-color-primary` | `intent.primary.rest` at 5% alpha |
+| `--bp-surface-layer-color-success` | `intent.success.rest` at 5% alpha |
+| `--bp-surface-layer-color-warning` | `intent.warning.rest` at 5% alpha |
+| `--bp-surface-layer-color-danger` | `intent.danger.rest` at 5% alpha |
+
+In browsers supporting relative color syntax, each layer-color reactively references the opacity token:
+
+```css
+--bp-surface-layer-color-primary: oklch(from var(--bp-intent-primary-rest) l c h / var(--bp-surface-layer-opacity));
+```
+
+`--bp-surface-layer-opacity` acts as a shared control knob — changing it from `0.05` to `0.1` makes every layer-color denser at once.
+
+#### Stackable layers
+
+`--bp-surface-layer-{intent}`
+
+These wrap each layer-color in `linear-gradient()` so they can be composited as background images:
+
+```css
+--bp-surface-layer-primary: linear-gradient(#2d72d20d 0 0);
+```
+
+This exists because CSS `background-color` only accepts one value, but `background-image` supports stacking multiple layers. The `linear-gradient(color 0 0)` trick creates a solid-color gradient that can be layered on top of a background:
+
+```scss
+// Stack a primary tint on top of the default surface
+background-color: var(--bp-surface-background-color-default-rest);
+background-image: var(--bp-surface-layer-primary);
+```
+
+The wrapping is triggered by the `com.blueprint.role: "stackable-layer"` annotation in the token JSON. The build system in `sd.config.ts` detects this role and applies the `linear-gradient()` wrapper during compilation.
+
+## Example: Button component
+
+The Button component (`src/components/button/`) demonstrates how surface and intent tokens work together. The key files are `_common.scss` (shared mixins) and `_button.scss` (component styles).
+
+### Surface tokens in Button
+
+Surface tokens control the button's dimensions and structural properties:
+
+```scss
+// Layout — spacing token used as a multiplier base
+@include pt-button-height(calc(var(--bp-surface-spacing) * 7.5)); // 30px default height
+padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2); // 4px 8px
+border-radius: var(--bp-surface-border-radius); // 4px
+
+// Box shadow — border-width token for inset border simulation
+box-shadow:
+    inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
+```
+
+The large button variant simply scales the multiplier: `calc(var(--bp-surface-spacing) * 10)` for height and `calc(var(--bp-surface-spacing) * 4)` for horizontal padding.
+
+### Intent tokens in Button
+
+Intent tokens drive the button's color across every interaction state. For non-default intents (primary, success, warning, danger), a Sass map wires each intent to its tokens:
+
+```scss
+$button-intents: (
+    "primary": (
+        var(--bp-intent-primary-rest),
+        // background
+        var(--bp-intent-primary-hover),
+        // background on hover
+        var(--bp-intent-primary-active),
+        // background on active
+        var(--bp-intent-primary-foreground),
+        // text color
+    ), // success, warning, danger follow the same pattern
+);
+```
+
+Disabled states reference `--bp-intent-default-disabled` at reduced opacity, and minimal/outlined variants use `--bp-surface-border-color-strong` for their borders.

--- a/packages/core/src/design-tokens/USAGE.md
+++ b/packages/core/src/design-tokens/USAGE.md
@@ -45,12 +45,12 @@ Beyond structural properties, surface tokens provide a three-tier system for bac
 
 These are fully resolved, ready-to-use background colors for each intent and interaction state. For the **default** intent, they are derived from intent colors with lightness/chroma scaling — `default-rest` compiles to white in light mode despite deriving from gray, because the token applies `lightnessScale: 1.909`:
 
-| Token | Light mode | Dark mode |
-| ----- | ---------- | --------- |
-| `--bp-surface-background-color-default-rest` | `#ffffff` | Derived with `lightnessScale: 0.248` |
-| `--bp-surface-background-color-default-hover` | `#f6f7f9` | Darker gray |
-| `--bp-surface-background-color-default-active` | `#edeff2` | Darker gray |
-| `--bp-surface-background-color-default-disabled` | `#ffffff` | Derived with `lightnessScale: 0.319` |
+| Token                                            | Light mode | Dark mode                            |
+| ------------------------------------------------ | ---------- | ------------------------------------ |
+| `--bp-surface-background-color-default-rest`     | `#ffffff`  | Derived with `lightnessScale: 0.248` |
+| `--bp-surface-background-color-default-hover`    | `#f6f7f9`  | Darker gray                          |
+| `--bp-surface-background-color-default-active`   | `#edeff2`  | Darker gray                          |
+| `--bp-surface-background-color-default-disabled` | `#ffffff`  | Derived with `lightnessScale: 0.319` |
 
 For **non-default** intents (primary, success, warning, danger), background colors pass through directly from the intent tokens with no derivation — the same blue works in both themes.
 
@@ -62,14 +62,14 @@ Dark mode overrides in `tokens/themes/dark/surface.tokens.json` only redefine th
 
 These are semi-transparent tints of each intent color, controlled by a shared opacity token:
 
-| Token | Value |
-| ----- | ----- |
-| `--bp-surface-layer-opacity` | `0.05` (5%) |
+| Token                              | Value                             |
+| ---------------------------------- | --------------------------------- |
+| `--bp-surface-layer-opacity`       | `0.05` (5%)                       |
 | `--bp-surface-layer-color-default` | `intent.default.rest` at 5% alpha |
 | `--bp-surface-layer-color-primary` | `intent.primary.rest` at 5% alpha |
 | `--bp-surface-layer-color-success` | `intent.success.rest` at 5% alpha |
 | `--bp-surface-layer-color-warning` | `intent.warning.rest` at 5% alpha |
-| `--bp-surface-layer-color-danger` | `intent.danger.rest` at 5% alpha |
+| `--bp-surface-layer-color-danger`  | `intent.danger.rest` at 5% alpha  |
 
 In browsers supporting relative color syntax, each layer-color reactively references the opacity token:
 
@@ -113,11 +113,17 @@ Surface tokens control the button's dimensions and structural properties:
 padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2); // 4px 8px
 border-radius: var(--bp-surface-border-radius); // 4px
 
-// Box shadow — border-width token for inset border simulation
+// Box shadow — two layers: inset border + depth shadow
 box-shadow:
-    inset 0 0 0 var(--bp-surface-border-width) color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+    inset 0 0 0 var(--bp-surface-border-width)
+        color-mix(in oklch, var(--bp-surface-border-color-strong) 90%, var(--bp-palette-black)),
     0 1px 2px color-mix(in oklch, var(--bp-palette-black) 10%, transparent);
 ```
+
+The button's box-shadow has two layers that use tokens differently:
+
+- **Inset border layer**: Simulates a 1px border using `--bp-surface-border-width`. In light mode, `--bp-surface-border-color-strong` is mixed 90% with `--bp-palette-black` to darken the gray token toward black for sufficient contrast. In dark mode, `--bp-surface-border-color-default` is scaled to 50% with `transparent` to halve the token's built-in 20% alpha down to 10%.
+- **Depth shadow layer**: Uses `--bp-palette-black` at varying opacity (`10%` at rest, `20%` on hover/active) for a consistent drop shadow across themes.
 
 The large button variant simply scales the multiplier: `calc(var(--bp-surface-spacing) * 10)` for height and `calc(var(--bp-surface-spacing) * 4)` for horizontal padding.
 


### PR DESCRIPTION
#### Based off of tokens generated by @ryannono 

#### Changes proposed in this pull request:

* Updates button configurations to use tokens to start

> [!NOTE]
>  The dark mode works well because of the use of `bp6-dark`, specifically namespaced to 6 right now. More versions can be added for support, but ideally we migrate so that `[data-bp-color-scheme="dark"]` is used instead

**Notes**
* Dark mode typography is currently overridden in a separate SCSS file - https://github.com/palantir/blueprint/blob/e341dc04af689725d096c20c6e651b8af2af97aa/packages/core/src/common/_typography-colors.scss#L90-L161
* Button uses the new intent tokens with color-mixing to white or black so the colors will be _slightly_ different. The most visually distinct change will be the `active` state, which currently uses `color-mix` with `srgb` to get as close to Blueprint 6 colors as possible.
  * Default will be different 


#### Token-to-Palette Mapping

The intent tokens map to these original Sass palette colors:

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-default-hover` | `#404854` | `$dark-gray5` |
| `--bp-intent-default-active` | `#383e47` | `$dark-gray4` |
| `--bp-intent-default-disabled` | `#8f99a8` | `$gray3` |
| `--bp-intent-default-foreground` | `#ffffff` | `$white` |
| `--bp-palette-black` | `#111418` | `$black` |
| `--bp-surface-border-color-strong` | `#5f6b7c40` | 25% opacity of `$gray1` |

#### Light Default Button

| State | Develop | Current |
|-------|---------|---------|
| Rest | `$light-gray5` = `#f6f7f9` | `color-mix(oklch, $gray1 5%, white)` |
| Hover | `$light-gray4` = `#edeff2` | `color-mix(oklch, $dark-gray5 8%, white)` |
| Active | `$light-gray2` = `#dce0e5` | `color-mix(srgb, $dark-gray4 15%, white)` |
| Disabled | `rgba($light-gray1, 0.5)` = `rgba(#d3d8de, 0.5)` | `color-mix(oklch, $gray3 20%, transparent)` |
| Disabled+active | `rgba($light-gray1, 0.7)` = `rgba(#d3d8de, 0.7)` | `color-mix(oklch, $gray3 28%, transparent)` |

**Differences:**
1. **Rest/Hover/Active base colors are darker.** Develop used light grays (`$light-gray5/4/2`) directly. Current derives from mid-to-dark grays (`$gray1`, `$dark-gray5`, `$dark-gray4`) mixed with white. The resulting colors are close but not identical due to oklch interpolation behavior.
2. **Active uses `srgb` while rest/hover use `oklch`.** Inconsistent interpolation space (deliberate — oklch produced a warm tint for active).
3. **Disabled base color differs.** Develop: `$light-gray1` (`#d3d8de`, L≈0.878). Current: `$gray3` (`#8f99a8`, L≈0.682). Much darker base at lower opacity to approximate the same result.
4. **Disabled+active base color differs.** Same as disabled — `$light-gray1` vs `$gray3`. Percentage adjusted from 70% to 28% to compensate.

#### Dark Default Button

| State | Develop | Current |
|-------|---------|---------|
| Rest | `$dark-gray3` = `#2f343c` | `color-mix(oklch, $gray1 40%, $black)` |
| Hover | `$dark-gray2` = `#252a31` | `color-mix(oklch, $gray1 29%, $black)` |
| Active | `$dark-gray1` = `#1c2127` | `color-mix(oklch, $gray1 19%, $black)` |
| Disabled | `rgba($dark-gray3, 0.15)` = `rgba(#2f343c, 0.15)` | `color-mix(oklch, $gray1 5%, transparent)` |
| Disabled+active | `rgba($dark-gray3, 0.7)` = `rgba(#2f343c, 0.7)` | `color-mix(oklch, $gray3 7%, transparent)` |

**Differences:**
5. **Dark rest/hover/active use `$gray1` instead of specific dark grays.** Develop used `$dark-gray3/2/1` directly. Current derives all three from `$gray1` mixed with `$black` (`#111418`). The oklch mix produces approximate but not exact matches.
6. **Dark disabled base color differs.** Develop: `$dark-gray3` (`#2f343c`). Current: `$gray1` (`#5f6b7c`). Different color at much lower opacity (5% vs 15%).
7. **Dark disabled+active base color differs.** Develop: `$dark-gray3` at 70%. Current: `$gray3` (`#8f99a8`) at 7%. Completely different base color and opacity.

#### Minimal Button

| State | Develop | Current |
|-------|---------|---------|
| Hover (light) | `rgba($gray3, 0.15)` = `rgba(#8f99a8, 0.15)` | `color-mix(oklch, $gray1 15%, transparent)` |
| Active (light) | `rgba($gray3, 0.3)` = `rgba(#8f99a8, 0.3)` | `color-mix(oklch, $gray1 30%, transparent)` |
| Disabled+active (light) | `rgba($gray3, 0.3)` | `color-mix(oklch, $gray3 30%, transparent)` |
| Hover (dark) | `rgba($gray3, 0.15)` | `color-mix(oklch, $gray1 15%, transparent)` |
| Active (dark) | `rgba($gray3, 0.3)` | `color-mix(oklch, $gray1 30%, transparent)` |
| Disabled+active (dark) | `rgba($gray3, 0.3)` | `color-mix(oklch, $gray3 30%, transparent)` |

**Differences:**
8. **Minimal hover/active use `$gray1` instead of `$gray3`.** Develop: `$gray3` (`#8f99a8`, lighter). Current: `$gray1` (`#5f6b7c`, darker). Same percentages (15%/30%) but darker base produces a more visible overlay.
9. **Minimal disabled+active matches** — both use `$gray3` at 30%.

#### Minimal Intent Button

| State | Develop | Current |
|-------|---------|---------|
| Hover (light) | `rgba($intent-color, 0.15)` | `color-mix(oklch, $intent-color 15%, transparent)` |
| Active (light) | `rgba($intent-color, 0.3)` | `color-mix(oklch, $intent-color 30%, transparent)` |
| Hover (dark) | `rgba($intent-color, 0.2)` | `color-mix(oklch, $intent-color 20%, transparent)` |
| Active (dark) | `rgba($intent-color, 0.3)` | `color-mix(oklch, $intent-color 30%, transparent)` |

**Differences:**
10. **Same tokens, same percentages but different color space.** Develop used `rgba()` (sRGB alpha). Current uses `color-mix(in oklch, ... transparent)`. oklch premultiplied alpha may produce slightly different visual results than sRGB alpha transparency.

#### Intent Button (Filled)

| State | Develop | Current |
|-------|---------|---------|
| Disabled | `rgba($default-color, 0.5)` | `color-mix(oklch, $default-color 50%, transparent)` |
| Disabled text | `rgba($white, 0.6)` | `color-mix(oklch, foreground 60%, transparent)` |

**Differences:**
11. **Same concept, different color space.** `rgba()` vs `color-mix(in oklch, ... transparent)` at equivalent percentages.

#### Outlined Button

| State | Develop | Current |
|-------|---------|---------|
| Border (light) | `rgba($dark-gray1, 0.2)` = `rgba(#1c2127, 0.2)` | `--bp-surface-border-color-strong` = `#5f6b7c40` |
| Border disabled (light) | `rgba($pt-text-color-disabled, 0.1)` | `--bp-surface-border-color-default` |
| Border (dark) | `rgba($white, 0.4)` = `rgba(#fff, 0.4)` | (from dark token override) |
| Border disabled (dark) | `rgba($white, 0.2)` | `color-mix(oklch, $dark-text-color 20%, transparent)` |

**Differences:**
12. **Outlined border base color differs.** Develop: 20% opacity of `$dark-gray1` (`#1c2127`, very dark). Current: 25% opacity of `$gray1` (`#5f6b7c`, mid-gray). The develop border appears darker/more defined because the base color is nearly black.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|-----------|
| 1-2 | Light rest/hover/active | Darker base tokens (`$gray1`/`$dark-gray5`/`$dark-gray4`) instead of light grays |
| 3 | Active color space | `srgb` vs `oklch` (to avoid warm tint) |
| 4-5 | Light disabled/disabled+active | `$gray3` base instead of `$light-gray1` |
| 6-7 | Dark rest/hover/active | Derived from `$gray1 + $black` instead of direct dark grays |
| 8-9 | Dark disabled/disabled+active | Different base colors and radically different percentages |
| 10 | Minimal hover/active | `$gray1` instead of `$gray3` |
| 11-12 | Intent/minimal alpha | `color-mix(oklch)` vs `rgba()` — different color spaces for transparency |
| 13 | Outlined border | `$gray1` at 25% instead of `$dark-gray1` at 20% |

#### Reviewers should focus on:

* Correct semantic/intent token use that makes sense
* Close visual inspection of variations

#### Screenshot

**Example: Active button**
| before | after |
| -- | -- | 
|  <img width="324" height="55" alt="current bp6" src="https://github.com/user-attachments/assets/25a9aa23-7d4b-4b78-ad99-14fae2cd8287" /> | <img width="317" height="46" alt="updated with tokens" src="https://github.com/user-attachments/assets/8997524c-04cc-443c-a1f3-85abe04ea649" /> |