### PR TITLE
[labs] Add individual `flexGrow`, `flexShrink`, & `flexBasis` support to Box component

### DIFF
--- a/packages/labs/src/components/box/_box.scss
+++ b/packages/labs/src/components/box/_box.scss
@@ -370,6 +370,49 @@ $relative-sizes: (
     flex: none;
   }
 
+  // flex-grow
+  &.#{bp.$ns}-flex-grow-0 {
+    flex-grow: 0;
+  }
+
+  &.#{bp.$ns}-flex-grow-1 {
+    flex-grow: 1;
+  }
+
+  // flex-shrink
+  &.#{bp.$ns}-flex-shrink-0 {
+    flex-shrink: 0;
+  }
+
+  &.#{bp.$ns}-flex-shrink-1 {
+    flex-shrink: 1;
+  }
+
+  // flex-basis
+  &.#{bp.$ns}-flex-basis-auto {
+    flex-basis: auto;
+  }
+
+  &.#{bp.$ns}-flex-basis-0 {
+    flex-basis: 0%;
+  }
+
+  &.#{bp.$ns}-flex-basis-25 {
+    flex-basis: 25%;
+  }
+
+  &.#{bp.$ns}-flex-basis-50 {
+    flex-basis: 50%;
+  }
+
+  &.#{bp.$ns}-flex-basis-75 {
+    flex-basis: 75%;
+  }
+
+  &.#{bp.$ns}-flex-basis-100 {
+    flex-basis: 100%;
+  }
+
   // flex-direction
   &.#{bp.$ns}-flex-row {
     flex-direction: row;

--- a/packages/labs/src/components/box/box.md
+++ b/packages/labs/src/components/box/box.md
@@ -32,7 +32,7 @@ Box supports a wide range of layout props that map to CSS properties:
 -   **Spacing**: `margin`, `padding` and their logical variants
 -   **Positioning**: `position`, `inset` and their logical variants
 -   **Sizing**: `width`, `height`
--   **Flexbox**: `display`, `flex`, `flexDirection`, `flexWrap`, `gap`
+-   **Flexbox**: `display`, `flex`, `flexGrow`, `flexShrink`, `flexBasis`, `flexDirection`, `flexWrap`, `gap`
 -   **Alignment**: `alignItems`, `alignContent`, `alignSelf`, `justifyContent`, `justifyItems`, `justifySelf`
 -   **Overflow**: `overflow`, `overflowX`, `overflowY`
 

--- a/packages/labs/src/components/box/box.test.tsx
+++ b/packages/labs/src/components/box/box.test.tsx
@@ -62,6 +62,19 @@ describe("<Box>", () => {
         expect(box).toHaveClass(`${NS}-margin-2`);
     });
 
