### PR TITLE
[core] Add nodeRef to PanelStack CSSTransition for React 19 compat

### DIFF
--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { useCallback, useMemo, useState } from "react";
+import { createRef, useCallback, useMemo, useRef, useState } from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
@@ -107,6 +107,18 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
     const prevStackLength = usePrevious(stack.length) ?? stack.length;
     const direction = stack.length - prevStackLength < 0 ? "pop" : "push";
 
+    // Map of CSSTransition key -> RefObject for the PanelView root DOM node.
+    // Each CSSTransition needs its own nodeRef to avoid ReactDOM.findDOMNode() usage.
+    const panelNodeRefs = useRef<Map<number, React.RefObject<HTMLDivElement>>>(new Map());
+    const getOrCreatePanelRef = useCallback((key: number): React.RefObject<HTMLDivElement> => {
+        let ref = panelNodeRefs.current.get(key);
+        if (ref == null) {
+            ref = createRef<HTMLDivElement>();
+            panelNodeRefs.current.set(key, ref);
+        }
+        return ref;
+    }, []);
+
     const handlePanelOpen = useCallback(
         (panel: T) => {
             onOpen?.(panel);
@@ -142,13 +154,15 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
             // second one, active changes only when the panel becomes or stops being active.
             const layer = stack.length - index;
             const key = renderActivePanelOnly ? stack.length : layer;
+            const panelRef = getOrCreatePanelRef(key);
 
             return (
-                <CSSTransition classNames={Classes.PANEL_STACK} key={key} timeout={400}>
+                <CSSTransition classNames={Classes.PANEL_STACK} key={key} nodeRef={panelRef} timeout={400}>
                     <PanelView<T>
                         onClose={handlePanelClose}
                         onOpen={handlePanelOpen}
                         panel={panel}
+                        panelNodeRef={panelRef}
                         previousPanel={stack[index + 1]}
                         showHeader={showPanelHeader}
                     />

--- a/packages/core/src/components/panel-stack/panelStack.tsx
+++ b/packages/core/src/components/panel-stack/panelStack.tsx
@@ -82,6 +82,11 @@ interface PanelStackComponent {
     displayName: string;
 }
 
+interface PanelNodeEntry {
+    ref: React.RefObject<HTMLDivElement>;
+    onExited: () => void;
+}
+
 /**
  * Panel stack component.
  *
@@ -107,16 +112,19 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
     const prevStackLength = usePrevious(stack.length) ?? stack.length;
     const direction = stack.length - prevStackLength < 0 ? "pop" : "push";
 
-    // Map of CSSTransition key -> RefObject for the PanelView root DOM node.
+    // Map of CSSTransition key -> PanelNodeEntry for each PanelView root DOM node.
     // Each CSSTransition needs its own nodeRef to avoid ReactDOM.findDOMNode() usage.
-    const panelNodeRefs = useRef<Map<number, React.RefObject<HTMLDivElement>>>(new Map());
-    const getOrCreatePanelRef = useCallback((key: number): React.RefObject<HTMLDivElement> => {
-        let ref = panelNodeRefs.current.get(key);
-        if (ref == null) {
-            ref = createRef<HTMLDivElement>();
-            panelNodeRefs.current.set(key, ref);
+    const panelNodes = useRef<Map<number, PanelNodeEntry>>(new Map());
+    const getOrCreatePanelNode = useCallback((key: number): PanelNodeEntry => {
+        let entry = panelNodes.current.get(key);
+        if (entry == null) {
+            entry = {
+                onExited: () => panelNodes.current.delete(key),
+                ref: createRef<HTMLDivElement>(),
+            };
+            panelNodes.current.set(key, entry);
         }
-        return ref;
+        return entry;
     }, []);
 
     const handlePanelOpen = useCallback(
@@ -154,10 +162,16 @@ export const PanelStack: PanelStackComponent = <T extends Panel<object>>(props: 
             // second one, active changes only when the panel becomes or stops being active.
             const layer = stack.length - index;
             const key = renderActivePanelOnly ? stack.length : layer;
-            const panelRef = getOrCreatePanelRef(key);
+            const { onExited, ref: panelRef } = getOrCreatePanelNode(key);
 
             return (
-                <CSSTransition classNames={Classes.PANEL_STACK} key={key} nodeRef={panelRef} timeout={400}>
+                <CSSTransition
+                    classNames={Classes.PANEL_STACK}
+                    key={key}
+                    nodeRef={panelRef}
+                    onExited={onExited}
+                    timeout={400}
+                >
                     <PanelView<T>
                         onClose={handlePanelClose}
                         onOpen={handlePanelOpen}

--- a/packages/core/src/components/panel-stack/panelView.tsx
+++ b/packages/core/src/components/panel-stack/panelView.tsx
@@ -38,6 +38,9 @@ export interface PanelViewProps<T extends Panel<object>> {
     /** The panel to be displayed. */
     panel: T;
 
+    /** Ref to the root DOM element, used by PanelStack to provide `nodeRef` to CSSTransition. */
+    panelNodeRef?: React.Ref<HTMLDivElement>;
+
     /** The previous panel in the stack, for rendering the "back" button. */
     previousPanel?: T;
 
@@ -54,6 +57,7 @@ export const PanelView: PanelViewComponent = <T extends Panel<object>>({
     panel,
     onClose,
     onOpen,
+    panelNodeRef,
     previousPanel,
     showHeader,
 }: PanelViewProps<T>) => {
@@ -97,7 +101,7 @@ export const PanelView: PanelViewComponent = <T extends Panel<object>>({
     );
 
     return (
-        <div className={Classes.PANEL_STACK_VIEW}>
+        <div className={Classes.PANEL_STACK_VIEW} ref={panelNodeRef}>
             {showHeader && (
                 <div className={Classes.PANEL_STACK_HEADER}>
                     {/* two <span> tags here ensure title is centered as long as possible, with `flex: 1` styling */}


### PR DESCRIPTION
## Problem
`PanelStack` uses `CSSTransition` from `react-transition-group` without passing a `nodeRef` prop. When `nodeRef` is absent, `CSSTransition` falls back to `ReactDOM.findDOMNode()` to locate the DOM node for applying transition classes. This is [deprecated in React 18 strict mode and removed entirely in React 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-reactdom-finddomnode), which will cause PanelStack transitions to break.

This is the same root cause that motivated the Overlay → Overlay2 migration (#3979, #6656), but PanelStack was never given the same treatment.

This issue was discovered while working on https://github.com/palantir/blueprint/pull/7801

## Fix

Add a `panelNodeRef` prop to the internal `PanelView` component (attached to its root `<div>`) and pass it as `nodeRef` to each `CSSTransition` (same pattern used in the Overlay2 migration).

## Reviewers should focus on

- [ ] No regressions to PanelStack behavior