### PR TITLE
[core] Integrating design tokens into tag input

### DIFF
--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -1,0 +1,295 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent } from "../../common";
+import { Button } from "../button/buttons";
+
+import { TagInput } from "./tagInput";
+
+// These props are deprecated on TagInput — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "children"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof TagInput>
+>;
+
+const INITIAL_VALUES = ["London", "New York", "San Francisco"];
+
+const meta: Meta<typeof TagInput> = {
+    title: "Core/TagInput",
+    component: TagInput,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        values: INITIAL_VALUES,
+        intent: "none",
+        size: "medium",
+        placeholder: "Add tags...",
+        leftIcon: undefined,
+        fill: false,
+        disabled: false,
+        addOnBlur: false,
+        addOnPaste: true,
+        autoResize: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "select",
+            options: ["medium", "large"],
+        },
+        leftIcon: {
+            control: "text",
+        },
+        placeholder: {
+            control: "text",
+        },
+        addOnBlur: {
+            control: "boolean",
+        },
+        addOnPaste: {
+            control: "boolean",
+        },
+        autoResize: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        onAdd: { action: "added" },
+        onChange: { action: "changed" },
+        onRemove: { action: "removed" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof TagInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic tag input with default styling and pre-populated values.
+ */
+export const Default: Story = {
+    args: {
+        values: INITIAL_VALUES,
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the tag input.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <TagInput
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        values={[intent.charAt(0).toUpperCase() + intent.slice(1)]}
+                        placeholder={`${intent} intent...`}
+                    />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the tag input dimensions. TagInput supports `"medium"` (default) and `"large"`.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <TagInput {...args} size="medium" values={["Medium"]} placeholder="Medium size..." />
+            <TagInput {...args} size="large" values={["Large"]} placeholder="Large size..." />
+        </div>
+    ),
+};
+
+/**
+ * TagInput supports `disabled` state which prevents all interaction.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <TagInput {...args} values={["Enabled"]} placeholder="Enabled..." />
+            <TagInput {...args} disabled={true} values={["Disabled"]} placeholder="Disabled..." />
+        </div>
+    ),
+};
+
+/**
+ * Use the `leftIcon` prop to render an icon on the left side of the input.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    argTypes: {
+        leftIcon: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <TagInput {...args} leftIcon="search" values={["Search"]} placeholder="With left icon..." />
+            <TagInput {...args} leftIcon="tag" values={["Tags"]} placeholder="With tag icon..." />
+        </div>
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the tag input expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <TagInput {...args} fill={true} values={["Full Width"]} placeholder="Fill..." />
+            <TagInput {...args} fill={false} values={["Auto Width"]} placeholder="Auto..." />
+        </div>
+    ),
+};
+
+/**
+ * Use the `autoResize` prop to automatically resize the input as the user types.
+ * This has no effect when `fill={true}`.
+ */
+export const AutoResizeExample: Story = {
+    name: "Auto Resize",
+    argTypes: {
+        autoResize: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <TagInput {...args} autoResize={true} values={["Auto Resize"]} placeholder="Type to resize..." />
+            <TagInput {...args} autoResize={false} values={["Fixed Width"]} placeholder="Fixed input width..." />
+        </div>
+    ),
+};
+
+/**
+ * All intents shown together for visual comparison.
+ */
+export const AllIntents: Story = {
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Intent).map(intent => (
+                <TagInput
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    values={[intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)]}
+                    placeholder={`${intent} intent...`}
+                />
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with fully functional add/remove and all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [values, setValues] = useState<string[]>([...INITIAL_VALUES]);
+
+        const handleAdd = useCallback(
+            (newValues: string[]) => {
+                setValues(prev => [...prev, ...newValues]);
+                args.onAdd?.(newValues, "default");
+            },
+            [args],
+        );
+
+        const handleRemove = useCallback(
+            (_value: React.ReactNode, index: number) => {
+                setValues(prev => prev.filter((_, i) => i !== index));
+                args.onRemove?.(_value, index);
+            },
+            [args],
+        );
+
+        const handleClear = useCallback(() => setValues([]), []);
+
+        const handleReset = useCallback(() => setValues([...INITIAL_VALUES]), []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+                <TagInput
+                    addOnBlur={args.addOnBlur}
+                    addOnPaste={args.addOnPaste}
+                    autoResize={args.autoResize}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    intent={args.intent}
+                    leftIcon={args.leftIcon}
+                    onAdd={handleAdd}
+                    onRemove={handleRemove}
+                    placeholder={args.placeholder}
+                    rightElement={
+                        values.length > 0 ? (
+                            <Button icon="cross" variant="minimal" size="small" onClick={handleClear} />
+                        ) : undefined
+                    }
+                    size={args.size}
+                    values={values}
+                />
+                {values.length === 0 && (
+                    <Button icon="refresh" variant="outlined" size="small" text="Reset tags" onClick={handleReset} />
+                )}
+            </div>
+        );
+    },
+    args: {
+        leftIcon: "tag",
+        placeholder: "Add cities...",
+    },
+};

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -1,4 +1,4 @@
-/* !
+/*
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
@@ -256,6 +256,11 @@ export const AllIntents: Story = {
  * Interactive playground with fully functional add/remove and all props togglable via Storybook controls.
  */
 export const Playground: Story = {
+    argTypes: {
+        values: {
+            table: { disable: true },
+        },
+    },
     render: function Render(args) {
         const [values, setValues] = useState<string[]>([...INITIAL_VALUES]);
 

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -39,8 +39,6 @@ const meta: Meta<typeof TagInput> = {
         leftIcon: undefined,
         fill: false,
         disabled: false,
-        addOnBlur: false,
-        addOnPaste: true,
         autoResize: false,
     },
     argTypes: {
@@ -58,12 +56,6 @@ const meta: Meta<typeof TagInput> = {
         placeholder: {
             control: "text",
         },
-        addOnBlur: {
-            control: "boolean",
-        },
-        addOnPaste: {
-            control: "boolean",
-        },
         autoResize: {
             control: "boolean",
         },
@@ -76,6 +68,7 @@ const meta: Meta<typeof TagInput> = {
         onAdd: { action: "added" },
         onChange: { action: "changed" },
         onRemove: { action: "removed" },
+        onInputChange: { action: "changed" },
         ...disabledArgs.reduce(
             (acc, argName) => {
                 acc[argName] = {
@@ -109,6 +102,9 @@ export const IntentExample: Story = {
     name: "Intent",
     argTypes: {
         intent: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -134,6 +130,9 @@ export const SizeExample: Story = {
     name: "Size",
     argTypes: {
         size: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -150,6 +149,9 @@ export const StateExample: Story = {
     name: "State",
     argTypes: {
         disabled: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -166,6 +168,9 @@ export const IconExample: Story = {
     name: "Icons",
     argTypes: {
         leftIcon: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -182,6 +187,9 @@ export const FillExample: Story = {
     name: "Fill",
     argTypes: {
         fill: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
     },
     decorators: [
         Story => (
@@ -206,6 +214,9 @@ export const AutoResizeExample: Story = {
     name: "Auto Resize",
     argTypes: {
         autoResize: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -219,8 +230,15 @@ export const AutoResizeExample: Story = {
  * All intents shown together for visual comparison.
  */
 export const AllIntents: Story = {
+    argTypes: {
+        intent: { table: { disable: true } },
+        values: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+        separator: { table: { disable: true } },
+    },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             {Object.values(Intent).map(intent => (
                 <TagInput
                     key={intent}

--- a/packages/core/src/components/tag-input/_resizable-input.scss
+++ b/packages/core/src/components/tag-input/_resizable-input.scss
@@ -4,7 +4,7 @@
 .#{$ns}-resizable-input-span {
   max-height: 0;
   max-width: 100%;
-  min-width: $pt-spacing * 20;
+  min-width: calc(var(--bp-surface-spacing) * 20);
   opacity: 0;
   overflow: hidden;
   position: absolute;

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -1,6 +1,8 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+/* stylelint-disable alpha-value-notation */
+
 @import "../../common/variables";
 @import "../forms/common";
 @import "../tag/common";
@@ -16,26 +18,26 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   cursor: text;
   height: auto;
   line-height: inherit;
-  min-height: $pt-input-height;
-  padding-left: $pt-spacing * 1.5;
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  padding-left: calc(var(--bp-surface-spacing) * 1.5);
   padding-right: 0;
 
   .#{$ns}-tag-input-icon {
-    color: $pt-icon-color;
-    margin-left: $tag-input-icon-padding - $tag-input-padding;
-    margin-right: $tag-input-icon-padding;
+    color: var(--bp-typography-color-muted);
+    margin-left: calc(var(--bp-surface-spacing) * 0.75);
+    margin-right: calc(var(--bp-surface-spacing) * 1.75);
     // margins to center icon in one-line input
-    margin-top: $tag-input-icon-padding;
+    margin-top: calc(var(--bp-surface-spacing) * 1.75);
   }
 
   .#{$ns}-tag-input-values {
-    @include pt-flex-container(row, $tag-input-padding);
+    @include pt-flex-container(row, var(--bp-surface-spacing));
     align-items: center;
     // fill vertical height
     align-self: stretch;
     flex-wrap: wrap;
-    margin-right: $pt-spacing;
-    margin-top: $pt-spacing;
+    margin-right: var(--bp-surface-spacing);
+    margin-top: var(--bp-surface-spacing);
     // allow tags to ellipse and not overflow the container
     min-width: 0;
     position: relative;
@@ -49,12 +51,12 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
 
       .#{$ns}-input-ghost {
         // some padding-left is already applied on the root component, so we should subtract that
-        padding-left: $input-padding-horizontal - $tag-input-padding;
+        padding-left: var(--bp-surface-spacing);
       }
     }
 
     > * {
-      margin-bottom: $pt-spacing;
+      margin-bottom: var(--bp-surface-spacing);
     }
   }
 
@@ -71,9 +73,9 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   .#{$ns}-input-ghost {
     // input fills remaining line
     flex: 1 1 auto;
-    line-height: $tag-height;
+    line-height: calc(var(--bp-surface-spacing) * 5);
     // essentially a min-width, cuz flex allows it to grow or shrink:
-    width: $pt-spacing * 20;
+    width: calc(var(--bp-surface-spacing) * 20);
 
     &:disabled,
     &.#{$ns}-disabled {
@@ -83,7 +85,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
 
   .#{$ns}-button,
   .#{$ns}-spinner {
-    margin: ($pt-input-height - $pt-button-height-small) * 0.5;
+    margin: calc(var(--bp-surface-spacing) * 0.75);
     margin-left: 0;
   }
 
@@ -92,27 +94,27 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   }
 
   &.#{$ns}-large {
-    @include pt-flex-margin(row, $tag-input-icon-padding-large);
+    @include pt-flex-margin(row, calc(var(--bp-surface-spacing) * 2.5));
     height: auto;
-    min-height: $pt-input-height-large;
+    min-height: calc(var(--bp-surface-spacing) * 10);
 
     .#{$ns}-tag-input-icon {
-      margin-left: $tag-input-icon-padding-large - $tag-input-padding;
-      margin-top: $tag-input-icon-padding-large;
+      margin-left: calc(var(--bp-surface-spacing) * 1.5);
+      margin-top: calc(var(--bp-surface-spacing) * 2.5);
     }
 
     .#{$ns}-input-ghost {
-      line-height: $tag-height-large;
+      line-height: calc(var(--bp-surface-spacing) * 7.5);
     }
 
     .#{$ns}-button {
       @include pt-button-height-default;
-      margin: ($pt-input-height-large - $pt-button-height) * 0.5;
+      margin: calc(var(--bp-surface-spacing) * 1.25);
       margin-left: 0;
     }
 
     .#{$ns}-spinner {
-      margin: ($pt-input-height-large - $pt-button-height-small) * 0.5;
+      margin: calc(var(--bp-surface-spacing) * 2);
       margin-left: 0;
     }
   }
@@ -121,23 +123,45 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     background-color: $input-background-color;
     box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
 
-    @each $intent, $color in $pt-intent-colors {
-      &.#{$ns}-intent-#{$intent} {
-        box-shadow: input-transition-shadow($color, true), $input-box-shadow-focus;
-      }
+    &.#{$ns}-intent-primary {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        $input-box-shadow-focus;
+    }
+
+    &.#{$ns}-intent-success {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        $input-box-shadow-focus;
+    }
+
+    &.#{$ns}-intent-warning {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        $input-box-shadow-focus;
+    }
+
+    &.#{$ns}-intent-danger {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        $input-box-shadow-focus;
     }
   }
 
   .#{$ns}-dark &,
   &.#{$ns}-dark {
     .#{$ns}-tag-input-icon {
-      color: $pt-dark-icon-color;
+      color: var(--bp-typography-color-muted);
     }
 
     .#{$ns}-input-ghost {
       @include pt-dark-input-placeholder;
 
-      color: $dark-input-color;
+      color: var(--bp-typography-color-default-rest);
     }
 
     &.#{$ns}-active {
@@ -146,10 +170,32 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
         dark-input-transition-shadow($dark-input-shadow-color-focus, true),
         $pt-dark-input-box-shadow;
 
-      @each $intent, $color in $pt-dark-input-intent-box-shadow-colors {
-        &.#{$ns}-intent-#{$intent} {
-          box-shadow: input-transition-shadow($color, true), $pt-dark-input-box-shadow;
-        }
+      &.#{$ns}-intent-primary {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
+          $pt-dark-input-box-shadow;
+      }
+
+      &.#{$ns}-intent-success {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
+          $pt-dark-input-box-shadow;
+      }
+
+      &.#{$ns}-intent-warning {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
+          $pt-dark-input-box-shadow;
+      }
+
+      &.#{$ns}-intent-danger {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
+          $pt-dark-input-box-shadow;
       }
     }
   }

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -1,8 +1,6 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-/* stylelint-disable alpha-value-notation */
-
 @import "../../common/variables";
 @import "../forms/common";
 @import "../tag/common";
@@ -124,6 +122,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
 
     &.#{$ns}-intent-primary {
+      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) l c h / 0.752)},
         0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) l c h / 0.752)},
