### PR TITLE
[core] fix: Dark minimal buttons base color lightened

### DIFF
--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -465,14 +465,14 @@ $button-dark-minimal-active-text-colors: (
 
     &:hover {
       // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-      // Using incorrect semantic token to get closer to current values
+      // TODO(BP7): Update this semantic token to use `--bp-intent-default-hover`
       background-color: color-mix(in srgb, var(--bp-intent-default-rest) 24%, transparent);
     }
 
     &:active,
     &.#{$ns}-active {
       // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-      // Using incorrect semantic token to get closer to current values
+      // TODO(BP7): Update this semantic token to use `--bp-intent-default-active`
       background-color: color-mix(in srgb, var(--bp-intent-default-rest) 49%, transparent);
     }
 

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -465,15 +465,15 @@ $button-dark-minimal-active-text-colors: (
 
     &:hover {
       // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-      // Higher % than light theme because base color is close to dark backgrounds
-      background-color: color-mix(in srgb, var(--bp-intent-default-hover) 15%, transparent);
+      // Using incorrect semantic token to get closer to current values
+      background-color: color-mix(in srgb, var(--bp-intent-default-rest) 24%, transparent);
     }
 
     &:active,
     &.#{$ns}-active {
       // Use srgb instead of oklch to avoid hue shift with near-neutral colors
-      // Higher % than light theme because base color is close to dark backgrounds
-      background-color: color-mix(in srgb, var(--bp-intent-default-active) 30%, transparent);
+      // Using incorrect semantic token to get closer to current values
+      background-color: color-mix(in srgb, var(--bp-intent-default-rest) 49%, transparent);
     }
 
     &:disabled,

--- a/packages/core/src/design-tokens/USAGE.md
+++ b/packages/core/src/design-tokens/USAGE.md
@@ -103,6 +103,9 @@ The wrapping is triggered by the `com.blueprint.role: "stackable-layer"` annotat
 
 The Button component (`src/components/button/`) demonstrates how surface and intent tokens work together. The key files are `_common.scss` (shared mixins) and `_button.scss` (component styles).
 
+> [!NOTE]
+> The Button component in dark mode currently derives the `active` and `hover` states for minimal and outline buttons from the `rest` token. This is expected to be updated with an updated palette.
+
 ### Surface tokens in Button
 
 Surface tokens control the button's dimensions and structural properties:


### PR DESCRIPTION
#### Fixes

Issue with dark minimal buttons being too dark given the new color assignments for semantic meaning. `default-hover` and `default-active` intents are darker than the current use for buttons.

#### Checklist

-   [ ] Includes tests
-   [x] Update documentation

#### Changes proposed in this pull request:

Switching from `default-hover` and `default-active` to `default-rest` as base token for the dark minimal background colors.

#### Reviewers should focus on:

Visual regressions with dark minimal buttons

#### Screenshot

| Before | After |
| ------ | ----- |
| <img width="230" height="46" alt="before dark minimal" src="https://github.com/user-attachments/assets/d18302a1-bb85-4622-93f8-517922819c3d" /> | <img width="231" height="43" alt="after dark minimal" src="https://github.com/user-attachments/assets/a5902601-7a70-489e-9379-64d7720dd5ca" /> |

