### PR TITLE
fix(core): make Dialog `isOpen` prop optional to restore backward compatibility

### DIFF
--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -41,8 +41,10 @@ export interface DialogProps extends OverlayableProps, BackdropProps, Props {
     /**
      * Toggles the visibility of the overlay and its children.
      * This prop is required because the component is controlled.
+     *
+     * @default false
      */
-    isOpen: boolean;
+    isOpen?: boolean;
 
     /**
      * Dialog always has a backdrop so this prop cannot be overriden.


### PR DESCRIPTION
The functional component refactor in #7438 removed `static defaultProps`, which caused `isOpen` to become strictly required at the call site. With the class component, TypeScript's `JSX.LibraryManagedAttributes` inferred optionality from
`defaultProps`, so consumers could pass `boolean | undefined`. The runtime default (`isOpen = false`) was already in place via destructuring; this change makes the type match.