@@ -131,6 +130,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     &.#{$ns}-intent-success {
+      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px #{oklch(from var(--bp-intent-success-rest) l c h / 0.752)},
         0 0 0 1px #{oklch(from var(--bp-intent-success-rest) l c h / 0.752)},
@@ -138,6 +138,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     &.#{$ns}-intent-warning {
+      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px #{oklch(from var(--bp-intent-warning-rest) l c h / 0.752)},
         0 0 0 1px #{oklch(from var(--bp-intent-warning-rest) l c h / 0.752)},
@@ -145,6 +146,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     &.#{$ns}-intent-danger {
+      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px #{oklch(from var(--bp-intent-danger-rest) l c h / 0.752)},
         0 0 0 1px #{oklch(from var(--bp-intent-danger-rest) l c h / 0.752)},
@@ -171,6 +173,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
         $pt-dark-input-box-shadow;
 
       &.#{$ns}-intent-primary {
+        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-hover) l c h / 0.752)},
           0 0 0 1px #{oklch(from var(--bp-intent-primary-hover) l c h / 0.752)},
@@ -178,6 +181,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       }
 
       &.#{$ns}-intent-success {
+        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px #{oklch(from var(--bp-intent-success-hover) l c h / 0.752)},
           0 0 0 1px #{oklch(from var(--bp-intent-success-hover) l c h / 0.752)},
