### PR TITLE
[core] Integrating design tokens into input, input group, numeric input, file input, label, form group

### DIFF
--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -154,6 +154,25 @@ export const ButtonTextExample: Story = {
 };
 
 /**
+ * A file input in the focused state, showing the focus ring.
+ */
+export const FocusedExample: Story = {
+    name: "Focused",
+    play: async ({ canvas }) => {
+        const label = canvas.getByText("Choose file...");
+        const input = label.closest("label")?.querySelector("input");
+        if (input) {
+            input.focus();
+        }
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <FileInput {...args} text="Choose file..." />
+        </div>
+    ),
+};
+
+/**
  * Interactive playground with file selection handling.
  */
 export const Playground: Story = {

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -166,9 +166,9 @@ export const FocusedExample: Story = {
         }
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex gap={3}>
             <FileInput {...args} text="Choose file..." />
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -228,6 +228,22 @@ export const FillExample: Story = {
 };
 
 /**
+ * An input in the focused state, showing the focus ring. Use controls to change the intent.
+ */
+export const FocusedExample: Story = {
+    name: "Focused",
+    play: async ({ canvas, userEvent }) => {
+        const input = canvas.getByPlaceholderText("Click to focus...");
+        await userEvent.click(input);
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <InputGroup {...args} placeholder="Click to focus..." />
+        </div>
+    ),
+};
+
+/**
  * Interactive playground with all props togglable via Storybook controls.
  */
 export const Playground: Story = {

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { storybookLayoutDecorator } from "@storybook-common";
 import { type ChangeEvent, useCallback, useState } from "react";
 
 import { Flex } from "@blueprintjs/labs";
@@ -16,13 +17,7 @@ import { InputGroup } from "./inputGroup";
 const meta: Meta<typeof InputGroup> = {
     title: "Core/Form/Inputs/InputGroup",
     component: InputGroup,
-    decorators: [
-        Story => (
-            <Flex flexDirection="column" gap={3} style={{ width: "100%", minWidth: "400px" }}>
-                <Story />
-            </Flex>
-        ),
-    ],
+    decorators: [storybookLayoutDecorator],
     tags: ["autodocs"],
     args: {
         intent: "none",
@@ -236,11 +231,7 @@ export const FocusedExample: Story = {
         const input = canvas.getByPlaceholderText("Click to focus...");
         await userEvent.click(input);
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-            <InputGroup {...args} placeholder="Click to focus..." />
-        </div>
-    ),
+    render: args => <InputGroup {...args} placeholder="Click to focus..." />,
 };
 
 /**

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -215,6 +215,22 @@ export const FillExample: Story = {
 };
 
 /**
+ * A numeric input in the focused state, showing the focus ring. Use controls to change the intent.
+ */
+export const FocusedExample: Story = {
+    name: "Focused",
+    play: async ({ canvas, userEvent }) => {
+        const input = canvas.getByPlaceholderText("Click to focus...");
+        await userEvent.click(input);
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <NumericInput {...args} placeholder="Click to focus..." />
+        </div>
+    ),
+};
+
+/**
  * Interactive playground with all props togglable via Storybook controls.
  */
 export const Playground: Story = {

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -224,9 +224,9 @@ export const FocusedExample: Story = {
         await userEvent.click(input);
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex gap={3}>
             <NumericInput {...args} placeholder="Click to focus..." />
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -144,7 +144,7 @@ $control-group-stack: (
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border: 1px solid buttonborder;
+    border: 1px solid $pt-high-contrast-mode-border-color;
   }
 }
 
@@ -171,7 +171,7 @@ $control-group-stack: (
 @mixin pt-input-large() {
   font-size: var(--bp-typography-size-body-large);
   height: calc(var(--bp-surface-spacing) * 10);
-  line-height: calc(var(--bp-surface-spacing) * 10);
+  line-height: calc(var(--bp-typography-line-height-default) * 10);
 
   &[type="search"],
   &.#{$ns}-round {
@@ -214,7 +214,7 @@ $control-group-stack: (
     0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
     inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
-  color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)"};
+  color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.239) calc(c - 0.011) h)"};
 
   &:focus {
     box-shadow:
@@ -242,22 +242,22 @@ $control-group-stack: (
   }
 }
 
-@mixin pt-input-intent($color-token) {
+@mixin pt-input-intent($color) {
   box-shadow:
-    inset 0 0 0 0 #{oklch(from $color-token l c h / 0)},
-    0 0 0 0 #{oklch(from $color-token l c h / 0)},
-    inset 0 0 0 1px $color-token,
+    inset 0 0 0 0 #{oklch(from $color l c h / 0)},
+    0 0 0 0 #{oklch(from $color l c h / 0)},
+    inset 0 0 0 1px $color,
     inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
 
   &:focus {
     box-shadow:
-      inset 0 0 0 1px #{oklch(from $color-token l c h / 0.752)},
-      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color-token l c h / 0.752)},
+      inset 0 0 0 1px #{oklch(from $color l c h / 0.752)},
+      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color l c h / 0.752)},
       inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px $color-token;
+    box-shadow: inset 0 0 0 1px $color;
   }
 
   &:disabled,
@@ -266,24 +266,24 @@ $control-group-stack: (
   }
 }
 
-@mixin pt-dark-input-intent($color-token) {
+@mixin pt-dark-input-intent($color) {
   box-shadow:
-    inset 0 0 0 0 #{oklch(from $color-token l c h / 0)},
-    0 0 0 0 #{oklch(from $color-token l c h / 0)},
-    inset 0 0 0 1px $color-token,
+    inset 0 0 0 0 #{oklch(from $color l c h / 0)},
+    0 0 0 0 #{oklch(from $color l c h / 0)},
+    inset 0 0 0 1px $color,
     inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
     inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
 
   &:focus {
     box-shadow:
-      inset 0 0 0 1px #{oklch(from $color-token l c h / 0.752)},
-      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color-token l c h / 0.752)},
+      inset 0 0 0 1px #{oklch(from $color l c h / 0.752)},
+      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color l c h / 0.752)},
       inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
       inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px $color-token;
+    box-shadow: inset 0 0 0 1px $color;
   }
 
   &:disabled,

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -1,6 +1,7 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+/* stylelint-disable alpha-value-notation */
 @import "@blueprintjs/icons/lib/scss/variables";
 @import "../../common/variables";
 @import "../button/common";
