### PR TITLE
[core] Integrating design tokens into tag

### DIFF
--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -223,7 +223,8 @@ $minimal-dark-tag-intent-colors: (
       }
     }
 
-    .#{$ns}-dark & {
+    .#{$ns}-dark &,
+    [data-bp-color-scheme="dark"] & {
       @include pt-tag-minimal-interactive(
         oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
         var(--bp-palette-white)

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -42,7 +42,7 @@ $tag-intent-colors: (
   "warning": (
     #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
     #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h)"},
-    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.21) c h)"},
+    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.20) calc(c + 0.05) h)"},
     #{"oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h)"},
   ),
   "danger": (

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -6,6 +6,8 @@
 @import "../../common/variables";
 @import "../../common/variables-extended";
 
+/* stylelint-disable alpha-value-notation */
+
 // Variables
 // ---------------------------------------------------------------------------------------------------------------------
 

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -28,74 +28,74 @@ $tag-round-adjustment: $pt-spacing * 0.5 !default;
 
 $tag-intent-colors: (
   "primary": (
-    $pt-intent-primary,
-    $blue2,
-    $blue1,
-    $white,
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
+    var(--bp-intent-primary-foreground),
   ),
   "success": (
-    $pt-intent-success,
-    $green2,
-    $green1,
-    $white,
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
+    var(--bp-intent-success-foreground),
   ),
   "warning": (
-    $orange5,
-    $orange4,
-    $orange3,
-    $pt-text-color,
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h),
+    oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h),
+    oklch(from var(--bp-intent-warning-active) calc(l + 0.21) c h),
+    oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h),
   ),
   "danger": (
-    $pt-intent-danger,
-    $red2,
-    $red1,
-    $white,
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
+    var(--bp-intent-danger-foreground),
   ),
 ) !default;
 
 $minimal-tag-intent-colors: (
   "primary": (
-    $pt-intent-primary,
-    $blue2,
-    $blue1,
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
   ),
   "success": (
-    $pt-intent-success,
-    $green2,
-    $green1,
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
   ),
   "warning": (
-    $pt-intent-warning,
-    $orange2,
-    $orange1,
+    var(--bp-intent-warning-rest),
+    var(--bp-intent-warning-hover),
+    var(--bp-intent-warning-active),
   ),
   "danger": (
-    $pt-intent-danger,
-    $red2,
-    $red1,
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
   ),
 ) !default;
 
 $minimal-dark-tag-intent-colors: (
   "primary": (
-    $pt-intent-primary,
-    $blue5,
-    $blue6,
+    var(--bp-intent-primary-rest),
+    oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h),
+    oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h),
   ),
   "success": (
-    $pt-intent-success,
-    $green5,
-    $green6,
+    var(--bp-intent-success-rest),
+    oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h),
+    oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h),
   ),
   "warning": (
-    $pt-intent-warning,
-    $orange5,
-    $orange6,
+    var(--bp-intent-warning-rest),
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h),
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h),
   ),
   "danger": (
-    $pt-intent-danger,
-    $red5,
-    $red6,
+    var(--bp-intent-danger-rest),
+    oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h),
+    oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h),
   ),
 ) !default;
 
@@ -103,19 +103,19 @@ $minimal-dark-tag-intent-colors: (
 // ---------------------------------------------------------------------------------------------------------------------
 
 @mixin pt-tag() {
-  @include pt-flex-container(row, $tag-icon-spacing, inline);
+  @include pt-flex-container(row, var(--bp-surface-spacing), inline);
   align-items: center;
-  background-color: $tag-default-color;
+  background-color: var(--bp-intent-default-rest);
   border: none;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   box-shadow: none;
-  color: $white;
-  font-size: $pt-font-size-small;
-  line-height: $tag-line-height;
+  color: var(--bp-intent-default-foreground);
+  font-size: var(--bp-typography-size-body-small);
+  line-height: calc(var(--bp-surface-spacing) * 4);
   max-width: 100%;
-  min-height: $tag-height;
-  min-width: $tag-height;
-  padding: $tag-padding-top $tag-padding;
+  min-height: calc(var(--bp-surface-spacing) * 5);
+  min-width: calc(var(--bp-surface-spacing) * 5);
+  padding: calc(var(--bp-surface-spacing) * 0.5) calc(var(--bp-surface-spacing) * 1.5);
   position: relative;
 
   // Center text for short content (e.g. single characters) only when the text
@@ -132,24 +132,24 @@ $minimal-dark-tag-intent-colors: (
     cursor: pointer;
 
     &:hover {
-      background: $dark-gray5;
+      background: var(--bp-intent-default-hover);
     }
 
     &:active,
     &.#{$ns}-active {
-      background: $dark-gray4;
+      background: var(--bp-intent-default-active);
     }
   }
 
   &.#{$ns}-round {
-    border-radius: $tag-height-large;
-    padding-left: $tag-padding + $tag-round-adjustment;
+    border-radius: calc(var(--bp-surface-spacing) * 7.5);
+    padding-left: calc(var(--bp-surface-spacing) * 2);
     // optical adjustment for rounded tags
-    padding-right: $tag-padding + $tag-round-adjustment;
+    padding-right: calc(var(--bp-surface-spacing) * 2);
   }
 
   > #{$icon-classes} {
-    fill: $white;
+    fill: var(--bp-intent-default-foreground);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -159,17 +159,17 @@ $minimal-dark-tag-intent-colors: (
 }
 
 @mixin pt-tag-large() {
-  @include pt-flex-margin(row, $tag-icon-spacing-large);
-  font-size: $pt-font-size;
-  line-height: $tag-line-height-large;
-  min-height: $tag-height-large;
-  min-width: $tag-height-large;
-  padding: ($tag-padding-large * 0.75) $tag-padding-large;
+  @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+  font-size: var(--bp-typography-size-body-medium);
+  line-height: calc(var(--bp-surface-spacing) * 4.5);
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
+  padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 2);
 
   &.#{$ns}-round {
-    padding-left: $tag-padding-large + $tag-round-adjustment;
+    padding-left: calc(var(--bp-surface-spacing) * 2.5);
     // optical adjustment for rounded tags
-    padding-right: $tag-padding-large + $tag-round-adjustment;
+    padding-right: calc(var(--bp-surface-spacing) * 2.5);
   }
 }
 
@@ -189,7 +189,7 @@ $minimal-dark-tag-intent-colors: (
   }
 
   .#{$ns}-tag-remove {
-    color: rgba($text-color, 0.7);
+    color: oklch(from $text-color l c h / 0.7);
 
     &:hover,
     &:active {
@@ -200,36 +200,42 @@ $minimal-dark-tag-intent-colors: (
 
 @mixin pt-tag-minimal() {
   > #{$icon-classes} {
-    fill: $pt-icon-color;
+    fill: var(--bp-typography-color-muted);
   }
 
   &:not([class*="#{$ns}-intent-"]) {
-    @include pt-tag-minimal-interactive($gray3, $black);
+    @include pt-tag-minimal-interactive(
+      oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
+      var(--bp-palette-black)
+    );
 
-    background-color: rgba($gray3, 0.15);
-    color: $pt-text-color;
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+    color: var(--bp-typography-color-default-rest);
 
     .#{$ns}-tag-remove {
-      color: $gray1;
+      color: var(--bp-typography-color-muted);
 
       &:hover,
       &:active {
-        color: $dark-gray5;
+        color: var(--bp-intent-default-hover);
       }
     }
 
     .#{$ns}-dark & {
-      @include pt-tag-minimal-interactive($gray3, $white);
+      @include pt-tag-minimal-interactive(
+        oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
+        var(--bp-palette-white)
+      );
 
-      background-color: rgba($gray3, 0.15);
-      color: $pt-dark-text-color;
+      background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+      color: var(--bp-typography-color-default-rest);
 
       .#{$ns}-tag-remove {
-        color: $pt-dark-icon-color;
+        color: var(--bp-typography-color-muted);
 
         &:hover,
         &:active {
-          color: $light-gray1;
+          color: var(--bp-palette-light-gray-1);
         }
       }
     }
