### PR TITLE
[stylelint] fix: Updating stylelint to address deprecation warning

### DIFF
--- a/packages/stylelint-plugin/src/rules/prefer-spacing-variable.ts
+++ b/packages/stylelint-plugin/src/rules/prefer-spacing-variable.ts
@@ -98,9 +98,11 @@ const ruleImpl =
                         const isNamespaced = namespace !== undefined;
 
                         const targetVar = isNamespaced ? `${namespace}.${spacingVariable}` : spacingVariable;
+                        const startIndex = declarationValueIndex(decl) + node.sourceIndex;
 
                         stylelint.utils.report({
-                            index: declarationValueIndex(decl) + node.sourceIndex,
+                            endIndex: startIndex + node.value.length,
+                            index: startIndex,
                             message: messages.expected(node.value, targetVar),
                             node: decl,
                             result,


### PR DESCRIPTION
#### Changes proposed in this pull request:

Fix for stylelint deprecation warning:
```
[stylelint:007] DeprecationWarning: Partial position information in the `utils.report()` function is deprecated ("@blueprintjs/prefer-spacing-variable").
Please pass both `index` and `endIndex` as arguments in the `utils.report()` function of "@blueprintjs/prefer-spacing-variable".
```

#### Reviewers should focus on:

No more warnings
