### PR TITLE
[core] fix: Update script to watch sass-compile

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,7 @@
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",
         "compile:esnext": "tsc -p ./src -t esnext --outDir lib/esnext",
-        "compile:css": "run-s build:tokens build:sass",
+        "compile:css": "run-s build:tokens && sass-compile ./src",
         "dev": "run-p \"compile:esm --watch\" \"compile:css --watch\"",
         "dist": "run-s \"dist:*\"",
         "dist:css": "css-dist lib/css",


### PR DESCRIPTION
#### Changes proposed in this pull request:

Updates the new script for `compile:css` to allow `--watch` on `sass-compile`, as opposed to `run-s` which is an invalid option.

#### Reviewers should focus on:

Run `pnpm dev` on core and it should not error out.