@@ -241,20 +247,20 @@ $minimal-dark-tag-intent-colors: (
     cursor: pointer;
 
     &:hover {
-      background-color: rgba($background-color, 0.3);
+      background-color: oklch(from $background-color l c h / 0.3);
       color: $text-color;
     }
 
     &.#{$ns}-active,
     &:active {
-      background-color: rgba($background-color, 0.35);
+      background-color: oklch(from $background-color l c h / 0.35);
       color: $text-color;
     }
   }
 }
 
 @mixin pt-tag-minimal-intent($background-color, $text-color, $hover-active-text-color) {
-  background-color: rgba($background-color, 0.1);
+  background-color: oklch(from $background-color l c h / 0.1);
   color: $text-color;
 
   > #{$icon-classes} {
@@ -263,13 +269,13 @@ $minimal-dark-tag-intent-colors: (
 
   &.#{$ns}-interactive {
     &:hover {
-      background-color: rgba($background-color, 0.2);
+      background-color: oklch(from $background-color l c h / 0.2);
       color: $hover-active-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
-      background-color: rgba($background-color, 0.3);
+      background-color: oklch(from $background-color l c h / 0.3);
       color: $hover-active-text-color;
     }
   }
@@ -285,18 +291,18 @@ $minimal-dark-tag-intent-colors: (
 }
 
 @mixin pt-tag-minimal-dark-intent($background-color, $text-color, $hover-active-text-color) {
-  background-color: rgba($background-color, 0.2);
+  background-color: oklch(from $background-color l c h / 0.2);
   color: $text-color;
 
   &.#{$ns}-interactive {
     &:hover {
-      background-color: rgba($background-color, 0.3);
+      background-color: oklch(from $background-color l c h / 0.3);
       color: $hover-active-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
-      background-color: rgba($background-color, 0.35);
+      background-color: oklch(from $background-color l c h / 0.35);
       color: $hover-active-text-color;
     }
   }
@@ -314,16 +320,16 @@ $minimal-dark-tag-intent-colors: (
 @mixin pt-tag-remove() {
   background: none;
   border: none;
-  color: rgba($white, 0.7);
+  color: oklch(from var(--bp-intent-default-foreground) l c h / 0.7);
   cursor: pointer;
   display: flex;
-  margin-bottom: -$tag-padding-top;
+  margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
   /* stylelint-disable-next-line declaration-no-important */
-  margin-right: -$tag-padding !important;
+  margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
   // top/bottom to allow for padding to enlarge click area,
   // right to tuck remove button into padding space.
-  margin-top: -$tag-padding-top;
-  padding: $tag-padding-top;
+  margin-top: calc(var(--bp-surface-spacing) * -0.5);
+  padding: calc(var(--bp-surface-spacing) * 0.5);
   padding-left: 0;
 
   &:hover {
@@ -338,7 +344,7 @@ $minimal-dark-tag-intent-colors: (
 
   &:hover,
   &:active {
-    color: $white;
+    color: var(--bp-intent-default-foreground);
   }
 
   // CSS API support
@@ -349,11 +355,12 @@ $minimal-dark-tag-intent-colors: (
 
   .#{$ns}-large & {
     /* stylelint-disable-next-line declaration-no-important */
-    margin-right: -$tag-padding-large !important;
-    padding: 0 ($tag-padding-large * 0.5) 0 0;
+    margin-right: calc(var(--bp-surface-spacing) * -2) !important;
+    padding: 0 var(--bp-surface-spacing) 0 0;
 
     &:empty::before {
-      @include pt-icon-sized($pt-icon-size-large);
+      // font-family name "blueprint-icons-20" requires a compile-time value for Sass string interpolation
+      @include pt-icon-sized(calc(var(--bp-surface-spacing) * 5), 20);
     }
   }
 }
@@ -402,15 +409,31 @@ $minimal-dark-tag-intent-colors: (
 }
 
 @mixin minimal-compound-tag-colors($base-color) {
-  $left-colors: (rgba($base-color, 0.2), rgba($base-color, 0.3), rgba($base-color, 0.4));
-  $right-colors: (rgba($base-color, 0.1), rgba($base-color, 0.2), rgba($base-color, 0.3));
+  $left-colors: (
+    oklch(from $base-color l c h / 0.2),
+    oklch(from $base-color l c h / 0.3),
+    oklch(from $base-color l c h / 0.4)
+  );
+  $right-colors: (
+    oklch(from $base-color l c h / 0.1),
+    oklch(from $base-color l c h / 0.2),
+    oklch(from $base-color l c h / 0.3)
+  );
 
   @include compound-tag-colors($left-colors, $right-colors);
 }
 
 @mixin dark-minimal-compound-tag-colors($base-color) {
-  $left-colors: (rgba($base-color, 0.4), rgba($base-color, 0.5), rgba($base-color, 0.55));
-  $right-colors: (rgba($base-color, 0.2), rgba($base-color, 0.3), rgba($base-color, 0.35));
+  $left-colors: (
+    oklch(from $base-color l c h / 0.4),
+    oklch(from $base-color l c h / 0.5),
+    oklch(from $base-color l c h / 0.55)
+  );
+  $right-colors: (
+    oklch(from $base-color l c h / 0.2),
+    oklch(from $base-color l c h / 0.3),
+    oklch(from $base-color l c h / 0.35)
+  );
 
   @include compound-tag-colors($left-colors, $right-colors);
 }

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -6,8 +6,6 @@
 @import "../../common/variables";
 @import "../../common/variables-extended";
 
-/* stylelint-disable alpha-value-notation */
-
 // Variables
 // ---------------------------------------------------------------------------------------------------------------------
 
@@ -191,6 +189,7 @@ $minimal-dark-tag-intent-colors: (
   }
 
   .#{$ns}-tag-remove {
+    /* stylelint-disable-next-line alpha-value-notation */
     color: oklch(from $text-color l c h / 0.7);
 
     &:hover,
@@ -211,6 +210,7 @@ $minimal-dark-tag-intent-colors: (
       var(--bp-palette-black)
     );
 
+    /* stylelint-disable-next-line alpha-value-notation */
     background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
     color: var(--bp-typography-color-default-rest);
 
@@ -230,6 +230,7 @@ $minimal-dark-tag-intent-colors: (
         var(--bp-palette-white)
       );
 
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
       color: var(--bp-typography-color-default-rest);
 
@@ -250,12 +251,14 @@ $minimal-dark-tag-intent-colors: (
     cursor: pointer;
 
     &:hover {
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from $background-color l c h / 0.3);
       color: $text-color;
     }
 
     &.#{$ns}-active,
     &:active {
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from $background-color l c h / 0.35);
       color: $text-color;
     }
@@ -263,6 +266,7 @@ $minimal-dark-tag-intent-colors: (
 }
 
 @mixin pt-tag-minimal-intent($background-color, $text-color, $hover-active-text-color) {
+  /* stylelint-disable-next-line alpha-value-notation */
   background-color: oklch(from $background-color l c h / 0.1);
   color: $text-color;
 
@@ -272,12 +276,14 @@ $minimal-dark-tag-intent-colors: (
 
   &.#{$ns}-interactive {
     &:hover {
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from $background-color l c h / 0.2);
       color: $hover-active-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from $background-color l c h / 0.3);
       color: $hover-active-text-color;
     }
@@ -294,17 +300,20 @@ $minimal-dark-tag-intent-colors: (
 }
 
 @mixin pt-tag-minimal-dark-intent($background-color, $text-color, $hover-active-text-color) {
+  /* stylelint-disable-next-line alpha-value-notation */
   background-color: oklch(from $background-color l c h / 0.2);
   color: $text-color;
 
   &.#{$ns}-interactive {
     &:hover {
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from $background-color l c h / 0.3);
       color: $hover-active-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
+      /* stylelint-disable-next-line alpha-value-notation */
       background-color: oklch(from $background-color l c h / 0.35);
       color: $hover-active-text-color;
     }
@@ -323,6 +332,7 @@ $minimal-dark-tag-intent-colors: (
 @mixin pt-tag-remove() {
   background: none;
   border: none;
+  /* stylelint-disable-next-line alpha-value-notation */
   color: oklch(from var(--bp-intent-default-foreground) l c h / 0.7);
   cursor: pointer;
   display: flex;
@@ -412,6 +422,7 @@ $minimal-dark-tag-intent-colors: (
 }
 
 @mixin minimal-compound-tag-colors($base-color) {
+  /* stylelint-disable alpha-value-notation */
   $left-colors: (
     oklch(from $base-color l c h / 0.2),
     oklch(from $base-color l c h / 0.3),
@@ -422,11 +433,13 @@ $minimal-dark-tag-intent-colors: (
     oklch(from $base-color l c h / 0.2),
     oklch(from $base-color l c h / 0.3)
   );
+  /* stylelint-enable alpha-value-notation */
 
   @include compound-tag-colors($left-colors, $right-colors);
 }
 
 @mixin dark-minimal-compound-tag-colors($base-color) {
+  /* stylelint-disable alpha-value-notation */
   $left-colors: (
     oklch(from $base-color l c h / 0.4),
     oklch(from $base-color l c h / 0.5),
@@ -437,6 +450,7 @@ $minimal-dark-tag-intent-colors: (
     oklch(from $base-color l c h / 0.3),
     oklch(from $base-color l c h / 0.35)
   );
+  /* stylelint-enable alpha-value-notation */
 
   @include compound-tag-colors($left-colors, $right-colors);
 }

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -27,430 +27,430 @@ $tag-icon-spacing-large: $pt-spacing * 2 !default;
 $tag-round-adjustment: $pt-spacing * 0.5 !default;
 
 $tag-intent-colors: (
-  "primary": (
-    var(--bp-intent-primary-rest),
-    var(--bp-intent-primary-hover),
-    var(--bp-intent-primary-active),
-    var(--bp-intent-primary-foreground),
-  ),
-  "success": (
-    var(--bp-intent-success-rest),
-    var(--bp-intent-success-hover),
-    var(--bp-intent-success-active),
-    var(--bp-intent-success-foreground),
-  ),
-  "warning": (
-    oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h),
-    oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h),
-    oklch(from var(--bp-intent-warning-active) calc(l + 0.21) c h),
-    oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h),
-  ),
-  "danger": (
-    var(--bp-intent-danger-rest),
-    var(--bp-intent-danger-hover),
-    var(--bp-intent-danger-active),
-    var(--bp-intent-danger-foreground),
-  ),
+    "primary": (
+        var(--bp-intent-primary-rest),
+        var(--bp-intent-primary-hover),
+        var(--bp-intent-primary-active),
+        var(--bp-intent-primary-foreground),
+    ),
+    "success": (
+        var(--bp-intent-success-rest),
+        var(--bp-intent-success-hover),
+        var(--bp-intent-success-active),
+        var(--bp-intent-success-foreground),
+    ),
+    "warning": (
+        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
+        #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h)"},
+        #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.21) c h)"},
+        #{"oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h)"},
+    ),
+    "danger": (
+        var(--bp-intent-danger-rest),
+        var(--bp-intent-danger-hover),
+        var(--bp-intent-danger-active),
+        var(--bp-intent-danger-foreground),
+    ),
 ) !default;
 
 $minimal-tag-intent-colors: (
-  "primary": (
-    var(--bp-intent-primary-rest),
-    var(--bp-intent-primary-hover),
-    var(--bp-intent-primary-active),
-  ),
-  "success": (
-    var(--bp-intent-success-rest),
-    var(--bp-intent-success-hover),
-    var(--bp-intent-success-active),
-  ),
-  "warning": (
-    var(--bp-intent-warning-rest),
-    var(--bp-intent-warning-hover),
-    var(--bp-intent-warning-active),
-  ),
-  "danger": (
-    var(--bp-intent-danger-rest),
-    var(--bp-intent-danger-hover),
-    var(--bp-intent-danger-active),
-  ),
+    "primary": (
+        var(--bp-intent-primary-rest),
+        var(--bp-intent-primary-hover),
+        var(--bp-intent-primary-active),
+    ),
+    "success": (
+        var(--bp-intent-success-rest),
+        var(--bp-intent-success-hover),
+        var(--bp-intent-success-active),
+    ),
+    "warning": (
+        var(--bp-intent-warning-rest),
+        var(--bp-intent-warning-hover),
+        var(--bp-intent-warning-active),
+    ),
+    "danger": (
+        var(--bp-intent-danger-rest),
+        var(--bp-intent-danger-hover),
+        var(--bp-intent-danger-active),
+    ),
 ) !default;
 
 $minimal-dark-tag-intent-colors: (
-  "primary": (
-    var(--bp-intent-primary-rest),
-    oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h),
-    oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h),
-  ),
-  "success": (
-    var(--bp-intent-success-rest),
-    oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h),
-    oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h),
-  ),
-  "warning": (
-    var(--bp-intent-warning-rest),
-    oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h),
-    oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h),
-  ),
-  "danger": (
-    var(--bp-intent-danger-rest),
-    oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h),
-    oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h),
-  ),
+    "primary": (
+        var(--bp-intent-primary-rest),
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"},
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h)"},
+    ),
+    "success": (
+        var(--bp-intent-success-rest),
+        #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"},
+        #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h)"},
+    ),
+    "warning": (
+        var(--bp-intent-warning-rest),
+        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"},
+        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h)"},
+    ),
+    "danger": (
+        var(--bp-intent-danger-rest),
+        #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"},
+        #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h)"},
+    ),
 ) !default;
 
 // Mixins - Tag component
 // ---------------------------------------------------------------------------------------------------------------------
 
 @mixin pt-tag() {
-  @include pt-flex-container(row, var(--bp-surface-spacing), inline);
-  align-items: center;
-  background-color: var(--bp-intent-default-rest);
-  border: none;
-  border-radius: var(--bp-surface-border-radius);
-  box-shadow: none;
-  color: var(--bp-intent-default-foreground);
-  font-size: var(--bp-typography-size-body-small);
-  line-height: calc(var(--bp-surface-spacing) * 4);
-  max-width: 100%;
-  min-height: calc(var(--bp-surface-spacing) * 5);
-  min-width: calc(var(--bp-surface-spacing) * 5);
-  padding: calc(var(--bp-surface-spacing) * 0.5) calc(var(--bp-surface-spacing) * 1.5);
-  position: relative;
+    @include pt-flex-container(row, var(--bp-surface-spacing), inline);
+    align-items: center;
+    background-color: var(--bp-intent-default-rest);
+    border: none;
+    border-radius: var(--bp-surface-border-radius);
+    box-shadow: none;
+    color: var(--bp-intent-default-foreground);
+    font-size: var(--bp-typography-size-body-small);
+    line-height: calc(var(--bp-surface-spacing) * 4);
+    max-width: 100%;
+    min-height: calc(var(--bp-surface-spacing) * 5);
+    min-width: calc(var(--bp-surface-spacing) * 5);
+    padding: calc(var(--bp-surface-spacing) * 0.5) calc(var(--bp-surface-spacing) * 1.5);
+    position: relative;
 
-  // Center text for short content (e.g. single characters) only when the text
-  // element is the sole child (no icons/remove button) and the tag is not fill.
-  &:not(.#{$ns}-fill) > .#{$ns}-fill:only-child {
-    text-align: center;
-  }
-
-  &:focus {
-    @include focus-outline(0);
-  }
-
-  &.#{$ns}-interactive {
-    cursor: pointer;
-
-    &:hover {
-      background: var(--bp-intent-default-hover);
+    // Center text for short content (e.g. single characters) only when the text
+    // element is the sole child (no icons/remove button) and the tag is not fill.
+    &:not(.#{$ns}-fill) > .#{$ns}-fill:only-child {
+        text-align: center;
     }
 
-    &:active,
-    &.#{$ns}-active {
-      background: var(--bp-intent-default-active);
+    &:focus {
+        @include focus-outline(0);
     }
-  }
 
-  &.#{$ns}-round {
-    border-radius: calc(var(--bp-surface-spacing) * 7.5);
-    padding-left: calc(var(--bp-surface-spacing) * 2);
-    // optical adjustment for rounded tags
-    padding-right: calc(var(--bp-surface-spacing) * 2);
-  }
+    &.#{$ns}-interactive {
+        cursor: pointer;
 