@@ -85,19 +86,19 @@ $control-group-stack: (
 @mixin pt-input() {
   @include pt-input-placeholder;
   appearance: none;
-  background: $input-background-color;
+  background: var(--bp-palette-white);
   border: none;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   box-shadow: input-transition-shadow($input-shadow-color-focus), $pt-input-box-shadow;
-  color: $input-color;
-  font-size: $pt-font-size;
+  color: var(--bp-typography-color-default-rest);
+  font-size: var(--bp-typography-size-body-medium);
   font-weight: $input-font-weight;
-  height: $pt-input-height;
-  line-height: $pt-input-height;
+  height: calc(var(--bp-surface-spacing) * 7.5);
+  line-height: calc(var(--bp-surface-spacing) * 7.5);
 
   outline: none;
-  padding: 0 $input-padding-horizontal;
-  transition: $input-transition;
+  padding: 0 calc(var(--bp-surface-spacing) * 2);
+  transition: box-shadow var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default);
   vertical-align: middle;
 
   &:focus,
@@ -107,14 +108,14 @@ $control-group-stack: (
 
   &[type="search"],
   &.#{$ns}-round {
-    border-radius: $pt-input-height;
+    border-radius: calc(var(--bp-surface-spacing) * 7.5);
     // override normalize.css
     box-sizing: border-box;
-    padding-left: $pt-spacing * 2;
+    padding-left: calc(var(--bp-surface-spacing) * 2);
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px $pt-divider-black;
+    box-shadow: inset 0 0 0 1px var(--bp-surface-border-color-default);
 
     &:focus {
       box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
@@ -127,80 +128,80 @@ $control-group-stack: (
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
   }
 }
 
 @mixin pt-input-placeholder() {
   &::placeholder {
-    color: $input-placeholder-color;
+    color: var(--bp-typography-color-muted);
     // normalize.css sets an opacity less than 1, we don't want this
     opacity: 1;
   }
 }
 
 @mixin pt-input-disabled() {
-  background: $input-background-color-disabled;
+  background: oklch(from var(--bp-palette-light-gray-1) l c h / 0.5);
   box-shadow: none;
-  color: $input-color-disabled;
+  color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
   resize: none;
 
   &::placeholder {
-    color: $input-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
   }
 }
 
 @mixin pt-input-large() {
-  font-size: $pt-font-size-large;
-  height: $pt-input-height-large;
-  line-height: $pt-input-height-large;
+  font-size: var(--bp-typography-size-body-large);
+  height: calc(var(--bp-surface-spacing) * 10);
+  line-height: calc(var(--bp-surface-spacing) * 10);
 
   &[type="search"],
   &.#{$ns}-round {
-    padding: 0 ($input-padding-horizontal * 1.5);
+    padding: 0 calc(var(--bp-surface-spacing) * 3);
   }
 }
 
 @mixin pt-input-small() {
-  font-size: $pt-font-size-small;
-  height: $pt-input-height-small;
-  line-height: $pt-input-height-small;
-  padding-left: $input-small-padding;
-  padding-right: $input-small-padding;
+  font-size: var(--bp-typography-size-body-small);
+  height: calc(var(--bp-surface-spacing) * 6);
+  line-height: calc(var(--bp-surface-spacing) * 6);
+  padding-left: calc(var(--bp-surface-spacing) * 2);
+  padding-right: calc(var(--bp-surface-spacing) * 2);
 
   &[type="search"],
   &.#{$ns}-round {
-    padding: 0 ($input-small-padding * 1.5);
+    padding: 0 calc(var(--bp-surface-spacing) * 3);
   }
 }
 
 @mixin pt-dark-input-disabled() {
-  background: $dark-input-background-color-disabled;
+  background: oklch(from var(--bp-intent-default-hover) l c h / 0.5);
   box-shadow: none;
-  color: $dark-input-color-disabled;
+  color: var(--bp-typography-color-default-disabled);
 }
 
 @mixin pt-dark-input-placeholder() {
   &::placeholder {
-    color: $dark-input-placeholder-color;
+    color: var(--bp-typography-color-muted);
   }
 }
 
 @mixin pt-dark-input() {
   @include pt-dark-input-placeholder;
-  background: $dark-input-background-color;
+  background: oklch(from var(--bp-palette-black) l c h / 0.3);
 
   box-shadow:
     dark-input-transition-shadow($dark-input-shadow-color-focus), $pt-dark-input-box-shadow;
-  color: $dark-input-color;
+  color: var(--bp-typography-color-default-rest);
 
   &:focus {
     box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px $pt-dark-divider-black;
+    box-shadow: inset 0 0 0 1px oklch(from var(--bp-palette-black) l c h / 0.4);
 
     &:focus {
       box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);
@@ -215,12 +216,12 @@ $control-group-stack: (
 
 @mixin pt-input-intent($color) {
   box-shadow:
-    input-transition-shadow($color, false, $pt-spacing * 0.5),
+    input-transition-shadow($color, false, calc(var(--bp-surface-spacing) * 0.5)),
     inset border-shadow(1, $color),
     $pt-input-box-shadow;
 
   &:focus {
-    box-shadow: input-transition-shadow($color, true, $pt-spacing * 0.5), $input-box-shadow-focus;
+    box-shadow: input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)), $input-box-shadow-focus;
   }
 
   &[readonly] {
@@ -235,13 +236,13 @@ $control-group-stack: (
 
 @mixin pt-dark-input-intent($color) {
   box-shadow:
-    dark-input-transition-shadow($color, false, $pt-spacing * 0.5),
+    dark-input-transition-shadow($color, false, calc(var(--bp-surface-spacing) * 0.5)),
     inset border-shadow(1, $color),
     $pt-dark-input-box-shadow;
 
   &:focus {
     box-shadow:
-      dark-input-transition-shadow($color, true, $pt-spacing * 0.5), $pt-dark-input-box-shadow;
+      dark-input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)), $pt-dark-input-box-shadow;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -90,7 +90,8 @@ $control-group-stack: (
   border: none;
   border-radius: var(--bp-surface-border-radius);
   box-shadow:
-    inset 0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
+    inset 0 0 0 0
+      #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
     0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
     inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
@@ -208,7 +209,8 @@ $control-group-stack: (
   background: #{oklch(from var(--bp-palette-black) l c h / 0.3)};
 
   box-shadow:
-    inset 0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
+    inset 0 0 0 0
+      #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
     0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
     inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -221,7 +221,9 @@ $control-group-stack: (
     $pt-input-box-shadow;
 
   &:focus {
-    box-shadow: input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)), $input-box-shadow-focus;
+    box-shadow:
+      input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)),
+      $input-box-shadow-focus;
   }
 
   &[readonly] {
@@ -242,7 +244,8 @@ $control-group-stack: (
 
   &:focus {
     box-shadow:
-      dark-input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)), $pt-dark-input-box-shadow;
+      dark-input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)),
+      $pt-dark-input-box-shadow;
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -199,7 +199,7 @@ $control-group-stack: (
 
 @mixin pt-dark-input-placeholder() {
   &::placeholder {
-    color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
+    color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
   }
 }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -141,7 +141,7 @@ $control-group-stack: (
 }
 
 @mixin pt-input-disabled() {
-  background: oklch(from var(--bp-palette-light-gray-1) l c h / 0.5);
+  background: #{oklch(from var(--bp-palette-light-gray-1) l c h / 0.5)};
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -177,7 +177,7 @@ $control-group-stack: (
 }
 
 @mixin pt-dark-input-disabled() {
-  background: oklch(from var(--bp-intent-default-hover) l c h / 0.5);
+  background: #{oklch(from var(--bp-intent-default-hover) l c h / 0.5)};
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
 }
@@ -190,7 +190,7 @@ $control-group-stack: (
 
 @mixin pt-dark-input() {
   @include pt-dark-input-placeholder;
-  background: oklch(from var(--bp-palette-black) l c h / 0.3);
+  background: #{oklch(from var(--bp-palette-black) l c h / 0.3)};
 
   box-shadow:
     dark-input-transition-shadow($dark-input-shadow-color-focus), $pt-dark-input-box-shadow;
@@ -201,7 +201,7 @@ $control-group-stack: (
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px oklch(from var(--bp-palette-black) l c h / 0.4);
+    box-shadow: inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.4)};
 
     &:focus {
       box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -57,16 +57,17 @@ $control-group-stack: (
 );
 
 // animating shadows requires the same number of shadows in different states
+// stylelint-disable alpha-value-notation
 @function input-transition-shadow(
   $color: $input-shadow-color-focus,
   $focus: false,
   $outer-shadow-focus-width: 1px
 ) {
   @if $focus {
-    @return inset border-shadow(0.752, $color, 1px),
-      border-shadow(0.752, $color, $outer-shadow-focus-width);
+    @return inset 0 0 0 1px #{oklch(from #{$color} l c h / 0.752)},
+      0 0 0 #{$outer-shadow-focus-width} #{oklch(from #{$color} l c h / 0.752)};
   } @else {
-    @return border-shadow(0, $color, 0), border-shadow(0, $color, 0);
+    @return 0 0 0 0 #{oklch(from #{$color} l c h / 0)}, 0 0 0 0 #{oklch(from #{$color} l c h / 0)};
   }
 }
 
@@ -76,23 +77,28 @@ $control-group-stack: (
   $outer-shadow-focus-width: 1px
 ) {
   @if $focus {
-    @return inset border-shadow(0.752, $color, 1px),
-      border-shadow(0.752, $color, $outer-shadow-focus-width);
+    @return inset 0 0 0 1px #{oklch(from #{$color} l c h / 0.752)},
+      0 0 0 #{$outer-shadow-focus-width} #{oklch(from #{$color} l c h / 0.752)};
   } @else {
-    @return border-shadow(0, $color, 0), border-shadow(0, $color, 0);
+    @return 0 0 0 0 #{oklch(from #{$color} l c h / 0)}, 0 0 0 0 #{oklch(from #{$color} l c h / 0)};
   }
 }
+// stylelint-enable alpha-value-notation
 
 @mixin pt-input() {
   @include pt-input-placeholder;
   appearance: none;
-  background: var(--bp-palette-white);
+  background: var(--bp-surface-background-color-default-rest);
   border: none;
   border-radius: var(--bp-surface-border-radius);
-  box-shadow: input-transition-shadow($input-shadow-color-focus), $pt-input-box-shadow;
+  box-shadow:
+    inset 0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)},
+    0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)},
+    inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
+    inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
   color: var(--bp-typography-color-default-rest);
   font-size: var(--bp-typography-size-body-medium);
-  font-weight: $input-font-weight;
+  font-weight: var(--bp-typography-weight-default);
   height: calc(var(--bp-surface-spacing) * 7.5);
   line-height: calc(var(--bp-surface-spacing) * 7.5);
 
@@ -103,7 +109,12 @@ $control-group-stack: (
 
   &:focus,
   &.#{$ns}-active {
-    box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+    box-shadow:
+      inset 0 0 0 1px
+        #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+      0 0 0 1px
+        #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+      inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
   }
 
   &[type="search"],
@@ -118,7 +129,13 @@ $control-group-stack: (
     box-shadow: inset 0 0 0 1px var(--bp-surface-border-color-default);
 
     &:focus {
-      box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+      box-shadow:
+        inset 0 0 0 1px
+          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        0 0 0 1px
+          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
+        inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
     }
   }
 
@@ -141,7 +158,7 @@ $control-group-stack: (
 }
 
 @mixin pt-input-disabled() {
-  background: #{oklch(from var(--bp-palette-light-gray-1) l c h / 0.5)};
+  background: #{oklch(from var(--bp-intent-default-disabled) calc(l + 0.200) calc(c - 0.015) h / 0.5)};
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -193,18 +210,29 @@ $control-group-stack: (
   background: #{oklch(from var(--bp-palette-black) l c h / 0.3)};
 
   box-shadow:
-    dark-input-transition-shadow($dark-input-shadow-color-focus), $pt-dark-input-box-shadow;
+    inset 0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)},
+    0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)},
+    inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
+    inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
   color: var(--bp-typography-color-default-rest);
 
   &:focus {
-    box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);
+    box-shadow:
+      inset 0 0 0 1px
+        #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+      0 0 0 1px
+        #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)};
   }
 
   &[readonly] {
     box-shadow: inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.4)};
 
     &:focus {
-      box-shadow: dark-input-transition-shadow($dark-input-shadow-color-focus, true);
+      box-shadow:
+        inset 0 0 0 1px
+          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+        0 0 0 1px
+          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)};
     }
   }
 
@@ -214,20 +242,22 @@ $control-group-stack: (
   }
 }
 
-@mixin pt-input-intent($color) {
+@mixin pt-input-intent($color-token) {
   box-shadow:
-    input-transition-shadow($color, false, calc(var(--bp-surface-spacing) * 0.5)),
-    inset border-shadow(1, $color),
-    $pt-input-box-shadow;
+    inset 0 0 0 0 #{oklch(from $color-token l c h / 0)},
+    0 0 0 0 #{oklch(from $color-token l c h / 0)},
+    inset 0 0 0 1px $color-token,
+    inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
 
   &:focus {
     box-shadow:
-      input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)),
-      $input-box-shadow-focus;
+      inset 0 0 0 1px #{oklch(from $color-token l c h / 0.752)},
+      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color-token l c h / 0.752)},
+      inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px $color;
+    box-shadow: inset 0 0 0 1px $color-token;
   }
 
   &:disabled,
@@ -236,20 +266,24 @@ $control-group-stack: (
   }
 }
 
