### PR TITLE
[docs] Fix latest version link in dropdown

### DIFF
--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -97,7 +97,7 @@ export class NavHeader extends PureComponent<NavHeaderProps> {
                         intent = "primary";
                     }
                 } else {
-                    href = v === currentVersion ? "/docs" : `/docs/versions/${major(v)}`;
+                    href = major(v) === major(currentVersion) ? "/docs" : `/docs/versions/${major(v)}`;
                 }
                 return <MenuItem href={href} intent={intent} key={v} text={v} />;
             });


### PR DESCRIPTION
#### Checklist

-   [ ] Includes tests
-   [x] Update documentation

#### Changes proposed in this pull request:

The version dropdown links to `/docs/versions/6` (404) instead of `/docs` because the versions list from npm can lag behind the local package.json version (see [documentalist](https://github.com/palantir/documentalist/blob/develop/packages/compiler/src/plugins/npm.ts#L69) npm extension), causing the exact string comparison to fail. Fix by comparing major versions instead.

#### Reviewers should focus on:

Link to latest version from the dropdown should take you to `/docs`

#### Screenshot

Before

https://github.com/user-attachments/assets/76791f14-6b28-4b2d-8e0b-52e894a07b87

After

https://github.com/user-attachments/assets/8411051a-0169-417a-bc91-6eb8a801b940