### PR TITLE
fix(select): prevent scroll-into-view on mouse click at scroll edges

### DIFF
--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -366,11 +366,17 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
         }
     }
 
-    public setActiveItem(activeItem: T | CreateNewItem | null) {
+    public setActiveItem(activeItem: T | CreateNewItem | null, shouldScrollIntoView = true) {
         this.expectedNextActiveItem = activeItem;
         if (this.props.activeItem === undefined) {
             // indicate that the active item may need to be scrolled into view after update.
-            this.shouldCheckActiveItemInViewport = true;
+            // when the active item change is triggered by a mouse/focus event (e.g. clicking
+            // or hovering over a partially visible item at the edge of a scrollable menu),
+            // we skip scrolling to prevent the item from moving out from under the cursor
+            // between mousedown and mouseup, which would cause the click to not register.
+            if (shouldScrollIntoView) {
+                this.shouldCheckActiveItemInViewport = true;
+            }
             this.setState({ activeItem });
         }
 
@@ -418,7 +424,7 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
 
             return this.props.itemRenderer(item, {
                 handleClick: e => this.handleItemSelect(item, e),
-                handleFocus: () => this.setActiveItem(item),
+                handleFocus: () => this.setActiveItem(item, false),
                 id: itemId,
                 index,
                 modifiers,
@@ -504,7 +510,7 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
     };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
-        this.setActiveItem(item);
+        this.setActiveItem(item, false);
         this.props.onItemSelect?.(item, event);
         this.maybeResetQuery();
     };


### PR DESCRIPTION
## Fixes #6655

### Problem

When clicking the first or last item in a scrollable `Select` menu (items that are partially visible at the scroll edges), the first click does not register as a selection. The item receives the active/highlighted style but is not actually selected.

### Root cause

When a user clicks a partially visible menu item:

1. The browser fires a `focus` event on the item
2. The `handleFocus` callback calls `setActiveItem()`, which sets `shouldCheckActiveItemInViewport = true`
3. On re-render, `componentDidUpdate` schedules `scrollActiveItemIntoView()` via `requestAnimationFrame`
4. The scroll adjusts the menu position, moving the DOM element out from under the cursor
5. The `mouseup` event fires on a different position than `mousedown`, so the browser does not dispatch a `click` event on the intended item

This means the item appears selected (blue highlight) but `onItemSelect` is never called.

### Fix

Added an optional `shouldScrollIntoView` parameter (default `true`) to `setActiveItem()`:

- **Mouse-initiated changes** (`handleFocus` from hover/click, `handleItemSelect` from click) pass `false` — no scroll adjustment needed since the user already sees and interacted with the item
- **Keyboard-initiated changes** (arrow key navigation via `handleKeyDown`) continue to pass `true` (the default) — scroll adjustment is needed to keep the active item visible

This is a minimal, backward-compatible change. The new parameter defaults to `true`, so all existing callers (including `Suggest.maybeResetActiveItemToSelectedItem()` and `setQuery()`) continue to work as before.

### Changelog

- `@blueprintjs/select`: Fixed `Select` not registering clicks on partially visible items at the edges of scrollable menus

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*