-@mixin pt-dark-input-intent($color) {
+@mixin pt-dark-input-intent($color-token) {
   box-shadow:
-    dark-input-transition-shadow($color, false, calc(var(--bp-surface-spacing) * 0.5)),
-    inset border-shadow(1, $color),
-    $pt-dark-input-box-shadow;
+    inset 0 0 0 0 #{oklch(from $color-token l c h / 0)},
+    0 0 0 0 #{oklch(from $color-token l c h / 0)},
+    inset 0 0 0 1px $color-token,
+    inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
+    inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
 
   &:focus {
     box-shadow:
-      dark-input-transition-shadow($color, true, calc(var(--bp-surface-spacing) * 0.5)),
-      $pt-dark-input-box-shadow;
+      inset 0 0 0 1px #{oklch(from $color-token l c h / 0.752)},
+      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color-token l c h / 0.752)},
+      inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
+      inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px $color;
+    box-shadow: inset 0 0 0 1px $color-token;
   }
 
   &:disabled,

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -90,8 +90,8 @@ $control-group-stack: (
   border: none;
   border-radius: var(--bp-surface-border-radius);
   box-shadow:
-    inset 0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)},
-    0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)},
+    inset 0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
+    0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
     inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
   color: var(--bp-typography-color-default-rest);
@@ -109,9 +109,9 @@ $control-group-stack: (
   &.#{$ns}-active {
     box-shadow:
       inset 0 0 0 1px
-        #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
       0 0 0 1px
-        #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
       inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
   }
 
@@ -129,9 +129,9 @@ $control-group-stack: (
     &:focus {
       box-shadow:
         inset 0 0 0 1px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
         0 0 0 1px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
         inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
         inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
     }
@@ -156,7 +156,7 @@ $control-group-stack: (
 }
 
 @mixin pt-input-disabled() {
-  background: #{oklch(from var(--bp-intent-default-disabled) calc(l + 0.2) calc(c - 0.015) h / 0.5)};
+  background: #{"oklch(from var(--bp-intent-default-disabled) calc(l + 0.2) calc(c - 0.015) h / 0.5)"};
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -199,7 +199,7 @@ $control-group-stack: (
 
 @mixin pt-dark-input-placeholder() {
   &::placeholder {
-    color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
+    color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
   }
 }
 
@@ -208,18 +208,18 @@ $control-group-stack: (
   background: #{oklch(from var(--bp-palette-black) l c h / 0.3)};
 
   box-shadow:
-    inset 0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)},
-    0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)},
+    inset 0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
+    0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
     inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
-  color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)};
+  color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)"};
 
   &:focus {
     box-shadow:
       inset 0 0 0 1px
-        #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
       0 0 0 1px
-        #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)};
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"};
   }
 
   &[readonly] {
@@ -228,9 +228,9 @@ $control-group-stack: (
     &:focus {
       box-shadow:
         inset 0 0 0 1px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
         0 0 0 1px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)};
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"};
     }
   }
 

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -199,7 +199,7 @@ $control-group-stack: (
 
 @mixin pt-dark-input-placeholder() {
   &::placeholder {
-    color: var(--bp-typography-color-muted);
+    color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
   }
 }
 
@@ -212,7 +212,7 @@ $control-group-stack: (
     0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
     inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
-  color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.24) calc(c - 0.012) h)};
+  color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)};
 
   &:focus {
     box-shadow:

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -57,7 +57,6 @@ $control-group-stack: (
 );
 
 // animating shadows requires the same number of shadows in different states
-// stylelint-disable alpha-value-notation
 @function input-transition-shadow(
   $color: $input-shadow-color-focus,
   $focus: false,
@@ -83,7 +82,6 @@ $control-group-stack: (
     @return 0 0 0 0 #{oklch(from #{$color} l c h / 0)}, 0 0 0 0 #{oklch(from #{$color} l c h / 0)};
   }
 }
-// stylelint-enable alpha-value-notation
 
 @mixin pt-input() {
   @include pt-input-placeholder;
@@ -158,7 +156,7 @@ $control-group-stack: (
 }
 
 @mixin pt-input-disabled() {
-  background: #{oklch(from var(--bp-intent-default-disabled) calc(l + 0.200) calc(c - 0.015) h / 0.5)};
+  background: #{oklch(from var(--bp-intent-default-disabled) calc(l + 0.2) calc(c - 0.015) h / 0.5)};
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -214,7 +212,7 @@ $control-group-stack: (
     0 0 0 0 #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)},
     inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
     inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
-  color: var(--bp-typography-color-default-rest);
+  color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.24) calc(c - 0.012) h)};
 
   &:focus {
     box-shadow:

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -72,7 +72,9 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     }
 
     .#{$ns}-dark & .#{$ns}-file-upload-input {
-      color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)};
+      color: #{oklch(
+          from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h
+        )};
     }
   }
 

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -72,7 +72,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     }
 
     .#{$ns}-dark & .#{$ns}-file-upload-input {
-      color: var(--bp-typography-color-default-rest);
+      color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)};
     }
   }
 

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -49,17 +49,17 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     &:focus + .#{$ns}-file-upload-input {
       box-shadow:
         inset 0 0 0 1px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
         0 0 0 1px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
-        inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
+        inset 0 1px 1px #{"oklch(from var(--bp-palette-black) l c h / 0.2)"};
 
       .#{$ns}-dark & {
         box-shadow:
           inset 0 0 0 1px
-            #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+            #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
           0 0 0 1px
-            #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+            #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
           inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
           inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
       }
@@ -72,9 +72,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     }
 
     .#{$ns}-dark & .#{$ns}-file-upload-input {
-      color: #{oklch(
-          from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h
-        )};
+      color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)"};
     }
   }
 
@@ -159,7 +157,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   .#{$ns}-dark & {
     @include pt-dark-input;
-    color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h / 0.6)};
+    color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h / 0.6)"};
 
     &::after {
       @include pt-dark-button-default-colors;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -48,14 +48,18 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     // borrows focus styles from pt-input and pt-dark-input mixins (see _common.scss)
     &:focus + .#{$ns}-file-upload-input {
       box-shadow:
-        inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
-        0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        inset 0 0 0 1px
+          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        0 0 0 1px
+          #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
         inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
 
       .#{$ns}-dark & {
         box-shadow:
-          inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
-          0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+          inset 0 0 0 1px
+            #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+          0 0 0 1px
+            #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
           inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
           inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
       }
@@ -94,7 +98,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 .#{$ns}-file-upload-input {
   @include pt-input;
   @include overflow-ellipsis;
-  color: var(--bp-typography-color-default-disabled);
+  color: #{oklch(from var(--bp-typography-color-muted) l c h / 0.6)};
   left: 0;
   padding-right: calc(var(--bp-surface-spacing) * 19.5);
   position: absolute;
@@ -153,7 +157,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   .#{$ns}-dark & {
     @include pt-dark-input;
-    color: var(--bp-typography-color-default-disabled);
+    color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h / 0.6)};
 
     &::after {
       @include pt-dark-button-default-colors;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -47,12 +47,17 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
     // borrows focus styles from pt-input and pt-dark-input mixins (see _common.scss)
     &:focus + .#{$ns}-file-upload-input {
-      box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
+      box-shadow:
+        inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)},
+        inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
 
       .#{$ns}-dark & {
         box-shadow:
-          dark-input-transition-shadow($dark-input-shadow-color-focus, true),
-          $pt-dark-input-box-shadow;
+          inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+          0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)},
+          inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
+          inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
       }
     }
   }
@@ -99,7 +104,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   &::after {
     @include pt-button-default-colors;
-    @include pt-button-height($pt-button-height-small);
+    @include pt-button-height(calc(var(--bp-surface-spacing) * 6));
     @include overflow-ellipsis;
     border-radius: var(--bp-surface-border-radius);
     content: "Browse";
@@ -127,7 +132,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     padding-right: calc(var(--bp-surface-spacing) * 23.25);
 
     &::after {
-      @include pt-button-height($pt-button-height);
+      @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
       line-height: calc(var(--bp-surface-spacing) * 7.5);
       margin: calc(var(--bp-surface-spacing) * 1.25);
       width: calc(var(--bp-surface-spacing) * 21.25);
@@ -139,7 +144,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     padding-right: calc(var(--bp-surface-spacing) * 15.75);
 
     &::after {
-      @include pt-button-height($pt-button-height-smaller);
+      @include pt-button-height(calc(var(--bp-surface-spacing) * 5));
       line-height: calc(var(--bp-surface-spacing) * 5);
       margin: calc(var(--bp-surface-spacing) * 0.5);
       width: calc(var(--bp-surface-spacing) * 13.75);
@@ -168,5 +173,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 // it doesn't render correct via the `pt-button` mixin
 /* stylelint-disable-next-line no-duplicate-selectors */
 .#{$ns}-file-upload-input::after {
-  box-shadow: $button-box-shadow;
+  box-shadow:
+    inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
+    0 1px 2px #{oklch(from var(--bp-palette-black) l c h / 0.1)};
 }

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -15,12 +15,12 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 .#{$ns}-file-input {
   cursor: pointer;
   display: inline-block;
-  height: $pt-input-height;
+  height: calc(var(--bp-surface-spacing) * 7.5);
   position: relative;
 
   input {
     margin: 0;
-    min-width: $pt-spacing * 50;
+    min-width: calc(var(--bp-surface-spacing) * 50);
     opacity: 0;
 
     // unlike other form controls that directly style native elements,
@@ -59,11 +59,11 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   &.#{$ns}-file-input-has-selection {
     .#{$ns}-file-upload-input {
-      color: $pt-text-color;
+      color: var(--bp-typography-color-default-rest);
     }
 
     .#{$ns}-dark & .#{$ns}-file-upload-input {
-      color: $pt-dark-text-color;
+      color: var(--bp-typography-color-default-rest);
     }
   }
 
@@ -73,12 +73,12 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   &.#{$ns}-large,
   .#{$ns}-large & {
-    height: $pt-input-height-large;
+    height: calc(var(--bp-surface-spacing) * 10);
   }
 
   &.#{$ns}-small,
   .#{$ns}-small & {