+    test("should support flexGrow, flexShrink, and flexBasis props", () => {
+        render(
+            <Box flexGrow={1} flexShrink={0} flexBasis={0}>
+                Test
+            </Box>,
+        );
+        const box = screen.getByText<HTMLDivElement>(/test/i);
+
+        expect(box).toHaveClass(`${NS}-flex-grow-1`);
+        expect(box).toHaveClass(`${NS}-flex-shrink-0`);
+        expect(box).toHaveClass(`${NS}-flex-basis-0`);
+    });
+
     test("should attach ref", () => {
         const ref = createRef<HTMLDivElement>();
         render(<Box ref={ref}>Test</Box>);

--- a/packages/labs/src/components/box/boxProps.ts
+++ b/packages/labs/src/components/box/boxProps.ts
@@ -130,6 +130,32 @@ export type Display =
 export type Flex = 1 | "1" | "auto" | "initial" | "none";
 
 /**
+ * The range of values shared by `flex-grow` and `flex-shrink`.
+ */
+type FlexGrowShrinkRange = 0 | 1;
+
+/**
+ * The range of values for `flex-grow`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-grow
+ */
+export type FlexGrow = FlexGrowShrinkRange | `${FlexGrowShrinkRange}`;
+
+/**
+ * The range of values for `flex-shrink`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
+ */
+export type FlexShrink = FlexGrowShrinkRange | `${FlexGrowShrinkRange}`;
+
+/**
+ * The range of values for `flex-basis`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis
+ */
+export type FlexBasis = "auto" | 0 | "0" | SizeRange | `${SizeRange}`;
+
+/**
  * The range of values for `flex-direction`.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction
@@ -306,6 +332,12 @@ export interface BoxProps extends React.ComponentPropsWithoutRef<"div"> {
     display?: Display;
     /** CSS `flex` (shorthand for `flex-grow`, `flex-shrink`, `flex-basis`) */
     flex?: Flex;
+    /** CSS `flex-grow` */
+    flexGrow?: FlexGrow;
+    /** CSS `flex-shrink` */
+    flexShrink?: FlexShrink;
+    /** CSS `flex-basis` */
+    flexBasis?: FlexBasis;
     /** CSS `flex-direction` */
     flexDirection?: FlexDirection;
     /** CSS `flex-wrap` */

--- a/packages/labs/src/components/box/buildStyles.ts
+++ b/packages/labs/src/components/box/buildStyles.ts
@@ -12,7 +12,10 @@ import type {
     AlignSelf,
     Display,
     Flex,
+    FlexBasis,
     FlexDirection,
+    FlexGrow,
+    FlexShrink,
     FlexWrap,
     Gap,
     Height,
@@ -179,6 +182,10 @@ const flex = mapping<Flex>({
     none: "flex-none",
 });
 
+const flexGrow = appendValue<FlexGrow>("flex-grow");
+const flexShrink = appendValue<FlexShrink>("flex-shrink");
+const flexBasis = appendValue<FlexBasis>("flex-basis");
+
 const flexDirection = mapping<FlexDirection>({
     row: "flex-row",
     "row-reverse": "flex-row-reverse",
@@ -295,6 +302,9 @@ const styles: Record<string, (value: any) => string> = {
     alignSelf,
     display,
     flex,
+    flexGrow,
+    flexShrink,
+    flexBasis,
     flexDirection,
     flexWrap,
     justifyContent,

--- a/packages/labs/src/components/flex/flex.md
+++ b/packages/labs/src/components/flex/flex.md
@@ -23,7 +23,7 @@ Flex supports all Box props except `display`, with common flexbox patterns:
 -   **Direction & Wrap**: `flexDirection`, `flexWrap`
 -   **Alignment**: `alignItems`, `alignContent`, `justifyContent`
 -   **Gap**: `gap` for spacing between items
--   **Child control**: `flex` for flex grow/shrink behavior
+-   **Child control**: `flex` shorthand, or individual `flexGrow`, `flexShrink`, `flexBasis`
 
 Each prop accepts Blueprint token values for consistent spacing and sizing.
 


### PR DESCRIPTION
## Summary
- Adds `flexGrow`, `flexShrink`, and `flexBasis` props to `BoxProps`, giving consumers more granular control over flex-item behavior beyond the existing flex shorthand
- The existing `flex` shorthand (`1 | "auto" | "initial" | "none"`) is unchanged; the new props complement it for cases that require individual property control
- Motivated by feedback: teams migrating from custom flex layout components need to express combinations like `flexGrow={1} flexShrink={0} flexBasis={0}` that can't be represented with shorthand presets

### Accepted values
| Prop | Values |
|--------|--------|
| `flexGrow` | `0 \| 1` |
| `flexShrink` | `0 \| 1` |
| `flexBasis` | `"auto" \| 0 \| 25 \| 50 \| 75 \| 100` (percentages, matching `SizeRange`) | 

All props accept both number and string forms (e.g. `flexGrow={1}` or `flexGrow="1"`), consistent with the existing spacing/sizing prop convention.

### Test plan
- [x]  Add test verifying the new props generate correct CSS class names
- [x]  Verify existing Box/Flex tests still pass (`pnpm --filter labs test`)
- [x]  Verify TypeScript compiles without errors (`pnpm --filter labs compile`)
- [ ]  Visual check: confirm new SCSS classes render correctly in a dev example