### PR TITLE
[chore]: Upgrade TypeScript from `5.3.3` to `5.9.x`

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.2.2",
+    "version": "5.9.3",
     "compilerOptions": {
         "allowSyntheticDefaultImports": true,
         "declaration": true,

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
         "stylelint": "~16.25.0",
         "stylelint-config-palantir": "^7.6.0",
         "stylelint-scss": "^6.12.1",
-        "typescript": "~5.3.3",
-        "typescript-eslint": "^8.23.0",
+        "typescript": "~5.9.3",
+        "typescript-eslint": "^8.56.1",
         "vitest": "catalog:",
         "yargs": "^17.7.2"
     },

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -31,7 +31,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "workspace:^",
         "mocha": "^10.2.0",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
         "react-test-renderer": "^18.3.1",
         "style-dictionary": "^5.0.3",
         "tsx": "^4.21.0",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "vitest": "catalog:",
         "webpack-cli": "^5.1.4"
     },

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -73,9 +73,9 @@
         "npm-run-all": "^4.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "typescript": "~5.3.3",
-        "webpack-cli": "^5.1.4",
-        "vitest": "catalog:"
+        "typescript": "~5.9.3",
+        "vitest": "catalog:",
+        "webpack-cli": "^5.1.4"
     },
     "repository": {
         "type": "git",

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -58,7 +58,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -59,7 +59,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "webpack-cli": "^5.1.4"
     },
     "repository": {

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -12,10 +12,10 @@
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.0.0",
         "globals": "^15.14.0",
-        "typescript-eslint": "^8.23.0"
+        "typescript-eslint": "^8.56.1"
     },
     "peerDependencies": {
-        "typescript": "^5.2.2"
+        "typescript": "^5.9.3"
     },
     "peerDependenciesMeta": {
         "typescript": {
@@ -23,7 +23,7 @@
         }
     },
     "devDependencies": {
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,7 +11,7 @@
         "test": "SWC_NODE_PROJECT=./tsconfig.test.json mocha --require @swc-node/register,test/setup.ts --watch-extensions ts,tsx 'test/**/*.{ts,tsx}'"
     },
     "dependencies": {
-        "@typescript-eslint/utils": "^8.23.0"
+        "@typescript-eslint/utils": "^8.56.1"
     },
     "peerDependencies": {
         "eslint": "^8.57 || ^9.0.0"
@@ -21,11 +21,11 @@
         "@swc-node/register": "^1.6.8",
         "@swc/core": "^1.3.105",
         "@types/dedent": "~0.7.2",
-        "@typescript-eslint/rule-tester": "^8.23.0",
+        "@typescript-eslint/rule-tester": "^8.56.1",
         "dedent": "^1.5.1",
         "mocha": "^10.2.0",
         "tslib": "catalog:",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -67,7 +67,7 @@
         "react-dom": "^18.3.1",
         "react-test-renderer": "^18.3.1",
         "svg-parser": "^2.0.4",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "webpack-cli": "^5.1.4"
     },
     "repository": {

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -56,7 +56,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "vitest": "catalog:"
     },
     "repository": {

--- a/packages/monaco-editor-theme/package.json
+++ b/packages/monaco-editor-theme/package.json
@@ -32,7 +32,7 @@
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "workspace:^",
         "npm-run-all": "^4.1.5",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/node-build-scripts/package.json
+++ b/packages/node-build-scripts/package.json
@@ -43,7 +43,7 @@
         "stylelint": "~16.25.0",
         "stylelint-junit-formatter": "^0.2.2",
         "svgo": "^1.3.2",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "yargs": "^17.7.2"
     },
     "devDependencies": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -66,7 +66,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-test-renderer": "^18.3.1",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "webpack-cli": "^5.1.4"
     },
     "repository": {

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -26,7 +26,7 @@
         "mocha": "^10.2.0",
         "postcss-scss": "^4.0.9",
         "stylelint": "~16.25.0",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -69,7 +69,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-test-renderer": "^18.3.1",
-        "typescript": "~5.3.3",
+        "typescript": "~5.9.3",
         "webpack": "^5.90.0"
     },
     "repository": {

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -64,7 +64,7 @@
         "npm-run-all": "^4.1.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "repository": {
         "type": "git",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -11,7 +11,7 @@
         "tslib": "catalog:",
         "tslint-react": "^5.0.0",
         "tsutils": "^3.21.0",
-        "typescript": "~5.3.3"
+        "typescript": "~5.9.3"
     },
     "peerDependencies": {
         "tslint": "^6.0.0"

--- a/packages/webpack-build-scripts/package.json
+++ b/packages/webpack-build-scripts/package.json
@@ -35,7 +35,7 @@
         "style-loader": "^3.3.4",
         "swc-loader": "^0.2.3",
         "terser-webpack-plugin": "^5.3.10",
-        "typescript": "^5.3.3",
+        "typescript": "^5.9.3",
         "webpack": "^5.90.0",
         "webpack-bundle-analyzer": "^4.10.1",
         "webpack-dev-server": "^4.15.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,10 +50,10 @@ importers:
     dependencies:
       '@lerna-lite/cli':
         specifier: ^3.11.0
-        version: 3.12.3(@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.3.3))(@types/node@24.10.0)(typescript@5.3.3)
+        version: 3.12.3(@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.9.3))(@types/node@24.10.0)(typescript@5.9.3)
       '@lerna-lite/version':
         specifier: ^3.11.0