-    height: $pt-input-height-small;
+    height: calc(var(--bp-surface-spacing) * 6);
   }
 
   .#{$ns}-file-upload-input-custom-text::after {
@@ -89,9 +89,9 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 .#{$ns}-file-upload-input {
   @include pt-input;
   @include overflow-ellipsis;
-  color: $pt-text-color-disabled;
+  color: var(--bp-typography-color-default-disabled);
   left: 0;
-  padding-right: $file-input-button-width + $input-padding-horizontal;
+  padding-right: calc(var(--bp-surface-spacing) * 19.5);
   position: absolute;
   right: 0;
   top: 0;
@@ -101,15 +101,15 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     @include pt-button-default-colors;
     @include pt-button-height($pt-button-height-small);
     @include overflow-ellipsis;
-    border-radius: $pt-border-radius;
+    border-radius: var(--bp-surface-border-radius);
     content: "Browse";
-    line-height: $pt-button-height-small;
-    margin: $file-input-button-padding;
+    line-height: calc(var(--bp-surface-spacing) * 6);
+    margin: calc(var(--bp-surface-spacing) * 0.75);
     position: absolute;
     right: 0;
     text-align: center;
     top: 0;
-    width: $file-input-button-width;
+    width: calc(var(--bp-surface-spacing) * 17.5);
   }
 
   &:hover::after {
@@ -124,31 +124,31 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   .#{$ns}-large & {
     @include pt-input-large;
-    padding-right: $file-input-button-width-large + $input-padding-horizontal;
+    padding-right: calc(var(--bp-surface-spacing) * 23.25);
 
     &::after {
       @include pt-button-height($pt-button-height);
-      line-height: $pt-button-height;
-      margin: $file-input-button-padding-large;
-      width: $file-input-button-width-large;
+      line-height: calc(var(--bp-surface-spacing) * 7.5);
+      margin: calc(var(--bp-surface-spacing) * 1.25);
+      width: calc(var(--bp-surface-spacing) * 21.25);
     }
   }
 
   .#{$ns}-small & {
     @include pt-input-small;
-    padding-right: $file-input-button-width-small + $input-padding-horizontal;
+    padding-right: calc(var(--bp-surface-spacing) * 15.75);
 
     &::after {
       @include pt-button-height($pt-button-height-smaller);
-      line-height: $pt-button-height-smaller;
-      margin: $file-input-button-padding-small;
-      width: $file-input-button-width-small;
+      line-height: calc(var(--bp-surface-spacing) * 5);
+      margin: calc(var(--bp-surface-spacing) * 0.5);
+      width: calc(var(--bp-surface-spacing) * 13.75);
     }
   }
 
   .#{$ns}-dark & {
     @include pt-dark-input;
-    color: $pt-dark-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
 
     &::after {
       @include pt-dark-button-default-colors;

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -5,9 +5,9 @@
 @import "../button/common";
 @import "../../common/mixins";
 
-$file-input-button-width: $pt-spacing * 17.5 !default;
-$file-input-button-width-large: $pt-spacing * 21.25 !default;
-$file-input-button-width-small: $pt-spacing * 13.75 !default;
+$file-input-button-width: calc(var(--bp-surface-spacing) * 17.5) !default;
+$file-input-button-width-large: calc(var(--bp-surface-spacing) * 21.25) !default;
+$file-input-button-width-small: calc(var(--bp-surface-spacing) * 13.75) !default;
 $file-input-button-padding: ($pt-input-height - $pt-button-height-small) * 0.5 !default;
 $file-input-button-padding-large: ($pt-input-height-large - $pt-button-height) * 0.5 !default;
 $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-smaller) * 0.5 !default;
@@ -100,7 +100,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
   @include overflow-ellipsis;
   color: #{oklch(from var(--bp-typography-color-muted) l c h / 0.6)};
   left: 0;
-  padding-right: calc(var(--bp-surface-spacing) * 19.5);
+  padding-right: calc($file-input-button-width + calc(var(--bp-surface-spacing) * 2));
   position: absolute;
   right: 0;
   top: 0;
@@ -118,7 +118,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     right: 0;
     text-align: center;
     top: 0;
-    width: calc(var(--bp-surface-spacing) * 17.5);
+    width: $file-input-button-width;
   }
 
   &:hover::after {
@@ -133,25 +133,25 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   .#{$ns}-large & {
     @include pt-input-large;
-    padding-right: calc(var(--bp-surface-spacing) * 23.25);
+    padding-right: calc($file-input-button-width-large + calc(var(--bp-surface-spacing) * 2));
 
     &::after {
       @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
       line-height: calc(var(--bp-surface-spacing) * 7.5);
       margin: calc(var(--bp-surface-spacing) * 1.25);
-      width: calc(var(--bp-surface-spacing) * 21.25);
+      width: $file-input-button-width-large;
     }
   }
 
   .#{$ns}-small & {
     @include pt-input-small;
-    padding-right: calc(var(--bp-surface-spacing) * 15.75);
+    padding-right: calc($file-input-button-width-small + calc(var(--bp-surface-spacing) * 2));
 
     &::after {
       @include pt-button-height(calc(var(--bp-surface-spacing) * 5));
       line-height: calc(var(--bp-surface-spacing) * 5);
       margin: calc(var(--bp-surface-spacing) * 0.5);
-      width: calc(var(--bp-surface-spacing) * 13.75);
+      width: $file-input-button-width-small;
     }
   }
 

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -8,36 +8,52 @@
 .#{$ns}-form-group {
   display: flex;
   flex-direction: column;
-  margin: 0 0 ($pt-spacing * 4);
+  margin: 0 0 calc(var(--bp-surface-spacing) * 4);
 
   label.#{$ns}-label {
-    margin-bottom: $pt-spacing;
+    margin-bottom: var(--bp-surface-spacing);
   }
 
   .#{$ns}-control {
-    margin-top: $pt-spacing * 2;
+    margin-top: calc(var(--bp-surface-spacing) * 2);
   }
 
   .#{$ns}-form-group-sub-label,
   .#{$ns}-form-helper-text {
-    color: $pt-text-color-muted;
-    font-size: $pt-font-size-small;
+    color: var(--bp-typography-color-muted);
+    font-size: var(--bp-typography-size-body-small);
   }
 
   .#{$ns}-form-group-sub-label {
-    margin-bottom: $pt-spacing;
+    margin-bottom: var(--bp-surface-spacing);
   }
 
   .#{$ns}-form-helper-text {
-    margin-top: $pt-spacing;
+    margin-top: var(--bp-surface-spacing);
   }
 
   /* stylelint-disable-next-line order/declaration-block-order */
-  @each $intent, $color in $pt-intent-text-colors {
-    &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-form-helper-text {
-        color: $color;
-      }
+  &.#{$ns}-intent-primary {
+    .#{$ns}-form-helper-text {
+      color: var(--bp-intent-primary-hover);
+    }
+  }
+
+  &.#{$ns}-intent-success {
+    .#{$ns}-form-helper-text {
+      color: var(--bp-intent-success-hover);
+    }
+  }
+
+  &.#{$ns}-intent-warning {
+    .#{$ns}-form-helper-text {
+      color: var(--bp-intent-warning-hover);
+    }
+  }
+
+  &.#{$ns}-intent-danger {
+    .#{$ns}-form-helper-text {
+      color: var(--bp-intent-danger-hover);
     }
   }
 
@@ -50,13 +66,13 @@
     flex-direction: row;
 
     &.#{$ns}-large label.#{$ns}-label {
-      line-height: $pt-input-height-large;
-      margin: 0 ($pt-spacing * 3) 0 0;
+      line-height: calc(var(--bp-surface-spacing) * 10);
+      margin: 0 calc(var(--bp-surface-spacing) * 3) 0 0;
     }
 
     label.#{$ns}-label {
-      line-height: $pt-input-height;
-      margin: 0 ($pt-spacing * 3) 0 0;
+      line-height: calc(var(--bp-surface-spacing) * 7.5);
+      margin: 0 calc(var(--bp-surface-spacing) * 3) 0 0;
     }
   }
 
@@ -67,22 +83,38 @@
     .#{$ns}-form-helper-text {
       // disabled state always overrides over styles
       /* stylelint-disable-next-line declaration-no-important */
-      color: $pt-text-color-disabled !important;
+      color: var(--bp-typography-color-default-disabled) !important;
     }
   }
 
   .#{$ns}-dark & {
-    @each $intent, $color in $pt-dark-intent-text-colors {
-      &.#{$ns}-intent-#{$intent} {
-        .#{$ns}-form-helper-text {
-          color: $color;
-        }
+    &.#{$ns}-intent-primary {
+      .#{$ns}-form-helper-text {
+        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      }
+    }
+
+    &.#{$ns}-intent-success {
+      .#{$ns}-form-helper-text {
+        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+      }
+    }
+
+    &.#{$ns}-intent-warning {
+      .#{$ns}-form-helper-text {
+        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+      }
+    }
+
+    &.#{$ns}-intent-danger {
+      .#{$ns}-form-helper-text {
+        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
       }
     }
 
     .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
-      color: $pt-dark-text-color-muted;
+      color: var(--bp-typography-color-muted);
     }
 
     &.#{$ns}-disabled {
@@ -92,7 +124,7 @@
       .#{$ns}-form-helper-text {
         // disabled state always overrides over styles
         /* stylelint-disable-next-line declaration-no-important */
-        color: $pt-dark-text-color-disabled !important;
+        color: var(--bp-typography-color-default-disabled) !important;
       }
     }
   }

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -114,7 +114,7 @@
 
     .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
-      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
+      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
     }
 
     &.#{$ns}-disabled {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -114,7 +114,7 @@
 
     .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
-      color: var(--bp-typography-color-muted);
+      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
     }
 
     &.#{$ns}-disabled {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -90,31 +90,31 @@
   .#{$ns}-dark & {
     &.#{$ns}-intent-primary {
       .#{$ns}-form-helper-text {
-        color: #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)};
+        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
       }
     }
 
     &.#{$ns}-intent-success {
       .#{$ns}-form-helper-text {
