### PR TITLE
Add Storybook configuration and initial Button stories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,10 @@ jobs:
       - attach_workspace: { at: "." }
       - run: sudo corepack enable
       - run: pnpm dist --parallel=7
+      - run: pnpm build-storybook
       - persist_to_workspace:
           root: "."
-          paths: [packages/*/lib, packages/*/dist]
+          paths: [packages/*/lib, packages/*/dist, storybook-static]
 
   test-node-libs:
     docker: *docker-node-image
@@ -180,6 +181,7 @@ jobs:
       - store_artifacts: { path: packages/landing-app/dist }
       - store_artifacts: { path: packages/table-dev-app/dist }
       - store_artifacts: { path: packages/demo-app/dist }
+      - store_artifacts: { path: storybook-static }
       - run: ./scripts/submit-preview-comment.sh
 
   store-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,10 +100,13 @@ jobs:
       - attach_workspace: { at: "." }
       - run: sudo corepack enable
       - run: pnpm dist --parallel=7
+      - persist_to_workspace:
+          root: "."
+          paths: [packages/*/lib, packages/*/dist]
       - run: pnpm build-storybook
       - persist_to_workspace:
           root: "."
-          paths: [packages/*/lib, packages/*/dist, storybook-static]
+          paths: [storybook-static]
 
   test-node-libs:
     docker: *docker-node-image

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ coverage/
 /docs
 docs-static/**/*.d.ts
 
+# Storybook
+storybook-static
+
 # exclude site except for site/docs/versions
 site/*
 site/docs/*

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -50,6 +50,6 @@ const storybookConfig: StorybookConfig = {
 // eslint-disable-next-line import/no-default-export
 export default storybookConfig;
 
-function getAbsolutePath(value: string): any {
+function getAbsolutePath(value: string): string {
     return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,14 +4,12 @@
 
 import type { StorybookConfig } from "@storybook/react-vite";
 import react from "@vitejs/plugin-react";
-import path, { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mergeConfig } from "vite";
 
-// eslint-disable-next-line no-underscore-dangle
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const rootDir = path.resolve(__dirname, "..");
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 const storybookConfig: StorybookConfig = {
     core: {
@@ -24,24 +22,24 @@ const storybookConfig: StorybookConfig = {
     stories: ["../packages/{core,datetime,labs,select,table}/src/**/*.stories.@(ts|tsx)"],
     async viteFinal(config) {
         return mergeConfig(config, {
-            plugins: [react()],
             optimizeDeps: {
                 // Pre-bundle icons and React so workspace packages resolve them from root
                 include: ["@blueprintjs/icons", "react", "react-dom"],
             },
+            plugins: [react()],
             resolve: {
                 // Blueprint workspace packages: use package names so preview and stories share one copy.
                 // Array form so order is guaranteed: more specific (core/lib) must match before core.
                 alias: [
-                    { find: "@blueprintjs/core/lib", replacement: path.resolve(rootDir, "packages/core/lib") },
-                    { find: "@blueprintjs/core", replacement: path.resolve(rootDir, "packages/core/src") },
-                    { find: "@blueprintjs/datetime", replacement: path.resolve(rootDir, "packages/datetime") },
-                    { find: "@blueprintjs/icons", replacement: path.resolve(rootDir, "packages/icons") },
-                    { find: "@blueprintjs/labs", replacement: path.resolve(rootDir, "packages/labs") },
-                    { find: "@blueprintjs/select", replacement: path.resolve(rootDir, "packages/select") },
-                    { find: "@blueprintjs/table", replacement: path.resolve(rootDir, "packages/table") },
-                    { find: "react", replacement: path.resolve(rootDir, "node_modules/react") },
-                    { find: "react-dom", replacement: path.resolve(rootDir, "node_modules/react-dom") },
+                    { find: "@blueprintjs/core/lib", replacement: resolve(rootDir, "packages/core/lib") },
+                    { find: "@blueprintjs/core", replacement: resolve(rootDir, "packages/core/src") },
+                    { find: "@blueprintjs/datetime", replacement: resolve(rootDir, "packages/datetime") },
+                    { find: "@blueprintjs/icons", replacement: resolve(rootDir, "packages/icons") },
+                    { find: "@blueprintjs/labs", replacement: resolve(rootDir, "packages/labs") },
+                    { find: "@blueprintjs/select", replacement: resolve(rootDir, "packages/select") },
+                    { find: "@blueprintjs/table", replacement: resolve(rootDir, "packages/table") },
+                    { find: "react", replacement: resolve(rootDir, "node_modules/react") },
+                    { find: "react-dom", replacement: resolve(rootDir, "node_modules/react-dom") },
                 ],
                 dedupe: ["react", "react-dom"],
             },

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,57 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { StorybookConfig } from "@storybook/react-vite";
+import react from "@vitejs/plugin-react";
+import path, { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { mergeConfig } from "vite";
+
+// eslint-disable-next-line no-underscore-dangle
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+
+const storybookConfig: StorybookConfig = {
+    core: {
+        disableTelemetry: true,
+    },
+    framework: {
+        name: getAbsolutePath("@storybook/react-vite"),
+        options: {},
+    },
+    stories: ["../packages/{core,datetime,labs,select,table}/src/**/*.stories.@(ts|tsx)"],
+    async viteFinal(config) {
+        return mergeConfig(config, {
+            plugins: [react()],
+            optimizeDeps: {
+                // Pre-bundle icons and React so workspace packages resolve them from root
+                include: ["@blueprintjs/icons", "react", "react-dom"],
+            },
+            resolve: {
+                // Blueprint workspace packages: use package names so preview and stories share one copy.
+                // Array form so order is guaranteed: more specific (core/lib) must match before core.
+                alias: [
+                    { find: "@blueprintjs/core/lib", replacement: path.resolve(rootDir, "packages/core/lib") },
+                    { find: "@blueprintjs/core", replacement: path.resolve(rootDir, "packages/core/src") },
+                    { find: "@blueprintjs/datetime", replacement: path.resolve(rootDir, "packages/datetime") },
+                    { find: "@blueprintjs/icons", replacement: path.resolve(rootDir, "packages/icons") },
+                    { find: "@blueprintjs/labs", replacement: path.resolve(rootDir, "packages/labs") },
+                    { find: "@blueprintjs/select", replacement: path.resolve(rootDir, "packages/select") },
+                    { find: "@blueprintjs/table", replacement: path.resolve(rootDir, "packages/table") },
+                    { find: "react", replacement: path.resolve(rootDir, "node_modules/react") },
+                    { find: "react-dom", replacement: path.resolve(rootDir, "node_modules/react-dom") },
+                ],
+                dedupe: ["react", "react-dom"],
+            },
+        });
+    },
+};
+
+// eslint-disable-next-line import/no-default-export
+export default storybookConfig;
+
+function getAbsolutePath(value: string): any {
+    return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));
+}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,79 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Preview } from "@storybook/react-vite";
+
+import { BlueprintProvider, Classes, Colors, FocusStyleManager } from "@blueprintjs/core";
+
+import { Icons } from "../packages/icons/src/iconLoader";
+
+FocusStyleManager.onlyShowFocusOnTabs();
+
+Icons.setLoaderOptions({ loader: "all" });
+
+// optionally, load the icons up-front so that future usage does not trigger a network request
+await Icons.loadAll();
+
+// Import Blueprint compiled CSS
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/datetime/lib/css/blueprint-datetime.css";
+import "@blueprintjs/labs/lib/css/blueprint-labs.css";
+import "@blueprintjs/select/lib/css/blueprint-select.css";
+import "@blueprintjs/table/lib/css/table.css";
+
+// Note: Icons CSS is not imported globally to avoid dependency optimization issues.
+// Stories that need icon styling can import "@blueprintjs/icons/lib/css/blueprint-icons.css".
+
+const preview: Preview = {
+    parameters: {
+        backgrounds: {
+            options: {
+                light: {
+                    name: "light",
+                    value: "#ffffff",
+                },
+
+                dark: {
+                    name: "dark",
+                    value: Colors.BLACK,
+                },
+            },
+        },
+        controls: {
+            matchers: {
+                color: /(background|color)$/i,
+                date: /Date$/i,
+            },
+        },
+    },
+
+    decorators: [
+        (Story, context) => {
+            // Toggle Blueprint dark mode via the Backgrounds toolbar (light / dark).
+            const bg = context.globals?.backgrounds;
+            const isDark = bg?.value === Colors.BLACK || bg?.value === "dark" || bg?.name === "dark";
+            if (typeof document !== "undefined" && document.body) {
+                if (isDark) {
+                    document.body.classList.add(Classes.DARK);
+                } else {
+                    document.body.classList.remove(Classes.DARK);
+                }
+            }
+            return (
+                <BlueprintProvider>
+                    <Story />
+                </BlueprintProvider>
+            );
+        },
+    ],
+
+    initialGlobals: {
+        backgrounds: {
+            value: "light",
+        },
+    },
+};
+
+// eslint-disable-next-line import/no-default-export
+export default preview;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -22,9 +22,6 @@ import "@blueprintjs/labs/lib/css/blueprint-labs.css";
 import "@blueprintjs/select/lib/css/blueprint-select.css";
 import "@blueprintjs/table/lib/css/table.css";
 
-// Note: Icons CSS is not imported globally to avoid dependency optimization issues.
-// Stories that need icon styling can import "@blueprintjs/icons/lib/css/blueprint-icons.css".
-
 const preview: Preview = {
     parameters: {
         backgrounds: {

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "extends": "../config/tsconfig.base.json",
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "module": "ESNext",
+        "target": "ES2020",
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "moduleResolution": "bundler",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "skipLibCheck": true,
+        "paths": {
+            "@blueprintjs/core": ["../packages/core/src"],
+            "@blueprintjs/datetime": ["../packages/datetime/src"],
+            "@blueprintjs/icons": ["../packages/icons/src"],
+            "@blueprintjs/labs": ["../packages/labs/src"],
+            "@blueprintjs/select": ["../packages/select/src"],
+            "@blueprintjs/table": ["../packages/table/src"]
+        }
+    },
+    "include": ["../packages/*/src/**/*", "./**/*"],
+    "exclude": ["../node_modules", "../**/node_modules", "../**/dist", "../**/lib"]
+}

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -3,11 +3,9 @@
     "compilerOptions": {
         "jsx": "react-jsx",
         "module": "ESNext",
-        "target": "ES2020",
-        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "target": "ESNext",
+        "lib": ["ESNext", "DOM", "DOM.Iterable"],
         "moduleResolution": "bundler",
-        "resolveJsonModule": true,
-        "isolatedModules": true,
         "skipLibCheck": true,
         "paths": {
             "@blueprintjs/core": ["../packages/core/src"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,6 +93,7 @@ module.exports = tseslint.config([
             "**/coverage",
             "**/__snapshots__",
             "**/generated",
+            "**/*.stories.{ts,tsx}",
         ],
     },
 ]);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,6 +85,19 @@ module.exports = tseslint.config([
         },
     },
     {
+        files: ["**/*.stories.{ts,tsx}"],
+        languageOptions: {
+            parserOptions: {
+                projectService: false,
+                project: `${__dirname}/.storybook/tsconfig.json`,
+            },
+        },
+        rules: {
+            "import/no-default-export": "off",
+            "sort-keys": "off",
+        },
+    },
+    {
         ignores: [
             "**/node_modules",
             "**/dist",
@@ -93,7 +106,6 @@ module.exports = tseslint.config([
             "**/coverage",
             "**/__snapshots__",
             "**/generated",
-            "**/*.stories.{ts,tsx}",
         ],
     },
 ]);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
         "site": "npm-run-all site:clean -p 'copy:*' -s serve",
         "site:clean": "git clean -xdfq site/",
         "test": "nx run-many -t test",
-        "verify": "npm-run-all -s compile dist -p test lint format-check"
+        "verify": "npm-run-all -s compile dist -p test lint format-check",
+        "storybook": "storybook dev -p 6006",
+        "build-storybook": "storybook build"
     },
     "dependencies": {
         "@lerna-lite/cli": "^3.11.0",
@@ -82,5 +84,14 @@
         "url": "git@github.com:palantir/blueprint.git"
     },
     "author": "Palantir Technologies",
-    "license": "Apache-2.0"
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "@storybook/icons": "^2.0.1",
+        "@storybook/react-dom-shim": "^10.2.14",
+        "@storybook/react-vite": "^10.2.14",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "storybook": "^10.2.14",
+        "vite": "^7.1.12"
+    }
 }

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
 import { Button } from "./buttons";
 
