### PR TITLE
[docs] Update datetime link in docs

### DIFF
--- a/packages/datetime/src/components/date-range-input/date-range-input.md
+++ b/packages/datetime/src/components/date-range-input/date-range-input.md
@@ -28,7 +28,7 @@ dates entered in the text inputs.
 @## Date formatting
 
 You may customize the date display format with the required `formatDate` and `parseDate` props.
-See [DateInput's date formatting docs](#datetime3/date-input.date-formatting) for more details.
+See [DateInput's date formatting docs](#datetime/date-input.date-formatting) for more details.
 
 @## Props interface
 


### PR DESCRIPTION
#### Part of https://github.com/palantir/blueprint/issues/7293

#### Checklist

-   [ ] Includes tests
-   [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

[This PR](https://github.com/palantir/blueprint/pull/7372) which removed `datetime2` docs also changed all links to `/datetime2` or `/datetime3` into `/datetime`. The change missed a line where a link to `/datetime3` was kept around, and currently leads to nothing.

#### Reviewers should focus on:

Link to date formatting docs on the `DateRangeInput` page leads to the correct place