-        color: #{oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)};
+        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
       }
     }
 
     &.#{$ns}-intent-warning {
       .#{$ns}-form-helper-text {
-        color: #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)};
+        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
       }
     }
 
     &.#{$ns}-intent-danger {
       .#{$ns}-form-helper-text {
-        color: #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)};
+        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
       }
     }
 
     .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
-      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
+      color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
     }
 
     &.#{$ns}-disabled {

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -90,25 +90,25 @@
   .#{$ns}-dark & {
     &.#{$ns}-intent-primary {
       .#{$ns}-form-helper-text {
-        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+        color: #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)};
       }
     }
 
     &.#{$ns}-intent-success {
       .#{$ns}-form-helper-text {
-        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+        color: #{oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)};
       }
     }
 
     &.#{$ns}-intent-warning {
       .#{$ns}-form-helper-text {
-        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+        color: #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)};
       }
     }
 
     &.#{$ns}-intent-danger {
       .#{$ns}-form-helper-text {
-        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
+        color: #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)};
       }
     }
 

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -97,7 +97,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       // same goes for dark
       /* stylelint-disable-next-line selector-max-compound-selectors */
       .#{$ns}-dark & {
-        color: var(--bp-typography-color-muted);
+        color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
       }
 
       #{$icon-classes} {
@@ -196,7 +196,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   .#{$ns}-dark & {
     .#{$ns}-icon {
-      color: var(--bp-typography-color-muted);
+      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
     }
 
     &.#{$ns}-disabled .#{$ns}-icon {

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -217,7 +217,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-primary-hover);
 
       .#{$ns}-dark & {
-        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+        color: #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)};
       }
     }
   }
@@ -235,7 +235,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-success-hover);
 
       .#{$ns}-dark & {
-        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+        color: #{oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)};
       }
     }
   }
@@ -253,7 +253,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-warning-hover);
 
       .#{$ns}-dark & {
-        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+        color: #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)};
       }
     }
   }
@@ -271,7 +271,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-danger-hover);
 
       .#{$ns}-dark & {
-        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
+        color: #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)};
       }
     }
   }

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -49,9 +49,9 @@ $input-button-height-small: $pt-button-height-smaller !default;
   }
 
   .#{$ns}-button {
-    @include pt-button-height($input-button-height);
+    @include pt-button-height(calc(var(--bp-surface-spacing) * 6));
     margin: calc(var(--bp-surface-spacing) * 0.75);
-    padding: $button-padding-small;
+    padding: 0 calc(var(--bp-surface-spacing) * 2);
 
     // icons CSS API support
     &:empty {
@@ -128,7 +128,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   &.#{$ns}-large {
     .#{$ns}-button {
-      @include pt-button-height($input-button-height-large);
+      @include pt-button-height(calc(var(--bp-surface-spacing) * 7.5));
       margin: calc(var(--bp-surface-spacing) * 1.25);
     }
 
@@ -153,12 +153,12 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   &.#{$ns}-small {
     .#{$ns}-button {
-      @include pt-button-height($pt-button-height-smaller);
+      @include pt-button-height(calc(var(--bp-surface-spacing) * 5));
       margin: calc(var(--bp-surface-spacing) * 0.5);
     }
 
     .#{$ns}-tag {
-      @include pt-button-height($pt-button-height-smaller);
+      @include pt-button-height(calc(var(--bp-surface-spacing) * 5));
       margin: calc(var(--bp-surface-spacing) * 0.5);
     }
 
@@ -206,10 +206,10 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   &.#{$ns}-intent-primary {
     .#{$ns}-input {
-      @include pt-input-intent($pt-intent-primary);
+      @include pt-input-intent(var(--bp-intent-primary-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent($blue4);
+        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)});
       }
     }
 
@@ -224,10 +224,10 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   &.#{$ns}-intent-success {
     .#{$ns}-input {
-      @include pt-input-intent($pt-intent-success);
+      @include pt-input-intent(var(--bp-intent-success-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent($green4);
+        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)});
       }
     }
 
@@ -242,10 +242,10 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   &.#{$ns}-intent-warning {
     .#{$ns}-input {
-      @include pt-input-intent($pt-intent-warning);
+      @include pt-input-intent(var(--bp-intent-warning-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent($orange4);
+        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)});
       }
     }
 
@@ -260,10 +260,10 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   &.#{$ns}-intent-danger {
     .#{$ns}-input {
-      @include pt-input-intent($pt-intent-danger);
+      @include pt-input-intent(var(--bp-intent-danger-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent($red4);
+        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.020) h)});
       }
     }
 

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -97,7 +97,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       // same goes for dark
       /* stylelint-disable-next-line selector-max-compound-selectors */
       .#{$ns}-dark & {
-        color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
+        color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
       }
 
       #{$icon-classes} {
@@ -196,7 +196,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   .#{$ns}-dark & {
     .#{$ns}-icon {
-      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
+      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
     }
 
     &.#{$ns}-disabled .#{$ns}-icon {

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -1,7 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@use "sass:map";
 @import "../../common/variables";
 @import "../../common/variables-extended";
 @import "../button/common";
@@ -24,11 +23,11 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
     // add space if there's something before or after the input
     &:not(:first-child) {
-      padding-left: $pt-input-height;
+      padding-left: calc(var(--bp-surface-spacing) * 7.5);
     }
 
     &:not(:last-child) {
-      padding-right: $pt-input-height;
+      padding-right: calc(var(--bp-surface-spacing) * 7.5);
     }
   }
 
@@ -51,7 +50,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   .#{$ns}-button {
     @include pt-button-height($input-button-height);
-    margin: ($pt-input-height - $input-button-height) * 0.5;
+    margin: calc(var(--bp-surface-spacing) * 0.75);
     padding: $button-padding-small;
 
     // icons CSS API support
@@ -69,7 +68,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
   // direct descendant to exclude icons in buttons
   > .#{$ns}-input-left-container > .#{$ns}-icon,
   > .#{$ns}-icon {
-    color: $pt-icon-color;
+    color: var(--bp-typography-color-muted);
 
     &:empty {
       @include pt-icon($pt-icon-size-standard);
@@ -81,11 +80,11 @@ $input-button-height-small: $pt-button-height-smaller !default;
   > .#{$ns}-input-left-container > .#{$ns}-icon,
   > .#{$ns}-icon,
   .#{$ns}-input-action > .#{$ns}-spinner {
-    margin: ($pt-input-height - $pt-icon-size-standard) * 0.5;
+    margin: calc(var(--bp-surface-spacing) * 1.75);
   }
 
   .#{$ns}-tag {
-    margin: $pt-spacing * 1.25;
+    margin: calc(var(--bp-surface-spacing) * 1.25);
   }
 
   // all buttons go gray in default state and assume their native colors only when hovered
@@ -93,26 +92,26 @@ $input-button-height-small: $pt-button-height-smaller !default;
   .#{$ns}-input:not(:focus) + .#{$ns}-button,
   .#{$ns}-input:not(:focus) + .#{$ns}-input-action .#{$ns}-button {
     &.#{$ns}-minimal:not(:hover):not(:focus) {
-      color: $pt-text-color-muted;
+      color: var(--bp-typography-color-muted);
 
       // same goes for dark
       /* stylelint-disable-next-line selector-max-compound-selectors */
       .#{$ns}-dark & {
-        color: $pt-dark-text-color-muted;
+        color: var(--bp-typography-color-muted);
       }
 
       #{$icon-classes} {
-        color: $pt-icon-color;
+        color: var(--bp-typography-color-muted);
       }
     }
 
     &.#{$ns}-minimal:disabled {
       // override more specific selector above
       /* stylelint-disable declaration-no-important */
-      color: $pt-icon-color-disabled !important;
+      color: var(--bp-typography-color-default-disabled) !important;
 
       #{$icon-classes} {
-        color: $pt-icon-color-disabled !important;
+        color: var(--bp-typography-color-default-disabled) !important;
       }
     }
   }
@@ -123,31 +122,31 @@ $input-button-height-small: $pt-button-height-smaller !default;
     cursor: not-allowed;
 
     .#{$ns}-icon {
-      color: $pt-icon-color-disabled;
+      color: var(--bp-typography-color-default-disabled);
     }
   }
 
   &.#{$ns}-large {
     .#{$ns}-button {
       @include pt-button-height($input-button-height-large);
-      margin: ($pt-input-height-large - $input-button-height-large) * 0.5;
+      margin: calc(var(--bp-surface-spacing) * 1.25);
     }
 
     > .#{$ns}-input-left-container > .#{$ns}-icon,
     > .#{$ns}-icon,
     .#{$ns}-input-action > .#{$ns}-spinner {
-      margin: ($pt-input-height-large - $pt-icon-size-standard) * 0.5;
+      margin: calc(var(--bp-surface-spacing) * 3);
     }
 
     .#{$ns}-input {
       @include pt-input-large;
 
       &:not(:first-child) {
-        padding-left: $pt-button-height-large;
+        padding-left: calc(var(--bp-surface-spacing) * 10);
       }
 
       &:not(:last-child) {
-        padding-right: $pt-button-height-large;
+        padding-right: calc(var(--bp-surface-spacing) * 10);
       }
     }
   }
@@ -155,29 +154,29 @@ $input-button-height-small: $pt-button-height-smaller !default;
   &.#{$ns}-small {
     .#{$ns}-button {
       @include pt-button-height($pt-button-height-smaller);
-      margin: ($pt-input-height-small - $pt-button-height-smaller) * 0.5;
+      margin: calc(var(--bp-surface-spacing) * 0.5);
     }
 
     .#{$ns}-tag {
       @include pt-button-height($pt-button-height-smaller);
-      margin: ($pt-input-height-small - $pt-button-height-smaller) * 0.5;
+      margin: calc(var(--bp-surface-spacing) * 0.5);
     }
 
     > .#{$ns}-input-left-container > .#{$ns}-icon,
     > .#{$ns}-icon,
     .#{$ns}-input-action > .#{$ns}-spinner {
