### PR TITLE
Fix Math.max returning -Infinity when columnIndices is empty array

### DIFF
--- a/packages/table/changelog/@unreleased/pr-7728.yml
+++ b/packages/table/changelog/@unreleased/pr-7728.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix `resizeRowsByTallestCell` returning -Infinity height when called with empty array
+  links:
+    - https://github.com/palantir/blueprint/pull/7728

--- a/packages/table/src/resizeRows.ts
+++ b/packages/table/src/resizeRows.ts
@@ -159,8 +159,10 @@ export function resizeRowsByTallestCell(
         }
     } else {
         const columnIndicesArray = Array.isArray(columnIndices) ? columnIndices : [columnIndices];
-        const tallestByColumns = columnIndicesArray.map(col => locator.getTallestVisibleCellInColumn(col));
-        tallest = Math.max(...tallestByColumns);
+        if (columnIndicesArray.length > 0) {
+            const tallestByColumns = columnIndicesArray.map(col => locator.getTallestVisibleCellInColumn(col));
+            tallest = Math.max(...tallestByColumns);
+        }
     }
     return Array(numRows).fill(tallest);
 }


### PR DESCRIPTION
## Summary

Fixes a bug in `resizeRowsByTallestCell` where passing an empty array `[]` for the `columnIndices` parameter causes all rows to be resized to `-Infinity` height.

## Problem

When `resizeRowsByTallestCell` is called with `columnIndices = []`:
1. Line 161: `columnIndicesArray` becomes `[]`
2. Line 162: `tallestByColumns` becomes `[]` (empty after map)
3. Line 163: `Math.max(...[])` returns `-Infinity`

This causes all rows to have `-Infinity` height, which is incorrect behavior.

```javascript
> Math.max(...[])
-Infinity
```

## Solution

Add a length check before calling `Math.max()`. When `columnIndicesArray` is empty, the default value of `tallest = 0` is preserved, which matches the expected behavior when no columns are specified.

## Testing

This edge case was not covered by existing tests. The fix ensures consistent behavior:
- `resizeRowsByTallestCell()` → uses viewport columns (existing)
- `resizeRowsByTallestCell([0, 1])` → uses specified columns (existing)
- `resizeRowsByTallestCell([])` → now correctly returns 0 height (fixed)