### PR TITLE
[fix] Remove LARGE toggle from ButtonGroupPopover

### DIFF
--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -38,7 +38,6 @@ import { VariantSelect } from "./common/variantSelect";
 export const ButtonGroupPopoverExample: React.FC<ExampleProps> = props => {
     const [alignText, setAlignText] = useState<TextAlignment>(TextAlignment.CENTER);
     const [fill, setFill] = useState(false);
-    const [large, setLarge] = useState(false);
     const [size, setSize] = useState<Size>("medium");
     const [variant, setVariant] = useState<ButtonVariant>("solid");
     const [vertical, setVertical] = useState(false);
@@ -47,7 +46,6 @@ export const ButtonGroupPopoverExample: React.FC<ExampleProps> = props => {
         <>
             <H5>Props</H5>
             <Switch label="Fill" checked={fill} onChange={handleBooleanChange(setFill)} />
-            <Switch label="Large" checked={large} onChange={handleBooleanChange(setLarge)} />
             <VariantSelect onChange={setVariant} variant={variant} />
             <Switch
                 label="Vertical"


### PR DESCRIPTION
#### FLUP to [[fix] Remove LARGE toggle from ButtongGroup](https://github.com/palantir/blueprint/pull/7868#top)

The `Large` toggle actually does nothing. When you toggle it, nothing happens. The stateful value isn't used anywhere either. The real value we track is `Size` which you can also set very easily in the playground.