-        version: 3.12.3(@types/node@24.10.0)(typescript@5.3.3)
+        version: 3.12.3(@types/node@24.10.0)(typescript@5.9.3)
       '@types/chai':
         specifier: ^5.0.0
         version: 5.2.3
@@ -110,7 +110,7 @@ importers:
         version: 4.1.5
       nx:
         specifier: ^22.3.1
-        version: 22.3.1(@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.3.3))(@swc/core@1.13.20)
+        version: 22.3.1(@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.13.20)
       octokit:
         specifier: ^5.0.5
         version: 5.0.5
@@ -122,19 +122,19 @@ importers:
         version: 17.0.2
       stylelint:
         specifier: ~16.25.0
-        version: 16.25.0(typescript@5.3.3)
+        version: 16.25.0(typescript@5.9.3)
       stylelint-config-palantir:
         specifier: ^7.6.0
-        version: 7.6.0(postcss-scss@4.0.9(postcss@8.5.6))(postcss@8.5.6)(stylelint@16.25.0(typescript@5.3.3))
+        version: 7.6.0(postcss-scss@4.0.9(postcss@8.5.6))(postcss@8.5.6)(stylelint@16.25.0(typescript@5.9.3))
       stylelint-scss:
         specifier: ^6.12.1
-        version: 6.12.1(stylelint@16.25.0(typescript@5.3.3))
+        version: 6.12.1(stylelint@16.25.0(typescript@5.9.3))
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       typescript-eslint:
-        specifier: ^8.23.0
-        version: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+        specifier: ^8.56.1
+        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.0.7(@types/node@24.10.0)(jiti@2.6.1)(jsdom@27.1.0)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
@@ -155,8 +155,8 @@ importers:
         specifier: ^10.2.0
         version: 10.8.2
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/core:
     dependencies:
@@ -255,8 +255,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.7(@types/node@24.10.0)(jiti@2.6.1)(jsdom@27.1.0)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
@@ -343,8 +343,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.7(@types/node@24.10.0)(jiti@2.6.1)(jsdom@27.1.0)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
@@ -395,8 +395,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/demo-app:
     dependencies:
@@ -596,7 +596,7 @@ importers:
         version: link:../docs-theme
       '@documentalist/compiler':
         specifier: ^5.0.0
-        version: 5.0.0(chokidar@3.6.0)(typescript@5.3.3)
+        version: 5.0.0(chokidar@3.6.0)(typescript@5.9.3)
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -659,8 +659,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.102.1)
@@ -678,7 +678,7 @@ importers:
         version: 3.1.1(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ~2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3))(eslint@9.38.0(jiti@2.6.1))
+        version: 2.31.0(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsdoc:
         specifier: ^48.0.2
         version: 48.11.0(eslint@9.38.0(jiti@2.6.1))
@@ -695,18 +695,18 @@ importers:
         specifier: ^15.14.0
         version: 15.15.0
       typescript-eslint:
-        specifier: ^8.23.0
-        version: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+        specifier: ^8.56.1
+        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
     devDependencies:
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/eslint-plugin:
     dependencies:
       '@typescript-eslint/utils':
-        specifier: ^8.23.0
-        version: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+        specifier: ^8.56.1
+        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^8.57 || ^9.0.0
         version: 9.38.0(jiti@2.6.1)
@@ -716,7 +716,7 @@ importers:
         version: link:../node-build-scripts
       '@swc-node/register':
         specifier: ^1.6.8
-        version: 1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.3.3)
+        version: 1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3)
       '@swc/core':
         specifier: ^1.3.105
         version: 1.13.20