-  > #{$icon-classes} {
-    fill: var(--bp-intent-default-foreground);
-  }
+        &:hover {
+            background: var(--bp-intent-default-hover);
+        }
 
-  @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    // Windows High Contrast dark theme
-    border: 1px solid $pt-high-contrast-mode-border-color;
-  }
+        &:active,
+        &.#{$ns}-active {
+            background: var(--bp-intent-default-active);
+        }
+    }
+
+    &.#{$ns}-round {
+        border-radius: calc(var(--bp-surface-spacing) * 7.5);
+        padding-left: calc(var(--bp-surface-spacing) * 2);
+        // optical adjustment for rounded tags
+        padding-right: calc(var(--bp-surface-spacing) * 2);
+    }
+
+    > #{$icon-classes} {
+        fill: var(--bp-intent-default-foreground);
+    }
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+        // Windows High Contrast dark theme
+        border: 1px solid $pt-high-contrast-mode-border-color;
+    }
 }
 
 @mixin pt-tag-large() {
-  @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
-  font-size: var(--bp-typography-size-body-medium);
-  line-height: calc(var(--bp-surface-spacing) * 4.5);
-  min-height: calc(var(--bp-surface-spacing) * 7.5);
-  min-width: calc(var(--bp-surface-spacing) * 7.5);
-  padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 2);
+    @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+    font-size: var(--bp-typography-size-body-medium);
+    line-height: calc(var(--bp-surface-spacing) * 4.5);
+    min-height: calc(var(--bp-surface-spacing) * 7.5);
+    min-width: calc(var(--bp-surface-spacing) * 7.5);
+    padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 2);
 
-  &.#{$ns}-round {
-    padding-left: calc(var(--bp-surface-spacing) * 2.5);
-    // optical adjustment for rounded tags
-    padding-right: calc(var(--bp-surface-spacing) * 2.5);
-  }
+    &.#{$ns}-round {
+        padding-left: calc(var(--bp-surface-spacing) * 2.5);
+        // optical adjustment for rounded tags
+        padding-right: calc(var(--bp-surface-spacing) * 2.5);
+    }
 }
 
 @mixin pt-tag-intent($background-color, $hover-color, $active-color, $text-color) {
-  background: $background-color;
-  color: $text-color;
+    background: $background-color;
+    color: $text-color;
 
-  &.#{$ns}-interactive {
-    &:hover {
-      background-color: $hover-color;
+    &.#{$ns}-interactive {
+        &:hover {
+            background-color: $hover-color;
+        }
+
+        &:active,
+        &.#{$ns}-active {
+            background-color: $active-color;
+        }
     }
-
-    &:active,
-    &.#{$ns}-active {
-      background-color: $active-color;
-    }
-  }
-
-  .#{$ns}-tag-remove {
-    /* stylelint-disable-next-line alpha-value-notation */
-    color: oklch(from $text-color l c h / 0.7);
-
-    &:hover,
-    &:active {
-      color: $text-color;
-    }
-  }
-}
-
-@mixin pt-tag-minimal() {
-  > #{$icon-classes} {
-    fill: var(--bp-typography-color-muted);
-  }
-
-  &:not([class*="#{$ns}-intent-"]) {
-    @include pt-tag-minimal-interactive(
-      oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
-      var(--bp-palette-black)
-    );
-
-    /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
-    color: var(--bp-typography-color-default-rest);
 
     .#{$ns}-tag-remove {
-      color: var(--bp-typography-color-muted);
-
-      &:hover,
-      &:active {
-        color: var(--bp-intent-default-hover);
-      }
-    }
-
-    .#{$ns}-dark &,
-    [data-bp-color-scheme="dark"] & {
-      @include pt-tag-minimal-interactive(
-        oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
-        var(--bp-palette-white)
-      );
-
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
-      color: var(--bp-typography-color-default-rest);
-
-      .#{$ns}-tag-remove {
-        color: var(--bp-typography-color-muted);
+        /* stylelint-disable-next-line alpha-value-notation */
+        color: #{"oklch(from "}#{$text-color}#{" l c h / 0.7)"};
 
         &:hover,
         &:active {
-          color: oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h);
+            color: $text-color;
         }
-      }
     }
-  }
+}
+
+@mixin pt-tag-minimal() {
+    > #{$icon-classes} {
+        fill: var(--bp-typography-color-muted);
+    }
+
+    &:not([class*="#{$ns}-intent-"]) {
+        @include pt-tag-minimal-interactive(
+            #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
+            var(--bp-palette-black)
+        );
+
+        /* stylelint-disable-next-line alpha-value-notation */
+        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+        color: var(--bp-typography-color-default-rest);
+
+        .#{$ns}-tag-remove {
+            color: var(--bp-typography-color-muted);
+
+            &:hover,
+            &:active {
+                color: var(--bp-intent-default-hover);
+            }
+        }
+
+        .#{$ns}-dark &,
+        [data-bp-color-scheme="dark"] & {
+            @include pt-tag-minimal-interactive(
+                #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
+                var(--bp-palette-white)
+            );
+
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+            color: var(--bp-typography-color-default-rest);
+
+            .#{$ns}-tag-remove {
+                color: var(--bp-typography-color-muted);
+
+                &:hover,
+                &:active {
+                    color: #{"oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h)"};
+                }
+            }
+        }
+    }
 }
 
 @mixin pt-tag-minimal-interactive($background-color, $text-color) {
-  &.#{$ns}-interactive {
-    cursor: pointer;
+    &.#{$ns}-interactive {
+        cursor: pointer;
 
-    &:hover {
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from $background-color l c h / 0.3);
-      color: $text-color;
-    }
+        &:hover {
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+            color: $text-color;
+        }
 
-    &.#{$ns}-active,
-    &:active {
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from $background-color l c h / 0.35);
-      color: $text-color;
+        &.#{$ns}-active,
+        &:active {
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
+            color: $text-color;
+        }
     }
-  }
 }
 
 @mixin pt-tag-minimal-intent($background-color, $text-color, $hover-active-text-color) {
-  /* stylelint-disable-next-line alpha-value-notation */
-  background-color: oklch(from $background-color l c h / 0.1);
-  color: $text-color;
-
-  > #{$icon-classes} {
-    fill: $text-color;
-  }
-
-  &.#{$ns}-interactive {
-    &:hover {
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from $background-color l c h / 0.2);
-      color: $hover-active-text-color;
-    }
-
-    &:active,
-    &.#{$ns}-active {
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from $background-color l c h / 0.3);
-      color: $hover-active-text-color;
-    }
-  }
-
-  .#{$ns}-tag-remove {
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.1)"};
     color: $text-color;
 
-    &:hover,
-    &:active {
-      color: $hover-active-text-color;
+    > #{$icon-classes} {
+        fill: $text-color;
     }
-  }
+
+    &.#{$ns}-interactive {
+        &:hover {
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
+            color: $hover-active-text-color;
+        }
+
+        &:active,
+        &.#{$ns}-active {
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+            color: $hover-active-text-color;
+        }
+    }
+
+    .#{$ns}-tag-remove {
+        color: $text-color;
+
+        &:hover,
+        &:active {
+            color: $hover-active-text-color;
+        }
+    }
 }
 
 @mixin pt-tag-minimal-dark-intent($background-color, $text-color, $hover-active-text-color) {
-  /* stylelint-disable-next-line alpha-value-notation */
-  background-color: oklch(from $background-color l c h / 0.2);
-  color: $text-color;
-
-  &.#{$ns}-interactive {
-    &:hover {
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from $background-color l c h / 0.3);
-      color: $hover-active-text-color;
-    }
-
-    &:active,
-    &.#{$ns}-active {
-      /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from $background-color l c h / 0.35);
-      color: $hover-active-text-color;
-    }
-  }
-
-  .#{$ns}-tag-remove {
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
     color: $text-color;
 
-    &:hover,
-    &:active {
-      color: $hover-active-text-color;
+    &.#{$ns}-interactive {
+        &:hover {
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+            color: $hover-active-text-color;
+        }
+
+        &:active,
+        &.#{$ns}-active {
+            /* stylelint-disable-next-line alpha-value-notation */
+            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
+            color: $hover-active-text-color;
+        }
     }
