### PR TITLE
[chore] Migrate all direct API calls of `userEvent` to use `userEvent.setup()`

### DIFF
--- a/packages/core/src/components/alert/alert.test.tsx
+++ b/packages/core/src/components/alert/alert.test.tsx
@@ -85,12 +85,13 @@ describe("<Alert>", () => {
         });
 
         it("should trigger onConfirm and onClose when clicked", async () => {
+            const user = userEvent.setup();
             const onConfirm = spy();
             const onClose = spy();
             render(<Alert isOpen={true} confirmButtonText="Confirm" onConfirm={onConfirm} onClose={onClose} />);
             const confirmButton = screen.getByRole("button", { name: "Confirm" });
 
-            await userEvent.click(confirmButton);
+            await user.click(confirmButton);
 
             expect(onConfirm.calledOnce).to.be.true;
             expect(onClose.calledOnce).to.be.true;
@@ -107,6 +108,7 @@ describe("<Alert>", () => {
         });
 
         it("should trigger 'onCancel' and 'onClose' when clicked", async () => {
+            const user = userEvent.setup();
             const onCancel = spy();
             const onClose = spy();
             render(
@@ -120,7 +122,7 @@ describe("<Alert>", () => {
             );
             const cancelButton = screen.getByText("Cancel");
 
-            await userEvent.click(cancelButton);
+            await user.click(cancelButton);
 
             expect(onCancel.calledOnce).to.be.true;
             expect(onClose.calledOnce).to.be.true;
@@ -148,6 +150,7 @@ describe("<Alert>", () => {
         });
 
         it("should not allow outside click by default", async () => {
+            const user = userEvent.setup();
             const onCancel = spy();
             const { baseElement } = render(<Alert isOpen={true} cancelButtonText="Cancel" onCancel={onCancel} />);
 
@@ -156,12 +159,13 @@ describe("<Alert>", () => {
 
             expect(backdrop).to.exist;
 
-            await userEvent.click(backdrop!);
+            await user.click(backdrop!);
 
             expect(onCancel.notCalled).to.be.true;
         });
 
         it("should allow outside click when canOutsideClickCancel is true", async () => {
+            const user = userEvent.setup();
             const onCancel = spy();
             const { baseElement } = render(
                 <Alert isOpen={true} cancelButtonText="Cancel" onCancel={onCancel} canOutsideClickCancel={true} />,
@@ -171,7 +175,7 @@ describe("<Alert>", () => {
 
             expect(backdrop).to.exist;
 
-            await userEvent.click(backdrop!);
+            await user.click(backdrop!);
 
             expect(onCancel.calledOnce).to.be.true;
         });
@@ -179,6 +183,7 @@ describe("<Alert>", () => {
 
     describe("loading", () => {
         it("should display loading state on buttons", async () => {
+            const user = userEvent.setup();
             const onCancel = spy();
             const onClose = spy();
 
@@ -195,8 +200,8 @@ describe("<Alert>", () => {
             const cancelButton = screen.getByRole("button", { name: "Cancel" });
             const confirmButton = screen.getByRole("progressbar", { name: "loading" }).closest("button");
 
-            await userEvent.click(cancelButton);
-            await userEvent.click(confirmButton!);
+            await user.click(cancelButton);
+            await user.click(confirmButton!);
 
             // Confirm that the buttons are disabled
             expect(onCancel.called).to.be.false;

--- a/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -32,19 +32,21 @@ describe("<Breadcrumb>", () => {
     });
 
     it("should trigger onClick when clicked", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Breadcrumb onClick={onClick} text="Test" />);
 
-        await userEvent.click(screen.getByText("Test"));
+        await user.click(screen.getByText("Test"));
 
         expect(onClick.calledOnce).to.be.true;
     });
 
     it("should not trigger onClick when disabled and clicked", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Breadcrumb disabled={true} onClick={onClick} text="Test" />);
 
-        await userEvent.click(screen.getByText("Test"));
+        await user.click(screen.getByText("Test"));
 
         expect(onClick.notCalled).to.be.true;
     });

--- a/packages/core/src/components/button/button.test.tsx
+++ b/packages/core/src/components/button/button.test.tsx
@@ -118,11 +118,12 @@ function commonTests(Component: typeof Button | typeof AnchorButton) {
     });
 
     it("should disable button while loading", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Component loading={true} onClick={onClick} />);
         const button = screen.getByRole("button");
 
-        await userEvent.click(button);
+        await user.click(button);
 
         expect(onClick.called).to.be.false;
     });
@@ -131,41 +132,45 @@ function commonTests(Component: typeof Button | typeof AnchorButton) {
     // made a long time ago which we rely on and should not break.
     // See https://github.com/palantir/blueprint/issues/3819#issuecomment-1189478596
     it("should disable button while loading, even when disabled prop is explicity set to false", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Component loading={true} disabled={false} onClick={onClick} />);
         const button = screen.getByRole("button");
 
-        await userEvent.click(button);
+        await user.click(button);
 
         expect(onClick.called).to.be.false;
     });
 
     it("should trigger onClick when clicked", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Component onClick={onClick} />);
         const button = screen.getByRole("button");
 
-        await userEvent.click(button);
+        await user.click(button);
 
         expect(onClick.called).to.be.true;
     });
 
     it("should call onClick when enter key is pressed", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Component onClick={onClick} />);
         const button = screen.getByRole("button");
 
-        await userEvent.type(button, "{enter}");
+        await user.type(button, "{enter}");
 
         expect(onClick.called).to.be.true;
     });
 
     it("should call onClick when space key is pressed", async () => {
+        const user = userEvent.setup();
         const onClick = spy();
         render(<Component onClick={onClick} />);
         const button = screen.getByRole("button");
 
-        await userEvent.type(button, "{space}");
+        await user.type(button, "{space}");
 
         expect(onClick.called).to.be.true;
     });

--- a/packages/core/src/components/card/card.test.tsx
+++ b/packages/core/src/components/card/card.test.tsx
@@ -49,11 +49,12 @@ describe("<Card>", () => {
     });
 
     it("should call onClick when card is clicked", async () => {
+        const user = userEvent.setup();
         const onClick = sinon.spy();
         render(<Card onClick={onClick}>Test</Card>);
         const card = screen.getByText("Test");
 
-        await userEvent.click(card);
+        await user.click(card);
 
         expect(onClick.calledOnce).to.be.true;
     });

--- a/packages/core/src/components/control-card/controlCard.test.tsx
+++ b/packages/core/src/components/control-card/controlCard.test.tsx
@@ -49,11 +49,12 @@ describe("ControlCard", () => {
         });
 
         it("should toggle switch state when clicked", async () => {
+            const user = userEvent.setup();
             const handleChange = spy();
             render(<SwitchCard onChange={handleChange} label="Test Switch" data-testid="test-switch" />);
             const switchInput = screen.getByRole("checkbox", { name: "Test Switch" });
 
-            await userEvent.click(switchInput);
+            await user.click(switchInput);
 
             expect(handleChange.calledOnce).to.be.true;
         });
@@ -172,6 +173,7 @@ describe("ControlCard", () => {
         });
 
         it("should work within a RadioGroup", async () => {
+            const user = userEvent.setup();
             const changeSpy = spy();
             render(
                 <RadioGroup onChange={changeSpy}>
@@ -183,8 +185,8 @@ describe("ControlCard", () => {
             const radioOne = screen.getByRole("radio", { name: "One" });
             const radioTwo = screen.getByRole("radio", { name: "Two" });
 
-            await userEvent.click(radioOne);
-            await userEvent.click(radioTwo);
+            await user.click(radioOne);
+            await user.click(radioTwo);
 
             expect(changeSpy.callCount).to.equal(2);
         });

--- a/packages/core/src/components/forms/inputGroup.test.tsx
+++ b/packages/core/src/components/forms/inputGroup.test.tsx
@@ -53,11 +53,12 @@ describe("<InputGroup>", () => {
     });
 
     it("should support onChange callback", async () => {
+        const user = userEvent.setup();
         const onChange = spy();
         render(<InputGroup onChange={onChange} />);
         const input = screen.getByRole<HTMLInputElement>("textbox");
 
-        await userEvent.type(input, "x");
+        await user.type(input, "x");
 
         expect(input.value).to.equal("x");
         expect(onChange.calledOnce).to.be.true;
@@ -67,11 +68,12 @@ describe("<InputGroup>", () => {
     });
 
     it("should support the onValueChange callback", async () => {
+        const user = userEvent.setup();
         const onValueChange = spy();
         render(<InputGroup onValueChange={onValueChange} />);
         const input = screen.getByRole<HTMLInputElement>("textbox");
 
-        await userEvent.type(input, "x");
+        await user.type(input, "x");
 
         expect(input.value).to.equal("x");
         expect(onValueChange.calledOnce).to.be.true;
@@ -107,12 +109,13 @@ describe("<InputGroup>", () => {
             return <InputGroup type="text" value={value} onChange={handleChange} />;
         }
 
+        const user = userEvent.setup();
         render(<TestComponent initialValue="abc" transformInput={(value: string) => value.substring(0, 3)} />);
         const input = screen.getByRole<HTMLInputElement>("textbox");
 
         expect(input.value).to.equal("abc");
 
-        await userEvent.type(input, "d");
+        await user.type(input, "d");
 
         expect(input.value).to.equal("abc");
     });

--- a/packages/core/src/components/forms/radioGroup.test.tsx
+++ b/packages/core/src/components/forms/radioGroup.test.tsx
@@ -58,6 +58,7 @@ describe("<RadioGroup>", () => {
     });
 
     it("invokes onChange handler when a radio is clicked", async () => {
+        const user = userEvent.setup();
         const onChange = spy();
         render(
             <RadioGroup onChange={onChange}>
@@ -67,7 +68,7 @@ describe("<RadioGroup>", () => {
         );
         const radio1 = screen.getByRole<HTMLInputElement>("radio", { name: "One" });
 
-        await userEvent.click(radio1);
+        await user.click(radio1);
 
         expect(onChange.calledOnce).to.be.true;
         expect(onChange.getCall(0).args[0].target.value).to.equal("one");

--- a/packages/core/src/components/overlay2/overlay2.test.tsx
+++ b/packages/core/src/components/overlay2/overlay2.test.tsx
@@ -129,6 +129,7 @@ describe("<Overlay2>", () => {
 
     describe("onClose", () => {
         it("should invoke on backdrop mousedown when canOutsideClickClose=true", async () => {
+            const user = userEvent.setup();
             const onClose = spy();
             const { container } = renderWithOverlaysProvider(
                 <Overlay2
@@ -143,12 +144,13 @@ describe("<Overlay2>", () => {
 
             expect(backdropElement).to.exist;
 
-            await userEvent.click(backdropElement!);
+            await user.click(backdropElement!);
 
             expect(onClose.calledOnce).to.be.true;
         });
 
         it("should not invoke on backdrop mousedown when canOutsideClickClose=false", async () => {
+            const user = userEvent.setup();
             const onClose = spy();
             const { container } = renderWithOverlaysProvider(
                 <Overlay2
@@ -163,12 +165,13 @@ describe("<Overlay2>", () => {
 
             expect(backdropElement).to.exist;
 
-            await userEvent.click(backdropElement!);
+            await user.click(backdropElement!);
 
             expect(onClose.notCalled).to.be.true;
         });
 
         it("should invoke on document mousedown when hasBackdrop=false", async () => {
+            const user = userEvent.setup();
             const onClose = spy();
             renderWithOverlaysProvider(
                 <Overlay2
@@ -180,12 +183,13 @@ describe("<Overlay2>", () => {
                 />,
             );
 
-            await userEvent.click(document.documentElement);
+            await user.click(document.documentElement);
 
             expect(onClose.calledOnce).to.be.true;
         });
 
         it("should not invoke on document mousedown when hasBackdrop=false and canOutsideClickClose=false", async () => {
+            const user = userEvent.setup();
             const onClose = spy();
             renderWithOverlaysProvider(
                 <Overlay2
@@ -198,12 +202,13 @@ describe("<Overlay2>", () => {
                 />,
             );
 
-            await userEvent.click(document.documentElement);
+            await user.click(document.documentElement);
 
             expect(onClose.notCalled).to.be.true;
         });
 
         it("should not invoke on click of a nested overlay", async () => {
+            const user = userEvent.setup();
             const onClose = spy();
             renderWithOverlaysProvider(
                 <Overlay2 transitionDuration={0} isOpen={true} onClose={onClose}>
@@ -217,7 +222,7 @@ describe("<Overlay2>", () => {
             );
             const innerElement = screen.getByText("inner content");
 
-            await userEvent.click(innerElement);
+            await user.click(innerElement);
 
             expect(onClose.notCalled).to.be.true;
         });
@@ -445,6 +450,7 @@ describe("<Overlay2>", () => {
         });
 
         it("should return focus to overlay after clicking the backdrop if enforceFocus=true", async () => {
+            const user = userEvent.setup();
             const { container } = renderWithOverlaysProvider(
                 <Overlay2
                     transitionDuration={0}
@@ -459,7 +465,7 @@ describe("<Overlay2>", () => {
 
             expect(backdropElement).to.exist;
 
-            await userEvent.click(backdropElement!);
+            await user.click(backdropElement!);
 
             await waitFor(
                 () =>
@@ -471,6 +477,7 @@ describe("<Overlay2>", () => {
         // requestAnimationFrame to delay focus manipulation (Overlay2), and RAF
         // timing in jsdom is inconsistent with userEvent clicks.
         it.skip("should return focus to overlay after clicking an outside element if enforceFocus=true", async () => {
+            const user = userEvent.setup();
             renderWithOverlaysProvider(
                 <div>
                     <Overlay2
@@ -489,7 +496,7 @@ describe("<Overlay2>", () => {
             );
             const buttonElement = screen.getByRole("button", { name: /button outside overlay/i });
 
-            await userEvent.click(buttonElement);
+            await user.click(buttonElement);
 
             await waitFor(
                 () =>
@@ -498,6 +505,7 @@ describe("<Overlay2>", () => {
         });
 
         it("should not result in maximum call stack if two overlays open with enforceFocus=true", async () => {
+            const user = userEvent.setup();
             const firstOverlayInstance = createRef<OverlayInstance>();
             const secondOverlayInputID = "inputId";
 
@@ -537,7 +545,7 @@ describe("<Overlay2>", () => {
             const secondOverlayInputElement = screen.getByTestId(secondOverlayInputID);
 
             // this click potentially triggers infinite recursion if both overlays try to bring focus back to themselves
-            await userEvent.click(secondOverlayInputElement!);
+            await user.click(secondOverlayInputElement!);
             // previous test suites for Overlay spied on bringFocusInsideOverlay and asserted it was called once here,
             // but that is more difficult to test with function components and breaches the abstraction of Overlay2.
         });

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -132,6 +132,7 @@ describe("<Popover>", () => {
 
     describe("rendering", () => {
         it("adds POPOVER_OPEN class to target when the popover is open", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover content="content">
                     <Button text="target" />
@@ -142,19 +143,20 @@ describe("<Popover>", () => {
             expect(popoverTarget).to.exist;
             expect(popoverTarget).not.toHaveClass(Classes.POPOVER_OPEN);
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             await waitFor(() => expect(popoverTarget).toHaveClass(Classes.POPOVER_OPEN));
         });
 
         it("renders Portal when usePortal=true", async () => {
+            const user = userEvent.setup();
             const { baseElement } = render(
                 <Popover content="content" usePortal={true}>
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
             expect(baseElement.querySelector(`.${Classes.PORTAL}`)).to.exist;
@@ -179,13 +181,14 @@ describe("<Popover>", () => {
         });
 
         it("does not render Portal when usePortal=false", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover content="content" isOpen={true} usePortal={false}>
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
             expect(container.querySelector(`.${Classes.PORTAL}`)).not.toBeInTheDocument();
@@ -324,6 +327,7 @@ describe("<Popover>", () => {
         });
 
         it("supports overlay lifecycle props", async () => {
+            const user = userEvent.setup();
             const onOpening = sinon.spy();
             render(
                 <Popover content="content" onOpening={onOpening}>
@@ -331,25 +335,26 @@ describe("<Popover>", () => {
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             expect(onOpening.calledOnce).to.be.true;
         });
 
         it.skip("escape key closes popover", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="content" canEscapeKeyClose={true}>
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             await waitFor(() => {
                 expect(screen.getByText("content")).to.exist;
             });
 
-            await userEvent.keyboard("{Escape}");
+            await user.keyboard("{Escape}");
 
             await waitFor(() => {
                 expect(screen.queryByText("content")).not.toBeInTheDocument();
@@ -359,6 +364,7 @@ describe("<Popover>", () => {
 
     describe("focus management when shouldReturnFocusOnClose={true}", () => {
         it("moves focus to overlay when opened and returns focus to target element when closed", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover
                     content={<Button className={Classes.POPOVER_DISMISS}>close</Button>}
@@ -370,7 +376,7 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            await userEvent.click(targetButton);
+            await user.click(targetButton);
 
             const overlay = container.querySelector(`.${Classes.OVERLAY}`);
 
@@ -382,7 +388,7 @@ describe("<Popover>", () => {
 
             const closeButton = screen.getByRole("button", { name: "close" });
 
-            await userEvent.click(closeButton);
+            await user.click(closeButton);
 
             await waitFor(() => {
                 expect(overlay).not.toHaveClass(Classes.OVERLAY_OPEN);
@@ -621,18 +627,20 @@ describe("<Popover>", () => {
         });
 
         it("state does not update on user (click) interaction", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="content" isOpen={false}>
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
         });
 
         it("state does not update on user (key) interaction", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="content" canEscapeKeyClose={true} isOpen={true}>
                     <Button text="target" />
@@ -641,7 +649,7 @@ describe("<Popover>", () => {
 
             expect(screen.getByText("content")).to.exist;
 
-            await userEvent.keyboard("{Escape}");
+            await user.keyboard("{Escape}");
 
             expect(screen.getByText("content")).to.exist;
         });
@@ -743,6 +751,7 @@ describe("<Popover>", () => {
         });
 
         it("onClose is invoked with event when popover would close", async () => {
+            const user = userEvent.setup();
             const onClose = sinon.spy();
             render(
                 <Popover
@@ -757,7 +766,7 @@ describe("<Popover>", () => {
 
             await waitFor(() => expect(closeButton).to.exist);
 
-            await userEvent.click(screen.getByRole("button", { name: "close" }));
+            await user.click(screen.getByRole("button", { name: "close" }));
 
             expect(onClose.calledOnce).to.be.true;
             expect(onClose.args[0][0]).to.exist;
@@ -765,6 +774,7 @@ describe("<Popover>", () => {
 
         describe("onInteraction()", () => {
             it("is invoked with `true` when closed popover target is clicked", async () => {
+                const user = userEvent.setup();
                 const onInteraction = sinon.spy();
                 render(
                     <Popover content="content" isOpen={false} onInteraction={onInteraction}>
@@ -772,13 +782,14 @@ describe("<Popover>", () => {
                     </Popover>,
                 );
 
-                await userEvent.click(screen.getByRole("button", { name: "target" }));
+                await user.click(screen.getByRole("button", { name: "target" }));
 
                 expect(onInteraction.calledOnce).to.be.true;
                 expect(onInteraction.calledWith(true)).to.be.true;
             });
 
             it("is invoked with `false` when open popover target is clicked", async () => {
+                const user = userEvent.setup();
                 const onInteraction = sinon.spy();
                 const { container } = render(
                     <Popover content="content" isOpen={true} onInteraction={onInteraction}>
@@ -789,13 +800,14 @@ describe("<Popover>", () => {
 
                 expect(target).to.exist;
 
-                await userEvent.click(target!);
+                await user.click(target!);
 
                 expect(onInteraction.calledOnce).to.be.true;
                 expect(onInteraction.calledWith(false)).to.be.true;
             });
 
             it("is invoked with `false` when open modal popover backdrop is clicked", async () => {
+                const user = userEvent.setup();
                 const onInteraction = sinon.spy();
                 render(
                     <Popover
@@ -811,13 +823,14 @@ describe("<Popover>", () => {
                 );
                 const backdrop = screen.getByTestId("test-backdrop");
 
-                await userEvent.click(backdrop);
+                await user.click(backdrop);
 
                 expect(onInteraction.calledOnce).to.be.true;
                 expect(onInteraction.calledWith(false)).to.be.true;
             });
 
             it("is invoked with `false` when clicking POPOVER_DISMISS", async () => {
+                const user = userEvent.setup();
                 const onInteraction = sinon.spy();
                 render(
                     <Popover
@@ -832,13 +845,14 @@ describe("<Popover>", () => {
 
                 await waitFor(() => expect(closeButton).to.exist);
 
-                await userEvent.click(closeButton);
+                await user.click(closeButton);
 
                 expect(onInteraction.calledOnce).to.be.true;
                 expect(onInteraction.calledWith(false)).to.be.true;
             });
 
             it("is invoked with `false` when the document is mousedowned", async () => {
+                const user = userEvent.setup();
                 const onInteraction = sinon.spy();
                 render(
                     <Popover content="content" isOpen={true} onInteraction={onInteraction}>
@@ -846,7 +860,7 @@ describe("<Popover>", () => {
                     </Popover>,
                 );
 
-                await userEvent.click(document.documentElement);
+                await user.click(document.documentElement);
 
                 expect(onInteraction.calledOnce).to.be.true;
                 expect(onInteraction.calledWith(false)).to.be.true;
@@ -877,6 +891,7 @@ describe("<Popover>", () => {
         });
 
         it("with defaultIsOpen=true, popover can still be closed", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content={<Button className={Classes.POPOVER_DISMISS}>close</Button>} defaultIsOpen={true}>
                     <Button text="target" />
@@ -885,12 +900,13 @@ describe("<Popover>", () => {
 
             await waitFor(() => expect(screen.getByRole("button", { name: "close" })).to.exist);
 
-            await userEvent.click(screen.getByRole("button", { name: "close" }));
+            await user.click(screen.getByRole("button", { name: "close" }));
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "close" })).not.toBeInTheDocument());
         });
 
         it("CLICK_TARGET_ONLY works properly", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover content="content" interactionKind="click-target">
                     <Button text="target" />
@@ -900,16 +916,17 @@ describe("<Popover>", () => {
 
             expect(target).to.exist;
 
-            await userEvent.click(target!);
+            await user.click(target!);
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-            await userEvent.click(target!);
+            await user.click(target!);
 
             await waitFor(() => expect(screen.queryByText("content")).not.toBeInTheDocument());
         });
 
         it("HOVER_TARGET_ONLY works properly", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover content="content" interactionKind="hover-target">
                     <Button text="target" />
@@ -919,16 +936,17 @@ describe("<Popover>", () => {
 
             expect(target).to.exist;
 
-            await userEvent.hover(target!);
+            await user.hover(target!);
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-            await userEvent.unhover(target!);
+            await user.unhover(target!);
 
             await waitFor(() => expect(screen.queryByText("content")).not.toBeInTheDocument());
         });
 
         it("inline HOVER_TARGET_ONLY works properly when openOnTargetFocus={false}", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover content="content" interactionKind="hover-target" openOnTargetFocus={false}>
                     <Button text="target" />
@@ -938,16 +956,17 @@ describe("<Popover>", () => {
 
             expect(target).to.exist;
 
-            await userEvent.hover(target!);
+            await user.hover(target!);
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-            await userEvent.unhover(target!);
+            await user.unhover(target!);
 
             await waitFor(() => expect(screen.queryByText("content")).not.toBeInTheDocument());
         });
 
         it("inline HOVER works properly", async () => {
+            const user = userEvent.setup();
             const { container } = render(
                 <Popover content="content" interactionKind="hover">
                     <Button text="target" />
@@ -956,16 +975,17 @@ describe("<Popover>", () => {
             const target = container.querySelector(`.${Classes.POPOVER_TARGET}`);
             expect(target).to.exist;
 
-            await userEvent.hover(target!);
+            await user.hover(target!);
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-            await userEvent.unhover(target!);
+            await user.unhover(target!);
 
             await waitFor(() => expect(screen.queryByText("content")).not.toBeInTheDocument());
         });
 
         it("clicking POPOVER_DISMISS closes popover when usePortal=true", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     content={<Button className={Classes.POPOVER_DISMISS}>close</Button>}
@@ -978,12 +998,13 @@ describe("<Popover>", () => {
 
             await waitFor(() => expect(screen.getByRole("button", { name: "close" })).to.exist);
 
-            await userEvent.click(screen.getByRole("button", { name: "close" }));
+            await user.click(screen.getByRole("button", { name: "close" }));
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "close" })).not.toBeInTheDocument());
         });
 
         it("clicking POPOVER_DISMISS closes popover when usePortal=false", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     content={<Button className={Classes.POPOVER_DISMISS}>close</Button>}
@@ -996,47 +1017,50 @@ describe("<Popover>", () => {
 
             await waitFor(() => expect(screen.getByRole("button", { name: "close" })).to.exist);
 
-            await userEvent.click(screen.getByRole("button", { name: "close" }));
+            await user.click(screen.getByRole("button", { name: "close" }));
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "close" })).not.toBeInTheDocument());
         });
 
         it.skip("pressing Escape closes popover when canEscapeKeyClose=true and usePortal=false", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="content" canEscapeKeyClose={true} usePortal={false}>
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-            await userEvent.keyboard("{Escape}");
+            await user.keyboard("{Escape}");
 
             await waitFor(() => expect(screen.queryByText("content")).not.toBeInTheDocument());
         });
 
         it("setting disabled=true prevents opening popover", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="content" disabled={true} interactionKind="click-target">
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
         });
 
         it("setting disabled=true hides open popover", async () => {
+            const user = userEvent.setup();
             const { rerender } = render(
                 <Popover content="content" interactionKind="click-target">
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
 
@@ -1062,13 +1086,14 @@ describe("<Popover>", () => {
         });
 
         it("does apply active class to target when open", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="content" interactionKind="click">
                     <Button text="target" />
                 </Popover>,
             );
 
-            await userEvent.click(screen.getByRole("button", { name: "target" }));
+            await user.click(screen.getByRole("button", { name: "target" }));
 
             expect(screen.getByRole("button", { name: "target" })).toHaveClass(Classes.ACTIVE);
         });
@@ -1076,6 +1101,7 @@ describe("<Popover>", () => {
 
     describe("when composed with <Tooltip>", () => {
         it("shows tooltip on hover", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="popover content">
                     <Tooltip content="tooltip content">
@@ -1085,12 +1111,13 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            await userEvent.hover(targetButton);
+            await user.hover(targetButton);
 
             await waitFor(() => expect(screen.getByText("tooltip content")).to.exist);
         });
 
         it("shows popover on click", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="popover content">
                     <Tooltip content="tooltip content">
@@ -1100,7 +1127,7 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            await userEvent.click(targetButton);
+            await user.click(targetButton);
 
             await waitFor(() => expect(screen.getByText("popover content")).to.exist);
 
@@ -1122,6 +1149,7 @@ describe("<Popover>", () => {
 
         describe("when disabled=true", () => {
             it("shows tooltip on hover", async () => {
+                const user = userEvent.setup();
                 render(
                     <Popover content="popover content" disabled={true}>
                         <Tooltip content="tooltip content">
@@ -1131,12 +1159,13 @@ describe("<Popover>", () => {
                 );
                 const targetButton = screen.getByRole("button", { name: "target" });
 
-                await userEvent.hover(targetButton);
+                await user.hover(targetButton);
 
                 await waitFor(() => expect(screen.getByText("tooltip content")).to.exist);
             });
 
             it("does not show popover on click", async () => {
+                const user = userEvent.setup();
                 render(
                     <Popover content="popover content" disabled={true}>
                         <Tooltip content="tooltip content">
@@ -1146,7 +1175,7 @@ describe("<Popover>", () => {
                 );
                 const targetButton = screen.getByRole("button", { name: "target" });
 
-                await userEvent.click(targetButton);
+                await user.click(targetButton);
 
                 expect(screen.queryByText("popover content")).not.toBeInTheDocument();
             });
@@ -1168,6 +1197,7 @@ describe("<Popover>", () => {
 
     describe("when composed with a disabled <Tooltip>", () => {
         it("does not show tooltip on hover", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="popover content">
                     <Tooltip content="tooltip content" disabled={true}>
@@ -1177,12 +1207,13 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            await userEvent.hover(targetButton);
+            await user.hover(targetButton);
 
             expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
         });
 
         it("shows popover on click", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content="popover content">
                     <Tooltip content="tooltip content" disabled={true}>
@@ -1192,7 +1223,7 @@ describe("<Popover>", () => {
             );
             const targetButton = screen.getByRole("button", { name: "target" });
 
-            await userEvent.click(targetButton);
+            await user.click(targetButton);
 
             await waitFor(() => expect(screen.getByText("popover content")).to.exist);
         });
@@ -1212,6 +1243,7 @@ describe("<Popover>", () => {
 
         describe("when disabled=true", () => {
             it("does not show tooltip on hover", async () => {
+                const user = userEvent.setup();
                 render(
                     <Popover content="popover content" disabled={true}>
                         <Tooltip content="tooltip content" disabled={true}>
@@ -1221,12 +1253,13 @@ describe("<Popover>", () => {
                 );
                 const targetButton = screen.getByRole("button", { name: "target" });
 
-                await userEvent.hover(targetButton);
+                await user.hover(targetButton);
 
                 expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
             });
 
             it("does not show popover on click", async () => {
+                const user = userEvent.setup();
                 render(
                     <Popover content="popover content" disabled={true}>
                         <Tooltip content="tooltip content" disabled={true}>
@@ -1236,7 +1269,7 @@ describe("<Popover>", () => {
                 );
                 const targetButton = screen.getByRole("button", { name: "target" });
 
-                await userEvent.click(targetButton);
+                await user.click(targetButton);
 
                 expect(screen.queryByText("popover content")).not.toBeInTheDocument();
             });
@@ -1308,6 +1341,7 @@ describe("<Popover>", () => {
 
     describe("closing on click", () => {
         it("Classes.POPOVER_DISMISS closes on click", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover content={<Button className={Classes.POPOVER_DISMISS}>dismiss</Button>} defaultIsOpen={true}>
                     <Button text="target" />
@@ -1316,12 +1350,13 @@ describe("<Popover>", () => {
 
             await waitFor(() => expect(screen.getByRole("button", { name: "dismiss" })).to.exist);
 
-            await userEvent.click(screen.getByRole("button", { name: "dismiss" }));
+            await user.click(screen.getByRole("button", { name: "dismiss" }));
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "dismiss" })).not.toBeInTheDocument());
         });
 
         it("Classes.POPOVER_DISMISS_OVERRIDE does not close", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     content={
@@ -1337,12 +1372,13 @@ describe("<Popover>", () => {
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
 
-            await userEvent.click(screen.getByRole("button", { name: "dismiss" }));
+            await user.click(screen.getByRole("button", { name: "dismiss" }));
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
         });
 
         it(":disabled does not close", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     content={<Button className={Classes.POPOVER_DISMISS} disabled={true} text="dismiss" />}
@@ -1354,12 +1390,13 @@ describe("<Popover>", () => {
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
 
-            await userEvent.click(screen.getByRole("button", { name: "dismiss" }));
+            await user.click(screen.getByRole("button", { name: "dismiss" }));
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
         });
 
         it("Classes.DISABLED does not close", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     content={
@@ -1376,12 +1413,13 @@ describe("<Popover>", () => {
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
 
-            await userEvent.click(screen.getByRole("button", { name: "dismiss" }));
+            await user.click(screen.getByRole("button", { name: "dismiss" }));
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
         });
 
         it("captureDismiss={true} inner dismiss does not close outer popover", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     captureDismiss={true}
@@ -1403,7 +1441,7 @@ describe("<Popover>", () => {
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
 
-            await userEvent.click(screen.getByRole("button", { name: "dismiss" }));
+            await user.click(screen.getByRole("button", { name: "dismiss" }));
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "dismiss" })).not.toBeInTheDocument());
 
@@ -1411,6 +1449,7 @@ describe("<Popover>", () => {
         });
 
         it("captureDismiss={false} inner dismiss closes outer popover", async () => {
+            const user = userEvent.setup();
             render(
                 <Popover
                     captureDismiss={true}
@@ -1432,7 +1471,7 @@ describe("<Popover>", () => {
 
             expect(screen.getByRole("button", { name: "dismiss" })).to.exist;
 
-            await userEvent.click(screen.getByRole("button", { name: "dismiss" }));
+            await user.click(screen.getByRole("button", { name: "dismiss" }));
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "dismiss" })).not.toBeInTheDocument());
             await waitFor(() => expect(screen.queryByRole("button", { name: "inner target" })).not.toBeInTheDocument());
@@ -1442,6 +1481,7 @@ describe("<Popover>", () => {
     describe("key interactions on Button target", () => {
         describe.skip("Space key down opens click interaction popover", () => {
             it("when autoFocus={true}", async () => {
+                const user = userEvent.setup();
                 const { container } = render(
                     <Popover content="content" autoFocus={true} usePortal={false}>
                         <Button text="target" />
@@ -1450,7 +1490,7 @@ describe("<Popover>", () => {
                 const targetButton = screen.getByRole("button", { name: "target" });
 
                 targetButton.focus();
-                await userEvent.keyboard("{space}");
+                await user.keyboard("{space}");
 
                 await waitFor(() => expect(screen.getByText("content")).to.exist);
 
@@ -1459,6 +1499,7 @@ describe("<Popover>", () => {
             });
 
             it("when autoFocus={false}", async () => {
+                const user = userEvent.setup();
                 render(
                     <Popover content="content" autoFocus={false}>
                         <Button text="target" />
@@ -1467,7 +1508,7 @@ describe("<Popover>", () => {
                 const targetButton = screen.getByRole("button", { name: "target" });
 
                 targetButton.focus();
-                await userEvent.keyboard("{space}");
+                await user.keyboard("{space}");
 
                 await waitFor(() => expect(screen.getByText("content")).to.exist);
 

--- a/packages/core/src/components/segmented-control/segmentedControl.test.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.test.tsx
@@ -112,11 +112,12 @@ describe("<SegmentedControl>", () => {
     });
 
     it("should select the correct option when clicked", async () => {
+        const user = userEvent.setup();
         const onValueChange = sinon.spy();
         render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
         const listButton = screen.getByRole("radio", { name: /list/i });
 
-        await userEvent.click(listButton);
+        await user.click(listButton);
 
         expect(onValueChange.called).to.be.true;
         expect(onValueChange.args[0][0]).to.equal("list");
@@ -124,24 +125,26 @@ describe("<SegmentedControl>", () => {
     });
 
     it("should not allow disabled options to be selected", async () => {
+        const user = userEvent.setup();
         const onValueChange = sinon.spy();
         render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
         const gridButton = screen.getByRole("radio", { name: /grid/i });
 
-        await userEvent.click(gridButton);
+        await user.click(gridButton);
 
         expect(onValueChange.called).to.be.false;
         expect(gridButton.getAttribute("aria-checked")).to.equal("false");
     });
 
     it("should not allow any options to be selected when disabled", async () => {
+        const user = userEvent.setup();
         const onValueChange = sinon.spy();
         render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} disabled={true} />);
         const listButton = screen.getByRole("radio", { name: /list/i });
         const gridButton = screen.getByRole("radio", { name: /grid/i });
 
-        await userEvent.click(listButton);
-        await userEvent.click(gridButton);
+        await user.click(listButton);
+        await user.click(gridButton);
 
         expect(onValueChange.called).to.be.false;
         expect(listButton.getAttribute("aria-checked")).to.equal("false");

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -101,6 +101,7 @@ describe("<Tooltip>", () => {
         });
 
         it("triggers on hover", async () => {
+            const user = userEvent.setup();
             render(
                 <Tooltip content="content" hoverOpenDelay={0}>
                     <Button text="target" />
@@ -109,7 +110,7 @@ describe("<Tooltip>", () => {
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
 
-            await userEvent.hover(screen.getByText("target"));
+            await user.hover(screen.getByText("target"));
 
             await waitFor(() => expect(screen.getByText("content")).to.exist);
         });
@@ -176,13 +177,14 @@ describe("<Tooltip>", () => {
         });
 
         it("setting disabled=true prevents opening tooltip", async () => {
+            const user = userEvent.setup();
             render(
                 <Tooltip content="content" disabled={true} hoverOpenDelay={0}>
                     <Button text="target" />
                 </Tooltip>,
             );
 
-            await userEvent.hover(screen.getByText("target"));
+            await user.hover(screen.getByText("target"));
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
         });
@@ -225,6 +227,7 @@ describe("<Tooltip>", () => {
 
         describe("onInteraction()", () => {
             it("is invoked with `true` when closed tooltip target is hovered", async () => {
+                const user = userEvent.setup();
                 const onInteraction = spy();
                 render(
                     <Tooltip content="content" hoverOpenDelay={0} isOpen={false} onInteraction={onInteraction}>
@@ -232,7 +235,7 @@ describe("<Tooltip>", () => {
                     </Tooltip>,
                 );
 
-                await userEvent.hover(screen.getByText("target"));
+                await user.hover(screen.getByText("target"));
 
                 expect(onInteraction.calledOnce).to.be.true;
                 expect(onInteraction.calledWith(true)).to.be.true;
@@ -241,6 +244,7 @@ describe("<Tooltip>", () => {
     });
 
     it("Escape key closes tooltip", async () => {
+        const user = userEvent.setup();
         const onClose = spy();
         render(
             <Tooltip content="content" hoverOpenDelay={0} isOpen={true} onClose={onClose}>
@@ -250,12 +254,13 @@ describe("<Tooltip>", () => {
 
         expect(screen.getByText("content")).to.exist;
 
-        await userEvent.keyboard("{Escape}");
+        await user.keyboard("{Escape}");
 
         expect(onClose.calledOnce).to.be.true;
     });
 
     it("Escape key closes only the most recently opened tooltip when multiple are open", async () => {
+        const user = userEvent.setup();
         render(
             <div>
                 <Tooltip content="first tooltip" defaultIsOpen={true} hoverOpenDelay={0}>
@@ -271,7 +276,7 @@ describe("<Tooltip>", () => {
         await waitFor(() => expect(screen.getByText("first tooltip")).to.exist);
 
         // Hover second tooltip to open it
-        await userEvent.hover(screen.getByText("second target"));
+        await user.hover(screen.getByText("second target"));
         await waitFor(() => expect(screen.getByText("second tooltip")).to.exist);
 
         // Both tooltips should be visible
@@ -279,13 +284,13 @@ describe("<Tooltip>", () => {
         expect(screen.getByText("second tooltip")).to.exist;
 
         // Press Escape to close second (most recent) tooltip
-        await userEvent.keyboard("{Escape}");
+        await user.keyboard("{Escape}");
 
         await waitFor(() => expect(screen.queryByText("second tooltip")).not.toBeInTheDocument());
         expect(screen.getByText("first tooltip")).to.exist;
 
         // Press Escape again to close the first tooltip
-        await userEvent.keyboard("{Escape}");
+        await user.keyboard("{Escape}");
 
         await waitFor(() => expect(screen.queryByText("first tooltip")).not.toBeInTheDocument());
     });


### PR DESCRIPTION
## Summary

Migrate `@testing-library/user-event` usage in core tests from the direct API (`userEvent.click(...)`) to the recommended instance-based API (`userEvent.setup()` + `user.click(...)`).

The setup API creates an instance that shares input device state across interactions within a test, more accurately simulating real user behavior. The direct API is a convenience shortcut that creates a new instance per call and is no longer the recommended approach as of v14.

**References:**
- https://testing-library.com/docs/user-event/intro
- https://testing-library.com/docs/user-event/setup