@@ -724,8 +724,8 @@ importers:
         specifier: ~0.7.2
         version: 0.7.2
       '@typescript-eslint/rule-tester':
-        specifier: ^8.23.0
-        version: 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+        specifier: ^8.56.1
+        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       dedent:
         specifier: ^1.5.1
         version: 1.7.0
@@ -736,8 +736,8 @@ importers:
         specifier: 'catalog:'
         version: 2.6.3
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/icons:
     dependencies:
@@ -794,8 +794,8 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.102.1)
@@ -903,8 +903,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.0.7(@types/node@24.10.0)(jiti@2.6.1)(jsdom@27.1.0)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
@@ -974,8 +974,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/node-build-scripts:
     dependencies:
@@ -1047,7 +1047,7 @@ importers:
         version: 5.0.0
       stylelint:
         specifier: ~16.25.0
-        version: 16.25.0(typescript@5.3.3)
+        version: 16.25.0(typescript@5.9.3)
       stylelint-junit-formatter:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1055,8 +1055,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1141,8 +1141,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.102.1)
@@ -1179,10 +1179,10 @@ importers:
         version: 4.0.9(postcss@8.5.6)
       stylelint:
         specifier: ~16.25.0
-        version: 16.25.0(typescript@5.3.3)
+        version: 16.25.0(typescript@5.9.3)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/table:
     dependencies:
@@ -1251,8 +1251,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
       webpack:
         specifier: ^5.90.0
         version: 5.102.1(@swc/core@1.13.20)
@@ -1367,8 +1367,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
 
   packages/tslint-config:
     dependencies:
@@ -1377,17 +1377,17 @@ importers:
         version: 2.6.3
       tslint-react:
         specifier: ^5.0.0
-        version: 5.0.0(tslint@6.1.3(typescript@5.3.3))(typescript@5.3.3)
+        version: 5.0.0(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3)
       tsutils:
         specifier: ^3.21.0
-        version: 3.21.0(typescript@5.3.3)
+        version: 3.21.0(typescript@5.9.3)
       typescript:
-        specifier: ~5.3.3
-        version: 5.3.3
+        specifier: ~5.9.3
+        version: 5.9.3
     devDependencies:
       tslint:
         specifier: ~6.1.3
-        version: 6.1.3(typescript@5.3.3)
+        version: 6.1.3(typescript@5.9.3)
 
   packages/webpack-build-scripts:
     dependencies:
@@ -1414,10 +1414,10 @@ importers:
         version: 6.1.2(postcss@8.5.6)
       fork-ts-checker-notifier-webpack-plugin:
         specifier: ^9.0.0
-        version: 9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20)))
+        version: 9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)))
       fork-ts-checker-webpack-plugin:
         specifier: ^9.0.2
-        version: 9.1.0(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))
       istanbul-instrumenter-loader:
         specifier: ^3.0.1
         version: 3.0.1(webpack@5.102.1(@swc/core@1.13.20))
@@ -1432,7 +1432,7 @@ importers:
         version: 6.0.2(postcss@8.5.6)
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.2.0(postcss@8.5.6)(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -1461,8 +1461,8 @@ importers:
         specifier: ^5.3.10
         version: 5.3.14(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20))
       typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^5.9.3
+        version: 5.9.3
       webpack:
         specifier: ^5.90.0
         version: 5.102.1(@swc/core@1.13.20)
@@ -2103,8 +2103,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@eslint-community/eslint-utils@4.9.0':
-    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
@@ -2237,14 +2237,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -3499,69 +3491,69 @@ packages:
   '@types/yargs@17.0.34':
     resolution: {integrity: sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==}
 
