### PR TITLE
[core] Add migration utilities for `Popover` → `PopoverNext`

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -92,6 +92,10 @@ export type {
     PopoverNextRootBoundary,
 } from "./popover-next/popoverNextProps";
 export { PopoverNext, type PopoverNextRef } from "./popover-next/popoverNext";
+export {
+    popoverPositionToNextPlacement,
+    popperModifiersToNextMiddleware,
+} from "./popover-next/popoverNextMigrationUtils";
 export type {
     DefaultPopoverTargetHTMLProps,
     PopoverSharedProps,

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -1,0 +1,268 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+
+import type { MiddlewareConfig } from "../..";
+import { PopoverPosition } from "../popover/popoverPosition";
+import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
+
+import { popoverPositionToNextPlacement, popperModifiersToNextMiddleware } from "./popoverNextMigrationUtils";
+
+describe("popoverPositionToNextPlacement", () => {
+    it("should convert top-left to top-start", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)).to.equal("top-start");
+    });
+
+    it("should convert top to top", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.TOP)).to.equal("top");
+    });
+
+    it("should convert top-right to top-end", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.TOP_RIGHT)).to.equal("top-end");
+    });
+
+    it("should convert right-top to right-start", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.RIGHT_TOP)).to.equal("right-start");
+    });
+
+    it("should convert right to right", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.RIGHT)).to.equal("right");
+    });
+
+    it("should convert right-bottom to right-end", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.RIGHT_BOTTOM)).to.equal("right-end");
+    });
+
+    it("should convert bottom-right to bottom-end", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.BOTTOM_RIGHT)).to.equal("bottom-end");
+    });
+
+    it("should convert bottom to bottom", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.BOTTOM)).to.equal("bottom");
+    });
+
+    it("should convert bottom-left to bottom-start", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.BOTTOM_LEFT)).to.equal("bottom-start");
+    });
+
+    it("should convert left-bottom to left-end", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.LEFT_BOTTOM)).to.equal("left-end");
+    });
+
+    it("should convert left to left", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.LEFT)).to.equal("left");
+    });
+
+    it("should convert left-top to left-start", () => {
+        expect(popoverPositionToNextPlacement(PopoverPosition.LEFT_TOP)).to.equal("left-start");
+    });
+
+    it("should return undefined for auto", () => {
+        expect(popoverPositionToNextPlacement("auto")).to.be.undefined;
+    });
+
+    it("should return undefined for auto-start", () => {
+        expect(popoverPositionToNextPlacement("auto-start")).to.be.undefined;
+    });
+
+    it("should return undefined for auto-end", () => {
+        expect(popoverPositionToNextPlacement("auto-end")).to.be.undefined;
+    });
+});
+
+describe("popperModifiersToNextMiddleware", () => {
+    it("should return empty config when given empty modifiers", () => {
+        expect(popperModifiersToNextMiddleware({})).to.deep.equal({});
+    });
+
+    describe("flip", () => {
+        it("should omit flip middleware when enabled is false", () => {
+            const value: PopperModifierOverrides = { flip: { enabled: false } };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map flip modifier to flip middleware", () => {
+            const value: PopperModifierOverrides = { flip: {} };
+            const expected: MiddlewareConfig = { flip: {} };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map flip padding option", () => {
+            const value: PopperModifierOverrides = { flip: { options: { padding: 8 } } };
+            const expected: MiddlewareConfig = { flip: { padding: 8 } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map flip fallbackPlacements option", () => {
+            const value: PopperModifierOverrides = { flip: { options: { fallbackPlacements: ["top", "bottom"] } } };
+            const expected: MiddlewareConfig = { flip: { fallbackPlacements: ["top", "bottom"] } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map flip flipVariations to flipAlignment", () => {
+            const value: PopperModifierOverrides = { flip: { options: { flipVariations: false } } };
+            const expected: MiddlewareConfig = { flip: { flipAlignment: false } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map flip mainAxis option", () => {
+            const value: PopperModifierOverrides = { flip: { options: { mainAxis: false } } };
+            const expected: MiddlewareConfig = { flip: { mainAxis: false } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map flip altAxis to crossAxis", () => {
+            const value: PopperModifierOverrides = { flip: { options: { altAxis: false } } };
+            const expected: MiddlewareConfig = { flip: { crossAxis: false } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+    });
+
+    describe("preventOverflow", () => {
+        it("should omit shift middleware when enabled is false", () => {
+            const value: PopperModifierOverrides = { preventOverflow: { enabled: false } };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map preventOverflow modifier to shift middleware", () => {
+            const value: PopperModifierOverrides = { preventOverflow: {} };
+            const expected: MiddlewareConfig = { shift: {} };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map preventOverflow padding option", () => {
+            const value: PopperModifierOverrides = { preventOverflow: { options: { padding: 4 } } };
+            const expected: MiddlewareConfig = { shift: { padding: 4 } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map preventOverflow mainAxis option", () => {
+            const value: PopperModifierOverrides = { preventOverflow: { options: { mainAxis: false } } };
+            const expected: MiddlewareConfig = { shift: { mainAxis: false } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map preventOverflow altAxis to crossAxis", () => {
+            const value: PopperModifierOverrides = { preventOverflow: { options: { altAxis: true } } };
+            const expected: MiddlewareConfig = { shift: { crossAxis: true } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+    });
+
+    describe("offset", () => {
+        it("should omit offset middleware when enabled is false", () => {
+            const value: PopperModifierOverrides = { offset: { enabled: false, options: { offset: [0, 10] } } };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map offset [skidding, distance] tuple to { crossAxis, mainAxis }", () => {
+            const value: PopperModifierOverrides = { offset: { options: { offset: [5, 10] } } };
+            const expected: MiddlewareConfig = { offset: { crossAxis: 5, mainAxis: 10 } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map offset [0, distance] tuple with zero skidding", () => {
+            const value: PopperModifierOverrides = { offset: { options: { offset: [0, 15] } } };
+            const expected: MiddlewareConfig = { offset: { crossAxis: 0, mainAxis: 15 } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should warn and omit offset when offset is a function", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const value: PopperModifierOverrides = { offset: { options: { offset: () => [0, 0] } } };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
+
+        it("should omit offset from result when no offset options provided", () => {
+            const value: PopperModifierOverrides = { offset: {} };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+    });
+
+    describe("arrow", () => {
+        it("should omit arrow middleware when enabled is false", () => {
+            const element = document.createElement("div");
+            const value: PopperModifierOverrides = { arrow: { enabled: false, options: { element } } };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map arrow modifier with element to arrow middleware", () => {
+            const element = document.createElement("div");
+            const value: PopperModifierOverrides = { arrow: { options: { element } } };
+            const expected: MiddlewareConfig = { arrow: { element } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map arrow padding option", () => {
+            const element = document.createElement("div");
+            const value: PopperModifierOverrides = { arrow: { options: { element, padding: 5 } } };
+            const expected: MiddlewareConfig = { arrow: { element, padding: 5 } };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should omit arrow from result when no element provided", () => {
+            const value: PopperModifierOverrides = { arrow: {} };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+    });
+
+    describe("hide", () => {
+        it("should omit hide middleware when enabled is false", () => {
+            const value: PopperModifierOverrides = { hide: { enabled: false } };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should map hide modifier to hide middleware", () => {
+            const value: PopperModifierOverrides = { hide: {} };
+            const expected: MiddlewareConfig = { hide: {} };
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+    });
+
+    describe("ignored modifiers", () => {
+        it("should not map computeStyles", () => {
+            const value: PopperModifierOverrides = { computeStyles: {} };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should not map eventListeners", () => {
+            const value: PopperModifierOverrides = { eventListeners: {} };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+
+        it("should not map popperOffsets", () => {
+            const value: PopperModifierOverrides = { popperOffsets: {} };
+            const expected: MiddlewareConfig = {};
+            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        });
+    });
+
+    it("should handle multiple modifiers together", () => {
+        const value: PopperModifierOverrides = {
+            flip: { options: { padding: 8 } },
+            hide: { enabled: false },
+            offset: { options: { offset: [0, 10] } },
+            preventOverflow: { options: { padding: 4 } },
+        };
+        const expected: MiddlewareConfig = {
+            flip: { padding: 8 },
+            offset: { crossAxis: 0, mainAxis: 10 },
+            shift: { padding: 4 },
+        };
+        expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+    });
+});

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -1,0 +1,129 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { positionToPlacement } from "../popover/popoverPlacementUtils";
+import { type PopoverPosition } from "../popover/popoverPosition";
+import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
+
+import type { MiddlewareConfig, PopoverNextPlacement } from "./middlewareTypes";
+
+/**
+ * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
+ *
+ * The `position` prop is not supported in `PopoverNext`; use the `placement` prop instead.
+ * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent — they return `undefined`,
+ * which causes `PopoverNext` to use its default automatic placement behavior.
+ *
+ * @example
+ * // Before (Popover)
+ * <Popover position={PopoverPosition.TOP_LEFT} />
+ *
+ * // After (PopoverNext)
+ * <PopoverNext placement={popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)} />
+ */
+export function popoverPositionToNextPlacement(position: PopoverPosition): PopoverNextPlacement | undefined {
+    switch (position) {
+        case "auto":
+        case "auto-start":
+        case "auto-end":
+            // PopoverNext uses autoPlacement middleware by default when placement is undefined.
+            return undefined;
+        default:
+            // positionToPlacement handles all remaining PopoverPosition values.
+            // The string literal values it returns are identical to PopoverNextPlacement.
+            return positionToPlacement(position) as PopoverNextPlacement;
+    }
+}
+
+/**
+ * Converts Popper.js v2 `modifiers` (used by `Popover`) to a Floating UI `MiddlewareConfig` (used by `PopoverNext`).
+ *
+ * The `modifiers` prop is not supported in `PopoverNext`; use the `middleware` prop instead.
+ *
+ * Modifier → middleware mappings:
+ * - `flip` → `flip`
+ * - `preventOverflow` → `shift` (Floating UI's equivalent "keep within boundary" concept)
+ * - `offset` → `offset` (tuple `[skidding, distance]` is converted to `{ crossAxis, mainAxis }`)
+ * - `arrow` → `arrow`
+ * - `hide` → `hide`
+ * - `computeStyles`, `eventListeners`, `popperOffsets` are not mapped (handled internally by Floating UI)
+ *
+ * **Note on offset:** If the Popper.js `offset` option is a function, it cannot be automatically
+ * converted and will be omitted with a console warning. Migrate it manually to a
+ * `{ mainAxis, crossAxis }` object in the `middleware` prop.
+ *
+ * @example
+ * // Before (Popover)
+ * <Popover modifiers={{ flip: { options: { padding: 8 } }, preventOverflow: { options: { padding: 4 } } }} />
+ *
+ * // After (PopoverNext)
+ * <PopoverNext middleware={popperModifiersToNextMiddleware({ flip: { options: { padding: 8 } }, preventOverflow: { options: { padding: 4 } } })} />
+ */
+export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrides): MiddlewareConfig {
+    const middleware: MiddlewareConfig = {};
+
+    if (modifiers.flip && modifiers.flip.enabled !== false) {
+        const { options } = modifiers.flip;
+        middleware.flip = {
+            ...(options?.boundary != null ? { boundary: options.boundary as Element } : {}),
+            ...(options?.rootBoundary != null ? { rootBoundary: options.rootBoundary } : {}),
+            ...(options?.padding != null ? { padding: options.padding } : {}),
+            ...(options?.fallbackPlacements != null
+                ? { fallbackPlacements: options.fallbackPlacements as PopoverNextPlacement[] }
+                : {}),
+            ...(options?.flipVariations != null ? { flipAlignment: options.flipVariations } : {}),
+            ...(options?.mainAxis != null ? { mainAxis: options.mainAxis } : {}),
+            ...(options?.altAxis != null ? { crossAxis: options.altAxis } : {}),
+        };
+    }
+
+    if (modifiers.preventOverflow && modifiers.preventOverflow.enabled !== false) {
+        const { options } = modifiers.preventOverflow;
+        middleware.shift = {
+            ...(options?.boundary != null ? { boundary: options.boundary as Element } : {}),
+            ...(options?.rootBoundary != null ? { rootBoundary: options.rootBoundary } : {}),
+            ...(options?.padding != null ? { padding: options.padding } : {}),
+            ...(options?.mainAxis != null ? { mainAxis: options.mainAxis } : {}),
+            ...(options?.altAxis != null ? { crossAxis: options.altAxis } : {}),
+        };
+    }
+
+    if (modifiers.offset && modifiers.offset.enabled !== false) {
+        const { options } = modifiers.offset;
+        if (options?.offset != null) {
+            if (typeof options.offset === "function") {
+                console.warn(
+                    "popperModifiersToNextMiddleware: The Popper.js `offset` function cannot be automatically " +
+                        "converted to a Floating UI middleware config. Migrate it manually to a " +
+                        "`{ mainAxis, crossAxis }` object in the `middleware` prop.",
+                );
+            } else {
+                const [skidding, distance] = options.offset;
+                middleware.offset = {
+                    ...(skidding != null ? { crossAxis: skidding } : {}),
+                    ...(distance != null ? { mainAxis: distance } : {}),
+                };
+            }
+        }
+    }
+
+    if (modifiers.arrow && modifiers.arrow.enabled !== false) {
+        const { options } = modifiers.arrow;
+        // Popper.js arrow element can be HTMLElement | string | null; string selectors are not supported by Floating UI.
+        if (options?.element != null && typeof options.element !== "string") {
+            middleware.arrow = {
+                element: options.element,
+                ...(options.padding != null && typeof options.padding !== "function"
+                    ? { padding: options.padding }
+                    : {}),
+            };
+        }
+    }
+
+    if (modifiers.hide && modifiers.hide.enabled !== false) {
+        middleware.hide = {};
+    }
+
+    return middleware;
+}


### PR DESCRIPTION
## Summary

Follow up to https://github.com/palantir/blueprint/pull/7573

The `PopoverNext` component drops two props from the legacy `Popover` component: `position` and `modifiers`. This PR adds two utility functions to core to bridge those gaps and ease incremental migration.


```tsx
// Before
<Popover
    modifiers={{ flip: { options: { padding: 8 } }  }}
    position={PopoverPosition.TOP_LEFT}
/>
```

```tsx
// After
import { popoverPositionToNextPlacement, popperModifiersToNextMiddleware } from "@blueprintjs/core";

<PopoverNext
    middleware={popperModifiersToNextMiddleware({ flip: { options: { padding: 8 } } })}
    placement={popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)}
/>
```