### PR TITLE
(chore) Enhance Card docs

### DIFF
--- a/packages/core/src/components/card/card.md
+++ b/packages/core/src/components/card/card.md
@@ -3,20 +3,26 @@
 A **Card** is a bounded container for grouping related content with a solid
 background color. It offers customizable padding, interactivity, and elevation.
 
-@## Import
+@## Usage
 
 ```tsx
 import { Card } from "@blueprintjs/core";
 ```
 
-@## Usage
+```tsx
+<Card>This is a simple card with some text</Card>
+```
+
+@## Examples
+
+@### Basic
 
 A **Card** provides a structured container for text, actions, or other content.
 Use it to present a cohesive unit of information.
 
 @reactCodeExample CardBasicExample
 
-@## Interactive
+@### Interactive
 
 The `interactive` prop makes a **Card** appear responsive to hover and click events.
 Combine it with an `onClick` handler to perform actions when the card is clicked,
@@ -26,13 +32,13 @@ Additionally, the `selected` prop can be used to indicate a selection state.
 
 @reactCodeExample CardInteractiveExample
 
-@## Compact
+@### Compact
 
 Enable the `compact` prop to reduce the padding of the **Card**, resulting in a more condensed appearance.
 
 @reactCodeExample CardCompactExample
 
-@## Elevation
+@### Elevation
 
 The `elevation` prop controls the shadow depth of the **Card**, creating a visual
 hierarchy. Five elevations are supported, from 0 to 4. Higher elevation values


### PR DESCRIPTION
#### Related to [(chore) Enhance Breadcrumbs docs](https://github.com/palantir/blueprint/pull/7824#top)

#### Changes proposed in this pull request:
We want to (a) begin instilling a sense of order/structure in our docs and (b) provide more plentiful examples of how to use the various props in the docs.

The `Card` docs are already pretty robust, so this is just a very minor structural tweak

#### Reviewers should focus on:
Readability, content, quality of examples.

#### Before
<img width="1412" height="890" alt="Screenshot 2026-03-11 at 3 05 16 PM" src="https://github.com/user-attachments/assets/04336c02-b568-4b69-902e-15a022e213fa" />

#### After
<img width="1474" height="977" alt="Screenshot 2026-03-11 at 3 11 24 PM" src="https://github.com/user-attachments/assets/e6503963-a7d9-4250-8447-a030466f3928" />