-      margin: ($pt-input-height-small - $pt-icon-size-standard) * 0.5;
+      margin: var(--bp-surface-spacing);
     }
 
     .#{$ns}-input {
       @include pt-input-small;
 
       &:not(:first-child) {
-        padding-left: $pt-icon-size-standard + $input-small-padding;
+        padding-left: calc(var(--bp-surface-spacing) * 6);
       }
 
       &:not(:last-child) {
-        padding-right: $pt-icon-size-standard + $input-small-padding;
+        padding-right: calc(var(--bp-surface-spacing) * 6);
       }
     }
   }
@@ -191,36 +190,88 @@ $input-button-height-small: $pt-button-height-smaller !default;
     .#{$ns}-button,
     .#{$ns}-input,
     .#{$ns}-tag {
-      border-radius: $pt-input-height;
+      border-radius: calc(var(--bp-surface-spacing) * 7.5);
     }
   }
 
   .#{$ns}-dark & {
     .#{$ns}-icon {
-      color: $pt-dark-icon-color;
+      color: var(--bp-typography-color-muted);
     }
 
     &.#{$ns}-disabled .#{$ns}-icon {
-      color: $pt-dark-icon-color-disabled;
+      color: var(--bp-typography-color-default-disabled);
     }
   }
 
-  @each $intent, $color in $pt-intent-colors {
-    &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-input {
-        @include pt-input-intent($color);
+  &.#{$ns}-intent-primary {
+    .#{$ns}-input {
+      @include pt-input-intent($pt-intent-primary);
 
-        .#{$ns}-dark & {
-          @include pt-dark-input-intent(map.get($pt-dark-input-intent-box-shadow-colors, $intent));
-        }
+      .#{$ns}-dark & {
+        @include pt-dark-input-intent($blue4);
       }
+    }
 
-      > .#{$ns}-icon {
-        color: map.get($pt-intent-text-colors, $intent);
+    > .#{$ns}-icon {
+      color: var(--bp-intent-primary-hover);
 
-        .#{$ns}-dark & {
-          color: map.get($pt-dark-intent-text-colors, $intent);
-        }
+      .#{$ns}-dark & {
+        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      }
+    }
+  }
+
+  &.#{$ns}-intent-success {
+    .#{$ns}-input {
+      @include pt-input-intent($pt-intent-success);
+
+      .#{$ns}-dark & {
+        @include pt-dark-input-intent($green4);
+      }
+    }
+
+    > .#{$ns}-icon {
+      color: var(--bp-intent-success-hover);
+
+      .#{$ns}-dark & {
+        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+      }
+    }
+  }
+
+  &.#{$ns}-intent-warning {
+    .#{$ns}-input {
+      @include pt-input-intent($pt-intent-warning);
+
+      .#{$ns}-dark & {
+        @include pt-dark-input-intent($orange4);
+      }
+    }
+
+    > .#{$ns}-icon {
+      color: var(--bp-intent-warning-hover);
+
+      .#{$ns}-dark & {
+        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+      }
+    }
+  }
+
+  &.#{$ns}-intent-danger {
+    .#{$ns}-input {
+      @include pt-input-intent($pt-intent-danger);
+
+      .#{$ns}-dark & {
+        @include pt-dark-input-intent($red4);
+      }
+    }
+
+    > .#{$ns}-icon {
+      color: var(--bp-intent-danger-hover);
+
+      .#{$ns}-dark & {
+        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
       }
     }
   }

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -209,7 +209,9 @@ $input-button-height-small: $pt-button-height-smaller !default;
       @include pt-input-intent(var(--bp-intent-primary-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)});
+        @include pt-dark-input-intent(
+          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)}
+        );
       }
     }
 
@@ -227,7 +229,9 @@ $input-button-height-small: $pt-button-height-smaller !default;
       @include pt-input-intent(var(--bp-intent-success-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)});
+        @include pt-dark-input-intent(
+          #{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)}
+        );
       }
     }
 
@@ -245,7 +249,9 @@ $input-button-height-small: $pt-button-height-smaller !default;
       @include pt-input-intent(var(--bp-intent-warning-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)});
+        @include pt-dark-input-intent(
+          #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)}
+        );
       }
     }
 
@@ -263,7 +269,9 @@ $input-button-height-small: $pt-button-height-smaller !default;
       @include pt-input-intent(var(--bp-intent-danger-rest));
 
       .#{$ns}-dark & {
-        @include pt-dark-input-intent(#{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.020) h)});
+        @include pt-dark-input-intent(
+          #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)}
+        );
       }
     }
 

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -97,7 +97,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       // same goes for dark
       /* stylelint-disable-next-line selector-max-compound-selectors */
       .#{$ns}-dark & {
-        color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
+        color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
       }
 
       #{$icon-classes} {
@@ -196,7 +196,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   .#{$ns}-dark & {
     .#{$ns}-icon {
-      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
+      color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
     }
 
     &.#{$ns}-disabled .#{$ns}-icon {
@@ -210,7 +210,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)}
+          #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)"}
         );
       }
     }
@@ -219,7 +219,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-primary-hover);
 
       .#{$ns}-dark & {
-        color: #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)};
+        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
       }
     }
   }
@@ -230,7 +230,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)}
+          #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"}
         );
       }
     }
@@ -239,7 +239,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-success-hover);
 
       .#{$ns}-dark & {
-        color: #{oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)};
+        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
       }
     }
   }
@@ -250,7 +250,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)}
+          #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)"}
         );
       }
     }
@@ -259,7 +259,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-warning-hover);
 
       .#{$ns}-dark & {
-        color: #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)};
+        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
       }
     }
   }
@@ -270,7 +270,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)}
+          #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)"}
         );
       }
     }
@@ -279,7 +279,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-danger-hover);
 
       .#{$ns}-dark & {
-        color: #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)};
+        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
       }
     }
   }

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -28,7 +28,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)}
+        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)"}
       );
     }
   }
@@ -38,7 +38,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)}
+        #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"}
       );
     }
   }
@@ -48,7 +48,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)}
+        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)"}
       );
     }
   }
@@ -58,7 +58,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)}
+        #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)"}
       );
     }
   }

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -24,34 +24,34 @@
   }
 
   &.#{$ns}-intent-primary {
-    @include pt-input-intent($pt-intent-primary);
+    @include pt-input-intent(var(--bp-intent-primary-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent($blue4);
+      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)});
     }
   }
 
   &.#{$ns}-intent-success {
-    @include pt-input-intent($pt-intent-success);
+    @include pt-input-intent(var(--bp-intent-success-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent($green4);
+      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)});
     }
   }
 
   &.#{$ns}-intent-warning {
-    @include pt-input-intent($pt-intent-warning);
+    @include pt-input-intent(var(--bp-intent-warning-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent($orange4);
+      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)});
     }
   }
 
   &.#{$ns}-intent-danger {
-    @include pt-input-intent($pt-intent-danger);
+    @include pt-input-intent(var(--bp-intent-danger-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent($red4);
+      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.020) h)});
     }
   }
 

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -1,7 +1,6 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@use "sass:map";
 @import "../../common/variables";
 
 .#{$ns}-input {
@@ -24,13 +23,35 @@
     @include pt-dark-input;
   }
 
-  @each $intent, $color in $pt-intent-colors {
-    &.#{$ns}-intent-#{$intent} {
-      @include pt-input-intent($color);
+  &.#{$ns}-intent-primary {
+    @include pt-input-intent($pt-intent-primary);
 
-      .#{$ns}-dark & {
-        @include pt-dark-input-intent(map.get($pt-dark-input-intent-box-shadow-colors, $intent));
-      }
+    .#{$ns}-dark & {
+      @include pt-dark-input-intent($blue4);
+    }
+  }
+
+  &.#{$ns}-intent-success {
+    @include pt-input-intent($pt-intent-success);
+
+    .#{$ns}-dark & {
+      @include pt-dark-input-intent($green4);
+    }
+  }
+
+  &.#{$ns}-intent-warning {
+    @include pt-input-intent($pt-intent-warning);
+
+    .#{$ns}-dark & {
+      @include pt-dark-input-intent($orange4);
+    }
+  }
+
+  &.#{$ns}-intent-danger {
+    @include pt-input-intent($pt-intent-danger);
+
+    .#{$ns}-dark & {
+      @include pt-dark-input-intent($red4);
     }
   }
 
@@ -46,10 +67,10 @@
     &:disabled,
     &.#{$ns}-disabled {
       opacity: 1;
-      -webkit-text-fill-color: $input-color-disabled;
+      -webkit-text-fill-color: var(--bp-typography-color-default-disabled);
 
       .#{$ns}-dark & {
-        -webkit-text-fill-color: $dark-input-color-disabled;
+        -webkit-text-fill-color: var(--bp-typography-color-default-disabled);
       }
     }
   }
@@ -58,7 +79,7 @@
 /* stylelint-disable-next-line selector-no-qualifying-type */
 textarea.#{$ns}-input {
   max-width: 100%;
-  padding: $input-padding-horizontal;
+  padding: calc(var(--bp-surface-spacing) * 2);
 
   &,
   &.#{$ns}-large,
@@ -70,7 +91,7 @@ textarea.#{$ns}-input {
   }
 
   &.#{$ns}-small {
-    padding: $input-small-padding;
+    padding: calc(var(--bp-surface-spacing) * 2);
   }
 }
 

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -27,7 +27,9 @@
     @include pt-input-intent(var(--bp-intent-primary-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)});
+      @include pt-dark-input-intent(
+        #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)}
+      );
     }
   }
 
@@ -35,7 +37,9 @@
     @include pt-input-intent(var(--bp-intent-success-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)});
+      @include pt-dark-input-intent(
+        #{oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)}
+      );
     }
   }
 
@@ -43,7 +47,9 @@
     @include pt-input-intent(var(--bp-intent-warning-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)});
+      @include pt-dark-input-intent(
+        #{oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)}
+      );
     }
   }
 
@@ -51,7 +57,9 @@
     @include pt-input-intent(var(--bp-intent-danger-rest));
 
     .#{$ns}-dark & {