+// These props are deprecated on Button — hide them from the Storybook controls panel.
 const disabledArgs = ["large", "minimal", "outlined", "rightIcon", "small", "type"] as const satisfies ReadonlyArray<
     keyof React.ComponentProps<typeof Button>
 >;

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -5,6 +5,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
+
 import { Button } from "./buttons";
 
 // These props are deprecated on Button — hide them from the Storybook controls panel.

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -1,0 +1,324 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common/intent";
+import { Button } from "./buttons";
+import { Alignment, ButtonVariant, Size } from "../../common";
+
+const disabledArgs = ["large", "minimal", "outlined", "rightIcon", "small", "type"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof Button>
+>;
+
+const meta: Meta<typeof Button> = {
+    title: "Core/Button",
+    component: Button,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        text: "Button",
+        intent: Intent.NONE,
+        variant: ButtonVariant.SOLID,
+        size: Size.MEDIUM,
+        alignText: Alignment.CENTER,
+        icon: undefined,
+        endIcon: undefined,
+        fill: false,
+        active: false,
+        loading: false,
+        disabled: false,
+    },
+    argTypes: {
+        text: {
+            control: "text",
+        },
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        variant: {
+            control: "select",
+            options: Object.values(ButtonVariant),
+        },
+        alignText: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        icon: {
+            control: "text",
+        },
+        endIcon: {
+            control: "text",
+        },
+        active: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        loading: {
+            control: "boolean",
+        },
+        onClick: { action: "clicked" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic button with default styling.
+ */
+export const Default: Story = {
+    args: {
+        text: "Button",
+    },
+};
+
+// Intent variants
+export const Primary: Story = {
+    args: {
+        text: "Primary Button",
+        intent: Intent.PRIMARY,
+    },
+};
+
+export const Success: Story = {
+    args: {
+        text: "Success Button",
+        intent: Intent.SUCCESS,
+    },
+};
+
+export const Warning: Story = {
+    args: {
+        text: "Warning Button",
+        intent: Intent.WARNING,
+    },
+};
+
+export const Danger: Story = {
+    args: {
+        text: "Danger Button",
+        intent: Intent.DANGER,
+    },
+};
+
+// Size variants
+export const Small: Story = {
+    args: {
+        text: "Small Button",
+        size: Size.SMALL,
+    },
+};
+
+export const Medium: Story = {
+    args: {
+        text: "Medium Button",
+        size: Size.MEDIUM,
+    },
+};
+
+export const Large: Story = {
+    args: {
+        text: "Large Button",
+        size: Size.LARGE,
+    },
+};
+
+// Visual style variants
+export const Solid: Story = {
+    args: {
+        text: "Solid Button",
+        variant: ButtonVariant.SOLID,
+        intent: Intent.PRIMARY,
+    },
+};
+
+export const Minimal: Story = {
+    args: {
+        text: "Minimal Button",
+        variant: ButtonVariant.MINIMAL,
+        intent: Intent.PRIMARY,
+    },
+};
+
+export const Outlined: Story = {
+    args: {
+        text: "Outlined Button",
+        variant: "outlined",
+        intent: Intent.PRIMARY,
+    },
+};
+
+// States
+export const Active: Story = {
+    args: {
+        text: "Active Button",
+        active: true,
+        intent: Intent.PRIMARY,
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        text: "Disabled Button",
+        disabled: true,
+    },
+};
+
+export const Loading: Story = {
+    args: {
+        text: "Loading Button",
+        loading: true,
+        intent: Intent.PRIMARY,
+    },
+};
+
+export const WithStartIcon: Story = {
+    args: {
+        text: "Upload",
+        icon: "upload",
+    },
+};
+
+export const WithEndIcon: Story = {
+    args: {
+        text: "Next",
+        endIcon: "arrow-right",
+        intent: "primary",
+    },
+};
+
+export const IconOnly: Story = {
+    args: {
+        icon: "search",
+        text: undefined,
+        "aria-label": "Search",
+    },
+};
+
+// Text alignment
+export const AlignStart: Story = {
+    args: {
+        text: "Start",
+        alignText: Alignment.START,
+        icon: "align-left",
+        endIcon: "caret-down",
+        fill: true,
+    },
+};
+
+export const AlignCenter: Story = {
+    args: {
+        text: "Center",
+        alignText: Alignment.CENTER,
+        icon: "align-center",
+        endIcon: "caret-down",
+        fill: true,
+    },
+};
+
+export const AlignEnd: Story = {
+    args: {
+        text: "End",
+        alignText: Alignment.END,
+        icon: "align-right",
+        endIcon: "caret-down",
+        fill: true,
+    },
+};
+
+// Fill
+export const Fill: Story = {
+    args: {
+        text: "Fill Container",
+        fill: true,
+        intent: "primary",
+    },
+};
+
+// All intents
+export const AllIntents: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div style={{ display: "flex", gap: 8 }}>
+                <Button>None</Button>
+                <Button intent="primary">Primary</Button>
+                <Button intent="success">Success</Button>
+                <Button intent="warning">Warning</Button>
+                <Button intent="danger">Danger</Button>
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+                <Button variant="minimal">None</Button>
+                <Button variant="minimal" intent="primary">
+                    Primary
+                </Button>
+                <Button variant="minimal" intent="success">
+                    Success
+                </Button>
+                <Button variant="minimal" intent="warning">
+                    Warning
+                </Button>
+                <Button variant="minimal" intent="danger">
+                    Danger
+                </Button>
+            </div>
+            <div style={{ display: "flex", gap: 8 }}>
+                <Button variant="outlined">None</Button>
+                <Button variant="outlined" intent="primary">
+                    Primary
+                </Button>
+                <Button variant="outlined" intent="success">
+                    Success
+                </Button>
+                <Button variant="outlined" intent="warning">
+                    Warning
+                </Button>
+                <Button variant="outlined" intent="danger">
+                    Danger
+                </Button>
+            </div>
+        </div>
+    ),
+};
+
+// All sizes
+export const AllSizes: Story = {
+    render: () => (
+        <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+            <Button size="small">Small</Button>
+            <Button size="medium">Medium</Button>
+            <Button size="large">Large</Button>
+        </div>
+    ),
+};

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -4,9 +4,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Intent } from "../../common/intent";
+import { Alignment, ButtonVariant, Intent, Size } from "../../common";
 import { Button } from "./buttons";