-  }
+
+    .#{$ns}-tag-remove {
+        color: $text-color;
+
+        &:hover,
+        &:active {
+            color: $hover-active-text-color;
+        }
+    }
 }
 
 @mixin pt-tag-remove() {
-  background: none;
-  border: none;
-  /* stylelint-disable-next-line alpha-value-notation */
-  color: oklch(from var(--bp-intent-default-foreground) l c h / 0.7);
-  cursor: pointer;
-  display: flex;
-  margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
-  /* stylelint-disable-next-line declaration-no-important */
-  margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
-  // top/bottom to allow for padding to enlarge click area,
-  // right to tuck remove button into padding space.
-  margin-top: calc(var(--bp-surface-spacing) * -0.5);
-  padding: calc(var(--bp-surface-spacing) * 0.5);
-  padding-left: 0;
-
-  &:hover {
     background: none;
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .#{$ns}-icon:first-child {
-    color: inherit;
-  }
-
-  &:hover,
-  &:active {
-    color: var(--bp-intent-default-foreground);
-  }
-
-  // CSS API support
-  &:empty::before {
-    @include pt-icon;
-    content: map.get($blueprint-icon-codepoints, "small-cross");
-  }
-
-  .#{$ns}-large & {
+    border: none;
+    /* stylelint-disable-next-line alpha-value-notation */
+    color: #{"oklch(from var(--bp-intent-default-foreground) l c h / 0.7)"};
+    cursor: pointer;
+    display: flex;
+    margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
     /* stylelint-disable-next-line declaration-no-important */
-    margin-right: calc(var(--bp-surface-spacing) * -2) !important;
-    padding: 0 var(--bp-surface-spacing) 0 0;
+    margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
+    // top/bottom to allow for padding to enlarge click area,
+    // right to tuck remove button into padding space.
+    margin-top: calc(var(--bp-surface-spacing) * -0.5);
+    padding: calc(var(--bp-surface-spacing) * 0.5);
+    padding-left: 0;
 
-    &:empty::before {
-      // font-family name "blueprint-icons-20" requires a compile-time value for Sass string interpolation
-      @include pt-icon-sized(calc(var(--bp-surface-spacing) * 5), 20);
+    &:hover {
+        background: none;
+        color: inherit;
+        text-decoration: none;
     }
-  }
+
+    .#{$ns}-icon:first-child {
+        color: inherit;
+    }
+
+    &:hover,
+    &:active {
+        color: var(--bp-intent-default-foreground);
+    }
+
+    // CSS API support
+    &:empty::before {
+        @include pt-icon;
+        content: map.get($blueprint-icon-codepoints, "small-cross");
+    }
+
+    .#{$ns}-large & {
+        /* stylelint-disable-next-line declaration-no-important */
+        margin-right: calc(var(--bp-surface-spacing) * -2) !important;
+        padding: 0 var(--bp-surface-spacing) 0 0;
+
+        &:empty::before {
+            // font-family name "blueprint-icons-20" requires a compile-time value for Sass string interpolation
+            @include pt-icon-sized(calc(var(--bp-surface-spacing) * 5), 20);
+        }
+    }
 }
 
 // Mixins - CompoundTag component
 // ---------------------------------------------------------------------------------------------------------------------
 
 @mixin compound-tag-colors(
-  /* each list is a (default, hover, active) tuple of background colors */ $left-colors,
-  $right-colors
+    /* each list is a (default, hover, active) tuple of background colors */ $left-colors,
+    $right-colors
 ) {
-  // override default tag background styles: this is important for minimal tags with opacity values
-  // which we want to define _absolutely_ in our design system and not by stacking opacities on top of each other.
-  background: none;
+    // override default tag background styles: this is important for minimal tags with opacity values
+    // which we want to define _absolutely_ in our design system and not by stacking opacities on top of each other.
+    background: none;
 
-  .#{$ns}-compound-tag-left {
-    background-color: list.nth($left-colors, 1);
-  }
-
-  .#{$ns}-compound-tag-right {
-    background-color: list.nth($right-colors, 1);
-  }
-
-  &.#{$ns}-interactive {
-    &:hover {
-      .#{$ns}-compound-tag-left {
-        background-color: list.nth($left-colors, 2);
-      }
-
-      .#{$ns}-compound-tag-right {
-        background-color: list.nth($right-colors, 2);
-      }
+    .#{$ns}-compound-tag-left {
+        background-color: list.nth($left-colors, 1);
     }
 
-    &:active,
-    &.#{$ns}-active {
-      .#{$ns}-compound-tag-left {
-        background-color: list.nth($left-colors, 3);
-      }
-
-      .#{$ns}-compound-tag-right {
-        background-color: list.nth($right-colors, 3);
-      }
+    .#{$ns}-compound-tag-right {
+        background-color: list.nth($right-colors, 1);
     }
-  }
+
+    &.#{$ns}-interactive {
+        &:hover {
+            .#{$ns}-compound-tag-left {
+                background-color: list.nth($left-colors, 2);
+            }
+
+            .#{$ns}-compound-tag-right {
+                background-color: list.nth($right-colors, 2);
+            }
+        }
+
+        &:active,
+        &.#{$ns}-active {
+            .#{$ns}-compound-tag-left {
+                background-color: list.nth($left-colors, 3);
+            }
+
+            .#{$ns}-compound-tag-right {
+                background-color: list.nth($right-colors, 3);
+            }
+        }
+    }
 }
 
 @mixin minimal-compound-tag-colors($base-color) {
-  /* stylelint-disable alpha-value-notation */
-  $left-colors: (
-    oklch(from $base-color l c h / 0.2),
-    oklch(from $base-color l c h / 0.3),
-    oklch(from $base-color l c h / 0.4)
-  );
-  $right-colors: (
-    oklch(from $base-color l c h / 0.1),
-    oklch(from $base-color l c h / 0.2),
-    oklch(from $base-color l c h / 0.3)
-  );
-  /* stylelint-enable alpha-value-notation */
+    /* stylelint-disable alpha-value-notation */
+    $left-colors: (
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"}
+    );
+    $right-colors: (
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.1)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"}
+    );
+    /* stylelint-enable alpha-value-notation */
 
-  @include compound-tag-colors($left-colors, $right-colors);
+    @include compound-tag-colors($left-colors, $right-colors);
 }
 
 @mixin dark-minimal-compound-tag-colors($base-color) {
-  /* stylelint-disable alpha-value-notation */
-  $left-colors: (
-    oklch(from $base-color l c h / 0.4),
-    oklch(from $base-color l c h / 0.5),
-    oklch(from $base-color l c h / 0.55)
-  );
-  $right-colors: (
-    oklch(from $base-color l c h / 0.2),
-    oklch(from $base-color l c h / 0.3),
-    oklch(from $base-color l c h / 0.35)
-  );
-  /* stylelint-enable alpha-value-notation */
+    /* stylelint-disable alpha-value-notation */
+    $left-colors: (
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.5)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.55)"}
+    );
+    $right-colors: (
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
+        #{"oklch(from "}#{$base-color}#{" l c h / 0.35)"}
+    );
+    /* stylelint-enable alpha-value-notation */
 
-  @include compound-tag-colors($left-colors, $right-colors);
+    @include compound-tag-colors($left-colors, $right-colors);
 }

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -238,7 +238,7 @@ $minimal-dark-tag-intent-colors: (
 
         &:hover,
         &:active {
-          color: var(--bp-palette-light-gray-1);
+          color: oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h);
         }
       }
     }
@@ -326,12 +326,12 @@ $minimal-dark-tag-intent-colors: (
   color: oklch(from var(--bp-intent-default-foreground) l c h / 0.7);
   cursor: pointer;
   display: flex;
-  margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
+  margin-bottom: calc(-1 * calc(var(--bp-surface-spacing) * 0.5));
   /* stylelint-disable-next-line declaration-no-important */
-  margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
+  margin-right: calc(-1 * calc(var(--bp-surface-spacing) * 1.5)) !important;
   // top/bottom to allow for padding to enlarge click area,
   // right to tuck remove button into padding space.
-  margin-top: calc(var(--bp-surface-spacing) * -0.5);
+  margin-top: calc(-1 * calc(var(--bp-surface-spacing) * 0.5));
   padding: calc(var(--bp-surface-spacing) * 0.5);
   padding-left: 0;
 
@@ -358,7 +358,7 @@ $minimal-dark-tag-intent-colors: (
 
   .#{$ns}-large & {
     /* stylelint-disable-next-line declaration-no-important */
-    margin-right: calc(var(--bp-surface-spacing) * -2) !important;
+    margin-right: calc(-1 * calc(var(--bp-surface-spacing) * 2)) !important;
     padding: 0 var(--bp-surface-spacing) 0 0;
 
     &:empty::before {

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -27,430 +27,430 @@ $tag-icon-spacing-large: $pt-spacing * 2 !default;
 $tag-round-adjustment: $pt-spacing * 0.5 !default;
 
 $tag-intent-colors: (
-    "primary": (
-        var(--bp-intent-primary-rest),
-        var(--bp-intent-primary-hover),
-        var(--bp-intent-primary-active),
-        var(--bp-intent-primary-foreground),
-    ),
-    "success": (
-        var(--bp-intent-success-rest),
-        var(--bp-intent-success-hover),
-        var(--bp-intent-success-active),
-        var(--bp-intent-success-foreground),
-    ),
-    "warning": (
-        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
-        #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h)"},
-        #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.21) c h)"},
-        #{"oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h)"},
-    ),
-    "danger": (
-        var(--bp-intent-danger-rest),
-        var(--bp-intent-danger-hover),
-        var(--bp-intent-danger-active),
-        var(--bp-intent-danger-foreground),
-    ),
+  "primary": (
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
+    var(--bp-intent-primary-foreground),
+  ),
+  "success": (
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
+    var(--bp-intent-success-foreground),
+  ),
+  "warning": (
+    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
+    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h)"},
+    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.21) c h)"},
+    #{"oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h)"},
+  ),
+  "danger": (
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
+    var(--bp-intent-danger-foreground),
+  ),
 ) !default;
 
 $minimal-tag-intent-colors: (
-    "primary": (
-        var(--bp-intent-primary-rest),
-        var(--bp-intent-primary-hover),
-        var(--bp-intent-primary-active),
-    ),
-    "success": (
-        var(--bp-intent-success-rest),
-        var(--bp-intent-success-hover),
-        var(--bp-intent-success-active),
-    ),
-    "warning": (
-        var(--bp-intent-warning-rest),
-        var(--bp-intent-warning-hover),
-        var(--bp-intent-warning-active),
-    ),
-    "danger": (
-        var(--bp-intent-danger-rest),
-        var(--bp-intent-danger-hover),
-        var(--bp-intent-danger-active),
-    ),
+  "primary": (
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
+  ),
+  "success": (
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
+  ),
+  "warning": (
+    var(--bp-intent-warning-rest),
+    var(--bp-intent-warning-hover),
+    var(--bp-intent-warning-active),
+  ),
+  "danger": (
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
+  ),
 ) !default;
 
 $minimal-dark-tag-intent-colors: (
-    "primary": (
-        var(--bp-intent-primary-rest),
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"},
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h)"},
-    ),
-    "success": (
-        var(--bp-intent-success-rest),
-        #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"},
-        #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h)"},
-    ),
-    "warning": (
-        var(--bp-intent-warning-rest),
-        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"},
-        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h)"},
-    ),
-    "danger": (
-        var(--bp-intent-danger-rest),
-        #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"},
-        #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h)"},
-    ),
+  "primary": (
+    var(--bp-intent-primary-rest),
+    #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"},
+    #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h)"},
+  ),
+  "success": (
+    var(--bp-intent-success-rest),
+    #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"},
+    #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h)"},
+  ),
+  "warning": (
+    var(--bp-intent-warning-rest),
+    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"},
+    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h)"},
+  ),
+  "danger": (
+    var(--bp-intent-danger-rest),
+    #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"},
+    #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h)"},
+  ),
 ) !default;
 
 // Mixins - Tag component
 // ---------------------------------------------------------------------------------------------------------------------
 
 @mixin pt-tag() {
-    @include pt-flex-container(row, var(--bp-surface-spacing), inline);
-    align-items: center;
-    background-color: var(--bp-intent-default-rest);
-    border: none;
-    border-radius: var(--bp-surface-border-radius);
-    box-shadow: none;
-    color: var(--bp-intent-default-foreground);
-    font-size: var(--bp-typography-size-body-small);
-    line-height: calc(var(--bp-surface-spacing) * 4);
-    max-width: 100%;
-    min-height: calc(var(--bp-surface-spacing) * 5);
-    min-width: calc(var(--bp-surface-spacing) * 5);
-    padding: calc(var(--bp-surface-spacing) * 0.5) calc(var(--bp-surface-spacing) * 1.5);
-    position: relative;
+  @include pt-flex-container(row, var(--bp-surface-spacing), inline);
+  align-items: center;
+  background-color: var(--bp-intent-default-rest);
+  border: none;
+  border-radius: var(--bp-surface-border-radius);
+  box-shadow: none;
+  color: var(--bp-intent-default-foreground);
+  font-size: var(--bp-typography-size-body-small);
+  line-height: calc(var(--bp-surface-spacing) * 4);
+  max-width: 100%;
+  min-height: calc(var(--bp-surface-spacing) * 5);
+  min-width: calc(var(--bp-surface-spacing) * 5);
+  padding: calc(var(--bp-surface-spacing) * 0.5) calc(var(--bp-surface-spacing) * 1.5);
+  position: relative;
 
-    // Center text for short content (e.g. single characters) only when the text
-    // element is the sole child (no icons/remove button) and the tag is not fill.
-    &:not(.#{$ns}-fill) > .#{$ns}-fill:only-child {
-        text-align: center;
+  // Center text for short content (e.g. single characters) only when the text
+  // element is the sole child (no icons/remove button) and the tag is not fill.
+  &:not(.#{$ns}-fill) > .#{$ns}-fill:only-child {
+    text-align: center;
+  }
+
+  &:focus {
+    @include focus-outline(0);
+  }
+
+  &.#{$ns}-interactive {
+    cursor: pointer;
+
+    &:hover {
+      background: var(--bp-intent-default-hover);
     }
 
-    &:focus {
-        @include focus-outline(0);
+    &:active,
+    &.#{$ns}-active {
+      background: var(--bp-intent-default-active);
     }
+  }
 
-    &.#{$ns}-interactive {
-        cursor: pointer;
+  &.#{$ns}-round {
+    border-radius: calc(var(--bp-surface-spacing) * 7.5);
+    padding-left: calc(var(--bp-surface-spacing) * 2);
+    // optical adjustment for rounded tags
+    padding-right: calc(var(--bp-surface-spacing) * 2);
+  }
 