-      @include pt-dark-input-intent(#{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.020) h)});
+      @include pt-dark-input-intent(
+        #{oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)}
+      );
     }
   }
 

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -5,7 +5,7 @@
 
 label.#{$ns}-label {
   display: block;
-  margin-bottom: $pt-spacing * 4;
+  margin-bottom: calc(var(--bp-surface-spacing) * 4);
   margin-top: 0;
 
   .#{$ns}-html-select,
@@ -14,12 +14,12 @@ label.#{$ns}-label {
   .#{$ns}-slider,
   .#{$ns}-popover-wrapper {
     display: block;
-    margin-top: $pt-spacing;
+    margin-top: var(--bp-surface-spacing);
     text-transform: none;
   }
 
   .#{$ns}-button-group {
-    margin-top: $pt-spacing;
+    margin-top: var(--bp-surface-spacing);
   }
 
   .#{$ns}-select select,
@@ -30,7 +30,7 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-control-group {
-    margin-top: $pt-spacing;
+    margin-top: var(--bp-surface-spacing);
 
     > .#{$ns}-button-group,
     > .#{$ns}-html-select,
@@ -45,12 +45,12 @@ label.#{$ns}-label {
   &.#{$ns}-disabled {
     &,
     .#{$ns}-text-muted {
-      color: $pt-text-color-disabled;
+      color: var(--bp-typography-color-default-disabled);
     }
   }
 
   &.#{$ns}-inline {
-    line-height: $pt-input-height;
+    line-height: calc(var(--bp-surface-spacing) * 7.5);
 
     .#{$ns}-html-select,
     .#{$ns}-input,
@@ -58,12 +58,12 @@ label.#{$ns}-label {
     .#{$ns}-select,
     .#{$ns}-popover-wrapper {
       display: inline-block;
-      margin: 0 0 0 $pt-spacing;
+      margin: 0 0 0 var(--bp-surface-spacing);
       vertical-align: top;
     }
 
     .#{$ns}-button-group {
-      margin: 0 0 0 $pt-spacing;
+      margin: 0 0 0 var(--bp-surface-spacing);
     }
 
     .#{$ns}-input-group .#{$ns}-input {
@@ -71,11 +71,11 @@ label.#{$ns}-label {
     }
 
     &.#{$ns}-large {
-      line-height: $pt-input-height-large;
+      line-height: calc(var(--bp-surface-spacing) * 10);
     }
 
     .#{$ns}-control-group {
-      margin: 0 0 0 $pt-spacing;
+      margin: 0 0 0 var(--bp-surface-spacing);
 
       > .#{$ns}-button-group,
       > .#{$ns}-html-select,
@@ -93,12 +93,12 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-dark & {
-    color: $pt-dark-heading-color;
+    color: var(--bp-typography-color-default-rest);
 
     &.#{$ns}-disabled {
       &,
       .#{$ns}-text-muted {
-        color: $pt-dark-text-color-disabled;
+        color: var(--bp-typography-color-default-disabled);
       }
     }
   }

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -93,7 +93,7 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-dark & {
-    color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2))"};
+    color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.452) calc(c + -0.028) calc(h + 6.2))"};
 
     &.#{$ns}-disabled {
       &,

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -93,9 +93,7 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-dark & {
-    color: #{oklch(
-        from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2)
-      )};
+    color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2))"};
 
     &.#{$ns}-disabled {
       &,

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -93,7 +93,7 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-dark & {
-    color: var(--bp-typography-color-default-rest);
+    color: #{oklch(from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2))};
 
     &.#{$ns}-disabled {
       &,

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -93,7 +93,9 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-dark & {
-    color: #{oklch(from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2))};
+    color: #{oklch(
+        from var(--bp-intent-default-rest) calc(l + 0.212) calc(c + -0.016) calc(h + 6.2)
+      )};
 
     &.#{$ns}-disabled {
       &,

--- a/packages/core/src/components/forms/_numeric-input.scss
+++ b/packages/core/src/components/forms/_numeric-input.scss
@@ -5,7 +5,7 @@
   // we need a very-specific selector here to override specificicty of selectors defined elsewhere.
   .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
     // let the buttons shrink to equal heights
-    flex: 1 1 calc(var(--bp-surface-spacing) * 2.75);
+    flex: 1 1 calc(var(--bp-surface-spacing) * 3 - 1);
     min-height: 0;
     padding: 0;
     width: calc(var(--bp-surface-spacing) * 6);

--- a/packages/core/src/components/forms/_numeric-input.scss
+++ b/packages/core/src/components/forms/_numeric-input.scss
@@ -5,17 +5,17 @@
   // we need a very-specific selector here to override specificicty of selectors defined elsewhere.
   .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
     // let the buttons shrink to equal heights
-    flex: 1 1 ($pt-button-height-small * 0.5 - 1);
+    flex: 1 1 calc(var(--bp-surface-spacing) * 2.75);
     min-height: 0;
     padding: 0;
-    width: $pt-button-height-small;
+    width: calc(var(--bp-surface-spacing) * 6);
   }
 
   &.#{$ns}-large .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
-    width: $pt-button-height-large;
+    width: calc(var(--bp-surface-spacing) * 10);
   }
 
   &.#{$ns}-small .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
-    width: $pt-button-height-small;
+    width: calc(var(--bp-surface-spacing) * 6);
   }
 }

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -230,9 +230,9 @@ export const FocusedExample: Story = {
         await userEvent.click(input);
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex gap={3}>
             <TagInput {...args} values={INITIAL_VALUES} inputProps={{ placeholder: "Click to focus..." }} />
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -221,6 +221,26 @@ export const AutoResizeExample: Story = {
 };
 
 /**
+ * A tag input in the focused state, showing the focus ring. Use controls to change the intent.
+ */
+export const FocusedExample: Story = {
+    name: "Focused",
+    play: async ({ canvas, userEvent }) => {
+        const input = canvas.getByPlaceholderText("Click to focus...");
+        await userEvent.click(input);
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <TagInput
+                {...args}
+                values={INITIAL_VALUES}
+                inputProps={{ placeholder: "Click to focus..." }}
+            />
+        </div>
+    ),
+};
+
+/**
  * Interactive playground with fully functional add/remove and all props togglable via Storybook controls.
  */
 export const Playground: Story = {

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -231,11 +231,7 @@ export const FocusedExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-            <TagInput
-                {...args}
-                values={INITIAL_VALUES}
-                inputProps={{ placeholder: "Click to focus..." }}
-            />
+            <TagInput {...args} values={INITIAL_VALUES} inputProps={{ placeholder: "Click to focus..." }} />
         </div>
     ),
 };

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -157,13 +157,13 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   .#{$ns}-dark &,
   &.#{$ns}-dark {
     .#{$ns}-tag-input-icon {
-      color: var(--bp-typography-color-muted);
+      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
     }
 
     .#{$ns}-input-ghost {
       @include pt-dark-input-placeholder;
 
-      color: var(--bp-typography-color-default-rest);
+      color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)};
     }
 
     &.#{$ns}-active {

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -157,13 +157,15 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   .#{$ns}-dark &,
   &.#{$ns}-dark {
     .#{$ns}-tag-input-icon {
-      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.240) calc(c - 0.011) h)};
+      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
     }
 
     .#{$ns}-input-ghost {
       @include pt-dark-input-placeholder;
 
-      color: #{oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)};
+      color: #{oklch(
+          from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h
+        )};
     }
 
     &.#{$ns}-active {

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -157,15 +157,13 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
   .#{$ns}-dark &,
   &.#{$ns}-dark {
     .#{$ns}-tag-input-icon {
-      color: #{oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)};
+      color: var(--bp-typography-color-muted);
     }
 
     .#{$ns}-input-ghost {
       @include pt-dark-input-placeholder;
 
-      color: #{oklch(
-          from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h
-        )};
+      color: var(--bp-typography-color-default-rest);
     }
 
     &.#{$ns}-active {


### PR DESCRIPTION
## Summary

Migrates 7 form-related SCSS files from legacy Sass variables to Blueprint design tokens (CSS custom properties). All changes compile, pass lint, and generate valid LESS output.

**Files changed:** `_common.scss`, `_input.scss`, `_input-group.scss`, `_numeric-input.scss`, `_file-input.scss`, `_label.scss`, `_form-group.scss`

---

## Token-to-Palette Reference

| Old Sass Variable | New Token / Value | Hex Equivalent |
|---|---|---|
| `$input-background-color` | `var(--bp-palette-white)` | `#ffffff` |
| `$pt-border-radius` | `var(--bp-surface-border-radius)` | `3px` |
| `$input-color` / `$dark-input-color` | `var(--bp-typography-color-default-rest)` | `#1c2127` / `#f6f7f9` |
| `$pt-font-size` | `var(--bp-typography-size-body-medium)` | `14px` |
| `$pt-font-size-large` | `var(--bp-typography-size-body-large)` | `16px` |
| `$pt-font-size-small` | `var(--bp-typography-size-body-small)` | `12px` |
| `$pt-input-height` | `calc(var(--bp-surface-spacing) * 7.5)` | `30px` |
| `$pt-input-height-large` | `calc(var(--bp-surface-spacing) * 10)` | `40px` |
| `$pt-input-height-small` | `calc(var(--bp-surface-spacing) * 6)` | `24px` |
| `$input-padding-horizontal` | `calc(var(--bp-surface-spacing) * 2)` | `10px → 8px` |
| `$pt-spacing` | `var(--bp-surface-spacing)` | `4px` |
| `$input-placeholder-color` / `$dark-input-placeholder-color` | `var(--bp-typography-color-muted)` | `#5f6b7c` / `#abb3bf` |
| `$input-color-disabled` / `$dark-input-color-disabled` | `var(--bp-typography-color-default-disabled)` | `rgba(95,107,124,0.6)` |
| `$input-background-color-disabled` | `oklch(from var(--bp-palette-light-gray-1) l c h / 0.5)` | `rgba(205,210,218,0.5)` |
| `$dark-input-background-color-disabled` | `oklch(from var(--bp-intent-default-hover) l c h / 0.5)` | `rgba(95,107,124,0.5)` |
| `$dark-input-background-color` | `oklch(from var(--bp-palette-black) l c h / 0.3)` | `rgba(17,20,24,0.3)` |
| `$pt-divider-black` | `var(--bp-surface-border-color-default)` | `rgba(17,20,24,0.15)` |
| `$pt-dark-divider-black` | `oklch(from var(--bp-palette-black) l c h / 0.4)` | `rgba(17,20,24,0.4)` |
| `$pt-icon-color` / `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` | `#5f6b7c` / `#abb3bf` |
| `$pt-text-color` / `$pt-dark-text-color` | `var(--bp-typography-color-default-rest)` | unified light/dark |
| `$pt-text-color-muted` / `$pt-dark-text-color-muted` | `var(--bp-typography-color-muted)` | unified light/dark |
| `$pt-text-color-disabled` / `$pt-dark-text-color-disabled` | `var(--bp-typography-color-default-disabled)` | unified light/dark |
| `$pt-high-contrast-mode-border-color` | `buttonborder` (native CSS) | system color |

