### PR TITLE
# [DRAFT] Reduce default Button height from 30px to 28px

### DIFF
--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -73,13 +73,13 @@ $pt-line-height: 1.28581 !default;
 $pt-border-radius: 4px !default;
 
 // Buttons
-$pt-button-height: $pt-spacing * 7.5 !default;
+$pt-button-height: $pt-spacing * 7 !default;
 $pt-button-height-small: $pt-spacing * 6 !default;
 $pt-button-height-smaller: $pt-spacing * 5 !default;
 $pt-button-height-large: $pt-spacing * 10 !default;
 
 // Inputs
-$pt-input-height: $pt-spacing * 7.5 !default;
+$pt-input-height: $pt-spacing * 7 !default;
 $pt-input-height-large: $pt-spacing * 10 !default;
 $pt-input-height-small: $pt-spacing * 6 !default;
 

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -5,6 +5,7 @@
 @import "../../common/variables";
 @import "../../common/variables-extended";
 @import "../button/common";
+@import "../tag/common";
 
 // 3px space between small button and regular input
 $input-button-height: $pt-button-height-small !default;
@@ -85,7 +86,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
   }
 
   .#{$ns}-tag {
-    margin: $pt-spacing * 1.25;
+    margin: ($pt-input-height - $tag-height) * 0.5;
   }
 
   // all buttons go gray in default state and assume their native colors only when hovered

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -17,7 +17,7 @@ $tag-padding-top: ($tag-height - $tag-line-height) * 0.5 !default;
 $tag-padding: $tag-padding-top * 3 !default;
 $tag-margin: ($pt-input-height - $tag-height) * 0.5 !default;
 
-$tag-height-large: $pt-spacing * 7.5 !default;
+$tag-height-large: $pt-spacing * 7 !default;
 $tag-line-height-large: $pt-spacing * 4.5 !default;
 $tag-padding-large: $pt-spacing * 2 !default;
 

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -7,7 +7,7 @@
 @import "../../common/variables-extended";
 @import "../../common/mixins";
 
-$tree-row-height: $pt-spacing * 7.5 !default;
+$tree-row-height: $pt-spacing * 7 !default;
 $tree-icon-spacing: $pt-spacing * 2 !default;
 
 $tree-row-height-compact: $pt-spacing * 6 !default;


### PR DESCRIPTION
> [!WARNING]
> **Experimental / Draft** — This PR is exploratory. These changes are intended for visual review and discussion before being finalized. Do not merge.

## Summary

Shrinks the default (medium) height of Buttons and other interactive components from **30px** (`$pt-spacing * 7.5`) to **28px** (`$pt-spacing * 7`), aligning more closely with the 4px grid system.

![diff](https://github.com/user-attachments/assets/78c517be-52e2-4427-8df7-6ae460db668d)

[Before](https://blueprintjs.com/docs/#core/components/buttons) | [After](https://output.circle-artifacts.com/output/job/c82c319e-6bbd-41a0-951b-4c3cfa0cafde/artifacts/0/packages/docs-app/dist/index.html#core/components/buttons)

### Variable changes

| Variable | Old | New |
|----------|-----|-----|
| `$pt-button-height` | `$pt-spacing * 7.5` (30px) | `$pt-spacing * 7` (28px) |
| `$pt-input-height` | `$pt-spacing * 7.5` (30px) | `$pt-spacing * 7` (28px) |
| `$tag-height-large` | `$pt-spacing * 7.5` (30px) | `$pt-spacing * 7` (28px) |
| `$tree-row-height` | `$pt-spacing * 7.5` (30px) | `$pt-spacing * 7` (28px) |

The two primary variable changes (`$pt-button-height`, `$pt-input-height`) automatically cascade to: Button, Input, HTMLSelect, FileInput, TagInput, InputGroup, NumericInput, Tabs, Dialog, Toast, CardList, Breadcrumbs, FormGroup, Label, and datetime pickers.

## Test plan

- [x] Core SCSS compiles without errors
- [ ] Visual review of Button alongside InputGroup, HTMLSelect, FileInput, TagInput, NumericInput in ControlGroup compositions
- [ ] Visual review of large Tags adjacent to default Buttons
- [ ] Visual review of Tree nodes
- [ ] Visual review of Tabs
- [ ] Check datetime pickers still render correctly