-        &:hover {
-            background: var(--bp-intent-default-hover);
-        }
+  > #{$icon-classes} {
+    fill: var(--bp-intent-default-foreground);
+  }
 
-        &:active,
-        &.#{$ns}-active {
-            background: var(--bp-intent-default-active);
-        }
-    }
-
-    &.#{$ns}-round {
-        border-radius: calc(var(--bp-surface-spacing) * 7.5);
-        padding-left: calc(var(--bp-surface-spacing) * 2);
-        // optical adjustment for rounded tags
-        padding-right: calc(var(--bp-surface-spacing) * 2);
-    }
-
-    > #{$icon-classes} {
-        fill: var(--bp-intent-default-foreground);
-    }
-
-    @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        // Windows High Contrast dark theme
-        border: 1px solid $pt-high-contrast-mode-border-color;
-    }
+  @media (forced-colors: active) and (prefers-color-scheme: dark) {
+    // Windows High Contrast dark theme
+    border: 1px solid $pt-high-contrast-mode-border-color;
+  }
 }
 
 @mixin pt-tag-large() {
-    @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
-    font-size: var(--bp-typography-size-body-medium);
-    line-height: calc(var(--bp-surface-spacing) * 4.5);
-    min-height: calc(var(--bp-surface-spacing) * 7.5);
-    min-width: calc(var(--bp-surface-spacing) * 7.5);
-    padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 2);
+  @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2));
+  font-size: var(--bp-typography-size-body-medium);
+  line-height: calc(var(--bp-surface-spacing) * 4.5);
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
+  padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 2);
 
-    &.#{$ns}-round {
-        padding-left: calc(var(--bp-surface-spacing) * 2.5);
-        // optical adjustment for rounded tags
-        padding-right: calc(var(--bp-surface-spacing) * 2.5);
-    }
+  &.#{$ns}-round {
+    padding-left: calc(var(--bp-surface-spacing) * 2.5);
+    // optical adjustment for rounded tags
+    padding-right: calc(var(--bp-surface-spacing) * 2.5);
+  }
 }
 
 @mixin pt-tag-intent($background-color, $hover-color, $active-color, $text-color) {
-    background: $background-color;
-    color: $text-color;
+  background: $background-color;
+  color: $text-color;
 
-    &.#{$ns}-interactive {
-        &:hover {
-            background-color: $hover-color;
-        }
-
-        &:active,
-        &.#{$ns}-active {
-            background-color: $active-color;
-        }
-    }
-
-    .#{$ns}-tag-remove {
-        /* stylelint-disable-next-line alpha-value-notation */
-        color: #{"oklch(from "}#{$text-color}#{" l c h / 0.7)"};
-
-        &:hover,
-        &:active {
-            color: $text-color;
-        }
-    }
-}
-
-@mixin pt-tag-minimal() {
-    > #{$icon-classes} {
-        fill: var(--bp-typography-color-muted);
-    }
-
-    &:not([class*="#{$ns}-intent-"]) {
-        @include pt-tag-minimal-interactive(
-            #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
-            var(--bp-palette-black)
-        );
-
-        /* stylelint-disable-next-line alpha-value-notation */
-        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
-        color: var(--bp-typography-color-default-rest);
-
-        .#{$ns}-tag-remove {
-            color: var(--bp-typography-color-muted);
-
-            &:hover,
-            &:active {
-                color: var(--bp-intent-default-hover);
-            }
-        }
-
-        .#{$ns}-dark &,
-        [data-bp-color-scheme="dark"] & {
-            @include pt-tag-minimal-interactive(
-                #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
-                var(--bp-palette-white)
-            );
-
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
-            color: var(--bp-typography-color-default-rest);
-
-            .#{$ns}-tag-remove {
-                color: var(--bp-typography-color-muted);
-
-                &:hover,
-                &:active {
-                    color: #{"oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h)"};
-                }
-            }
-        }
-    }
-}
-
-@mixin pt-tag-minimal-interactive($background-color, $text-color) {
-    &.#{$ns}-interactive {
-        cursor: pointer;
-
-        &:hover {
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
-            color: $text-color;
-        }
-
-        &.#{$ns}-active,
-        &:active {
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
-            color: $text-color;
-        }
-    }
-}
-
-@mixin pt-tag-minimal-intent($background-color, $text-color, $hover-active-text-color) {
-    /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.1)"};
-    color: $text-color;
-
-    > #{$icon-classes} {
-        fill: $text-color;
-    }
-
-    &.#{$ns}-interactive {
-        &:hover {
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
-            color: $hover-active-text-color;
-        }
-
-        &:active,
-        &.#{$ns}-active {
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
-            color: $hover-active-text-color;
-        }
-    }
-
-    .#{$ns}-tag-remove {
-        color: $text-color;
-
-        &:hover,
-        &:active {
-            color: $hover-active-text-color;
-        }
-    }
-}
-
-@mixin pt-tag-minimal-dark-intent($background-color, $text-color, $hover-active-text-color) {
-    /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
-    color: $text-color;
-
-    &.#{$ns}-interactive {
-        &:hover {
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
-            color: $hover-active-text-color;
-        }
-
-        &:active,
-        &.#{$ns}-active {
-            /* stylelint-disable-next-line alpha-value-notation */
-            background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
-            color: $hover-active-text-color;
-        }
-    }
-
-    .#{$ns}-tag-remove {
-        color: $text-color;
-
-        &:hover,
-        &:active {
-            color: $hover-active-text-color;
-        }
-    }
-}
-
-@mixin pt-tag-remove() {
-    background: none;
-    border: none;
-    /* stylelint-disable-next-line alpha-value-notation */
-    color: #{"oklch(from var(--bp-intent-default-foreground) l c h / 0.7)"};
-    cursor: pointer;
-    display: flex;
-    margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
-    /* stylelint-disable-next-line declaration-no-important */
-    margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
-    // top/bottom to allow for padding to enlarge click area,
-    // right to tuck remove button into padding space.
-    margin-top: calc(var(--bp-surface-spacing) * -0.5);
-    padding: calc(var(--bp-surface-spacing) * 0.5);
-    padding-left: 0;
-
+  &.#{$ns}-interactive {
     &:hover {
-        background: none;
-        color: inherit;
-        text-decoration: none;
+      background-color: $hover-color;
     }
 
-    .#{$ns}-icon:first-child {
-        color: inherit;
+    &:active,
+    &.#{$ns}-active {
+      background-color: $active-color;
     }
+  }
+
+  .#{$ns}-tag-remove {
+    /* stylelint-disable-next-line alpha-value-notation */
+    color: #{"oklch(from "}#{$text-color}#{" l c h / 0.7)"};
 
     &:hover,
     &:active {
-        color: var(--bp-intent-default-foreground);
+      color: $text-color;
+    }
+  }
+}
+
+@mixin pt-tag-minimal() {
+  > #{$icon-classes} {
+    fill: var(--bp-typography-color-muted);
+  }
+
+  &:not([class*="#{$ns}-intent-"]) {
+    @include pt-tag-minimal-interactive(
+      #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
+      var(--bp-palette-black)
+    );
+
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+    color: var(--bp-typography-color-default-rest);
+
+    .#{$ns}-tag-remove {
+      color: var(--bp-typography-color-muted);
+
+      &:hover,
+      &:active {
+        color: var(--bp-intent-default-hover);
+      }
     }
 
-    // CSS API support
-    &:empty::before {
-        @include pt-icon;
-        content: map.get($blueprint-icon-codepoints, "small-cross");
-    }
+    .#{$ns}-dark &,
+    [data-bp-color-scheme="dark"] & {
+      @include pt-tag-minimal-interactive(
+        #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
+        var(--bp-palette-white)
+      );
 
-    .#{$ns}-large & {
-        /* stylelint-disable-next-line declaration-no-important */
-        margin-right: calc(var(--bp-surface-spacing) * -2) !important;
-        padding: 0 var(--bp-surface-spacing) 0 0;
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+      color: var(--bp-typography-color-default-rest);
 
-        &:empty::before {
-            // font-family name "blueprint-icons-20" requires a compile-time value for Sass string interpolation
-            @include pt-icon-sized(calc(var(--bp-surface-spacing) * 5), 20);
+      .#{$ns}-tag-remove {
+        color: var(--bp-typography-color-muted);
+
+        &:hover,
+        &:active {
+          color: #{"oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h)"};
         }
+      }
     }