-import { Alignment, ButtonVariant, Size } from "../../common";
 
 const disabledArgs = ["large", "minimal", "outlined", "rightIcon", "small", "type"] as const satisfies ReadonlyArray<
     keyof React.ComponentProps<typeof Button>
@@ -28,10 +27,10 @@ const meta: Meta<typeof Button> = {
     tags: ["autodocs"],
     args: {
         text: "Button",
-        intent: Intent.NONE,
-        variant: ButtonVariant.SOLID,
-        size: Size.MEDIUM,
-        alignText: Alignment.CENTER,
+        intent: "none",
+        variant: "solid",
+        size: "medium",
+        alignText: "center",
         icon: undefined,
         endIcon: undefined,
         fill: false,
@@ -108,28 +107,28 @@ export const Default: Story = {
 export const Primary: Story = {
     args: {
         text: "Primary Button",
-        intent: Intent.PRIMARY,
+        intent: "primary",
     },
 };
 
 export const Success: Story = {
     args: {
         text: "Success Button",
-        intent: Intent.SUCCESS,
+        intent: "success",
     },
 };
 
 export const Warning: Story = {
     args: {
         text: "Warning Button",
-        intent: Intent.WARNING,
+        intent: "warning",
     },
 };
 
 export const Danger: Story = {
     args: {
         text: "Danger Button",
-        intent: Intent.DANGER,
+        intent: "danger",
     },
 };
 
@@ -137,21 +136,21 @@ export const Danger: Story = {
 export const Small: Story = {
     args: {
         text: "Small Button",
-        size: Size.SMALL,
+        size: "small",
     },
 };
 
 export const Medium: Story = {
     args: {
         text: "Medium Button",
-        size: Size.MEDIUM,
+        size: "medium",
     },
 };
 
 export const Large: Story = {
     args: {
         text: "Large Button",
-        size: Size.LARGE,
+        size: "large",
     },
 };
 
@@ -159,16 +158,16 @@ export const Large: Story = {
 export const Solid: Story = {
     args: {
         text: "Solid Button",
-        variant: ButtonVariant.SOLID,
-        intent: Intent.PRIMARY,
+        variant: "solid",
+        intent: "primary",
     },
 };
 
 export const Minimal: Story = {
     args: {
         text: "Minimal Button",
-        variant: ButtonVariant.MINIMAL,
-        intent: Intent.PRIMARY,
+        variant: "minimal",
+        intent: "primary",
     },
 };
 
@@ -176,7 +175,7 @@ export const Outlined: Story = {
     args: {
         text: "Outlined Button",
         variant: "outlined",
-        intent: Intent.PRIMARY,
+        intent: "primary",
     },
 };
 
@@ -185,7 +184,7 @@ export const Active: Story = {
     args: {
         text: "Active Button",
         active: true,
-        intent: Intent.PRIMARY,
+        intent: "primary",
     },
 };
 
@@ -200,7 +199,7 @@ export const Loading: Story = {
     args: {
         text: "Loading Button",
         loading: true,
-        intent: Intent.PRIMARY,
+        intent: "primary",
     },
 };
 
@@ -231,7 +230,7 @@ export const IconOnly: Story = {
 export const AlignStart: Story = {
     args: {
         text: "Start",
-        alignText: Alignment.START,
+        alignText: "start",
         icon: "align-left",
         endIcon: "caret-down",
         fill: true,
@@ -241,7 +240,7 @@ export const AlignStart: Story = {
 export const AlignCenter: Story = {
     args: {
         text: "Center",
-        alignText: Alignment.CENTER,
+        alignText: "center",
         icon: "align-center",
         endIcon: "caret-down",
         fill: true,
@@ -251,7 +250,7 @@ export const AlignCenter: Story = {
 export const AlignEnd: Story = {
     args: {
         text: "End",
-        alignText: Alignment.END,
+        alignText: "end",
         icon: "align-right",
         endIcon: "caret-down",
         fill: true,

--- a/packages/core/src/tsconfig.build.json
+++ b/packages/core/src/tsconfig.build.json
@@ -7,6 +7,8 @@
     "exclude": [
         "**/*.test.ts",
         "**/*.test.tsx",
+        "**/*.stories.tsx",
+        "**/*.stories.ts",
         "vitest-env.d.ts",
         "design-tokens/build.ts",
         "design-tokens/sd.config.ts"

--- a/packages/core/src/tsconfig.test.json
+++ b/packages/core/src/tsconfig.test.json
@@ -6,5 +6,5 @@
         "skipLibCheck": true
     },
     "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx", "vitest-env.d.ts"],
-    "exclude": ["design-tokens/build.ts", "design-tokens/sd.config.ts"]
+    "exclude": ["design-tokens/build.ts", "design-tokens/sd.config.ts", "**/*.stories.tsx"]
 }

--- a/packages/datetime/src/common/dateFnsLocaleUtils.ts
+++ b/packages/datetime/src/common/dateFnsLocaleUtils.ts
@@ -27,6 +27,7 @@ import type { DateFnsLocaleLoader } from "./dateFnsLocaleProps";
 export async function loadDateFnsLocale(localeCode: string): Promise<Locale | undefined> {
     try {
         const localeModule = await import(
+            /* @vite-ignore */
             /* webpackChunkName: "date-fns-locale-[request]" */
             `date-fns/locale/${localeCode}/index.js`
         );

--- a/packages/datetime/src/tsconfig.build.json
+++ b/packages/datetime/src/tsconfig.build.json
@@ -5,6 +5,8 @@
         "outDir": "../lib/esm"
     },
     "exclude": [
+        "**/*.stories.tsx",
+        "**/*.stories.ts",
         "**/*.test.ts",
         "**/*.test.tsx",
         "common/dateFormatTestUtils.ts",

--- a/packages/datetime/src/tsconfig.test.json
+++ b/packages/datetime/src/tsconfig.test.json
@@ -6,5 +6,5 @@
         "skipLibCheck": true
     },
     "include": ["**/*.ts", "**/*.tsx", "**/*.test.ts", "**/*.test.tsx", "vitest-env.d.ts"],
-    "exclude": []
+    "exclude": ["**/*.stories.tsx"]
 }

--- a/packages/labs/src/tsconfig.json
+++ b/packages/labs/src/tsconfig.json
@@ -4,5 +4,6 @@
         "outDir": "../lib/esm",
         "skipLibCheck": true // Avoiding type conflicts with node_modules
     },
-    "include": ["**/*.ts", "**/*.tsx", "vitest-env.d.ts"]
+    "include": ["**/*.ts", "**/*.tsx", "vitest-env.d.ts"],
+    "exclude": ["**/*.stories.ts", "**/*.stories.tsx"]
 }

--- a/packages/select/src/tsconfig.json
+++ b/packages/select/src/tsconfig.json
@@ -2,5 +2,6 @@
     "extends": "../../../config/tsconfig.web",
     "compilerOptions": {
         "outDir": "../lib/esm"
-    }
+    },
+    "exclude": ["**/*.stories.ts", "**/*.stories.tsx"]
 }

--- a/packages/table/src/tsconfig.json
+++ b/packages/table/src/tsconfig.json
@@ -3,5 +3,6 @@
     "compilerOptions": {
         "lib": ["dom", "es5", "es6"],
         "outDir": "../lib/esm"
-    }
+    },
+    "exclude": ["**/*.stories.ts", "**/*.stories.tsx"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,13 +134,35 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.56.1
-        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 'catalog:'
         version: 4.0.7(@types/node@24.10.0)(jiti@2.6.1)(jsdom@27.1.0)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
+    devDependencies:
+      '@storybook/icons':
+        specifier: ^2.0.1
+        version: 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/react-dom-shim':
+        specifier: ^10.2.14
+        version: 10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/react-vite':
+        specifier: ^10.2.14
+        version: 10.2.14(esbuild@0.27.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+      storybook:
+        specifier: ^10.2.14
+        version: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      vite:
+        specifier: ^7.1.12
+        version: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/colors:
     dependencies:
@@ -460,7 +482,7 @@ importers:
         version: 4.1.5
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@4.15.2)(webpack@5.102.1)
@@ -578,7 +600,7 @@ importers:
         version: 4.0.2(webpack@5.102.1)
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@4.15.2)(webpack@5.102.1)
@@ -678,7 +700,7 @@ importers:
         version: 3.1.1(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ~2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
+        version: 2.31.0(@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))
       eslint-plugin-jsdoc:
         specifier: ^48.0.2
         version: 48.11.0(eslint@9.38.0(jiti@2.6.1))
@@ -696,7 +718,7 @@ importers:
         version: 15.15.0
       typescript-eslint:
         specifier: ^8.56.1
-        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
     devDependencies:
       typescript:
         specifier: ~5.9.3
@@ -706,7 +728,7 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.56.1
-        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: ^8.57 || ^9.0.0
         version: 9.38.0(jiti@2.6.1)
@@ -725,7 +747,7 @@ importers:
         version: 0.7.2
       '@typescript-eslint/rule-tester':
         specifier: ^8.56.1
-        version: 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       dedent:
         specifier: ^1.5.1
         version: 1.7.0
@@ -807,7 +829,7 @@ importers:
         version: link:../webpack-build-scripts
       istanbul-instrumenter-loader:
         specifier: ^3.0.1
-        version: 3.0.1(webpack@5.102.1(@swc/core@1.13.20))
+        version: 3.0.1(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       karma:
         specifier: ^6.4.2
         version: 6.4.4
@@ -837,13 +859,13 @@ importers:
         version: 0.4.0
       karma-webpack:
         specifier: ^5.0.0
-        version: 5.0.1(webpack@5.102.1(@swc/core@1.13.20))
+        version: 5.0.1(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   packages/labs:
     dependencies:
@@ -950,7 +972,7 @@ importers:
         version: 4.0.2(webpack@5.102.1)
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@4.15.2)(webpack@5.102.1)
@@ -1255,7 +1277,7 @@ importers:
         version: 5.9.3
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   packages/table-dev-app:
     dependencies:
@@ -1307,7 +1329,7 @@ importers:
         version: 4.1.5
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack-dev-server@4.15.2)(webpack@5.102.1)
@@ -1396,7 +1418,7 @@ importers:
         version: link:../node-build-scripts
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.11
-        version: 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.102.1(@swc/core@1.13.20)))(webpack@5.102.1(@swc/core@1.13.20))
+        version: 0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       '@swc/core':
         specifier: ^1.3.105
         version: 1.13.20
@@ -1408,22 +1430,22 @@ importers:
         version: 10.4.21(postcss@8.5.6)
       css-loader:
         specifier: ^6.9.1
-        version: 6.11.0(webpack@5.102.1(@swc/core@1.13.20))
+        version: 6.11.0(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       cssnano:
         specifier: ^6.0.3
         version: 6.1.2(postcss@8.5.6)
       fork-ts-checker-notifier-webpack-plugin:
         specifier: ^9.0.0
-        version: 9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)))
+        version: 9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)))
       fork-ts-checker-webpack-plugin:
         specifier: ^9.0.2
