### PR TITLE
[chore]: Replace sinon with vitest in core tests

### DIFF
--- a/packages/core/src/common/utils.test.tsx
+++ b/packages/core/src/common/utils.test.tsx
@@ -15,9 +15,9 @@
  */
 
 import { Fragment } from "react/jsx-runtime";
-import { type SinonSpy, spy } from "sinon";
+import type { MockInstance } from "vitest";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import * as Utils from "./utils";
 
@@ -137,13 +137,13 @@ describe("Utils", () => {
     });
 
     describe("throttleReactEventCallback", () => {
-        let callback: SinonSpy;
+        let callback: MockInstance;
         let fakeEvent: any; // cast as `any` to avoid having to set every required property on the event
         let throttledCallback: (event2: React.SyntheticEvent<any>, ...otherArgs2: any[]) => void;
 
         beforeEach(() => {
-            callback = spy();
-            fakeEvent = { persist: spy(), preventDefault: spy() };
+            callback = vi.fn();
+            fakeEvent = { persist: vi.fn(), preventDefault: vi.fn() };
         });
 
         afterEach(() => {
@@ -153,7 +153,7 @@ describe("Utils", () => {
         it("invokes event.persist() to prevent React from pooling before we can reference the event in rAF", () => {
             throttledCallback = Utils.throttleReactEventCallback(callback);
             throttledCallback(fakeEvent as any);
-            assert.isTrue(fakeEvent.persist.calledOnce);
+            expect(fakeEvent.persist).toHaveBeenCalledOnce();
         });
 
         it("can preventDefault", () => {
@@ -161,7 +161,7 @@ describe("Utils", () => {
                 preventDefault: true,
             });
             throttledCallback(fakeEvent as any);
-            assert.isTrue(fakeEvent.preventDefault.calledOnce);
+            expect(fakeEvent.preventDefault).toHaveBeenCalledOnce();
         });
 
         // TODO: how to test this properly? perhaps with the help of https://github.com/alexreardon/raf-stub?

--- a/packages/core/src/common/utils.test.tsx
+++ b/packages/core/src/common/utils.test.tsx
@@ -15,9 +15,17 @@
  */
 
 import { Fragment } from "react/jsx-runtime";
-import type { MockInstance } from "vitest";
 
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import {
+    afterEach,
+    assert,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type MockInstance,
+    vi,
+} from "@blueprintjs/test-commons/vitest";
 
 import * as Utils from "./utils";
 

--- a/packages/core/src/components/alert/alert.test.tsx
+++ b/packages/core/src/components/alert/alert.test.tsx
@@ -16,9 +16,8 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { type SinonStub, spy, stub } from "sinon";
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
@@ -33,8 +32,8 @@ describe("<Alert>", () => {
                 isOpen={true}
                 confirmButtonText="Delete"
                 cancelButtonText="Cancel"
-                onClose={spy}
-                onCancel={spy}
+                onClose={vi.fn()}
+                onCancel={vi.fn()}
             >
                 <p>Are you sure you want to delete this file?</p>
             </Alert>,
@@ -72,10 +71,10 @@ describe("<Alert>", () => {
     });
 
     it("should support overlay lifecycle props", async () => {
-        const onOpening = spy();
+        const onOpening = vi.fn();
         render(<Alert isOpen={true} onOpening={onOpening} />);
 
-        await waitFor(() => expect(onOpening.calledOnce).to.be.true);
+        await waitFor(() => expect(onOpening).toHaveBeenCalledOnce());
     });
 
     describe("confirm button", () => {
@@ -88,22 +87,22 @@ describe("<Alert>", () => {
 
         it("should trigger onConfirm and onClose when clicked", async () => {
             const user = userEvent.setup();
-            const onConfirm = spy();
-            const onClose = spy();
+            const onConfirm = vi.fn();
+            const onClose = vi.fn();
             render(<Alert isOpen={true} confirmButtonText="Confirm" onConfirm={onConfirm} onClose={onClose} />);
             const confirmButton = screen.getByRole("button", { name: "Confirm" });
 
             await user.click(confirmButton);
 
-            expect(onConfirm.calledOnce).to.be.true;
-            expect(onClose.calledOnce).to.be.true;
-            expect(onClose.args[0][0]).to.be.true;
+            expect(onConfirm).toHaveBeenCalledOnce();
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(onClose.mock.calls[0][0]).toBe(true);
         });
     });
 
     describe("cancel button", () => {
         it("should have correct text and no intent", () => {
-            render(<Alert intent="primary" isOpen={true} cancelButtonText="Cancel" onCancel={spy} />);
+            render(<Alert intent="primary" isOpen={true} cancelButtonText="Cancel" onCancel={vi.fn()} />);
             const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
             expect(cancelButton).not.toHaveClass(Classes.INTENT_PRIMARY);
@@ -111,8 +110,8 @@ describe("<Alert>", () => {
 
         it("should trigger 'onCancel' and 'onClose' when clicked", async () => {
             const user = userEvent.setup();
-            const onCancel = spy();
-            const onClose = spy();
+            const onCancel = vi.fn();
+            const onClose = vi.fn();
             render(
                 <Alert
                     intent="primary"
@@ -126,34 +125,34 @@ describe("<Alert>", () => {
 
             await user.click(cancelButton);
 
-            expect(onCancel.calledOnce).to.be.true;
-            expect(onClose.calledOnce).to.be.true;
-            expect(onClose.args[0][0]).to.be.false;
+            expect(onCancel).toHaveBeenCalledOnce();
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(onClose.mock.calls[0][0]).toBe(false);
         });
 
         it("should not be escape key cancelable by default", () => {
-            const onCancel = spy();
-            render(<Alert isOpen={true} cancelButtonText="Cancel" onCancel={spy} />);
+            const onCancel = vi.fn();
+            render(<Alert isOpen={true} cancelButtonText="Cancel" onCancel={vi.fn()} />);
             const dialog = screen.getByRole("alertdialog");
 
             fireEvent.keyDown(dialog, { key: "Escape" });
 
-            expect(onCancel.notCalled).to.be.true;
+            expect(onCancel).not.toHaveBeenCalled();
         });
 
         it("should be escape key cancelable when canEscapeKeyCancel is true", async () => {
-            const onCancel = spy();
+            const onCancel = vi.fn();
             render(<Alert isOpen={true} cancelButtonText="Cancel" onCancel={onCancel} canEscapeKeyCancel={true} />);
             const dialog = screen.getByRole("alertdialog");
 
             fireEvent.keyDown(dialog, { key: "Escape" });
 
-            expect(onCancel.calledOnce).to.be.true;
+            expect(onCancel).toHaveBeenCalledOnce();
         });
 
         it("should not allow outside click by default", async () => {
             const user = userEvent.setup();
-            const onCancel = spy();
+            const onCancel = vi.fn();
             const { baseElement } = render(<Alert isOpen={true} cancelButtonText="Cancel" onCancel={onCancel} />);
 
             // using baseElement since overlay is rendered in a portal
@@ -163,12 +162,12 @@ describe("<Alert>", () => {
 
             await user.click(backdrop!);
 
-            expect(onCancel.notCalled).to.be.true;
+            expect(onCancel).not.toHaveBeenCalled();
         });
 
         it("should allow outside click when canOutsideClickCancel is true", async () => {
             const user = userEvent.setup();
-            const onCancel = spy();
+            const onCancel = vi.fn();
             const { baseElement } = render(
                 <Alert isOpen={true} cancelButtonText="Cancel" onCancel={onCancel} canOutsideClickCancel={true} />,
             );
@@ -179,15 +178,15 @@ describe("<Alert>", () => {
 
             await user.click(backdrop!);
 
-            expect(onCancel.calledOnce).to.be.true;
+            expect(onCancel).toHaveBeenCalledOnce();
         });
     });
 
     describe("loading", () => {
         it("should display loading state on buttons", async () => {
             const user = userEvent.setup();
-            const onCancel = spy();
-            const onClose = spy();
+            const onCancel = vi.fn();
+            const onClose = vi.fn();
 
             render(
                 <Alert
@@ -206,33 +205,32 @@ describe("<Alert>", () => {
             await user.click(confirmButton!);
 
             // Confirm that the buttons are disabled
-            expect(onCancel.called).to.be.false;
-            expect(onClose.called).to.be.false;
+            expect(onCancel).not.toHaveBeenCalled();
+            expect(onClose).not.toHaveBeenCalled();
         });
     });
 
     describe("warnings", () => {
-        let warnSpy: SinonStub;
-        beforeAll(() => (warnSpy = stub(console, "warn")));
-        afterEach(() => warnSpy.resetHistory());
-        afterAll(() => warnSpy.restore());
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+        afterEach(() => warnSpy.mockClear());
+        afterAll(() => warnSpy.mockRestore());
 
         it("cancelButtonText without cancel handler", () => {
             render(<Alert cancelButtonText="cancel" isOpen={false} />);
 
-            expect(warnSpy.calledOnceWithExactly(Errors.ALERT_WARN_CANCEL_PROPS)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(Errors.ALERT_WARN_CANCEL_PROPS);
         });
 
         it("canEscapeKeyCancel without cancel handler", () => {
             render(<Alert canEscapeKeyCancel={true} isOpen={false} />);
 
-            expect(warnSpy.calledOnceWithExactly(Errors.ALERT_WARN_CANCEL_ESCAPE_KEY)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(Errors.ALERT_WARN_CANCEL_ESCAPE_KEY);
         });
 
         it("canOutsideClickCancel without cancel handler", () => {
             render(<Alert canOutsideClickCancel={true} isOpen={false} />);
 
-            expect(warnSpy.calledOnceWithExactly(Errors.ALERT_WARN_CANCEL_OUTSIDE_CLICK)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledExactlyOnceWith(Errors.ALERT_WARN_CANCEL_OUTSIDE_CLICK);
         });
     });
 });

--- a/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumb.test.tsx
@@ -16,9 +16,8 @@
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { spy } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -35,22 +34,22 @@ describe("<Breadcrumb>", () => {
 
     it("should trigger onClick when clicked", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Breadcrumb onClick={onClick} text="Test" />);
 
         await user.click(screen.getByText("Test"));
 
-        expect(onClick.calledOnce).to.be.true;
+        expect(onClick).toHaveBeenCalledOnce();
     });
 
     it("should not trigger onClick when disabled and clicked", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Breadcrumb disabled={true} onClick={onClick} text="Test" />);
 
         await user.click(screen.getByText("Test"));
 
-        expect(onClick.notCalled).to.be.true;
+        expect(onClick).not.toHaveBeenCalled();
     });
 
     it("should render an a tag when clickable", () => {

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { spy } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Boundary } from "../../common/boundary";
@@ -107,17 +106,17 @@ describe("<Breadcrumbs>", () => {
     });
 
     it("should call currentBreadcrumbRenderer (only) for the current breadcrumb", () => {
-        const breadcrumbRenderer = spy();
+        const breadcrumbRenderer = vi.fn();
         render(
             <Breadcrumbs currentBreadcrumbRenderer={breadcrumbRenderer} items={ITEMS} minVisibleItems={ITEMS.length} />,
         );
 
-        expect(breadcrumbRenderer.calledOnce).to.be.true;
-        expect(breadcrumbRenderer.calledWith(ITEMS[ITEMS.length - 1])).to.be.true;
+        expect(breadcrumbRenderer).toHaveBeenCalledOnce();
+        expect(breadcrumbRenderer).toHaveBeenCalledWith(ITEMS[ITEMS.length - 1]);
     });
 
     it("should not call breadcrumbRenderer for the current breadcrumb when there is a currentBreadcrumbRenderer", () => {
-        const breadcrumbRenderer = spy();
+        const breadcrumbRenderer = vi.fn();
         render(
             <Breadcrumbs
                 breadcrumbRenderer={breadcrumbRenderer}
@@ -127,14 +126,14 @@ describe("<Breadcrumbs>", () => {
             />,
         );
 
-        expect(breadcrumbRenderer.callCount).to.equal(ITEMS.length - 1);
-        expect(breadcrumbRenderer.neverCalledWith(ITEMS[ITEMS.length - 1])).to.be.true;
+        expect(breadcrumbRenderer).toHaveBeenCalledTimes(ITEMS.length - 1);
+        expect(breadcrumbRenderer).not.toHaveBeenCalledWith(ITEMS[ITEMS.length - 1]);
     });
 
     it("should call breadcrumbRenderer", () => {
-        const breadcrumbRenderer = spy();
+        const breadcrumbRenderer = vi.fn();
         render(<Breadcrumbs breadcrumbRenderer={breadcrumbRenderer} items={ITEMS} minVisibleItems={ITEMS.length} />);
 
-        expect(breadcrumbRenderer.callCount).to.equal(ITEMS.length);
+        expect(breadcrumbRenderer).toHaveBeenCalledTimes(ITEMS.length);
     });
 });

--- a/packages/core/src/components/button/button.test.tsx
+++ b/packages/core/src/components/button/button.test.tsx
@@ -17,10 +17,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
-import { spy } from "sinon";
 
 import { IconNames } from "@blueprintjs/icons";
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
@@ -122,13 +121,13 @@ function commonTests(Component: typeof Button | typeof AnchorButton) {
 
     it("should disable button while loading", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Component loading={true} onClick={onClick} />);
         const button = screen.getByRole("button");
 
         await user.click(button);
 
-        expect(onClick.called).to.be.false;
+        expect(onClick).not.toHaveBeenCalled();
     });
 
     // This tests some subtle (potentialy unexpected) behavior, but it was an API decision we
@@ -136,45 +135,45 @@ function commonTests(Component: typeof Button | typeof AnchorButton) {
     // See https://github.com/palantir/blueprint/issues/3819#issuecomment-1189478596
     it("should disable button while loading, even when disabled prop is explicity set to false", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Component loading={true} disabled={false} onClick={onClick} />);
         const button = screen.getByRole("button");
 
         await user.click(button);
 
-        expect(onClick.called).to.be.false;
+        expect(onClick).not.toHaveBeenCalled();
     });
 
     it("should trigger onClick when clicked", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Component onClick={onClick} />);
         const button = screen.getByRole("button");
 
         await user.click(button);
 
-        expect(onClick.called).to.be.true;
+        expect(onClick).toHaveBeenCalled();
     });
 
     it("should call onClick when enter key is pressed", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Component onClick={onClick} />);
         const button = screen.getByRole("button");
 
         await user.type(button, "{enter}");
 
-        expect(onClick.called).to.be.true;
+        expect(onClick).toHaveBeenCalled();
     });
 
     it("should call onClick when space key is pressed", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<Component onClick={onClick} />);
         const button = screen.getByRole("button");
 
         await user.type(button, "{space}");
 
-        expect(onClick.called).to.be.true;
+        expect(onClick).toHaveBeenCalled();
     });
 }

--- a/packages/core/src/components/card/card.test.tsx
+++ b/packages/core/src/components/card/card.test.tsx
@@ -17,9 +17,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef } from "react";
-import sinon from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { H4 } from "../html/html";
@@ -53,17 +52,17 @@ describe("<Card>", () => {
 
     it("should call onClick when card is clicked", async () => {
         const user = userEvent.setup();
-        const onClick = sinon.spy();
+        const onClick = vi.fn();
         render(<Card onClick={onClick}>Test</Card>);
         const card = screen.getByText("Test");
 
         await user.click(card);
 
-        expect(onClick.calledOnce).to.be.true;
+        expect(onClick).toHaveBeenCalledOnce();
     });
 
     it("should support HTML props", () => {
-        const onChange = sinon.spy();
+        const onChange = vi.fn();
         render(
             <Card onChange={onChange} title="foo" tabIndex={4000}>
                 Test

--- a/packages/core/src/components/context-menu/contextMenu.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.test.tsx
@@ -17,9 +17,8 @@
 import classNames from "classnames";
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef, useCallback } from "react";
-import { spy } from "sinon";
 
-import { afterAll, afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Utils } from "../../common";
 import { Drawer } from "../drawer/drawer";
@@ -124,8 +123,8 @@ describe("ContextMenu", () => {
         });
 
         it("clicks inside popover don't propagate to context menu wrapper", () => {
-            const itemClickSpy = spy();
-            const wrapperClickSpy = spy();
+            const itemClickSpy = vi.fn();
+            const wrapperClickSpy = vi.fn();
             const ctxMenu = mountTestMenu({
                 content: (
                     <Menu>
@@ -136,8 +135,8 @@ describe("ContextMenu", () => {
             });
             openCtxMenu(ctxMenu);
             ctxMenu.find("[data-testid='item']").hostNodes().simulate("click");
-            assert.isTrue(itemClickSpy.calledOnce, "menu item click handler should be called once");
-            assert.isFalse(wrapperClickSpy.called, "ctx menu wrapper click handler should not be called");
+            expect(itemClickSpy).toHaveBeenCalledOnce();
+            expect(wrapperClickSpy).not.toHaveBeenCalled();
         });
 
         it("allows overrding some Popover props", () => {

--- a/packages/core/src/components/control-card/controlCard.test.tsx
+++ b/packages/core/src/components/control-card/controlCard.test.tsx
@@ -16,9 +16,8 @@
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { spy } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { RadioGroup } from "../forms/radioGroup";
@@ -55,13 +54,13 @@ describe("ControlCard", () => {
 
         it("should toggle switch state when clicked", async () => {
             const user = userEvent.setup();
-            const handleChange = spy();
+            const handleChange = vi.fn();
             render(<SwitchCard onChange={handleChange} label="Test Switch" data-testid="test-switch" />);
             const switchInput = screen.getByRole("checkbox", { name: "Test Switch" });
 
             await user.click(switchInput);
 
-            expect(handleChange.calledOnce).to.be.true;
+            expect(handleChange).toHaveBeenCalledOnce();
         });
 
         it("should show as selected when checked", () => {
@@ -154,7 +153,7 @@ describe("ControlCard", () => {
         });
 
         it("should show as selected when checked", () => {
-            const onChange = spy();
+            const onChange = vi.fn();
             render(
                 <RadioGroup selectedValue="one" onChange={onChange}>
                     <RadioCard value="one" label="One" />
@@ -179,7 +178,7 @@ describe("ControlCard", () => {
 
         it("should work within a RadioGroup", async () => {
             const user = userEvent.setup();
-            const changeSpy = spy();
+            const changeSpy = vi.fn();
             render(
                 <RadioGroup onChange={changeSpy}>
                     <RadioCard value="one" label="One" />
@@ -193,7 +192,7 @@ describe("ControlCard", () => {
             await user.click(radioOne);
             await user.click(radioTwo);
 
-            expect(changeSpy.callCount).to.equal(2);
+            expect(changeSpy).toHaveBeenCalledTimes(2);
         });
     });
 });

--- a/packages/core/src/components/drawer/drawer.test.tsx
+++ b/packages/core/src/components/drawer/drawer.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount, type ReactWrapper } from "enzyme";
-import { spy } from "sinon";
 
-import { afterEach, assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Position } from "../../common";
 import { Button } from "../button/buttons";
@@ -171,46 +170,46 @@ describe("<Drawer>", () => {
         );
         drawer.unmount();
         document.body.removeChild(container);
-        const onClose = spy();
+        const onClose = vi.fn();
         mountDrawer(
             <Drawer isOpen={true} onClose={onClose} usePortal={false}>
                 {createDrawerContents()}
             </Drawer>,
         );
         drawer.find(`.${Classes.OVERLAY_BACKDROP}`).simulate("mousedown");
-        assert.isTrue(onClose.calledOnce);
+        expect(onClose).toHaveBeenCalledOnce();
     });
 
     it("doesn't close when canOutsideClickClose=false and overlay backdrop element is moused down", () => {
-        const onClose = spy();
+        const onClose = vi.fn();
         mountDrawer(
             <Drawer canOutsideClickClose={false} isOpen={true} onClose={onClose} usePortal={false}>
                 {createDrawerContents()}
             </Drawer>,
         );
         drawer.find(`.${Classes.OVERLAY_BACKDROP}`).simulate("mousedown");
-        assert.isTrue(onClose.notCalled);
+        expect(onClose).not.toHaveBeenCalled();
     });
 
     it("doesn't close when canEscapeKeyClose=false and escape key is pressed", () => {
-        const onClose = spy();
+        const onClose = vi.fn();
         mountDrawer(
             <Drawer canEscapeKeyClose={false} isOpen={true} onClose={onClose} usePortal={false}>
                 {createDrawerContents()}
             </Drawer>,
         );
         drawer.simulate("keydown", { key: "Escape" });
-        assert.isTrue(onClose.notCalled);
+        expect(onClose).not.toHaveBeenCalled();
     });
 
     it("supports overlay lifecycle props", () => {
-        const onOpening = spy();
+        const onOpening = vi.fn();
         mountDrawer(
             <Drawer isOpen={true} onOpening={onOpening}>
                 body
             </Drawer>,
         );
-        assert.isTrue(onOpening.calledOnce);
+        expect(onOpening).toHaveBeenCalledOnce();
     });
 
     describe("header", () => {
@@ -245,14 +244,14 @@ describe("<Drawer>", () => {
         });
 
         it("clicking close button triggers onClose", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             mountDrawer(
                 <Drawer isCloseButtonShown={true} isOpen={true} onClose={onClose} title="Hello!" usePortal={false}>
                     drawer body
                 </Drawer>,
             );
             drawer.find(`.${Classes.DRAWER_HEADER}`).find(Button).simulate("click");
-            assert.isTrue(onClose.calledOnce, "onClose not called");
+            expect(onClose).toHaveBeenCalledOnce();
         });
     });
 

--- a/packages/core/src/components/editable-text/editableText.test.tsx
+++ b/packages/core/src/components/editable-text/editableText.test.tsx
@@ -16,9 +16,8 @@
 
 import { mount, type ReactWrapper, shallow } from "enzyme";
 import { act } from "react";
-import { spy } from "sinon";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { EditableText } from "./editableText";
 
@@ -67,7 +66,7 @@ describe("<EditableText>", () => {
         });
 
         it("calls onChange when input is changed", () => {
-            const changeSpy = spy();
+            const changeSpy = vi.fn();
             const wrapper = mount(
                 <EditableText isEditing={true} onChange={changeSpy} placeholder="Edit..." value="alphabet" />,
             );
@@ -76,23 +75,23 @@ describe("<EditableText>", () => {
                 .simulate("change", { target: { value: "hello" } })
                 .simulate("change", { target: { value: " " } })
                 .simulate("change", { target: { value: "world" } });
-            assert.isTrue(changeSpy.calledThrice, "onChange not called thrice");
-            assert.deepEqual(changeSpy.args, [["hello"], [" "], ["world"]]);
+            expect(changeSpy).toHaveBeenCalledTimes(3);
+            expect(changeSpy.mock.calls).toEqual([["hello"], [" "], ["world"]]);
         });
 
         it("calls onChange when escape key pressed and value is unconfirmed", () => {
-            const changeSpy = spy();
+            const changeSpy = vi.fn();
             mount(<EditableText isEditing={true} onChange={changeSpy} placeholder="Edit..." defaultValue="alphabet" />)
                 .find("input")
                 .simulate("change", { target: { value: "hello" } })
                 .simulate("keydown", { key: "Escape" });
-            assert.equal(changeSpy.callCount, 2, "onChange not called twice"); // change & escape
-            assert.deepEqual(changeSpy.args[1], ["alphabet"], `unexpected argument "${changeSpy.args[1][0]}"`);
+            expect(changeSpy).toHaveBeenCalledTimes(2); // change & escape
+            expect(changeSpy.mock.calls[1]).toEqual(["alphabet"]);
         });
 
         it("calls onCancel, does not call onConfirm, and reverts value when escape key pressed", () => {
-            const cancelSpy = spy();
-            const confirmSpy = spy();
+            const cancelSpy = vi.fn();
+            const confirmSpy = vi.fn();
 
             const OLD_VALUE = "alphabet";
             const NEW_VALUE = "hello";
@@ -105,15 +104,15 @@ describe("<EditableText>", () => {
                 .simulate("change", { target: { value: NEW_VALUE } })
                 .simulate("keydown", { key: "Escape" });
 
-            assert.isTrue(confirmSpy.notCalled, "onConfirm called");
-            assert.isTrue(cancelSpy.calledOnce, "onCancel not called once");
-            assert.isTrue(cancelSpy.calledWith(OLD_VALUE), `unexpected argument "${cancelSpy.args[0][0]}"`);
+            expect(confirmSpy).not.toHaveBeenCalled();
+            expect(cancelSpy).toHaveBeenCalledOnce();
+            expect(cancelSpy.mock.calls[0][0]).toBe(OLD_VALUE);
             assert.strictEqual(component.state().value, OLD_VALUE, "did not revert to original value");
         });
 
         it("calls onConfirm, does not call onCancel, and saves value when enter key pressed", () => {
-            const cancelSpy = spy();
-            const confirmSpy = spy();
+            const cancelSpy = vi.fn();
+            const confirmSpy = vi.fn();
 
             const OLD_VALUE = "alphabet";
             const NEW_VALUE = "hello";
@@ -126,15 +125,15 @@ describe("<EditableText>", () => {
                 .simulate("change", { target: { value: NEW_VALUE } })
                 .simulate("keydown", { key: "Enter" });
 
-            assert.isTrue(cancelSpy.notCalled, "onCancel called");
-            assert.isTrue(confirmSpy.calledOnce, "onConfirm not called once");
-            assert.isTrue(confirmSpy.calledWith(NEW_VALUE), `unexpected argument "${confirmSpy.args[0][0]}"`);
+            expect(cancelSpy).not.toHaveBeenCalled();
+            expect(confirmSpy).toHaveBeenCalledOnce();
+            expect(confirmSpy.mock.calls[0][0]).toBe(NEW_VALUE);
             assert.strictEqual(component.state().value, NEW_VALUE, "did not save new value");
         });
 
         it("calls onConfirm when enter key pressed even if value didn't change", () => {
-            const cancelSpy = spy();
-            const confirmSpy = spy();
+            const cancelSpy = vi.fn();
+            const confirmSpy = vi.fn();
 
             const OLD_VALUE = "alphabet";
             const NEW_VALUE = "hello";
@@ -148,19 +147,19 @@ describe("<EditableText>", () => {
                 .simulate("change", { target: { value: OLD_VALUE } }) // revert
                 .simulate("keydown", { key: "Enter" });
 
-            assert.isTrue(cancelSpy.notCalled, "onCancel called");
-            assert.isTrue(confirmSpy.calledOnce, "onConfirm not called once");
-            assert.isTrue(confirmSpy.calledWith(OLD_VALUE), `unexpected argument "${confirmSpy.args[0][0]}"`);
+            expect(cancelSpy).not.toHaveBeenCalled();
+            expect(confirmSpy).toHaveBeenCalledOnce();
+            expect(confirmSpy.mock.calls[0][0]).toBe(OLD_VALUE);
         });
 
         it("calls onEdit when entering edit mode and passes the initial value to the callback", () => {
-            const editSpy = spy();
+            const editSpy = vi.fn();
             const INIT_VALUE = "hello";
             mount(<EditableText onEdit={editSpy} defaultValue={INIT_VALUE} />)
                 .find("div")
                 .simulate("focus");
-            assert.isTrue(editSpy.calledOnce, "onEdit called once");
-            assert.isTrue(editSpy.calledWith(INIT_VALUE), `unexpected argument "${editSpy.args[0][0]}"`);
+            expect(editSpy).toHaveBeenCalledOnce();
+            expect(editSpy.mock.calls[0][0]).toBe(INIT_VALUE);
         });
 
         it("stops editing when disabled", () => {
@@ -217,16 +216,16 @@ describe("<EditableText>", () => {
         });
 
         it("does not call onConfirm when enter key is pressed", () => {
-            const confirmSpy = spy();
+            const confirmSpy = vi.fn();
             mount(<EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} />)
                 .find("textarea")
                 .simulate("change", { target: { value: "hello" } })
                 .simulate("keydown", { key: "Enter" });
-            assert.isTrue(confirmSpy.notCalled, "onConfirm called");
+            expect(confirmSpy).not.toHaveBeenCalled();
         });
 
         it("calls onConfirm when cmd+, ctrl+, shift+, or alt+ enter is pressed", () => {
-            const confirmSpy = spy();
+            const confirmSpy = vi.fn();
             const wrapper = mount(<EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} />);
             simulateHelper(wrapper, "control", { ctrlKey: true, key: "Enter" });
             act(() => {
@@ -250,26 +249,26 @@ describe("<EditableText>", () => {
                 preventDefault: (): void => undefined,
             });
             assert.isFalse(wrapper.state("isEditing"));
-            assert.strictEqual(confirmSpy.callCount, 4, "onConfirm not called four times");
-            assert.strictEqual(confirmSpy.firstCall.args[0], "control");
-            assert.strictEqual(confirmSpy.secondCall.args[0], "meta");
-            assert.strictEqual(confirmSpy.thirdCall.args[0], "shift");
-            assert.strictEqual(confirmSpy.lastCall.args[0], "alt");
+            expect(confirmSpy).toHaveBeenCalledTimes(4);
+            expect(confirmSpy.mock.calls[0][0]).toBe("control");
+            expect(confirmSpy.mock.calls[1][0]).toBe("meta");
+            expect(confirmSpy.mock.calls[2][0]).toBe("shift");
+            expect(confirmSpy.mock.calls[3][0]).toBe("alt");
         });
 
         it("confirmOnEnterKey={true} calls onConfirm when enter is pressed", () => {
-            const confirmSpy = spy();
+            const confirmSpy = vi.fn();
             const wrapper = mount(
                 <EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} confirmOnEnterKey={true} />,
             );
             simulateHelper(wrapper, "control", { key: "Enter" });
             assert.isFalse(wrapper.state("isEditing"));
-            assert.isTrue(confirmSpy.calledOnce, "onConfirm not called");
-            assert.strictEqual(confirmSpy.firstCall.args[0], "control");
+            expect(confirmSpy).toHaveBeenCalledOnce();
+            expect(confirmSpy.mock.calls[0][0]).toBe("control");
         });
 
         it("confirmOnEnterKey={true} adds newline when cmd+, ctrl+, shift+, or alt+ enter is pressed", () => {
-            const confirmSpy = spy();
+            const confirmSpy = vi.fn();
             const wrapper = mount(
                 <EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} confirmOnEnterKey={true} />,
             );
@@ -293,7 +292,7 @@ describe("<EditableText>", () => {
             });
             assert.strictEqual(textarea.value, "\n");
             assert.isTrue(wrapper.state("isEditing"));
-            assert.isTrue(confirmSpy.notCalled, "onConfirm called");
+            expect(confirmSpy).not.toHaveBeenCalled();
         });
 
         // fake interface because React's KeyboardEvent properties are not optional

--- a/packages/core/src/components/forms/asyncControllableInput.test.tsx
+++ b/packages/core/src/components/forms/asyncControllableInput.test.tsx
@@ -16,9 +16,8 @@
 
 import { mount } from "enzyme";
 import { PureComponent } from "react";
-import { spy } from "sinon";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest"; // this component is not part of the public API, but we want to test its implementation in isolation
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest"; // this component is not part of the public API, but we want to test its implementation in isolation
 
 import { sleep } from "../../common/test-utils";
 import { ASYNC_CONTROLLABLE_VALUE_COMPOSITION_END_DELAY } from "../../hooks/useAsyncControllableValue";
@@ -52,19 +51,19 @@ describe("asyncControllable tests", () => {
         describe(element, () => {
             describe("uncontrolled mode", () => {
                 it(`renders a ${element}`, () => {
-                    const handleChangeSpy = spy();
+                    const handleChangeSpy = vi.fn();
                     const wrapper = mount(<Component defaultValue="hi" onChange={handleChangeSpy} type={type} />);
                     assert.strictEqual(wrapper.childAt(0).type(), element);
                 });
 
                 it("triggers onChange", () => {
-                    const handleChangeSpy = spy();
+                    const handleChangeSpy = vi.fn();
                     const wrapper = mount(<Component defaultValue="hi" onChange={handleChangeSpy} type={type} />);
                     const input = wrapper.find(element);
                     input.simulate("change", { target: { value: "bye" } });
-                    const simulatedEvent: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement> =
-                        handleChangeSpy.getCall(0).lastArg;
-                    assert.strictEqual(simulatedEvent.target.value, "bye");
+                    expect(handleChangeSpy).toHaveBeenCalledWith(
+                        expect.objectContaining({ target: expect.objectContaining({ value: "bye" }) }),
+                    );
                 });
             });
 
@@ -82,7 +81,7 @@ describe("asyncControllable tests", () => {
                 });
 
                 it("triggers onChange events during composition", () => {
-                    const handleChangeSpy = spy();
+                    const handleChangeSpy = vi.fn();
                     const wrapper = mount(<Component value="hi" onChange={handleChangeSpy} type={type} />);
                     const input = wrapper.find(element);
 
@@ -94,7 +93,7 @@ describe("asyncControllable tests", () => {
                     input.simulate("change", { target: { value: "hi ." } });
                     input.simulate("compositionend", { data: " ." });
 
-                    assert.strictEqual(handleChangeSpy.callCount, 2);
+                    expect(handleChangeSpy).toHaveBeenCalledTimes(2);
                 });
 
                 it("external updates DO NOT override in-progress composition", async () => {

--- a/packages/core/src/components/forms/fileInput.test.tsx
+++ b/packages/core/src/components/forms/fileInput.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
-import sinon from "sinon";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -77,9 +76,9 @@ describe("<FileInput>", () => {
     });
 
     it("invokes change callbacks", () => {
-        const inputProps = { onChange: sinon.spy() };
-        const onChange = sinon.spy();
-        const onInputChange = sinon.spy();
+        const inputProps = { onChange: vi.fn() };
+        const onChange = vi.fn();
+        const onInputChange = vi.fn();
 
         const wrapper = shallow(
             <FileInput inputProps={inputProps} onChange={onChange} onInputChange={onInputChange} />,
@@ -87,9 +86,9 @@ describe("<FileInput>", () => {
         const input = getInput(wrapper);
         input.simulate("change");
 
-        assert.isFalse(onChange.called, "onChange not called"); // because it's spread to the label, not the input
-        assert.isTrue(onInputChange.calledOnce, "onInputChange called");
-        assert.isTrue(inputProps.onChange.calledOnce, "inputProps.onChange called");
+        expect(onChange).not.toHaveBeenCalled(); // because it's spread to the label, not the input
+        expect(onInputChange).toHaveBeenCalledOnce();
+        expect(inputProps.onChange).toHaveBeenCalledOnce();
     });
 });
 

--- a/packages/core/src/components/forms/inputGroup.test.tsx
+++ b/packages/core/src/components/forms/inputGroup.test.tsx
@@ -17,9 +17,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, useState } from "react";
-import { spy } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -56,31 +55,31 @@ describe("<InputGroup>", () => {
 
     it("should support onChange callback", async () => {
         const user = userEvent.setup();
-        const onChange = spy();
+        const onChange = vi.fn();
         render(<InputGroup onChange={onChange} />);
         const input = screen.getByRole<HTMLInputElement>("textbox");
 
         await user.type(input, "x");
 
         expect(input.value).to.equal("x");
-        expect(onChange.calledOnce).to.be.true;
+        expect(onChange).toHaveBeenCalledOnce();
 
-        const event = onChange.getCall(0).args[0] as React.ChangeEvent<HTMLInputElement>;
+        const event = onChange.mock.calls[0][0] as React.ChangeEvent<HTMLInputElement>;
         expect(event.target.value).to.equal("x");
     });
 
     it("should support the onValueChange callback", async () => {
         const user = userEvent.setup();
-        const onValueChange = spy();
+        const onValueChange = vi.fn();
         render(<InputGroup onValueChange={onValueChange} />);
         const input = screen.getByRole<HTMLInputElement>("textbox");
 
         await user.type(input, "x");
 
         expect(input.value).to.equal("x");
-        expect(onValueChange.calledOnce).to.be.true;
-        expect(onValueChange.getCall(0).args[0]).to.equal("x");
-        expect(onValueChange.getCall(0).args[1].value).to.equal("x");
+        expect(onValueChange).toHaveBeenCalledOnce();
+        expect(onValueChange.mock.calls[0][0]).to.equal("x");
+        expect(onValueChange.mock.calls[0][1].value).to.equal("x");
     });
 
     it("should support custom type attribute", () => {

--- a/packages/core/src/components/forms/numericInput.test.tsx
+++ b/packages/core/src/components/forms/numericInput.test.tsx
@@ -21,9 +21,8 @@ import {
     shallow as untypedShallow,
 } from "enzyme";
 import { act, PureComponent } from "react";
-import { type SinonStub, spy, stub } from "sinon";
 
-import { afterAll, afterEach, assert, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
 import { type HTMLInputProps, Position } from "../../common";
@@ -144,25 +143,25 @@ describe("<NumericInput>", () => {
         });
 
         it("provides numeric value to onValueChange as a number and a string", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
             const nextValue = "1";
 
             component.find("input").simulate("change", { target: { value: nextValue } });
 
-            expect(onValueChangeSpy.calledOnce).to.be.true;
-            expect(onValueChangeSpy.calledWith(+nextValue, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledOnce();
+            expect(onValueChangeSpy).toHaveBeenCalledWith(+nextValue, nextValue, expect.anything());
         });
 
         it("provides non-numeric value to onValueChange as NaN and a string", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
             const invalidValue = "non-numeric-value";
 
             component.find("input").simulate("change", { target: { value: invalidValue } });
 
-            expect(onValueChangeSpy.calledOnce).to.be.true;
-            expect(onValueChangeSpy.calledWith(NaN, invalidValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledOnce();
+            expect(onValueChangeSpy).toHaveBeenCalledWith(NaN, invalidValue, expect.anything());
         });
 
         it("accepts a numeric value", () => {
@@ -178,7 +177,7 @@ describe("<NumericInput>", () => {
         });
 
         it("fires onValueChange with the number value, string value, and input element when the value changes", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
 
             const incrementButton = component.find(Button).first();
@@ -186,11 +185,11 @@ describe("<NumericInput>", () => {
             dispatchMouseEvent(document, "mouseup");
 
             const inputElement = component.find("input").first().getDOMNode();
-            expect(onValueChangeSpy.calledOnceWithExactly(1, "1", inputElement)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(1, "1", inputElement);
         });
 
         it("fires onButtonClick with the number value and the string value when either button is pressed", () => {
-            const onButtonClickSpy = spy();
+            const onButtonClickSpy = vi.fn();
             const component = mount(<NumericInput onButtonClick={onButtonClickSpy} />);
 
             const incrementButton = component.find(Button).first();
@@ -200,14 +199,14 @@ describe("<NumericInput>", () => {
             incrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
-            expect(onButtonClickSpy.calledOnce).to.be.true;
-            expect(onButtonClickSpy.firstCall.args).to.deep.equal([1, "1"]);
-            onButtonClickSpy.resetHistory();
+            expect(onButtonClickSpy).toHaveBeenCalledOnce();
+            expect(onButtonClickSpy.mock.calls[0]).toEqual([1, "1"]);
+            onButtonClickSpy.mockClear();
 
             // decrementing from 1 now
             decrementButton.simulate("mousedown");
-            expect(onButtonClickSpy.calledOnce).to.be.true;
-            expect(onButtonClickSpy.firstCall.args).to.deep.equal([0, "0"]);
+            expect(onButtonClickSpy).toHaveBeenCalledOnce();
+            expect(onButtonClickSpy.mock.calls[0]).toEqual([0, "0"]);
         });
     });
 
@@ -608,7 +607,7 @@ describe("<NumericInput>", () => {
             });
 
             it("fires onValueChange with clamped value if nextProps.min > value ", () => {
-                const onValueChangeSpy = spy();
+                const onValueChangeSpy = vi.fn();
                 const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
 
                 component.setProps({ min: 0 });
@@ -617,18 +616,18 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
+                expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(0, "0", inputElement);
             });
 
             it("does not fire onValueChange if nextProps.min < value", () => {
-                const onValueChangeSpy = spy();
+                const onValueChangeSpy = vi.fn();
                 const component = mount(<NumericInput value={-10} onValueChange={onValueChangeSpy} />);
 
                 component.setProps({ min: -20 });
 
                 const newValue = component.state().value;
                 expect(newValue).to.equal("-10");
-                expect(onValueChangeSpy.called).to.be.false;
+                expect(onValueChangeSpy).not.toHaveBeenCalled();
             });
         });
 
@@ -682,7 +681,7 @@ describe("<NumericInput>", () => {
             });
 
             it("fires onValueChange with clamped value if nextProps.max < value ", () => {
-                const onValueChangeSpy = spy();
+                const onValueChangeSpy = vi.fn();
                 const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
 
                 component.setProps({ max: 0 });
@@ -691,24 +690,24 @@ describe("<NumericInput>", () => {
                 expect(newValue).to.equal("0");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                expect(onValueChangeSpy.calledOnceWithExactly(0, "0", inputElement)).to.be.true;
+                expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(0, "0", inputElement);
             });
 
             it("does not fire onValueChange if nextProps.max > value", () => {
-                const onValueChangeSpy = spy();
+                const onValueChangeSpy = vi.fn();
                 const component = mount(<NumericInput value={10} onValueChange={onValueChangeSpy} />);
 
                 component.setProps({ max: 20 });
 
                 const newValue = component.state().value;
                 expect(newValue).to.equal("10");
-                expect(onValueChangeSpy.called).to.be.false;
+                expect(onValueChangeSpy).not.toHaveBeenCalled();
             });
         });
 
         describe("if min === max", () => {
             it("never changes value", () => {
-                const onValueChangeSpy = spy();
+                const onValueChangeSpy = vi.fn();
                 const component = mount(<NumericInput min={2} max={2} onValueChange={onValueChangeSpy} />);
                 // repeated interactions, no change in state
                 component
@@ -722,7 +721,7 @@ describe("<NumericInput>", () => {
                 expect(component.state().value).to.equal("2");
 
                 const inputElement = component.find("input").first().getDOMNode();
-                expect(onValueChangeSpy.calledOnceWithExactly(2, "2", inputElement)).to.be.true;
+                expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(2, "2", inputElement);
             });
         });
 
@@ -730,7 +729,7 @@ describe("<NumericInput>", () => {
             it("does not clamp or invoke onValueChange on blur if clampValueOnBlur=false", () => {
                 // should be false by default
                 const VALUE = "-5";
-                const onValueChange = spy();
+                const onValueChange = vi.fn();
                 const component = mount(<NumericInput clampValueOnBlur={false} onValueChange={onValueChange} />);
                 const inputField = component.find("input");
 
@@ -738,7 +737,7 @@ describe("<NumericInput>", () => {
                 inputField.simulate("blur");
 
                 expect(component.state().value).to.equal(VALUE);
-                expect(onValueChange.calledOnce).to.be.true;
+                expect(onValueChange).toHaveBeenCalledOnce();
             });
 
             it("clamps an out-of-bounds value to min", () => {
@@ -762,7 +761,7 @@ describe("<NumericInput>", () => {
             });
 
             it("invokes onValueChange when out-of-bounds value clamped on blur", () => {
-                const onValueChange = spy();
+                const onValueChange = vi.fn();
                 const MIN = 0;
                 const component = mount(
                     <NumericInput clampValueOnBlur={true} min={MIN} onValueChange={onValueChange} />,
@@ -772,8 +771,8 @@ describe("<NumericInput>", () => {
                 inputField.simulate("change", { target: { value: "-5" } });
                 inputField.simulate("blur", { target: { value: "-5" } });
 
-                const args = onValueChange.getCall(1).args;
-                expect(onValueChange.calledTwice).to.be.true;
+                const args = onValueChange.mock.calls[1];
+                expect(onValueChange).toHaveBeenCalledTimes(2);
                 expect(args[0]).to.equal(MIN);
                 expect(args[1]).to.equal(MIN.toString());
             });
@@ -783,40 +782,40 @@ describe("<NumericInput>", () => {
     // Note: we don't call mount() here since React 16 throws before we can even validate the errors thrown
     // in component constructors
     describe("Validation", () => {
-        let consoleError: SinonStub;
+        let consoleError: ReturnType<typeof vi.spyOn>;
 
-        beforeAll(() => (consoleError = stub(console, "error")));
-        afterEach(() => consoleError.resetHistory());
-        afterAll(() => consoleError.restore());
+        beforeAll(() => (consoleError = vi.spyOn(console, "error").mockImplementation(vi.fn())));
+        afterEach(() => consoleError.mockClear());
+        afterAll(() => consoleError.mockRestore());
 
         it("logs an error if min >= max", () => {
             mount(<NumericInput min={2} max={1} />);
-            expect(consoleError.calledWith(Errors.NUMERIC_INPUT_MIN_MAX)).to.be.true;
+            expect(consoleError).toHaveBeenCalledWith(Errors.NUMERIC_INPUT_MIN_MAX);
         });
 
         it("logs an error if stepSize <= 0", () => {
             mount(<NumericInput stepSize={-1} />);
-            expect(consoleError.calledWith(Errors.NUMERIC_INPUT_STEP_SIZE_NON_POSITIVE)).to.be.true;
+            expect(consoleError).toHaveBeenCalledWith(Errors.NUMERIC_INPUT_STEP_SIZE_NON_POSITIVE);
         });
 
         it("logs an error if minorStepSize <= 0", () => {
             mount(<NumericInput minorStepSize={-0.1} />);
-            expect(consoleError.calledWith(Errors.NUMERIC_INPUT_MINOR_STEP_SIZE_NON_POSITIVE)).to.be.true;
+            expect(consoleError).toHaveBeenCalledWith(Errors.NUMERIC_INPUT_MINOR_STEP_SIZE_NON_POSITIVE);
         });
 
         it("logs an error if majorStepSize <= 0", () => {
             mount(<NumericInput majorStepSize={-0.1} />);
-            expect(consoleError.calledWith(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_NON_POSITIVE)).to.be.true;
+            expect(consoleError).toHaveBeenCalledWith(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_NON_POSITIVE);
         });
 
         it("logs an error if majorStepSize <= stepSize", () => {
             mount(<NumericInput majorStepSize={0.5} />);
-            expect(consoleError.calledWith(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_BOUND)).to.be.true;
+            expect(consoleError).toHaveBeenCalledWith(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_BOUND);
         });
 
         it("logs an error if stepSize <= minorStepSize", () => {
             mount(<NumericInput minorStepSize={2} />);
-            expect(consoleError.calledWith(Errors.NUMERIC_INPUT_MINOR_STEP_SIZE_BOUND)).to.be.true;
+            expect(consoleError).toHaveBeenCalledWith(Errors.NUMERIC_INPUT_MINOR_STEP_SIZE_BOUND);
         });
 
         it("clears the field if the value is invalid when incrementing", () => {
@@ -848,15 +847,15 @@ describe("<NumericInput>", () => {
 
     describe("Controlled mode", () => {
         it("value prop updates do not trigger onValueChange", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput min={0} value={0} max={1} onValueChange={onValueChangeSpy} />);
             component.setProps({ value: 1 });
-            expect(onValueChangeSpy.notCalled).to.be.true;
+            expect(onValueChangeSpy).not.toHaveBeenCalled();
         });
 
         it("state.value only changes with prop change", () => {
             const initialValue = 10;
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput value={initialValue} onValueChange={onValueChangeSpy} />);
 
             const incrementButton = component.find(Button).first();
@@ -865,7 +864,7 @@ describe("<NumericInput>", () => {
 
             let inputElement = component.find("input");
             expect(inputElement.props().value).to.equal("10");
-            expect(onValueChangeSpy.calledOnceWithExactly(11, "11", inputElement.getDOMNode()));
+            expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(11, "11", inputElement.getDOMNode());
 
             component.setProps({ value: 11 }).update();
             inputElement = component.find("input");
@@ -873,7 +872,7 @@ describe("<NumericInput>", () => {
         });
 
         it("accepts successive value changes containing non-numeric characters", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
             component.setProps({ value: "1" });
             expect(component.state().value).to.equal("1");
@@ -886,70 +885,70 @@ describe("<NumericInput>", () => {
 
     describe("Localization", () => {
         it("accepts the number in a different locale", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} locale={"de-DE"} />);
             const nextValue = "99,99";
             const nextValueNumber = 99.99;
 
             component.find("input").simulate("change", { target: { value: nextValue } });
 
-            expect(onValueChangeSpy.calledOnce).to.be.true;
-            expect(onValueChangeSpy.calledWith(nextValueNumber, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledOnce();
+            expect(onValueChangeSpy).toHaveBeenCalledWith(nextValueNumber, nextValue, expect.anything());
         });
 
         it("accepts the number in a different locale [Arabic - Bahrain (ar-BH)]", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} locale={"ar-BH"} />);
             const nextValue = "٩٫٩٩";
             const nextValueNumber = 9.99;
 
             component.find("input").simulate("change", { target: { value: nextValue } });
 
-            expect(onValueChangeSpy.calledOnce).to.be.true;
-            expect(onValueChangeSpy.calledWith(nextValueNumber, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledOnce();
+            expect(onValueChangeSpy).toHaveBeenCalledWith(nextValueNumber, nextValue, expect.anything());
         });
 
         it("changing the locale it changes the value (en-US to it-IT)", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
             const nextValue = "99.99";
             const formattedValue = "99,99";
 
             component.find("input").simulate("change", { target: { value: nextValue } });
-            expect(onValueChangeSpy.lastCall.calledWith(+nextValue, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenLastCalledWith(+nextValue, nextValue, expect.anything());
 
             component.setProps({ locale: "it-IT" });
 
-            expect(onValueChangeSpy.lastCall.calledWith(+nextValue, formattedValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenLastCalledWith(+nextValue, formattedValue, expect.anything());
         });
 
         it("changing the locale it changes the value (it-IT to undefined)", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} locale={"it-IT"} />);
             const nextValue = "99,99";
             const usValue = "99.99";
 
             component.find("input").simulate("change", { target: { value: nextValue } });
-            expect(onValueChangeSpy.lastCall.calledWith(+usValue, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenLastCalledWith(+usValue, nextValue, expect.anything());
 
             component.setProps({ locale: undefined });
 
-            expect(onValueChangeSpy.lastCall.calledWith(+usValue, usValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenLastCalledWith(+usValue, usValue, expect.anything());
         });
 
         it("doesn't accept the number in a different format", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} />);
             const invalidValue = "77,99";
 
             component.find("input").simulate("change", { target: { value: invalidValue } });
 
-            expect(onValueChangeSpy.calledOnce).to.be.true;
-            expect(onValueChangeSpy.calledWith(NaN, invalidValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledOnce();
+            expect(onValueChangeSpy).toHaveBeenCalledWith(NaN, invalidValue, expect.anything());
         });
 
         it("increments the number with the specified locale", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} locale={"de-DE"} />);
             const nextValue = "7,9";
             const nextValueNumber = 7.9;
@@ -958,17 +957,21 @@ describe("<NumericInput>", () => {
 
             component.find("input").simulate("change", { target: { value: nextValue } });
 
-            expect(onValueChangeSpy.calledWith(nextValueNumber, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledWith(nextValueNumber, nextValue, expect.anything());
 
             const incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
-            expect(onValueChangeSpy.calledWith(valueNumberAfterDecrement, valueAfterDecrement)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledWith(
+                valueNumberAfterDecrement,
+                valueAfterDecrement,
+                expect.anything(),
+            );
         });
 
         it("decrements the number with the specified locale", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(<NumericInput onValueChange={onValueChangeSpy} locale={"de-DE"} />);
             const nextValue = "7,9";
             const nextValueNumber = 7.9;
@@ -980,13 +983,17 @@ describe("<NumericInput>", () => {
                 .first()
                 .simulate("change", { target: { value: nextValue } });
 
-            expect(onValueChangeSpy.calledWith(nextValueNumber, nextValue)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledWith(nextValueNumber, nextValue, expect.anything());
 
             const decrementButton = component.find(Button).last();
             decrementButton.simulate("mousedown");
             dispatchMouseEvent(document, "mouseup");
 
-            expect(onValueChangeSpy.calledWith(valueNumberAfterDecrement, valueAfterDecrement)).to.be.true;
+            expect(onValueChangeSpy).toHaveBeenCalledWith(
+                valueNumberAfterDecrement,
+                valueAfterDecrement,
+                expect.anything(),
+            );
         });
     });
 
@@ -1106,7 +1113,7 @@ describe("<NumericInput>", () => {
         });
 
         it("handle big decimal numbers", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(
                 <NumericInput
                     onValueChange={onValueChangeSpy}
@@ -1117,11 +1124,11 @@ describe("<NumericInput>", () => {
             );
             const input = component.find("input");
             input.simulate("keydown", { key: "ArrowUp" });
-            assert.isTrue(onValueChangeSpy.calledWith(0.000000000000000001));
+            expect(onValueChangeSpy).toHaveBeenCalledWith(0.000000000000000001, expect.anything(), expect.anything());
         });
 
         it("changes max precision appropriately when the min/max stepSize props change", () => {
-            const onValueChangeSpy = spy();
+            const onValueChangeSpy = vi.fn();
             const component = mount(
                 <NumericInput
                     majorStepSize={1}
@@ -1135,22 +1142,22 @@ describe("<NumericInput>", () => {
             // excess digits should truncate to max precision
             let incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", { altKey: true });
-            expect(onValueChangeSpy.calledOnceWith(0.001, "0.001"));
-            onValueChangeSpy.resetHistory();
+            expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(0.001, "0.001", expect.anything());
+            onValueChangeSpy.mockClear();
 
             // now try a smaller step size, and expect no truncation
             component.setProps({ minorStepSize: 0.0001 });
             incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", { altKey: true });
-            expect(onValueChangeSpy.calledOnceWith(0.0002, "0.0002"));
-            onValueChangeSpy.resetHistory();
+            expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(0.0002, "0.0002", expect.anything());
+            onValueChangeSpy.mockClear();
 
             // now try a larger step size, and expect more truncation than before
             component.setProps({ minorStepSize: 0.1 });
             incrementButton = component.find(Button).first();
             incrementButton.simulate("mousedown", { altKey: true });
-            expect(onValueChangeSpy.calledOnceWith(0.01, "0.01"));
-            onValueChangeSpy.resetHistory();
+            expect(onValueChangeSpy).toHaveBeenCalledExactlyOnceWith(0.1, "0.1", expect.anything());
+            onValueChangeSpy.mockClear();
         });
 
         it("must not call handleButtonClick if component is disabled", () => {
@@ -1159,7 +1166,7 @@ describe("<NumericInput>", () => {
             const component = mount(<NumericInput disabled={true} />);
 
             const incrementButton = component.find(Button).first();
-            const handleButtonClickSpy = spy(component.instance(), "handleButtonClick" as any);
+            const handleButtonClickSpy = vi.spyOn(component.instance(), "handleButtonClick" as any);
 
             incrementButton.simulate("mousedown");
             incrementButton.simulate("mousedown", { altKey: true });
@@ -1172,7 +1179,7 @@ describe("<NumericInput>", () => {
             decrementButton.simulate("keyDown", SPACE_KEYSTROKE);
             decrementButton.simulate("keyDown", { ...SPACE_KEYSTROKE, altKey: true });
 
-            expect(handleButtonClickSpy.notCalled).to.be.true;
+            expect(handleButtonClickSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -1384,7 +1391,7 @@ describe("<NumericInput>", () => {
         eventOptions?: Partial<KeyboardEvent>,
         allowNumericCharactersOnly?: boolean,
     ) {
-        const onKeyPressSpy = spy();
+        const onKeyPressSpy = vi.fn();
         const component = mount(
             // eslint-disable-next-line @typescript-eslint/no-deprecated
             <NumericInput allowNumericCharactersOnly={allowNumericCharactersOnly} onKeyPress={onKeyPressSpy} />,
@@ -1393,7 +1400,7 @@ describe("<NumericInput>", () => {
 
         invalidKeyNames.forEach((keyName, i) => {
             inputField.simulate("keypress", { key: keyName, ...eventOptions });
-            const event = onKeyPressSpy.getCall(i).args[0] as KeyboardEvent;
+            const event = onKeyPressSpy.mock.calls[i][0] as KeyboardEvent;
             const valueToCheck = expectDefaultPrevented === true ? event.defaultPrevented : !event.defaultPrevented; // can be undefined, so just check that it's falsey.
             expect(valueToCheck).to.be.true;
         });

--- a/packages/core/src/components/forms/radioGroup.test.tsx
+++ b/packages/core/src/components/forms/radioGroup.test.tsx
@@ -16,9 +16,8 @@
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { spy, stub } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, type OptionProps } from "../../common";
 import { RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX } from "../../common/errors";
@@ -62,7 +61,7 @@ describe("<RadioGroup>", () => {
 
     it("invokes onChange handler when a radio is clicked", async () => {
         const user = userEvent.setup();
-        const onChange = spy();
+        const onChange = vi.fn();
         render(
             <RadioGroup onChange={onChange}>
                 <Radio value="one" label="One" />
@@ -73,8 +72,8 @@ describe("<RadioGroup>", () => {
 
         await user.click(radio1);
 
-        expect(onChange.calledOnce).to.be.true;
-        expect(onChange.getCall(0).args[0].target.value).to.equal("one");
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange.mock.calls[0][0].target.value).to.equal("one");
     });
 
     it("renders options as radio buttons", () => {
@@ -107,7 +106,7 @@ describe("<RadioGroup>", () => {
     });
 
     it("uses options if given both options and children (with conosle warning)", () => {
-        const warnSpy = stub(console, "warn");
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
         render(
             <RadioGroup onChange={emptyHandler} options={[]}>
                 <Radio value="one" />
@@ -115,8 +114,8 @@ describe("<RadioGroup>", () => {
         );
 
         expect(screen.queryByRole("radio")).not.toBeInTheDocument();
-        expect(warnSpy.calledWith(RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX)).to.be.true;
-        warnSpy.restore();
+        expect(warnSpy).toHaveBeenCalledWith(RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX);
+        warnSpy.mockRestore();
     });
 
     it("renders non-Radio children too", () => {

--- a/packages/core/src/components/hotkeys/hotkey.test.tsx
+++ b/packages/core/src/components/hotkeys/hotkey.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { render, screen } from "@testing-library/react";
-import { type SinonStub, stub } from "sinon";
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Hotkey } from "./";
 
@@ -28,15 +27,13 @@ describe("Hotkey", () => {
     });
 
     describe("validation", () => {
-        let consoleError: SinonStub;
-
-        beforeAll(() => (consoleError = stub(console, "error")));
-        afterEach(() => consoleError.resetHistory());
-        afterAll(() => consoleError.restore());
+        const consoleError = vi.spyOn(console, "error").mockImplementation(vi.fn());
+        afterEach(() => consoleError.mockClear());
+        afterAll(() => consoleError.mockRestore());
 
         it("logs an error for non-global hotkey without a group", () => {
             render(<Hotkey combo="cmd+C" label="test copy me" />);
-            expect(consoleError.callCount).to.equal(1);
+            expect(consoleError.mock.calls.length).to.equal(1);
         });
     });
 });

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -15,11 +15,10 @@
  */
 
 import { mount } from "enzyme";
-import type { MockInstance } from "vitest";
 
 import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
-import { afterEach, assert, beforeAll, describe, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeAll, describe, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Intent } from "../../common";
 

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -15,32 +15,40 @@
  */
 
 import { mount } from "enzyme";
-import { type SinonStub, stub } from "sinon";
+import type { MockInstance } from "vitest";
 
 import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
-import { afterEach, assert, beforeAll, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeAll, describe, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Intent } from "../../common";
 
 import { Icon, type IconProps } from "./icon";
 
 describe("<Icon>", () => {
-    let iconLoader: SinonStub;
+    let iconLoader: MockInstance;
 
     beforeAll(() => {
-        stub(Icons, "load").resolves(undefined);
+        vi.spyOn(Icons, "load").mockResolvedValue(undefined);
         // stub the dynamic icon loader with a synchronous, static one
-        iconLoader = stub(Icons, "getPaths");
-        iconLoader.returns(undefined);
-        iconLoader.withArgs("add").returns(Add);
-        iconLoader.withArgs("airplane").returns(Airplane);
-        iconLoader.withArgs("calendar").returns(Calendar);
-        iconLoader.withArgs("graph").returns(Graph);
+        iconLoader = vi.spyOn(Icons, "getPaths").mockImplementation((name: string) => {
+            switch (name) {
+                case "add":
+                    return Add;
+                case "airplane":
+                    return Airplane;
+                case "calendar":
+                    return Calendar;
+                case "graph":
+                    return Graph;
+                default:
+                    return undefined;
+            }
+        });
     });
 
     afterEach(() => {
-        iconLoader?.resetHistory();
+        iconLoader?.mockClear();
     });
 
     it("tagName dictates HTML tag", async () => {

--- a/packages/core/src/components/menu/menuItem.test.tsx
+++ b/packages/core/src/components/menu/menuItem.test.tsx
@@ -17,9 +17,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
-import { spy } from "sinon";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Button } from "../button/buttons";
@@ -97,42 +96,42 @@ describe("MenuItem", () => {
     });
 
     it("disabled MenuItem blocks mouse listeners", () => {
-        const mouseSpy = spy();
+        const mouseSpy = vi.fn();
         mount(<MenuItem disabled={true} text="disabled" onClick={mouseSpy} onMouseEnter={mouseSpy} />)
             .simulate("click")
             .simulate("mouseenter")
             .simulate("click");
-        assert.strictEqual(mouseSpy.callCount, 0);
+        expect(mouseSpy).not.toHaveBeenCalled();
     });
 
     it("clicking MenuItem triggers onClick prop", () => {
-        const onClick = spy();
+        const onClick = vi.fn();
         shallow(<MenuItem text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("click");
-        assert.isTrue(onClick.calledOnce);
+        expect(onClick).toHaveBeenCalledOnce();
     });
 
     it("pressing enter on MenuItem triggers onClick prop", async () => {
         const user = userEvent.setup();
-        const onClick = spy();
+        const onClick = vi.fn();
         render(<MenuItem text="Graph" onClick={onClick} />);
         const menuItem = screen.getByRole("menuitem");
         menuItem.focus();
         await user.keyboard("{Enter}");
-        assert.isTrue(onClick.calledOnce);
+        expect(onClick).toHaveBeenCalledOnce();
     });
 
     it("clicking disabled MenuItem does not trigger onClick prop", () => {
-        const onClick = spy();
+        const onClick = vi.fn();
         shallow(<MenuItem disabled={true} text="Graph" onClick={onClick} />)
             .find("a")
             .simulate("click");
-        assert.isTrue(onClick.notCalled);
+        expect(onClick).not.toHaveBeenCalled();
     });
 
     it("shouldDismissPopover=false prevents a clicked MenuItem from closing the Popover automatically", () => {
-        const handleClose = spy();
+        const handleClose = vi.fn();
         const menu = <MenuItem text="Graph" shouldDismissPopover={false} />;
         const wrapper = mount(
             <Popover content={menu} isOpen={true} onInteraction={handleClose} usePortal={false}>
@@ -140,7 +139,7 @@ describe("MenuItem", () => {
             </Popover>,
         );
         wrapper.find(MenuItem).find("a").simulate("click");
-        assert.isTrue(handleClose.notCalled);
+        expect(handleClose).not.toHaveBeenCalled();
     });
 
     it("submenuProps are forwarded to the Menu", () => {

--- a/packages/core/src/components/overflow-list/overflowList.test.tsx
+++ b/packages/core/src/components/overflow-list/overflowList.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount, type ReactWrapper } from "enzyme";
-import { spy } from "sinon";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { OverflowList, type OverflowListProps, type OverflowListState } from "./overflowList";
 
@@ -35,7 +34,7 @@ const TestOverflow: React.FC<{ items: TestItemProps[] }> = () => <div />;
 
 describe.skip("<OverflowList>", { retry: 3 }, () => {
     // these tests rely on DOM measurement which can be flaky, so we allow some retries
-    const onOverflowSpy = spy();
+    const onOverflowSpy = vi.fn();
     let containerElement: HTMLElement;
     let wrapper: OverflowListWrapper;
 
@@ -49,7 +48,7 @@ describe.skip("<OverflowList>", { retry: 3 }, () => {
         wrapper?.unmount();
         wrapper?.detach();
         containerElement.remove();
-        onOverflowSpy.resetHistory();
+        onOverflowSpy.mockClear();
     });
 
     it("adds className to itself", () => {
@@ -126,7 +125,7 @@ describe.skip("<OverflowList>", { retry: 3 }, () => {
 
         it("not invoked on initial render if all visible", async () => {
             await overflowList(200).waitForResize();
-            assert.isTrue(onOverflowSpy.notCalled, "not called");
+            expect(onOverflowSpy).not.toHaveBeenCalled();
         });
 
         it("invoked once per resize", async () => {
@@ -143,7 +142,7 @@ describe.skip("<OverflowList>", { retry: 3 }, () => {
                 (await wrapper.setWidth(width).waitForResize()).assertLastOnOverflowArgs(overflowIds);
             }
             // ensure onOverflow is not called additional times.
-            assert.equal(onOverflowSpy.callCount, tests.length, "should invoke once per resize");
+            expect(onOverflowSpy).toHaveBeenCalledTimes(tests.length);
         });
 
         it("not invoked if resize doesn't change overflow", async () => {
@@ -151,22 +150,22 @@ describe.skip("<OverflowList>", { retry: 3 }, () => {
             await overflowList(22).waitForResize();
             // small adjustments don't change overflow state, but it is recomputed internally.
             // assert that the callback was not invoked because the appearance hasn't changed.
-            onOverflowSpy.resetHistory();
+            onOverflowSpy.mockClear();
             await wrapper.setWidth(25).waitForResize();
             await wrapper.setWidth(28).waitForResize();
             await wrapper.setWidth(29).waitForResize();
             await wrapper.setWidth(26).waitForResize();
             await wrapper.setWidth(22).waitForResize();
-            assert.isTrue(onOverflowSpy.notCalled, "should not invoke");
+            expect(onOverflowSpy).not.toHaveBeenCalled();
         });
 
         it("invoked when items change", async () => {
             await overflowList(22).waitForResize();
             // copy of same items so overflow state should end up the same.
             await wrapper.setProps({ items: [...ITEMS] }).waitForResize();
-            assert.isTrue(onOverflowSpy.calledTwice, "should be called twice");
-            const [one, two] = onOverflowSpy.args;
-            assert.sameDeepMembers(one, two, "items should be the same");
+            expect(onOverflowSpy).toHaveBeenCalledTimes(2);
+            expect(onOverflowSpy.mock.calls[0][0]).toEqual(expect.arrayContaining(onOverflowSpy.mock.calls[1][0]));
+            expect(onOverflowSpy.mock.calls[1][0]).toEqual(expect.arrayContaining(onOverflowSpy.mock.calls[0][0]));
         });
     });
 
@@ -212,10 +211,7 @@ describe.skip("<OverflowList>", { retry: 3 }, () => {
 
         /** Asserts that the last call to `onOverflow` received the given item IDs. */
         wrapper.assertLastOnOverflowArgs = (ids: number[]) => {
-            assert.sameMembers(
-                onOverflowSpy.lastCall.args[0].map((i: TestItemProps) => i.id),
-                ids,
-            );
+            expect(onOverflowSpy.mock.calls.at(-1)![0].map((i: TestItemProps) => i.id)).toEqual(ids);
             return wrapper;
         };
 

--- a/packages/core/src/components/overlay/overlay.test.tsx
+++ b/packages/core/src/components/overlay/overlay.test.tsx
@@ -24,9 +24,8 @@
 import { waitFor } from "@testing-library/dom";
 import { mount, ReactWrapper, shallow } from "enzyme";
 import { createRef } from "react";
-import { spy } from "sinon";
 
-import { afterAll, afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes, Utils } from "../../common";
@@ -173,31 +172,31 @@ describe("<Overlay>", () => {
 
     describe("onClose", () => {
         it("invoked on backdrop mousedown when canOutsideClickClose=true", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             const overlay = shallow(
                 <Overlay canOutsideClickClose={true} isOpen={true} onClose={onClose} usePortal={false}>
                     {createOverlayContents()}
                 </Overlay>,
             );
             overlay.find(BACKDROP_SELECTOR).simulate("mousedown");
-            assert.isTrue(onClose.calledOnce);
+            expect(onClose).toHaveBeenCalledOnce();
             overlay.unmount();
         });
 
         it("not invoked on backdrop mousedown when canOutsideClickClose=false", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             const overlay = shallow(
                 <Overlay canOutsideClickClose={false} isOpen={true} onClose={onClose} usePortal={false}>
                     {createOverlayContents()}
                 </Overlay>,
             );
             overlay.find(BACKDROP_SELECTOR).simulate("mousedown");
-            assert.isTrue(onClose.notCalled);
+            expect(onClose).not.toHaveBeenCalled();
             overlay.unmount();
         });
 
         it("invoked on document mousedown when hasBackdrop=false", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             // mounting cuz we need document events + lifecycle
             mountWrapper(
                 <Overlay hasBackdrop={false} isOpen={true} onClose={onClose} usePortal={false}>
@@ -206,11 +205,11 @@ describe("<Overlay>", () => {
             );
 
             dispatchMouseEvent(document.documentElement, "mousedown");
-            assert.isTrue(onClose.calledOnce);
+            expect(onClose).toHaveBeenCalledOnce();
         });
 
         it("not invoked on document mousedown when hasBackdrop=false and canOutsideClickClose=false", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             mountWrapper(
                 <Overlay
                     canOutsideClickClose={false}
@@ -224,11 +223,11 @@ describe("<Overlay>", () => {
             );
 
             dispatchMouseEvent(document.documentElement, "mousedown");
-            assert.isTrue(onClose.notCalled);
+            expect(onClose).not.toHaveBeenCalled();
         });
 
         it("not invoked on click of a nested overlay", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             mountWrapper(
                 <Overlay isOpen={true} onClose={onClose}>
                     <div id="outer-element">
@@ -241,29 +240,29 @@ describe("<Overlay>", () => {
             );
             // this hackery is necessary for React 15 support, where Portals break trees.
             findInPortal(findInPortal(wrapper, "#outer-element"), "#inner-element").simulate("mousedown");
-            assert.isTrue(onClose.notCalled);
+            expect(onClose).not.toHaveBeenCalled();
         });
 
         it("invoked on escape key", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             mountWrapper(
                 <Overlay isOpen={true} onClose={onClose} usePortal={false}>
                     {createOverlayContents()}
                 </Overlay>,
             );
             wrapper.simulate("keydown", { key: "Escape" });
-            assert.isTrue(onClose.calledOnce);
+            expect(onClose).toHaveBeenCalledOnce();
         });
 
         it("not invoked on escape key when canEscapeKeyClose=false", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             const overlay = shallow(
                 <Overlay canEscapeKeyClose={false} isOpen={true} onClose={onClose} usePortal={false}>
                     {createOverlayContents()}
                 </Overlay>,
             );
             overlay.simulate("keydown", { key: "Escape" });
-            assert.isTrue(onClose.notCalled);
+            expect(onClose).not.toHaveBeenCalled();
             overlay.unmount();
         });
 
@@ -389,12 +388,12 @@ describe("<Overlay>", () => {
                 </Overlay>,
             );
             // ES6 class property vs prototype, see: https://github.com/airbnb/enzyme/issues/365
-            const bringFocusSpy = spy(wrapper.instance() as Overlay, "bringFocusInsideOverlay");
+            const bringFocusSpy = vi.spyOn(wrapper.instance() as Overlay, "bringFocusInsideOverlay");
             wrapper.setProps({ isOpen: true });
 
             // triggers the infinite recursion
             wrapper.find("#inputId").simulate("click");
-            assert.isTrue(bringFocusSpy.calledOnce);
+            expect(bringFocusSpy).toHaveBeenCalledOnce();
 
             // don't need spy.restore() since the wrapper will be destroyed after test anyways
             temporaryWrapper.unmount();
@@ -558,10 +557,10 @@ describe("<Overlay>", () => {
     it.skip("lifecycle methods called as expected", async () => {
         // these lifecycles are passed directly to CSSTransition from react-transition-group
         // so we do not need to test these extensively. one integration test should do.
-        const onClosed = spy();
-        const onClosing = spy();
-        const onOpened = spy();
-        const onOpening = spy();
+        const onClosed = vi.fn();
+        const onClosing = vi.fn();
+        const onOpened = vi.fn();
+        const onOpening = vi.fn();
         wrapper = mountWrapper(
             <Overlay
                 {...{ onClosed, onClosing, onOpened, onOpening }}
@@ -573,22 +572,22 @@ describe("<Overlay>", () => {
                 {createOverlayContents()}
             </Overlay>,
         );
-        assert.isTrue(onOpening.calledOnce, "onOpening");
-        assert.isFalse(onOpened.calledOnce, "onOpened not called yet");
+        expect(onOpening).toHaveBeenCalledOnce();
+        expect(onOpened).not.toHaveBeenCalled();
 
         await sleep(10);
 
         // on*ed called after transition completes
-        assert.isTrue(onOpened.calledOnce, "onOpened");
+        expect(onOpened).toHaveBeenCalledOnce();
 
         wrapper.setProps({ isOpen: false });
         // on*ing called immediately when prop changes
-        assert.isTrue(onClosing.calledOnce, "onClosing");
-        assert.isFalse(onClosed.calledOnce, "onClosed not called yet");
+        expect(onClosing).toHaveBeenCalledOnce();
+        expect(onClosed).not.toHaveBeenCalled();
 
         await sleep(10);
 
-        assert.isTrue(onClosed.calledOnce, "onOpened");
+        expect(onClosed).toHaveBeenCalledOnce();
     });
 
     let index = 0;

--- a/packages/core/src/components/overlay2/overlay2.test.tsx
+++ b/packages/core/src/components/overlay2/overlay2.test.tsx
@@ -17,9 +17,8 @@
 import { fireEvent, render, type RenderOptions, type RenderResult, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, useState } from "react";
-import { spy } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { OverlaysProvider } from "../../context/overlays/overlaysProvider";
@@ -134,7 +133,7 @@ describe("<Overlay2>", () => {
     describe("onClose", () => {
         it("should invoke on backdrop mousedown when canOutsideClickClose=true", async () => {
             const user = userEvent.setup();
-            const onClose = spy();
+            const onClose = vi.fn();
             const { container } = renderWithOverlaysProvider(
                 <Overlay2
                     transitionDuration={0}
@@ -150,12 +149,12 @@ describe("<Overlay2>", () => {
 
             await user.click(backdropElement!);
 
-            expect(onClose.calledOnce).to.be.true;
+            expect(onClose).toHaveBeenCalledOnce();
         });
 
         it("should not invoke on backdrop mousedown when canOutsideClickClose=false", async () => {
             const user = userEvent.setup();
-            const onClose = spy();
+            const onClose = vi.fn();
             const { container } = renderWithOverlaysProvider(
                 <Overlay2
                     transitionDuration={0}
@@ -171,12 +170,12 @@ describe("<Overlay2>", () => {
 
             await user.click(backdropElement!);
 
-            expect(onClose.notCalled).to.be.true;
+            expect(onClose).not.toHaveBeenCalled();
         });
 
         it("should invoke on document mousedown when hasBackdrop=false", async () => {
             const user = userEvent.setup();
-            const onClose = spy();
+            const onClose = vi.fn();
             renderWithOverlaysProvider(
                 <Overlay2
                     transitionDuration={0}
@@ -189,12 +188,12 @@ describe("<Overlay2>", () => {
 
             await user.click(document.documentElement);
 
-            expect(onClose.calledOnce).to.be.true;
+            expect(onClose).toHaveBeenCalledOnce();
         });
 
         it("should not invoke on document mousedown when hasBackdrop=false and canOutsideClickClose=false", async () => {
             const user = userEvent.setup();
-            const onClose = spy();
+            const onClose = vi.fn();
             renderWithOverlaysProvider(
                 <Overlay2
                     transitionDuration={0}
@@ -208,12 +207,12 @@ describe("<Overlay2>", () => {
 
             await user.click(document.documentElement);
 
-            expect(onClose.notCalled).to.be.true;
+            expect(onClose).not.toHaveBeenCalled();
         });
 
         it("should not invoke on click of a nested overlay", async () => {
             const user = userEvent.setup();
-            const onClose = spy();
+            const onClose = vi.fn();
             renderWithOverlaysProvider(
                 <Overlay2 transitionDuration={0} isOpen={true} onClose={onClose}>
                     <>
@@ -228,11 +227,11 @@ describe("<Overlay2>", () => {
 
             await user.click(innerElement);
 
-            expect(onClose.notCalled).to.be.true;
+            expect(onClose).not.toHaveBeenCalled();
         });
 
         it("should invoke on escape key", async () => {
-            const onClose = spy();
+            const onClose = vi.fn();
 
             function TestOverlay() {
                 const [isOpen, setIsOpen] = useState(true);
@@ -260,13 +259,13 @@ describe("<Overlay2>", () => {
 
             fireEvent.keyDown(overlayElement!, { key: "Escape" });
 
-            expect(onClose.calledOnce).to.be.true;
+            expect(onClose).toHaveBeenCalledOnce();
 
             await waitFor(() => expect(screen.queryByText("test content")).not.toBeInTheDocument());
         });
 
         it("should not invoke on escape key when canEscapeKeyClose is false", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
 
             function TestOverlay() {
                 const [isOpen, setIsOpen] = useState(true);
@@ -295,14 +294,14 @@ describe("<Overlay2>", () => {
 
             fireEvent.keyDown(overlayElement!, { key: "Escape" });
 
-            expect(onClose.notCalled).to.be.true;
+            expect(onClose).not.toHaveBeenCalled();
 
             expect(screen.queryByText("test content")).to.exist;
         });
 
         it("should close second overlay with escape key and return focus to first overlay", async () => {
-            const firstOnClose = spy();
-            const secondOnClose = spy();
+            const firstOnClose = vi.fn();
+            const secondOnClose = vi.fn();
 
             function TestOverlays() {
                 const [isFirstOpen, setIsFirstOpen] = useState(true);
@@ -353,8 +352,8 @@ describe("<Overlay2>", () => {
             fireEvent.keyDown(secondOverlayContainer!, { key: "Escape" });
 
             // Verify only the second overlay's onClose was called
-            expect(firstOnClose.notCalled).to.be.true;
-            expect(secondOnClose.calledOnce).to.be.true;
+            expect(firstOnClose).not.toHaveBeenCalled();
+            expect(secondOnClose).toHaveBeenCalledOnce();
 
             // Wait for the second overlay to close
             await waitFor(() => expect(screen.queryByTestId("second-overlay-input")).not.toBeInTheDocument());
@@ -811,10 +810,10 @@ describe("<Overlay2>", () => {
         it("should call lifecycle methods as expected", async () => {
             // these lifecycles are passed directly to CSSTransition from react-transition-group
             // so we do not need to test these extensively. one integration test should do.
-            const onClosed = spy();
-            const onClosing = spy();
-            const onOpened = spy();
-            const onOpening = spy();
+            const onClosed = vi.fn();
+            const onClosing = vi.fn();
+            const onOpened = vi.fn();
+            const onOpening = vi.fn();
 
             const { rerender } = renderWithOverlaysProvider(
                 <Overlay2
@@ -832,14 +831,14 @@ describe("<Overlay2>", () => {
             );
 
             // Wait for onOpening to be called
-            await waitFor(() => expect(onOpening.calledOnce, "onOpening").to.be.true);
-            expect(onOpened.calledOnce, "onOpened not called yet").to.be.false;
+            await waitFor(() => expect(onOpening).toHaveBeenCalledOnce());
+            expect(onOpened).not.toHaveBeenCalled();
 
             // Wait for transition to complete and onOpened to be called
-            await waitFor(() => expect(onOpened.calledOnce, "onOpened").to.be.true, { timeout: 100 });
+            await waitFor(() => expect(onOpened).toHaveBeenCalledOnce(), { timeout: 100 });
 
             // on*ed called after transition completes
-            expect(onOpened.calledOnce, "onOpened").to.be.true;
+            expect(onOpened).toHaveBeenCalledOnce();
 
             rerender(
                 <Overlay2
@@ -856,10 +855,10 @@ describe("<Overlay2>", () => {
             );
 
             // Wait for onClosing to be called when prop changes
-            await waitFor(() => expect(onClosing.calledOnce, "onClosing").to.be.true, { timeout: 200 });
+            await waitFor(() => expect(onClosing).toHaveBeenCalledOnce(), { timeout: 200 });
 
             // Wait for transition to complete and onClosed to be called
-            await waitFor(() => expect(onClosed.calledOnce, "onClosed").to.be.true, { timeout: 200 });
+            await waitFor(() => expect(onClosed).toHaveBeenCalledOnce(), { timeout: 200 });
         });
     });
 });

--- a/packages/core/src/components/panel-stack/panelStack.test.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.test.tsx
@@ -16,9 +16,8 @@
 
 import { mount, type ReactWrapper } from "enzyme";
 import { useState } from "react";
-import { spy } from "sinon";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { NumericInput } from "../forms/numericInput";
@@ -116,32 +115,32 @@ describe("<PanelStack>", () => {
         });
 
         it("does not call the callback handler onClose when there is only a single panel on the stack", () => {
-            const onClose = spy();
+            const onClose = vi.fn();
             panelStackWrapper = renderPanelStack({ initialPanel, onClose });
 
             const closePanel = panelStackWrapper.find("#close-panel-button");
             assert.exists(closePanel);
 
             closePanel.simulate("click");
-            assert.equal(onClose.callCount, 0);
+            expect(onClose).not.toHaveBeenCalled();
         });
 
         it("calls the callback handlers onOpen and onClose", () => {
-            const onOpen = spy();
-            const onClose = spy();
+            const onOpen = vi.fn();
+            const onClose = vi.fn();
             panelStackWrapper = renderPanelStack({ initialPanel, onClose, onOpen });
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
             assert.exists(newPanelButton);
             newPanelButton.simulate("click");
-            assert.isTrue(onOpen.calledOnce);
-            assert.isFalse(onClose.calledOnce);
+            expect(onOpen).toHaveBeenCalledOnce();
+            expect(onClose).not.toHaveBeenCalled();
 
             const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
             assert.exists(backButton);
             backButton.simulate("click");
-            assert.isTrue(onClose.calledOnce);
-            assert.isTrue(onOpen.calledOnce);
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(onOpen).toHaveBeenCalledOnce();
         });
 
         it("does not have the back button when only a single panel is on the stack", () => {

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -16,9 +16,17 @@
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { MockInstance } from "vitest";
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import {
+    afterAll,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    type MockInstance,
+    vi,
+} from "@blueprintjs/test-commons/vitest";
 
 import { Button, PopupKind, Tooltip } from "..";
 import { Classes } from "../../common";

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -16,9 +16,9 @@
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import sinon from "sinon";
+import type { MockInstance } from "vitest";
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Button, PopupKind, Tooltip } from "..";
 import { Classes } from "../../common";
@@ -29,17 +29,17 @@ import { type PopoverInteractionKind } from "./popoverProps";
 
 describe("<Popover>", () => {
     describe("validation", () => {
-        let warnSpy: sinon.SinonStub;
+        let warnSpy: MockInstance;
 
-        // use sinon.stub to prevent warnings from appearing in the test logs
-        beforeAll(() => (warnSpy = sinon.stub(console, "warn")));
-        beforeEach(() => warnSpy.resetHistory());
-        afterAll(() => warnSpy.restore());
+        // use vi.spyOn to prevent warnings from appearing in the test logs
+        beforeAll(() => (warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn())));
+        beforeEach(() => warnSpy.mockClear());
+        afterAll(() => warnSpy.mockRestore());
 
         it("throws error if given no target", () => {
             render(<Popover />);
 
-            expect(warnSpy.calledWith(Errors.POPOVER_REQUIRES_TARGET)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_REQUIRES_TARGET);
         });
 
         it("warns if given > 1 target elements", () => {
@@ -50,18 +50,18 @@ describe("<Popover>", () => {
                 </Popover>,
             );
 
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_TOO_MANY_CHILDREN)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_TOO_MANY_CHILDREN);
         });
 
         it("warns if given children and renderTarget prop", () => {
             render(<Popover renderTarget={() => <span>"boom"</span>}>pow</Popover>);
 
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_DOUBLE_TARGET)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_DOUBLE_TARGET);
         });
 
         it("warns if given targetProps and renderTarget", () => {
             render(<Popover targetProps={{ role: "none" }} renderTarget={() => <span>"boom"</span>} />);
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_TARGET_PROPS_WITH_RENDER_TARGET)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_TARGET_PROPS_WITH_RENDER_TARGET);
         });
 
         it("warns if attempting to open a popover with empty content", () => {
@@ -71,7 +71,7 @@ describe("<Popover>", () => {
                 </Popover>,
             );
 
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_EMPTY_CONTENT)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_EMPTY_CONTENT);
         });
 
         it("warns if backdrop enabled when rendering inline", () => {
@@ -81,7 +81,7 @@ describe("<Popover>", () => {
                 </Popover>,
             );
 
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_HAS_BACKDROP_INLINE)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_HAS_BACKDROP_INLINE);
         });
 
         it("warns and disables if given undefined content", async () => {
@@ -92,7 +92,7 @@ describe("<Popover>", () => {
             );
 
             expect(container.querySelector(`.${Classes.OVERLAY}`)).not.toBeInTheDocument();
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_EMPTY_CONTENT)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_EMPTY_CONTENT);
         });
 
         it("warns and disables if given empty string content", () => {
@@ -104,7 +104,7 @@ describe("<Popover>", () => {
             );
 
             expect(container.querySelector(`.${Classes.OVERLAY}`)).not.toBeInTheDocument();
-            expect(warnSpy.calledWith(Errors.POPOVER_WARN_EMPTY_CONTENT)).to.be.true;
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_EMPTY_CONTENT);
         });
 
         describe("throws error if backdrop enabled with non-CLICK interactionKind", () => {
@@ -124,7 +124,7 @@ describe("<Popover>", () => {
                         </Popover>,
                     );
 
-                    expect(warnSpy.calledWith(Errors.POPOVER_HAS_BACKDROP_INTERACTION)).to.be.true;
+                    expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_HAS_BACKDROP_INTERACTION);
                 });
             }
         });
@@ -328,7 +328,7 @@ describe("<Popover>", () => {
 
         it("supports overlay lifecycle props", async () => {
             const user = userEvent.setup();
-            const onOpening = sinon.spy();
+            const onOpening = vi.fn();
             render(
                 <Popover content="content" onOpening={onOpening}>
                     <Button text="target" />
@@ -337,7 +337,7 @@ describe("<Popover>", () => {
 
             await user.click(screen.getByRole("button", { name: "target" }));
 
-            expect(onOpening.calledOnce).to.be.true;
+            expect(onOpening).toHaveBeenCalledOnce();
         });
 
         it.skip("escape key closes popover", async () => {
@@ -666,14 +666,14 @@ describe("<Popover>", () => {
             });
 
             it("onInteraction not called if changing from closed to open (b/c popover is still closed)", () => {
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 const { rerender } = render(
                     <Popover content="content" disabled={true} isOpen={false} onInteraction={onInteraction}>
                         <Button text="target" />
                     </Popover>,
                 );
 
-                expect(onInteraction.called).to.be.false;
+                expect(onInteraction).not.toHaveBeenCalled();
 
                 rerender(
                     <Popover content="content" disabled={true} isOpen={true} onInteraction={onInteraction}>
@@ -682,18 +682,18 @@ describe("<Popover>", () => {
                 );
 
                 expect(screen.queryByText("content")).not.toBeInTheDocument();
-                expect(onInteraction.called).to.be.false;
+                expect(onInteraction).not.toHaveBeenCalled();
             });
 
             it("onInteraction not called if changing from open to closed (b/c popover was already closed)", () => {
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 const { rerender } = render(
                     <Popover content="content" disabled={true} isOpen={true} onInteraction={onInteraction}>
                         <Button text="target" />
                     </Popover>,
                 );
 
-                expect(onInteraction.called).to.be.false;
+                expect(onInteraction).not.toHaveBeenCalled();
 
                 rerender(
                     <Popover content="content" disabled={true} isOpen={false} onInteraction={onInteraction}>
@@ -702,11 +702,11 @@ describe("<Popover>", () => {
                 );
 
                 expect(screen.queryByText("content")).not.toBeInTheDocument();
-                expect(onInteraction.called).to.be.false;
+                expect(onInteraction).not.toHaveBeenCalled();
             });
 
             it("onInteraction called if open and changing to disabled (b/c popover will close)", async () => {
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 const { rerender } = render(
                     <Popover content="content" disabled={false} isOpen={true} onInteraction={onInteraction}>
                         <Button text="target" />
@@ -715,7 +715,7 @@ describe("<Popover>", () => {
 
                 await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-                expect(onInteraction.called).to.be.false;
+                expect(onInteraction).not.toHaveBeenCalled();
 
                 rerender(
                     <Popover content="content" disabled={true} isOpen={true} onInteraction={onInteraction}>
@@ -725,18 +725,18 @@ describe("<Popover>", () => {
 
                 await waitFor(() => expect(screen.queryByText("content")).not.toBeInTheDocument());
 
-                expect(onInteraction.called).to.be.true;
+                expect(onInteraction).toHaveBeenCalled();
             });
 
             it("onInteraction called if open and changing to not-disabled (b/c popover will open)", async () => {
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 const { rerender } = render(
                     <Popover content="content" disabled={true} isOpen={true} onInteraction={onInteraction}>
                         <Button text="target" />
                     </Popover>,
                 );
 
-                expect(onInteraction.called).to.be.false;
+                expect(onInteraction).not.toHaveBeenCalled();
 
                 rerender(
                     <Popover content="content" disabled={false} isOpen={true} onInteraction={onInteraction}>
@@ -746,13 +746,13 @@ describe("<Popover>", () => {
 
                 await waitFor(() => expect(screen.getByText("content")).to.exist);
 
-                expect(onInteraction.called).to.be.true;
+                expect(onInteraction).toHaveBeenCalled();
             });
         });
 
         it("onClose is invoked with event when popover would close", async () => {
             const user = userEvent.setup();
-            const onClose = sinon.spy();
+            const onClose = vi.fn();
             render(
                 <Popover
                     content={<Button className={Classes.POPOVER_DISMISS}>close</Button>}
@@ -768,14 +768,14 @@ describe("<Popover>", () => {
 
             await user.click(screen.getByRole("button", { name: "close" }));
 
-            expect(onClose.calledOnce).to.be.true;
-            expect(onClose.args[0][0]).to.exist;
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(onClose.mock.calls[0][0]).toBeDefined();
         });
 
         describe("onInteraction()", () => {
             it("is invoked with `true` when closed popover target is clicked", async () => {
                 const user = userEvent.setup();
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 render(
                     <Popover content="content" isOpen={false} onInteraction={onInteraction}>
                         <Button text="target" />
@@ -784,13 +784,13 @@ describe("<Popover>", () => {
 
                 await user.click(screen.getByRole("button", { name: "target" }));
 
-                expect(onInteraction.calledOnce).to.be.true;
-                expect(onInteraction.calledWith(true)).to.be.true;
+                expect(onInteraction).toHaveBeenCalledOnce();
+                expect(onInteraction).toHaveBeenCalledWith(true, expect.anything());
             });
 
             it("is invoked with `false` when open popover target is clicked", async () => {
                 const user = userEvent.setup();
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 const { container } = render(
                     <Popover content="content" isOpen={true} onInteraction={onInteraction}>
                         <Button text="target" />
@@ -802,13 +802,13 @@ describe("<Popover>", () => {
 
                 await user.click(target!);
 
-                expect(onInteraction.calledOnce).to.be.true;
-                expect(onInteraction.calledWith(false)).to.be.true;
+                expect(onInteraction).toHaveBeenCalledOnce();
+                expect(onInteraction).toHaveBeenCalledWith(false, expect.anything());
             });
 
             it("is invoked with `false` when open modal popover backdrop is clicked", async () => {
                 const user = userEvent.setup();
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 render(
                     <Popover
                         // @ts-ignore
@@ -825,13 +825,13 @@ describe("<Popover>", () => {
 
                 await user.click(backdrop);
 
-                expect(onInteraction.calledOnce).to.be.true;
-                expect(onInteraction.calledWith(false)).to.be.true;
+                expect(onInteraction).toHaveBeenCalledOnce();
+                expect(onInteraction).toHaveBeenCalledWith(false, expect.anything());
             });
 
             it("is invoked with `false` when clicking POPOVER_DISMISS", async () => {
                 const user = userEvent.setup();
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 render(
                     <Popover
                         content={<Button className={Classes.POPOVER_DISMISS}>close</Button>}
@@ -847,13 +847,13 @@ describe("<Popover>", () => {
 
                 await user.click(closeButton);
 
-                expect(onInteraction.calledOnce).to.be.true;
-                expect(onInteraction.calledWith(false)).to.be.true;
+                expect(onInteraction).toHaveBeenCalledOnce();
+                expect(onInteraction).toHaveBeenCalledWith(false, expect.anything());
             });
 
             it("is invoked with `false` when the document is mousedowned", async () => {
                 const user = userEvent.setup();
-                const onInteraction = sinon.spy();
+                const onInteraction = vi.fn();
                 render(
                     <Popover content="content" isOpen={true} onInteraction={onInteraction}>
                         <Button text="target" />
@@ -862,8 +862,8 @@ describe("<Popover>", () => {
 
                 await user.click(document.documentElement);
 
-                expect(onInteraction.calledOnce).to.be.true;
-                expect(onInteraction.calledWith(false)).to.be.true;
+                expect(onInteraction).toHaveBeenCalledOnce();
+                expect(onInteraction).toHaveBeenCalledWith(false, expect.anything());
             });
         });
 
@@ -1074,15 +1074,15 @@ describe("<Popover>", () => {
         });
 
         it("console.warns if onInteraction is set", () => {
-            const warnSpy = sinon.stub(console, "warn");
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
             render(
                 <Popover content="content" onInteraction={() => false}>
                     <Button text="target" />
                 </Popover>,
             );
 
-            expect(warnSpy.firstCall.args[0]).to.equal(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
-            warnSpy.restore();
+            expect(warnSpy.mock.calls[0][0]).toBe(Errors.POPOVER_WARN_UNCONTROLLED_ONINTERACTION);
+            warnSpy.mockRestore();
         });
 
         it("does apply active class to target when open", async () => {

--- a/packages/core/src/components/resize-sensor/resizeSensor.test.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.test.tsx
@@ -16,9 +16,9 @@
 
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef } from "react";
-import { spy } from "sinon";
+import type { MockInstance } from "vitest";
 
-import { afterAll, afterEach, assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { sleep } from "../../common/test-utils";
 
@@ -39,26 +39,26 @@ describe.skip("<ResizeSensor>", () => {
     afterAll(() => containerElement.remove());
 
     it("onResize is called when size changes", async () => {
-        const onResize = spy();
+        const onResize = vi.fn();
         mountResizeSensor({ onResize });
         await resize({ width: 200 });
         await resize({ height: 100 });
         await resize({ width: 55 });
-        assert.equal(onResize.callCount, 3);
+        expect(onResize).toHaveBeenCalledTimes(3);
         assertResizeArgs(onResize, ["200x0", "200x100", "55x100"]);
     });
 
     it("onResize is NOT called redundantly when size is unchanged", async () => {
-        const onResize = spy();
+        const onResize = vi.fn();
         mountResizeSensor({ onResize });
         await resize({ width: 200 });
         await resize({ width: 200 }); // this one should be ignored
-        assert.equal(onResize.callCount, 1);
+        expect(onResize).toHaveBeenCalledOnce();
         assertResizeArgs(onResize, ["200x0"]);
     });
 
     it("onResize is called when element changes", async () => {
-        const onResize = spy();
+        const onResize = vi.fn();
         mountResizeSensor({ onResize });
         await resize({ id: 1, width: 200 });
         await resize({ id: 2, width: 200 }); // not ignored bc element recreated
@@ -67,26 +67,26 @@ describe.skip("<ResizeSensor>", () => {
     });
 
     it("onResize can be changed", async () => {
-        const onResize1 = spy();
+        const onResize1 = vi.fn();
         mountResizeSensor({ onResize: onResize1 });
         await resize({ id: 1, width: 200 });
 
-        const onResize2 = spy();
+        const onResize2 = vi.fn();
         wrapper!.setProps({ onResize: onResize2 });
         await resize({ height: 100, id: 2 });
         await resize({ id: 3, width: 55 });
 
-        assert.equal(onResize1.callCount, 1, "first callback should have been called exactly once");
-        assert.equal(onResize2.callCount, 2, "second callback should have been called exactly twice");
+        expect(onResize1).toHaveBeenCalledOnce();
+        expect(onResize2).toHaveBeenCalledTimes(2);
     });
 
     it("still works when user sets their own targetRef", async () => {
-        const onResize = spy();
+        const onResize = vi.fn();
         const targetRef = createRef<HTMLElement>();
         const RESIZE_WIDTH = 200;
         mountResizeSensor({ onResize, targetRef });
         await resize({ width: RESIZE_WIDTH });
-        assert.equal(onResize.callCount, 1, "onResize should be called");
+        expect(onResize).toHaveBeenCalledOnce();
         assertResizeArgs(onResize, [`${RESIZE_WIDTH}x0`]);
         assert.isNotNull(targetRef.current, "user-provided targetRef should be set");
         assert.strictEqual(targetRef.current?.clientWidth, RESIZE_WIDTH, "user-provided targetRef.current.clientWidth");
@@ -106,13 +106,12 @@ describe.skip("<ResizeSensor>", () => {
         await sleep(30);
     }
 
-    function assertResizeArgs(onResize: sinon.SinonSpy, sizes: string[]) {
-        assert.sameMembers(
-            onResize.args
-                .map(args => (args[0] as ResizeObserverEntry[])[0].contentRect)
-                .map(r => `${r.width}x${r.height}`),
-            sizes,
-        );
+    function assertResizeArgs(onResize: MockInstance, sizes: string[]) {
+        const mapped = onResize.mock.calls
+            .map(args => (args[0] as ResizeObserverEntry[])[0].contentRect)
+            .map(r => `${r.width}x${r.height}`);
+        expect(mapped).toHaveLength(sizes.length);
+        expect(mapped).toEqual(expect.arrayContaining(sizes));
     }
 });
 

--- a/packages/core/src/components/resize-sensor/resizeSensor.test.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.test.tsx
@@ -16,9 +16,17 @@
 
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef } from "react";
-import type { MockInstance } from "vitest";
 
-import { afterAll, afterEach, assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import {
+    afterAll,
+    afterEach,
+    assert,
+    describe,
+    expect,
+    it,
+    type MockInstance,
+    vi,
+} from "@blueprintjs/test-commons/vitest";
 
 import { sleep } from "../../common/test-utils";
 

--- a/packages/core/src/components/segmented-control/segmentedControl.test.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.test.tsx
@@ -17,10 +17,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
-import sinon from "sinon";
 
 import { IconNames } from "@blueprintjs/icons";
-import { afterEach, assert, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, type OptionProps } from "../../common";
 
@@ -115,32 +114,32 @@ describe("<SegmentedControl>", () => {
 
     it("should select the correct option when clicked", async () => {
         const user = userEvent.setup();
-        const onValueChange = sinon.spy();
+        const onValueChange = vi.fn();
         render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
         const listButton = screen.getByRole("radio", { name: /list/i });
 
         await user.click(listButton);
 
-        expect(onValueChange.called).to.be.true;
-        expect(onValueChange.args[0][0]).to.equal("list");
+        expect(onValueChange).toHaveBeenCalled();
+        expect(onValueChange.mock.calls[0][0]).to.equal("list");
         expect(listButton.getAttribute("aria-checked")).to.equal("true");
     });
 
     it("should not allow disabled options to be selected", async () => {
         const user = userEvent.setup();
-        const onValueChange = sinon.spy();
+        const onValueChange = vi.fn();
         render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
         const gridButton = screen.getByRole("radio", { name: /grid/i });
 
         await user.click(gridButton);
 
-        expect(onValueChange.called).to.be.false;
+        expect(onValueChange).not.toHaveBeenCalled();
         expect(gridButton.getAttribute("aria-checked")).to.equal("false");
     });
 
     it("should not allow any options to be selected when disabled", async () => {
         const user = userEvent.setup();
-        const onValueChange = sinon.spy();
+        const onValueChange = vi.fn();
         render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} disabled={true} />);
         const listButton = screen.getByRole("radio", { name: /list/i });
         const gridButton = screen.getByRole("radio", { name: /grid/i });
@@ -148,7 +147,7 @@ describe("<SegmentedControl>", () => {
         await user.click(listButton);
         await user.click(gridButton);
 
-        expect(onValueChange.called).to.be.false;
+        expect(onValueChange).not.toHaveBeenCalled();
         expect(listButton.getAttribute("aria-checked")).to.equal("false");
         expect(gridButton.getAttribute("aria-checked")).to.equal("false");
     });

--- a/packages/core/src/components/slider/handle.test.tsx
+++ b/packages/core/src/components/slider/handle.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount, type ReactWrapper } from "enzyme";
-import sinon from "sinon";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Handle, type HandleState, type InternalHandleProps } from "./handle";
 import { DRAG_SIZE, simulateMovement } from "./sliderTestUtils";
@@ -46,32 +45,32 @@ describe("<Handle>", () => {
     afterEach(() => containerElement.remove());
 
     it("disabled handle never invokes event handlers", () => {
-        const eventSpy = sinon.spy();
+        const eventSpy = vi.fn();
         const handle = mountHandle(0, { disabled: true, onChange: eventSpy, onRelease: eventSpy });
         simulateMovement(handle, { dragTimes: 3 });
         handle.simulate("keydown", { key: "ArrowUp" });
-        assert.isTrue(eventSpy.notCalled);
+        expect(eventSpy).not.toHaveBeenCalled();
     });
 
     describe("keyboard events", () => {
         it("pressing arrow key down reduces value by stepSize", () => {
-            const onChange = sinon.spy();
+            const onChange = vi.fn();
             mountHandle(3, { onChange, stepSize: 2 }).simulate("keydown", { key: "ArrowDown" });
-            assert.isTrue(onChange.calledWithExactly(1));
+            expect(onChange).toHaveBeenCalledWith(1);
         });
 
         it("pressing arrow key up increases value by stepSize", () => {
-            const onChange = sinon.spy();
+            const onChange = vi.fn();
             mountHandle(3, { onChange, stepSize: 4 }).simulate("keydown", { key: "ArrowUp" });
-            assert.isTrue(onChange.calledWithExactly(7));
+            expect(onChange).toHaveBeenCalledWith(7);
         });
 
         it("releasing arrow key calls onRelease with value", () => {
-            const onRelease = sinon.spy();
+            const onRelease = vi.fn();
             mountHandle(3, { onRelease, stepSize: 4 })
                 .simulate("keydown", { key: "ArrowUp" })
                 .simulate("keyup", { key: "ArrowUp" });
-            assert.isTrue(onRelease.calledWithExactly(3));
+            expect(onRelease).toHaveBeenCalledWith(3);
         });
     });
 
@@ -80,44 +79,44 @@ describe("<Handle>", () => {
             describe(`${vertical ? "vertical " : ""}${touch ? "touch" : "mouse"} events`, () => {
                 const options = { touch, vertical, verticalHeight: 0 };
                 it("onChange is invoked each time movement changes value", () => {
-                    const onChange = sinon.spy();
+                    const onChange = vi.fn();
                     simulateMovement(mountHandle(0, { onChange, vertical }), {
                         dragTimes: 3,
                         ...options,
                     });
-                    assert.strictEqual(onChange.callCount, 3);
-                    assert.deepEqual(onChange.args, [[1], [2], [3]]);
+                    expect(onChange).toHaveBeenCalledTimes(3);
+                    expect(onChange.mock.calls).toEqual([[1], [2], [3]]);
                 });
 
                 it("onChange is not invoked if new value === props.value", () => {
-                    const onChange = sinon.spy();
+                    const onChange = vi.fn();
                     // move around same value
                     simulateMovement(mountHandle(0, { onChange, vertical }), {
                         dragSize: 0.1,
                         dragTimes: 4,
                         ...options,
                     });
-                    assert.strictEqual(onChange.callCount, 0);
+                    expect(onChange).not.toHaveBeenCalled();
                 });
 
                 it("onRelease is invoked once on mouseup", () => {
-                    const onRelease = sinon.spy();
+                    const onRelease = vi.fn();
                     simulateMovement(mountHandle(0, { onRelease, vertical }), {
                         dragTimes: 3,
                         ...options,
                     });
-                    assert.strictEqual(onRelease.callCount, 1);
-                    assert.strictEqual(onRelease.args[0][0], 3);
+                    expect(onRelease).toHaveBeenCalledOnce();
+                    expect(onRelease.mock.calls[0][0]).toBe(3);
                 });
 
                 it("onRelease is invoked if new value === props.value", () => {
-                    const onRelease = sinon.spy();
+                    const onRelease = vi.fn();
                     simulateMovement(mountHandle(0, { onRelease, vertical }), {
                         dragTimes: 0,
                         ...options,
                     });
-                    assert.strictEqual(onRelease.callCount, 1);
-                    assert.isTrue(onRelease.calledWithExactly(0));
+                    expect(onRelease).toHaveBeenCalledOnce();
+                    expect(onRelease).toHaveBeenCalledWith(0);
                 });
             });
         });

--- a/packages/core/src/components/slider/handle.test.tsx
+++ b/packages/core/src/components/slider/handle.test.tsx
@@ -105,8 +105,7 @@ describe("<Handle>", () => {
                         dragTimes: 3,
                         ...options,
                     });
-                    expect(onRelease).toHaveBeenCalledOnce();
-                    expect(onRelease.mock.calls[0][0]).toBe(3);
+                    expect(onRelease).toHaveBeenCalledExactlyOnceWith(3);
                 });
 
                 it("onRelease is invoked if new value === props.value", () => {
@@ -115,8 +114,7 @@ describe("<Handle>", () => {
                         dragTimes: 0,
                         ...options,
                     });
-                    expect(onRelease).toHaveBeenCalledOnce();
-                    expect(onRelease).toHaveBeenCalledWith(0);
+                    expect(onRelease).toHaveBeenCalledExactlyOnceWith(0);
                 });
             });
         });

--- a/packages/core/src/components/slider/multiSlider.test.tsx
+++ b/packages/core/src/components/slider/multiSlider.test.tsx
@@ -15,10 +15,9 @@
  */
 
 import { mount, type ReactWrapper } from "enzyme";
-import sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -31,8 +30,8 @@ const STEP_SIZE = 20;
 describe("<MultiSlider>", () => {
     let containerElement: HTMLElement;
 
-    let onChange: sinon.SinonSpy;
-    let onRelease: sinon.SinonSpy;
+    let onChange: ReturnType<typeof vi.fn>;
+    let onRelease: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
         // need an element in the document for tickSize to be a real number
@@ -41,8 +40,8 @@ describe("<MultiSlider>", () => {
         containerElement.style.width = `${STEP_SIZE * 10}px`;
         document.body.appendChild(containerElement);
 
-        onChange = sinon.spy();
-        onRelease = sinon.spy();
+        onChange = vi.fn();
+        onRelease = vi.fn();
     });
 
     afterEach(() => {
@@ -54,8 +53,8 @@ describe("<MultiSlider>", () => {
             const slider = renderSlider({ onRelease, values: [5, 10, 0] });
             slider.find(Handle).first().simulate("mousedown", { clientX: 0 });
             mouseUpHorizontal(0);
-            assert.equal(onRelease.callCount, 1);
-            assert.deepEqual(onRelease.firstCall.args[0], [0, 5, 10]);
+            expect(onRelease).toHaveBeenCalledOnce();
+            expect(onRelease.mock.calls[0][0]).toEqual([0, 5, 10]);
         });
 
         it("propagates className to the handles", () => {
@@ -73,16 +72,13 @@ describe("<MultiSlider>", () => {
             const slider = renderSlider({ onChange });
             simulateMovement(slider, { dragSize: STEP_SIZE, dragTimes: 4, handleIndex: 0 });
             // called 3 times for the move to 1, 2, 3, and 4
-            assert.equal(onChange.callCount, 4);
-            assert.deepEqual(
-                onChange.args.map(arg => arg[0]),
-                [
-                    [1, 5, 10],
-                    [2, 5, 10],
-                    [3, 5, 10],
-                    [4, 5, 10],
-                ],
-            );
+            expect(onChange).toHaveBeenCalledTimes(4);
+            expect(onChange.mock.calls.map(arg => arg[0])).toEqual([
+                [1, 5, 10],
+                [2, 5, 10],
+                [3, 5, 10],
+                [4, 5, 10],
+            ]);
         });
 
         it.skip("moving mouse on the middle handle updates the middle value", () => {
@@ -94,16 +90,13 @@ describe("<MultiSlider>", () => {
                 handleIndex: 1,
             });
             // called 3 times for the move to 6, 7, 8, and 9
-            assert.equal(onChange.callCount, 4);
-            assert.deepEqual(
-                onChange.args.map(arg => arg[0]),
-                [
-                    [0, 6, 10],
-                    [0, 7, 10],
-                    [0, 8, 10],
-                    [0, 9, 10],
-                ],
-            );
+            expect(onChange).toHaveBeenCalledTimes(4);
+            expect(onChange.mock.calls.map(arg => arg[0])).toEqual([
+                [0, 6, 10],
+                [0, 7, 10],
+                [0, 8, 10],
+                [0, 9, 10],
+            ]);
         });
 
         it.skip("moving mouse on the last handle updates the last value", () => {
@@ -115,57 +108,54 @@ describe("<MultiSlider>", () => {
                 handleIndex: 2,
             });
             // called 3 times for the move to 9, 8, 7, and 6
-            assert.equal(onChange.callCount, 4);
-            assert.deepEqual(
-                onChange.args.map(arg => arg[0]),
-                [
-                    [0, 5, 9],
-                    [0, 5, 8],
-                    [0, 5, 7],
-                    [0, 5, 6],
-                ],
-            );
+            expect(onChange).toHaveBeenCalledTimes(4);
+            expect(onChange.mock.calls.map(arg => arg[0])).toEqual([
+                [0, 5, 9],
+                [0, 5, 8],
+                [0, 5, 7],
+                [0, 5, 6],
+            ]);
         });
 
         it.skip("releasing mouse on a track value closer to the first handle moves the first handle", () => {
             const slider = renderSlider({ onChange });
             slider.simulate("mousedown", { clientX: STEP_SIZE });
-            assert.equal(onChange.callCount, 1);
-            assert.deepEqual(onChange.firstCall.args[0], [1, 5, 10]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([1, 5, 10]);
         });
 
         it.skip("releasing mouse on a track value slightly below the middle handle moves the middle handle", () => {
             const slider = renderSlider({ onChange });
             slider.simulate("mousedown", { clientX: STEP_SIZE * 4 });
-            assert.equal(onChange.callCount, 1);
-            assert.deepEqual(onChange.firstCall.args[0], [0, 4, 10]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([0, 4, 10]);
         });
 
         it.skip("releasing mouse on a track value slightly above the middle handle moves the middle handle", () => {
             const slider = renderSlider({ onChange });
             slider.simulate("mousedown", { clientX: STEP_SIZE * 6 });
-            assert.equal(onChange.callCount, 1);
-            assert.deepEqual(onChange.firstCall.args[0], [0, 6, 10]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([0, 6, 10]);
         });
 
         it.skip("releasing mouse on a track value closer to the last handle moves the last handle", () => {
             const slider = renderSlider({ onChange });
             slider.simulate("mousedown", { clientX: STEP_SIZE * 9 });
-            assert.equal(onChange.callCount, 1);
-            assert.deepEqual(onChange.firstCall.args[0], [0, 5, 9]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([0, 5, 9]);
         });
 
         it.skip("when values are equal, releasing mouse on a track still moves the nearest handle", () => {
             const slider = renderSlider({ onChange, values: [5, 5, 7] });
 
             slider.simulate("mousedown", { clientX: STEP_SIZE * 1 });
-            assert.equal(onChange.callCount, 1, "one lower handle invokes onChange");
-            assert.deepEqual(onChange.firstCall.args[0], [1, 5, 7], "one lower handle moves");
-            onChange.resetHistory();
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([1, 5, 7]);
+            onChange.mockClear();
 
             slider.simulate("mousedown", { clientX: STEP_SIZE * 9 });
-            assert.equal(onChange.callCount, 1, "higher handle invokes onChange");
-            assert.deepEqual(onChange.firstCall.args[0], [5, 5, 9], "higher handle moves");
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([5, 5, 9]);
         });
 
         it("values outside of bounds are clamped", () => {

--- a/packages/core/src/components/slider/rangeSlider.test.tsx
+++ b/packages/core/src/components/slider/rangeSlider.test.tsx
@@ -15,10 +15,9 @@
  */
 
 import { mount } from "enzyme";
-import sinon from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -65,11 +64,11 @@ describe("<RangeSlider>", () => {
     });
 
     it("disabled slider does not respond to key presses", () => {
-        const changeSpy = sinon.spy();
+        const changeSpy = vi.fn();
         const handles = renderSlider(<RangeSlider disabled={true} onChange={changeSpy} />).find(Handle);
         handles.first().simulate("keydown", { key: "ArrowDown" });
         handles.last().simulate("keydown", { key: "ArrowDown" });
-        assert.isTrue(changeSpy.notCalled, "onChange was called when disabled");
+        expect(changeSpy).not.toHaveBeenCalled();
     });
 
     function renderSlider(slider: React.JSX.Element) {

--- a/packages/core/src/components/slider/slider.test.tsx
+++ b/packages/core/src/components/slider/slider.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount } from "enzyme";
-import sinon from "sinon";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -80,35 +79,35 @@ describe("<Slider>", () => {
     });
 
     it.skip("moving mouse calls onChange with nearest value", () => {
-        const changeSpy = sinon.spy();
+        const changeSpy = vi.fn();
         simulateMovement(renderSlider(<Slider onChange={changeSpy} />), {
             dragSize: STEP_SIZE,
             dragTimes: 4,
         });
         // called 4 times, for the move to 1, 2, 3, and 4
-        assert.equal(changeSpy.callCount, 4, "call count");
-        assert.deepEqual(changeSpy.args, [[1], [2], [3], [4]]);
+        expect(changeSpy).toHaveBeenCalledTimes(4);
+        expect(changeSpy.mock.calls).toEqual([[1], [2], [3], [4]]);
     });
 
     it.skip("releasing mouse calls onRelease with nearest value", () => {
-        const releaseSpy = sinon.spy();
+        const releaseSpy = vi.fn();
         simulateMovement(renderSlider(<Slider onRelease={releaseSpy} />), {
             dragSize: STEP_SIZE,
             dragTimes: 1,
         });
-        assert.isTrue(releaseSpy.calledOnce, "onRelease not called exactly once");
-        assert.equal(releaseSpy.args[0][0], 1);
+        expect(releaseSpy).toHaveBeenCalledOnce();
+        expect(releaseSpy.mock.calls[0][0]).toBe(1);
     });
 
     it.skip("disabled slider never invokes event handlers", () => {
-        const eventSpy = sinon.spy();
+        const eventSpy = vi.fn();
         const slider = renderSlider(<Slider disabled={true} onChange={eventSpy} onRelease={eventSpy} />);
         // handle drag and keys
         simulateMovement(slider, { dragTimes: 3 });
         slider.simulate("keydown", { key: "ArrowUp" });
         // track click
         slider.find(TRACK_SELECTOR).simulate("mousedown", { target: containerElement.querySelector(TRACK_SELECTOR) });
-        assert.isTrue(eventSpy.notCalled);
+        expect(eventSpy).not.toHaveBeenCalled();
     });
 
     function renderSlider(slider: React.JSX.Element) {

--- a/packages/core/src/components/spinner/spinner.test.tsx
+++ b/packages/core/src/components/spinner/spinner.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount, type ReactWrapper, shallow } from "enzyme";
-import { stub } from "sinon";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { SPINNER_WARN_CLASSES_SIZE } from "../../common/errors";
@@ -61,11 +60,11 @@ describe("Spinner", () => {
     });
 
     it("size overrides Classes.LARGE/SMALL", () => {
-        const warnSpy = stub(console, "warn");
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
         const root = mount(<Spinner className={Classes.SMALL} size={32} />);
         assert.equal(root.find("svg").prop("height"), 32, "size prop");
-        assert.equal(warnSpy.args[0][0], SPINNER_WARN_CLASSES_SIZE);
-        warnSpy.restore();
+        expect(warnSpy.mock.calls[0][0]).toBe(SPINNER_WARN_CLASSES_SIZE);
+        warnSpy.mockRestore();
     });
 
     it("defaults to spinning quarter circle", () => {

--- a/packages/core/src/components/tabs/tabs.test.tsx
+++ b/packages/core/src/components/tabs/tabs.test.tsx
@@ -16,9 +16,8 @@
 import { waitFor } from "@testing-library/dom";
 import { mount, type ReactWrapper } from "enzyme";
 import { act } from "react";
-import { spy } from "sinon";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -196,7 +195,7 @@ describe("<Tabs>", () => {
 
     it("clicking selected tab still fires onChange", () => {
         const tabId = TAB_IDS[0];
-        const changeSpy = spy();
+        const changeSpy = vi.fn();
         const wrapper = mount(
             <Tabs defaultSelectedTabId={tabId} id={ID} onChange={changeSpy}>
                 {getTabsContents()}
@@ -204,11 +203,11 @@ describe("<Tabs>", () => {
             { attachTo: containerElement },
         );
         findTabById(wrapper, tabId).simulate("click");
-        assert.isTrue(changeSpy.calledWith(tabId, tabId));
+        expect(changeSpy).toHaveBeenCalledWith(tabId, tabId, expect.anything());
     });
 
     it("clicking nested tab should not affect parent", () => {
-        const changeSpy = spy();
+        const changeSpy = vi.fn();
         const wrapper = mount(
             <Tabs id={ID} onChange={changeSpy}>
                 {getTabsContents()}
@@ -222,7 +221,7 @@ describe("<Tabs>", () => {
         // last Tab is inside nested
         wrapper.find(TAB_SELECTOR).last().simulate("click");
         assert.equal(wrapper.state("selectedTabId"), TAB_IDS[0]);
-        assert.isTrue(changeSpy.notCalled, "onChange invoked");
+        expect(changeSpy).not.toHaveBeenCalled();
     });
 
     it("changes tab focus when arrow keys are pressed", () => {
@@ -250,7 +249,7 @@ describe("<Tabs>", () => {
     });
 
     it("enter and space keys click focused tab", () => {
-        const changeSpy = spy();
+        const changeSpy = vi.fn();
         const wrapper = mount(
             <Tabs id={ID} onChange={changeSpy}>
                 {getTabsContents()}
@@ -264,9 +263,9 @@ describe("<Tabs>", () => {
         tabList.simulate("keypress", { key: "Enter", target: tabElements[1] });
         tabList.simulate("keypress", { key: " ", target: tabElements[2] });
 
-        assert.equal(changeSpy.callCount, 2);
-        assert.includeDeepMembers(changeSpy.args[0], [TAB_IDS[1], TAB_IDS[0]]);
-        assert.includeDeepMembers(changeSpy.args[1], [TAB_IDS[2], TAB_IDS[1]]);
+        expect(changeSpy).toHaveBeenCalledTimes(2);
+        expect(changeSpy.mock.calls[0]).toEqual(expect.arrayContaining([TAB_IDS[1], TAB_IDS[0]]));
+        expect(changeSpy.mock.calls[1]).toEqual(expect.arrayContaining([TAB_IDS[2], TAB_IDS[1]]));
     });
 
     it("animate=false removes moving indicator element", () => {
@@ -331,7 +330,7 @@ describe("<Tabs>", () => {
         });
 
         it("invokes onChange() callback", () => {
-            const onChangeSpy = spy();
+            const onChangeSpy = vi.fn();
             const wrapper = mount(
                 <Tabs id={ID} onChange={onChangeSpy}>
                     {getTabsContents()}
@@ -339,9 +338,9 @@ describe("<Tabs>", () => {
             );
 
             findTabById(wrapper, TAB_ID_TO_SELECT).simulate("click");
-            assert.isTrue(onChangeSpy.calledOnce);
+            expect(onChangeSpy).toHaveBeenCalledOnce();
             // initial selection is first tab
-            assert.isTrue(onChangeSpy.calledWith(TAB_ID_TO_SELECT, TAB_IDS[0]));
+            expect(onChangeSpy).toHaveBeenCalledWith(TAB_ID_TO_SELECT, TAB_IDS[0], expect.anything());
         });
 
         it("moves indicator as expected", () => {
@@ -378,7 +377,7 @@ describe("<Tabs>", () => {
         });
 
         it("invokes onChange() callback but does not change state", () => {
-            const onChangeSpy = spy();
+            const onChangeSpy = vi.fn();
             const tabs = mount(
                 <Tabs id={ID} selectedTabId={SELECTED_TAB_ID} onChange={onChangeSpy}>
                     {getTabsContents()}
@@ -386,9 +385,9 @@ describe("<Tabs>", () => {
             );
 
             findTabById(tabs, TAB_ID_TO_SELECT).simulate("click");
-            assert.isTrue(onChangeSpy.calledOnce);
+            expect(onChangeSpy).toHaveBeenCalledOnce();
             // old selection is 0
-            assert.includeDeepMembers(onChangeSpy.args[0], [TAB_ID_TO_SELECT, SELECTED_TAB_ID]);
+            expect(onChangeSpy.mock.calls[0]).toEqual(expect.arrayContaining([TAB_ID_TO_SELECT, SELECTED_TAB_ID]));
             assert.deepEqual(tabs.state("selectedTabId"), SELECTED_TAB_ID);
         });
 

--- a/packages/core/src/components/tag-input/tagInput.test.tsx
+++ b/packages/core/src/components/tag-input/tagInput.test.tsx
@@ -17,9 +17,8 @@
 import { waitFor } from "@testing-library/dom";
 import { type MountRendererProps, type ReactWrapper, mount as untypedMount } from "enzyme";
 import { act } from "react";
-import sinon from "sinon";
 
-import { assert, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Intent } from "../../common";
 import { Button } from "../button/buttons";
@@ -37,13 +36,13 @@ const VALUES = ["one", "two", "three"];
 
 describe("<TagInput>", () => {
     it("passes inputProps to input element", () => {
-        const onBlur = sinon.spy();
+        const onBlur = vi.fn();
         const input = mount(<TagInput values={VALUES} inputProps={{ autoFocus: true, onBlur }} />).find("input");
         assert.isTrue(input.prop("autoFocus"));
         // check that event handler is proxied
         const fakeEvent = { flag: "yes" };
         input.prop("onBlur")?.(fakeEvent as any);
-        assert.strictEqual(onBlur.args[0][0], fakeEvent);
+        expect(onBlur.mock.calls[0][0]).toBe(fakeEvent);
     });
 
     it("renders a Tag for each value", () => {
@@ -98,48 +97,48 @@ describe("<TagInput>", () => {
     });
 
     it("tagProps function is invoked for each Tag", () => {
-        const tagProps = sinon.spy();
+        const tagProps = vi.fn();
         mount(<TagInput tagProps={tagProps} values={VALUES} />);
-        assert.isTrue(tagProps.calledThrice);
+        expect(tagProps).toHaveBeenCalledTimes(3);
     });
 
     it("clicking Tag remove button invokes onRemove with that value", () => {
-        const onRemove = sinon.spy();
+        const onRemove = vi.fn();
         // requires full mount to support data attributes and parentElement
         const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
         wrapper.find("button").at(1).simulate("click");
-        assert.isTrue(onRemove.calledOnce);
-        assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
+        expect(onRemove).toHaveBeenCalledOnce();
+        expect(onRemove.mock.calls[0]).toEqual([VALUES[1], 1]);
     });
 
     describe("onAdd", () => {
         const NEW_VALUE = "new item";
 
         it("is not invoked on enter when input is empty", () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mountTagInput(onAdd);
             pressEnterInInput(wrapper, "");
-            assert.isTrue(onAdd.notCalled);
+            expect(onAdd).not.toHaveBeenCalled();
         });
 
         it("is not invoked on enter when input is composing", () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mountTagInput(onAdd);
             pressEnterInInputWhenComposing(wrapper, "构成");
-            assert.isTrue(onAdd.notCalled);
+            expect(onAdd).not.toHaveBeenCalled();
         });
 
         it("is invoked on enter", () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mountTagInput(onAdd);
             pressEnterInInput(wrapper, NEW_VALUE);
-            assert.isTrue(onAdd.calledOnce);
-            assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
-            assert.deepEqual(onAdd.args[0][1], "default");
+            expect(onAdd).toHaveBeenCalledOnce();
+            expect(onAdd.mock.calls[0][0]).toEqual([NEW_VALUE]);
+            expect(onAdd.mock.calls[0][1]).toEqual("default");
         });
 
         it("is invoked on blur when addOnBlur=true", async () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mount(<TagInput values={VALUES} addOnBlur={true} onAdd={onAdd} />);
             // simulate typing input text
             wrapper.setProps({ inputProps: { value: NEW_VALUE } });
@@ -148,71 +147,71 @@ describe("<TagInput>", () => {
 
             // Wait for focus to change after blur event
             await waitFor(() => {
-                assert.isTrue(onAdd.calledOnce);
-                assert.deepEqual(onAdd.args[0][0], [NEW_VALUE]);
-                assert.equal(onAdd.args[0][1], "blur");
+                expect(onAdd).toHaveBeenCalledOnce();
+                expect(onAdd.mock.calls[0][0]).toEqual([NEW_VALUE]);
+                expect(onAdd.mock.calls[0][1]).toBe("blur");
             });
         });
 
         it("is not invoked on blur when addOnBlur=true but inputValue is empty", async () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mount(<TagInput values={VALUES} addOnBlur={true} onAdd={onAdd} />);
             wrapper.simulate("blur");
             // Wait for focus to change after blur event
             await waitFor(() => {
-                assert.isTrue(onAdd.notCalled);
+                expect(onAdd).not.toHaveBeenCalled();
             });
         });
 
         it("is not invoked on blur when addOnBlur=false", async () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mount(<TagInput values={VALUES} inputProps={{ value: NEW_VALUE }} onAdd={onAdd} />);
             wrapper.simulate("blur");
             // Wait for focus to change after blur event
             await waitFor(() => {
-                assert.isTrue(onAdd.notCalled);
+                expect(onAdd).not.toHaveBeenCalled();
             });
         });
 
         describe("when addOnPaste=true", () => {
             it("is invoked on paste if the text contains a delimiter between values", () => {
                 const text = "pasted\ntext";
-                const onAdd = sinon.stub();
+                const onAdd = vi.fn();
                 const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
                 wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
-                assert.isTrue(onAdd.calledOnce);
-                assert.deepEqual(onAdd.args[0][0], ["pasted", "text"]);
+                expect(onAdd).toHaveBeenCalledOnce();
+                expect(onAdd.mock.calls[0][0]).toEqual(["pasted", "text"]);
             });
 
             it("is invoked on paste if the text contains a trailing delimiter", () => {
                 const text = "pasted\n";
-                const onAdd = sinon.stub();
+                const onAdd = vi.fn();
                 const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
                 wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
-                assert.isTrue(onAdd.calledOnce);
-                assert.deepEqual(onAdd.args[0][0], ["pasted"]);
-                assert.equal(onAdd.args[0][1], "paste");
+                expect(onAdd).toHaveBeenCalledOnce();
+                expect(onAdd.mock.calls[0][0]).toEqual(["pasted"]);
+                expect(onAdd.mock.calls[0][1]).toBe("paste");
             });
 
             it("is not invoked on paste if the text does not include a delimiter", () => {
                 const text = "pasted";
-                const onAdd = sinon.stub();
+                const onAdd = vi.fn();
                 const wrapper = mount(<TagInput values={VALUES} addOnPaste={true} onAdd={onAdd} />);
                 wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
-                assert.isTrue(onAdd.notCalled);
+                expect(onAdd).not.toHaveBeenCalled();
             });
         });
 
         it("is not invoked on paste when addOnPaste=false", () => {
             const text = "pasted\ntext";
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mount(<TagInput values={VALUES} addOnPaste={false} onAdd={onAdd} />);
             wrapper.find("input").simulate("paste", { clipboardData: { getData: () => text } });
-            assert.isTrue(onAdd.notCalled);
+            expect(onAdd).not.toHaveBeenCalled();
         });
 
         it("does not clear the input if onAdd returns false", () => {
-            const onAdd = sinon.stub().returns(false);
+            const onAdd = vi.fn().mockReturnValue(false);
             const wrapper = mountTagInput(onAdd);
             act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
@@ -222,7 +221,7 @@ describe("<TagInput>", () => {
         });
 
         it("clears the input if onAdd returns true", () => {
-            const onAdd = sinon.stub().returns(true);
+            const onAdd = vi.fn().mockReturnValue(true);
             const wrapper = mountTagInput(onAdd);
             act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
@@ -232,7 +231,7 @@ describe("<TagInput>", () => {
         });
 
         it("clears the input if onAdd returns nothing", () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mountTagInput(onAdd);
             act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
@@ -242,63 +241,63 @@ describe("<TagInput>", () => {
         });
 
         it("does not clear the input if the input is controlled", () => {
-            const wrapper = mountTagInput(sinon.stub(), { inputValue: NEW_VALUE });
+            const wrapper = mountTagInput(vi.fn(), { inputValue: NEW_VALUE });
             pressEnterInInput(wrapper, NEW_VALUE);
             assert.strictEqual(wrapper.state().inputValue, NEW_VALUE);
         });
 
         it("splits input value on separator RegExp", () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             // this is actually the defaultProps value, but reproducing here for explicitness
             const wrapper = mountTagInput(onAdd, { separator: /,\s*/g });
             // various forms of whitespace properly ignored
             pressEnterInInput(wrapper, [NEW_VALUE, NEW_VALUE, "    ", NEW_VALUE].join(",   "));
-            assert.deepEqual(onAdd.args[0][0], [NEW_VALUE, NEW_VALUE, NEW_VALUE]);
+            expect(onAdd.mock.calls[0][0]).toEqual([NEW_VALUE, NEW_VALUE, NEW_VALUE]);
         });
 
         it("splits input value on separator string", () => {
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mountTagInput(onAdd, { separator: "  |  " });
             pressEnterInInput(wrapper, "1 |  2  |   3   |    4    |  \t  |   ");
-            assert.deepEqual(onAdd.args[0][0], ["1 |  2", "3", "4"]);
+            expect(onAdd.mock.calls[0][0]).toEqual(["1 |  2", "3", "4"]);
         });
 
         it("separator=false emits one-element values array", () => {
             const value = "one, two, three";
-            const onAdd = sinon.stub();
+            const onAdd = vi.fn();
             const wrapper = mountTagInput(onAdd, { separator: false });
             pressEnterInInput(wrapper, value);
-            assert.deepEqual(onAdd.args[0][0], [value]);
+            expect(onAdd.mock.calls[0][0]).toEqual([value]);
         });
 
-        function mountTagInput(onAdd: sinon.SinonStub, props?: Partial<TagInputProps>) {
+        function mountTagInput(onAdd: ReturnType<typeof vi.fn>, props?: Partial<TagInputProps>) {
             return mount(<TagInput onAdd={onAdd} values={VALUES} {...props} />);
         }
     });
 
     describe("onRemove", () => {
         it("pressing backspace focuses last item", () => {
-            const onRemove = sinon.spy();
+            const onRemove = vi.fn();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
             wrapper.find("input").simulate("keydown", { key: "Backspace" });
 
             assert.equal(wrapper.state("activeIndex"), VALUES.length - 1);
-            assert.isTrue(onRemove.notCalled);
+            expect(onRemove).not.toHaveBeenCalled();
         });
 
         it("pressing backspace again removes last item", () => {
-            const onRemove = sinon.spy();
+            const onRemove = vi.fn();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
             wrapper.find("input").simulate("keydown", { key: "Backspace" }).simulate("keydown", { key: "Backspace" });
 
             assert.equal(wrapper.state("activeIndex"), VALUES.length - 2);
-            assert.isTrue(onRemove.calledOnce);
+            expect(onRemove).toHaveBeenCalledOnce();
             const lastIndex = VALUES.length - 1;
-            assert.sameMembers(onRemove.args[0], [VALUES[lastIndex], lastIndex]);
+            expect(onRemove.mock.calls[0]).toEqual([VALUES[lastIndex], lastIndex]);
         });
 
         it("pressing left arrow key navigates active item and backspace removes it", () => {
-            const onRemove = sinon.spy();
+            const onRemove = vi.fn();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
             // select and remove middle item
             wrapper
@@ -308,12 +307,12 @@ describe("<TagInput>", () => {
                 .simulate("keydown", { key: "Backspace" });
 
             assert.equal(wrapper.state("activeIndex"), 0);
-            assert.isTrue(onRemove.calledOnce);
-            assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
+            expect(onRemove).toHaveBeenCalledOnce();
+            expect(onRemove.mock.calls[0]).toEqual([VALUES[1], 1]);
         });
 
         it("pressing left arrow key navigates active item and delete removes it", () => {
-            const onRemove = sinon.spy();
+            const onRemove = vi.fn();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
             // select and remove middle item
             wrapper
@@ -325,18 +324,18 @@ describe("<TagInput>", () => {
             // in this case we're not moving into the previous item but
             // we rather "take the place" of the item we just removed
             assert.equal(wrapper.state("activeIndex"), 1);
-            assert.isTrue(onRemove.calledOnce);
-            assert.sameMembers(onRemove.args[0], [VALUES[1], 1]);
+            expect(onRemove).toHaveBeenCalledOnce();
+            expect(onRemove.mock.calls[0]).toEqual([VALUES[1], 1]);
         });
 
         it("pressing delete with no selection does nothing", () => {
-            const onRemove = sinon.spy();
+            const onRemove = vi.fn();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
 
             wrapper.find("input").simulate("keydown", { key: "Delete" });
 
             assert.equal(wrapper.state("activeIndex"), -1);
-            assert.isTrue(onRemove.notCalled);
+            expect(onRemove).not.toHaveBeenCalled();
         });
 
         it("pressing right arrow key in initial state does nothing", () => {
@@ -350,46 +349,46 @@ describe("<TagInput>", () => {
         const NEW_VALUE = "new item";
 
         it("is not invoked on enter when input is empty", () => {
-            const onChange = sinon.stub();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             pressEnterInInput(wrapper, "");
-            assert.isTrue(onChange.notCalled);
+            expect(onChange).not.toHaveBeenCalled();
         });
 
         it("is invoked on enter with non-empty input", () => {
-            const onChange = sinon.stub();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             pressEnterInInput(wrapper, NEW_VALUE);
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.args[0][0], [...VALUES, NEW_VALUE]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([...VALUES, NEW_VALUE]);
         });
 
         it("can add multiple tags at once with separator", () => {
-            const onChange = sinon.stub();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             pressEnterInInput(wrapper, [NEW_VALUE, NEW_VALUE, NEW_VALUE].join(", "));
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.args[0][0], [...VALUES, NEW_VALUE, NEW_VALUE, NEW_VALUE]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([...VALUES, NEW_VALUE, NEW_VALUE, NEW_VALUE]);
         });
 
         it("is invoked when a tag is removed by clicking", () => {
-            const onChange = sinon.stub();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             wrapper.find("button").at(1).simulate("click");
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.args[0][0], [VALUES[0], VALUES[2]]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([VALUES[0], VALUES[2]]);
         });
 
         it("is invoked when a tag is removed by backspace", () => {
-            const onChange = sinon.stub();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             wrapper.find("input").simulate("keydown", { key: "Backspace" }).simulate("keydown", { key: "Backspace" });
-            assert.isTrue(onChange.calledOnce);
-            assert.deepEqual(onChange.args[0][0], [VALUES[0], VALUES[1]]);
+            expect(onChange).toHaveBeenCalledOnce();
+            expect(onChange.mock.calls[0][0]).toEqual([VALUES[0], VALUES[1]]);
         });
 
         it("does not clear the input if onChange returns false", () => {
-            const onChange = sinon.stub().returns(false);
+            const onChange = vi.fn().mockReturnValue(false);
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
@@ -399,7 +398,7 @@ describe("<TagInput>", () => {
         });
 
         it("clears the input if onChange returns true", () => {
-            const onChange = sinon.stub().returns(true);
+            const onChange = vi.fn().mockReturnValue(true);
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
@@ -409,7 +408,7 @@ describe("<TagInput>", () => {
         });
 
         it("clears the input if onChange returns nothing", () => {
-            const onChange = sinon.spy();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} />);
             act(() => {
                 wrapper.setState({ inputValue: NEW_VALUE });
@@ -419,7 +418,7 @@ describe("<TagInput>", () => {
         });
 
         it("does not clear the input if the input is controlled", () => {
-            const onChange = sinon.stub();
+            const onChange = vi.fn();
             const wrapper = mount(<TagInput onChange={onChange} values={VALUES} inputValue={NEW_VALUE} />);
             pressEnterInInput(wrapper, NEW_VALUE);
             assert.strictEqual(wrapper.state().inputValue, NEW_VALUE);
@@ -475,10 +474,10 @@ describe("<TagInput>", () => {
 
     describe("when input is not empty", () => {
         it("pressing backspace does not remove item", () => {
-            const onRemove = sinon.spy();
+            const onRemove = vi.fn();
             const wrapper = mount(<TagInput onRemove={onRemove} values={VALUES} />);
             wrapper.find("input").simulate("keydown", createInputKeydownEventMetadata("text", "Backspace", false));
-            assert.isTrue(onRemove.notCalled);
+            expect(onRemove).not.toHaveBeenCalled();
         });
     });
 
@@ -493,7 +492,7 @@ describe("<TagInput>", () => {
             undefined,
         ];
 
-        const onChange = sinon.spy();
+        const onChange = vi.fn();
         const wrapper = mount(<TagInput onChange={onChange} values={MIXED_VALUES} />);
         assert.lengthOf(wrapper.find(Tag), 3, "should render only real values");
         const input = wrapper.find("input");
@@ -508,12 +507,8 @@ describe("<TagInput>", () => {
         keydownAndAssertIndex("ArrowLeft", 3);
         keydownAndAssertIndex("Backspace", 1);
 
-        assert.isTrue(onChange.calledOnce);
-        assert.lengthOf(
-            onChange.args[0][0],
-            MIXED_VALUES.length - 1,
-            "should remove one item and preserve other falsy values",
-        );
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange.mock.calls[0][0]).toHaveLength(MIXED_VALUES.length - 1);
     });
 
     it("is non-interactive when disabled", () => {
@@ -532,18 +527,18 @@ describe("<TagInput>", () => {
 
     describe("onInputChange", () => {
         it("is not invoked on enter when input is empty", () => {
-            const onInputChange = sinon.stub();
+            const onInputChange = vi.fn();
             const wrapper = mount(<TagInput onInputChange={onInputChange} values={VALUES} />);
             pressEnterInInput(wrapper, "");
-            assert.isTrue(onInputChange.notCalled);
+            expect(onInputChange).not.toHaveBeenCalled();
         });
 
         it("is invoked when input text changes", () => {
-            const changeSpy: any = sinon.spy();
+            const changeSpy = vi.fn();
             const wrapper = mount(<TagInput onInputChange={changeSpy} values={VALUES} />);
             wrapper.find("input").prop("onChange")?.({ currentTarget: { value: "hello" } } as any);
-            assert.isTrue(changeSpy.calledOnce, "onChange called");
-            assert.equal("hello", changeSpy.args[0][0].currentTarget.value);
+            expect(changeSpy).toHaveBeenCalledOnce();
+            expect(changeSpy.mock.calls[0][0].currentTarget.value).toBe("hello");
         });
     });
 
@@ -580,7 +575,7 @@ describe("<TagInput>", () => {
 
     describe("when autoResize={true}", () => {
         it("passes inputProps to input element", () => {
-            const onBlur = sinon.spy();
+            const onBlur = vi.fn();
             const input = mount(
                 <TagInput autoResize={true} values={VALUES} inputProps={{ autoFocus: true, onBlur }} />,
             ).find("input");
@@ -588,7 +583,7 @@ describe("<TagInput>", () => {
             // check that event handler is proxied
             const fakeEvent = { flag: "yes" };
             input.prop("onBlur")?.(fakeEvent as any);
-            assert.strictEqual(onBlur.args[0][0], fakeEvent);
+            expect(onBlur.mock.calls[0][0]).toBe(fakeEvent);
         });
 
         it("renders a Tag for each value", () => {
@@ -621,8 +616,8 @@ describe("<TagInput>", () => {
 });
 
 function runKeyPressTest(callbackName: "onKeyDown" | "onKeyUp", startIndex: number, expectedIndex: number | undefined) {
-    const callbackSpy = sinon.spy();
-    const inputProps = { [callbackName]: sinon.spy() };
+    const callbackSpy = vi.fn();
+    const inputProps = { [callbackName]: vi.fn() };
     const wrapper = mount(<TagInput values={VALUES} inputProps={inputProps} {...{ [callbackName]: callbackSpy }} />);
 
     act(() => {
@@ -632,9 +627,9 @@ function runKeyPressTest(callbackName: "onKeyDown" | "onKeyUp", startIndex: numb
     const eventName = callbackName === "onKeyDown" ? "keydown" : "keyup";
     wrapper.find("input").simulate("focus").simulate(eventName, { key: "Enter" });
 
-    assert.strictEqual(callbackSpy.callCount, 1, "container callback call count");
-    assert.strictEqual(callbackSpy.firstCall.args[0].key, "Enter", "first arg (event)");
-    assert.strictEqual(callbackSpy.firstCall.args[1], expectedIndex, "second arg (active index)");
+    expect(callbackSpy).toHaveBeenCalledOnce();
+    expect(callbackSpy.mock.calls[0][0].key).toBe("Enter");
+    expect(callbackSpy.mock.calls[0][1]).toBe(expectedIndex);
     // invokes inputProps.callbackSpy as well
-    assert.strictEqual(inputProps[callbackName].callCount, 1, "inputProps.onKeyDown call count");
+    expect(inputProps[callbackName]).toHaveBeenCalledOnce();
 }

--- a/packages/core/src/components/tag/compoundTag.test.tsx
+++ b/packages/core/src/components/tag/compoundTag.test.tsx
@@ -17,9 +17,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import { createRef } from "react";
-import { spy } from "sinon";
 
-import { assert, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
@@ -60,7 +59,7 @@ describe("<CompoundTag>", () => {
 
     it("renders close button when onRemove is a function", () => {
         const wrapper = mount(
-            <CompoundTag onRemove={spy()} leftContent="Hello">
+            <CompoundTag onRemove={vi.fn()} leftContent="Hello">
                 World
             </CompoundTag>,
         );
@@ -68,7 +67,7 @@ describe("<CompoundTag>", () => {
     });
 
     it("clicking close button triggers onRemove", () => {
-        const handleRemove = spy();
+        const handleRemove = vi.fn();
         mount(
             <CompoundTag onRemove={handleRemove} leftContent="Hello">
                 World
@@ -76,7 +75,7 @@ describe("<CompoundTag>", () => {
         )
             .find(`.${Classes.TAG_REMOVE}`)
             .simulate("click");
-        assert.isTrue(handleRemove.calledOnce);
+        expect(handleRemove).toHaveBeenCalledOnce();
     });
 
     it(`passes other props onto .${Classes.COMPOUND_TAG} element`, () => {
@@ -89,7 +88,7 @@ describe("<CompoundTag>", () => {
     });
 
     it("passes all props to the onRemove handler", () => {
-        const handleRemove = spy();
+        const handleRemove = vi.fn();
         const DATA_ATTR_FOO = "data-foo";
         const tagProps = {
             [DATA_ATTR_FOO]: {
@@ -105,9 +104,11 @@ describe("<CompoundTag>", () => {
         )
             .find(`.${Classes.TAG_REMOVE}`)
             .simulate("click");
-        assert.isTrue(handleRemove.args.length > 0 && handleRemove.args[0].length === 2);
-        assert.isTrue(handleRemove.args[0][1][DATA_ATTR_FOO] !== undefined);
-        assert.deepEqual(handleRemove.args[0][1][DATA_ATTR_FOO], tagProps[DATA_ATTR_FOO]);
+        expect(handleRemove).toHaveBeenCalledOnce();
+        expect(handleRemove).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ [DATA_ATTR_FOO]: tagProps[DATA_ATTR_FOO] }),
+        );
     });
 
     it("supports ref objects", async () => {

--- a/packages/core/src/components/tag/tag.test.tsx
+++ b/packages/core/src/components/tag/tag.test.tsx
@@ -17,9 +17,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import { createRef } from "react";
-import { spy } from "sinon";
 
-import { assert, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
@@ -62,26 +61,26 @@ describe("<Tag>", () => {
     });
 
     it("renders close button when onRemove is a function", () => {
-        const wrapper = mount(<Tag onRemove={spy()}>Hello</Tag>);
+        const wrapper = mount(<Tag onRemove={vi.fn()}>Hello</Tag>);
         assert.lengthOf(wrapper.find(`.${Classes.TAG_REMOVE}`), 1);
     });
 
     it("clicking close button triggers onRemove", () => {
-        const handleRemove = spy();
+        const handleRemove = vi.fn();
         mount(<Tag onRemove={handleRemove}>Hello</Tag>)
             .find(`.${Classes.TAG_REMOVE}`)
             .simulate("click");
-        assert.isTrue(handleRemove.calledOnce);
+        expect(handleRemove).toHaveBeenCalledOnce();
     });
 
     it("should be interactive when onClick is provided", () => {
-        const wrapper = mount(<Tag onClick={spy()}>Hello</Tag>);
+        const wrapper = mount(<Tag onClick={vi.fn()}>Hello</Tag>);
         assert.lengthOf(wrapper.find(`.${Classes.INTERACTIVE}`), 1);
     });
 
     it("should not be interactive when interactive={false}", () => {
         const wrapper = mount(
-            <Tag onClick={spy()} interactive={false}>
+            <Tag onClick={vi.fn()} interactive={false}>
                 Hello
             </Tag>,
         );
@@ -94,7 +93,7 @@ describe("<Tag>", () => {
     });
 
     it("passes all props to the onRemove handler", () => {
-        const handleRemove = spy();
+        const handleRemove = vi.fn();
         const DATA_ATTR_FOO = "data-foo";
         const tagProps = {
             [DATA_ATTR_FOO]: {
@@ -106,9 +105,11 @@ describe("<Tag>", () => {
         mount(<Tag {...tagProps}>Hello</Tag>)
             .find(`.${Classes.TAG_REMOVE}`)
             .simulate("click");
-        assert.isTrue(handleRemove.args.length > 0 && handleRemove.args[0].length === 2);
-        assert.isTrue(handleRemove.args[0][1][DATA_ATTR_FOO] !== undefined);
-        assert.deepEqual(handleRemove.args[0][1][DATA_ATTR_FOO], tagProps[DATA_ATTR_FOO]);
+        expect(handleRemove).toHaveBeenCalledOnce();
+        expect(handleRemove).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ [DATA_ATTR_FOO]: tagProps[DATA_ATTR_FOO] }),
+        );
     });
 
     it("supports ref objects", async () => {

--- a/packages/core/src/components/toast/overlayToaster.test.tsx
+++ b/packages/core/src/components/toast/overlayToaster.test.tsx
@@ -16,10 +16,9 @@
 
 import { waitFor } from "@testing-library/dom";
 import { createRoot, type Root } from "react-dom/client";
-import sinon, { spy } from "sinon";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
-import { afterAll, afterEach, assert, beforeAll, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { TOASTER_MAX_TOASTS_INVALID } from "../../common/errors";
@@ -168,7 +167,7 @@ describe("OverlayToaster", () => {
         });
 
         it("action onClick callback invoked when action clicked", async () => {
-            const onClick = spy();
+            const onClick = vi.fn();
             toaster.show({
                 action: { onClick, text: "action" },
                 message: "message",
@@ -180,11 +179,11 @@ describe("OverlayToaster", () => {
             // action is first descendant button
             const action = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
             action?.click();
-            assert.isTrue(onClick.calledOnce, "expected onClick to be called once");
+            expect(onClick).toHaveBeenCalledOnce();
         });
 
         it("onDismiss callback invoked when close button clicked", async () => {
-            const handleDismiss = spy();
+            const handleDismiss = vi.fn();
             toaster.show({
                 message: "dismiss",
                 onDismiss: handleDismiss,
@@ -196,28 +195,28 @@ describe("OverlayToaster", () => {
             // without action, dismiss is first descendant button
             const dismiss = document.querySelector<HTMLElement>(`.${Classes.TOAST} .${Classes.BUTTON}`);
             dismiss?.click();
-            await waitFor(() => assert.isTrue(handleDismiss.calledOnce));
+            await waitFor(() => expect(handleDismiss).toHaveBeenCalledOnce());
         });
 
         it("onDismiss callback invoked on toaster.dismiss()", async () => {
-            const onDismiss = spy();
+            const onDismiss = vi.fn();
             const key = toaster.show({ message: "dismiss me", onDismiss });
             toaster.dismiss(key);
-            await waitFor(() => assert.isTrue(onDismiss.calledOnce, "onDismiss not called"));
+            await waitFor(() => expect(onDismiss).toHaveBeenCalledOnce());
         });
 
         it("onDismiss callback invoked on toaster.clear()", async () => {
-            const onDismiss = spy();
+            const onDismiss = vi.fn();
             toaster.show({ message: "dismiss me", onDismiss });
             await waitFor(() => {
                 /* noop */
             });
             toaster.clear();
-            await waitFor(() => assert.isTrue(onDismiss.calledOnce, "onDismiss not called"));
+            await waitFor(() => expect(onDismiss).toHaveBeenCalledOnce());
         });
 
         it("reusing props object does not produce React errors", () => {
-            const errorSpy = spy(console, "error");
+            const errorSpy = vi.spyOn(console, "error").mockImplementation(vi.fn());
             try {
                 // if Toaster doesn't clone the props object beforeAll injecting key then there will be a
                 // React error that both toasts have the same key, because both instances refer to the
@@ -225,12 +224,12 @@ describe("OverlayToaster", () => {
                 const toast = { message: "repeat" };
                 toaster.show(toast);
                 toaster.show(toast);
-                assert.isFalse(errorSpy.calledWithMatch("two children with the same key"), "mutation side effect!");
+                expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("two children with the same key"));
             } finally {
                 // Restore console.error. Otherwise other tests will fail
                 // with "TypeError: Attempted to wrap error which is already
                 // wrapped" when attempting to spy on console.error again.
-                sinon.restore();
+                vi.restoreAllMocks();
             }
         });
     });

--- a/packages/core/src/components/toast/toast.test.tsx
+++ b/packages/core/src/components/toast/toast.test.tsx
@@ -15,9 +15,8 @@
  */
 
 import { mount, shallow } from "enzyme";
-import { type SinonSpy, spy } from "sinon";
 
-import { assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { sleep } from "../../common/test-utils";
 import { AnchorButton, Button } from "../button/buttons";
@@ -32,10 +31,10 @@ describe("<Toast>", () => {
     });
 
     it("clicking dismiss button triggers onDismiss callback with `false`", () => {
-        const handleDismiss = spy();
+        const handleDismiss = vi.fn();
         wrap(<Toast message="Hello" onDismiss={handleDismiss} />).dismiss.simulate("click");
-        assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
-        assert.isTrue(handleDismiss.calledWith(false), "onDismiss not called with false");
+        expect(handleDismiss).toHaveBeenCalledOnce();
+        expect(handleDismiss).toHaveBeenCalledWith(false);
     });
 
     it("renders action button when action string prop provided", () => {
@@ -46,16 +45,16 @@ describe("<Toast>", () => {
     });
 
     it("clicking action button triggers onClick callback", () => {
-        const onClick = spy();
+        const onClick = vi.fn();
         wrap(<Toast action={{ onClick, text: "Undo" }} message="Hello" />).action.simulate("click");
-        assert.isTrue(onClick.calledOnce, "action onClick not called once");
+        expect(onClick).toHaveBeenCalledOnce();
     });
 
     it("clicking action button also triggers onDismiss callback with `false`", () => {
-        const handleDismiss = spy();
+        const handleDismiss = vi.fn();
         wrap(<Toast action={{ text: "Undo" }} message="Hello" onDismiss={handleDismiss} />).action.simulate("click");
-        assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
-        assert.isTrue(handleDismiss.calledWith(false), "onDismiss not called with false");
+        expect(handleDismiss).toHaveBeenCalledOnce();
+        expect(handleDismiss).toHaveBeenCalledWith(false);
     });
 
     function wrap(toast: React.JSX.Element) {
@@ -68,16 +67,16 @@ describe("<Toast>", () => {
     }
 
     describe("timeout", () => {
-        let handleDismiss: SinonSpy;
-        beforeEach(() => (handleDismiss = spy()));
+        let handleDismiss: ReturnType<typeof vi.fn>;
+        beforeEach(() => (handleDismiss = vi.fn()));
 
         it("calls onDismiss automatically after timeout expires with `true`", async () => {
             // mounting for lifecycle methods to start timeout
             mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />);
             await sleep(20);
 
-            assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
-            assert.isTrue(handleDismiss.firstCall.args[0], "onDismiss not called with `true`");
+            expect(handleDismiss).toHaveBeenCalledOnce();
+            expect(handleDismiss.mock.calls[0][0]).toBe(true);
         });
 
         it("updating with timeout={0} cancels timeout", async () => {
@@ -85,7 +84,7 @@ describe("<Toast>", () => {
                 timeout: 0,
             });
             await sleep(20);
-            assert.isTrue(handleDismiss.notCalled, "onDismiss was called");
+            expect(handleDismiss).not.toHaveBeenCalled();
         });
 
         it("updating timeout={0} with timeout={X} starts timeout", async () => {
@@ -94,8 +93,8 @@ describe("<Toast>", () => {
             });
             await sleep(20);
 
-            assert.isTrue(handleDismiss.calledOnce, "onDismiss not called once");
-            assert.isTrue(handleDismiss.firstCall.args[0], "onDismiss not called with `true`");
+            expect(handleDismiss).toHaveBeenCalledOnce();
+            expect(handleDismiss.mock.calls[0][0]).toBe(true);
         });
     });
 });

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -16,9 +16,8 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { spy, stub } from "sinon";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Button } from "..";
 import { Classes } from "../../common";
@@ -78,14 +77,14 @@ describe("<Tooltip>", () => {
 
     describe("basic functionality", () => {
         it("supports overlay lifecycle props", () => {
-            const onOpening = spy();
+            const onOpening = vi.fn();
             render(
                 <Tooltip content="content" hoverOpenDelay={0} isOpen={true} onOpening={onOpening}>
                     <Button text="target" />
                 </Tooltip>,
             );
 
-            expect(onOpening.calledOnce).to.be.true;
+            expect(onOpening).toHaveBeenCalledOnce();
         });
     });
 
@@ -149,7 +148,7 @@ describe("<Tooltip>", () => {
         });
 
         it("empty content disables Popover and warns with empty string", () => {
-            const warnSpy = stub(console, "warn");
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
             render(
                 <Tooltip content="" hoverOpenDelay={0} isOpen={true}>
                     <Button text="target" />
@@ -157,13 +156,13 @@ describe("<Tooltip>", () => {
             );
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
-            expect(warnSpy.called).to.be.true;
+            expect(warnSpy).toHaveBeenCalled();
 
-            warnSpy.restore();
+            warnSpy.mockRestore();
         });
 
         it("empty content disables Popover and warns with whitespace", () => {
-            const warnSpy = stub(console, "warn");
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
             render(
                 <Tooltip content="   " hoverOpenDelay={0} isOpen={true}>
                     <Button text="target" />
@@ -171,9 +170,9 @@ describe("<Tooltip>", () => {
             );
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
-            expect(warnSpy.called).to.be.true;
+            expect(warnSpy).toHaveBeenCalled();
 
-            warnSpy.restore();
+            warnSpy.mockRestore();
         });
 
         it("setting disabled=true prevents opening tooltip", async () => {
@@ -212,7 +211,7 @@ describe("<Tooltip>", () => {
         });
 
         it("empty content disables Popover and warns", () => {
-            const warnSpy = stub(console, "warn");
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
             render(
                 <Tooltip content="" hoverOpenDelay={0} isOpen={true}>
                     <Button text="target" />
@@ -220,15 +219,15 @@ describe("<Tooltip>", () => {
             );
 
             expect(screen.queryByText("content")).not.toBeInTheDocument();
-            expect(warnSpy.called).to.be.true;
+            expect(warnSpy).toHaveBeenCalled();
 
-            warnSpy.restore();
+            warnSpy.mockRestore();
         });
 
         describe("onInteraction()", () => {
             it("is invoked with `true` when closed tooltip target is hovered", async () => {
                 const user = userEvent.setup();
-                const onInteraction = spy();
+                const onInteraction = vi.fn();
                 render(
                     <Tooltip content="content" hoverOpenDelay={0} isOpen={false} onInteraction={onInteraction}>
                         <Button text="target" />
@@ -237,15 +236,15 @@ describe("<Tooltip>", () => {
 
                 await user.hover(screen.getByText("target"));
 
-                expect(onInteraction.calledOnce).to.be.true;
-                expect(onInteraction.calledWith(true)).to.be.true;
+                expect(onInteraction).toHaveBeenCalledOnce();
+                expect(onInteraction).toHaveBeenCalledWith(true, expect.anything());
             });
         });
     });
 
     it("Escape key closes tooltip", async () => {
         const user = userEvent.setup();
-        const onClose = spy();
+        const onClose = vi.fn();
         render(
             <Tooltip content="content" hoverOpenDelay={0} isOpen={true} onClose={onClose}>
                 <Button text="target" />
@@ -256,7 +255,7 @@ describe("<Tooltip>", () => {
 
         await user.keyboard("{Escape}");
 
-        expect(onClose.calledOnce).to.be.true;
+        expect(onClose).toHaveBeenCalledOnce();
     });
 
     it("Escape key closes only the most recently opened tooltip when multiple are open", async () => {

--- a/packages/core/src/components/tree/tree.test.tsx
+++ b/packages/core/src/components/tree/tree.test.tsx
@@ -16,9 +16,8 @@
 
 import { waitFor } from "@testing-library/dom";
 import { mount, type ReactWrapper } from "enzyme";
-import { spy } from "sinon";
 
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -103,13 +102,13 @@ describe("<Tree>", () => {
     });
 
     it("event callbacks are fired correctly", () => {
-        const onNodeClick = spy();
-        const onNodeCollapse = spy();
-        const onNodeContextMenu = spy();
-        const onNodeDoubleClick = spy();
-        const onNodeExpand = spy();
-        const onNodeMouseEnter = spy();
-        const onNodeMouseLeave = spy();
+        const onNodeClick = vi.fn();
+        const onNodeCollapse = vi.fn();
+        const onNodeContextMenu = vi.fn();
+        const onNodeDoubleClick = vi.fn();
+        const onNodeExpand = vi.fn();
+        const onNodeMouseEnter = vi.fn();
+        const onNodeMouseLeave = vi.fn();
 
         const contents = createDefaultContents();
         contents[3].isExpanded = true;
@@ -126,44 +125,44 @@ describe("<Tree>", () => {
         });
 
         tree.find(`.c0 > .${Classes.TREE_NODE_CONTENT}`).simulate("click");
-        assert.isTrue(onNodeClick.calledOnce);
-        assert.deepEqual(onNodeClick.args[0][1], [0]);
+        expect(onNodeClick).toHaveBeenCalledOnce();
+        expect(onNodeClick.mock.calls[0][1]).toEqual([0]);
 
         findNodeClass(tree, "c1", Classes.TREE_NODE_CARET).simulate("click");
-        assert.isTrue(onNodeExpand.calledOnce);
-        assert.deepEqual(onNodeExpand.args[0][1], [1]);
+        expect(onNodeExpand).toHaveBeenCalledOnce();
+        expect(onNodeExpand.mock.calls[0][1]).toEqual([1]);
         // make sure that onNodeClick isn't fired again, only onNodeExpand should be
-        assert.isTrue(onNodeClick.calledOnce);
+        expect(onNodeClick).toHaveBeenCalledOnce();
 
         tree.find(`.c6 > .${Classes.TREE_NODE_CONTENT}`).simulate("dblclick");
-        assert.isTrue(onNodeDoubleClick.calledOnce);
-        assert.deepEqual(onNodeDoubleClick.args[0][1], [3, 0]);
+        expect(onNodeDoubleClick).toHaveBeenCalledOnce();
+        expect(onNodeDoubleClick.mock.calls[0][1]).toEqual([3, 0]);
 
         findNodeClass(tree, "c3", Classes.TREE_NODE_CARET).simulate("click");
-        assert.isTrue(onNodeCollapse.calledOnce);
-        assert.deepEqual(onNodeCollapse.args[0][1], [3]);
+        expect(onNodeCollapse).toHaveBeenCalledOnce();
+        expect(onNodeCollapse.mock.calls[0][1]).toEqual([3]);
 
         tree.find(`.c0 > .${Classes.TREE_NODE_CONTENT}`).simulate("contextmenu");
-        assert.isTrue(onNodeContextMenu.calledOnce);
-        assert.deepEqual(onNodeContextMenu.args[0][1], [0]);
+        expect(onNodeContextMenu).toHaveBeenCalledOnce();
+        expect(onNodeContextMenu.mock.calls[0][1]).toEqual([0]);
 
         tree.find(`.c2 > .${Classes.TREE_NODE_CONTENT}`).simulate("mouseenter");
-        assert.isTrue(onNodeMouseEnter.calledOnce);
-        assert.deepEqual(onNodeMouseEnter.args[0][1], [2]);
+        expect(onNodeMouseEnter).toHaveBeenCalledOnce();
+        expect(onNodeMouseEnter.mock.calls[0][1]).toEqual([2]);
 
         tree.find(`.c2 > .${Classes.TREE_NODE_CONTENT}`).simulate("mouseleave");
-        assert.isTrue(onNodeMouseLeave.calledOnce);
-        assert.deepEqual(onNodeMouseLeave.args[0][1], [2]);
+        expect(onNodeMouseLeave).toHaveBeenCalledOnce();
+        expect(onNodeMouseLeave.mock.calls[0][1]).toEqual([2]);
     });
 
     it("if disabled, event callbacks are not fired", () => {
-        const onNodeClick = spy();
-        const onNodeCollapse = spy();
-        const onNodeContextMenu = spy();
-        const onNodeDoubleClick = spy();
-        const onNodeExpand = spy();
-        const onNodeMouseEnter = spy();
-        const onNodeMouseLeave = spy();
+        const onNodeClick = vi.fn();
+        const onNodeCollapse = vi.fn();
+        const onNodeContextMenu = vi.fn();
+        const onNodeDoubleClick = vi.fn();
+        const onNodeExpand = vi.fn();
+        const onNodeMouseEnter = vi.fn();
+        const onNodeMouseLeave = vi.fn();
 
         const contents = createDefaultContents();
         contents[0].disabled = true;
@@ -186,25 +185,25 @@ describe("<Tree>", () => {
         const treeNodeCaret = treeNodeContent.find(`.${Classes.TREE_NODE_CARET}`).first();
 
         treeNodeContent.simulate("click");
-        assert.isTrue(onNodeClick.notCalled);
+        expect(onNodeClick).not.toHaveBeenCalled();
 
         treeNodeContent.simulate("dblclick");
-        assert.isTrue(onNodeDoubleClick.notCalled);
+        expect(onNodeDoubleClick).not.toHaveBeenCalled();
 
         treeNodeContent.simulate("contextmenu");
-        assert.isTrue(onNodeContextMenu.notCalled);
+        expect(onNodeContextMenu).not.toHaveBeenCalled();
 
         treeNodeContent.simulate("mouseenter");
-        assert.isTrue(onNodeMouseEnter.notCalled);
+        expect(onNodeMouseEnter).not.toHaveBeenCalled();
 
         treeNodeContent.simulate("mouseleave");
-        assert.isTrue(onNodeMouseLeave.notCalled);
+        expect(onNodeMouseLeave).not.toHaveBeenCalled();
 
         treeNodeCaret.simulate("click");
-        assert.isTrue(onNodeExpand.notCalled);
+        expect(onNodeExpand).not.toHaveBeenCalled();
 
         treeNodeCaret.simulate("click");
-        assert.isTrue(onNodeCollapse.notCalled);
+        expect(onNodeCollapse).not.toHaveBeenCalled();
     });
 
     it("disabled nodes are rendered correctly", () => {

--- a/packages/core/src/hooks/useHotkeys.test.tsx
+++ b/packages/core/src/hooks/useHotkeys.test.tsx
@@ -17,9 +17,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMemo } from "react";
-import { type SinonStub, spy, stub } from "sinon";
 
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { InputGroup } from "../components/forms/inputGroup";
 import { HotkeysProvider } from "../context";
@@ -80,8 +79,8 @@ const TestComponent: React.FC<TestComponentProps> = ({ bindExtraKeys, isInputRea
 };
 
 describe("useHotkeys", () => {
-    const onKeyASpy = spy();
-    const onKeyBSpy = spy();
+    const onKeyASpy = vi.fn();
+    const onKeyBSpy = vi.fn();
 
     const TestComponentContainer = (props: TestComponentContainerProps) => {
         return (
@@ -93,8 +92,8 @@ describe("useHotkeys", () => {
     };
 
     afterEach(() => {
-        onKeyASpy.resetHistory();
-        onKeyBSpy.resetHistory();
+        onKeyASpy.mockClear();
+        onKeyBSpy.mockClear();
     });
 
     it("binds local hotkey", async () => {
@@ -103,7 +102,7 @@ describe("useHotkeys", () => {
         const target = screen.getByTestId("target-inside-component");
         target.focus();
         await user.keyboard("a");
-        expect(onKeyASpy.callCount).to.equal(1, "hotkey a should be called once");
+        expect(onKeyASpy).toHaveBeenCalledOnce();
     });
 
     it("binds global hotkey", async () => {
@@ -112,7 +111,7 @@ describe("useHotkeys", () => {
         const target = screen.getByTestId("target-outside-component");
         target.focus();
         await user.keyboard("b");
-        expect(onKeyBSpy.callCount).to.equal(1, "hotkey b should be called once");
+        expect(onKeyBSpy).toHaveBeenCalledOnce();
     });
 
     it("binds new local hotkeys when hook arg is updated", async () => {
@@ -123,7 +122,7 @@ describe("useHotkeys", () => {
         target.focus();
         // bindExtraKeys adds "shift+A" combo, so we need Shift held during keypress
         await user.keyboard("{Shift>}a{/Shift}");
-        expect(onKeyASpy.callCount).to.equal(1, "hotkey A should be called once");
+        expect(onKeyASpy).toHaveBeenCalledOnce();
     });
 
     it("binds new global hotkeys when hook arg is updated", async () => {
@@ -134,7 +133,7 @@ describe("useHotkeys", () => {
         target.focus();
         // bindExtraKeys adds "shift+B" combo, so we need Shift held during keypress
         await user.keyboard("{Shift>}b{/Shift}");
-        expect(onKeyBSpy.callCount).to.equal(1, "hotkey B should be called once");
+        expect(onKeyBSpy).toHaveBeenCalledOnce();
     });
 
     it("removes local hotkeys when hook arg is updated", async () => {
@@ -145,7 +144,7 @@ describe("useHotkeys", () => {
         target.focus();
         // "shift+A" combo should no longer be bound after removing extra keys
         await user.keyboard("{Shift>}a{/Shift}");
-        expect(onKeyASpy.callCount).to.equal(0, "hotkey A should not be called");
+        expect(onKeyASpy).not.toHaveBeenCalled();
     });
 
     it("removes global hotkeys when hook arg is updated", async () => {
@@ -156,7 +155,7 @@ describe("useHotkeys", () => {
         target.focus();
         // "shift+B" combo should no longer be bound after removing extra keys
         await user.keyboard("{Shift>}b{/Shift}");
-        expect(onKeyBSpy.callCount).to.equal(0, "hotkey B should not be called");
+        expect(onKeyBSpy).not.toHaveBeenCalled();
     });
 
     it("does not trigger hotkeys inside text inputs", async () => {
@@ -165,7 +164,7 @@ describe("useHotkeys", () => {
         const target = screen.getByTestId("input-target");
         target.focus();
         await user.keyboard("a");
-        expect(onKeyASpy.callCount).to.equal(0, "hotkey A should not be called");
+        expect(onKeyASpy).not.toHaveBeenCalled();
     });
 
     it("does trigger hotkeys inside readonly text inputs", async () => {
@@ -174,19 +173,17 @@ describe("useHotkeys", () => {
         const target = screen.getByTestId("input-target");
         target.focus();
         await user.keyboard("a");
-        expect(onKeyASpy.callCount).to.equal(1, "hotkey A should be called once");
+        expect(onKeyASpy).toHaveBeenCalledOnce();
     });
 
     describe("working with HotkeysProvider", () => {
-        let warnSpy: SinonStub | undefined;
-
-        beforeAll(() => (warnSpy = stub(console, "warn")));
-        afterEach(() => warnSpy?.resetHistory());
-        afterAll(() => warnSpy?.restore());
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+        beforeEach(() => warnSpy.mockClear());
+        afterAll(() => warnSpy.mockRestore());
 
         it("logs a warning when used outside of HotkeysProvider context", () => {
             render(<TestComponentContainer />);
-            expect(warnSpy?.calledOnce).to.be.true;
+            expect(warnSpy).toHaveBeenCalledOnce();
         });
 
         it("does NOT log a warning when used inside a HotkeysProvider context", () => {
@@ -195,7 +192,7 @@ describe("useHotkeys", () => {
                     <TestComponentContainer />
                 </HotkeysProvider>,
             );
-            expect(warnSpy?.notCalled).to.be.true;
+            expect(warnSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/core/src/hooks/useOverlayStack.test.tsx
+++ b/packages/core/src/hooks/useOverlayStack.test.tsx
@@ -16,9 +16,8 @@
 
 import { render } from "@testing-library/react";
 import { createRef, useEffect, useId, useMemo } from "react";
-import { spy } from "sinon";
 
-import { afterEach, beforeAll, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import type { OverlayProps } from "../components/overlay/overlayProps";
 import type { OverlayInstance } from "../components/overlay2/overlayInstance";
@@ -103,7 +102,7 @@ const TestComponentWithProvider: React.FC<TestComponentProps> = props => {
 };
 
 describe("useOverlayStack()", () => {
-    const handleLastOpenedChange = spy();
+    const handleLastOpenedChange = vi.fn();
     const containerRef = createRef<HTMLDivElement>();
     const TEST_PROPS_CLOSED: TestComponentProps = {
         autoFocus: true,
@@ -120,7 +119,7 @@ describe("useOverlayStack()", () => {
     };
 
     afterEach(() => {
-        handleLastOpenedChange.resetHistory();
+        handleLastOpenedChange.mockClear();
     });
 
     describe("with <OverlaysProvider>", () => {
@@ -134,11 +133,8 @@ describe("useOverlayStack()", () => {
             // so it wont' trigger a change in getLastOpened() until the second re-render.
             rerender(<TestComponentWithProvider {...TEST_PROPS_OPEN} />);
             rerender(<TestComponentWithProvider {...TEST_PROPS_OPEN} />);
-            expect(
-                handleLastOpenedChange.calledOnce,
-                `expected getLastOpened() result to change after re-rendering with isOpen={true}`,
-            ).to.be.true;
-            const lastOpenedInstance = handleLastOpenedChange.getCall(0).args[0] as OverlayInstance;
+            expect(handleLastOpenedChange).toHaveBeenCalledOnce();
+            const lastOpenedInstance = handleLastOpenedChange.mock.calls[0][0] as OverlayInstance;
             expect(lastOpenedInstance).to.exist;
             expect(containerRef.current).to.exist;
             expect(lastOpenedInstance.containerElement.current).to.equal(containerRef.current);
@@ -161,11 +157,8 @@ describe("useOverlayStack()", () => {
             // so it wont' trigger a change in getLastOpened() until the second re-render.
             rerender(<TestComponentWithoutProvider {...TEST_PROPS_OPEN} />);
             rerender(<TestComponentWithoutProvider {...TEST_PROPS_OPEN} />);
-            expect(
-                handleLastOpenedChange.callCount > 0,
-                `expected getLastOpened() result to change after re-rendering with isOpen={true}`,
-            ).to.be.true;
-            const lastOpenedInstance = handleLastOpenedChange.getCall(0).args[0] as OverlayInstance;
+            expect(handleLastOpenedChange).toHaveBeenCalled();
+            const lastOpenedInstance = handleLastOpenedChange.mock.calls[0][0] as OverlayInstance;
             expect(lastOpenedInstance).to.exist;
             expect(containerRef.current).to.exist;
             expect(

--- a/packages/core/src/hooks/useValidateProps.test.tsx
+++ b/packages/core/src/hooks/useValidateProps.test.tsx
@@ -3,17 +3,16 @@
  */
 
 import { render } from "@testing-library/react";
-import * as sinon from "sinon";
 
-import { beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { useValidateProps } from "./useValidateProps";
 
 describe("useValidateProps", () => {
-    const validatorSpy = sinon.spy();
+    const validatorSpy = vi.fn();
 
     beforeEach(() => {
-        validatorSpy.resetHistory();
+        validatorSpy.mockClear();
     });
 
     const TestComponent: React.FC<{ value?: number }> = ({ value }) => {
@@ -23,7 +22,7 @@ describe("useValidateProps", () => {
 
     it("calls validator in development environment", () => {
         render(<TestComponent />);
-        expect(validatorSpy.called).to.be.true;
+        expect(validatorSpy).toHaveBeenCalled();
     });
 
     it.skip("does not call validator in production environment", () => {
@@ -32,16 +31,16 @@ describe("useValidateProps", () => {
 
     it("calls validator when dependencies change", () => {
         const { rerender } = render(<TestComponent value={1} />);
-        expect(validatorSpy.callCount).to.equal(1);
+        expect(validatorSpy).toHaveBeenCalledOnce();
 
         rerender(<TestComponent value={2} />);
-        expect(validatorSpy.callCount).to.equal(2);
+        expect(validatorSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does not call validator when dependencies haven't changed", () => {
         const { rerender } = render(<TestComponent value={1} />);
 
         rerender(<TestComponent value={1} />);
-        expect(validatorSpy.callCount).to.equal(1);
+        expect(validatorSpy).toHaveBeenCalledOnce();
     });
 });

--- a/packages/test-commons/src/vitest.ts
+++ b/packages/test-commons/src/vitest.ts
@@ -21,4 +21,16 @@
  * import { test, describe, expect, vi } from "@blueprintjs/test-commons/vitest";
  */
 
-export { test, it, beforeAll, afterAll, describe, beforeEach, afterEach, expect, assert, vi } from "vitest";
+export {
+    afterAll,
+    afterEach,
+    assert,
+    beforeAll,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    test,
+    type MockInstance,
+    vi,
+} from "vitest";

--- a/packages/test-commons/vitest.d.ts
+++ b/packages/test-commons/vitest.d.ts
@@ -6,3 +6,4 @@
 /// <reference types="@testing-library/jest-dom/vitest" />
 
 export { test, it, beforeAll, afterAll, describe, beforeEach, afterEach, expect, assert, vi } from "vitest";
+export type { MockInstance } from "vitest";


### PR DESCRIPTION
## Summary
Replaces all [sinon](https://sinonjs.org/#get-started) spy/stub/mock usage with Vitest's `vi` [mocking API](https://vitest.dev/api/mock) across test files in core. Since we have moved core to Vitest, sinon is redundant: `vi.fn()` and `vi.spyOn()` do the same thing and work better with Vitest's assertion matchers.

## What changed
- `spy()` / `sinon.spy()` replaced with `vi.fn()`
- `stub()` / `sinon.stub()` replaced with `vi.spyOn(...).mockImplementation()`
- `SinonSpy` / `SinonStub` types replaced with `MockInstance`
- `spy.resetHistory()` -> `spy.mockClear()`, `spy.restore()` -> `spy.mockRestore()`
- Sinon assertion patterns replaced with Vitest matchers:
  - `spy.calledOnce` -> `expect(spy).toHaveBeenCalledOnce()`
  - `spy.calledWith(a, b)` -> `expect(spy).toHaveBeenCalledWith(a, b)`
  - `spy.callCount` -> `expect(spy).toHaveBeenCalledTimes(n)`
  - `spy.args[n]` / `spy.getCall(n).args` -> `spy.mock.calls[n]`

One gotcha worth noting: Sinon's `calledWith` does partial argument matching, but Vitest's `toHaveBeenCalledWith` requires an exact match on all arguments. For callbacks that receive a React SyntheticEvent (which has circular refs), a failed assertion causes Vitest to try serializing the event for its diff output, which OOMs the process. Fixed by adding `expect.anything()` for those event args.

### `assert` -> `expect`
Mock-related assertions that used Chai assert (like `assert.isTrue(spy.calledOnce)`) have been converted to expect matchers. There are still assert calls on non-mock assertions throughout core tests. I want to eventually migrate these to expect too for consistency, but that's a separate FLUP. (https://github.com/palantir/blueprint/pull/7768)