+  }
+}
+
+@mixin pt-tag-minimal-interactive($background-color, $text-color) {
+  &.#{$ns}-interactive {
+    cursor: pointer;
+
+    &:hover {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+      color: $text-color;
+    }
+
+    &.#{$ns}-active,
+    &:active {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
+      color: $text-color;
+    }
+  }
+}
+
+@mixin pt-tag-minimal-intent($background-color, $text-color, $hover-active-text-color) {
+  /* stylelint-disable-next-line alpha-value-notation */
+  background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.1)"};
+  color: $text-color;
+
+  > #{$icon-classes} {
+    fill: $text-color;
+  }
+
+  &.#{$ns}-interactive {
+    &:hover {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
+      color: $hover-active-text-color;
+    }
+
+    &:active,
+    &.#{$ns}-active {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+      color: $hover-active-text-color;
+    }
+  }
+
+  .#{$ns}-tag-remove {
+    color: $text-color;
+
+    &:hover,
+    &:active {
+      color: $hover-active-text-color;
+    }
+  }
+}
+
+@mixin pt-tag-minimal-dark-intent($background-color, $text-color, $hover-active-text-color) {
+  /* stylelint-disable-next-line alpha-value-notation */
+  background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
+  color: $text-color;
+
+  &.#{$ns}-interactive {
+    &:hover {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+      color: $hover-active-text-color;
+    }
+
+    &:active,
+    &.#{$ns}-active {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
+      color: $hover-active-text-color;
+    }
+  }
+
+  .#{$ns}-tag-remove {
+    color: $text-color;
+
+    &:hover,
+    &:active {
+      color: $hover-active-text-color;
+    }
+  }
+}
+
+@mixin pt-tag-remove() {
+  background: none;
+  border: none;
+  /* stylelint-disable-next-line alpha-value-notation */
+  color: #{"oklch(from var(--bp-intent-default-foreground) l c h / 0.7)"};
+  cursor: pointer;
+  display: flex;
+  margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
+  /* stylelint-disable-next-line declaration-no-important */
+  margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
+  // top/bottom to allow for padding to enlarge click area,
+  // right to tuck remove button into padding space.
+  margin-top: calc(var(--bp-surface-spacing) * -0.5);
+  padding: calc(var(--bp-surface-spacing) * 0.5);
+  padding-left: 0;
+
+  &:hover {
+    background: none;
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .#{$ns}-icon:first-child {
+    color: inherit;
+  }
+
+  &:hover,
+  &:active {
+    color: var(--bp-intent-default-foreground);
+  }
+
+  // CSS API support
+  &:empty::before {
+    @include pt-icon;
+    content: map.get($blueprint-icon-codepoints, "small-cross");
+  }
+
+  .#{$ns}-large & {
+    /* stylelint-disable-next-line declaration-no-important */
+    margin-right: calc(var(--bp-surface-spacing) * -2) !important;
+    padding: 0 var(--bp-surface-spacing) 0 0;
+
+    &:empty::before {
+      // font-family name "blueprint-icons-20" requires a compile-time value for Sass string interpolation
+      @include pt-icon-sized(calc(var(--bp-surface-spacing) * 5), 20);
+    }
+  }
 }
 
 // Mixins - CompoundTag component
 // ---------------------------------------------------------------------------------------------------------------------
 
 @mixin compound-tag-colors(
-    /* each list is a (default, hover, active) tuple of background colors */ $left-colors,
-    $right-colors
+  /* each list is a (default, hover, active) tuple of background colors */ $left-colors,
+  $right-colors
 ) {
-    // override default tag background styles: this is important for minimal tags with opacity values
-    // which we want to define _absolutely_ in our design system and not by stacking opacities on top of each other.
-    background: none;
+  // override default tag background styles: this is important for minimal tags with opacity values
+  // which we want to define _absolutely_ in our design system and not by stacking opacities on top of each other.
+  background: none;
 
-    .#{$ns}-compound-tag-left {
-        background-color: list.nth($left-colors, 1);
+  .#{$ns}-compound-tag-left {
+    background-color: list.nth($left-colors, 1);
+  }
+
+  .#{$ns}-compound-tag-right {
+    background-color: list.nth($right-colors, 1);
+  }
+
+  &.#{$ns}-interactive {
+    &:hover {
+      .#{$ns}-compound-tag-left {
+        background-color: list.nth($left-colors, 2);
+      }
+
+      .#{$ns}-compound-tag-right {
+        background-color: list.nth($right-colors, 2);
+      }
     }
 
-    .#{$ns}-compound-tag-right {
-        background-color: list.nth($right-colors, 1);
+    &:active,
+    &.#{$ns}-active {
+      .#{$ns}-compound-tag-left {
+        background-color: list.nth($left-colors, 3);
+      }
+
+      .#{$ns}-compound-tag-right {
+        background-color: list.nth($right-colors, 3);
+      }
     }
-
-    &.#{$ns}-interactive {
-        &:hover {
-            .#{$ns}-compound-tag-left {
-                background-color: list.nth($left-colors, 2);
-            }
-
-            .#{$ns}-compound-tag-right {
-                background-color: list.nth($right-colors, 2);
-            }
-        }
-
-        &:active,
-        &.#{$ns}-active {
-            .#{$ns}-compound-tag-left {
-                background-color: list.nth($left-colors, 3);
-            }
-
-            .#{$ns}-compound-tag-right {
-                background-color: list.nth($right-colors, 3);
-            }
-        }
-    }
+  }
 }
 
 @mixin minimal-compound-tag-colors($base-color) {
-    /* stylelint-disable alpha-value-notation */
-    $left-colors: (
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"}
-    );
-    $right-colors: (
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.1)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"}
-    );
-    /* stylelint-enable alpha-value-notation */
+  /* stylelint-disable alpha-value-notation */
+  $left-colors: (
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"}
+  );
+  $right-colors: (
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.1)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"}
+  );
+  /* stylelint-enable alpha-value-notation */
 
-    @include compound-tag-colors($left-colors, $right-colors);
+  @include compound-tag-colors($left-colors, $right-colors);
 }
 
 @mixin dark-minimal-compound-tag-colors($base-color) {
-    /* stylelint-disable alpha-value-notation */
-    $left-colors: (
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.5)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.55)"}
-    );
-    $right-colors: (
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
-        #{"oklch(from "}#{$base-color}#{" l c h / 0.35)"}
-    );
-    /* stylelint-enable alpha-value-notation */
+  /* stylelint-disable alpha-value-notation */
+  $left-colors: (
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.5)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.55)"}
+  );
+  $right-colors: (
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
+    #{"oklch(from "}#{$base-color}#{" l c h / 0.35)"}
+  );
+  /* stylelint-enable alpha-value-notation */
 
-    @include compound-tag-colors($left-colors, $right-colors);
+  @include compound-tag-colors($left-colors, $right-colors);
 }

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -326,12 +326,12 @@ $minimal-dark-tag-intent-colors: (
   color: oklch(from var(--bp-intent-default-foreground) l c h / 0.7);
   cursor: pointer;
   display: flex;
-  margin-bottom: calc(-1 * calc(var(--bp-surface-spacing) * 0.5));
+  margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
   /* stylelint-disable-next-line declaration-no-important */
-  margin-right: calc(-1 * calc(var(--bp-surface-spacing) * 1.5)) !important;
+  margin-right: calc(var(--bp-surface-spacing) * -1.5) !important;
   // top/bottom to allow for padding to enlarge click area,
   // right to tuck remove button into padding space.
-  margin-top: calc(-1 * calc(var(--bp-surface-spacing) * 0.5));
+  margin-top: calc(var(--bp-surface-spacing) * -0.5);
   padding: calc(var(--bp-surface-spacing) * 0.5);
   padding-left: 0;
 
@@ -358,7 +358,7 @@ $minimal-dark-tag-intent-colors: (
 
   .#{$ns}-large & {
     /* stylelint-disable-next-line declaration-no-important */
-    margin-right: calc(-1 * calc(var(--bp-surface-spacing) * 2)) !important;
+    margin-right: calc(var(--bp-surface-spacing) * -2) !important;
     padding: 0 var(--bp-surface-spacing) 0 0;
 
     &:empty::before {

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -7,8 +7,6 @@
 @import "../../common/mixins";
 @import "./common";
 
-/* stylelint-disable alpha-value-notation */
-
 /*
 Compound Tags
 */

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -12,30 +12,38 @@ Compound Tags
 */
 
 // some of these values are copied from _common.scss, but our mixins have a different shape here
-$compound-tag-left-default-colors: ($dark-gray5, $dark-gray4, $dark-gray3) !default;
-$compound-tag-right-default-colors: ($gray1, $dark-gray5, $dark-gray4) !default;
+$compound-tag-left-default-colors: (
+  oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h),
+  oklch(from var(--bp-intent-default-hover) calc(l - 0.05) c h),
+  oklch(from var(--bp-intent-default-active) calc(l - 0.03) c h)
+) !default;
+$compound-tag-right-default-colors: (
+  var(--bp-intent-default-rest),
+  var(--bp-intent-default-hover),
+  var(--bp-intent-default-active)
+) !default;
 
 // one shade darker than $tag-intent-colors
 $compound-tag-left-intent-colors: (
   "primary": (
-    $blue2,
-    $blue1,
-    $blue0,
+    oklch(from var(--bp-intent-primary-rest) calc(l - 0.06) c h),
+    oklch(from var(--bp-intent-primary-hover) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-primary-active) calc(l - 0.07) c h),
   ),
   "success": (
-    $green2,
-    $green1,
-    $green0,
+    oklch(from var(--bp-intent-success-rest) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-success-hover) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-success-active) calc(l - 0.09) c h),
   ),
   "warning": (
-    $orange4,
-    $orange3,
-    $orange2,
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.11) c h),
+    oklch(from var(--bp-intent-warning-hover) calc(l + 0.13) c h),
+    oklch(from var(--bp-intent-warning-active) calc(l + 0.08) c h),
   ),
   "danger": (
-    $red2,
-    $red1,
-    $red0,
+    oklch(from var(--bp-intent-danger-rest) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-danger-hover) calc(l - 0.05) c h),
+    oklch(from var(--bp-intent-danger-active) calc(l - 0.04) c h),
   ),
 ) !default;
 
@@ -52,27 +60,27 @@ $compound-tag-left-intent-colors: (
   .#{$ns}-compound-tag-right {
     align-items: center;
     display: inline-flex;
-    padding: ($pt-spacing * 0.5) $pt-spacing;
+    padding: calc(var(--bp-surface-spacing) * 0.5) var(--bp-surface-spacing);
   }
 
   .#{$ns}-compound-tag-left {
-    border-bottom-left-radius: $pt-border-radius;
-    border-top-left-radius: $pt-border-radius;
+    border-bottom-left-radius: var(--bp-surface-border-radius);
+    border-top-left-radius: var(--bp-surface-border-radius);
     margin-right: 0; // override pt-tag() pt-flex-container() style
 
     > #{$icon-classes} {
-      margin-right: $pt-spacing;
+      margin-right: var(--bp-surface-spacing);
     }
   }
 
   .#{$ns}-compound-tag-right {
-    border-bottom-right-radius: $pt-border-radius;
-    border-top-right-radius: $pt-border-radius;
+    border-bottom-right-radius: var(--bp-surface-border-radius);
+    border-top-right-radius: var(--bp-surface-border-radius);
     flex-grow: 1;
-    padding: ($pt-spacing * 0.5) $pt-spacing;
+    padding: calc(var(--bp-surface-spacing) * 0.5) var(--bp-surface-spacing);
 
     > #{$icon-classes} {
