### PR TITLE
(chore) Enhance Button docs

### DIFF
--- a/packages/core/src/components/button/buttons.md
+++ b/packages/core/src/components/button/buttons.md
@@ -2,40 +2,46 @@
 
 A **Button** is a clickable element used to trigger actions or events. Buttons allow users to perform an action or navigate to another page with a single click. They are typically found in forms, toolbars, dialogs, and other areas where users need to make choices or initiate actions.
 
-@## Import
+@## Usage
 
 ```tsx
 import { Button } from "@blueprintjs/core";
 ```
 
-@## Usage
+```tsx
+<Button>Click Me</Button>
+```
+
+@## Examples
+
+@### Basic
 
 The `text` prop defines the label displayed on the button. Alternatively, content can be provided as children, allowing for more flexibility, such as including multiple elements or custom markup.
 
 @reactCodeExample ButtonBasicExample
 
-@## Intent
+@### Intent
 
 The `intent` prop is used to visually communicate the purpose or importance of the action associated with a button. Blueprint provides several intent options to convey meaning through color:
 
--   **Primary**: Indicates the main action and is usually styled more prominently.
--   **Success**: Represents a positive outcome or confirmation.
--   **Warning**: Used to alert users to potentially dangerous actions.
--   **Danger**: Signifies a destructive or critical action.
+- **Primary**: Indicates the main action and is usually styled more prominently.
+- **Success**: Represents a positive outcome or confirmation.
+- **Warning**: Used to alert users to potentially dangerous actions.
+- **Danger**: Signifies a destructive or critical action.
 
 @reactCodeExample ButtonIntentExample
 
-@## Variant
+@### Variant
 
 Buttons come in three different variants that support different use cases:
 
--   `solid` (the default) is useful for the primary action in a set of buttons.
--   `minimal` is useful for subtle actions or secondary options that shouldn't draw too much attention.
--   `outlined` provides a button with an outline, creating a middle ground between a prominent solid button and a subtle minimal button.
+- `solid` (the default) is useful for the primary action in a set of buttons.
+- `minimal` is useful for subtle actions or secondary options that shouldn't draw too much attention.
+- `outlined` provides a button with an outline, creating a middle ground between a prominent solid button and a subtle minimal button.
 
 @reactCodeExample ButtonVariantExample
 
-@## Minimal
+@### Minimal
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h5 class="@ns-heading">
@@ -50,7 +56,7 @@ The `minimal` prop offers a button without borders or background, ideal for subt
 
 @reactCodeExample ButtonMinimalExample
 
-@## Outlined
+@### Outlined
 
 <div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
     <h5 class="@ns-heading">
@@ -65,49 +71,49 @@ The `outlined` prop provides a button with an outline, creating a middle ground 
 
 @reactCodeExample ButtonOutlinedExample
 
-@## Size
+@### Size
 
 The `size` prop allows for adjusting the size of a button to fit different use cases.
 
 @reactCodeExample ButtonSizeExample
 
-@## Fill
+@### Fill
 
 The `fill` prop allows a button to expand and fill the available space in its container.
 
 @reactCodeExample ButtonFillExample
 
-@## Aligned text
+@### Aligned text
 
 The `alignText` prop controls the horizontal alignment of a button's text and icons.
 
 @reactCodeExample ButtonAlignTextExample
 
-@## Ellipsized text
+@### Ellipsized text
 
 The `ellipsizeText` prop allows text within a button to be truncated with an ellipsis if it exceeds the available space. This is useful for cases where the button needs to remain compact without overflowing, especially when the text content is dynamic or potentially lengthy.
 
 @reactCodeExample ButtonEllipsizeTextExample
 
-@## Icons with text
+@### Icons with text
 
-Buttons can include icons alongside text for extra context or visual cues. Icons can be added to either the before or after the  text/children with the `icon` and `endIcon` props respectively. These icons can either be specified as string identifiers (e.g. `"arrow-right"`), dynamically-loaded [`<Icon>` components](#core/components/icon), [static icon components](#core/components/icon.static-components) (e.g. `<ArrowRight />`), or any custom JSX element.
+Buttons can include icons alongside text for extra context or visual cues. Icons can be added to either the before or after the text/children with the `icon` and `endIcon` props respectively. These icons can either be specified as string identifiers (e.g. `"arrow-right"`), dynamically-loaded [`<Icon>` components](#core/components/icon), [static icon components](#core/components/icon.static-components) (e.g. `<ArrowRight />`), or any custom JSX element.
 
 @reactCodeExample ButtonIconWithTextExample
 
-@## Icon buttons
+@### Icon buttons
 
 Icon buttons display only an icon without any accompanying text. Icon buttons are used when an action can be clearly conveyed through a visual symbol, making the interface more compact and visually appealing. They are ideal for toolbars or areas with limited space.
 
 @reactCodeExample ButtonIconExample
 
-@## Button states
+@### Button states
 
 Buttons have different states to show their interaction status. The `active`, `disabled`, and `loading` props provide visual feedback to help users understand available actions and when to wait.
 
--   **Active**: Indicates that the button is currently being pressed or interacted with.
--   **Disabled**: Shows that the button is non-interactive.
--   **Loading**: Displays a loading spinner to indicate that an action is in progress.
+- **Active**: Indicates that the button is currently being pressed or interacted with.
+- **Disabled**: Shows that the button is non-interactive.
+- **Loading**: Displays a loading spinner to indicate that an action is in progress.
 
 @reactCodeExample ButtonStatesExample
 


### PR DESCRIPTION
#### Related to [(chore) Enhance Breadcrumbs docs](https://github.com/palantir/blueprint/pull/7824#top)

#### Changes proposed in this pull request:
We want to (a) begin instilling a sense of order/structure in our docs and (b) provide more plentiful examples of how to use the various props in the docs.

These docs are already pretty rich with content, so the point of this particular PR is just structure, not the actual quantity of content.

#### Reviewers should focus on:
Readability, content, quality of examples.

#### Before
<img width="1411" height="773" alt="Screenshot 2026-03-10 at 4 51 43 PM" src="https://github.com/user-attachments/assets/da35c14e-7104-4179-b0ca-bbe553c32d71" />

#### After
<img width="1533" height="867" alt="Screenshot 2026-03-10 at 4 53 56 PM" src="https://github.com/user-attachments/assets/c928599f-de61-42c7-a211-264346ecf978" />
