### PR TITLE
Replace instances of `dispatchTestKeyboardEvent` in core

### DIFF
--- a/packages/core/src/components/dialog/multistepDialog.test.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.test.tsx
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
+import userEvent from "@testing-library/user-event";
 import { mount, type ReactWrapper } from "enzyme";
-import { act } from "react";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
-import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons/vitest-utils";
 
 import { AnchorButton, Classes, DialogStep, MultistepDialog } from "../..";
 
@@ -163,7 +162,8 @@ describe("<MultistepDialog>", () => {
         dialog.unmount();
     });
 
-    it("pressing enter on older step takes effect", () => {
+    it("pressing enter on older step takes effect", async () => {
+        const user = userEvent.setup();
         const containerElement = document.createElement("div");
         document.documentElement.appendChild(containerElement);
         const dialog = mount(
@@ -177,10 +177,8 @@ describe("<MultistepDialog>", () => {
         findButtonWithText(dialog, "Next").simulate("click");
         assert.strictEqual(dialog.state("selectedIndex"), 1);
         const step = dialog.find(`.${Classes.DIALOG_STEP}`);
-        step.at(0).simulate("focus");
-        act(() => {
-            dispatchTestKeyboardEvent(step.at(0).getDOMNode(), "keydown", "Enter");
-        });
+        (step.at(0).getDOMNode() as HTMLElement).focus();
+        await user.keyboard("{Enter}");
         assert.strictEqual(dialog.state("selectedIndex"), 0);
         dialog.unmount();
         containerElement.remove();

--- a/packages/core/src/components/menu/menuItem.test.tsx
+++ b/packages/core/src/components/menu/menuItem.test.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
 import { spy } from "sinon";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
-import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons/vitest-utils";
 
 import {
     Button,
@@ -115,12 +115,13 @@ describe("MenuItem", () => {
         assert.isTrue(onClick.calledOnce);
     });
 
-    it("pressing enter on MenuItem triggers onClick prop", () => {
-        const containerElement = document.createElement("div");
-        document.documentElement.appendChild(containerElement);
+    it("pressing enter on MenuItem triggers onClick prop", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
-        const wrapper = mount(<MenuItem text="Graph" onClick={onClick} />, { attachTo: containerElement });
-        dispatchTestKeyboardEvent(wrapper.find("a").getDOMNode(), "keydown", "Enter");
+        render(<MenuItem text="Graph" onClick={onClick} />);
+        const menuItem = screen.getByRole("menuitem");
+        menuItem.focus();
+        await user.keyboard("{Enter}");
         assert.isTrue(onClick.calledOnce);
     });
 

--- a/packages/core/src/hooks/useHotkeys.test.tsx
+++ b/packages/core/src/hooks/useHotkeys.test.tsx
@@ -15,13 +15,11 @@
  */
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { useMemo } from "react";
 import { type SinonStub, spy, stub } from "sinon";
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
-import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons/vitest-utils";
-// N.B. { fireEvent } from "@testing-library/react" does not generate "real" enough events which
-// work with our hotkey parser implementation (worth investigating...)
 
 import { InputGroup } from "../components/forms/inputGroup";
 import { HotkeysProvider } from "../context";
@@ -75,7 +73,7 @@ const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputRea
 
     return (
         <div onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
-            <div data-testid="target-inside-component" />
+            <div data-testid="target-inside-component" tabIndex={0} />
             <InputGroup data-testid="input-target" readOnly={isInputReadOnly} />
         </div>
     );
@@ -99,63 +97,79 @@ describe("useHotkeys", () => {
         onKeyBSpy.resetHistory();
     });
 
-    it("binds local hotkey", () => {
+    it("binds local hotkey", async () => {
+        const user = userEvent.setup();
         render(<TestComponentContainer />);
         const target = screen.getByTestId("target-inside-component");
-        dispatchTestKeyboardEvent(target, "keydown", "a");
+        target.focus();
+        await user.keyboard("a");
         expect(onKeyASpy.callCount).to.equal(1, "hotkey a should be called once");
     });
 
-    it("binds global hotkey", () => {
+    it("binds global hotkey", async () => {
+        const user = userEvent.setup();
         render(<TestComponentContainer />);
         const target = screen.getByTestId("target-outside-component");
-        dispatchTestKeyboardEvent(target, "keydown", "b");
+        target.focus();
+        await user.keyboard("b");
         expect(onKeyBSpy.callCount).to.equal(1, "hotkey b should be called once");
     });
 
-    it("binds new local hotkeys when hook arg is updated", () => {
+    it("binds new local hotkeys when hook arg is updated", async () => {
+        const user = userEvent.setup();
         const { rerender } = render(<TestComponentContainer />);
         rerender(<TestComponentContainer bindExtraKeys={true} />);
         const target = screen.getByTestId("target-inside-component");
-        dispatchTestKeyboardEvent(target, "keydown", "a", true);
+        target.focus();
+        await user.keyboard("{Shift>}a{/Shift}");
         expect(onKeyASpy.callCount).to.equal(1, "hotkey A should be called once");
     });
 
-    it("binds new global hotkeys when hook arg is updated", () => {
+    it("binds new global hotkeys when hook arg is updated", async () => {
+        const user = userEvent.setup();
         const { rerender } = render(<TestComponentContainer />);
         rerender(<TestComponentContainer bindExtraKeys={true} />);
         const target = screen.getByTestId("target-outside-component");
-        dispatchTestKeyboardEvent(target, "keydown", "b", true);
+        target.focus();
+        await user.keyboard("{Shift>}b{/Shift}");
         expect(onKeyBSpy.callCount).to.equal(1, "hotkey B should be called once");
     });
 
-    it("removes local hotkeys when hook arg is updated", () => {
+    it("removes local hotkeys when hook arg is updated", async () => {
+        const user = userEvent.setup();
         const { rerender } = render(<TestComponentContainer bindExtraKeys={true} />);
         rerender(<TestComponentContainer />);
         const target = screen.getByTestId("target-inside-component");
-        dispatchTestKeyboardEvent(target, "keydown", "a", true);
+        target.focus();
+        await user.keyboard("{Shift>}a{/Shift}");
         expect(onKeyASpy.callCount).to.equal(0, "hotkey A should not be called");
     });
 
-    it("removes global hotkeys when hook arg is updated", () => {
+    it("removes global hotkeys when hook arg is updated", async () => {
+        const user = userEvent.setup();
         const { rerender } = render(<TestComponentContainer bindExtraKeys={true} />);
         rerender(<TestComponentContainer />);
         const target = screen.getByTestId("target-outside-component");
-        dispatchTestKeyboardEvent(target, "keydown", "b", true);
+        target.focus();
+        await user.keyboard("{Shift>}b{/Shift}");
         expect(onKeyBSpy.callCount).to.equal(0, "hotkey B should not be called");
     });
 
-    it("does not trigger hotkeys inside text inputs", () => {
+    it("does not trigger hotkeys inside text inputs", async () => {
+        const user = userEvent.setup();
         render(<TestComponentContainer />);
         const target = screen.getByTestId("input-target");
-        dispatchTestKeyboardEvent(target, "keydown", "a");
+        target.focus();
+        await user.keyboard("a");
         expect(onKeyASpy.callCount).to.equal(0, "hotkey A should not be called");
     });
 
-    it("does trigger hotkeys inside readonly text inputs", () => {
+    it("does trigger hotkeys inside readonly text inputs", async () => {
+        const user = userEvent.setup();
         render(<TestComponentContainer isInputReadOnly={true} />);
         const target = screen.getByTestId("input-target");
-        dispatchTestKeyboardEvent(target, "keydown", "a");
+        target.focus();
+        await user.keyboard("a");
         expect(onKeyASpy.callCount).to.equal(1, "hotkey A should be called once");
     });
 

--- a/packages/core/src/hooks/useHotkeys.test.tsx
+++ b/packages/core/src/hooks/useHotkeys.test.tsx
@@ -121,6 +121,7 @@ describe("useHotkeys", () => {
         rerender(<TestComponentContainer bindExtraKeys={true} />);
         const target = screen.getByTestId("target-inside-component");
         target.focus();
+        // bindExtraKeys adds "shift+A" combo, so we need Shift held during keypress
         await user.keyboard("{Shift>}a{/Shift}");
         expect(onKeyASpy.callCount).to.equal(1, "hotkey A should be called once");
     });
@@ -131,6 +132,7 @@ describe("useHotkeys", () => {
         rerender(<TestComponentContainer bindExtraKeys={true} />);
         const target = screen.getByTestId("target-outside-component");
         target.focus();
+        // bindExtraKeys adds "shift+B" combo, so we need Shift held during keypress
         await user.keyboard("{Shift>}b{/Shift}");
         expect(onKeyBSpy.callCount).to.equal(1, "hotkey B should be called once");
     });
@@ -141,6 +143,7 @@ describe("useHotkeys", () => {
         rerender(<TestComponentContainer />);
         const target = screen.getByTestId("target-inside-component");
         target.focus();
+        // "shift+A" combo should no longer be bound after removing extra keys
         await user.keyboard("{Shift>}a{/Shift}");
         expect(onKeyASpy.callCount).to.equal(0, "hotkey A should not be called");
     });
@@ -151,6 +154,7 @@ describe("useHotkeys", () => {
         rerender(<TestComponentContainer />);
         const target = screen.getByTestId("target-outside-component");
         target.focus();
+        // "shift+B" combo should no longer be bound after removing extra keys
         await user.keyboard("{Shift>}b{/Shift}");
         expect(onKeyBSpy.callCount).to.equal(0, "hotkey B should not be called");
     });

--- a/packages/test-commons/src/vitest-utils.ts
+++ b/packages/test-commons/src/vitest-utils.ts
@@ -23,23 +23,6 @@
  * For Karma/Chrome tests, use the utilities from utils.ts instead.
  */
 
-/**
- * Dispatch a native KeyboardEvent on the target element.
- * Works with Vitest + jsdom/happy-dom environments.
- */
-export function dispatchTestKeyboardEvent(target: EventTarget, eventType: string, key: string, shift = false) {
-    const event = new KeyboardEvent(eventType, {
-        altKey: false,
-        bubbles: true,
-        cancelable: true,
-        ctrlKey: false,
-        key,
-        location: 0,
-        shiftKey: shift,
-    });
-    target.dispatchEvent(event);
-}
-
 // see http://stackoverflow.com/questions/16802795/click-not-working-in-mocha-phantomjs-on-certain-elements
 // tl;dr PhantomJS sucks so we have to manually create click events
 export function createMouseEvent(eventType = "click", clientX = 0, clientY = 0) {


### PR DESCRIPTION
## Changes

Replace outdated custom `dispatchTestKeyboardEvent` implementation in core with methods from RTL/[userEvent](https://github.com/testing-library/user-event).
