### PR TITLE
(chore) Enhance CompoundTag docs pt.2

### DIFF
--- a/packages/core/src/components/tag/compound-tag.md
+++ b/packages/core/src/components/tag/compound-tag.md
@@ -2,15 +2,11 @@
 
 CompoundTag is a variant of [**Tag**](#core/components/tag) that displays content as a visually segmented key-value pair.
 
-@## Import
+@## Usage
 
 ```tsx
 import { CompoundTag } from "@blueprintjs/core";
 ```
-
-@## Usage
-
-Content for the left side of the tag is specified with the `leftContent` prop, while `children` are rendered on the right side. CompoundTag supports all valid `<span>` DOM attributes.
 
 ```tsx
 <CompoundTag leftContent="City" id="city-tag">
@@ -20,7 +16,9 @@ Content for the left side of the tag is specified with the `leftContent` prop, w
 
 @## Examples
 
-@### Basic Usage
+@### Basic
+
+Content for the left side of the tag is specified with the `leftContent` prop, while `children` are rendered on the right side. CompoundTag supports all valid `<span>` DOM attributes.
 
 @reactCodeExample CompoundTagBasicExample
 


### PR DESCRIPTION
#### FLUP to [(chore) Enhance CompoundTag docs](https://github.com/palantir/blueprint/pull/7752/changes#top)

#### Purpose of this PR
@ggdouglas and I went over some of our ideal structural changes in [(chore) Enhance Breadcrumbs docs](https://github.com/palantir/blueprint/pull/7824#top). Given our alignment and hierarchy desires, I wanted to adjust this prior PR.

#### Before this PR
<img width="1338" height="887" alt="Screenshot 2026-03-10 at 4 34 59 PM" src="https://github.com/user-attachments/assets/67fea13c-bcb0-4771-9363-60d3da2c009e" />

#### After this PR
<img width="1415" height="1124" alt="Screenshot 2026-03-10 at 4 37 00 PM" src="https://github.com/user-attachments/assets/cc89fa83-5e3e-4c26-b0f4-68aac5e887da" />
