### PR TITLE
fix(Dialog): Render header when title prop is empty string

### DIFF
--- a/packages/core/src/components/dialog/dialog.test.tsx
+++ b/packages/core/src/components/dialog/dialog.test.tsx
@@ -134,6 +134,26 @@ describe("<Dialog>", () => {
             expect(header.closest(`.${Classes.DIALOG_HEADER}`)).toBeInTheDocument();
         });
 
+        it("should render header when title is an empty string", () => {
+            render(
+                <Dialog {...COMMON_PROPS} title="">
+                    <DialogBodyAndFooter />
+                </Dialog>,
+            );
+            const dialog = screen.getByRole("dialog");
+            expect(dialog.querySelector(`.${Classes.DIALOG_HEADER}`)).toBeInTheDocument();
+        });
+
+        it("should not render header when title is null", () => {
+            render(
+                <Dialog {...COMMON_PROPS} title={null}>
+                    <DialogBodyAndFooter />
+                </Dialog>,
+            );
+            const dialog = screen.getByRole("dialog");
+            expect(dialog.querySelector(`.${Classes.DIALOG_HEADER}`)).not.toBeInTheDocument();
+        });
+
         it("should render and remove close button based on isCloseButtonShown", async () => {
             const user = userEvent.setup();
             const onClose = vi.fn();

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -54,13 +54,13 @@ export interface DialogProps extends OverlayableProps, BackdropProps, Props {
     /**
      * Name of a Blueprint UI icon (or an icon element) to render in the
      * dialog's header. Note that the header will only be rendered if `title` is
-     * provided.
+     * not null or undefined.
      */
     icon?: IconName | MaybeElement;
 
     /**
      * Whether to show the close button in the dialog's header.
-     * Note that the header will only be rendered if `title` is provided.
+     * Note that the header will only be rendered if `title` is not null or undefined.
      *
      * @default true
      */
@@ -79,8 +79,10 @@ export interface DialogProps extends OverlayableProps, BackdropProps, Props {
     style?: React.CSSProperties;
 
     /**
-     * Title of the dialog. If provided, an element with `Classes.DIALOG_HEADER`
+     * Title of the dialog. If not null or undefined, an element with `Classes.DIALOG_HEADER`
      * will be rendered inside the dialog before any children elements.
+     * An empty string `""` will render the header without a visible title (useful for
+     * showing the close button without a title).
      */
     title?: React.ReactNode;
 
@@ -159,13 +161,13 @@ export const Dialog: React.FC<DialogProps> & { displayName?: string } = props =>
             <div className={Classes.DIALOG_CONTAINER} ref={mergeRefs(containerRef, childRef)}>
                 <div
                     aria-describedby={overlayProps["aria-describedby"]}
-                    aria-labelledby={overlayProps["aria-labelledby"] || (title ? titleId : undefined)}
+                    aria-labelledby={overlayProps["aria-labelledby"] || (title != null ? titleId : undefined)}
                     aria-modal={overlayProps.enforceFocus ?? true}
                     className={classNames(Classes.DIALOG, className)}
                     role={role}
                     style={style}
                 >
-                    {title && (
+                    {title != null && (
                         <div className={Classes.DIALOG_HEADER}>
                             <Icon icon={icon} size={IconSize.STANDARD} aria-hidden={true} tabIndex={-1} />
                             <TitleTagName id={titleId}>{title}</TitleTagName>


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #7438 where passing `title=""` to `Dialog` would suppress the header entirely (including the close button), because the functional component refactor changed the header guard from `title == null` to the truthy short-circuit `title &&`, which treats `""` as falsy.

- Change header render condition from `{title && ...}` to `{title != null && ...}`
- Add regression tests for `title=""` (header renders) and `title={null}` (header does not render)