### PR TITLE
Add bordered to Section

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -257,6 +257,9 @@ export const SECTION_HEADER_TABS = `${SECTION_HEADER}-tabs`;
 export const SECTION_HEADER_RIGHT = `${SECTION_HEADER}-right`;
 export const SECTION_HEADER_COLLAPSE_CARET = `${SECTION_HEADER}-collapse-caret`;
 export const SECTION_CARD = `${SECTION}-card`;
+export const SECTION_CARD_BORDERED = `${SECTION_CARD}-bordered`;
+export const SECTION_CARD_NOT_BORDERED = `${SECTION_CARD}-not-bordered`;
+export const SECTION_BORDERED = `${SECTION}-bordered`;
 
 export const NAVBAR = `${NS}-navbar`;
 export const NAVBAR_GROUP = `${NAVBAR}-group`;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -128,9 +128,9 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
   }
 }
 
-// SectionCard explicit border overrides — placed after Section rules so that
-// equal-specificity (0,3,0) ties resolve in favor of the card-level override via source order.
-.#{$ns}-section-card.#{$ns}-section-card-bordered:not(:last-child) {
+// SectionCard explicit border overrides — prefixed with .bpx-section to match the Section-level
+// rule specificity of (0,4,0), so source order resolves ties in favor of the card-level override.
+.#{$ns}-section .#{$ns}-section-card.#{$ns}-section-card-bordered:not(:last-child) {
   border-bottom: 1px solid $pt-divider-black;
 
   .#{$ns}-dark & {
@@ -138,6 +138,6 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
   }
 }
 
-.#{$ns}-section-card.#{$ns}-section-card-not-bordered:not(:last-child) {
+.#{$ns}-section .#{$ns}-section-card.#{$ns}-section-card-not-bordered:not(:last-child) {
   border-bottom: none;
 }

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -23,7 +23,6 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
 
   &-header {
     align-items: center;
-    border-bottom: 1px solid $pt-divider-black;
     display: flex;
     gap: $pt-spacing * 5;
     justify-content: space-between;
@@ -31,11 +30,6 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
     padding: 0 $section-padding-horizontal;
     position: relative;
     width: 100%;
-
-    &.#{$ns}-dark,
-    .#{$ns}-dark & {
-      border-color: $pt-dark-divider-white;
-    }
 
     &-left {
       align-items: center;
@@ -89,8 +83,17 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
     &.#{$ns}-padded {
       padding: $section-card-padding;
     }
+  }
 
-    &:not(:last-child) {
+  &.#{$ns}-section-collapsed {
+    .#{$ns}-section-header {
+      border: none;
+    }
+  }
+
+  // Bordered Section: apply header divider and inter-card dividers
+  &.#{$ns}-section-bordered {
+    .#{$ns}-section-header {
       border-bottom: 1px solid $pt-divider-black;
 
       &.#{$ns}-dark,
@@ -98,11 +101,14 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
         border-color: $pt-dark-divider-white;
       }
     }
-  }
 
-  &.#{$ns}-section-collapsed {
-    .#{$ns}-section-header {
-      border: none;
+    .#{$ns}-section-card:not(:last-child) {
+      border-bottom: 1px solid $pt-divider-black;
+
+      &.#{$ns}-dark,
+      .#{$ns}-dark & {
+        border-color: $pt-dark-divider-white;
+      }
     }
   }
 
@@ -120,4 +126,18 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
       padding: $section-card-padding-compact;
     }
   }
+}
+
+// SectionCard explicit border overrides — placed after Section rules so that
+// equal-specificity (0,3,0) ties resolve in favor of the card-level override via source order.
+.#{$ns}-section-card.#{$ns}-section-card-bordered:not(:last-child) {
+  border-bottom: 1px solid $pt-divider-black;
+
+  .#{$ns}-dark & {
+    border-color: $pt-dark-divider-white;
+  }
+}
+
+.#{$ns}-section-card.#{$ns}-section-card-not-bordered:not(:last-child) {
+  border-bottom: none;
 }