-  '@typescript-eslint/eslint-plugin@8.46.2':
-    resolution: {integrity: sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==}
+  '@typescript-eslint/eslint-plugin@8.56.1':
+    resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.46.2
-      eslint: ^8.57.0 || ^9.0.0
+      '@typescript-eslint/parser': ^8.56.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.46.2':
-    resolution: {integrity: sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==}
+  '@typescript-eslint/parser@8.56.1':
+    resolution: {integrity: sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/project-service@8.46.2':
-    resolution: {integrity: sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/rule-tester@8.46.2':
-    resolution: {integrity: sha512-95F3U8JcJmQEvMyD/VH88c96EWTg3d5F7iIb7puZPowweIArCiVFHbnBJVXw7nhJGsCFMG6LavdMWkkJaOxBdw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-
-  '@typescript-eslint/scope-manager@8.46.2':
-    resolution: {integrity: sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.46.2':
-    resolution: {integrity: sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==}
+  '@typescript-eslint/project-service@8.56.1':
+    resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/type-utils@8.46.2':
-    resolution: {integrity: sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==}
+  '@typescript-eslint/rule-tester@8.56.1':
+    resolution: {integrity: sha512-EWuV5Vq1EFYJEOVcILyWPO35PjnT0c6tv99PCpD12PgfZae5/Jo+F17hGjsEs2Moe+Dy1J7KIr8y037cK8+/rQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
-  '@typescript-eslint/types@8.46.2':
-    resolution: {integrity: sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==}
+  '@typescript-eslint/scope-manager@8.56.1':
+    resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/typescript-estree@8.46.2':
-    resolution: {integrity: sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==}
+  '@typescript-eslint/tsconfig-utils@8.56.1':
+    resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.56.1':
+    resolution: {integrity: sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.56.1':
+    resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.56.1':
+    resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.46.2':
-    resolution: {integrity: sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==}
+  '@typescript-eslint/utils@8.56.1':
+    resolution: {integrity: sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.46.2':
-    resolution: {integrity: sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==}
+  '@typescript-eslint/visitor-keys@8.56.1':
+    resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@5.1.0':
@@ -4078,6 +4070,10 @@ packages:
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4139,6 +4135,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5225,6 +5225,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.38.0:
     resolution: {integrity: sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5721,9 +5725,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  graphemer@1.4.0:
-    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
@@ -6947,9 +6948,9 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -8963,8 +8964,8 @@ packages:
     resolution: {integrity: sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==}
     engines: {node: '>=0.10.0'}
 
-  ts-api-utils@2.1.0:
-    resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
@@ -9106,15 +9107,15 @@ packages:
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
 
-  typescript-eslint@8.46.2:
-    resolution: {integrity: sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==}
+  typescript-eslint@8.56.1:
+    resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -9987,7 +9988,7 @@ snapshots:
 
   '@documentalist/client@5.0.0': {}
 
-  '@documentalist/compiler@5.0.0(chokidar@3.6.0)(typescript@5.3.3)':
+  '@documentalist/compiler@5.0.0(chokidar@3.6.0)(typescript@5.9.3)':
     dependencies:
       '@documentalist/client': 5.0.0
       '@types/kss': 3.0.4
@@ -9996,7 +9997,7 @@ snapshots:
       kss: 3.1.0(chokidar@3.6.0)
       marked: 4.3.0
       tsconfig-resolver: 3.0.1
-      typedoc: 0.25.13(typescript@5.3.3)
+      typedoc: 0.25.13(typescript@5.9.3)
       yargs: 17.7.2
     transitivePeerDependencies:
       - chokidar
@@ -10179,7 +10180,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.38.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.38.0(jiti@2.6.1))':
     dependencies:
       eslint: 9.38.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
@@ -10310,12 +10311,6 @@ snapshots:
   '@inquirer/type@3.0.9(@types/node@24.10.0)':
     optionalDependencies:
       '@types/node': 24.10.0
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.0':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -10598,10 +10593,10 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@lerna-lite/cli@3.12.3(@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.3.3))(@types/node@24.10.0)(typescript@5.3.3)':
+  '@lerna-lite/cli@3.12.3(@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.9.3))(@types/node@24.10.0)(typescript@5.9.3)':
     dependencies:
-      '@lerna-lite/core': 3.12.3(@types/node@24.10.0)(typescript@5.3.3)
-      '@lerna-lite/init': 3.12.3(@types/node@24.10.0)(typescript@5.3.3)
+      '@lerna-lite/core': 3.12.3(@types/node@24.10.0)(typescript@5.9.3)
+      '@lerna-lite/init': 3.12.3(@types/node@24.10.0)(typescript@5.9.3)
       '@lerna-lite/npmlog': 3.12.1
       dedent: 1.7.0
       dotenv: 16.6.1
@@ -10609,7 +10604,7 @@ snapshots:
       load-json-file: 7.0.1
       yargs: 17.7.2
     optionalDependencies:
-      '@lerna-lite/version': 3.12.3(@types/node@24.10.0)(typescript@5.3.3)
+      '@lerna-lite/version': 3.12.3(@types/node@24.10.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10617,7 +10612,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/core@3.12.3(@types/node@24.10.0)(typescript@5.3.3)':
+  '@lerna-lite/core@3.12.3(@types/node@24.10.0)(typescript@5.9.3)':
     dependencies:
       '@inquirer/expand': 4.0.21(@types/node@24.10.0)
       '@inquirer/input': 4.2.5(@types/node@24.10.0)
@@ -10626,7 +10621,7 @@ snapshots:
       '@npmcli/run-script': 8.1.0
       clone-deep: 4.0.1
       config-chain: 1.1.13
-      cosmiconfig: 9.0.0(typescript@5.3.3)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       dedent: 1.7.0
       execa: 8.0.1
       fs-extra: 11.3.2
@@ -10656,9 +10651,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna-lite/init@3.12.3(@types/node@24.10.0)(typescript@5.3.3)':
+  '@lerna-lite/init@3.12.3(@types/node@24.10.0)(typescript@5.9.3)':
     dependencies:
-      '@lerna-lite/core': 3.12.3(@types/node@24.10.0)(typescript@5.3.3)
+      '@lerna-lite/core': 3.12.3(@types/node@24.10.0)(typescript@5.9.3)
       fs-extra: 11.3.2
       p-map: 7.0.3
       write-json-file: 6.0.0
@@ -10680,10 +10675,10 @@ snapshots:
       string-width: 7.2.0
       wide-align: 1.1.5
 
-  '@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.3.3)':
+  '@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.9.3)':
     dependencies:
-      '@lerna-lite/cli': 3.12.3(@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.3.3))(@types/node@24.10.0)(typescript@5.3.3)
-      '@lerna-lite/core': 3.12.3(@types/node@24.10.0)(typescript@5.3.3)
+      '@lerna-lite/cli': 3.12.3(@lerna-lite/version@3.12.3(@types/node@24.10.0)(typescript@5.9.3))(@types/node@24.10.0)(typescript@5.9.3)
+      '@lerna-lite/core': 3.12.3(@types/node@24.10.0)(typescript@5.9.3)
       '@lerna-lite/npmlog': 3.12.1
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 21.1.1
@@ -11318,7 +11313,7 @@ snapshots:
       '@swc/core': 1.13.20
       '@swc/types': 0.1.25
 
-  '@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.3.3)':
+  '@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3)':
     dependencies:
       '@swc-node/core': 1.14.1(@swc/core@1.13.20)(@swc/types@0.1.25)
       '@swc-node/sourcemap-support': 0.6.1
@@ -11328,7 +11323,7 @@ snapshots:
       oxc-resolver: 11.11.1
       pirates: 4.0.7
       tslib: 2.8.1
-      typescript: 5.3.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@swc/types'
       - supports-color
@@ -11715,49 +11710,48 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/type-utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 8.46.2
+      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/type-utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
       eslint: 9.38.0(jiti@2.6.1)
-      graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.3.3)
-      typescript: 5.3.3
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/visitor-keys': 8.46.2
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.38.0(jiti@2.6.1)
-      typescript: 5.3.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.2(typescript@5.3.3)':
+  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/types': 8.46.2
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
       debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.3.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)':
+  '@typescript-eslint/rule-tester@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       ajv: 6.12.6
       eslint: 9.38.0(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
@@ -11767,60 +11761,59 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/scope-manager@8.46.2':
+  '@typescript-eslint/scope-manager@8.56.1':
     dependencies:
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/visitor-keys': 8.46.2
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
 
-  '@typescript-eslint/tsconfig-utils@8.46.2(typescript@5.3.3)':
+  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)':
+  '@typescript-eslint/type-utils@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.38.0(jiti@2.6.1)
-      ts-api-utils: 2.1.0(typescript@5.3.3)
-      typescript: 5.3.3
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.46.2': {}
+  '@typescript-eslint/types@8.56.1': {}
 
-  '@typescript-eslint/typescript-estree@8.46.2(typescript@5.3.3)':
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/tsconfig-utils': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/visitor-keys': 8.46.2
+      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3(supports-color@8.1.1)
-      fast-glob: 3.3.3
-      is-glob: 4.0.3
-      minimatch: 9.0.5
+      minimatch: 10.2.4
       semver: 7.7.3
-      ts-api-utils: 2.1.0(typescript@5.3.3)
-      typescript: 5.3.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.46.2
-      '@typescript-eslint/types': 8.46.2
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.3.3)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
-      typescript: 5.3.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.46.2':
+  '@typescript-eslint/visitor-keys@8.56.1':
     dependencies:
-      '@typescript-eslint/types': 8.46.2
-      eslint-visitor-keys: 4.2.1
+      '@typescript-eslint/types': 8.56.1
+      eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@5.1.0(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
@@ -12446,6 +12439,8 @@ snapshots:
 
   balanced-match@2.0.0: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
@@ -12516,6 +12511,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -12971,23 +12970,23 @@ snapshots:
 
   corser@2.0.1: {}
 
-  cosmiconfig@8.3.6(typescript@5.3.3):
+  cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.9.3
 
-  cosmiconfig@9.0.0(typescript@5.3.3):
+  cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.9.3
 
   create-jest@29.7.0(@types/node@24.10.0):
     dependencies:
@@ -13739,11 +13738,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -13753,7 +13752,7 @@ snapshots:
     dependencies:
       eslint: 9.38.0(jiti@2.6.1)
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13764,7 +13763,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13776,7 +13775,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -13858,9 +13857,11 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.38.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.1
@@ -14181,17 +14182,17 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-notifier-webpack-plugin@9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20))):
+  fork-ts-checker-notifier-webpack-plugin@9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))):
     dependencies:
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))
       node-notifier: 10.0.1
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
       chokidar: 4.0.3
