### PR TITLE
[icons] Remove `defaultProps` from generated icon components

### DIFF
--- a/packages/icons/scripts/iconComponent.tsx.hbs
+++ b/packages/icons/scripts/iconComponent.tsx.hbs
@@ -19,12 +19,12 @@ import { IconSize } from "../../iconTypes";
 import { SVGIconContainer } from "../../svgIconContainer";
 
 export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>((props, ref) => {
-    const isLarge = props.size! >= IconSize.LARGE;
+    const isLarge = (props.size ?? IconSize.STANDARD) >= IconSize.LARGE;
     const pixelGridSize = isLarge ? IconSize.LARGE : IconSize.STANDARD;
     const translation = `${-1 * pixelGridSize / {{pathScaleFactor}} / 2}`;
     const style = { transformOrigin: "center" };
     return (
-        <SVGIconContainer iconName="{{iconName}}" ref={ref}  {...props}>
+        <SVGIconContainer iconName="{{iconName}}" ref={ref} {...props}>
             <path
                 d={isLarge ? "{{icon20pxPath}}" : "{{icon16pxPath}}"}
                 fillRule="evenodd"
@@ -34,8 +34,5 @@ export const {{pascalCase iconName}}: React.FC<SVGIconProps> = React.forwardRef<
         </SVGIconContainer>
    );
 });
-{{pascalCase iconName}}.defaultProps = {
-    size: IconSize.STANDARD,
-};
 {{pascalCase iconName}}.displayName = `Blueprint6.Icon.{{pascalCase iconName}}`;
 export default {{pascalCase iconName}};


### PR DESCRIPTION
## Summary

- Remove `defaultProps` from generated SVG icon components for React 19 compatibility. 
- The `defaultProps` on function components was [deprecated in React 18.3 and removed in React 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis).

### Example diff for a generated icon component

```diff
 export const AddChild: React.FC<SVGIconProps> = React.forwardRef<any, SVGIconProps>((props, ref) => {
-    const isLarge = props.size! >= IconSize.LARGE;
+    const isLarge = (props.size ?? IconSize.STANDARD) >= IconSize.LARGE;
     const pixelGridSize = isLarge ? IconSize.LARGE : IconSize.STANDARD;
     // ...
 });
-AddChild.defaultProps = {
-    size: IconSize.STANDARD,
-};
 AddChild.displayName = `Blueprint6.Icon.AddChild`;
```