--- a/packages/core/src/components/section/section.md
+++ b/packages/core/src/components/section/section.md
@@ -28,4 +28,13 @@ Multiple **SectionCard** child components can be added under one **Section**, th
 </Section>
 ```
 
+The `bordered` prop on **SectionCard** can be used to override the parent Section's `bordered` setting for that individual card. This allows, for example, a borderless Section (with no header divider) to still show a dividing border between specific cards:
+
+```tsx
+<Section bordered={false}>
+    <SectionCard bordered={true}>{/* ... */}</SectionCard>
+    <SectionCard bordered={true}>{/* ... */}</SectionCard>
+</Section>
+```
+
 @interface SectionCardProps

--- a/packages/core/src/components/section/section.test.tsx
+++ b/packages/core/src/components/section/section.test.tsx
@@ -48,6 +48,16 @@ describe("<Section>", () => {
         containerElement.remove();
     });
 
+    it("renders bordered class by default", () => {
+        const wrapper = mount(<Section />, { attachTo: containerElement });
+        assert.isTrue(wrapper.find(`.${Classes.SECTION_BORDERED}`).hostNodes().exists());
+    });
+
+    it("omits bordered class when bordered={false}", () => {
+        const wrapper = mount(<Section bordered={false} />, { attachTo: containerElement });
+        assert.isFalse(wrapper.find(`.${Classes.SECTION_BORDERED}`).hostNodes().exists());
+    });
+
     it("supports className", () => {
         const wrapper = mount(<Section className="foo" />, {
             attachTo: containerElement,
@@ -113,6 +123,24 @@ describe("<Section>", () => {
                 { attachTo: containerElement },
             );
             assertIsClosed(wrapper);
+        });
+    });
+
+    describe("SectionCard bordered", () => {
+        it("does not apply bordered or not-bordered class when bordered is omitted", () => {
+            const wrapper = mount(<SectionCard />, { attachTo: containerElement });
+            assert.isFalse(wrapper.find(`.${Classes.SECTION_CARD_BORDERED}`).hostNodes().exists());
+            assert.isFalse(wrapper.find(`.${Classes.SECTION_CARD_NOT_BORDERED}`).hostNodes().exists());
+        });
+
+        it("applies section-card-bordered class when bordered={true}", () => {
+            const wrapper = mount(<SectionCard bordered={true} />, { attachTo: containerElement });
+            assert.isTrue(wrapper.find(`.${Classes.SECTION_CARD_BORDERED}`).hostNodes().exists());
+        });
+
+        it("applies section-card-not-bordered class when bordered={false}", () => {
+            const wrapper = mount(<SectionCard bordered={false} />, { attachTo: containerElement });
+            assert.isTrue(wrapper.find(`.${Classes.SECTION_CARD_NOT_BORDERED}`).hostNodes().exists());
         });
     });
 

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -75,6 +75,14 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
     collapseProps?: SectionCollapseProps;
 
     /**
+     * Whether to render border lines between the section header and its content,
+     * and between consecutive SectionCard children.
+     *
+     * @default true
+     */
+    bordered?: boolean;
+
+    /**
      * Whether this section should use compact styles.
      *
      * @default false
@@ -129,6 +137,7 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
  */
 export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
     const {
+        bordered = true,
         children,
         className,
         collapseProps,
@@ -166,6 +175,7 @@ export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
     return (
         <Card
             className={classNames(className, Classes.SECTION, {
+                [Classes.SECTION_BORDERED]: bordered,
                 [Classes.COMPACT]: compact,
                 [Classes.SECTION_COLLAPSED]: (collapsible && isCollapsed) || Utils.isReactNodeEmpty(children),
             })}

--- a/packages/core/src/components/section/sectionCard.tsx
+++ b/packages/core/src/components/section/sectionCard.tsx
@@ -22,6 +22,12 @@ import { DISPLAYNAME_PREFIX, type HTMLDivProps, type Props } from "../../common/
 
 export interface SectionCardProps extends Props, HTMLDivProps, React.RefAttributes<HTMLDivElement> {
     /**
+     * Whether to render a bottom border below this card, separating it from the next sibling SectionCard.
+     * When omitted, border visibility is inherited from the parent Section's `bordered` prop.
+     */
+    bordered?: boolean;
+
+    /**
      * Whether to apply visual padding inside the content container element.
      *
      * @default true
@@ -35,8 +41,16 @@ export interface SectionCardProps extends Props, HTMLDivProps, React.RefAttribut
  * @see https://blueprintjs.com/docs/#core/components/section.section-card
  */
 export const SectionCard: React.FC<SectionCardProps> = forwardRef((props, ref) => {
-    const { className, children, padded = true, ...htmlProps } = props;
-    const classes = classNames(Classes.SECTION_CARD, { [Classes.PADDED]: padded }, className);
+    const { bordered, className, children, padded = true, ...htmlProps } = props;
+    const classes = classNames(
+        Classes.SECTION_CARD,
+        {
+            [Classes.PADDED]: padded,
+            [Classes.SECTION_CARD_BORDERED]: bordered === true,
+            [Classes.SECTION_CARD_NOT_BORDERED]: bordered === false,
+        },
+        className,
+    );
     return (
         <div className={classes} ref={ref} {...htmlProps}>
             {children}

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -64,7 +64,9 @@ export const SectionExample: React.FC<ExampleProps> = props => {
     const [hasMultipleCards, setHasMultipleCards] = useState(false);
     const [hasRightElement, setHasRightElement] = useState(true);
     const [isBordered, setIsBordered] = useState(true);
-    const [isSectionCardBordered, setIsSectionCardBordered] = useState<boolean | undefined>(undefined);
+    const [isSectionCardBordered, setIsSectionCardBordered] = useState<boolean | undefined>(
+        undefined,
+    );
     const [isCompact, setIsCompact] = useState(false);
     const [isControlled, setIsControlled] = useState(false);
     const [isOpen, setIsOpen] = useState(true);

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -41,6 +41,7 @@ export interface SectionExampleState {
     hasIcon: boolean;
     hasMultipleCards: boolean;
     hasRightElement: boolean;
+    isBordered: boolean;
     isCompact: boolean;
     isControlled: boolean;
     isOpen: boolean;
@@ -62,6 +63,8 @@ export const SectionExample: React.FC<ExampleProps> = props => {
     const [hasIcon, setHasIcon] = useState(false);
     const [hasMultipleCards, setHasMultipleCards] = useState(false);
     const [hasRightElement, setHasRightElement] = useState(true);
+    const [isBordered, setIsBordered] = useState(true);
+    const [isSectionCardBordered, setIsSectionCardBordered] = useState<boolean | undefined>(undefined);
     const [isCompact, setIsCompact] = useState(false);
     const [isControlled, setIsControlled] = useState(false);
     const [isOpen, setIsOpen] = useState(true);
@@ -82,6 +85,11 @@ export const SectionExample: React.FC<ExampleProps> = props => {
         <>
             <div>
                 <H5>Section Props</H5>
+                <Switch
+                    checked={isBordered}
+                    label="Bordered"
+                    onChange={handleBooleanChange(setIsBordered)}
+                />
                 <Switch
                     checked={isCompact}
                     label="Compact"
@@ -146,6 +154,11 @@ export const SectionExample: React.FC<ExampleProps> = props => {
 
                 <H5>SectionCard Props</H5>
                 <Switch
+                    checked={isSectionCardBordered ?? true}
+                    label="Bordered"
+                    onChange={handleBooleanChange(setIsSectionCardBordered)}
+                />
+                <Switch
                     checked={isPanelPadded}
                     label="Padded"
                     onChange={handleBooleanChange(setIsPanelPadded)}
@@ -164,6 +177,7 @@ export const SectionExample: React.FC<ExampleProps> = props => {
                 // the local state in the `Collapse` component is not
                 // updated.
                 key={String(defaultIsOpen)}
+                bordered={isBordered}
                 collapsible={collapsible}
                 collapseProps={collapseProps}
                 compact={isCompact}
@@ -182,7 +196,7 @@ export const SectionExample: React.FC<ExampleProps> = props => {
                 subtitle={hasDescription ? "Ocimum basilicum" : undefined}
                 title="Basil"
             >
-                <SectionCard padded={isPanelPadded}>
+                <SectionCard bordered={isSectionCardBordered} padded={isPanelPadded}>
                     <EditableText
                         defaultValue={BASIL_DESCRIPTION_TEXT}
                         disabled={!hasRightElement}
@@ -191,7 +205,7 @@ export const SectionExample: React.FC<ExampleProps> = props => {
                     />
                 </SectionCard>
                 {hasMultipleCards && (
-                    <SectionCard padded={isPanelPadded}>
+                    <SectionCard bordered={isSectionCardBordered} padded={isPanelPadded}>
                         <div className="metadata-panel">
                             <div>
                                 <span className={Classes.TEXT_MUTED}>Kingdom</span>Plantae


### PR DESCRIPTION
#### Fixes #6577

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adds a `bordered` prop to the `Section` and `SectionCard` components, allowing consumers to control the visibility of internal border lines.

- **`Section bordered`** (default `true`) — controls the `border-bottom` on the section header (dividing it from the body) and the `border-bottom` between consecutive `SectionCard` children
- **`SectionCard bordered`** (no default, inherits from parent `Section`) — allows per-card override of the Section-level `bordered` setting, e.g. a borderless `Section` with selectively bordered cards
- New CSS classes: `bp5-section-bordered`, `bp5-section-card-bordered`, `bp5-section-card-not-bordered`
- Updated playground example with "Bordered" toggles under both "Section Props" and "SectionCard Props"
- Updated `section.md` with prose explaining the `SectionCard` override behavior

#### Reviewers should focus on:

- The CSS specificity strategy in `_section.scss`: borders are scoped under `.bp5-section-bordered`, and `SectionCard` override rules are placed after Section rules in the same file so that equal-specificity (0,3,0) ties resolve via source order in favor of the card-level override.
- The default value of `bordered` on `Section` is `true` — preserving existing visual behavior for all current consumers with no changes required.
- `SectionCard bordered` intentionally has no default (i.e. `undefined` means "inherit from parent Section via CSS cascade"), unlike most Blueprint boolean props which have an explicit default.

#### Screenshot
**Section bordered = false**

Single SectionCard
<img width="717" height="179" alt="image" src="https://github.com/user-attachments/assets/54e4a006-1fc9-46cb-93a1-1feadc3685cc" />
with SectionCard bordered = true

Multiple SectionCards
<img width="698" height="278" alt="image" src="https://github.com/user-attachments/assets/6f0408da-c6d8-4b62-aab0-4e7be20be664" />

with SectionCard bordered = true
<img width="715" height="285" alt="image" src="https://github.com/user-attachments/assets/54854be1-2deb-43f0-96ea-d3724cff155b" />

**Section bordered = true**
SectionCard bordered is ignored

<img width="718" height="176" alt="image" src="https://github.com/user-attachments/assets/3d2d88c2-d553-4c17-b14d-a24c8d4b5e27" />

Multiple SectionCards
<img width="721" height="286" alt="image" src="https://github.com/user-attachments/assets/bf2f5b10-c8fa-4b23-9a68-0df38fe7f310" />


**Example**
![bordered](https://github.com/user-attachments/assets/d4bcadf0-43f5-4abd-9fb3-68b4bea83549)


<!-- Include an image of the most relevant user-facing change, if any. -->

<details>
<summary>Decisions</summary>

# Section Component — Design Decisions

## Adding `bordered` support (resolves [#6577](https://github.com/palantir/blueprint/issues/6577))

### Ask

Add a way for consumers to remove the border lines from a `Section` and reduce the visual gap between the header and the body when those borders are absent.

### Decisions

#### 1. Use `bordered`, not `outlined` or `compact`

The issue asks to control internal dividing lines within the Section — the `border-bottom` on the section header (between header and body) and the `border-bottom` between consecutive `SectionCard` children. This is the definition of `bordered`: borders *between child items*. It is distinct from:

- `outlined` — controls the outer container boundary (the card `box-shadow` and `border-radius`), implemented separately (see below)
- `compact` — reduces overall density and spacing, already exists on `Section`

#### 2. `bordered` on `Section` affects both the header divider and inter-card dividers

Two borders exist inside a Section:

- `.bp5-section-header` `border-bottom` — the line separating the header from the body
- `.bp5-section-card:not(:last-child)` `border-bottom` — the line separating consecutive `SectionCard` children

Both are internal dividers, so both should respond to `bordered`. Removing only the header border while leaving inter-card borders would be visually inconsistent.

#### 3. `bordered` is also added to `SectionCard` for consumer override

When `Section bordered={false}` suppresses inter-card borders at the container level, consumers can restore borders on individual cards via `SectionCard bordered={true}`. This allows a borderless Section header with selectively bordered cards. This mirrors the existing pattern of `SectionCard padded` being independently controllable from the Section level.

#### 4. The spacing ask is already covered by the existing `compact` prop

The issue asks to reduce the gap between header and body when `bordered=false`. This is a density concern, already addressed by `compact`, which reduces the header `min-height` and horizontal padding. Consumers who want tighter spacing alongside a borderless Section should combine `bordered={false} compact={true}`. The two props are kept orthogonal — `bordered` does not implicitly trigger compact spacing.

---

## Adding `outlined` support

### Ask

Allow consumers to embed a `Section` inside another bordered container without the Section's own card `box-shadow` and `border-radius` creating visual noise.

### Decisions

#### 1. `outlined` controls the outer card shadow and border-radius, not internal borders

`Section` renders as a `Card`, which always applies a `box-shadow` (even at `Elevation.ZERO`, a 1px border-like shadow is present). The `outlined` prop suppresses both the `box-shadow` and the `border-radius` when `false`, producing a flat rectangular container. This is distinct from `bordered`, which controls internal dividers.

#### 2. `outlined` defaults to `true` to preserve existing behavior

All existing consumers see no change. Setting `outlined={false}` is an explicit opt-in to the flat appearance.

#### 3. Both `box-shadow` and `border-radius` are suppressed together

Rounded corners without any shadow or border ring look odd in most embedding contexts. This mirrors the behavior of `CardList bordered={false}`, which similarly removes both properties together.

#### 4. `outlined` does not affect `SectionCard`

`SectionCard` is a plain `div` with no `box-shadow` or `border-radius` of its own. No changes to `SectionCard` are required.

#### 5. `outlined` and `bordered` are fully orthogonal

The four combinations are all valid:

| `outlined` | `bordered` | Visual result |
|---|---|---|
| `true` | `true` | Default — shadowed container with internal dividers |
| `true` | `false` | Shadowed container, no internal dividers |
| `false` | `true` | Flat container with internal dividers |
| `false` | `false` | Fully flat, no visual boundaries — suitable for seamless embedding |

#### 6. CSS implementation uses `:not(.bp5-section-outlined)` with specificity (0,2,0)

The Card base styles that provide `box-shadow` and `border-radius` have specificity (0,1,0). The `:not(.bp5-section-outlined)` selector on `.bp5-section` compiles to specificity (0,2,0), which is sufficient to override them without `!important`.

</details>