-      margin-left: $pt-spacing;
+      margin-left: var(--bp-surface-spacing);
     }
 
     .#{$ns}-compound-tag-right-content {
@@ -80,28 +88,27 @@ $compound-tag-left-intent-colors: (
     }
 
     .#{$ns}-tag-remove {
-      margin-left: $pt-spacing * 0.5;
+      margin-left: calc(var(--bp-surface-spacing) * 0.5);
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
-      margin-right: -$pt-spacing !important;
+      margin-right: calc(var(--bp-surface-spacing) * -1) !important;
     }
   }
 
   // Variant: round
   &.#{$ns}-round {
-    $tag-round-horizontal-padding: ($tag-height * 0.5) - $tag-round-adjustment;
     padding: 0;
 
     .#{$ns}-compound-tag-left {
-      border-bottom-left-radius: $tag-height;
-      border-top-left-radius: $tag-height;
-      padding-left: $tag-round-horizontal-padding;
+      border-bottom-left-radius: calc(var(--bp-surface-spacing) * 5);
+      border-top-left-radius: calc(var(--bp-surface-spacing) * 5);
+      padding-left: calc(var(--bp-surface-spacing) * 2);
     }
 
     .#{$ns}-compound-tag-right {
-      border-bottom-right-radius: $tag-height;
-      border-top-right-radius: $tag-height;
-      padding-right: $tag-round-horizontal-padding;
+      border-bottom-right-radius: calc(var(--bp-surface-spacing) * 5);
+      border-top-right-radius: calc(var(--bp-surface-spacing) * 5);
+      padding-right: calc(var(--bp-surface-spacing) * 2);
     }
   }
 
@@ -111,43 +118,42 @@ $compound-tag-left-intent-colors: (
 
     .#{$ns}-compound-tag-left,
     .#{$ns}-compound-tag-right {
-      padding: ($pt-spacing * 1.5) ($pt-spacing * 2);
+      padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 2);
     }
 
     .#{$ns}-compound-tag-left {
       > #{$icon-classes} {
-        margin-right: $pt-spacing * 2;
+        margin-right: calc(var(--bp-surface-spacing) * 2);
       }
     }
 
     .#{$ns}-compound-tag-right {
       > #{$icon-classes} {
-        margin-left: $pt-spacing * 2;
+        margin-left: calc(var(--bp-surface-spacing) * 2);
       }
     }
 
     .#{$ns}-tag-remove {
-      margin-left: $pt-spacing * 2;
+      margin-left: calc(var(--bp-surface-spacing) * 2);
       // overriding pt-tag-remove() style
       /* stylelint-disable-next-line declaration-no-important */
-      margin-right: $pt-spacing * -2.5 !important;
+      margin-right: calc(var(--bp-surface-spacing) * -2.5) !important;
     }
 
     // Variant: large & round
     &.#{$ns}-round {
-      $tag-round-horizontal-padding-large: ($tag-padding-large) + $tag-round-adjustment;
       padding: 0;
 
       .#{$ns}-compound-tag-left {
-        border-bottom-left-radius: $tag-height-large;
-        border-top-left-radius: $tag-height-large;
-        padding-left: $tag-round-horizontal-padding-large;
+        border-bottom-left-radius: calc(var(--bp-surface-spacing) * 7.5);
+        border-top-left-radius: calc(var(--bp-surface-spacing) * 7.5);
+        padding-left: calc(var(--bp-surface-spacing) * 2.5);
       }
 
       .#{$ns}-compound-tag-right {
-        border-bottom-right-radius: $tag-height-large;
-        border-top-right-radius: $tag-height-large;
-        padding-right: $tag-round-horizontal-padding-large;
+        border-bottom-right-radius: calc(var(--bp-surface-spacing) * 7.5);
+        border-top-right-radius: calc(var(--bp-surface-spacing) * 7.5);
+        padding-right: calc(var(--bp-surface-spacing) * 7.5);
       }
     }
   }
@@ -155,14 +161,24 @@ $compound-tag-left-intent-colors: (
   &.#{$ns}-minimal {
     // Variants: minimal default & interactive
     &:not([class*="#{$ns}-intent-"]) {
-      @include minimal-compound-tag-colors($gray1);
+      @include minimal-compound-tag-colors(var(--bp-intent-default-rest));
     }
 
     // Variant: minimal intent
-    @each $intent, $color in $pt-intent-colors {
-      &.#{$ns}-intent-#{$intent} {
-        @include minimal-compound-tag-colors($color);
-      }
+    &.#{$ns}-intent-primary {
+      @include minimal-compound-tag-colors(var(--bp-intent-primary-rest));
+    }
+
+    &.#{$ns}-intent-success {
+      @include minimal-compound-tag-colors(var(--bp-intent-success-rest));
+    }
+
+    &.#{$ns}-intent-warning {
+      @include minimal-compound-tag-colors(var(--bp-intent-warning-rest));
+    }
+
+    &.#{$ns}-intent-danger {
+      @include minimal-compound-tag-colors(var(--bp-intent-danger-rest));
     }
   }
 
@@ -176,14 +192,24 @@ $compound-tag-left-intent-colors: (
     &.#{$ns}-minimal {
       // Variants: dark minimal default & interactive
       &:not([class*="#{$ns}-intent-"]) {
-        @include dark-minimal-compound-tag-colors($gray1);
+        @include dark-minimal-compound-tag-colors(var(--bp-intent-default-rest));
       }
 
       // Variant: dark minimal intent
-      @each $intent, $color in $pt-intent-colors {
-        &.#{$ns}-intent-#{$intent} {
-          @include dark-minimal-compound-tag-colors($color);
-        }
+      &.#{$ns}-intent-primary {
+        @include dark-minimal-compound-tag-colors(var(--bp-intent-primary-rest));
+      }
+
+      &.#{$ns}-intent-success {
+        @include dark-minimal-compound-tag-colors(var(--bp-intent-success-rest));
+      }
+
+      &.#{$ns}-intent-warning {
+        @include dark-minimal-compound-tag-colors(var(--bp-intent-warning-rest));
+      }
+
+      &.#{$ns}-intent-danger {
+        @include dark-minimal-compound-tag-colors(var(--bp-intent-danger-rest));
       }
     }
   }

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -155,7 +155,7 @@ $compound-tag-left-intent-colors: (
       .#{$ns}-compound-tag-right {
         border-bottom-right-radius: calc(var(--bp-surface-spacing) * 7.5);
         border-top-right-radius: calc(var(--bp-surface-spacing) * 7.5);
-        padding-right: calc(var(--bp-surface-spacing) * 7.5);
+        padding-right: calc(var(--bp-surface-spacing) * 2.5);
       }
     }
   }

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -184,7 +184,8 @@ $compound-tag-left-intent-colors: (
     }
   }
 
-  .#{$ns}-dark & {
+  .#{$ns}-dark &,
+  [data-bp-color-scheme="dark"] & {
     // Variants: dark default & interactive
     // colors are identical to light theme, so we don't need any styles here
 

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -13,9 +13,9 @@ Compound Tags
 
 // some of these values are copied from _common.scss, but our mixins have a different shape here
 $compound-tag-left-default-colors: (
-  oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h),
-  oklch(from var(--bp-intent-default-hover) calc(l - 0.05) c h),
-  oklch(from var(--bp-intent-default-active) calc(l - 0.03) c h)
+  #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h)"},
+  #{"oklch(from var(--bp-intent-default-hover) calc(l - 0.05) c h)"},
+  #{"oklch(from var(--bp-intent-default-active) calc(l - 0.03) c h)"}
 ) !default;
 $compound-tag-right-default-colors: (
   var(--bp-intent-default-rest),
@@ -26,24 +26,24 @@ $compound-tag-right-default-colors: (
 // one shade darker than $tag-intent-colors
 $compound-tag-left-intent-colors: (
   "primary": (
-    oklch(from var(--bp-intent-primary-rest) calc(l - 0.06) c h),
-    oklch(from var(--bp-intent-primary-hover) calc(l - 0.07) c h),
-    oklch(from var(--bp-intent-primary-active) calc(l - 0.07) c h),
+    #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.06) c h)"},
+    #{"oklch(from var(--bp-intent-primary-hover) calc(l - 0.07) c h)"},
+    #{"oklch(from var(--bp-intent-primary-active) calc(l - 0.07) c h)"},
   ),
   "success": (
-    oklch(from var(--bp-intent-success-rest) calc(l - 0.07) c h),
-    oklch(from var(--bp-intent-success-hover) calc(l - 0.07) c h),
-    oklch(from var(--bp-intent-success-active) calc(l - 0.09) c h),
+    #{"oklch(from var(--bp-intent-success-rest) calc(l - 0.07) c h)"},
+    #{"oklch(from var(--bp-intent-success-hover) calc(l - 0.07) c h)"},
+    #{"oklch(from var(--bp-intent-success-active) calc(l - 0.09) c h)"},
   ),
   "warning": (
-    oklch(from var(--bp-intent-warning-rest) calc(l + 0.11) c h),
-    oklch(from var(--bp-intent-warning-hover) calc(l + 0.13) c h),
-    oklch(from var(--bp-intent-warning-active) calc(l + 0.08) c h),
+    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.11) c h)"},
+    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.13) c h)"},
+    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.08) c h)"},
   ),
   "danger": (
-    oklch(from var(--bp-intent-danger-rest) calc(l - 0.07) c h),
-    oklch(from var(--bp-intent-danger-hover) calc(l - 0.05) c h),
-    oklch(from var(--bp-intent-danger-active) calc(l - 0.04) c h),
+    #{"oklch(from var(--bp-intent-danger-rest) calc(l - 0.07) c h)"},
+    #{"oklch(from var(--bp-intent-danger-hover) calc(l - 0.05) c h)"},
+    #{"oklch(from var(--bp-intent-danger-active) calc(l - 0.04) c h)"},
   ),
 ) !default;
 

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -7,6 +7,8 @@
 @import "../../common/mixins";
 @import "./common";
 
+/* stylelint-disable alpha-value-notation */
+
 /*
 Compound Tags
 */

--- a/packages/core/src/components/tag/_tag.scss
+++ b/packages/core/src/components/tag/_tag.scss
@@ -35,7 +35,8 @@
 
     @each $intent, $colors in $minimal-dark-tag-intent-colors {
       &.#{$ns}-intent-#{$intent} {
-        .#{$ns}-dark & {
+        .#{$ns}-dark &,
+        [data-bp-color-scheme="dark"] & {
           @include pt-tag-minimal-dark-intent($colors...);
         }
       }


### PR DESCRIPTION
#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Tag and CompoundTag components from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-default-hover` | `#404854` | `$dark-gray5` |
| `--bp-intent-default-active` | `#383e47` | `$dark-gray4` |
| `--bp-intent-default-foreground` | `#ffffff` | `$white` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary` / `$blue3` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success` / `$green3` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning` / `$orange3` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger` / `$red3` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |
| `--bp-surface-border-radius` | `2px` | `$pt-border-radius` |

#### Tag (Default, Filled)

