### PR TITLE
docs(select): document renderFilteredItems() helper

### DIFF
--- a/packages/select/changelog/@unreleased/pr-7740.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-7740.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Add documentation for `renderFilteredItems()` helper function
-  links:
-  - https://github.com/palantir/blueprint/pull/7740

--- a/packages/select/changelog/@unreleased/pr-7740.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-7740.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add documentation for `renderFilteredItems()` helper function
+  links:
+  - https://github.com/palantir/blueprint/pull/7740

--- a/packages/select/src/components/select/select-component.md
+++ b/packages/select/src/components/select/select-component.md
@@ -398,4 +398,59 @@ const FilmSelect: React.FC = () => (
 );
 ```
 
+@### Using renderFilteredItems()
+
+This package also exports a `renderFilteredItems()` helper function for custom item list rendering. It handles the
+`noResults` and `initialContent` states automatically.
+
+<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+
+`renderFilteredItems()` calls `renderItem()` for each filtered item, so you don't need to map through
+`filteredItems` yourself.
+
+</div>
+
+```tsx
+import { ItemListRenderer, renderFilteredItems } from "@blueprintjs/select";
+
+const renderMenu: ItemListRenderer<Film> = (listProps) => {
+    return (
+        <Menu role="listbox" ulRef={listProps.itemsParentRef} {...listProps.menuProps}>
+            {renderFilteredItems(
+                listProps,
+                // shown when no items match the query
+                <MenuItem disabled={true} text="No results." roleStructure="listoption" />,
+                // shown when query is empty
+                <MenuItem disabled={true} text="Start typing to search..." roleStructure="listoption" />
+            )}
+        </Menu>
+    );
+};
+
+const FilmSelect: React.FC = () => (
+    <Select<Film>
+        itemListRenderer={renderMenu}
+        itemPredicate={filterFilm}
+        itemRenderer={renderFilm}
+        items={...}
+        onItemSelect={...}
+    />
+);
+```
+
+The function signature is:
+
+```ts
+function renderFilteredItems(
+    props: ItemListRendererProps<T>,
+    noResults?: React.ReactNode,
+    initialContent?: React.ReactNode | null,
+): React.ReactNode;
+```
+
+-   `props`: the props object passed to your `itemListRenderer` callback.
+-   `noResults`: (optional) content to render when `filteredItems` is empty.
+-   `initialContent`: (optional) content to render when `query` is empty. Pass `null` to render nothing;
+    pass `undefined` (or omit) to render items normally.
+
 @interface ItemListRendererProps


### PR DESCRIPTION
## Summary

Adds documentation for the `renderFilteredItems()` utility function to the Select component docs. This helper was exported but only documented in JSDoc comments, not on the docs site.

The new section covers:
- What the function does and when to use it
- Import statement
- Complete usage example with `noResults` and `initialContent`
- Function signature with parameter descriptions

Fixes #3864