### PR TITLE
[chore] Fix and update gh-pages deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "copy:ci-config": "mkdir -p site/.circleci && cp .circleci/config-gh-pages.yml site/.circleci/config.yml",
         "copy:docs-app": "cp -rf packages/docs-app/dist/ site/docs",
         "copy:landing-app": "cp -rf packages/landing-app/dist/ site",
-        "deploy": "gh-pages -d site -b gh-pages",
+        "deploy:site": "gh-pages -d site -b gh-pages",
         "dev": "nx run-many -t dev --exclude @blueprintjs/landing-app @blueprintjs/table-dev-app",
         "dev:core": "nx run-many -t dev -p @blueprintjs/core @blueprintjs/icons @blueprintjs/docs-app",
         "dev:docs": "nx run-many -t dev -p @blueprintjs/docs-app @blueprintjs/docs-theme",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "chai": "^5.0.0",
         "dedent": "^1.5.1",
         "eslint": "^9.20.0",
-        "gh-pages": "^6.1.1",
+        "gh-pages": "^6.3.0",
         "globals": "^15.14.0",
         "http-server": "^14.1.1",
         "npm-run-all": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         specifier: ^9.20.0
         version: 9.38.0(jiti@2.6.1)
       gh-pages:
-        specifier: ^6.1.1
+        specifier: ^6.3.0
         version: 6.3.0
       globals:
         specifier: ^15.14.0


### PR DESCRIPTION
## Summary

The `deploy` script in `package.json` conflicted with pnpm's built-in [`pnpm deploy`](https://pnpm.io/cli/deploy) command, causing:

```
ERR_PNPM_NOTHING_TO_DEPLOY  No project was selected for deployment
```

This likely worked previously when the project used yarn, but has been broken since the migration to pnpm (https://github.com/palantir/blueprint/pull/7598).

## Changes

- Rename `deploy` script → `deploy:site` to avoid the collision with pnpm's built-in and follow the existing colon-namespace convention (e.g. `site:clean`)
- Bump `gh-pages` from [`6.1.1`](https://github.com/tschaub/gh-pages/releases/tag/v6.1.1) → [`6.3.0`](https://github.com/tschaub/gh-pages/releases/tag/v6.3.0)

## Testing

Run `pnpm deploy:site` after a `pnpm site` build to deploy to the `gh-pages` branch.