| Property | Develop | Current |
|----------|---------|---------|
| Background (rest) | `$gray1` | `var(--bp-intent-default-rest)` |
| Background (hover) | `$dark-gray5` | `var(--bp-intent-default-hover)` |
| Background (active) | `$dark-gray4` | `var(--bp-intent-default-active)` |
| Text color | `$white` | `var(--bp-intent-default-foreground)` |
| Icon fill | `$white` | `var(--bp-intent-default-foreground)` |
| Font size | `$pt-font-size-small` | `var(--bp-typography-size-body-small)` |
| Font size (large) | `$pt-font-size` | `var(--bp-typography-size-body-medium)` |
| Border radius | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| High contrast border | `$pt-high-contrast-mode-border-color` | `buttonborder` (native CSS system color) |
| All spacing/sizing | `$tag-*` local vars (derived from `$pt-spacing`) | `calc(var(--bp-surface-spacing) * N)` inline |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables like `$tag-height`, `$tag-padding`, `$tag-padding-top` have been replaced with inline `calc()` expressions. The local variable definitions still exist but are now effectively dead code within these mixins.
2. **High contrast border uses native CSS system color** (`buttonborder`) instead of a SCSS variable.

#### Tag Intent Colors (`$tag-intent-colors` map)

| Intent | Develop (rest, hover, active, foreground) | Current |
|--------|-------------------------------------------|---------|
| Primary | `$blue3`, `$blue2`, `$blue1`, `$white` | `--bp-intent-primary-{rest,hover,active,foreground}` |
| Success | `$green3`, `$green2`, `$green1`, `$white` | `--bp-intent-success-{rest,hover,active,foreground}` |
| Warning | `$orange5`, `$orange4`, `$orange3`, `$pt-text-color` | `oklch(from --bp-intent-warning-{rest,hover,active,foreground} ...)` with lightness adjustments |
| Danger | `$red3`, `$red2`, `$red1`, `$white` | `--bp-intent-danger-{rest,hover,active,foreground}` |

**Differences:**
3. **Warning intent uses oklch lightness adjustments.** Warning tags used lighter palette shades (`$orange5/4/3`) rather than the intent color directly. The migration uses `oklch(from var(--bp-intent-warning-*) calc(l + 0.19) c h)` etc. to derive lighter variants from the base intent token. Visual output will be close but not pixel-identical due to oklch interpolation.
4. **Warning foreground** changed from `$pt-text-color` (dark gray) to `oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h)` — semantically derived from the intent foreground token.

#### Tag Minimal (Default, No Intent)

| Property | Develop | Current |
|----------|---------|---------|
| Background | `rgba($gray3, 0.15)` | `oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)` |
| Text color | `$pt-text-color` | `var(--bp-typography-color-default-rest)` |
| Icon fill | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| Remove button color | `$gray1` | `var(--bp-typography-color-muted)` |
| Remove button hover | `$dark-gray5` | `var(--bp-intent-default-hover)` |
| Interactive hover bg | `rgba($gray3, 0.3)` | `oklch(from ... l c h / 0.3)` |
| Interactive active bg | `rgba($gray3, 0.35)` | `oklch(from ... l c h / 0.35)` |
| Dark text color | `$pt-dark-text-color` | `var(--bp-typography-color-default-rest)` |
| Dark interactive text | `$white` | `var(--bp-palette-white)` |
| Dark remove hover | `$light-gray1` | `oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h);` |
| Dark remove icon | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |

**Differences:**
5. **Background base color differs.** Develop used `$gray3` (`#8f99a8`) directly. Current derives from `--bp-intent-default-rest` (`$gray1` = `#5f6b7c`) with `calc(l + 0.16)` lightness boost. The resulting base color for the oklch alpha blend will be slightly different.
6. **`rgba()` → `oklch()` for all transparency.** Same alpha percentages but different color space interpolation.

#### Tag Minimal Intent

| Property | Develop | Current |
|----------|---------|---------|
| Background (rest) | `rgba($intent-color, 0.1)` | `oklch(from $intent-color l c h / 0.1)` |
| Background (hover) | `rgba($intent-color, 0.2)` | `oklch(from $intent-color l c h / 0.2)` |
| Background (active) | `rgba($intent-color, 0.3)` | `oklch(from $intent-color l c h / 0.3)` |
| Dark background (rest) | `rgba($intent-color, 0.2)` | `oklch(from $intent-color l c h / 0.2)` |
| Dark background (hover) | `rgba($intent-color, 0.3)` | `oklch(from $intent-color l c h / 0.3)` |
| Dark background (active) | `rgba($intent-color, 0.35)` | `oklch(from $intent-color l c h / 0.35)` |

**Differences:**
7. **Same percentages, different color space.** All `rgba()` calls replaced with `oklch()` relative color syntax at identical alpha values. oklch premultiplied alpha may produce subtly different visual results than sRGB alpha transparency.

#### Tag Minimal Dark Intent (`$minimal-dark-tag-intent-colors` map)

| Intent | Develop (rest, hover, active) | Current |
|--------|-------------------------------|---------|
| Primary | `$blue3`, `$blue5`, `$blue6` | `--bp-intent-primary-rest`, `oklch(... calc(l + 0.22) ...)`, `oklch(... calc(l + 0.3) ...)` |
| Success | `$green3`, `$green5`, `$green6` | `--bp-intent-success-rest`, `oklch(... calc(l + 0.25) ...)`, `oklch(... calc(l + 0.33) ...)` |
| Warning | `$orange3`, `$orange5`, `$orange6` | `--bp-intent-warning-rest`, `oklch(... calc(l + 0.18) ...)`, `oklch(... calc(l + 0.26) ...)` |
| Danger | `$red3`, `$red5`, `$red6` | `--bp-intent-danger-rest`, `oklch(... calc(l + 0.2) ...)`, `oklch(... calc(l + 0.28) ...)` |

**Differences:**
8. **Lighter shades derived via oklch instead of palette steps.** Develop used explicit lighter palette colors (`$blue5`, `$blue6`). Current derives them from the rest token with lightness/chroma adjustments. This keeps colors themeable but may not be pixel-identical.

#### Tag Remove Button

| Property | Develop | Current |
|----------|---------|---------|
| Color (rest) | `rgba($white, 0.7)` | `oklch(from var(--bp-intent-default-foreground) l c h / 0.7)` |
| Color (hover/active) | `$white` | `var(--bp-intent-default-foreground)` |
| Intent remove color | `rgba($text-color, 0.7)` | `oklch(from $text-color l c h / 0.7)` |
| All margins/padding | `$tag-padding-top`, `$tag-padding`, `$tag-padding-large` | `calc(var(--bp-surface-spacing) * N)` |
| Large icon size | `$pt-icon-size-large` | `calc(var(--bp-surface-spacing) * 5)` |

#### CompoundTag Default Colors

| Side | Develop (rest, hover, active) | Current |
|------|-------------------------------|---------|
| Left | `$dark-gray5`, `$dark-gray4`, `$dark-gray3` | `oklch(from --bp-intent-default-{rest,hover,active} calc(l - 0.14/0.05/0.03) c h)` |
| Right | `$gray1`, `$dark-gray5`, `$dark-gray4` | `--bp-intent-default-{rest,hover,active}` |

**Differences:**
9. **Left panel colors derived via oklch darkening.** Develop used specific dark gray palette colors. Current darkens the intent token with oklch lightness subtraction. The exact shade will differ slightly.

#### CompoundTag Intent Left Colors

| Intent | Develop (rest, hover, active) | Current |
|--------|-------------------------------|---------|
| Primary | `$blue2`, `$blue1`, `$blue0` | `oklch(from --bp-intent-primary-{rest,hover,active} calc(l - 0.06/0.07/0.07) c h)` |
| Success | `$green2`, `$green1`, `$green0` | `oklch(from --bp-intent-success-{rest,hover,active} calc(l - 0.07/0.07/0.09) c h)` |
| Warning | `$orange4`, `$orange3`, `$orange2` | `oklch(from --bp-intent-warning-{rest,hover,active} calc(l + 0.11/0.13/0.08) c h)` |
| Danger | `$red2`, `$red1`, `$red0` | `oklch(from --bp-intent-danger-{rest,hover,active} calc(l - 0.07/0.05/0.04) c h)` |

#### CompoundTag Minimal

| Property | Develop | Current |
|----------|---------|---------|
| Default base color | `$gray1` | `var(--bp-intent-default-rest)` |
| Intent base colors | `@each $intent, $color in $pt-intent-colors` | Explicit per-intent `var(--bp-intent-*-rest)` calls |
| Transparency | `rgba($base-color, alpha)` | `oklch(from $base-color l c h / alpha)` |

**Differences:**
10. **Loop replaced with explicit intent rules.** Develop used `@each` over `$pt-intent-colors` map. Current lists each intent explicitly to pass CSS custom properties directly, since CSS vars can't be iterated in a Sass map.

#### CompoundTag Spacing

| Property | Develop | Current |
|----------|---------|---------|
| All padding | `$pt-spacing * N` | `calc(var(--bp-surface-spacing) * N)` |
| Border radius | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| Round border radius | `$tag-height` / `$tag-height-large` | `calc(var(--bp-surface-spacing) * 5)` / `calc(var(--bp-surface-spacing) * 7.5)` |
| Local round padding calc | `($tag-height * 0.5) - $tag-round-adjustment` | `calc(var(--bp-surface-spacing) * 2)` |

**Differences:**
11. **Local computed vars removed.** `$tag-round-horizontal-padding` and `$tag-round-horizontal-padding-large` local variables have been eliminated in favor of direct `calc()` expressions.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local `$tag-*` SCSS vars replaced with `calc()` expressions |
| 2 | High contrast | Native CSS `buttonborder` instead of SCSS variable |
| 3-4 | Warning intent | oklch lightness adjustments instead of explicit palette shades |
| 5 | Minimal background base | `$gray1` + oklch lightness boost instead of `$gray3` |
| 6-7 | All transparency | `oklch()` instead of `rgba()` — different color space |
| 8 | Dark minimal lighter shades | oklch derived from rest token instead of palette `$*5`/`$*6` |
| 9 | CompoundTag left panel | oklch darkening from intent token instead of explicit dark grays |
| 10 | CompoundTag minimal loop | `@each` over SCSS map → explicit per-intent rules (CSS var compat) |
| 11 | CompoundTag local vars | Removed intermediate computed SCSS variables |

#### Reviewers should focus on:

- Warning intent tag appearance (most visually distinct change due to oklch lightness adjustments)
- Minimal tag transparency (oklch vs rgba color space difference)
- CompoundTag left panel shading accuracy

#### Screenshot

**Tag**

| Before | After |
| ------ | ----- |
| <img width="770" height="486" alt="develop tag" src="https://github.com/user-attachments/assets/ddec44fc-27d7-40f0-9889-f0fc76d97492" /> | <img width="766" height="486" alt="design tokens tag" src="https://github.com/user-attachments/assets/a979fc5a-8b8e-497d-9e23-d8a0a562ff4d" /> |

**Compound Tag**

| Before | After |
| ------ | ----- |
| <img width="769" height="486" alt="develop compound tag" src="https://github.com/user-attachments/assets/587f6122-2066-4f06-a648-c5e0f32bab1f" /> | <img width="769" height="483" alt="design tokens compound tag" src="https://github.com/user-attachments/assets/e6f18f3b-573e-4c82-8a2c-5e54d6e649dd" /> |
