### PR TITLE
[chore]: Modify test import paths in core

### DIFF
--- a/packages/core/src/components/alert/alert.test.tsx
+++ b/packages/core/src/components/alert/alert.test.tsx
@@ -20,8 +20,10 @@ import { type SinonStub, spy, stub } from "sinon";
 
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Alert, Classes } from "../..";
+import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
+
+import { Alert } from "./alert";
 
 describe("<Alert>", () => {
     it("should render contents", () => {

--- a/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -20,7 +20,9 @@ import { spy } from "sinon";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Breadcrumb, Classes } from "../..";
+import { Classes } from "../../common";
+
+import { Breadcrumb } from "./breadcrumb";
 
 describe("<Breadcrumb>", () => {
     it("should render its contents", () => {

--- a/packages/core/src/components/button/button.test.tsx
+++ b/packages/core/src/components/button/button.test.tsx
@@ -22,7 +22,10 @@ import { spy } from "sinon";
 import { IconNames } from "@blueprintjs/icons";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { AnchorButton, Button, Classes, Icon } from "../..";
+import { Classes } from "../../common";
+import { Icon } from "../icon/icon";
+
+import { AnchorButton, Button } from "./buttons";
 
 describe("<Button>", () => {
     commonTests(Button);

--- a/packages/core/src/components/callout/callout.test.tsx
+++ b/packages/core/src/components/callout/callout.test.tsx
@@ -19,7 +19,9 @@ import { render, screen } from "@testing-library/react";
 import { IconNames } from "@blueprintjs/icons";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Callout, Classes, Intent } from "../..";
+import { Classes, Intent } from "../../common";
+
+import { Callout } from "./callout";
 
 describe("<Callout>", () => {
     it("should support className", () => {

--- a/packages/core/src/components/card-list/cardList.test.tsx
+++ b/packages/core/src/components/card-list/cardList.test.tsx
@@ -19,7 +19,10 @@ import { createRef } from "react";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Card, CardList, Classes } from "../..";
+import { Classes } from "../../common";
+import { Card } from "../card/card";
+
+import { CardList } from "./cardList";
 
 describe("<CardList>", () => {
     it("should support className prop", () => {

--- a/packages/core/src/components/card/card.test.tsx
+++ b/packages/core/src/components/card/card.test.tsx
@@ -21,7 +21,10 @@ import sinon from "sinon";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Card, Classes, H4 } from "../..";
+import { Classes } from "../../common";
+import { H4 } from "../html/html";
+
+import { Card } from "./card";
 
 describe("<Card>", () => {
     it("should support elevation, interactive, and className props", () => {

--- a/packages/core/src/components/collapse/collapse.test.tsx
+++ b/packages/core/src/components/collapse/collapse.test.tsx
@@ -18,7 +18,8 @@ import { mount, shallow } from "enzyme";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, MenuItem } from "../..";
+import { Classes } from "../../common";
+import { MenuItem } from "../menu/menuItem";
 
 import { AnimationStates, Collapse } from "./collapse";
 

--- a/packages/core/src/components/context-menu/contextMenu.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.test.tsx
@@ -21,20 +21,15 @@ import { spy } from "sinon";
 
 import { afterAll, afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import {
-    Classes,
-    ContextMenu,
-    type ContextMenuContentProps,
-    type ContextMenuProps,
-    Drawer,
-    Menu,
-    MenuItem,
-    Popover,
-    PopoverInteractionKind,
-    Tooltip,
-    type TooltipProps,
-    Utils,
-} from "../..";
+import { Classes, Utils } from "../../common";
+import { Drawer } from "../drawer/drawer";
+import { Menu } from "../menu/menu";
+import { MenuItem } from "../menu/menuItem";
+import { Popover } from "../popover/popover";
+import { PopoverInteractionKind } from "../popover/popoverProps";
+import { Tooltip, type TooltipProps } from "../tooltip/tooltip";
+
+import { ContextMenu, type ContextMenuContentProps, type ContextMenuProps } from "./contextMenu";
 
 // use a unique ID to avoid collisons with other tests
 const MENU_CLASSNAME = Utils.uniqueId("test-menu");

--- a/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
@@ -17,7 +17,11 @@
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
-import { Classes, hideContextMenu, Menu, MenuItem, showContextMenu, Utils } from "../..";
+import { Classes, Utils } from "../../common";
+import { Menu } from "../menu/menu";
+import { MenuItem } from "../menu/menuItem";
+
+import { hideContextMenu, showContextMenu } from "./contextMenuSingleton";
 
 // use a unique ID to avoid collisons with other tests
 const MENU_CLASSNAME = Utils.uniqueId("test-menu");

--- a/packages/core/src/components/control-card/controlCard.test.tsx
+++ b/packages/core/src/components/control-card/controlCard.test.tsx
@@ -20,7 +20,12 @@ import { spy } from "sinon";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { CheckboxCard, Classes, RadioCard, RadioGroup, SwitchCard } from "../..";
+import { Classes } from "../../common";
+import { RadioGroup } from "../forms/radioGroup";
+
+import { CheckboxCard } from "./checkboxCard";
+import { RadioCard } from "./radioCard";
+import { SwitchCard } from "./switchCard";
 
 describe("ControlCard", () => {
     describe("SwitchCard", () => {

--- a/packages/core/src/components/dialog/dialog.test.tsx
+++ b/packages/core/src/components/dialog/dialog.test.tsx
@@ -21,7 +21,12 @@ import { createRef } from "react";
 
 import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
-import { Button, Classes, Dialog, DialogBody, DialogFooter, type DialogProps } from "../..";
+import { Classes } from "../../common";
+import { Button } from "../button/buttons";
+
+import { Dialog, type DialogProps } from "./dialog";
+import { DialogBody } from "./dialogBody";
+import { DialogFooter } from "./dialogFooter";
 
 const COMMON_PROPS: DialogProps = {
     backdropProps: { role: "presentation" },

--- a/packages/core/src/components/dialog/multistepDialog.test.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.test.tsx
@@ -20,7 +20,11 @@ import { act } from "react";
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons/vitest-utils";
 
-import { AnchorButton, Classes, DialogStep, MultistepDialog } from "../..";
+import { Classes } from "../../common";
+import { AnchorButton } from "../button/buttons";
+
+import { DialogStep } from "./dialogStep";
+import { MultistepDialog } from "./multistepDialog";
 
 // TODO: button selectors in these tests should not be tied so closely to implementation; we shouldn't
 // need to reference AnchorButton directly

--- a/packages/core/src/components/drawer/drawer.test.tsx
+++ b/packages/core/src/components/drawer/drawer.test.tsx
@@ -19,7 +19,10 @@ import { spy } from "sinon";
 
 import { afterEach, assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Button, Classes, Drawer, type DrawerProps, Position } from "../..";
+import { Classes, Position } from "../../common";
+import { Button } from "../button/buttons";
+
+import { Drawer, type DrawerProps } from "./drawer";
 
 describe("<Drawer>", () => {
     let drawer: ReactWrapper<DrawerProps, any>;

--- a/packages/core/src/components/editable-text/editableText.test.tsx
+++ b/packages/core/src/components/editable-text/editableText.test.tsx
@@ -20,7 +20,7 @@ import { spy } from "sinon";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { EditableText } from "../..";
+import { EditableText } from "./editableText";
 
 describe("<EditableText>", () => {
     it("renders value", () => {

--- a/packages/core/src/components/entity-title/entityTitle.test.tsx
+++ b/packages/core/src/components/entity-title/entityTitle.test.tsx
@@ -19,8 +19,11 @@ import { mount } from "enzyme";
 import { IconNames } from "@blueprintjs/icons";
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, EntityTitle, H5 } from "../..";
+import { Classes } from "../../common";
 import { Tag } from "../../index";
+import { H5 } from "../html/html";
+
+import { EntityTitle } from "./entityTitle";
 
 describe("<EntityTitle>", () => {
     let containerElement: HTMLElement;

--- a/packages/core/src/components/forms/controls.test.tsx
+++ b/packages/core/src/components/forms/controls.test.tsx
@@ -18,7 +18,7 @@ import { render, screen } from "@testing-library/react";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes } from "../..";
+import { Classes } from "../../common";
 
 import { Checkbox, Radio, Switch } from "./controls";
 

--- a/packages/core/src/components/forms/fileInput.test.tsx
+++ b/packages/core/src/components/forms/fileInput.test.tsx
@@ -19,7 +19,9 @@ import sinon from "sinon";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, FileInput } from "../..";
+import { Classes } from "../../common";
+
+import { FileInput } from "./fileInput";
 
 describe("<FileInput>", () => {
     it(`supports className, fill, & size="large"`, () => {

--- a/packages/core/src/components/forms/formGroup.test.tsx
+++ b/packages/core/src/components/forms/formGroup.test.tsx
@@ -18,7 +18,9 @@ import { shallow } from "enzyme";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, FormGroup, Intent } from "../..";
+import { Classes, Intent } from "../../common";
+
+import { FormGroup } from "./formGroup";
 
 describe("<FormGroup>", () => {
     it("supports className & intent", () => {

--- a/packages/core/src/components/forms/inputGroup.test.tsx
+++ b/packages/core/src/components/forms/inputGroup.test.tsx
@@ -21,7 +21,9 @@ import { spy } from "sinon";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, InputGroup } from "../..";
+import { Classes } from "../../common";
+
+import { InputGroup } from "./inputGroup";
 
 describe("<InputGroup>", () => {
     it("should render left icon before input", () => {

--- a/packages/core/src/components/forms/numericInput.test.tsx
+++ b/packages/core/src/components/forms/numericInput.test.tsx
@@ -26,18 +26,15 @@ import { type SinonStub, spy, stub } from "sinon";
 import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
-import {
-    Button,
-    ButtonGroup,
-    ControlGroup,
-    type HTMLInputProps,
-    Icon,
-    InputGroup,
-    NumericInput,
-    type NumericInputProps,
-    Position,
-} from "../..";
+import { type HTMLInputProps, Position } from "../../common";
 import * as Errors from "../../common/errors";
+import { ButtonGroup } from "../button/buttonGroup";
+import { Button } from "../button/buttons";
+import { Icon } from "../icon/icon";
+
+import { ControlGroup } from "./controlGroup";
+import { InputGroup } from "./inputGroup";
+import { NumericInput, type NumericInputProps } from "./numericInput";
 
 /**
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26979#issuecomment-465304376

--- a/packages/core/src/components/forms/radioGroup.test.tsx
+++ b/packages/core/src/components/forms/radioGroup.test.tsx
@@ -20,8 +20,11 @@ import { spy, stub } from "sinon";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, type OptionProps, Radio, RadioGroup } from "../..";
+import { Classes, type OptionProps } from "../../common";
 import { RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX } from "../../common/errors";
+
+import { Radio } from "./controls";
+import { RadioGroup } from "./radioGroup";
 
 const emptyHandler = () => {
     return;

--- a/packages/core/src/components/forms/textArea.test.tsx
+++ b/packages/core/src/components/forms/textArea.test.tsx
@@ -19,7 +19,7 @@ import { createRef } from "react";
 
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { TextArea } from "../..";
+import { TextArea } from "./textArea";
 
 describe("<TextArea>", () => {
     let containerElement: HTMLElement;

--- a/packages/core/src/components/html-select/htmlSelect.test.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.test.tsx
@@ -18,7 +18,9 @@ import { mount } from "enzyme";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { HTMLSelect, type OptionProps } from "../..";
+import { type OptionProps } from "../../common";
+
+import { HTMLSelect } from "./htmlSelect";
 
 describe("<HtmlSelect>", () => {
     const emptyHandler = () => true;

--- a/packages/core/src/components/html/html.test.tsx
+++ b/packages/core/src/components/html/html.test.tsx
@@ -18,7 +18,7 @@ import { mount } from "enzyme";
 
 import { describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Label } from "../..";
+import { Label } from "./html";
 
 describe("HTML components", () => {
     describe("<Label>", () => {

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -21,7 +21,9 @@ import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 import { afterEach, assert, beforeAll, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Icon, type IconProps, Intent } from "../..";
+import { Classes, Intent } from "../../common";
+
+import { Icon, type IconProps } from "./icon";
 
 describe("<Icon>", () => {
     let iconLoader: SinonStub;

--- a/packages/core/src/components/link/link.test.tsx
+++ b/packages/core/src/components/link/link.test.tsx
@@ -8,7 +8,9 @@ import { createRef } from "react";
 
 import { describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Intent, Link } from "../..";
+import { Classes, Intent } from "../../common";
+
+import { Link } from "./link";
 
 describe("<Link>", () => {
     it("should render an anchor tag with href", () => {

--- a/packages/core/src/components/menu/menu.test.tsx
+++ b/packages/core/src/components/menu/menu.test.tsx
@@ -18,7 +18,12 @@ import { shallow } from "enzyme";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, H6, Menu, MenuDivider, MenuItem } from "../..";
+import { Classes } from "../../common";
+import { H6 } from "../html/html";
+
+import { Menu } from "./menu";
+import { MenuDivider } from "./menuDivider";
+import { MenuItem } from "./menuItem";
 
 describe("<MenuDivider>", () => {
     it("React renders MenuDivider", () => {

--- a/packages/core/src/components/menu/menuItem.test.tsx
+++ b/packages/core/src/components/menu/menuItem.test.tsx
@@ -21,17 +21,15 @@ import { spy } from "sinon";
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 import { dispatchTestKeyboardEvent } from "@blueprintjs/test-commons/vitest-utils";
 
-import {
-    Button,
-    Classes,
-    Icon,
-    MenuItem,
-    type MenuItemProps,
-    type MenuProps,
-    Popover,
-    PopoverInteractionKind,
-    Text,
-} from "../..";
+import { Classes } from "../../common";
+import { Button } from "../button/buttons";
+import { Icon } from "../icon/icon";
+import { Popover } from "../popover/popover";
+import { PopoverInteractionKind } from "../popover/popoverProps";
+import { Text } from "../text/text";
+
+import { type MenuProps } from "./menu";
+import { MenuItem, type MenuItemProps } from "./menuItem";
 
 describe("MenuItem", () => {
     it("basic rendering", () => {

--- a/packages/core/src/components/non-ideal-state/nonIdealState.test.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.test.tsx
@@ -18,7 +18,10 @@ import { shallow } from "enzyme";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, H4, NonIdealState } from "../..";
+import { Classes } from "../../common";
+import { H4 } from "../html/html";
+
+import { NonIdealState } from "./nonIdealState";
 
 describe("<NonIdealState>", () => {
     it("renders its contents", () => {

--- a/packages/core/src/components/overlay/overlay.test.tsx
+++ b/packages/core/src/components/overlay/overlay.test.tsx
@@ -29,8 +29,12 @@ import { spy } from "sinon";
 import { afterAll, afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
-import { Classes, Overlay, type OverlayProps, Portal, type PortalProps, Utils } from "../..";
+import { Classes, Utils } from "../../common";
 import { sleep } from "../../common/test-utils";
+import { Portal, type PortalProps } from "../portal/portal";
+
+import { Overlay } from "./overlay";
+import { type OverlayProps } from "./overlayProps";
 
 function findInPortal<P>(overlay: ReactWrapper<P>, selector: string) {
     // React 16: createPortal preserves React tree so simple find works.

--- a/packages/core/src/components/overlay2/overlay2.test.tsx
+++ b/packages/core/src/components/overlay2/overlay2.test.tsx
@@ -21,7 +21,11 @@ import { spy } from "sinon";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Overlay2, type Overlay2Props, type OverlayInstance, OverlaysProvider } from "../..";
+import { Classes } from "../../common";
+import { OverlaysProvider } from "../../context/overlays/overlaysProvider";
+
+import { Overlay2, type Overlay2Props } from "./overlay2";
+import { type OverlayInstance } from "./overlayInstance";
 
 import "../../../test/overlay2/overlay2-test-debugging.scss";
 

--- a/packages/core/src/components/panel-stack/panelStack.test.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.test.tsx
@@ -20,7 +20,11 @@ import { spy } from "sinon";
 
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, NumericInput, type Panel, type PanelProps, PanelStack, type PanelStackProps } from "../..";
+import { Classes } from "../../common";
+import { NumericInput } from "../forms/numericInput";
+
+import { PanelStack, type PanelStackProps } from "./panelStack";
+import { type Panel, type PanelProps } from "./panelTypes";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type TestPanelInfo = {};

--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -7,7 +7,7 @@ import userEvent from "@testing-library/user-event";
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
-import { Classes } from "../..";
+import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
 import { Button, PopupKind, Tooltip } from "../../components";
 import type { PopoverInteractionKind } from "../popover/popoverProps";

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -21,7 +21,7 @@ import sinon from "sinon";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Button, PopupKind, Tooltip } from "..";
-import { Classes } from "../..";
+import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
 
 import { Popover } from "./popover";

--- a/packages/core/src/components/portal/portal.test.tsx
+++ b/packages/core/src/components/portal/portal.test.tsx
@@ -18,7 +18,10 @@ import { mount, type ReactWrapper } from "enzyme";
 
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Portal, type PortalProps, PortalProvider } from "../..";
+import { Classes } from "../../common";
+import { PortalProvider } from "../../context/portal/portalProvider";
+
+import { Portal, type PortalProps } from "./portal";
 
 describe("<Portal>", () => {
     let rootElement: HTMLElement | undefined;

--- a/packages/core/src/components/progress-bar/progressBar.test.tsx
+++ b/packages/core/src/components/progress-bar/progressBar.test.tsx
@@ -18,7 +18,9 @@ import { mount } from "enzyme";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, ProgressBar } from "../..";
+import { Classes } from "../../common";
+
+import { ProgressBar } from "./progressBar";
 
 describe("ProgressBar", () => {
     it("renders a PROGRESS_BAR", () => {

--- a/packages/core/src/components/section/section.test.tsx
+++ b/packages/core/src/components/section/section.test.tsx
@@ -19,7 +19,11 @@ import { mount, type ReactWrapper } from "enzyme";
 import { IconNames } from "@blueprintjs/icons";
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, H5, H6, Section, SectionCard } from "../..";
+import { Classes } from "../../common";
+import { H5, H6 } from "../html/html";
+
+import { Section } from "./section";
+import { SectionCard } from "./sectionCard";
 
 describe("<Section>", () => {
     let containerElement: HTMLElement;

--- a/packages/core/src/components/segmented-control/segmentedControl.test.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.test.tsx
@@ -22,7 +22,9 @@ import sinon from "sinon";
 import { IconNames } from "@blueprintjs/icons";
 import { afterEach, assert, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, type OptionProps, SegmentedControl, type SegmentedControlProps } from "../..";
+import { Classes, type OptionProps } from "../../common";
+
+import { SegmentedControl, type SegmentedControlProps } from "./segmentedControl";
 
 const OPTIONS: Array<OptionProps<string>> = [
     {

--- a/packages/core/src/components/slider/multiSlider.test.tsx
+++ b/packages/core/src/components/slider/multiSlider.test.tsx
@@ -20,10 +20,10 @@ import sinon from "sinon";
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, MultiSlider, type MultiSliderProps } from "../..";
+import { Classes } from "../../common";
 
 import { Handle } from "./handle";
-import { MultiSliderHandle } from "./multiSlider";
+import { MultiSlider, MultiSliderHandle, type MultiSliderProps } from "./multiSlider";
 import { mouseUpHorizontal, simulateMovement } from "./sliderTestUtils";
 
 const STEP_SIZE = 20;

--- a/packages/core/src/components/slider/rangeSlider.test.tsx
+++ b/packages/core/src/components/slider/rangeSlider.test.tsx
@@ -20,9 +20,10 @@ import sinon from "sinon";
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, RangeSlider } from "../..";
+import { Classes } from "../../common";
 
 import { Handle } from "./handle";
+import { RangeSlider } from "./rangeSlider";
 
 const STEP_SIZE = 20;
 

--- a/packages/core/src/components/slider/slider.test.tsx
+++ b/packages/core/src/components/slider/slider.test.tsx
@@ -19,9 +19,10 @@ import sinon from "sinon";
 
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Slider } from "../..";
+import { Classes } from "../../common";
 
 import { Handle } from "./handle";
+import { Slider } from "./slider";
 import { simulateMovement } from "./sliderTestUtils";
 
 const STEP_SIZE = 20;

--- a/packages/core/src/components/spinner/spinner.test.tsx
+++ b/packages/core/src/components/spinner/spinner.test.tsx
@@ -19,8 +19,10 @@ import { stub } from "sinon";
 
 import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Spinner, SpinnerSize } from "../..";
+import { Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
+
+import { Spinner, SpinnerSize } from "./spinner";
 
 describe("Spinner", () => {
     it("renders a spinner and two paths", () => {

--- a/packages/core/src/components/tag-input/tagInput.test.tsx
+++ b/packages/core/src/components/tag-input/tagInput.test.tsx
@@ -21,7 +21,11 @@ import sinon from "sinon";
 
 import { assert, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Button, Classes, Intent, Tag, TagInput, type TagInputProps } from "../..";
+import { Classes, Intent } from "../../common";
+import { Button } from "../button/buttons";
+import { Tag } from "../tag/tag";
+
+import { TagInput, type TagInputProps } from "./tagInput";
 
 /**
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/26979#issuecomment-465304376

--- a/packages/core/src/components/tag/compoundTag.test.tsx
+++ b/packages/core/src/components/tag/compoundTag.test.tsx
@@ -21,7 +21,10 @@ import { spy } from "sinon";
 
 import { assert, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, CompoundTag, Icon } from "../..";
+import { Classes } from "../../common";
+import { Icon } from "../icon/icon";
+
+import { CompoundTag } from "./compoundTag";
 
 describe("<CompoundTag>", () => {
     it("renders its text", () => {

--- a/packages/core/src/components/tag/tag.test.tsx
+++ b/packages/core/src/components/tag/tag.test.tsx
@@ -21,7 +21,11 @@ import { spy } from "sinon";
 
 import { assert, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Icon, Tag, Text } from "../..";
+import { Classes } from "../../common";
+import { Icon } from "../icon/icon";
+import { Text } from "../text/text";
+
+import { Tag } from "./tag";
 
 describe("<Tag>", () => {
     it("renders its text", () => {

--- a/packages/core/src/components/text/text.test.tsx
+++ b/packages/core/src/components/text/text.test.tsx
@@ -18,7 +18,9 @@ import { mount } from "enzyme";
 
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Text } from "../..";
+import { Classes } from "../../common";
+
+import { Text } from "./text";
 
 describe("<Text>", () => {
     it("adds the className prop", () => {

--- a/packages/core/src/components/toast/overlayToaster.test.tsx
+++ b/packages/core/src/components/toast/overlayToaster.test.tsx
@@ -21,10 +21,11 @@ import sinon, { spy } from "sinon";
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { afterAll, afterEach, assert, beforeAll, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, OverlayToaster, type Toaster } from "../..";
+import { Classes } from "../../common";
 import { TOASTER_MAX_TOASTS_INVALID } from "../../common/errors";
 
-import { OVERLAY_TOASTER_DELAY_MS, type OverlayToasterDOMRenderer } from "./overlayToaster";
+import { OVERLAY_TOASTER_DELAY_MS, OverlayToaster, type OverlayToasterDOMRenderer } from "./overlayToaster";
+import { type Toaster } from "./toaster";
 
 let react18Root: Root | undefined;
 

--- a/packages/core/src/components/toast/toast.test.tsx
+++ b/packages/core/src/components/toast/toast.test.tsx
@@ -19,8 +19,10 @@ import { type SinonSpy, spy } from "sinon";
 
 import { assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { AnchorButton, Button, Toast } from "../..";
 import { sleep } from "../../common/test-utils";
+import { AnchorButton, Button } from "../button/buttons";
+
+import { Toast } from "./toast";
 
 describe("<Toast>", () => {
     it("renders only dismiss button by default", () => {

--- a/packages/core/src/components/tree/tree.test.tsx
+++ b/packages/core/src/components/tree/tree.test.tsx
@@ -20,7 +20,10 @@ import { spy } from "sinon";
 
 import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Tree, type TreeNodeInfo, type TreeProps } from "../..";
+import { Classes } from "../../common";
+
+import { Tree, type TreeProps } from "./tree";
+import { type TreeNodeInfo } from "./treeTypes";
 
 describe("<Tree>", () => {
     let containerElement: HTMLElement;

--- a/packages/core/src/tsconfig.test.json
+++ b/packages/core/src/tsconfig.test.json
@@ -2,7 +2,6 @@
     "extends": "./tsconfig.build.json",
     "compilerOptions": {
         "composite": true,
-        "declaration": false,
         "noEmit": true,
         "skipLibCheck": true
     },

--- a/packages/core/src/tsconfig.test.json
+++ b/packages/core/src/tsconfig.test.json
@@ -6,6 +6,6 @@
         "noEmit": true,
         "skipLibCheck": true
     },
-    "include": ["**/*.test.ts", "**/*.test.tsx", "vitest-env.d.ts"],
+    "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx", "vitest-env.d.ts"],
     "exclude": []
 }


### PR DESCRIPTION
FLUP to https://github.com/palantir/blueprint/pull/7714

## Proposed changes
- Update `tsconfig.test.json` to only include test files and remove unnecessary `"declaration": false`
- Replace barrel imports (`../..`) across core test files with direct module paths

## Reviewers should focus on:
Correctness of the resolved import paths, especially for cross-component imports 