### PR TITLE
[core] fix: Adding back reference to static colors for controls

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -42,7 +42,7 @@
   }
 
   // intents
-  @each $intent, $colors in $button-intents {
+  @each $intent, $colors in $button-intent-states {
     &.#{$ns}-intent-#{$intent} {
       @include pt-button-intent($colors...);
     }

--- a/packages/core/src/components/button/_common.scss
+++ b/packages/core/src/components/button/_common.scss
@@ -82,8 +82,65 @@ $button-outlined-border-disabled-intent-opacity: 0.2 !default;
   }
 }
 
-// "intent": (default, hover, active colors)
+// TODO(bp7): Replace with $button-intent-states
 $button-intents: (
+  "primary": (
+    $blue3,
+    $blue2,
+    $blue1,
+  ),
+  "success": (
+    $green3,
+    $green2,
+    $green1,
+  ),
+  "warning": (
+    $orange3,
+    $orange2,
+    $orange1,
+  ),
+  "danger": (
+    $red3,
+    $red2,
+    $red1,
+  ),
+) !default;
+
+// Intent at each state
+$button-intent-states: (
+  "primary": (
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
+    var(--bp-intent-primary-foreground),
+  ),
+  "success": (
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
+    var(--bp-intent-success-foreground),
+  ),
+  "warning": (
+    var(--bp6-button-warning-rest),
+    var(--bp-intent-warning-hover),
+    var(--bp-intent-warning-active),
+    var(--bp-intent-warning-foreground),
+  ),
+  "danger": (
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
+    var(--bp-intent-danger-foreground),
+  ),
+  "default": (
+    var(--bp-intent-default-rest),
+    var(--bp-intent-default-hover),
+    var(--bp-intent-default-active),
+    var(--bp-intent-default-foreground),
+  ),
+) !default;
+
+$button-intent-states: (
   "primary": (
     var(--bp-intent-primary-rest),
     var(--bp-intent-primary-hover),
@@ -490,7 +547,7 @@ $button-dark-minimal-active-text-colors: (
     }
   }
 
-  @each $intent, $colors in $button-intents {
+  @each $intent, $colors in $button-intent-states {
     &.#{$ns}-intent-#{$intent} {
       @include pt-button-minimal-intent($intent);
     }
@@ -590,7 +647,7 @@ $button-dark-minimal-active-text-colors: (
     }
   }
 
-  @each $intent, $colors in $button-intents {
+  @each $intent, $colors in $button-intent-states {
     $text-color: map.get($button-minimal-intent-text-colors, $intent);
     $dark-text-color: map.get($button-dark-intent-text-colors, $intent);
 

--- a/packages/core/src/design-tokens/USAGE.md
+++ b/packages/core/src/design-tokens/USAGE.md
@@ -132,7 +132,7 @@ The large button variant simply scales the multiplier: `calc(var(--bp-surface-sp
 Intent tokens drive the button's color across every interaction state. For non-default intents (primary, success, warning, danger), a Sass map wires each intent to its tokens:
 
 ```scss
-$button-intents: (
+$button-intent-states: (
     "primary": (
         var(--bp-intent-primary-rest),
         // background


### PR DESCRIPTION
#### Fixes #7829

#### Checklist

-   [ ] Includes tests
-   [x] Update documentation

#### Changes proposed in this pull request:

* Reverts `$button-intents` variable to original definition to be consumed by controls and file input
* Uses a new `$button-intent-states` variable within the button file

#### Reviewers should focus on:

* Checkbox can be checked and disabled and end up with valid CSS
* Docs app banner has the correct backgrounds (and do not change with intent color changes)

#### Screenshot

| Before | After |
| ------ | ------ |
| <img width="776" height="584" alt="bug checkbox" src="https://github.com/user-attachments/assets/9eacc88b-2211-42d0-9ddf-80ff0e9c14b4" /> | <img width="801" height="570" alt="checkbox" src="https://github.com/user-attachments/assets/046d6b6f-ae88-4f53-9801-b345a353b9f1" /> |