@@ -185,6 +189,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       }
 
       &.#{$ns}-intent-warning {
+        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px #{oklch(from var(--bp-intent-warning-hover) l c h / 0.752)},
           0 0 0 1px #{oklch(from var(--bp-intent-warning-hover) l c h / 0.752)},
@@ -192,6 +197,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       }
 
       &.#{$ns}-intent-danger {
+        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px #{oklch(from var(--bp-intent-danger-hover) l c h / 0.752)},
           0 0 0 1px #{oklch(from var(--bp-intent-danger-hover) l c h / 0.752)},

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -125,29 +125,29 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
 
     &.#{$ns}-intent-primary {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) l c h / 0.752)},
+        0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) l c h / 0.752)},
         $input-box-shadow-focus;
     }
 
     &.#{$ns}-intent-success {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        inset 0 0 0 1px #{oklch(from var(--bp-intent-success-rest) l c h / 0.752)},
+        0 0 0 1px #{oklch(from var(--bp-intent-success-rest) l c h / 0.752)},
         $input-box-shadow-focus;
     }
 
     &.#{$ns}-intent-warning {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        inset 0 0 0 1px #{oklch(from var(--bp-intent-warning-rest) l c h / 0.752)},
+        0 0 0 1px #{oklch(from var(--bp-intent-warning-rest) l c h / 0.752)},
         $input-box-shadow-focus;
     }
 
     &.#{$ns}-intent-danger {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        inset 0 0 0 1px #{oklch(from var(--bp-intent-danger-rest) l c h / 0.752)},
