### PR TITLE
[Tag/CompoundTag] Add center text alignment to address single char content

### DIFF
--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -117,6 +117,7 @@ $minimal-dark-tag-intent-colors: (
   min-width: $tag-height;
   padding: $tag-padding-top $tag-padding;
   position: relative;
+  text-align: center;
 
   &:focus {
     @include focus-outline(0);


### PR DESCRIPTION
Fixes #7743, Fixes #5395

## Changes

Adds `text-align: center` to Tag styles to center single-character content within tags.

## Screenshot

<img width="608" height="692" alt="Screenshot 2026-02-05 at 22 38 39@2x" src="https://github.com/user-attachments/assets/1c6a7ad0-e3a1-4198-b2ee-ca490de6f417" />

---

### Diff
![Screenshot 2026-02-05 at 22 38 54](https://github.com/user-attachments/assets/6dcc68ce-3f59-4ed0-ac21-35db84ff48d9)

## Test plan
- [x] Verify single-character `<Tag>` content is centered (letters, numbers, symbols)
- [x] Verify `round` variant tags display content centered
- [x] Verify longer text content in tags still renders correctly
- [x] Verify `<CompoundTag>` layout is not affected by the change