### PR TITLE
Update `HotkeysProvider` and `BlueprintProvider` documentation

### DIFF
--- a/packages/core/src/context/blueprint-provider.md
+++ b/packages/core/src/context/blueprint-provider.md
@@ -1,32 +1,35 @@
 @# BlueprintProvider
 
 **BlueprintProvider** is a compound [React context](https://react.dev/learn/passing-data-deeply-with-context)
-provider which enables & manages various global behaviors of Blueprint applications. It must be rendered
-at the root of your application and may only be used once as a singleton provider.
+provider which enables & manages various global behaviors of Blueprint applications. It should be rendered
+near the top of your application tree and may only be used once as a singleton provider.
 
 Concretely, this provider renders the following provider components _in the correct nesting order_
 and allows customization of their options via props:
 
--   [**OverlaysProvider**](#core/context/overlays-provider)
--   [**HotkeysProvider**](#core/context/hotkeys-provider)
--   [**PortalProvider**](#core/context/portal-provider)
+- [**OverlaysProvider**](#core/context/overlays-provider)
+- [**HotkeysProvider**](#core/context/hotkeys-provider)
+- [**PortalProvider**](#core/context/portal-provider)
 
 ## Usage
 
-To use **BlueprintProvider**, wrap your application with it at the root level:
+To use **BlueprintProvider**, wrap the parts of your application that need Blueprint features.
+If your app uses a router or other providers (e.g. `RouterProvider`, `ApolloProvider`), nest
+**BlueprintProvider** underneath them:
 
 ```tsx
 import { BlueprintProvider } from "@blueprintjs/core";
-import * as React from "react";
-import * as ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
-
-root.render(
-    <BlueprintProvider>
-        <div>My app has overlays, hotkeys, and portal customization 😎</div>
-    </BlueprintProvider>,
-);
+function App() {
+    return (
+        <RouterProvider router={router}>
+            <BlueprintProvider>
+                <div>My app has overlays, hotkeys, and portal customization 😎</div>
+            </BlueprintProvider>
+        </RouterProvider>
+    );
+}
 ```
 
 ## Props interface

--- a/packages/core/src/context/blueprint-provider.md
+++ b/packages/core/src/context/blueprint-provider.md
@@ -29,6 +29,28 @@ root.render(
 );
 ```
 
+## Usage with other providers
+
+If your app uses a router or other providers (e.g. `RouterProvider`, `ApolloProvider`), nest
+**BlueprintProvider** underneath them:
+
+```tsx
+import { BlueprintProvider } from "@blueprintjs/core";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+const router = createBrowserRouter([...]);
+
+function App() {
+    return (
+        <RouterProvider router={router}>
+            <BlueprintProvider>
+                <div>My app has overlays, hotkeys, and portal customization 😎</div>
+            </BlueprintProvider>
+        </RouterProvider>
+    );
+}
+```
+
 ## Props interface
 
 @interface BlueprintProviderProps

--- a/packages/core/src/context/blueprint-provider.md
+++ b/packages/core/src/context/blueprint-provider.md
@@ -1,35 +1,32 @@
 @# BlueprintProvider
 
 **BlueprintProvider** is a compound [React context](https://react.dev/learn/passing-data-deeply-with-context)
-provider which enables & manages various global behaviors of Blueprint applications. It should be rendered
-near the top of your application tree and may only be used once as a singleton provider.
+provider which enables & manages various global behaviors of Blueprint applications. It must be rendered
+at the root of your application and may only be used once as a singleton provider.
 
 Concretely, this provider renders the following provider components _in the correct nesting order_
 and allows customization of their options via props:
 
-- [**OverlaysProvider**](#core/context/overlays-provider)
-- [**HotkeysProvider**](#core/context/hotkeys-provider)
-- [**PortalProvider**](#core/context/portal-provider)
+-   [**OverlaysProvider**](#core/context/overlays-provider)
+-   [**HotkeysProvider**](#core/context/hotkeys-provider)
+-   [**PortalProvider**](#core/context/portal-provider)
 
 ## Usage
 
-To use **BlueprintProvider**, wrap the parts of your application that need Blueprint features.
-If your app uses a router or other providers (e.g. `RouterProvider`, `ApolloProvider`), nest
-**BlueprintProvider** underneath them:
+To use **BlueprintProvider**, wrap your application with it at the root level:
 
 ```tsx
 import { BlueprintProvider } from "@blueprintjs/core";
-import { RouterProvider } from "react-router-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
-function App() {
-    return (
-        <RouterProvider router={router}>
-            <BlueprintProvider>
-                <div>My app has overlays, hotkeys, and portal customization 😎</div>
-            </BlueprintProvider>
-        </RouterProvider>
-    );
-}
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
+    <BlueprintProvider>
+        <div>My app has overlays, hotkeys, and portal customization 😎</div>
+    </BlueprintProvider>,
+);
 ```
 
 ## Props interface

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -36,6 +36,28 @@ root.render(
 );
 ```
 
+@## Usage with other providers
+
+If your app uses a router or other providers (e.g. `RouterProvider`, `ApolloProvider`), nest
+**HotkeysProvider** underneath them:
+
+```tsx
+import { HotkeysProvider } from "@blueprintjs/core";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+const router = createBrowserRouter([...]);
+
+function App() {
+    return (
+        <RouterProvider router={router}>
+            <HotkeysProvider>
+                <div>My app has hotkeys 😎</div>
+            </HotkeysProvider>
+        </RouterProvider>
+    );
+}
+```
+
 @## Advanced usage
 
 **HotkeysProvider** should not be nested, except in special cases. If you have a rendering boundary within your application

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -20,23 +20,20 @@ enables & configures multiple providers automatically and is simpler to use than
 
 </div>
 
-To use **HotkeysProvider**, wrap the parts of your application that need hotkeys support.
-If your app uses a router or other providers (e.g. `RouterProvider`, `ApolloProvider`), nest
-**HotkeysProvider** underneath them:
+To use **HotkeysProvider**, wrap your application with it at the root level:
 
 ```tsx
 import { HotkeysProvider } from "@blueprintjs/core";
-import { RouterProvider } from "react-router-dom";
+import * as React from "react";
+import * as ReactDOM from "react-dom/client";
 
-function App() {
-    return (
-        <RouterProvider router={router}>
-            <HotkeysProvider>
-                <div>My app has hotkeys 😎</div>
-            </HotkeysProvider>
-        </RouterProvider>
-    );
-}
+const root = ReactDOM.createRoot(document.getElementById("root"));
+
+root.render(
+    <HotkeysProvider>
+        <div>My app has hotkeys 😎</div>
+    </HotkeysProvider>,
+);
 ```
 
 @## Advanced usage

--- a/packages/core/src/context/hotkeys/hotkeys-provider.md
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.md
@@ -20,20 +20,23 @@ enables & configures multiple providers automatically and is simpler to use than
 
 </div>
 
-To use **HotkeysProvider**, wrap your application with it at the root level:
+To use **HotkeysProvider**, wrap the parts of your application that need hotkeys support.
+If your app uses a router or other providers (e.g. `RouterProvider`, `ApolloProvider`), nest
+**HotkeysProvider** underneath them:
 
 ```tsx
 import { HotkeysProvider } from "@blueprintjs/core";
-import * as React from "react";
-import * as ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
-
-root.render(
-    <HotkeysProvider>
-        <div>My app has hotkeys 😎</div>
-    </HotkeysProvider>,
-);
+function App() {
+    return (
+        <RouterProvider router={router}>
+            <HotkeysProvider>
+                <div>My app has hotkeys 😎</div>
+            </HotkeysProvider>
+        </RouterProvider>
+    );
+}
 ```
 
 @## Advanced usage


### PR DESCRIPTION
#### Checklist
-   [x] Includes tests
-   [x] Update documentation

#### Changes proposed in this pull request:
Having a router nested under `HotkeysProvider` or `BlueprintProvider` causes issues with state management. This PR updates the docs to recommend nesting those providers under the application's `RouterProvider`.

#### Reviewers should focus on:

#### Screenshot