+        0 0 0 1px #{oklch(from var(--bp-intent-danger-rest) l c h / 0.752)},
         $input-box-shadow-focus;
     }
   }
@@ -172,29 +172,29 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
 
       &.#{$ns}-intent-primary {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
+          inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-hover) l c h / 0.752)},
+          0 0 0 1px #{oklch(from var(--bp-intent-primary-hover) l c h / 0.752)},
           $pt-dark-input-box-shadow;
       }
 
       &.#{$ns}-intent-success {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
+          inset 0 0 0 1px #{oklch(from var(--bp-intent-success-hover) l c h / 0.752)},
+          0 0 0 1px #{oklch(from var(--bp-intent-success-hover) l c h / 0.752)},
           $pt-dark-input-box-shadow;
       }
 
       &.#{$ns}-intent-warning {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
+          inset 0 0 0 1px #{oklch(from var(--bp-intent-warning-hover) l c h / 0.752)},
+          0 0 0 1px #{oklch(from var(--bp-intent-warning-hover) l c h / 0.752)},
           $pt-dark-input-box-shadow;
       }
 
       &.#{$ns}-intent-danger {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
+          inset 0 0 0 1px #{oklch(from var(--bp-intent-danger-hover) l c h / 0.752)},
+          0 0 0 1px #{oklch(from var(--bp-intent-danger-hover) l c h / 0.752)},
           $pt-dark-input-box-shadow;
       }
     }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [x] Includes tests
