### PR TITLE
fix(Tag): Fix text-align regression for tags with icons or fill

### DIFF
--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -117,7 +117,12 @@ $minimal-dark-tag-intent-colors: (
   min-width: $tag-height;
   padding: $tag-padding-top $tag-padding;
   position: relative;
-  text-align: center;
+
+  // Center text for short content (e.g. single characters) only when the text
+  // element is the sole child (no icons/remove button) and the tag is not fill.
+  &:not(.#{$ns}-fill) > .#{$ns}-fill:only-child {
+    text-align: center;
+  }
 
   &:focus {
     @include focus-outline(0);


### PR DESCRIPTION
## Summary

- Fixes a regression from #7744 where `text-align: center` on the tag container caused text to be centered in all tags, including those with icons or `fill={true}`
- Scopes the `text-align: center` rule to only apply when the text element is the sole child of a non-fill tag, which targets the original single-character centering fix without affecting other tag layouts

## Test plan
- [ ] Verify single-character tags (no icon) still center their content
- [x] Verify `fill={true}` tags have left-aligned text (no regression)
- [x] Verify tags with icons have left-aligned text (no regression)
- [x] Verify CompoundTag layout is unaffected