-      cosmiconfig: 8.3.6(typescript@5.3.3)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
@@ -14200,7 +14201,7 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.7.3
       tapable: 2.3.0
-      typescript: 5.3.3
+      typescript: 5.9.3
       webpack: 5.102.1(@swc/core@1.13.20)
 
   form-data@4.0.4:
@@ -14397,7 +14398,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.2.4
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -14471,8 +14472,6 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
-
-  graphemer@1.4.0: {}
 
   growly@1.3.0: {}
 
@@ -15923,9 +15922,9 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@10.1.1:
+  minimatch@10.2.4:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      brace-expansion: 5.0.4
 
   minimatch@3.0.8:
     dependencies:
@@ -16263,7 +16262,7 @@ snapshots:
     optionalDependencies:
       chokidar: 3.6.0
 
-  nx@22.3.1(@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.3.3))(@swc/core@1.13.20):
+  nx@22.3.1(@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.13.20):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0
@@ -16311,7 +16310,7 @@ snapshots:
       '@nx/nx-linux-x64-musl': 22.3.1
       '@nx/nx-win32-arm64-msvc': 22.3.1
       '@nx/nx-win32-x64-msvc': 22.3.1
-      '@swc-node/register': 1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.3.3)
+      '@swc-node/register': 1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3)
       '@swc/core': 1.13.20
     transitivePeerDependencies:
       - debug
