### PR TITLE
Add outlined to Section

### DIFF
--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -260,6 +260,7 @@ export const SECTION_CARD = `${SECTION}-card`;
 export const SECTION_CARD_BORDERED = `${SECTION_CARD}-bordered`;
 export const SECTION_CARD_NOT_BORDERED = `${SECTION_CARD}-not-bordered`;
 export const SECTION_BORDERED = `${SECTION}-bordered`;
+export const SECTION_OUTLINED = `${SECTION}-outlined`;
 
 export const NAVBAR = `${NS}-navbar`;
 export const NAVBAR_GROUP = `${NAVBAR}-group`;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -21,6 +21,13 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
     padding: 0;
   }
 
+  // When not outlined, suppress the Card box-shadow and border-radius.
+  // Specificity (0,2,0) beats .bp5-card and .bp5-elevation-* (0,1,0 each).
+  &:not(.#{$ns}-section-outlined) {
+    border-radius: 0;
+    box-shadow: none;
+  }
+
   &-header {
     align-items: center;
     display: flex;

--- a/packages/core/src/components/section/section.test.tsx
+++ b/packages/core/src/components/section/section.test.tsx
@@ -48,6 +48,16 @@ describe("<Section>", () => {
         containerElement.remove();
     });
 
+    it("renders outlined class by default", () => {
+        const wrapper = mount(<Section />, { attachTo: containerElement });
+        assert.isTrue(wrapper.find(`.${Classes.SECTION_OUTLINED}`).hostNodes().exists());
+    });
+
+    it("omits outlined class when outlined={false}", () => {
+        const wrapper = mount(<Section outlined={false} />, { attachTo: containerElement });
+        assert.isFalse(wrapper.find(`.${Classes.SECTION_OUTLINED}`).hostNodes().exists());
+    });
+
     it("renders bordered class by default", () => {
         const wrapper = mount(<Section />, { attachTo: containerElement });
         assert.isTrue(wrapper.find(`.${Classes.SECTION_BORDERED}`).hostNodes().exists());

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -69,6 +69,14 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
     collapsible?: boolean;
 
     /**
+     * Whether to render the outer box-shadow and border-radius of this section.
+     * Set to `false` to render a flat section suitable for embedding inside another bordered container.
+     *
+     * @default true
+     */
+    outlined?: boolean;
+
+    /**
      * Subset of props to forward to the underlying {@link Collapse} component, with the addition of a
      * `defaultIsOpen` option which sets the default open state of the component when in uncontrolled mode.
      */
@@ -144,6 +152,7 @@ export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
         collapsible,
         compact = false,
         elevation = Elevation.ZERO,
+        outlined = true,
         icon,
         rightElement,
         subtitle,
@@ -176,6 +185,7 @@ export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
         <Card
             className={classNames(className, Classes.SECTION, {
                 [Classes.SECTION_BORDERED]: bordered,
+                [Classes.SECTION_OUTLINED]: outlined,
                 [Classes.COMPACT]: compact,
                 [Classes.SECTION_COLLAPSED]: (collapsible && isCollapsed) || Utils.isReactNodeEmpty(children),
             })}

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -64,6 +64,7 @@ export const SectionExample: React.FC<ExampleProps> = props => {
     const [hasMultipleCards, setHasMultipleCards] = useState(false);
     const [hasRightElement, setHasRightElement] = useState(true);
     const [isBordered, setIsBordered] = useState(true);
+    const [isOutlined, setIsOutlined] = useState(true);
     const [isSectionCardBordered, setIsSectionCardBordered] = useState<boolean | undefined>(
         undefined,
     );
@@ -87,6 +88,11 @@ export const SectionExample: React.FC<ExampleProps> = props => {
         <>
             <div>
                 <H5>Section Props</H5>
+                <Switch
+                    checked={isOutlined}
+                    label="Outlined"
+                    onChange={handleBooleanChange(setIsOutlined)}
+                />
                 <Switch
                     checked={isBordered}
                     label="Bordered"
@@ -180,6 +186,7 @@ export const SectionExample: React.FC<ExampleProps> = props => {
                 // updated.
                 key={String(defaultIsOpen)}
                 bordered={isBordered}
+                outlined={isOutlined}
                 collapsible={collapsible}
                 collapseProps={collapseProps}
                 compact={isCompact}


### PR DESCRIPTION
#### Fixes #6577

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adds an `outlined` prop to the `Section` component, allowing consumers to suppress the outer card `box-shadow` and `border-radius` when embedding a Section inside another bordered container.

- **`Section outlined`** (default `true`) — when `false`, sets `box-shadow: none` and `border-radius: 0` on the underlying Card, producing a flat rectangular container suitable for seamless embedding
- New CSS class: `bp5-section-outlined`
- Updated playground example with an "Outlined" toggle under "Section Props"

#### Reviewers should focus on:

- `outlined` and `bordered` are orthogonal — suppressing the outer shadow does not affect internal header or inter-card dividers. All four combinations (`outlined` × `bordered`) are valid and intentional.
- The CSS uses `:not(.bp5-section-outlined)` scoped inside `.bp5-section`, giving specificity (0,2,0) which beats the Card base styles at (0,1,0) without needing `!important`.
- Both `box-shadow` and `border-radius` are suppressed together when `outlined={false}`, consistent with the behavior of `CardList bordered={false}`.
- `SectionCard` requires no changes — it is a plain `div` with no shadow or border-radius of its own.

#### Screenshot
Default outlined
<img width="707" height="303" alt="image" src="https://github.com/user-attachments/assets/a72a9a99-28f4-4449-a90a-5043c62fb42c" />

no outline
<img width="694" height="315" alt="image" src="https://github.com/user-attachments/assets/641ab4ce-35f8-48f1-ab8f-99bc47280007" />

<!-- Include an image of the most relevant user-facing change, if any. -->
