### PR TITLE
[chore] Fix CI flake in `test-react-18` job setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
       - browser-tools/install_chrome:
-          chrome_version: "143.0.7499.192"
+          chrome_version: "145.0.7632.159"
       - browser-tools/install_chromedriver
       - run:
           name: Verify Chrome browser installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
   - &docker-node-browsers-image
     - image: cimg/node:24.11-browsers
       environment:
-        CHROME_BIN: "/usr/bin/google-chrome"
+        CHROME_BIN: "/usr/local/bin/chrome"
 
   - &restore-pnpm-cache
     name: Restore pnpm store cache
@@ -136,13 +136,12 @@ jobs:
       - run: sudo corepack enable
       # Use an explicit version of Chrome for better test reproducibility.
       - run: sudo apt-get update
-      - browser-tools/install_chrome:
-          chrome_version: "145.0.7632.159"
-      - browser-tools/install_chromedriver
+      - browser-tools/install_chrome_for_testing:
+          version: "145.0.7632.159"
       - run:
           name: Verify Chrome browser installed
           command: |
-            google-chrome --version
+            chrome --version
             chromedriver --version
       - run: mkdir -p ./reports
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
       - run: sudo apt-get update
       - browser-tools/install_chrome_for_testing:
           version: "145.0.7632.159"
+          install_chromedriver: true
       - run:
           name: Verify Chrome browser installed
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,8 @@ jobs:
       - run: sudo apt-get update
       - browser-tools/install_chrome_for_testing:
           version: "145.0.7632.159"
-          install_chromedriver: true
+          install_chromedriver: false
+      - browser-tools/install_chromedriver
       - run:
           name: Verify Chrome browser installed
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@2.1.0
+  browser-tools: circleci/browser-tools@2.4.0
 
 aliases:
   - &docker-node-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,6 @@ jobs:
       - run: sudo apt-get update
       - browser-tools/install_chrome:
           chrome_version: "143.0.7499.192"
-      - browser-tools/install_chrome
       - browser-tools/install_chromedriver
       - run:
           name: Verify Chrome browser installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
       - browser-tools/install_chrome_for_testing:
           version: "145.0.7632.159"
           install_chromedriver: false
+      - run: sudo ln -fs /usr/local/bin/chrome /usr/bin/google-chrome
       - browser-tools/install_chromedriver
       - run:
           name: Verify Chrome browser installed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
   - &docker-node-browsers-image
     - image: cimg/node:24.11-browsers
       environment:
-        CHROME_BIN: "/usr/local/bin/chrome"
+        CHROME_BIN: "/usr/bin/google-chrome"
 
   - &restore-pnpm-cache
     name: Restore pnpm store cache
@@ -134,17 +134,12 @@ jobs:
       - checkout
       - attach_workspace: { at: "." }
       - run: sudo corepack enable
-      # Use an explicit version of Chrome for better test reproducibility.
-      - run: sudo apt-get update
-      - browser-tools/install_chrome_for_testing:
-          version: "145.0.7632.159"
-          install_chromedriver: false
-      - run: sudo ln -fs /usr/local/bin/chrome /usr/bin/google-chrome
+      - browser-tools/install_chrome
       - browser-tools/install_chromedriver
       - run:
           name: Verify Chrome browser installed
           command: |
-            chrome --version
+            google-chrome --version
             chromedriver --version
       - run: mkdir -p ./reports
       - run:


### PR DESCRIPTION
## Summary

The `test-react-18` CI job is failing at the "Install Google Chrome" step. The `browser-tools/install_chrome` orb command uses `wget` to download a pinned Chrome `.deb` file, but `wget` receives a `SIGHUP` during the download, causing it to silently continue in the background. CircleCI sees no stdout for 10 minutes and kills the step.

The root cause is that pinning a Chrome version triggers a `wget`-based download path in the orb, while using `latest` installs via `apt-get`, which doesn't have this issue.

**Changes:**
- Upgrade `circleci/browser-tools` orb from `2.1.0` to `2.4.0` (adds retry logic and configurable timeouts)
- Remove pinned `chrome_version` and use `latest` instead, which installs Chrome via `apt-get` rather than `wget`, avoiding the `SIGHUP` timeout
- Remove the now-unnecessary `sudo apt-get update` step (the orb handles this internally)
- Remove duplicate `browser-tools/install_chrome` call (no-args duplicate carried over since #7469)

## Reviewers should focus on:

- Whether dropping the pinned Chrome version is acceptable. The pinned version was intended for test reproducibility, but in practice it has needed manual bumps 3+ times (#7469, #7691) whenever Google removes old builds from their servers.