@@ -16756,9 +16755,9 @@ snapshots:
       postcss: 8.5.6
       tsx: 4.21.0
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.3.3)(webpack@5.102.1(@swc/core@1.13.20)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.3.3)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.3
@@ -17913,36 +17912,36 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  stylelint-config-palantir@7.6.0(postcss-scss@4.0.9(postcss@8.5.6))(postcss@8.5.6)(stylelint@16.25.0(typescript@5.3.3)):
+  stylelint-config-palantir@7.6.0(postcss-scss@4.0.9(postcss@8.5.6))(postcss@8.5.6)(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@5.3.3)
-      stylelint-config-standard: 36.0.1(stylelint@16.25.0(typescript@5.3.3))
-      stylelint-order: 6.0.4(stylelint@16.25.0(typescript@5.3.3))
+      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint-config-standard: 36.0.1(stylelint@16.25.0(typescript@5.9.3))
+      stylelint-order: 6.0.4(stylelint@16.25.0(typescript@5.9.3))
     optionalDependencies:
       postcss: 8.5.6
       postcss-scss: 4.0.9(postcss@8.5.6)
-      stylelint-scss: 6.12.1(stylelint@16.25.0(typescript@5.3.3))
+      stylelint-scss: 6.12.1(stylelint@16.25.0(typescript@5.9.3))
 
