### PR TITLE
[core] Add back test:typeCheck script

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,8 +41,9 @@
         "lint:es": "es-lint",
         "lint-fix": "es-lint --fix && sass-lint --fix",
         "prepack": "run-s compile dist",
-        "test": "run-s test:iso test:vitest:run",
+        "test": "run-s test:typeCheck test:iso test:vitest:run",
         "test:iso": "vitest run --config vitest.config.isotest.mts",
+        "test:typeCheck": "tsc -p ./src/tsconfig.test.json",
         "test:vitest": "vitest",
         "test:vitest:run": "vitest run",
         "verify": "npm-run-all compile -p dist test lint"

--- a/packages/core/src/common/utils.test.tsx
+++ b/packages/core/src/common/utils.test.tsx
@@ -16,7 +16,7 @@
 
 import { Fragment } from "react/jsx-runtime";
 
-import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
+import { beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import * as Utils from "./utils";
 
@@ -136,22 +136,19 @@ describe("Utils", () => {
     });
 
     describe("throttleReactEventCallback", () => {
-        let callback: MockInstance;
-        let fakeEvent: any; // cast as `any` to avoid having to set every required property on the event
-        let throttledCallback: (event2: React.SyntheticEvent<any>, ...otherArgs2: any[]) => void;
+        const callback = vi.fn();
+        const fakeEvent = { persist: vi.fn(), preventDefault: vi.fn() };
+        let throttledCallback: (event: React.SyntheticEvent) => void;
 
         beforeEach(() => {
-            callback = vi.fn();
-            fakeEvent = { persist: vi.fn(), preventDefault: vi.fn() };
-        });
-
-        afterEach(() => {
-            fakeEvent = undefined;
+            callback.mockReset();
+            fakeEvent.persist.mockReset();
+            fakeEvent.preventDefault.mockReset();
         });
 
         it("invokes event.persist() to prevent React from pooling before we can reference the event in rAF", () => {
             throttledCallback = Utils.throttleReactEventCallback(callback);
-            throttledCallback(fakeEvent as any);
+            throttledCallback(fakeEvent as unknown as React.SyntheticEvent);
             expect(fakeEvent.persist).toHaveBeenCalledOnce();
         });
 
@@ -159,7 +156,7 @@ describe("Utils", () => {
             throttledCallback = Utils.throttleReactEventCallback(callback, {
                 preventDefault: true,
             });
-            throttledCallback(fakeEvent as any);
+            throttledCallback(fakeEvent as unknown as React.SyntheticEvent);
             expect(fakeEvent.preventDefault).toHaveBeenCalledOnce();
         });
 

--- a/packages/core/src/components/forms/numericInput.test.tsx
+++ b/packages/core/src/components/forms/numericInput.test.tsx
@@ -22,7 +22,7 @@ import {
 } from "enzyme";
 import { act, PureComponent } from "react";
 
-import { afterAll, afterEach, assert, beforeAll, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterAll, afterEach, assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
 import { type HTMLInputProps, Position } from "../../common";
@@ -782,9 +782,8 @@ describe("<NumericInput>", () => {
     // Note: we don't call mount() here since React 16 throws before we can even validate the errors thrown
     // in component constructors
     describe("Validation", () => {
-        let consoleError: ReturnType<typeof vi.spyOn>;
+        const consoleError = vi.spyOn(console, "error").mockImplementation(vi.fn());
 
-        beforeAll(() => (consoleError = vi.spyOn(console, "error").mockImplementation(vi.fn())));
         afterEach(() => consoleError.mockClear());
         afterAll(() => consoleError.mockRestore());
 

--- a/packages/core/src/components/slider/multiSlider.test.tsx
+++ b/packages/core/src/components/slider/multiSlider.test.tsx
@@ -30,8 +30,8 @@ const STEP_SIZE = 20;
 describe("<MultiSlider>", () => {
     let containerElement: HTMLElement;
 
-    let onChange: ReturnType<typeof vi.fn>;
-    let onRelease: ReturnType<typeof vi.fn>;
+    const onChange = vi.fn();
+    const onRelease = vi.fn();
 
     beforeEach(() => {
         // need an element in the document for tickSize to be a real number
@@ -40,8 +40,8 @@ describe("<MultiSlider>", () => {
         containerElement.style.width = `${STEP_SIZE * 10}px`;
         document.body.appendChild(containerElement);
 
-        onChange = vi.fn();
-        onRelease = vi.fn();
+        onChange.mockReset();
+        onRelease.mockReset();
     });
 
     afterEach(() => {

--- a/packages/core/src/components/tag-input/tagInput.test.tsx
+++ b/packages/core/src/components/tag-input/tagInput.test.tsx
@@ -270,7 +270,7 @@ describe("<TagInput>", () => {
             expect(onAdd.mock.calls[0][0]).toEqual([value]);
         });
 
-        function mountTagInput(onAdd: ReturnType<typeof vi.fn>, props?: Partial<TagInputProps>) {
+        function mountTagInput(onAdd: TagInputProps["onAdd"], props?: Partial<TagInputProps>) {
             return mount(<TagInput onAdd={onAdd} values={VALUES} {...props} />);
         }
     });

--- a/packages/core/src/components/toast/toast.test.tsx
+++ b/packages/core/src/components/toast/toast.test.tsx
@@ -67,8 +67,8 @@ describe("<Toast>", () => {
     }
 
     describe("timeout", () => {
-        let handleDismiss: ReturnType<typeof vi.fn>;
-        beforeEach(() => (handleDismiss = vi.fn()));
+        const handleDismiss = vi.fn();
+        beforeEach(() => handleDismiss.mockReset());
 
         it("calls onDismiss automatically after timeout expires with `true`", async () => {
             // mounting for lifecycle methods to start timeout

--- a/packages/core/src/tsconfig.test.json
+++ b/packages/core/src/tsconfig.test.json
@@ -6,5 +6,5 @@
         "skipLibCheck": true
     },
     "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx", "vitest-env.d.ts"],
-    "exclude": []
+    "exclude": ["design-tokens/build.ts", "design-tokens/sd.config.ts"]
 }


### PR DESCRIPTION
## Summary
- Re-adds the `test:typeCheck` script to `@blueprintjs/core`, which was removed in https://github.com/palantir/blueprint/pull/7714
- Excludes `design-tokens/` files from the test tsconfig to match the build config
- Fixes type errors in core tests
