### PR TITLE
[core] Allow `className` to be passed to PopoverNext target

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -116,6 +116,17 @@ describe("<PopoverNext>", () => {
     });
 
     describe("rendering", () => {
+        it("applies className to the target wrapper element", () => {
+            const { container } = render(
+                <PopoverNext className="my-custom-class" content="content">
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+            const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+
+            expect(popoverTarget).toHaveClass("my-custom-class");
+        });
+
         it("adds POPOVER_OPEN class to target when the popover is open", async () => {
             const user = userEvent.setup();
             const { container } = render(

--- a/packages/core/src/components/popover-next/popoverNextProps.ts
+++ b/packages/core/src/components/popover-next/popoverNextProps.ts
@@ -74,6 +74,11 @@ export interface PopoverNextProps<T extends DefaultPopoverTargetHTMLProps = Defa
     /** Whether the popover can be closed by pressing the Escape key. */
     canEscapeKeyClose?: boolean;
 
+    /**
+     * A space-delimited string of class names applied to the popover's target wrapper element.
+     */
+    className?: string;
+
     /** Interactive element which will trigger the popover. */
     children?: React.ReactNode;
 


### PR DESCRIPTION
## Summary

Follow up to #7573

- Add `className` prop to `PopoverNext` for parity with legacy `Popover`
- The className is applied to the target wrapper element, matching the legacy behavior
- `PopoverTarget` already supported this internally; this change exposes it on the public API

## Test plan
- Added unit test verifying `className` is applied to the target wrapper element