-  stylelint-config-recommended@14.0.1(stylelint@16.25.0(typescript@5.3.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@5.3.3)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint-config-standard@36.0.1(stylelint@16.25.0(typescript@5.3.3)):
+  stylelint-config-standard@36.0.1(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.25.0(typescript@5.3.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.25.0(typescript@5.3.3))
+      stylelint: 16.25.0(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.25.0(typescript@5.9.3))
 
   stylelint-junit-formatter@0.2.2:
     dependencies:
       xmlbuilder: 13.0.2
 
-  stylelint-order@6.0.4(stylelint@16.25.0(typescript@5.3.3)):
+  stylelint-order@6.0.4(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.6
       postcss-sorting: 8.0.2(postcss@8.5.6)
-      stylelint: 16.25.0(typescript@5.3.3)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint-scss@6.12.1(stylelint@16.25.0(typescript@5.3.3)):
+  stylelint-scss@6.12.1(stylelint@16.25.0(typescript@5.9.3)):
     dependencies:
       css-tree: 3.1.0
       is-plain-object: 5.0.0
@@ -17952,9 +17951,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
-      stylelint: 16.25.0(typescript@5.3.3)
+      stylelint: 16.25.0(typescript@5.9.3)
 
-  stylelint@16.25.0(typescript@5.3.3):
+  stylelint@16.25.0(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
@@ -17963,7 +17962,7 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.2.1
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.0(typescript@5.3.3)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       css-functions-list: 3.2.3
       css-tree: 3.1.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -18231,9 +18230,9 @@ snapshots:
 
   trim-right@1.0.1: {}
 
-  ts-api-utils@2.1.0(typescript@5.3.3):
+  ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.9.3
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -18263,13 +18262,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tslint-react@5.0.0(tslint@6.1.3(typescript@5.3.3))(typescript@5.3.3):
+  tslint-react@5.0.0(tslint@6.1.3(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
-      tslint: 6.1.3(typescript@5.3.3)
-      tsutils: 3.21.0(typescript@5.3.3)
-      typescript: 5.3.3
+      tslint: 6.1.3(typescript@5.9.3)
+      tsutils: 3.21.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  tslint@6.1.3(typescript@5.3.3):
+  tslint@6.1.3(typescript@5.9.3):
     dependencies:
       '@babel/code-frame': 7.27.1
       builtin-modules: 1.1.1
@@ -18283,18 +18282,18 @@ snapshots:
       resolve: 1.22.11
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@5.3.3)
-      typescript: 5.3.3
+      tsutils: 2.29.0(typescript@5.9.3)
+      typescript: 5.9.3
 
-  tsutils@2.29.0(typescript@5.3.3):
+  tsutils@2.29.0(typescript@5.9.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.3.3
+      typescript: 5.9.3
 
-  tsutils@3.21.0(typescript@5.3.3):
+  tsutils@3.21.0(typescript@5.9.3):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.3.3
+      typescript: 5.9.3
 
   tsx@4.21.0:
     dependencies:
@@ -18396,26 +18395,26 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typedoc@0.25.13(typescript@5.3.3):
+  typedoc@0.25.13(typescript@5.9.3):
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
       minimatch: 9.0.5
       shiki: 0.14.7
-      typescript: 5.3.3
+      typescript: 5.9.3
 
-  typescript-eslint@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3):
+  typescript-eslint@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
-      '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
-      '@typescript-eslint/typescript-estree': 8.46.2(typescript@5.3.3)
-      '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
-      typescript: 5.3.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.3.3: {}
+  typescript@5.9.3: {}
 
   ua-parser-js@0.7.41: {}
 


### PR DESCRIPTION
## Description:

Upgrades TypeScript to `5.9.3` and bumps `typescript-eslint` to `8.56.1` for compatibility.

- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-9.html
- https://typescript-eslint.io
- https://github.com/typescript-eslint/typescript-eslint/releases