### PR TITLE
chore(core): migrate test assertions from assert to expect

### DIFF
--- a/packages/core/src/common/props.test.ts
+++ b/packages/core/src/common/props.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { removeNonHTMLProps } from "./props";
 
@@ -36,7 +36,7 @@ describe("Props", () => {
         });
 
         it("removes only from curated denylist when supplied 1 argument", () => {
-            assert.deepEqual(removeNonHTMLProps(props), {
+            expect(removeNonHTMLProps(props)).toEqual({
                 apple: true,
                 banana: true,
                 cat: true,
@@ -44,7 +44,7 @@ describe("Props", () => {
         });
 
         it("removes only from the supplied array when supplied 2 arguments", () => {
-            assert.deepEqual(removeNonHTMLProps(props, ["apple", "banana"]), {
+            expect(removeNonHTMLProps(props, ["apple", "banana"])).toEqual({
                 cat: true,
                 containerRef: true,
                 icon: true,
@@ -55,7 +55,7 @@ describe("Props", () => {
         });
 
         it("removes from the curated denylist and the supplied array when shouldMerge=true", () => {
-            assert.deepEqual(removeNonHTMLProps(props, ["apple", "banana"], true), { cat: true });
+            expect(removeNonHTMLProps(props, ["apple", "banana"], true)).toEqual({ cat: true });
         });
     });
 });

--- a/packages/core/src/common/utils.test.tsx
+++ b/packages/core/src/common/utils.test.tsx
@@ -16,37 +16,28 @@
 
 import { Fragment } from "react/jsx-runtime";
 
-import {
-    afterEach,
-    assert,
-    beforeEach,
-    describe,
-    expect,
-    it,
-    type MockInstance,
-    vi,
-} from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
 import * as Utils from "./utils";
 
 describe("Utils", () => {
     it("isFunction", () => {
-        assert.isTrue(Utils.isFunction(() => 3));
-        assert.isFalse(Utils.isFunction(undefined));
+        expect(Utils.isFunction(() => 3)).toBe(true);
+        expect(Utils.isFunction(undefined)).toBe(false);
     });
 
     it("isReactNodeEmpty", () => {
         // empty nodes
-        assert.isTrue(Utils.isReactNodeEmpty(undefined), "undefined");
-        assert.isTrue(Utils.isReactNodeEmpty(null), "null");
-        assert.isTrue(Utils.isReactNodeEmpty(""), '""');
-        assert.isTrue(Utils.isReactNodeEmpty([]), "[]");
-        assert.isTrue(Utils.isReactNodeEmpty([undefined, null, false, ""]), "array");
+        expect(Utils.isReactNodeEmpty(undefined), "undefined").toBe(true);
+        expect(Utils.isReactNodeEmpty(null), "null").toBe(true);
+        expect(Utils.isReactNodeEmpty(""), '""').toBe(true);
+        expect(Utils.isReactNodeEmpty([]), "[]").toBe(true);
+        expect(Utils.isReactNodeEmpty([undefined, null, false, ""]), "array").toBe(true);
         // not empty nodes
-        assert.isFalse(Utils.isReactNodeEmpty(0), "0");
-        assert.isFalse(Utils.isReactNodeEmpty("text"), "text");
-        assert.isFalse(Utils.isReactNodeEmpty(<div />), "<div />");
-        assert.isFalse(Utils.isReactNodeEmpty([null, <div key="div" />]), "array");
+        expect(Utils.isReactNodeEmpty(0), "0").toBe(false);
+        expect(Utils.isReactNodeEmpty("text"), "text").toBe(false);
+        expect(Utils.isReactNodeEmpty(<div />), "<div />").toBe(false);
+        expect(Utils.isReactNodeEmpty([null, <div key="div" />]), "array").toBe(false);
     });
 
     it("elementIsOrContains", () => {
@@ -57,55 +48,55 @@ describe("Utils", () => {
         parent.appendChild(child);
         grandparent.appendChild(parent);
 
-        assert.isTrue(Utils.elementIsOrContains(child, child));
-        assert.isTrue(Utils.elementIsOrContains(parent, child));
-        assert.isTrue(Utils.elementIsOrContains(grandparent, parent));
-        assert.isTrue(Utils.elementIsOrContains(grandparent, child));
+        expect(Utils.elementIsOrContains(child, child)).toBe(true);
+        expect(Utils.elementIsOrContains(parent, child)).toBe(true);
+        expect(Utils.elementIsOrContains(grandparent, parent)).toBe(true);
+        expect(Utils.elementIsOrContains(grandparent, child)).toBe(true);
 
-        assert.isFalse(Utils.elementIsOrContains(child, parent));
-        assert.isFalse(Utils.elementIsOrContains(parent, grandparent));
+        expect(Utils.elementIsOrContains(child, parent)).toBe(false);
+        expect(Utils.elementIsOrContains(parent, grandparent)).toBe(false);
     });
 
     it("arrayLengthCompare", () => {
-        assert.isAbove(Utils.arrayLengthCompare([1, 2], []), 0);
-        assert.strictEqual(Utils.arrayLengthCompare([1, 2], [1, 2]), 0);
-        assert.isBelow(Utils.arrayLengthCompare([], [1, 2]), 0);
+        expect(Utils.arrayLengthCompare([1, 2], [])).toBeGreaterThan(0);
+        expect(Utils.arrayLengthCompare([1, 2], [1, 2])).toBe(0);
+        expect(Utils.arrayLengthCompare([], [1, 2])).toBeLessThan(0);
 
-        assert.isAbove(Utils.arrayLengthCompare([1]), 0);
-        assert.strictEqual(Utils.arrayLengthCompare(), 0);
-        assert.isBelow(Utils.arrayLengthCompare(undefined, [1]), 0);
+        expect(Utils.arrayLengthCompare([1])).toBeGreaterThan(0);
+        expect(Utils.arrayLengthCompare()).toBe(0);
+        expect(Utils.arrayLengthCompare(undefined, [1])).toBeLessThan(0);
     });
 
     it("approxEqual", () => {
         const DEFAULT_EPSILON = 0.00001;
-        assert.isTrue(Utils.approxEqual(0, DEFAULT_EPSILON));
-        assert.isTrue(Utils.approxEqual(-1 * DEFAULT_EPSILON, -2 * DEFAULT_EPSILON));
-        assert.isFalse(Utils.approxEqual(10, 10 + DEFAULT_EPSILON + DEFAULT_EPSILON / 10));
-        assert.isFalse(Utils.approxEqual(10, 10 - DEFAULT_EPSILON - DEFAULT_EPSILON / 10));
+        expect(Utils.approxEqual(0, DEFAULT_EPSILON)).toBe(true);
+        expect(Utils.approxEqual(-1 * DEFAULT_EPSILON, -2 * DEFAULT_EPSILON)).toBe(true);
+        expect(Utils.approxEqual(10, 10 + DEFAULT_EPSILON + DEFAULT_EPSILON / 10)).toBe(false);
+        expect(Utils.approxEqual(10, 10 - DEFAULT_EPSILON - DEFAULT_EPSILON / 10)).toBe(false);
     });
 
     it("clamp", () => {
-        assert.strictEqual(Utils.clamp(10, 0, 20), 10, "value between min/max");
-        assert.strictEqual(Utils.clamp(0, 10, 20), 10, "value below min");
-        assert.strictEqual(Utils.clamp(40, 0, 20), 20, "value above max");
-        assert.throws(() => Utils.clamp(0, 20, 10), /less than/);
+        expect(Utils.clamp(10, 0, 20), "value between min/max").toBe(10);
+        expect(Utils.clamp(0, 10, 20), "value below min").toBe(10);
+        expect(Utils.clamp(40, 0, 20), "value above max").toBe(20);
+        expect(() => Utils.clamp(0, 20, 10)).toThrow(/less than/);
     });
 
     it("countDecimalPlaces", () => {
-        assert.equal(Utils.countDecimalPlaces(1), 0);
-        assert.equal(Utils.countDecimalPlaces(0.11), 2);
-        assert.equal(Utils.countDecimalPlaces(-1.1111111111), 10);
-        assert.equal(Utils.countDecimalPlaces(1e-10), 10);
-        assert.equal(Utils.countDecimalPlaces(NaN), 0);
+        expect(Utils.countDecimalPlaces(1)).toBe(0);
+        expect(Utils.countDecimalPlaces(0.11)).toBe(2);
+        expect(Utils.countDecimalPlaces(-1.1111111111)).toBe(10);
+        expect(Utils.countDecimalPlaces(1e-10)).toBe(10);
+        expect(Utils.countDecimalPlaces(NaN)).toBe(0);
     });
 
     it("uniqueId", () => {
         const ns = "testNamespace";
         const otherNs = "otherNamespace";
-        assert.equal(Utils.uniqueId(ns), `${ns}-0`);
-        assert.equal(Utils.uniqueId(ns), `${ns}-1`);
-        assert.equal(Utils.uniqueId(ns), `${ns}-2`);
-        assert.equal(Utils.uniqueId(otherNs), `${otherNs}-0`);
+        expect(Utils.uniqueId(ns)).toBe(`${ns}-0`);
+        expect(Utils.uniqueId(ns)).toBe(`${ns}-1`);
+        expect(Utils.uniqueId(ns)).toBe(`${ns}-2`);
+        expect(Utils.uniqueId(otherNs)).toBe(`${otherNs}-0`);
     });
 
     // TODO: not sure how to test this. perhaps with the help of https://github.com/alexreardon/raf-stub?
@@ -113,22 +104,22 @@ describe("Utils", () => {
 
     describe("ensureElement", () => {
         it("handles undefined/null", () => {
-            assert.isUndefined(Utils.ensureElement(undefined));
-            assert.isUndefined(Utils.ensureElement(null));
+            expect(Utils.ensureElement(undefined)).toBeUndefined();
+            expect(Utils.ensureElement(null)).toBeUndefined();
         });
 
         it("wraps strings & numbers", () => {
-            assert.strictEqual(Utils.ensureElement("foo")?.type, "span");
-            assert.strictEqual(Utils.ensureElement(1234)?.type, "span");
+            expect(Utils.ensureElement("foo")?.type).toBe("span");
+            expect(Utils.ensureElement(1234)?.type).toBe("span");
         });
 
         it("returns undefined for whitespace strings", () => {
-            assert.isUndefined(Utils.ensureElement("   "));
+            expect(Utils.ensureElement("   ")).toBeUndefined();
         });
 
         it("passes through JSX elements", () => {
             const el = <div>my element</div>;
-            assert.strictEqual(Utils.ensureElement(el), el);
+            expect(Utils.ensureElement(el)).toBe(el);
         });
 
         // React 16 only
@@ -139,7 +130,7 @@ describe("Utils", () => {
                         one <em>two</em> three
                     </>,
                 );
-                assert.strictEqual(el?.type, "span");
+                expect(el?.type).toBe("span");
             });
         }
     });

--- a/packages/core/src/components/context-menu/contextMenu.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.test.tsx
@@ -87,26 +87,26 @@ describe("ContextMenu", () => {
     describe("basic usage", () => {
         it("renders children and Popover", () => {
             const ctxMenu = mountTestMenu();
-            assert.isTrue(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists());
-            assert.isTrue(ctxMenu.find(Popover).exists());
+            expect(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists()).toBe(true);
+            expect(ctxMenu.find(Popover).exists()).toBe(true);
         });
 
         it("opens popover on right click", () => {
             const ctxMenu = mountTestMenu();
             openCtxMenu(ctxMenu);
-            assert.isTrue(ctxMenu.find(Popover).prop("isOpen"));
+            expect(ctxMenu.find(Popover).prop("isOpen")).toBe(true);
         });
 
         it("renders custom HTML tag if specified", () => {
             const ctxMenu = mountTestMenu({ tagName: "span" });
-            assert.isTrue(ctxMenu.find(`span.${Classes.CONTEXT_MENU}`).exists());
+            expect(ctxMenu.find(`span.${Classes.CONTEXT_MENU}`).exists()).toBe(true);
         });
 
         it("supports custom refs", () => {
             const ref = createRef<HTMLElement>();
             mountTestMenu({ className: "test-container", ref });
-            assert.isDefined(ref.current);
-            assert.isTrue(ref.current?.classList.contains("test-container"));
+            expect(ref.current).toBeDefined();
+            expect(ref.current?.classList.contains("test-container")).toBe(true);
         });
 
         it("closes popover on ESC key press", () => {
@@ -119,7 +119,7 @@ describe("ContextMenu", () => {
                     key: "Escape",
                     nativeEvent: new KeyboardEvent("keydown"),
                 });
-            assert.isFalse(ctxMenu.find(Popover).prop("isOpen"));
+            expect(ctxMenu.find(Popover).prop("isOpen")).toBe(false);
         });
 
         it("clicks inside popover don't propagate to context menu wrapper", () => {
@@ -147,10 +147,7 @@ describe("ContextMenu", () => {
             const popoverWithTopPlacement = document.querySelector(
                 `.${popoverClassName}.${Classes.POPOVER_CONTENT_PLACEMENT}-${placement}`,
             );
-            assert.exists(
-                popoverWithTopPlacement,
-                `popover element with custom class '${popoverClassName}' and '${placement}' placement should exist`,
-            );
+            expect(popoverWithTopPlacement).toBeDefined();
         });
 
         function mountTestMenu(props: Partial<ContextMenuProps> = {}) {
@@ -168,32 +165,32 @@ describe("ContextMenu", () => {
     describe("advanced usage (child render function API)", () => {
         it("renders children and Popover", () => {
             const ctxMenu = mountTestMenu();
-            assert.isTrue(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists());
-            assert.isTrue(ctxMenu.find(Popover).exists());
+            expect(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists()).toBe(true);
+            expect(ctxMenu.find(Popover).exists()).toBe(true);
         });
 
         it("opens popover on right click", () => {
             const ctxMenu = mountTestMenu();
             openCtxMenu(ctxMenu);
-            assert.isTrue(ctxMenu.find(Popover).prop("isOpen"));
+            expect(ctxMenu.find(Popover).prop("isOpen")).toBe(true);
         });
 
         it("handles context menu event, even if content is undefined", () => {
             const ctxMenu = mountTestMenu({ content: undefined });
             let clickedInfo = ctxMenu.find("[data-testid='content-clicked-info']");
-            assert.strictEqual(clickedInfo.text().trim(), renderClickedInfo(undefined));
+            expect(clickedInfo.text().trim()).toBe(renderClickedInfo(undefined));
             openCtxMenu(ctxMenu);
             clickedInfo = ctxMenu.find("[data-testid='content-clicked-info']");
-            assert.strictEqual(clickedInfo.text().trim(), renderClickedInfo({ left: 10, top: 10 }));
+            expect(clickedInfo.text().trim()).toBe(renderClickedInfo({ left: 10, top: 10 }));
         });
 
         it("does not handle context menu event when disabled={true}", () => {
             const ctxMenu = mountTestMenu({ disabled: true });
             let clickedInfo = ctxMenu.find("[data-testid='content-clicked-info']");
-            assert.strictEqual(clickedInfo.text().trim(), renderClickedInfo(undefined));
+            expect(clickedInfo.text().trim()).toBe(renderClickedInfo(undefined));
             openCtxMenu(ctxMenu);
             clickedInfo = ctxMenu.find("[data-testid='content-clicked-info']");
-            assert.strictEqual(clickedInfo.text().trim(), renderClickedInfo(undefined));
+            expect(clickedInfo.text().trim()).toBe(renderClickedInfo(undefined));
         });
 
         function mountTestMenu(props?: Partial<ContextMenuProps>) {
@@ -224,20 +221,20 @@ describe("ContextMenu", () => {
         it("renders children and menu content, prevents default context menu handler", () =>
             new Promise<void>(done => {
                 const onContextMenu = (e: React.MouseEvent) => {
-                    assert.isTrue(e.defaultPrevented);
+                    expect(e.defaultPrevented).toBe(true);
                     done();
                 };
                 const wrapper = mountTestMenu({ onContextMenu });
-                assert.isTrue(wrapper.find(`.${TARGET_CLASSNAME}`).exists());
+                expect(wrapper.find(`.${TARGET_CLASSNAME}`).exists()).toBe(true);
                 openCtxMenu(wrapper);
-                assert.isTrue(wrapper.find(`.${MENU_CLASSNAME}`).exists());
+                expect(wrapper.find(`.${MENU_CLASSNAME}`).exists()).toBe(true);
                 closeCtxMenu(wrapper);
             }));
 
         it("triggers native context menu if content function returns undefined", () =>
             new Promise<void>(done => {
                 const onContextMenu = (e: React.MouseEvent) => {
-                    assert.isFalse(e.defaultPrevented);
+                    expect(e.defaultPrevented).toBe(false);
                     done();
                 };
                 const wrapper = mountTestMenu({
@@ -251,10 +248,10 @@ describe("ContextMenu", () => {
         it("updates menu if content prop value changes", () => {
             const ctxMenu = mountTestMenu();
             openCtxMenu(ctxMenu);
-            assert.isTrue(ctxMenu.find(`.${MENU_CLASSNAME}`).exists());
-            assert.isFalse(ctxMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+            expect(ctxMenu.find(`.${MENU_CLASSNAME}`).exists()).toBe(true);
+            expect(ctxMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists()).toBe(false);
             ctxMenu.setProps({ content: renderAlternativeContent });
-            assert.isTrue(ctxMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+            expect(ctxMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists()).toBe(true);
         });
 
         it("updates menu if content render function return value changes", () => {
@@ -263,10 +260,10 @@ describe("ContextMenu", () => {
             });
             mountedWrappers.push(testMenu);
             openCtxMenu(testMenu);
-            assert.isTrue(testMenu.find(`.${MENU_CLASSNAME}`).exists());
-            assert.isFalse(testMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+            expect(testMenu.find(`.${MENU_CLASSNAME}`).exists()).toBe(true);
+            expect(testMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists()).toBe(false);
             testMenu.setProps({ useAltContent: true });
-            assert.isTrue(testMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists());
+            expect(testMenu.find(`.${ALT_CONTENT_WRAPPER}`).exists()).toBe(true);
         });
 
         function renderContent({ mouseEvent, targetOffset }: ContextMenuContentProps) {
@@ -318,10 +315,7 @@ describe("ContextMenu", () => {
 
             openCtxMenu(wrapper);
             const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
-            assert.isTrue(
-                ctxMenuPopover.hasClass(Classes.DARK),
-                "ContextMenu popover should be open WITH dark theme applied",
-            );
+            expect(ctxMenuPopover.hasClass(Classes.DARK)).toBe(true);
             closeCtxMenu(wrapper);
         });
 
@@ -338,10 +332,7 @@ describe("ContextMenu", () => {
             wrapper.setProps({ className: undefined });
             openCtxMenu(wrapper);
             const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
-            assert.isFalse(
-                ctxMenuPopover.hasClass(Classes.DARK),
-                "ContextMenu popover should be open WITHOUT dark theme applied",
-            );
+            expect(ctxMenuPopover.hasClass(Classes.DARK)).toBe(false);
             closeCtxMenu(wrapper);
         });
     });
@@ -360,10 +351,10 @@ describe("ContextMenu", () => {
 
                 openTooltip(wrapper);
                 openCtxMenu(wrapper);
-                assert.isTrue(
+                expect(
                     wrapper.find(ContextMenu).find(Popover).prop("isOpen"),
                     "ContextMenu popover should be open",
-                );
+                ).toBe(true);
                 assertTooltipClosed(wrapper);
                 closeCtxMenu(wrapper);
             });
@@ -380,10 +371,10 @@ describe("ContextMenu", () => {
 
                 openTooltip(wrapper);
                 openCtxMenu(wrapper);
-                assert.isTrue(
+                expect(
                     wrapper.find(ContextMenu).find(Popover).first().prop("isOpen"),
                     "ContextMenu popover should be open",
-                );
+                ).toBe(true);
                 // this assertion is difficult to unit test, but we know that the tooltip closes in manual testing,
                 // see https://github.com/palantir/blueprint/pull/4744
                 // assertTooltipClosed(wrapper);
@@ -391,13 +382,13 @@ describe("ContextMenu", () => {
             });
 
             function assertTooltipClosed(wrapper: ReactWrapper) {
-                assert.isFalse(
+                expect(
                     wrapper
                         .find(Popover)
                         .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                         .state("isOpen"),
                     "Tooltip should be closed",
-                );
+                ).toBe(false);
             }
         });
 
@@ -408,25 +399,25 @@ describe("ContextMenu", () => {
                 it("closes tooltip when inner menu opens", () => {
                     const wrapper = mountTestCase();
                     openTooltip(wrapper);
-                    assert.lengthOf(wrapper.find(TOOLTIP_SELECTOR), 1, "tooltip should be open");
+                    expect(wrapper.find(TOOLTIP_SELECTOR), "tooltip should be open").toHaveLength(1);
                     openCtxMenu(wrapper);
                     assertTooltipClosed(wrapper);
                     const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
-                    assert.isTrue(ctxMenuPopover.exists(), "ContextMenu popover should be open");
-                    assert.isTrue(ctxMenuPopover.text().includes("first"), "inner ContextMenu should be open");
+                    expect(ctxMenuPopover.exists(), "ContextMenu popover should be open").toBe(true);
+                    expect(ctxMenuPopover.text().includes("first"), "inner ContextMenu should be open").toBe(true);
                     closeCtxMenu(wrapper);
                 });
 
                 it("closes tooltip when outer menu opens", () => {
                     const wrapper = mountTestCase();
                     openTooltip(wrapper, OUTER_TARGET_CLASSNAME);
-                    assert.lengthOf(wrapper.find(TOOLTIP_SELECTOR), 1, "tooltip should be open");
+                    expect(wrapper.find(TOOLTIP_SELECTOR), "tooltip should be open").toHaveLength(1);
                     openCtxMenu(wrapper, OUTER_TARGET_CLASSNAME);
                     // this assertion is difficult to test, but we know that the tooltip eventually does close in manual testing
                     // assertTooltipClosed(wrapper);
                     const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
-                    assert.isTrue(ctxMenuPopover.exists(), "ContextMenu popover should be open");
-                    assert.isTrue(ctxMenuPopover.text().includes("Align"), "outer ContextMenu should be open");
+                    expect(ctxMenuPopover.exists(), "ContextMenu popover should be open").toBe(true);
+                    expect(ctxMenuPopover.text().includes("Align"), "outer ContextMenu should be open").toBe(true);
                     closeCtxMenu(wrapper);
                 });
 
@@ -480,13 +471,13 @@ describe("ContextMenu", () => {
                 }
 
                 function assertTooltipClosed(wrapper: ReactWrapper) {
-                    assert.isFalse(
+                    expect(
                         wrapper
                             .find(Popover)
                             .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                             .state("isOpen"),
                         "Tooltip should be closed",
-                    );
+                    ).toBe(false);
                 }
             });
 
@@ -499,19 +490,19 @@ describe("ContextMenu", () => {
                     const wrapper = mountTestCase();
                     wrapper.find(`.${OUTER_TARGET_CLASSNAME}`).simulate("mouseenter");
                     openTooltip(wrapper);
-                    assert.lengthOf(wrapper.find(`.${Classes.TOOLTIP}`), 1, "tooltip should be open");
+                    expect(wrapper.find(`.${Classes.TOOLTIP}`), "tooltip should be open").toHaveLength(1);
                     openCtxMenu(wrapper);
                     // this assertion is difficult to test, but we know that the tooltip eventually does close in manual testing
-                    assert.isFalse(
+                    expect(
                         wrapper
                             .find(Popover)
                             .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                             .first()
                             .state("isOpen"),
                         "Tooltip should be closed",
-                    );
+                    ).toBe(false);
                     const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
-                    assert.isTrue(ctxMenuPopover.exists(), "ContextMenu popover should be open");
+                    expect(ctxMenuPopover.exists(), "ContextMenu popover should be open").toBe(true);
                     closeCtxMenu(wrapper);
                     wrapper.find(`.${OUTER_TARGET_CLASSNAME}`).simulate("mouseleave");
                 });
@@ -519,7 +510,7 @@ describe("ContextMenu", () => {
                 it("closes outer tooltip when menu opens (after hovering ctx menu target)", () => {
                     const wrapper = mountTestCase();
                     openTooltip(wrapper, CTX_MENU_CLASSNAME);
-                    assert.lengthOf(wrapper.find(`.${Classes.TOOLTIP}`), 1, "tooltip should be open");
+                    expect(wrapper.find(`.${Classes.TOOLTIP}`), "tooltip should be open").toHaveLength(1);
                     openCtxMenu(wrapper, CTX_MENU_CLASSNAME);
                     // this assertion is difficult to test, but we know that the tooltip eventually does close in manual testing
                     // assert.isFalse(
@@ -531,8 +522,8 @@ describe("ContextMenu", () => {
                     //     "Tooltip should be closed",
                     // );
                     const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
-                    assert.isTrue(ctxMenuPopover.exists(), "ContextMenu popover should be open");
-                    assert.isTrue(ctxMenuPopover.text().includes("Align"), "outer ContextMenu should be open");
+                    expect(ctxMenuPopover.exists(), "ContextMenu popover should be open").toBe(true);
+                    expect(ctxMenuPopover.text().includes("Align"), "outer ContextMenu should be open").toBe(true);
                     closeCtxMenu(wrapper);
                     wrapper.find(`.${OUTER_TARGET_CLASSNAME}`).simulate("mouseleave");
                 });
@@ -601,12 +592,12 @@ describe("ContextMenu", () => {
                 );
                 mountedWrappers.push(wrapper);
                 const target = wrapper.find(`.${TARGET_CLASSNAME}`).hostNodes();
-                assert.isTrue(target.exists(), "target should exist");
+                expect(target.exists(), "target should exist").toBe(true);
                 const nonExistentPopover = wrapper.find(`.${POPOVER_CLASSNAME}`).hostNodes();
-                assert.isFalse(
+                expect(
                     nonExistentPopover.exists(),
                     "ContextMenu popover should not be open before triggering contextmenu event",
-                );
+                ).toBe(false);
 
                 const targetRect = target.getDOMNode().getBoundingClientRect();
                 // right click on the target
@@ -618,7 +609,7 @@ describe("ContextMenu", () => {
                 };
                 target.simulate("contextmenu", simulateArgs);
                 const popover = wrapper.find(`.${POPOVER_CLASSNAME}`).hostNodes();
-                assert.isTrue(popover.exists(), "ContextMenu popover should be open");
+                expect(popover.exists(), "ContextMenu popover should be open").toBe(true);
             });
         });
 

--- a/packages/core/src/components/drawer/drawer.test.tsx
+++ b/packages/core/src/components/drawer/drawer.test.tsx
@@ -16,7 +16,7 @@
 
 import { mount, type ReactWrapper } from "enzyme";
 
-import { afterEach, assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Position } from "../../common";
 import { Button } from "../button/buttons";
@@ -55,7 +55,7 @@ describe("<Drawer>", () => {
             </Drawer>,
         );
         [Classes.DRAWER, Classes.DRAWER_BODY, Classes.DRAWER_FOOTER, Classes.OVERLAY_BACKDROP].forEach(className => {
-            assert.lengthOf(drawer.find(`.${className}`), 1, `missing ${className}`);
+            expect(drawer.find(`.${className}`), `missing ${className}`).toHaveLength(1);
         });
     });
 
@@ -67,7 +67,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.equal(drawer.find(`.${Classes.DRAWER}`).prop("style")?.width, 100);
+                expect(drawer.find(`.${Classes.DRAWER}`).prop("style")?.width).toBe(100);
             });
 
             it("position right, adds appropriate classes (default behavior)", () => {
@@ -76,7 +76,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.isTrue(drawer.find(`.${Classes.POSITION_RIGHT}`).exists());
+                expect(drawer.find(`.${Classes.POSITION_RIGHT}`).exists()).toBe(true);
             });
         });
 
@@ -87,7 +87,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.equal(drawer.find(`.${Classes.DRAWER}`).prop("style")?.height, 100);
+                expect(drawer.find(`.${Classes.DRAWER}`).prop("style")?.height).toBe(100);
             });
 
             it("position top, adds appropriate classes (vertical, reverse)", () => {
@@ -96,7 +96,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.isTrue(drawer.find(`.${Classes.POSITION_TOP}`).exists());
+                expect(drawer.find(`.${Classes.POSITION_TOP}`).exists()).toBe(true);
             });
         });
 
@@ -107,7 +107,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.equal(drawer.find(`.${Classes.DRAWER}`).prop("style")?.height, 100);
+                expect(drawer.find(`.${Classes.DRAWER}`).prop("style")?.height).toBe(100);
             });
 
             it("position bottom, adds appropriate classes (vertical)", () => {
@@ -116,7 +116,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.isTrue(drawer.find(`.${Classes.POSITION_BOTTOM}`).exists());
+                expect(drawer.find(`.${Classes.POSITION_BOTTOM}`).exists()).toBe(true);
             });
         });
 
@@ -127,7 +127,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.equal(drawer.find(`.${Classes.DRAWER}`).prop("style")?.width, 100);
+                expect(drawer.find(`.${Classes.DRAWER}`).prop("style")?.width).toBe(100);
             });
 
             it("position left, adds appropriate classes (reverse)", () => {
@@ -136,7 +136,7 @@ describe("<Drawer>", () => {
                         {createDrawerContents()}
                     </Drawer>,
                 );
-                assert.isTrue(drawer.find(`.${Classes.POSITION_LEFT}`).exists());
+                expect(drawer.find(`.${Classes.POSITION_LEFT}`).exists()).toBe(true);
             });
         });
     });
@@ -147,7 +147,7 @@ describe("<Drawer>", () => {
                 {createDrawerContents()}
             </Drawer>,
         );
-        assert.equal(drawer.find(`.${Classes.DRAWER}`).prop("style")?.width, 100);
+        expect(drawer.find(`.${Classes.DRAWER}`).prop("style")?.width).toBe(100);
     });
 
     it("portalClassName appears on Portal", () => {
@@ -157,7 +157,7 @@ describe("<Drawer>", () => {
                 {createDrawerContents()}
             </Drawer>,
         );
-        assert.isDefined(document.querySelector(`.${Classes.PORTAL}.${TEST_CLASS}`));
+        expect(document.querySelector(`.${Classes.PORTAL}.${TEST_CLASS}`)).toBeDefined();
     });
 
     it("renders contents to specified container correctly", () => {
@@ -219,7 +219,7 @@ describe("<Drawer>", () => {
                     drawer body
                 </Drawer>,
             );
-            assert.isFalse(drawer.find(`.${Classes.DRAWER_HEADER}`).exists());
+            expect(drawer.find(`.${Classes.DRAWER_HEADER}`).exists()).toBe(false);
         });
 
         it(`renders .${Classes.DRAWER_HEADER} if title prop is given`, () => {
@@ -228,7 +228,7 @@ describe("<Drawer>", () => {
                     drawer body
                 </Drawer>,
             );
-            assert.match(drawer.find(`.${Classes.DRAWER_HEADER}`).text(), /^Hello!/);
+            expect(drawer.find(`.${Classes.DRAWER_HEADER}`).text()).toMatch(/^Hello!/);
         });
 
         it(`renders close button if isCloseButtonShown={true}`, () => {
@@ -237,10 +237,10 @@ describe("<Drawer>", () => {
                     drawer body
                 </Drawer>,
             );
-            assert.lengthOf(drawer.find(`.${Classes.DRAWER_HEADER}`).find(Button), 1);
+            expect(drawer.find(`.${Classes.DRAWER_HEADER}`).find(Button)).toHaveLength(1);
 
             drawer.setProps({ isCloseButtonShown: false });
-            assert.lengthOf(drawer.find(`.${Classes.DRAWER_HEADER}`).find(Button), 0);
+            expect(drawer.find(`.${Classes.DRAWER_HEADER}`).find(Button)).toHaveLength(0);
         });
 
         it("clicking close button triggers onClose", () => {
@@ -257,7 +257,7 @@ describe("<Drawer>", () => {
 
     it("only adds its className in one location", () => {
         mountDrawer(<Drawer className="foo" isOpen={true} title="title" usePortal={false} />);
-        assert.lengthOf(drawer.find(".foo").hostNodes(), 1);
+        expect(drawer.find(".foo").hostNodes()).toHaveLength(1);
     });
 
     // everything else about Drawer is tested by Overlay

--- a/packages/core/src/components/editable-text/editableText.test.tsx
+++ b/packages/core/src/components/editable-text/editableText.test.tsx
@@ -17,52 +17,52 @@
 import { mount, type ReactWrapper, shallow } from "enzyme";
 import { act } from "react";
 
-import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { EditableText } from "./editableText";
 
 describe("<EditableText>", () => {
     it("renders value", () => {
-        assert.equal(shallow(<EditableText value="alphabet" />).text(), "alphabet");
+        expect(shallow(<EditableText value="alphabet" />).text()).toBe("alphabet");
     });
 
     it("renders defaultValue", () => {
-        assert.equal(shallow(<EditableText defaultValue="default" />).text(), "default");
+        expect(shallow(<EditableText defaultValue="default" />).text()).toBe("default");
     });
 
     it("renders placeholder", () => {
-        assert.equal(shallow(<EditableText placeholder="Edit..." />).text(), "Edit...");
+        expect(shallow(<EditableText placeholder="Edit..." />).text()).toBe("Edit...");
     });
 
     it("cannot be edited when disabled", () => {
         const editable = shallow(<EditableText disabled={true} isEditing={true} />);
-        assert.isFalse(editable.state("isEditing"));
+        expect(editable.state("isEditing")).toBe(false);
     });
 
     it("allows resetting controlled value to undefined or null", () => {
         const editable = shallow(<EditableText isEditing={false} placeholder="placeholder" value="alphabet" />);
-        assert.strictEqual(editable.text(), "alphabet");
+        expect(editable.text()).toBe("alphabet");
         editable.setProps({ value: null });
-        assert.strictEqual(editable.text(), "placeholder");
+        expect(editable.text()).toBe("placeholder");
     });
 
     it("passes an ID to the underlying span", () => {
         const editable = shallow(<EditableText disabled={true} isEditing={true} contentId="my-id" />).find("span");
-        assert.strictEqual(editable.prop("id"), "my-id");
+        expect(editable.prop("id")).toBe("my-id");
     });
 
     describe("when editing", () => {
         it('renders <input type="text"> when editing', () => {
             const input = shallow(<EditableText isEditing={true} />).find("input");
-            assert.lengthOf(input, 1);
-            assert.strictEqual(input.prop("type"), "text");
+            expect(input).toHaveLength(1);
+            expect(input.prop("type")).toBe("text");
         });
 
         it("unrenders input when done editing", () => {
             const wrapper = shallow(<EditableText isEditing={true} placeholder="Edit..." value="alphabet" />);
-            assert.lengthOf(wrapper.find("input"), 1);
+            expect(wrapper.find("input")).toHaveLength(1);
             wrapper.setProps({ isEditing: false });
-            assert.lengthOf(wrapper.find("input"), 0);
+            expect(wrapper.find("input")).toHaveLength(0);
         });
 
         it("calls onChange when input is changed", () => {
@@ -107,7 +107,7 @@ describe("<EditableText>", () => {
             expect(confirmSpy).not.toHaveBeenCalled();
             expect(cancelSpy).toHaveBeenCalledOnce();
             expect(cancelSpy.mock.calls[0][0]).toBe(OLD_VALUE);
-            assert.strictEqual(component.state().value, OLD_VALUE, "did not revert to original value");
+            expect(component.state().value, "did not revert to original value").toBe(OLD_VALUE);
         });
 
         it("calls onConfirm, does not call onCancel, and saves value when enter key pressed", () => {
@@ -128,7 +128,7 @@ describe("<EditableText>", () => {
             expect(cancelSpy).not.toHaveBeenCalled();
             expect(confirmSpy).toHaveBeenCalledOnce();
             expect(confirmSpy.mock.calls[0][0]).toBe(NEW_VALUE);
-            assert.strictEqual(component.state().value, NEW_VALUE, "did not save new value");
+            expect(component.state().value, "did not save new value").toBe(NEW_VALUE);
         });
 
         it("calls onConfirm when enter key pressed even if value didn't change", () => {
@@ -164,7 +164,7 @@ describe("<EditableText>", () => {
 
         it("stops editing when disabled", () => {
             const wrapper = mount(<EditableText isEditing={true} disabled={true} />);
-            assert.isFalse(wrapper.state("isEditing"));
+            expect(wrapper.state("isEditing")).toBe(false);
         });
 
         it("caret is placed at the end of the input box", () => {
@@ -172,8 +172,8 @@ describe("<EditableText>", () => {
             const containerElement = document.createElement("div");
             mount(<EditableText isEditing={true} value="alphabet" />, { attachTo: containerElement });
             const input = containerElement.querySelector<HTMLInputElement>("input")!;
-            assert.strictEqual(input.selectionStart, 8);
-            assert.strictEqual(input.selectionEnd, 8);
+            expect(input.selectionStart).toBe(8);
+            expect(input.selectionEnd).toBe(8);
         });
 
         it("controlled mode can only change value via props", () => {
@@ -183,20 +183,20 @@ describe("<EditableText>", () => {
 
             const input = wrapper.find("input");
             input.simulate("change", { target: { value: "hello" } });
-            assert.strictEqual(inputElement.value, expected, "controlled mode can only change via props");
+            expect(inputElement.value, "controlled mode can only change via props").toBe(expected);
 
             expected = "hello world";
             wrapper.setProps({ value: expected });
-            assert.strictEqual(inputElement.value, expected, "controlled mode should be changeable via props");
+            expect(inputElement.value, "controlled mode should be changeable via props").toBe(expected);
         });
 
         it("applies defaultValue only on initial render", () => {
             const wrapper = mount(<EditableText isEditing={true} defaultValue="default" placeholder="placeholder" />);
-            assert.strictEqual(wrapper.state("value"), "default");
+            expect(wrapper.state("value")).toBe("default");
             // type new value, then change a prop to cause re-render
             wrapper.find("input").simulate("change", { target: { value: "hello" } });
             wrapper.setProps({ placeholder: "new placeholder" });
-            assert.strictEqual(wrapper.state("value"), "hello");
+            expect(wrapper.state("value")).toBe("hello");
         });
 
         it("the full input box is highlighted when selectAllOnFocus is true", () => {
@@ -205,14 +205,14 @@ describe("<EditableText>", () => {
                 attachTo: containerElement,
             });
             const input = containerElement.querySelector<HTMLInputElement>("input")!;
-            assert.strictEqual(input.selectionStart, 0);
-            assert.strictEqual(input.selectionEnd, 8);
+            expect(input.selectionStart).toBe(0);
+            expect(input.selectionEnd).toBe(8);
         });
     });
 
     describe("multiline", () => {
         it("renders a <textarea> when editing", () => {
-            assert.lengthOf(mount(<EditableText isEditing={true} multiline={true} />).find("textarea"), 1);
+            expect(mount(<EditableText isEditing={true} multiline={true} />).find("textarea")).toHaveLength(1);
         });
 
         it("does not call onConfirm when enter key is pressed", () => {
@@ -248,7 +248,7 @@ describe("<EditableText>", () => {
                 key: "Enter",
                 preventDefault: (): void => undefined,
             });
-            assert.isFalse(wrapper.state("isEditing"));
+            expect(wrapper.state("isEditing")).toBe(false);
             expect(confirmSpy).toHaveBeenCalledTimes(4);
             expect(confirmSpy.mock.calls[0][0]).toBe("control");
             expect(confirmSpy.mock.calls[1][0]).toBe("meta");
@@ -262,7 +262,7 @@ describe("<EditableText>", () => {
                 <EditableText isEditing={true} onConfirm={confirmSpy} multiline={true} confirmOnEnterKey={true} />,
             );
             simulateHelper(wrapper, "control", { key: "Enter" });
-            assert.isFalse(wrapper.state("isEditing"));
+            expect(wrapper.state("isEditing")).toBe(false);
             expect(confirmSpy).toHaveBeenCalledOnce();
             expect(confirmSpy.mock.calls[0][0]).toBe("control");
         });
@@ -274,24 +274,24 @@ describe("<EditableText>", () => {
             );
             const textarea = wrapper.getDOMNode().querySelector<HTMLTextAreaElement>("textarea")!;
             simulateHelper(wrapper, "", { ctrlKey: true, key: "Enter", target: textarea });
-            assert.strictEqual(textarea.value, "\n");
+            expect(textarea.value).toBe("\n");
             simulateHelper(wrapper, "", { key: "Enter", metaKey: true, target: textarea });
-            assert.strictEqual(textarea.value, "\n");
+            expect(textarea.value).toBe("\n");
             simulateHelper(wrapper, "", {
                 key: "Enter",
                 preventDefault: (): void => undefined,
                 shiftKey: true,
                 target: textarea,
             });
-            assert.strictEqual(textarea.value, "\n");
+            expect(textarea.value).toBe("\n");
             simulateHelper(wrapper, "", {
                 altKey: true,
                 key: "Enter",
                 preventDefault: (): void => undefined,
                 target: textarea,
             });
-            assert.strictEqual(textarea.value, "\n");
-            assert.isTrue(wrapper.state("isEditing"));
+            expect(textarea.value).toBe("\n");
+            expect(wrapper.state("isEditing")).toBe(true);
             expect(confirmSpy).not.toHaveBeenCalled();
         });
 
@@ -322,18 +322,18 @@ describe("<EditableText>", () => {
             const wrapper = mount(
                 <EditableText isEditing={true} multiline={true} customInputAttributes={customProps} />,
             ).find("textarea");
-            assert.strictEqual(wrapper.prop("data-gramm"), "false");
-            assert.strictEqual(wrapper.prop("spellcheck"), "false");
-            assert.strictEqual(wrapper.prop("aria-label"), "Edit description");
+            expect(wrapper.prop("data-gramm")).toBe("false");
+            expect(wrapper.prop("spellcheck")).toBe("false");
+            expect(wrapper.prop("aria-label")).toBe("Edit description");
         });
 
         it("passes custom attributes to input when multiline is false", () => {
             const wrapper = mount(
                 <EditableText isEditing={true} multiline={false} customInputAttributes={customProps} />,
             ).find("input");
-            assert.strictEqual(wrapper.prop("data-gramm"), "false");
-            assert.strictEqual(wrapper.prop("spellcheck"), "false");
-            assert.strictEqual(wrapper.prop("aria-label"), "Edit description");
+            expect(wrapper.prop("data-gramm")).toBe("false");
+            expect(wrapper.prop("spellcheck")).toBe("false");
+            expect(wrapper.prop("aria-label")).toBe("Edit description");
         });
     });
 });

--- a/packages/core/src/components/forms/fileInput.test.tsx
+++ b/packages/core/src/components/forms/fileInput.test.tsx
@@ -16,7 +16,7 @@
 
 import { mount, type ReactWrapper, shallow, type ShallowWrapper } from "enzyme";
 
-import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -26,10 +26,10 @@ describe("<FileInput>", () => {
     it(`supports className, fill, & size="large"`, () => {
         const CUSTOM_CLASS = "foo";
         const wrapper = shallow(<FileInput className={CUSTOM_CLASS} fill={true} size="large" />);
-        assert.isTrue(wrapper.hasClass(Classes.FILE_INPUT), "Classes.FILE_INPUT");
-        assert.isTrue(wrapper.hasClass(CUSTOM_CLASS), CUSTOM_CLASS);
-        assert.isTrue(wrapper.hasClass(Classes.FILL), "Classes.FILL");
-        assert.isTrue(wrapper.hasClass(Classes.LARGE), "Classes.LARGE");
+        expect(wrapper.hasClass(Classes.FILE_INPUT), "Classes.FILE_INPUT").toBe(true);
+        expect(wrapper.hasClass(CUSTOM_CLASS), CUSTOM_CLASS).toBe(true);
+        expect(wrapper.hasClass(Classes.FILL), "Classes.FILL").toBe(true);
+        expect(wrapper.hasClass(Classes.LARGE), "Classes.LARGE").toBe(true);
     });
 
     it("supports custom input props", () => {
@@ -44,23 +44,23 @@ describe("<FileInput>", () => {
         );
         const input = getInput(wrapper);
 
-        assert.isTrue(input.hasClass("bar"), "has custom class");
-        assert.isTrue(input.prop("required"), "required attribute");
-        assert.strictEqual(input.prop("type"), "file", "type attribute");
+        expect(input.hasClass("bar"), "has custom class").toBe(true);
+        expect(input.prop("required"), "required attribute").toBe(true);
+        expect(input.prop("type"), "type attribute").toBe("file");
     });
 
     it("applies top-level disabled prop to the root and input (overriding inputProps.disabled)", () => {
         const wrapper = mount(<FileInput disabled={true} inputProps={{ disabled: false }} />);
 
         // should ignore inputProps.disabled in favor of the top-level prop
-        assert.isTrue(wrapper.children().hasClass(Classes.DISABLED), "wrapper has disabled class");
-        assert.isTrue(getInput(wrapper).prop("disabled"), "input is disabled");
+        expect(wrapper.children().hasClass(Classes.DISABLED), "wrapper has disabled class").toBe(true);
+        expect(getInput(wrapper).prop("disabled"), "input is disabled").toBe(true);
 
         wrapper.setProps({ disabled: false, inputProps: { disabled: true } });
 
         // ensure inputProps.disabled is overriden in this case too
-        assert.isFalse(wrapper.children().hasClass(Classes.DISABLED), "wrapper no longer has disabled class");
-        assert.isFalse(getInput(wrapper).prop("disabled"), "input no longer disabled");
+        expect(wrapper.children().hasClass(Classes.DISABLED), "wrapper no longer has disabled class").toBe(false);
+        expect(getInput(wrapper).prop("disabled"), "input no longer disabled").toBe(false);
     });
 
     it("renders default or custom text", () => {
@@ -68,11 +68,11 @@ describe("<FileInput>", () => {
         const span = wrapper.find(`.${Classes.FILE_UPLOAD_INPUT}`);
 
         // default text
-        assert.strictEqual(span.text(), "Choose file...");
+        expect(span.text()).toBe("Choose file...");
 
         // custom text
         wrapper.setProps({ text: "Input file..." });
-        assert.strictEqual(span.text(), "Input file...");
+        expect(span.text()).toBe("Input file...");
     });
 
     it("invokes change callbacks", () => {

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -18,7 +18,7 @@ import { mount } from "enzyme";
 
 import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
-import { afterEach, assert, beforeAll, describe, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeAll, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Intent } from "../../common";
 
@@ -53,7 +53,7 @@ describe("<Icon>", () => {
     it("tagName dictates HTML tag", async () => {
         const wrapper = mount(<Icon icon="calendar" tagName="i" />);
         wrapper.update();
-        assert.isTrue(wrapper.find("i").exists());
+        expect(wrapper.find("i").exists()).toBe(true);
     });
 
     it("size=16 renders standard size", async () =>
@@ -64,7 +64,7 @@ describe("<Icon>", () => {
 
     it("renders intent class", async () => {
         const wrapper = mount(<Icon icon="add" intent={Intent.DANGER} />);
-        assert.isTrue(wrapper.find(`.${Classes.INTENT_DANGER}`).exists());
+        expect(wrapper.find(`.${Classes.INTENT_DANGER}`).exists()).toBe(true);
     });
 
     it.skip("renders icon name", async () => {
@@ -82,13 +82,13 @@ describe("<Icon>", () => {
     it("unknown icon name renders blank icon", async () => {
         const wrapper = mount(<Icon icon={"unknown" as any} />);
         wrapper.update();
-        assert.lengthOf(wrapper.find("path"), 0);
+        expect(wrapper.find("path")).toHaveLength(0);
     });
 
     it("prefixed icon renders blank icon", async () => {
         const wrapper = mount(<Icon icon={Classes.iconClass("airplane") as any} />);
         wrapper.update();
-        assert.lengthOf(wrapper.find("path"), 0);
+        expect(wrapper.find("path")).toHaveLength(0);
     });
 
     it("icon element passes through unchanged", async () => {
@@ -97,30 +97,30 @@ describe("<Icon>", () => {
         const onClick = () => true;
         const wrapper = mount(<Icon icon={<article onClick={onClick} />} />);
         wrapper.update();
-        assert.isTrue(wrapper.childAt(0).is("article"));
-        assert.strictEqual(wrapper.find("article").prop("onClick"), onClick);
+        expect(wrapper.childAt(0).is("article")).toBe(true);
+        expect(wrapper.find("article").prop("onClick")).toBe(onClick);
     });
 
     it("icon=undefined renders nothing", async () => {
         const wrapper = mount(<Icon icon={undefined} />);
         wrapper.update();
-        assert.isTrue(wrapper.isEmptyRender());
+        expect(wrapper.isEmptyRender()).toBe(true);
     });
 
     it("title sets content of <title> element", async () => {
         const wrapper = mount(<Icon icon="airplane" title="bird" />);
         wrapper.update();
-        assert.equal(wrapper.find("title").text(), "bird");
+        expect(wrapper.find("title").text()).toBe("bird");
     });
 
     it("does not add desc if title is not provided", () => {
         const icon = mount(<Icon icon="airplane" />);
-        assert.isEmpty(icon.find("desc"));
+        expect(icon.find("desc")).toHaveLength(0);
     });
 
     it("applies aria-hidden=true if title is not defined", () => {
         const icon = mount(<Icon icon="airplane" />);
-        assert.isTrue(icon.find(`.${Classes.ICON}`).hostNodes().prop("aria-hidden"));
+        expect(icon.find(`.${Classes.ICON}`).hostNodes().prop("aria-hidden")).toBe(true);
     });
 
     it("supports mouse event handlers of type React.MouseEventHandler", () => {
@@ -140,15 +140,15 @@ describe("<Icon>", () => {
     it("allows specifying the root element as <svg> when tagName={null}", () => {
         const handleClick: React.MouseEventHandler<SVGSVGElement> = () => undefined;
         const wrapper = mount(<Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />);
-        assert.isFalse(wrapper.find("span").exists());
+        expect(wrapper.find("span").exists()).toBe(false);
     });
 
     /** Asserts that rendered icon has an SVG path. */
     async function assertIconHasPath(icon: React.ReactElement<IconProps>, iconName: IconName) {
         const wrapper = mount(icon);
         wrapper.update();
-        assert.strictEqual(wrapper.text(), iconName);
-        assert.isAbove(wrapper.find("path").length, 0, "should find at least one path element");
+        expect(wrapper.text()).toBe(iconName);
+        expect(wrapper.find("path").length, "should find at least one path element").toBeGreaterThan(0);
     }
 
     /** Asserts that rendered icon has width/height equal to size. */
@@ -156,8 +156,8 @@ describe("<Icon>", () => {
         const wrapper = mount(icon);
         wrapper.update();
         const svg = wrapper.find("svg");
-        assert.strictEqual(svg.prop("width"), size);
-        assert.strictEqual(svg.prop("height"), size);
+        expect(svg.prop("width")).toBe(size);
+        expect(svg.prop("height")).toBe(size);
     }
 
     /** Asserts that rendered icon has color equal to color. */
@@ -165,6 +165,6 @@ describe("<Icon>", () => {
         const wrapper = mount(icon);
         wrapper.update();
         const svg = wrapper.find("svg");
-        assert.deepEqual(svg.prop("fill"), color);
+        expect(svg.prop("fill")).toEqual(color);
     }
 });

--- a/packages/core/src/components/panel-stack/panelStack.test.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.test.tsx
@@ -17,7 +17,7 @@
 import { mount, type ReactWrapper } from "enzyme";
 import { useState } from "react";
 
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { NumericInput } from "../forms/numericInput";
@@ -73,45 +73,45 @@ describe("<PanelStack>", () => {
     describe("uncontrolled mode", () => {
         it("renders a basic panel and allows opening and closing", () => {
             panelStackWrapper = renderPanelStack({ initialPanel });
-            assert.exists(panelStackWrapper);
+            expect(panelStackWrapper).toBeDefined();
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
+            expect(newPanelButton).toBeDefined();
             newPanelButton.simulate("click");
 
             const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(newPanelHeader);
-            assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
+            expect(newPanelHeader).toBeDefined();
+            expect(newPanelHeader.at(0).text()).toBe("New Panel 1");
 
             const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.exists(backButton);
+            expect(backButton).toBeDefined();
             backButton.simulate("click");
 
             const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(oldPanelHeader);
-            assert.equal(oldPanelHeader.at(1).text(), "Test Title");
+            expect(oldPanelHeader).toBeDefined();
+            expect(oldPanelHeader.at(1).text()).toBe("Test Title");
         });
 
         it("renders a panel stack without header and allows opening and closing", () => {
             panelStackWrapper = renderPanelStack({ initialPanel, showPanelHeader: false });
-            assert.exists(panelStackWrapper);
+            expect(panelStackWrapper).toBeDefined();
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
+            expect(newPanelButton).toBeDefined();
             newPanelButton.simulate("click");
 
             const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.lengthOf(newPanelHeader, 0);
+            expect(newPanelHeader).toHaveLength(0);
 
             const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.lengthOf(backButton, 0);
+            expect(backButton).toHaveLength(0);
 
             const closePanel = panelStackWrapper.find("#close-panel-button");
-            assert.exists(closePanel);
+            expect(closePanel).toBeDefined();
             closePanel.last().simulate("click");
 
             const oldPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.lengthOf(oldPanelHeader, 0);
+            expect(oldPanelHeader).toHaveLength(0);
         });
 
         it("does not call the callback handler onClose when there is only a single panel on the stack", () => {
@@ -119,7 +119,7 @@ describe("<PanelStack>", () => {
             panelStackWrapper = renderPanelStack({ initialPanel, onClose });
 
             const closePanel = panelStackWrapper.find("#close-panel-button");
-            assert.exists(closePanel);
+            expect(closePanel).toBeDefined();
 
             closePanel.simulate("click");
             expect(onClose).not.toHaveBeenCalled();
@@ -131,13 +131,13 @@ describe("<PanelStack>", () => {
             panelStackWrapper = renderPanelStack({ initialPanel, onClose, onOpen });
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
+            expect(newPanelButton).toBeDefined();
             newPanelButton.simulate("click");
             expect(onOpen).toHaveBeenCalledOnce();
             expect(onClose).not.toHaveBeenCalled();
 
             const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.exists(backButton);
+            expect(backButton).toBeDefined();
             backButton.simulate("click");
             expect(onClose).toHaveBeenCalledOnce();
             expect(onOpen).toHaveBeenCalledOnce();
@@ -146,44 +146,42 @@ describe("<PanelStack>", () => {
         it("does not have the back button when only a single panel is on the stack", () => {
             panelStackWrapper = renderPanelStack({ initialPanel });
             const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.lengthOf(backButton, 0);
+            expect(backButton).toHaveLength(0);
         });
 
         it("assigns the class to TransitionGroup", () => {
             const TEST_CLASS_NAME = "TEST_CLASS_NAME";
             panelStackWrapper = renderPanelStack({ className: TEST_CLASS_NAME, initialPanel });
-            assert.isTrue(panelStackWrapper.hasClass(TEST_CLASS_NAME));
+            expect(panelStackWrapper.hasClass(TEST_CLASS_NAME)).toBe(true);
 
             const transitionGroupClassName = panelStackWrapper.findClass(TEST_CLASS_NAME).props().className;
-            assert.exists(transitionGroupClassName);
-            assert.equal(transitionGroupClassName!.indexOf(Classes.PANEL_STACK), 0);
+            expect(transitionGroupClassName).toBeDefined();
+            expect(transitionGroupClassName!.indexOf(Classes.PANEL_STACK)).toBe(0);
         });
 
         it("can render a panel without a title", () => {
             panelStackWrapper = renderPanelStack({ initialPanel: emptyTitleInitialPanel });
-            assert.exists(panelStackWrapper);
+            expect(panelStackWrapper).toBeDefined();
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
+            expect(newPanelButton).toBeDefined();
             newPanelButton.simulate("click");
 
             const backButtonWithoutTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.equal(
+            expect(
                 backButtonWithoutTitle.prop("aria-label"),
-                "Back",
                 "expected icon-only back button to have accessible label",
-            );
+            ).toBe("Back");
 
             const newPanelButtonOnNotEmpty = panelStackWrapper.find("#new-panel-button").hostNodes().at(1);
-            assert.exists(newPanelButtonOnNotEmpty);
+            expect(newPanelButtonOnNotEmpty).toBeDefined();
             newPanelButtonOnNotEmpty.simulate("click");
 
             const backButtonWithTitle = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK).hostNodes().at(1);
-            assert.equal(
+            expect(
                 backButtonWithTitle.prop("aria-label"),
-                "Back",
                 "expected icon-only back button to have accessible label",
-            );
+            ).toBe("Back");
         });
     });
 
@@ -191,16 +189,16 @@ describe("<PanelStack>", () => {
         it("can render a panel stack in controlled mode", () => {
             const stack = [initialPanel];
             panelStackWrapper = renderPanelStack({ stack });
-            assert.exists(panelStackWrapper);
+            expect(panelStackWrapper).toBeDefined();
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
+            expect(newPanelButton).toBeDefined();
             newPanelButton.simulate("click");
 
             // Expect the same panel as before since onOpen is not handled
             const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(newPanelHeader);
-            assert.equal(newPanelHeader.at(0).text(), "Test Title");
+            expect(newPanelHeader).toBeDefined();
+            expect(newPanelHeader.at(0).text()).toBe("Test Title");
         });
 
         it("can open a panel in controlled mode", () => {
@@ -211,16 +209,16 @@ describe("<PanelStack>", () => {
                 },
                 stack,
             });
-            assert.exists(panelStackWrapper);
+            expect(panelStackWrapper).toBeDefined();
 
             const newPanelButton = panelStackWrapper.find("#new-panel-button");
-            assert.exists(newPanelButton);
+            expect(newPanelButton).toBeDefined();
             newPanelButton.simulate("click");
             panelStackWrapper.setProps({ stack });
 
             const newPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(newPanelHeader);
-            assert.equal(newPanelHeader.at(0).text(), "New Panel 1");
+            expect(newPanelHeader).toBeDefined();
+            expect(newPanelHeader.at(0).text()).toBe("New Panel 1");
         });
 
         it("can render a panel stack with multiple initial panels and close one", () => {
@@ -231,20 +229,20 @@ describe("<PanelStack>", () => {
                 },
                 stack,
             });
-            assert.exists(panelStackWrapper);
+            expect(panelStackWrapper).toBeDefined();
 
             const panelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(panelHeader);
-            assert.equal(panelHeader.at(0).text(), "New Panel 1");
+            expect(panelHeader).toBeDefined();
+            expect(panelHeader.at(0).text()).toBe("New Panel 1");
 
             const backButton = panelStackWrapper.findClass(Classes.PANEL_STACK_HEADER_BACK);
-            assert.exists(backButton);
+            expect(backButton).toBeDefined();
             backButton.simulate("click");
             panelStackWrapper.setProps({ stack });
 
             const firstPanelHeader = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(firstPanelHeader);
-            assert.equal(firstPanelHeader.at(0).text(), "Test Title");
+            expect(firstPanelHeader).toBeDefined();
+            expect(firstPanelHeader.at(0).text()).toBe("Test Title");
         });
 
         it("renders only one panel by default", () => {
@@ -255,9 +253,9 @@ describe("<PanelStack>", () => {
             panelStackWrapper = renderPanelStack({ stack });
 
             const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
-            assert.exists(panelHeaders);
-            assert.lengthOf(panelHeaders, 1);
-            assert.equal(panelHeaders.at(0).text(), stack[1].title);
+            expect(panelHeaders).toBeDefined();
+            expect(panelHeaders).toHaveLength(1);
+            expect(panelHeaders.at(0).text()).toBe(stack[1].title);
         });
 
         describe("with renderActivePanelOnly={false}", () => {
@@ -269,10 +267,10 @@ describe("<PanelStack>", () => {
                 panelStackWrapper = renderPanelStack({ renderActivePanelOnly: false, stack });
 
                 const panelHeaders = panelStackWrapper.findClass(Classes.HEADING);
-                assert.exists(panelHeaders);
-                assert.lengthOf(panelHeaders, 2);
-                assert.equal(panelHeaders.at(0).text(), stack[0].title);
-                assert.equal(panelHeaders.at(1).text(), stack[1].title);
+                expect(panelHeaders).toBeDefined();
+                expect(panelHeaders).toHaveLength(2);
+                expect(panelHeaders.at(0).text()).toBe(stack[0].title);
+                expect(panelHeaders.at(1).text()).toBe(stack[1].title);
             });
 
             it("keeps panels mounted", () => {
@@ -289,9 +287,9 @@ describe("<PanelStack>", () => {
                 });
 
                 const incrementButton = panelStackWrapper.find(`[aria-label="increment"]`);
-                assert.exists(incrementButton);
+                expect(incrementButton).toBeDefined();
                 incrementButton.hostNodes().simulate("mousedown");
-                assert.equal(getFirstPanelCounterValue(), 1, "clicking increment button should increase counter");
+                expect(getFirstPanelCounterValue(), "clicking increment button should increase counter").toBe(1);
 
                 const newPanelButton = panelStackWrapper.find("#new-panel-button");
                 newPanelButton.hostNodes().simulate("click");
@@ -300,16 +298,15 @@ describe("<PanelStack>", () => {
                 const backButton = panelStackWrapper.find(`[aria-label="Back"]`);
                 backButton.hostNodes().simulate("click");
                 panelStackWrapper.setProps({ stack });
-                assert.equal(
+                expect(
                     getFirstPanelCounterValue(),
-                    1,
                     "first panel should retain its counter state when we return to it",
-                );
+                ).toBe(1);
             });
 
             function getFirstPanelCounterValue() {
                 const counterValue = panelStackWrapper.find(`[aria-label="counter value"]`);
-                assert.exists(counterValue);
+                expect(counterValue).toBeDefined();
                 return parseInt(counterValue.hostNodes().first().text().trim(), 10);
             }
         });

--- a/packages/core/src/components/resize-sensor/resizeSensor.test.tsx
+++ b/packages/core/src/components/resize-sensor/resizeSensor.test.tsx
@@ -17,16 +17,7 @@
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef } from "react";
 
-import {
-    afterAll,
-    afterEach,
-    assert,
-    describe,
-    expect,
-    it,
-    type MockInstance,
-    vi,
-} from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
 import { sleep } from "../../common/test-utils";
 
@@ -96,8 +87,8 @@ describe.skip("<ResizeSensor>", () => {
         await resize({ width: RESIZE_WIDTH });
         expect(onResize).toHaveBeenCalledOnce();
         assertResizeArgs(onResize, [`${RESIZE_WIDTH}x0`]);
-        assert.isNotNull(targetRef.current, "user-provided targetRef should be set");
-        assert.strictEqual(targetRef.current?.clientWidth, RESIZE_WIDTH, "user-provided targetRef.current.clientWidth");
+        expect(targetRef.current, "user-provided targetRef should be set").not.toBeNull();
+        expect(targetRef.current?.clientWidth, "user-provided targetRef.current.clientWidth").toBe(RESIZE_WIDTH);
     });
 
     function mountResizeSensor(props: Omit<ResizeSensorProps, "children">) {

--- a/packages/core/src/components/slider/rangeSlider.test.tsx
+++ b/packages/core/src/components/slider/rangeSlider.test.tsx
@@ -17,7 +17,7 @@
 import { mount } from "enzyme";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -41,15 +41,15 @@ describe("<RangeSlider>", () => {
 
     it("renders two interactive <Handle>s", () => {
         const handles = renderSlider(<RangeSlider />).find(Handle);
-        assert.lengthOf(handles, 2);
+        expect(handles).toHaveLength(2);
     });
 
     it.skip("renders primary track segment between two values", () => {
         const track = renderSlider(<RangeSlider value={[2, 5]} />).find(
             `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
         );
-        assert.lengthOf(track, 1);
-        assert.equal(track.getDOMNode().getBoundingClientRect().width, STEP_SIZE * 3);
+        expect(track).toHaveLength(1);
+        expect(track.getDOMNode().getBoundingClientRect().width).toBe(STEP_SIZE * 3);
     });
 
     it("throws error if range value contains null", () => {

--- a/packages/core/src/components/tag/compoundTag.test.tsx
+++ b/packages/core/src/components/tag/compoundTag.test.tsx
@@ -18,7 +18,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import { createRef } from "react";
 
-import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
@@ -27,12 +27,11 @@ import { CompoundTag } from "./compoundTag";
 
 describe("<CompoundTag>", () => {
     it("renders its text", () => {
-        assert.strictEqual(
+        expect(
             shallow(<CompoundTag leftContent="Hello">World</CompoundTag>)
                 .find(`.${Classes.COMPOUND_TAG_RIGHT_CONTENT}`)
                 .prop("children"),
-            "World",
-        );
+        ).toBe("World");
     });
 
     it("renders icons", () => {
@@ -41,7 +40,7 @@ describe("<CompoundTag>", () => {
                 World
             </CompoundTag>,
         );
-        assert.lengthOf(wrapper.find(Icon), 2);
+        expect(wrapper.find(Icon)).toHaveLength(2);
     });
 
     it("prefers endIcon to rightIcon", () => {
@@ -63,7 +62,7 @@ describe("<CompoundTag>", () => {
                 World
             </CompoundTag>,
         );
-        assert.lengthOf(wrapper.find(`.${Classes.TAG_REMOVE}`), 1);
+        expect(wrapper.find(`.${Classes.TAG_REMOVE}`)).toHaveLength(1);
     });
 
     it("clicking close button triggers onRemove", () => {
@@ -84,7 +83,7 @@ describe("<CompoundTag>", () => {
                 World
             </CompoundTag>,
         ).find(`.${Classes.COMPOUND_TAG}`);
-        assert.deepEqual(element.prop("title"), "baz qux");
+        expect(element.prop("title")).toEqual("baz qux");
     });
 
     it("passes all props to the onRemove handler", () => {
@@ -121,7 +120,7 @@ describe("<CompoundTag>", () => {
 
         // wait for the whole lifecycle to run
         await waitFor(() => {
-            assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
+            expect(elementRef.current).toBe(wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
         });
     });
 });

--- a/packages/core/src/components/tag/tag.test.tsx
+++ b/packages/core/src/components/tag/tag.test.tsx
@@ -18,7 +18,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { mount, shallow } from "enzyme";
 import { createRef } from "react";
 
-import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
@@ -28,25 +28,24 @@ import { Tag } from "./tag";
 
 describe("<Tag>", () => {
     it("renders its text", () => {
-        assert.strictEqual(
+        expect(
             shallow(<Tag>Hello</Tag>)
                 .find(Text)
                 .prop("children"),
-            "Hello",
-        );
+        ).toBe("Hello");
     });
 
     it("text is not rendered if omitted", () => {
-        assert.isFalse(
+        expect(
             shallow(<Tag icon="tick" />)
                 .find(Text)
                 .exists(),
-        );
+        ).toBe(false);
     });
 
     it("renders icons", () => {
         const wrapper = shallow(<Tag icon="tick" endIcon="airplane" />);
-        assert.lengthOf(wrapper.find(Icon), 2);
+        expect(wrapper.find(Icon)).toHaveLength(2);
     });
 
     it("prefers endIcon to rightIcon", () => {
@@ -62,7 +61,7 @@ describe("<Tag>", () => {
 
     it("renders close button when onRemove is a function", () => {
         const wrapper = mount(<Tag onRemove={vi.fn()}>Hello</Tag>);
-        assert.lengthOf(wrapper.find(`.${Classes.TAG_REMOVE}`), 1);
+        expect(wrapper.find(`.${Classes.TAG_REMOVE}`)).toHaveLength(1);
     });
 
     it("clicking close button triggers onRemove", () => {
@@ -75,7 +74,7 @@ describe("<Tag>", () => {
 
     it("should be interactive when onClick is provided", () => {
         const wrapper = mount(<Tag onClick={vi.fn()}>Hello</Tag>);
-        assert.lengthOf(wrapper.find(`.${Classes.INTERACTIVE}`), 1);
+        expect(wrapper.find(`.${Classes.INTERACTIVE}`)).toHaveLength(1);
     });
 
     it("should not be interactive when interactive={false}", () => {
@@ -84,12 +83,12 @@ describe("<Tag>", () => {
                 Hello
             </Tag>,
         );
-        assert.lengthOf(wrapper.find(`.${Classes.INTERACTIVE}`), 0);
+        expect(wrapper.find(`.${Classes.INTERACTIVE}`)).toHaveLength(0);
     });
 
     it(`passes other props onto .${Classes.TAG} element`, () => {
         const element = shallow(<Tag title="baz qux">Hello</Tag>).find("." + Classes.TAG);
-        assert.deepEqual(element.prop("title"), "baz qux");
+        expect(element.prop("title")).toEqual("baz qux");
     });
 
     it("passes all props to the onRemove handler", () => {
@@ -118,7 +117,7 @@ describe("<Tag>", () => {
 
         // wait for the whole lifecycle to run
         await waitFor(() => {
-            assert.equal(elementRef.current, wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
+            expect(elementRef.current).toBe(wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
         });
     });
 });


### PR DESCRIPTION
## Summary

Replace `assert.*` calls with` expect()` equivalents across test files in `packages/core`

## Motivation

This is a follow-up to https://github.com/palantir/blueprint/pull/7760. That PR replaced mocking utilities but left many assert (Chai-style) calls in place. This PR standardizes on `expect` for a few reasons:

1. **Consistency** - one assertion style to use across the entire test suite
2. **Compatibility with jest-dom** - [`@testing-library/jest-dom`](https://github.com/testing-library/jest-dom) extends expect with DOM-specific matchers (e.g. `toBeInTheDocument`, `toHaveClass`). Using `expect` everywhere lets us adopt these incrementally.
3. **Alignment with React Testing Library** - RTL docs and examples use `expect`. Matching that convention reduces friction as we migrate away from Enzyme.