### PR TITLE
[fix] Remove LARGE toggle from ButtongGroup

### DIFF
--- a/packages/docs-app/src/examples/core-examples/buttonGroupPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPlaygroundExample.tsx
@@ -43,7 +43,6 @@ export const ButtonGroupPlaygroundExample: React.FC<ExampleProps> = props => {
     const [fill, setFill] = useState(false);
     const [iconOnly, setIconOnly] = useState(false);
     const [intent, setIntent] = useState<Intent>(Intent.NONE);
-    const [large, setLarge] = useState(false);
     const [size, setSize] = useState<Size>("medium");
     const [variant, setVariant] = useState<ButtonVariant>("solid");
     const [vertical, setVertical] = useState(false);
@@ -52,7 +51,6 @@ export const ButtonGroupPlaygroundExample: React.FC<ExampleProps> = props => {
         <>
             <H5>Props</H5>
             <Switch checked={fill} label="Fill" onChange={handleBooleanChange(setFill)} />
-            <Switch checked={large} label="Large" onChange={handleBooleanChange(setLarge)} />
             <Switch
                 checked={vertical}
                 label="Vertical"


### PR DESCRIPTION
#### Changes proposed in this pull request:
The `Large` toggle in the Interactive Playground actually does nothing. When you toggle it, nothing happens. The stateful value isn't used anywhere either. The real value we track is `Size` which you can also set very easily in the playground.

#### Where is this
<img width="840" height="605" alt="Screenshot 2026-03-16 at 9 29 49 AM" src="https://github.com/user-attachments/assets/a4ed5b17-d4ad-4359-b20c-1cb7a32ccfc0" />
