### PR TITLE
[docs-theme] Fix broken @see links in props interface tables

### DIFF
--- a/packages/docs-theme/changelog/@unreleased/pr-7832.v2.yml
+++ b/packages/docs-theme/changelog/@unreleased/pr-7832.v2.yml
@@ -2,4 +2,4 @@ type: fix
 fix:
   description: Fix broken @see links in props interface tables
   links:
-    - https://github.com/palantir/blueprint/pull/7832
+  - https://github.com/palantir/blueprint/pull/7832

--- a/packages/docs-theme/changelog/@unreleased/pr-7832.v2.yml
+++ b/packages/docs-theme/changelog/@unreleased/pr-7832.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix broken @see links in props interface tables
+  links:
+    - https://github.com/palantir/blueprint/pull/7832

--- a/packages/docs-theme/src/tags/see.tsx
+++ b/packages/docs-theme/src/tags/see.tsx
@@ -22,6 +22,36 @@ import { DocumentationContext } from "../common/context";
 
 export const SeeTag: React.FC<Tag> = ({ value }) => {
     const { renderType } = useContext(DocumentationContext);
-    return <p>See: {renderType(value)}</p>;
+    return <p>See: {renderSeeTagValue(value) ?? renderType(value)}</p>;
 };
 SeeTag.displayName = `${COMPONENT_DISPLAY_NAMESPACE}.SeeTag`;
+
+function renderSeeTagValue(value: string) {
+    const link = getSeeTagLink(value);
+    if (link == null) {
+        return undefined;
+    }
+
+    return <a href={link.href}>{link.text}</a>;
+}
+
+function getSeeTagLink(value: string) {
+    const trimmedValue = value.trim();
+    const linkTagMatch = trimmedValue.match(/^\{@link\s+([^}\s]+)(?:\s+([^}]+))?\}$/);
+    const linkValue = linkTagMatch?.[1] ?? trimmedValue;
+
+    if (!isHttpLink(linkValue)) {
+        return undefined;
+    }
+
+    return { href: linkValue, text: linkTagMatch?.[2] ?? linkValue };
+}
+
+function isHttpLink(value: string) {
+    try {
+        const url = new URL(value);
+        return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- update `SeeTag` to render HTTP(S) values from `@see` as clickable anchor links
- add support for JSDoc `{@link ...}` syntax inside `@see` values
- preserve existing type-rendering behavior as fallback for non-link values

## Why
Fixes #6553. In props interface tables, many `@see` tags are URL references, but they were being rendered through `renderType(...)`, which is intended for TypeScript type expressions.

## Validation
- `pnpm nx compile @blueprintjs/docs-theme`
- `pnpm nx compile @blueprintjs/eslint-plugin`
- `pnpm nx lint @blueprintjs/docs-theme`

(Executed with Node `v22.14.0`; repository prints an engine warning because it currently prefers Node `>=24.11.0`.)