-   [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the TagInput component (and ResizableInput) from SCSS palette variables to CSS design tokens.

> [!NOTE]
> Intent focus-ring `rgba()` calls have been replaced with `oklch()` relative color syntax. The alpha values are identical (0.752) but the color space differs, which may produce very subtle visual differences in semi-transparent focus rings.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary` / `$blue3` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue4` (dark input shadow) |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success` / `$green3` |
| `--bp-intent-success-hover` | `#1c6e42` | `$green4` (dark input shadow) |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning` / `$orange3` |
| `--bp-intent-warning-hover` | `#935610` | `$orange4` (dark input shadow) |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger` / `$red3` |
| `--bp-intent-danger-hover` | `#ac2f33` | `$red4` (dark input shadow) |
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-icon-color` / `$pt-dark-icon-color` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$dark-input-color` / `$pt-dark-text-color` |

#### TagInput — Default (`.bp6-tag-input`)

| Property | Develop | Current |
|----------|---------|---------|
| `min-height` | `$pt-input-height` (30px) | `calc(var(--bp-surface-spacing) * 7.5)` |
| `padding-left` | `$pt-spacing * 1.5` (6px) | `calc(var(--bp-surface-spacing) * 1.5)` |

#### TagInput — Icon (`.bp6-tag-input-icon`)

| Property | Develop | Current |
|----------|---------|---------|
| `color` | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| `margin-left` | `$tag-input-icon-padding - $tag-input-padding` (3px) | `calc(var(--bp-surface-spacing) * 0.75)` |
| `margin-right` | `$tag-input-icon-padding` (7px) | `calc(var(--bp-surface-spacing) * 1.75)` |
| `margin-top` | `$tag-input-icon-padding` (7px) | `calc(var(--bp-surface-spacing) * 1.75)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables `$tag-input-icon-padding` and `$tag-input-padding` replaced with pre-computed `calc()` expressions. The `!default` definitions are retained for backward compatibility but no longer used internally.

#### TagInput — Values container (`.bp6-tag-input-values`)

| Property | Develop | Current |
|----------|---------|---------|
| flex gap | `$tag-input-padding` (4px) | `var(--bp-surface-spacing)` |
| `margin-right` | `$pt-spacing` (4px) | `var(--bp-surface-spacing)` |
| `margin-top` | `$pt-spacing` (4px) | `var(--bp-surface-spacing)` |
| child `padding-left` | `$input-padding-horizontal - $tag-input-padding` (4px) | `var(--bp-surface-spacing)` |
| child `margin-bottom` | `$pt-spacing` (4px) | `var(--bp-surface-spacing)` |

#### TagInput — Ghost input (`.bp6-input-ghost`)

| Property | Develop | Current |
|----------|---------|---------|
| `line-height` | `$tag-height` (20px) | `calc(var(--bp-surface-spacing) * 5)` |
| `width` | `$pt-spacing * 20` (80px) | `calc(var(--bp-surface-spacing) * 20)` |

#### TagInput — Button/Spinner

| Property | Develop | Current |
|----------|---------|---------|
| `margin` | `($pt-input-height - $pt-button-height-small) * 0.5` (3px) | `calc(var(--bp-surface-spacing) * 0.75)` |

#### TagInput — Large variant (`.bp6-large`)

| Property | Develop | Current |
|----------|---------|---------|
| flex margin | `$tag-input-icon-padding-large` (10px) | `calc(var(--bp-surface-spacing) * 2.5)` |
| `min-height` | `$pt-input-height-large` (40px) | `calc(var(--bp-surface-spacing) * 10)` |
| icon `margin-left` | `$tag-input-icon-padding-large - $tag-input-padding` (6px) | `calc(var(--bp-surface-spacing) * 1.5)` |
| icon `margin-top` | `$tag-input-icon-padding-large` (10px) | `calc(var(--bp-surface-spacing) * 2.5)` |
| ghost `line-height` | `$tag-height-large` (30px) | `calc(var(--bp-surface-spacing) * 7.5)` |
| button `margin` | `($pt-input-height-large - $pt-button-height) * 0.5` (5px) | `calc(var(--bp-surface-spacing) * 1.25)` |
| spinner `margin` | `($pt-input-height-large - $pt-button-height-small) * 0.5` (8px) | `calc(var(--bp-surface-spacing) * 2)` |

#### TagInput — Active intent focus rings (light theme)

| Intent | Develop | Current |
|--------|---------|---------|
| Primary | `input-transition-shadow($blue3, true)` via `@each` | `oklch(from var(--bp-intent-primary-rest) l c h / 0.752)` inline |
| Success | `input-transition-shadow($green3, true)` via `@each` | `oklch(from var(--bp-intent-success-rest) l c h / 0.752)` inline |
| Warning | `input-transition-shadow($orange3, true)` via `@each` | `oklch(from var(--bp-intent-warning-rest) l c h / 0.752)` inline |
| Danger | `input-transition-shadow($red3, true)` via `@each` | `oklch(from var(--bp-intent-danger-rest) l c h / 0.752)` inline |

**Differences:**
2. **Loop expansion.** `@each $intent, $color in $pt-intent-colors` replaced with four explicit per-intent rules. This avoids passing CSS custom properties into the `border-shadow()` Sass function (which uses Sass `rgba()` internally and requires compile-time color values).
3. **Transparency color space.** Focus ring shadows used `rgba($color, 0.752)` (sRGB), now use `oklch(from var(--bp-intent-*-rest) l c h / 0.752)` (OKLCH). Alpha is identical; color space differs.

#### TagInput — Dark theme

| Property | Develop | Current |
|----------|---------|---------|
| icon `color` | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |
| ghost input `color` | `$dark-input-color` | `var(--bp-typography-color-default-rest)` |

#### TagInput — Dark active intent focus rings

| Intent | Develop | Current |
|--------|---------|---------|
| Primary | `input-transition-shadow($blue4, true)` via `@each` | `oklch(from var(--bp-intent-primary-hover) l c h / 0.752)` inline |
| Success | `input-transition-shadow($green4, true)` via `@each` | `oklch(from var(--bp-intent-success-hover) l c h / 0.752)` inline |
| Warning | `input-transition-shadow($orange4, true)` via `@each` | `oklch(from var(--bp-intent-warning-hover) l c h / 0.752)` inline |
| Danger | `input-transition-shadow($red4, true)` via `@each` | `oklch(from var(--bp-intent-danger-hover) l c h / 0.752)` inline |

**Differences:**
4. **Dark loop expansion.** Same as #2 — `@each $intent, $color in $pt-dark-input-intent-box-shadow-colors` replaced with four explicit rules using `-hover` state tokens (mapping `$blue4` → `--bp-intent-primary-hover`, etc.).
5. **Dark transparency color space.** Same as #3 — `rgba()` → `oklch()`.

#### ResizableInput (`.bp6-resizable-input-span`)

| Property | Develop | Current |
|----------|---------|---------|
| `min-width` | `$pt-spacing * 20` (80px) | `calc(var(--bp-surface-spacing) * 20)` |

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local `$tag-input-*` SCSS vars replaced with `calc()` expressions |
| 2, 4 | Loop expansion | `@each` over `$pt-intent-colors` / `$pt-dark-input-intent-box-shadow-colors` expanded to explicit per-intent rules to avoid passing CSS vars into Sass `rgba()` |
| 3, 5 | Transparency color space | Focus ring `rgba()` (sRGB) replaced with `oklch()` — same alpha, different color space |

#### Reviewers should focus on:

- Intent focus ring appearance: the `oklch()` vs `rgba()` color space change may produce very subtle differences in semi-transparent focus ring borders
- Dark theme icon and text colors now use auto-resolving typography tokens (`--bp-typography-color-muted`, `--bp-typography-color-default-rest`) instead of explicit `$pt-dark-*` variables