---

## Per-Component Changes

### `_common.scss` (mixins)

| Mixin | Changes |
|---|---|
| `pt-input()` | background → `--bp-palette-white`; border-radius → `--bp-surface-border-radius`; color → `--bp-typography-color-default-rest`; font-size → `--bp-typography-size-body-medium`; height/line-height → `calc(--bp-surface-spacing * 7.5)`; padding → `calc(--bp-surface-spacing * 2)`; transition → token duration + ease; readonly box-shadow → `--bp-surface-border-color-default`; high-contrast border → `buttonborder` |
| `pt-input-placeholder()` | color → `--bp-typography-color-muted` |
| `pt-input-disabled()` | background → oklch from `--bp-palette-light-gray-1`; color → `--bp-typography-color-default-disabled` |
| `pt-input-large()` | font-size → `--bp-typography-size-body-large`; height/line-height → `calc(--bp-surface-spacing * 10)` |
| `pt-input-small()` | font-size → `--bp-typography-size-body-small`; height/line-height → `calc(--bp-surface-spacing * 6)` |
| `pt-dark-input()` | background → oklch from `--bp-palette-black`; color → `--bp-typography-color-default-rest`; readonly → oklch divider |
| `pt-dark-input-disabled()` | background → oklch from `--bp-intent-default-hover`; color → `--bp-typography-color-default-disabled` |
| `pt-input-intent()` / `pt-dark-input-intent()` | box-shadow spread → `calc(--bp-surface-spacing * 0.5)` |

### `_input.scss`

| Section | Changes |
|---|---|
| Intent loop | `@each` loop over `$pt-intent-colors` + `$pt-dark-input-intent-box-shadow-colors` → 4 explicit intent blocks (primary/success/warning/danger) |
| Disabled `-webkit-text-fill-color` | `$input-color-disabled` / `$dark-input-color-disabled` → `var(--bp-typography-color-default-disabled)` (same token light & dark) |
| Textarea padding | `$input-padding-horizontal` / `$input-small-padding` → `calc(var(--bp-surface-spacing) * 2)` |
| Sass import | Removed `@use "sass:map"` (no longer needed) |

### `_input-group.scss`

| Section | Changes |
|---|---|
| Input padding (default) | `$pt-input-height` → `calc(--bp-surface-spacing * 7.5)` |
| Button margin (default) | `($pt-input-height - $input-button-height) * 0.5` → `calc(--bp-surface-spacing * 0.75)` |
| Icon color | `$pt-icon-color` → `var(--bp-typography-color-muted)` |
| Icon/spinner margin | computed → `calc(--bp-surface-spacing * 1.75)` |
| Tag margin | `$pt-spacing * 1.25` → `calc(--bp-surface-spacing * 1.25)` |
| Muted button colors | `$pt-text-color-muted` / `$pt-dark-text-color-muted` → `var(--bp-typography-color-muted)` |
| Disabled button/icon | `$pt-icon-color-disabled` → `var(--bp-typography-color-default-disabled)` |
| Large variant | margins/paddings computed from `$pt-input-height-large` → pre-computed `calc()` values |
| Small variant | margins/paddings computed from `$pt-input-height-small` → pre-computed `calc()` values |
| Round border-radius | `$pt-input-height` → `calc(--bp-surface-spacing * 7.5)` |
| Dark icon colors | `$pt-dark-icon-color` / `$pt-dark-icon-color-disabled` → unified tokens |
| Intent loop | `@each` loop → 4 explicit intent blocks with oklch dark theme derivations |

### `_numeric-input.scss`

| Section | Changes |
|---|---|
| Button flex-basis | `$pt-button-height-small * 0.5 - 1` → `calc(--bp-surface-spacing * 2.75)` |
| Button width (default/small) | `$pt-button-height-small` → `calc(--bp-surface-spacing * 6)` |
| Button width (large) | `$pt-button-height-large` → `calc(--bp-surface-spacing * 10)` |

### `_file-input.scss`

| Section | Changes |
|---|---|
| Container height | `$pt-input-height` → `calc(--bp-surface-spacing * 7.5)` |
| Input min-width | `$pt-spacing * 50` → `calc(--bp-surface-spacing * 50)` |
| Has-selection color | `$pt-text-color` / `$pt-dark-text-color` → `var(--bp-typography-color-default-rest)` |
| Large/small heights | input height variables → computed `calc()` values |
| Upload input color | `$pt-text-color-disabled` → `var(--bp-typography-color-default-disabled)` |
| Browse button | border-radius → `--bp-surface-border-radius`; line-height, margin, width → pre-computed `calc()` values |
| Large/small browse | all dimensions → pre-computed `calc()` values |
| Dark upload input | `$pt-dark-text-color-disabled` → `var(--bp-typography-color-default-disabled)` |

### `_label.scss`

| Section | Changes |
|---|---|
| Label margin-bottom | `$pt-spacing * 4` → `calc(--bp-surface-spacing * 4)` |
| Child margin-top | `$pt-spacing` → `var(--bp-surface-spacing)` |
| Disabled color | `$pt-text-color-disabled` → `var(--bp-typography-color-default-disabled)` |
| Inline line-height | `$pt-input-height` → `calc(--bp-surface-spacing * 7.5)` |
| Inline margins | `$pt-spacing` → `var(--bp-surface-spacing)` |
| Inline large line-height | `$pt-input-height-large` → `calc(--bp-surface-spacing * 10)` |
| Dark label color | `$pt-dark-heading-color` → `var(--bp-typography-color-default-rest)` |
| Dark disabled | `$pt-dark-text-color-disabled` → `var(--bp-typography-color-default-disabled)` |

### `_form-group.scss`

| Section | Changes |
|---|---|
| Form group margin | `$pt-spacing * 4` → `calc(--bp-surface-spacing * 4)` |
| Label/sub-label/helper margins | `$pt-spacing` → `var(--bp-surface-spacing)` |
| Helper text color/size | `$pt-text-color-muted` + `$pt-font-size-small` → `var(--bp-typography-color-muted)` + `var(--bp-typography-size-body-small)` |
| Control margin-top | `$pt-spacing * 2` → `calc(--bp-surface-spacing * 2)` |
| Intent loop (light) | `@each $pt-intent-text-colors` → 4 explicit blocks using `var(--bp-intent-{name}-hover)` |
| Intent loop (dark) | `@each $pt-dark-intent-text-colors` → 4 explicit blocks using oklch derivations |
| Inline label line-height/margin | `$pt-input-height` → `calc(--bp-surface-spacing * 7.5)`; margin → `calc(--bp-surface-spacing * 3)` |
| Disabled helper | `$pt-text-color-disabled` / `$pt-dark-text-color-disabled` → `var(--bp-typography-color-default-disabled)` |
| Dark muted text | `$pt-dark-text-color-muted` → `var(--bp-typography-color-muted)` |

---

## Summary of All Differences

| # | Category | Description | Files Affected |
|---|---|---|---|
| 1 | **Spacing inlined** | Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions | All 7 files |
| 2 | **High contrast** | `$pt-high-contrast-mode-border-color` → native CSS `buttonborder` | `_common.scss` |
| 3 | **oklch transparency** | `rgba()` calls → `oklch(from var(...) l c h / alpha)` for disabled/dark backgrounds | `_common.scss` |
| 4 | **Dark theme oklch derivations** | Dark intent text colors use `oklch()` lightness/chroma adjustments from intent rest tokens | `_input-group.scss`, `_form-group.scss` |
| 5 | **Loop expansions** | 4 `@each` loops expanded to explicit per-intent blocks (removes `sass:map` dependency) | `_input.scss`, `_input-group.scss`, `_form-group.scss` |
| 6 | **Unified light/dark tokens** | Typography tokens auto-resolve in dark theme; both `$pt-text-color` and `$pt-dark-text-color` → same token | `_common.scss`, `_input.scss`, `_input-group.scss`, `_file-input.scss`, `_label.scss`, `_form-group.scss` |
| 7 | **Transition tokens** | Hardcoded `$input-transition` → `box-shadow var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default)` | `_common.scss` |

---

## Reviewers should focus on

- [ ] **oklch dark theme fidelity** — The `oklch(from var(...) calc(l + N) calc(c - M) h)` expressions for dark intent text colors are approximations of the previous `$blue4`, `$green4`, `$orange4`, `$red4` values. Verify visual parity in dark mode.
- [ ] **Pre-computed margins** — Spacing values like `calc(var(--bp-surface-spacing) * 0.75)` replace arithmetic like `($pt-input-height - $input-button-height) * 0.5`. These are correct at the default 4px spacing unit but may diverge if spacing is customized.
- [ ] **Unified light/dark tokens** — Several properties now use the same token for both light and dark themes (e.g., `--bp-typography-color-default-rest`). This assumes the token system handles theme switching.
- [ ] **Intent loop expansion** — Each of the 3 expanded loops now has 4 explicit blocks instead of iterating `$pt-intent-colors`. Verify all 4 intents (primary, success, warning, danger) are covered correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