-        version: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       istanbul-instrumenter-loader:
         specifier: ^3.0.1
-        version: 3.0.1(webpack@5.102.1(@swc/core@1.13.20))
+        version: 3.0.1(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       mini-css-extract-plugin:
         specifier: ^2.7.7
-        version: 2.9.4(webpack@5.102.1(@swc/core@1.13.20))
+        version: 2.9.4(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       postcss:
         specifier: ^8.4.33
         version: 8.5.6
@@ -1432,7 +1454,7 @@ importers:
         version: 6.0.2(postcss@8.5.6)
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -1444,34 +1466,34 @@ importers:
         version: 1.93.2
       sass-loader:
         specifier: ^16.0.6
-        version: 16.0.6(sass@1.93.2)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 16.0.6(sass@1.93.2)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       source-map-loader:
         specifier: ^5.0.0
-        version: 5.0.0(webpack@5.102.1(@swc/core@1.13.20))
+        version: 5.0.0(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       stream-browserify:
         specifier: ^3.0.0
         version: 3.0.0
       style-loader:
         specifier: ^3.3.4
-        version: 3.3.4(webpack@5.102.1(@swc/core@1.13.20))
+        version: 3.3.4(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       swc-loader:
         specifier: ^0.2.3
-        version: 0.2.6(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 0.2.6(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       terser-webpack-plugin:
         specifier: ^5.3.10
-        version: 5.3.14(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20))
+        version: 5.3.14(@swc/core@1.13.20)(esbuild@0.27.2)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       webpack:
         specifier: ^5.90.0
-        version: 5.102.1(@swc/core@1.13.20)
+        version: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
       webpack-bundle-analyzer:
         specifier: ^4.10.1
         version: 4.10.2
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.2(webpack@5.102.1(@swc/core@1.13.20))
+        version: 4.15.2(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       webpack-notifier:
         specifier: ^1.15.0
         version: 1.15.0
@@ -2340,6 +2362,15 @@ packages:
     resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4':
+    resolution: {integrity: sha512-6PyZBYKnnVNqOSB0YFly+62R7dmov8segT27A+RVTBVd4iAE6kbW9QBJGlyR2yG4D4ohzhZSTIu7BK1UTtmFFA==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2959,6 +2990,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.43':
     resolution: {integrity: sha512-5Uxg7fQUCmfhax7FJke2+8B6cqgeUJUD9o2uXIKXhD+mG0mL6NObmVoi9wXEU1tY89mZKgAYA6fTbftx3q2ZPQ==}
 
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.52.5':
     resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
     cpu: [arm]
@@ -3119,6 +3159,65 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@storybook/builder-vite@10.2.14':
+    resolution: {integrity: sha512-4b/opKbbTg+npeFXzj4GwZ7SDJdqsJbcJYxFpAznpl9FqMhP+ktH/7QSDs1DtOXpCanKcrmj6UQQgKR8OGypUQ==}
+    peerDependencies:
+      storybook: ^10.2.14
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/csf-plugin@10.2.14':
+    resolution: {integrity: sha512-N4frSzhig3pkhaWdN0kAnhgEi9IGEy6rJnpuNAocS6d70fSahGQk958TMml2JCG3LLiVamuXySyUrVtFiHrxvg==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.2.14
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.0.1':
+    resolution: {integrity: sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.2.14':
+    resolution: {integrity: sha512-hO/Yzhf3fX/HhB5MDc/ERM5QLA1+yLgnyt0a4NGDqeWeXQ90YSjEski1RppdAI9oNGyhNwWllZPUrozrL7ECyg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.2.14
+
+  '@storybook/react-vite@10.2.14':
+    resolution: {integrity: sha512-qfHkDjv0ElJFqhXN/uD+fuuMBVOI7xzJbMqLi9I4TKt4645B0P6X7s83oyLgU9y9xQEi4Dr2zSJq0VtNBe+VBg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.2.14
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@storybook/react@10.2.14':
+    resolution: {integrity: sha512-GzbbsfyOeGpTqLoss6yyb9m7eYO7oXSV8cey+y0gxVplOmK8XISA8q0AtH7gWzw6pDUOaBpEfnrE/jgOOKwQlw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.2.14
+      typescript: '>= 4.9.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@swc-node/core@1.14.1':
     resolution: {integrity: sha512-jrt5GUaZUU6cmMS+WTJEvGvaB6j1YNKPHPzC2PUi2BjaFbtxURHj6641Az6xN7b665hNniAIdvjxWcRml5yCnw==}
@@ -3329,6 +3428,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/doctrine@0.0.9':
+    resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
+
   '@types/downloadjs@1.4.6':
     resolution: {integrity: sha512-mp3w70vsaiLRT9ix92fmI9Ob2yJAPZm6tShJtofo2uHbN11G2i6a0ApIEjBl/kv3e9V7Pv7jMjk1bUwYWvMHvA==}
 
@@ -3491,69 +3593,69 @@ packages:
   '@types/yargs@17.0.34':
     resolution: {integrity: sha512-KExbHVa92aJpw9WDQvzBaGVE2/Pz+pLZQloT2hjL8IqsZnV62rlPOYvNnLmf/L2dyllfVUOVBj64M0z/46eR2A==}
 
-  '@typescript-eslint/eslint-plugin@8.56.1':
-    resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
+  '@typescript-eslint/eslint-plugin@8.57.0':
+    resolution: {integrity: sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.56.1
+      '@typescript-eslint/parser': ^8.57.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.56.1':
-    resolution: {integrity: sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.56.1':
-    resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/rule-tester@8.56.1':
-    resolution: {integrity: sha512-EWuV5Vq1EFYJEOVcILyWPO35PjnT0c6tv99PCpD12PgfZae5/Jo+F17hGjsEs2Moe+Dy1J7KIr8y037cK8+/rQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-
-  '@typescript-eslint/scope-manager@8.56.1':
-    resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.56.1':
-    resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.56.1':
-    resolution: {integrity: sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==}
+  '@typescript-eslint/parser@8.57.0':
+    resolution: {integrity: sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.56.1':
-    resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.56.1':
-    resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
+  '@typescript-eslint/project-service@8.57.0':
+    resolution: {integrity: sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.56.1':
-    resolution: {integrity: sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==}
+  '@typescript-eslint/rule-tester@8.57.0':
+    resolution: {integrity: sha512-qs4OapXmAIj3so85/20lQG1WrBSSvDE/3b42Orl3lpZkaOlNXtbfKzL+9EPaY5wSEgdlhKEpympAMFHPG9i72Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
+  '@typescript-eslint/scope-manager@8.57.0':
+    resolution: {integrity: sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.57.0':
+    resolution: {integrity: sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.57.0':
+    resolution: {integrity: sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.56.1':
-    resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
+  '@typescript-eslint/types@8.57.0':
+    resolution: {integrity: sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.57.0':
+    resolution: {integrity: sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.57.0':
+    resolution: {integrity: sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.57.0':
+    resolution: {integrity: sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@5.1.0':
@@ -3571,6 +3673,9 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
   '@vitest/expect@4.0.7':
     resolution: {integrity: sha512-jGRG6HghnJDjljdjYIoVzX17S6uCVCBRFnsgdLGJ6CaxfPh8kzUKe/2n533y4O/aeZ/sIr7q7GbuEbeGDsWv4Q==}
 
@@ -3585,6 +3690,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
   '@vitest/pretty-format@4.0.7':
     resolution: {integrity: sha512-YY//yxqTmk29+/pK+Wi1UB4DUH3lSVgIm+M10rAJ74pOSMgT7rydMSc+vFuq9LjZLhFvVEXir8EcqMke3SVM6Q==}
 
@@ -3594,8 +3702,14 @@ packages:
   '@vitest/snapshot@4.0.7':
     resolution: {integrity: sha512-xJL+Nkw0OjaUXXQf13B8iKK5pI9QVtN9uOtzNHYuG/o/B7fIEg0DQ+xOe0/RcqwDEI15rud1k7y5xznBKGUXAA==}
 
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
   '@vitest/spy@4.0.7':
     resolution: {integrity: sha512-FW4X8hzIEn4z+HublB4hBF/FhCVaXfIHm8sUfvlznrcy1MQG7VooBgZPMtVCGZtHi0yl3KESaXTqsKh16d8cFg==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.0.7':
     resolution: {integrity: sha512-HNrg9CM/Z4ZWB6RuExhuC6FPmLipiShKVMnT9JlQvfhwR47JatWLChA6mtZqVHqypE6p/z6ofcjbyWpM7YLxPQ==}
@@ -3968,6 +4082,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
   ast-v8-to-istanbul@0.3.10:
     resolution: {integrity: sha512-p4K7vMz2ZSk3wN8l5o3y2bJAoZXT3VuJI5OLTATY/01CYWumWvwkUw0SqDBnNq6IiTO3qDa1eSQDibAV8g7XOQ==}
 
@@ -4171,6 +4289,10 @@ packages:
   builtin-modules@1.1.1:
     resolution: {integrity: sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==}
     engines: {node: '>=0.10.0'}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -4780,6 +4902,14 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.4.0:
+    resolution: {integrity: sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==}
+    engines: {node: '>=18'}
+
   default-gateway@6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
     engines: {node: '>= 10'}
@@ -4794,6 +4924,10 @@ packages:
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -4875,6 +5009,10 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -4976,6 +5114,10 @@ packages:
   emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -5276,6 +5418,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -5671,6 +5816,10 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -6047,6 +6196,11 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -6074,6 +6228,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -6204,6 +6363,10 @@ packages:
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+
+  is-wsl@3.1.0:
+    resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
+    engines: {node: '>=16'}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -7009,8 +7172,8 @@ packages:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -7318,6 +7481,10 @@ packages:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
 
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -7493,9 +7660,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
@@ -7951,6 +8118,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qified@0.5.1:
@@ -8004,6 +8172,15 @@ packages:
     peerDependencies:
       date-fns: ^2.28.0 || ^3.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  react-docgen-typescript@2.4.0:
+    resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
+    peerDependencies:
+      typescript: '>= 4.3.x'
+
+  react-docgen@8.0.2:
+    resolution: {integrity: sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==}
+    engines: {node: ^20.9.0 || >=22}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -8099,6 +8276,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -8204,6 +8385,10 @@ packages:
 
   rst-selector-parser@2.2.3:
     resolution: {integrity: sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -8563,6 +8748,15 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  storybook@10.2.14:
+    resolution: {integrity: sha512-HGAgLbDAAbLOgjERsBXPpHUMxynHumYgoCRNBnAH57HfKuHL9LA3nKvKpbhFbYb/8PSG5X3hiKukki0R6Op7Aw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
@@ -8660,6 +8854,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -8883,6 +9081,9 @@ packages:
     resolution: {integrity: sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==}
     engines: {node: '>=0.12'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8902,6 +9103,10 @@ packages:
 
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.17:
@@ -8969,6 +9174,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
@@ -9107,8 +9316,8 @@ packages:
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x
 
-  typescript-eslint@8.56.1:
-    resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
+  typescript-eslint@8.57.0:
+    resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -9183,6 +9392,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unquote@1.1.1:
     resolution: {integrity: sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==}
@@ -9428,6 +9641,9 @@ packages:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   webpack@5.102.1:
     resolution: {integrity: sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==}
     engines: {node: '>=10.13.0'}
@@ -9586,6 +9802,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -10524,6 +10744,14 @@ snapshots:
       '@types/yargs': 17.0.34
       chalk: 4.1.2
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      glob: 13.0.6
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -11188,7 +11416,7 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.102.1(@swc/core@1.13.20)))(webpack@5.102.1(@swc/core@1.13.20))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@4.41.0)(webpack-dev-server@4.15.2(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.46.0
@@ -11198,16 +11426,24 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 4.15.2(webpack@5.102.1(@swc/core@1.13.20))
+      webpack-dev-server: 4.15.2(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
 
   '@polka/url@1.0.0-next.29': {}
 
   '@popperjs/core@2.11.8': {}
 
   '@rolldown/pluginutils@1.0.0-beta.43': {}
+
+  '@rollup/pluginutils@5.3.0(rollup@4.52.5)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.52.5
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     optional: true
@@ -11307,6 +11543,75 @@ snapshots:
   '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@storybook/builder-vite@10.2.14(esbuild@0.27.2)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))':
+    dependencies:
+      '@storybook/csf-plugin': 10.2.14(esbuild@0.27.2)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ts-dedent: 2.2.0
+      vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.2.14(esbuild@0.27.2)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))':
+    dependencies:
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.2
+      rollup: 4.52.5
+      vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@storybook/react-dom-shim@10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  '@storybook/react-vite@10.2.14(esbuild@0.27.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+      '@storybook/builder-vite': 10.2.14(esbuild@0.27.2)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
+      '@storybook/react': 10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+      empathic: 2.0.0
+      magic-string: 0.30.21
+      react: 18.3.1
+      react-docgen: 8.0.2
+      react-dom: 18.3.1(react@18.3.1)
+      resolve: 1.22.11
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tsconfig-paths: 4.2.0
+      vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - supports-color
+      - typescript
+      - webpack
+
+  '@storybook/react@10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/react-dom-shim': 10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      react: 18.3.1
+      react-docgen: 8.0.2
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@swc-node/core@1.14.1(@swc/core@1.13.20)(@swc/types@0.1.25)':
     dependencies:
@@ -11533,6 +11838,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/doctrine@0.0.9': {}
+
   '@types/downloadjs@1.4.6': {}
 
   '@types/enzyme-adapter-react-16@1.0.9':
@@ -11710,14 +12017,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/type-utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.56.1
+      '@typescript-eslint/parser': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/type-utils': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.57.0
       eslint: 9.38.0(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -11726,32 +12033,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.56.1
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.38.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/rule-tester@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       ajv: 6.12.6
       eslint: 9.38.0(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
@@ -11761,20 +12068,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/scope-manager@8.56.1':
+  '@typescript-eslint/scope-manager@8.57.0':
     dependencies:
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/visitor-keys': 8.56.1
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
 
-  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.38.0(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -11782,14 +12089,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.56.1': {}
+  '@typescript-eslint/types@8.57.0': {}
 
-  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/visitor-keys': 8.56.1
+      '@typescript-eslint/project-service': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/visitor-keys': 8.57.0
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
       semver: 7.7.3
@@ -11799,20 +12106,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.38.0(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/types': 8.56.1
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.57.0
+      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.56.1':
+  '@typescript-eslint/visitor-keys@8.57.0':
     dependencies:
-      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/types': 8.57.0
       eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@5.1.0(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
@@ -11844,6 +12151,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.0.7':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -11861,6 +12176,10 @@ snapshots:
     optionalDependencies:
       vite: 7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
 
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.0.7':
     dependencies:
       tinyrainbow: 3.0.3
@@ -11876,7 +12195,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
   '@vitest/spy@4.0.7': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.0.7':
     dependencies:
@@ -11961,24 +12290,24 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.102.1)':
     dependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.102.1)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.102.1)':
     dependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.102.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@4.15.2)(webpack@5.102.1)':
     dependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@4.15.2)(webpack@5.102.1)
     optionalDependencies:
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.102.1)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.102.1)':
     dependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.102.1)
 
   '@xmldom/xmldom@0.7.13': {}
@@ -12277,6 +12606,10 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
   ast-v8-to-istanbul@0.3.10:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -12552,6 +12885,10 @@ snapshots:
 
   builtin-modules@1.1.1: {}
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   cacache@16.1.3:
@@ -12583,7 +12920,7 @@ snapshots:
       fs-minipass: 3.0.3
       glob: 10.5.0
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -12955,7 +13292,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
 
   core-js-pure@3.46.0: {}
 
@@ -13023,7 +13360,7 @@ snapshots:
 
   css-functions-list@3.2.3: {}
 
-  css-loader@6.11.0(webpack@5.102.1(@swc/core@1.13.20)):
+  css-loader@6.11.0(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -13034,7 +13371,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   css-select-base-adapter@0.1.1: {}
 
@@ -13239,6 +13576,13 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.4.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   default-gateway@6.0.3:
     dependencies:
       execa: 5.1.1
@@ -13254,6 +13598,8 @@ snapshots:
       gopd: 1.2.0
 
   define-lazy-prop@2.0.0: {}
+
+  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
@@ -13307,6 +13653,10 @@ snapshots:
       '@leichtgewicht/ip-codec': 2.0.5
 
   doctrine@2.1.0:
+    dependencies:
+      esutils: 2.0.3
+
+  doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
 
@@ -13414,6 +13764,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   emojis-list@3.0.0: {}
+
+  empathic@2.0.0: {}
 
   encodeurl@1.0.2: {}
 
@@ -13738,11 +14090,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -13752,7 +14104,7 @@ snapshots:
     dependencies:
       eslint: 9.38.0(jiti@2.6.1)
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13763,7 +14115,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.38.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.38.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13775,7 +14127,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -13930,6 +14282,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -14182,12 +14536,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-notifier-webpack-plugin@9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))):
+  fork-ts-checker-notifier-webpack-plugin@9.0.0(fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))):
     dependencies:
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       node-notifier: 10.0.1
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -14202,7 +14556,7 @@ snapshots:
       semver: 7.7.3
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   form-data@4.0.4:
     dependencies:
@@ -14259,7 +14613,7 @@ snapshots:
 
   fs-minipass@3.0.3:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   fs-monkey@1.1.0: {}
 
@@ -14390,7 +14744,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -14399,9 +14753,15 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
       minimatch: 10.2.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
-      path-scurry: 2.0.1
+      path-scurry: 2.0.2
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@5.0.15:
     dependencies:
@@ -14808,6 +15168,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -14831,6 +15193,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@1.0.0: {}
 
@@ -14935,6 +15301,10 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
+  is-wsl@3.1.0:
+    dependencies:
+      is-inside-container: 1.0.0
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -14947,13 +15317,13 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  istanbul-instrumenter-loader@3.0.1(webpack@5.102.1(@swc/core@1.13.20)):
+  istanbul-instrumenter-loader@3.0.1(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       convert-source-map: 1.9.0
       istanbul-lib-instrument: 1.10.2
       loader-utils: 1.4.2
       schema-utils: 0.3.0
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -15528,11 +15898,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
 
-  karma-webpack@5.0.1(webpack@5.102.1(@swc/core@1.13.20)):
+  karma-webpack@5.0.1(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       glob: 7.2.3
       minimatch: 9.0.5
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
       webpack-merge: 4.2.2
 
   karma@6.4.4:
@@ -15802,7 +16172,7 @@ snapshots:
       cacache: 18.0.4
       http-cache-semantics: 4.2.0
       is-lambda: 1.0.1
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-fetch: 3.0.5
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -15912,11 +16282,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.4(webpack@5.102.1(@swc/core@1.13.20)):
+  mini-css-extract-plugin@2.9.4(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -15954,7 +16324,7 @@ snapshots:
 
   minipass-collect@2.0.1:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   minipass-fetch@2.1.2:
     dependencies:
@@ -15966,7 +16336,7 @@ snapshots:
 
   minipass-fetch@3.0.5:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-sized: 1.0.3
       minizlib: 2.1.2
     optionalDependencies:
@@ -15990,7 +16360,7 @@ snapshots:
 
   minipass@5.0.0: {}
 
-  minipass@7.1.2: {}
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -16032,7 +16402,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.45.0
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
 
   monaco-editor@0.45.0: {}
 
@@ -16410,6 +16780,13 @@ snapshots:
     dependencies:
       mimic-fn: 4.0.0
 
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.4.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
   open@8.4.2:
     dependencies:
       define-lazy-prop: 2.0.0
@@ -16617,12 +16994,12 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
-  path-scurry@2.0.1:
+  path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.6
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-to-regexp@0.1.12: {}
 
@@ -16755,14 +17132,14 @@ snapshots:
       postcss: 8.5.6
       tsx: 4.21.0
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)):
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.3)
       jiti: 2.6.1
       postcss: 8.5.6
       semver: 7.7.3
     optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
     transitivePeerDependencies:
       - typescript
 
@@ -17059,12 +17436,31 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
 
   react-day-picker@8.10.1(date-fns@2.30.0)(react@18.3.1):
     dependencies:
       date-fns: 2.30.0
       react: 18.3.1
+
+  react-docgen-typescript@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  react-docgen@8.0.2:
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@types/babel__core': 7.20.5
+      '@types/babel__traverse': 7.28.0
+      '@types/doctrine': 0.0.9
+      '@types/resolve': 1.20.6
+      doctrine: 3.0.0
+      resolve: 1.22.11
+      strip-indent: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -17184,6 +17580,14 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   rechoir@0.8.0:
     dependencies:
@@ -17313,6 +17717,8 @@ snapshots:
       lodash.flattendeep: 4.4.0
       nearley: 2.20.1
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -17342,12 +17748,12 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.6(sass@1.93.2)(webpack@5.102.1(@swc/core@1.13.20)):
+  sass-loader@16.0.6(sass@1.93.2)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.93.2
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   sass@1.93.2:
     dependencies:
@@ -17640,11 +18046,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.102.1(@swc/core@1.13.20)):
+  source-map-loader@5.0.0(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   source-map-support@0.5.13:
     dependencies:
@@ -17713,7 +18119,7 @@ snapshots:
 
   ssri@10.0.6:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   ssri@9.0.1:
     dependencies:
@@ -17739,6 +18145,29 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      esbuild: 0.27.2
+      open: 10.2.0
+      recast: 0.23.11
+      semver: 7.7.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      ws: 8.18.3
+    optionalDependencies:
+      prettier: 3.6.2
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - react
+      - react-dom
+      - utf-8-validate
 
   stream-browserify@3.0.0:
     dependencies:
@@ -17875,6 +18304,8 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-indent@4.1.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strip-outer@1.0.1:
@@ -17902,9 +18333,9 @@ snapshots:
       prettier: 3.6.2
       tinycolor2: 1.6.0
 
-  style-loader@3.3.4(webpack@5.102.1(@swc/core@1.13.20)):
+  style-loader@3.3.4(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   stylehacks@6.1.1(postcss@8.5.6):
     dependencies:
@@ -18072,11 +18503,11 @@ snapshots:
 
   svgpath@2.6.0: {}
 
-  swc-loader@0.2.6(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20)):
+  swc-loader@0.2.6(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       '@swc/core': 1.13.20
       '@swc/counter': 0.1.3
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   symbol-tree@3.2.4: {}
 
@@ -18116,27 +18547,29 @@ snapshots:
 
   temp-dir@3.0.0: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20)):
+  terser-webpack-plugin@5.3.14(@swc/core@1.13.20)(esbuild@0.27.2)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
     optionalDependencies:
       '@swc/core': 1.13.20
+      esbuild: 0.27.2
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.13.20)(webpack@5.102.1):
+  terser-webpack-plugin@5.3.14(@swc/core@1.13.20)(esbuild@0.27.2)(webpack@5.102.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.13.20
+      esbuild: 0.27.2
 
   terser@5.44.0:
     dependencies:
@@ -18173,6 +18606,8 @@ snapshots:
       es5-ext: 0.10.64
       next-tick: 1.1.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinycolor2@1.6.0: {}
@@ -18187,6 +18622,8 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.0.3: {}
+
+  tinyspy@4.0.4: {}
 
   tldts-core@7.0.17: {}
 
@@ -18233,6 +18670,8 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-dedent@2.2.0: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -18403,12 +18842,12 @@ snapshots:
       shiki: 0.14.7
       typescript: 5.9.3
 
-  typescript-eslint@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18465,6 +18904,13 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.15.0
+      picomatch: 4.0.3
+      webpack-virtual-modules: 0.6.2
 
   unquote@1.1.1: {}
 
@@ -18666,7 +19112,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-dev-server: 4.15.2(webpack-cli@5.1.4)(webpack@5.102.1)
@@ -18685,17 +19131,17 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@5.3.4(webpack@5.102.1(@swc/core@1.13.20)):
+  webpack-dev-middleware@5.3.4(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
 
   webpack-dev-middleware@5.3.4(webpack@5.102.1):
     dependencies:
@@ -18704,7 +19150,7 @@ snapshots:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.3.3
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
 
   webpack-dev-server@4.15.2(webpack-cli@5.1.4)(webpack@5.102.1):
     dependencies:
@@ -18739,7 +19185,7 @@ snapshots:
       webpack-dev-middleware: 5.3.4(webpack@5.102.1)
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@4.15.2)(webpack@5.102.1)
     transitivePeerDependencies:
       - bufferutil
@@ -18747,7 +19193,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.15.2(webpack@5.102.1(@swc/core@1.13.20)):
+  webpack-dev-server@4.15.2(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18777,10 +19223,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.4(webpack@5.102.1(@swc/core@1.13.20))
+      webpack-dev-middleware: 5.3.4(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.20)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18804,7 +19250,9 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.102.1(@swc/core@1.13.20):
+  webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -18828,7 +19276,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.20)(webpack@5.102.1(@swc/core@1.13.20))
+      terser-webpack-plugin: 5.3.14(@swc/core@1.13.20)(esbuild@0.27.2)(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -18836,7 +19284,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.102.1(@swc/core@1.13.20)(webpack-cli@5.1.4):
+  webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -18860,7 +19308,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.20)(webpack@5.102.1)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.13.20)(esbuild@0.27.2)(webpack@5.102.1)
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -19017,6 +19465,10 @@ snapshots:
   ws@8.17.1: {}
 
   ws@8.18.3: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.0
 
   xml-name-validator@5.0.0: {}
 

--- a/scripts/submit-comment-with-artifact-links.mjs
+++ b/scripts/submit-comment-with-artifact-links.mjs
@@ -37,6 +37,7 @@ const ARTIFACTS = {
     landing: "packages/landing-app/dist/index.html",
     table: "packages/table-dev-app/dist/index.html",
     demo: "packages/demo-app/dist/index.html",
+    storybook: "storybook-static/index.html",
 };
 
 function getArtifactAnchorLink(pkg) {


### PR DESCRIPTION
## Summary

FLUP to experimental PR #7682

- Add Storybook (v10) config using `@storybook/react-vite`, pointed at Blueprint workspace packages
- Add Button stories for intents, sizes, variants, states, icons, and alignment
- Build and publish Storybook as a CI artifact alongside the existing preview apps
- Available locally via `pnpm storybook` and on PR preview links

<img width="3456" height="1634" alt="Screenshot 2026-03-13 at 16 08 40@2x" src="https://github.com/user-attachments/assets/86042ef1-7ddb-4468-ba0b-ab5ac0f6705d" />

## Test plan

-  Run `pnpm storybook` locally, check Button stories render
-  Confirm `pnpm build-storybook` succeeds
-  Check the CI preview comment includes a "storybook" link