### PR TITLE
[chore]: Do not use React's `FormEvent` types

### DIFF
--- a/packages/core/src/components/control-card/control-card.md
+++ b/packages/core/src/components/control-card/control-card.md
@@ -48,7 +48,7 @@ import React from "react";
 
 function RadioCardGroupExample() {
     const [selectedValue, setSelectedValue] = React.useState<string | undefined>();
-    const handleChange = React.useCallback((event: React.FormEvent<HTMLInputElement>) => {
+    const handleChange = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         setSelectedValue(event.currentTarget.value);
     }, []);
 

--- a/packages/core/src/components/editable-text/editableText.tsx
+++ b/packages/core/src/components/editable-text/editableText.tsx
@@ -351,7 +351,7 @@ export class EditableText extends AbstractPureComponent<EditableTextProps, Edita
         }
     };
 
-    private handleTextChange = (event: React.FormEvent<HTMLElement>) => {
+    private handleTextChange = (event: React.ChangeEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
         const value = (event.target as HTMLInputElement).value;
         // state value should be updated only when uncontrolled
         if (this.props.value == null) {

--- a/packages/core/src/components/forms/fileInput.tsx
+++ b/packages/core/src/components/forms/fileInput.tsx
@@ -64,7 +64,7 @@ export interface FileInputProps extends React.LabelHTMLAttributes<HTMLLabelEleme
      * __Note:__ The top-level `onChange` prop is passed to the `<label>` element rather than the `<input>`,
      * which may not be what you expect.
      */
-    onInputChange?: React.FormEventHandler<HTMLInputElement>;
+    onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
 
     /**
      * Whether the file input should appear with small styling.
@@ -139,7 +139,7 @@ export const FileInput = (props: FileInputProps) => {
         }),
     } satisfies React.HTMLProps<HTMLElement>;
 
-    const handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         onInputChange?.(e);
         inputProps?.onChange?.(e);
     };

--- a/packages/core/src/components/forms/radioGroup.tsx
+++ b/packages/core/src/components/forms/radioGroup.tsx
@@ -66,7 +66,7 @@ export interface RadioGroupProps extends Props, HTMLDivProps {
      * Use `event.currentTarget.value` to read the currently selected value.
      * This prop is required because this component only supports controlled usage.
      */
-    onChange: (event: React.FormEvent<HTMLInputElement>) => void;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 
     /**
      * Array of options to render in the group. This prop is mutually exclusive

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -144,7 +144,7 @@ export interface TagInputProps extends IntentProps, Props {
      * Callback invoked when the value of `<input>` element is changed.
      * This is shorthand for `inputProps={{ onChange }}`.
      */
-    onInputChange?: React.FormEventHandler<HTMLInputElement>;
+    onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
 
     /**
      * Callback invoked when the user depresses a keyboard key.

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -457,11 +457,11 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
 
         switch (e.type) {
             case "blur":
-                this.handleInputBlur(e, boundary);
+                this.handleInputBlur(e as React.FocusEvent<HTMLInputElement>, boundary);
                 inputProps?.onBlur?.(e as React.FocusEvent<HTMLInputElement>);
                 break;
             case "change":
-                this.handleInputChange(e, boundary);
+                this.handleInputChange(e as React.ChangeEvent<HTMLInputElement>, boundary);
                 inputProps?.onChange?.(e as React.ChangeEvent<HTMLInputElement>);
                 break;
             case "click":
@@ -470,7 +470,7 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
                 inputProps?.onClick?.(e);
                 break;
             case "focus":
-                this.handleInputFocus(e, boundary);
+                this.handleInputFocus(e as React.FocusEvent<HTMLInputElement>, boundary);
                 inputProps?.onFocus?.(e as React.FocusEvent<HTMLInputElement>);
                 break;
             case "keydown":
@@ -649,7 +649,7 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         e.stopPropagation();
     };
 
-    private handleInputFocus = (_e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
+    private handleInputFocus = (_e: React.FocusEvent<HTMLInputElement>, boundary: Boundary) => {
         const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
         const isValueControlled = this.isControlled();
         // We may be reacting to a programmatic focus triggered by componentDidUpdate() at a point when
@@ -677,7 +677,7 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         });
     };
 
-    private handleInputBlur = (_e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
+    private handleInputBlur = (_e: React.FocusEvent<HTMLInputElement>, boundary: Boundary) => {
         const { keys, values } = this.getStateKeysAndValuesForBoundary(boundary);
 
         const maybeNextDate = this.parseDate(values.inputString);
@@ -715,8 +715,8 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         this.setState(nextState);
     };
 
-    private handleInputChange = (e: React.FormEvent<HTMLInputElement>, boundary: Boundary) => {
-        const inputString = (e.target as HTMLInputElement).value;
+    private handleInputChange = (e: React.ChangeEvent<HTMLInputElement>, boundary: Boundary) => {
+        const inputString = e.target.value;
 
         const { keys } = this.getStateKeysAndValuesForBoundary(boundary);
         const maybeNextDate = this.parseDate(inputString);

--- a/packages/datetime/src/components/react-day-picker/datePickerCaption.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerCaption.tsx
@@ -102,8 +102,8 @@ export const DatePickerCaption = (props: CaptionProps) => {
     }
 
     const handleMonthSelectChange = useCallback(
-        (e: React.FormEvent<HTMLSelectElement>) => {
-            const newMonth = parseInt((e.target as HTMLSelectElement).value, 10);
+        (e: React.ChangeEvent<HTMLSelectElement>) => {
+            const newMonth = parseInt(e.target.value, 10);
             // ignore change events with invalid values to prevent crash on iOS Safari (#4178)
             if (isNaN(newMonth)) {
                 return;
@@ -150,7 +150,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
     );
 
     const handleYearSelectChange = useCallback(
-        (e: React.FormEvent<HTMLSelectElement>) => {
+        (e: React.ChangeEvent<HTMLSelectElement>) => {
             const newYear = parseInt((e.target as HTMLSelectElement).value, 10);
             // ignore change events with invalid values to prevent crash on iOS Safari (#4178)
             if (isNaN(newYear)) {

--- a/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/entityTitleExample.tsx
@@ -53,7 +53,7 @@ export const EntityTitleExample: React.FC<ExampleProps> = props => {
     const [withSubtitle, setWithSubtitle] = useState<boolean>(false);
     const [withTag, setWithTag] = useState<boolean>(false);
 
-    const handleHeadingChange = (event: React.FormEvent<HTMLSelectElement>) => {
+    const handleHeadingChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
         setHeading(event.currentTarget.value);
     };
 

--- a/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/multistepDialogExample.tsx
@@ -187,7 +187,7 @@ export const MultistepDialogExample: React.FC<ExampleProps<BlueprintExampleData>
 };
 
 interface SelectPanelProps {
-    onChange: (event: React.FormEvent<HTMLInputElement>) => void;
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     selectedValue: string;
 }
 

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -198,7 +198,7 @@ const FilterMenu: React.FC = () => (
 
 interface SelectMenuProps {
     label: string;
-    onChange: React.FormEventHandler;
+    onChange: React.ChangeEventHandler;
     options: OptionProps[];
     value: number | string;
 }

--- a/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
+++ b/packages/docs-app/src/examples/datetime-examples/common/precisionSelect.tsx
@@ -35,7 +35,7 @@ export interface PrecisionSelectProps {
     /**
      * The callback to fire when the selected value changes.
      */
-    onChange: (event: React.FormEvent<HTMLElement>) => void;
+    onChange: (event: React.ChangeEvent<HTMLElement>) => void;
 
     /**
      * Whether or not to allow a `"none"` option.

--- a/packages/docs-theme/src/common/eventHandlerUtils.ts
+++ b/packages/docs-theme/src/common/eventHandlerUtils.ts
@@ -42,17 +42,17 @@ export function createKeyEventHandler<T = HTMLElement>(actions: KeyEventMap<T>, 
 
 /** Event handler that exposes the target element's value as a boolean. */
 export function handleBooleanChange(handler: (checked: boolean) => void) {
-    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).checked);
+    return (event: React.ChangeEvent<HTMLElement>) => handler((event.target as HTMLInputElement).checked);
 }
 
 /** Event handler that exposes the target element's value as a string. */
 export function handleStringChange(handler: (value: string) => void) {
-    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
+    return (event: React.ChangeEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
 }
 
 /** Event handler that exposes the target element's value as an inferred generic type. */
 export function handleValueChange<T>(handler: (value: T) => void) {
-    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value as unknown as T);
+    return (event: React.ChangeEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value as unknown as T);
 }
 
 /** Event handler that exposes the target element's value as a number. */

--- a/packages/table-dev-app/src/mutableTable.tsx
+++ b/packages/table-dev-app/src/mutableTable.tsx
@@ -81,7 +81,9 @@ export enum SelectedRegionTransformPreset {
     COLUMN = "column",
 }
 
-type MutableStateUpdateCallback = (stateKey: keyof MutableTableState) => (event: React.FormEvent<HTMLElement>) => void;
+type MutableStateUpdateCallback = (
+    stateKey: keyof MutableTableState,
+) => (event: React.ChangeEvent<HTMLElement>) => void;
 
 const COLUMN_COUNTS = [0, 1, 5, 20, 100, 1000];
 const ROW_COUNTS = [0, 1, 5, 20, 100, 1000, 100000];
@@ -155,12 +157,12 @@ const CELL_CONTENT_GENERATORS: { [name: string]: (ri: number, ci: number) => str
 
 /** Event handler that exposes the target element's value as a boolean. */
 function handleBooleanChange(handler: (checked: boolean) => void) {
-    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).checked);
+    return (event: React.ChangeEvent<HTMLElement>) => handler((event.target as HTMLInputElement).checked);
 }
 
 /** Event handler that exposes the target element's value as a string. */
 function handleStringChange(handler: (value: string) => void) {
-    return (event: React.FormEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
+    return (event: React.ChangeEvent<HTMLElement>) => handler((event.target as HTMLInputElement).value);
 }
 
 /** Event handler that exposes the target element's value as a number. */


### PR DESCRIPTION

#### Fixes #0000

No existing issue.

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

`FormEvent` and `FormEventHandler` are deprecated in React 19 types. Use more correct event-specific types instead.

#### Reviewers should focus on:

PR that deprecated the types: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74383
<!-- Fill this out. -->

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
