### PR TITLE
Replace instances of custom `hasClass` util in core with `toHaveClass`

### DIFF
--- a/packages/core/src/common/test-utils.ts
+++ b/packages/core/src/common/test-utils.ts
@@ -17,5 +17,3 @@
 export async function sleep(timeout?: number) {
     return new Promise(resolve => window.setTimeout(resolve, timeout));
 }
-
-export const hasClass = (element: Element, className: string) => element.classList.contains(className);

--- a/packages/core/src/components/alert/alert.test.tsx
+++ b/packages/core/src/components/alert/alert.test.tsx
@@ -22,7 +22,6 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "@blueprint
 
 import { Alert, Classes } from "../..";
 import * as Errors from "../../common/errors";
-import { hasClass } from "../../common/test-utils";
 
 describe("<Alert>", () => {
     it("should render contents", () => {
@@ -40,7 +39,7 @@ describe("<Alert>", () => {
         );
         const alert = screen.getByRole("alertdialog");
 
-        expect(hasClass(alert, "test-class")).to.be.true;
+        expect(alert).toHaveClass("test-class");
         screen.getByText("Are you sure you want to delete this file?");
         screen.getByRole("button", { name: "Cancel" });
         screen.getByRole("button", { name: "Delete" });
@@ -82,7 +81,7 @@ describe("<Alert>", () => {
             render(<Alert intent="primary" isOpen={true} confirmButtonText="Confirm" />);
             const confirmButton = screen.getByRole("button", { name: "Confirm" });
 
-            expect(hasClass(confirmButton, Classes.INTENT_PRIMARY)).to.be.true;
+            expect(confirmButton).toHaveClass(Classes.INTENT_PRIMARY);
         });
 
         it("should trigger onConfirm and onClose when clicked", async () => {
@@ -104,7 +103,7 @@ describe("<Alert>", () => {
             render(<Alert intent="primary" isOpen={true} cancelButtonText="Cancel" onCancel={spy} />);
             const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
-            expect(hasClass(cancelButton, Classes.INTENT_PRIMARY)).to.be.false;
+            expect(cancelButton).not.toHaveClass(Classes.INTENT_PRIMARY);
         });
 
         it("should trigger 'onCancel' and 'onClose' when clicked", async () => {

--- a/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -21,15 +21,14 @@ import { spy } from "sinon";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Breadcrumb, Classes } from "../..";
-import { hasClass } from "../../common/test-utils";
 
 describe("<Breadcrumb>", () => {
     it("should render its contents", () => {
         render(<Breadcrumb className="foo" text="Test" />);
         const breadcrumb = screen.getByText("Test");
 
-        expect(hasClass(breadcrumb, Classes.BREADCRUMB)).to.be.true;
-        expect(hasClass(breadcrumb, "foo")).to.be.true;
+        expect(breadcrumb).toHaveClass(Classes.BREADCRUMB);
+        expect(breadcrumb).toHaveClass("foo");
     });
 
     it("should trigger onClick when clicked", async () => {

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -21,7 +21,6 @@ import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Boundary } from "../../common/boundary";
-import { hasClass } from "../../common/test-utils";
 
 import { type BreadcrumbProps } from "./breadcrumb";
 import { Breadcrumbs } from "./breadcrumbs";
@@ -39,18 +38,18 @@ describe("<Breadcrumbs>", () => {
         );
         const overflowList = screen.getByRole("list");
 
-        expect(hasClass(overflowList, Classes.BREADCRUMBS)).to.be.true;
-        expect(hasClass(overflowList, "breadcrumbs-class")).to.be.true;
-        expect(hasClass(overflowList, "overflow-list-class")).to.be.true;
+        expect(overflowList).toHaveClass(Classes.BREADCRUMBS);
+        expect(overflowList).toHaveClass("breadcrumbs-class");
+        expect(overflowList).toHaveClass("overflow-list-class");
     });
 
     it("should make the last breadcrumb current", () => {
         render(<Breadcrumbs items={ITEMS} minVisibleItems={ITEMS.length} />);
 
         expect(screen.getAllByRole("listitem")).to.have.length(3);
-        expect(hasClass(screen.getByText("1"), Classes.BREADCRUMB_CURRENT)).to.be.false;
-        expect(hasClass(screen.getByText("2"), Classes.BREADCRUMB_CURRENT)).to.be.false;
-        expect(hasClass(screen.getByText("3"), Classes.BREADCRUMB_CURRENT)).to.be.true;
+        expect(screen.getByText("1")).not.toHaveClass(Classes.BREADCRUMB_CURRENT);
+        expect(screen.getByText("2")).not.toHaveClass(Classes.BREADCRUMB_CURRENT);
+        expect(screen.getByText("3")).toHaveClass(Classes.BREADCRUMB_CURRENT);
     });
 
     it("should render overflow/collapsed indicator when items don't fit", () => {
@@ -62,7 +61,7 @@ describe("<Breadcrumbs>", () => {
         );
         const button = screen.getByRole("button", { name: /collapsed breadcrumbs/i });
 
-        expect(hasClass(button, Classes.BREADCRUMBS_COLLAPSED)).to.be.true;
+        expect(button).toHaveClass(Classes.BREADCRUMBS_COLLAPSED);
     });
 
     it.skip("should render the correct overflow menu items", () => {
@@ -104,7 +103,7 @@ describe("<Breadcrumbs>", () => {
         );
 
         expect(screen.getAllByRole("menuitem")).to.have.lengthOf(ITEMS.length);
-        expect(hasClass(screen.getByRole("menuitem", { name: "1" }), Classes.DISABLED)).to.be.true;
+        expect(screen.getByRole("menuitem", { name: "1" })).toHaveClass(Classes.DISABLED);
     });
 
     it("should call currentBreadcrumbRenderer (only) for the current breadcrumb", () => {

--- a/packages/core/src/components/callout/callout.test.tsx
+++ b/packages/core/src/components/callout/callout.test.tsx
@@ -20,14 +20,13 @@ import { IconNames } from "@blueprintjs/icons";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Callout, Classes, Intent } from "../..";
-import { hasClass } from "../../common/test-utils";
 
 describe("<Callout>", () => {
     it("should support className", () => {
         render(<Callout className="foo">Test</Callout>);
         const callout = screen.getByText("Test");
 
-        expect(hasClass(callout, "foo")).to.be.true;
+        expect(callout).toHaveClass("foo");
     });
 
     it("should not render icon by default", () => {
@@ -46,7 +45,7 @@ describe("<Callout>", () => {
         render(<Callout intent={Intent.DANGER}>Test</Callout>);
         const callout = screen.getByText("Test");
 
-        expect(hasClass(callout, Classes.INTENT_DANGER)).to.be.true;
+        expect(callout).toHaveClass(Classes.INTENT_DANGER);
     });
 
     it(`should render the associated default icon when intent="primary"`, () => {
@@ -71,6 +70,6 @@ describe("<Callout>", () => {
         render(<Callout title="title" />);
         const heading = screen.getByText("title");
 
-        expect(hasClass(heading, Classes.HEADING)).to.be.true;
+        expect(heading).toHaveClass(Classes.HEADING);
     });
 });

--- a/packages/core/src/components/card-list/cardList.test.tsx
+++ b/packages/core/src/components/card-list/cardList.test.tsx
@@ -20,7 +20,6 @@ import { createRef } from "react";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Card, CardList, Classes } from "../..";
-import { hasClass } from "../../common/test-utils";
 
 describe("<CardList>", () => {
     it("should support className prop", () => {
@@ -33,8 +32,8 @@ describe("<CardList>", () => {
         );
         const cardList = screen.getByRole("list");
 
-        expect(hasClass(cardList, Classes.CARD_LIST)).to.be.true;
-        expect(hasClass(cardList, TEST_CLASS)).to.be.true;
+        expect(cardList).toHaveClass(Classes.CARD_LIST);
+        expect(cardList).toHaveClass(TEST_CLASS);
     });
 
     it("should support HTML props", () => {

--- a/packages/core/src/components/card/card.test.tsx
+++ b/packages/core/src/components/card/card.test.tsx
@@ -22,7 +22,6 @@ import sinon from "sinon";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Card, Classes, H4 } from "../..";
-import { hasClass } from "../../common/test-utils";
 
 describe("<Card>", () => {
     it("should support elevation, interactive, and className props", () => {
@@ -33,10 +32,10 @@ describe("<Card>", () => {
         );
         const card = screen.getByText("Test");
 
-        expect(hasClass(card, Classes.CARD)).to.be.true;
-        expect(hasClass(card, Classes.ELEVATION_3)).to.be.true;
-        expect(hasClass(card, Classes.INTERACTIVE)).to.be.true;
-        expect(hasClass(card, Classes.TEXT_MUTED)).to.be.true;
+        expect(card).toHaveClass(Classes.CARD);
+        expect(card).toHaveClass(Classes.ELEVATION_3);
+        expect(card).toHaveClass(Classes.INTERACTIVE);
+        expect(card).toHaveClass(Classes.TEXT_MUTED);
     });
 
     it("should render children", () => {

--- a/packages/core/src/components/control-card/controlCard.test.tsx
+++ b/packages/core/src/components/control-card/controlCard.test.tsx
@@ -21,7 +21,6 @@ import { spy } from "sinon";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { CheckboxCard, Classes, RadioCard, RadioGroup, SwitchCard } from "../..";
-import { hasClass } from "../../common/test-utils";
 
 describe("ControlCard", () => {
     describe("SwitchCard", () => {
@@ -30,7 +29,7 @@ describe("ControlCard", () => {
             const card = screen.getByRole("checkbox", { name: "Test Switch" }).closest(`.${Classes.CARD}`);
 
             expect(card).to.exist;
-            expect(hasClass(card!, Classes.CONTROL_CARD)).to.be.true;
+            expect(card).toHaveClass(Classes.CONTROL_CARD);
         });
 
         it("should be end-aligned by default", () => {
@@ -38,7 +37,7 @@ describe("ControlCard", () => {
             const control = screen.getByRole("checkbox", { name: "Test Switch" }).closest(`.${Classes.CONTROL}`);
 
             expect(control).to.exist;
-            expect(hasClass(control!, Classes.ALIGN_RIGHT)).to.be.true;
+            expect(control).toHaveClass(Classes.ALIGN_RIGHT);
         });
 
         it("should be start-aligned when alignIndicator is start", () => {
@@ -46,7 +45,7 @@ describe("ControlCard", () => {
             const control = screen.getByRole("checkbox", { name: "Test Switch" }).closest(`.${Classes.CONTROL}`);
 
             expect(control).to.exist;
-            expect(hasClass(control!, Classes.ALIGN_LEFT)).to.be.true;
+            expect(control).toHaveClass(Classes.ALIGN_LEFT);
         });
 
         it("should toggle switch state when clicked", async () => {
@@ -63,7 +62,7 @@ describe("ControlCard", () => {
             render(<SwitchCard defaultChecked={true} label="Test Switch" data-testid="test-switch" />);
             const card = screen.getByTestId("test-switch");
 
-            expect(hasClass(card, Classes.SELECTED)).to.be.true;
+            expect(card).toHaveClass(Classes.SELECTED);
         });
 
         it("should not show selected state on card when showAsSelectedWhenChecked is false", () => {
@@ -77,7 +76,7 @@ describe("ControlCard", () => {
             );
             const card = screen.getByTestId("test-switch");
 
-            expect(hasClass(card, Classes.SELECTED)).to.be.false;
+            expect(card).not.toHaveClass(Classes.SELECTED);
         });
     });
 
@@ -87,7 +86,7 @@ describe("ControlCard", () => {
             const card = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CARD}`);
 
             expect(card).to.exist;
-            expect(hasClass(card!, Classes.CONTROL_CARD)).to.be.true;
+            expect(card).toHaveClass(Classes.CONTROL_CARD);
         });
 
         it("should be start-aligned by default", () => {
@@ -95,7 +94,7 @@ describe("ControlCard", () => {
             const control = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CONTROL}`);
 
             expect(control).to.exist;
-            expect(hasClass(control!, Classes.ALIGN_LEFT)).to.be.true;
+            expect(control).toHaveClass(Classes.ALIGN_LEFT);
         });
 
         it("should be end-aligned when alignIndicator is end", () => {
@@ -103,7 +102,7 @@ describe("ControlCard", () => {
             const control = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CONTROL}`);
 
             expect(control).to.exist;
-            expect(hasClass(control!, Classes.ALIGN_RIGHT)).to.be.true;
+            expect(control).toHaveClass(Classes.ALIGN_RIGHT);
         });
 
         it("should show as selected when checked", async () => {
@@ -111,7 +110,7 @@ describe("ControlCard", () => {
             const card = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CARD}`);
 
             expect(card).to.exist;
-            expect(hasClass(card!, Classes.SELECTED)).to.be.true;
+            expect(card).toHaveClass(Classes.SELECTED);
         });
 
         it("should not show selected state on card when showAsSelectedWhenChecked is false", () => {
@@ -119,7 +118,7 @@ describe("ControlCard", () => {
             const card = screen.getByRole("checkbox", { name: "Test Checkbox" }).closest(`.${Classes.CARD}`);
 
             expect(card).to.exist;
-            expect(hasClass(card!, Classes.SELECTED)).to.be.false;
+            expect(card).not.toHaveClass(Classes.SELECTED);
         });
     });
 
@@ -129,7 +128,7 @@ describe("ControlCard", () => {
             const card = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CARD}`);
 
             expect(card).to.exist;
-            expect(hasClass(card!, Classes.CONTROL_CARD)).to.be.true;
+            expect(card).toHaveClass(Classes.CONTROL_CARD);
         });
 
         it("should be end-aligned by default", () => {
@@ -137,7 +136,7 @@ describe("ControlCard", () => {
             const control = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CONTROL}`);
 
             expect(control).to.exist;
-            expect(hasClass(control!, Classes.ALIGN_RIGHT)).to.be.true;
+            expect(control).toHaveClass(Classes.ALIGN_RIGHT);
         });
 
         it("should be start-aligned when alignIndicator is start", () => {
@@ -145,7 +144,7 @@ describe("ControlCard", () => {
             const control = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CONTROL}`);
 
             expect(control).to.exist;
-            expect(hasClass(control!, Classes.ALIGN_LEFT)).to.be.true;
+            expect(control).toHaveClass(Classes.ALIGN_LEFT);
         });
 
         it("should show as selected when checked", () => {
@@ -160,8 +159,8 @@ describe("ControlCard", () => {
             const cardOne = screen.getByRole("radio", { name: "One" }).closest(`.${Classes.CARD}`);
             const cardTwo = screen.getByRole("radio", { name: "Two" }).closest(`.${Classes.CARD}`);
 
-            expect(hasClass(cardOne!, Classes.SELECTED)).to.be.true;
-            expect(hasClass(cardTwo!, Classes.SELECTED)).to.be.false;
+            expect(cardOne).toHaveClass(Classes.SELECTED);
+            expect(cardTwo).not.toHaveClass(Classes.SELECTED);
         });
 
         it("should not show selected state on card when showAsSelectedWhenChecked is false", () => {
@@ -169,7 +168,7 @@ describe("ControlCard", () => {
             const card = screen.getByRole("radio", { name: "Test Radio" }).closest(`.${Classes.CARD}`);
 
             expect(card).to.exist;
-            expect(hasClass(card!, Classes.SELECTED)).to.be.false;
+            expect(card).not.toHaveClass(Classes.SELECTED);
         });
 
         it("should work within a RadioGroup", async () => {

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -23,7 +23,6 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "@blueprin
 import { Button, PopupKind, Tooltip } from "..";
 import { Classes } from "../..";
 import * as Errors from "../../common/errors";
-import { hasClass } from "../../common/test-utils";
 
 import { Popover } from "./popover";
 import { type PopoverInteractionKind } from "./popoverProps";
@@ -141,11 +140,11 @@ describe("<Popover>", () => {
             const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
 
             expect(popoverTarget).to.exist;
-            expect(hasClass(popoverTarget!, Classes.POPOVER_OPEN)).to.be.false;
+            expect(popoverTarget).not.toHaveClass(Classes.POPOVER_OPEN);
 
             await userEvent.click(screen.getByRole("button", { name: "target" }));
 
-            await waitFor(() => expect(hasClass(popoverTarget!, Classes.POPOVER_OPEN)).to.be.true);
+            await waitFor(() => expect(popoverTarget).toHaveClass(Classes.POPOVER_OPEN));
         });
 
         it("renders Portal when usePortal=true", async () => {
@@ -235,7 +234,7 @@ describe("<Popover>", () => {
             const popoverElement = container.querySelector(`.${Classes.POPOVER}`);
 
             expect(popoverElement).to.exist;
-            expect(hasClass(popoverElement!, Classes.DARK)).to.be.true;
+            expect(popoverElement).toHaveClass(Classes.DARK);
         });
 
         it("renders with aria-haspopup attr", () => {
@@ -277,7 +276,7 @@ describe("<Popover>", () => {
             const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
 
             expect(popoverTarget).to.exist;
-            expect(hasClass(popoverTarget!, Classes.FILL)).to.be.true;
+            expect(popoverTarget).toHaveClass(Classes.FILL);
         });
 
         it("does not apply FILL class to target when fill={false}", () => {
@@ -289,7 +288,7 @@ describe("<Popover>", () => {
             const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
 
             expect(popoverTarget).to.exist;
-            expect(hasClass(popoverTarget!, Classes.FILL)).to.be.false;
+            expect(popoverTarget).not.toHaveClass(Classes.FILL);
         });
     });
 
@@ -306,7 +305,7 @@ describe("<Popover>", () => {
             const popoverElement = baseElement.querySelector(`.${Classes.POPOVER}`);
 
             expect(popoverElement).to.exist;
-            expect(hasClass(popoverElement!, Classes.DARK)).to.be.true;
+            expect(popoverElement).toHaveClass(Classes.DARK);
         });
 
         it("inheritDarkTheme=false disables inheriting dark theme from trigger ancestor", () => {
@@ -321,7 +320,7 @@ describe("<Popover>", () => {
             const popoverElement = baseElement.querySelector(`.${Classes.POPOVER}`);
 
             expect(popoverElement).to.exist;
-            expect(hasClass(popoverElement!, Classes.DARK)).to.be.false;
+            expect(popoverElement).not.toHaveClass(Classes.DARK);
         });
 
         it("supports overlay lifecycle props", async () => {
@@ -377,7 +376,7 @@ describe("<Popover>", () => {
 
             await waitFor(() => {
                 expect(overlay).to.exist;
-                expect(hasClass(overlay!, Classes.OVERLAY_OPEN)).to.be.true;
+                expect(overlay).toHaveClass(Classes.OVERLAY_OPEN);
                 expect(overlay?.contains(document.activeElement)).to.be.true;
             });
 
@@ -386,7 +385,7 @@ describe("<Popover>", () => {
             await userEvent.click(closeButton);
 
             await waitFor(() => {
-                expect(hasClass(overlay!, Classes.OVERLAY_OPEN)).to.be.false;
+                expect(overlay).not.toHaveClass(Classes.OVERLAY_OPEN);
                 expect(targetButton).to.equal(document.activeElement);
             });
         });
@@ -862,7 +861,7 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            expect(hasClass(targetButton, Classes.ACTIVE)).to.be.false;
+            expect(targetButton).not.toHaveClass(Classes.ACTIVE);
         });
     });
 
@@ -1071,7 +1070,7 @@ describe("<Popover>", () => {
 
             await userEvent.click(screen.getByRole("button", { name: "target" }));
 
-            expect(hasClass(screen.getByRole("button", { name: "target" }), Classes.ACTIVE)).to.be.true;
+            expect(screen.getByRole("button", { name: "target" })).toHaveClass(Classes.ACTIVE);
         });
     });
 


### PR DESCRIPTION
## Changes

Replace custom `hasClass` utility with [`toHaveClass`](https://github.com/testing-library/jest-dom?tab=readme-ov-file#tohaveclass) matcher (now that we're on vitest/jest-dom)