### PR TITLE
(chore) Enhance CardList docs

### DIFF
--- a/packages/core/src/components/card-list/card-list.md
+++ b/packages/core/src/components/card-list/card-list.md
@@ -10,26 +10,35 @@ Long lists can be styled with CSS for vertical scrolling.
 import { CardList } from "@blueprintjs/core";
 ```
 
-@## Usage
+```tsx
+<CardList>
+    <Card>Option 1</Card>
+    <Card>Option 2</Card>
+</CardList>
+```
+
+@## Examples
+
+@### Basic
 
 Use **CardList** to group multiple cards together in a vertical list.
 
 @reactCodeExample CardListBasicExample
 
-@## Bordered
+@### Bordered
 
 To remove borders, set `bordered={false}`. This creates a seamless appearance
 when nesting **CardList** within other components.
 
 @reactCodeExample CardListBorderedExample
 
-@## Compact
+@### Compact
 
 Enable the `compact` prop to reduce the padding inside each card in the list.
 
 @reactCodeExample CardListCompactExample
 
-@## Combining with section
+@### Combining with section
 
 The **CardList** component can be embedded in a [**Section**](#core/components/section)
 component to add a title or description above the list.

--- a/packages/core/src/components/card-list/card-list.md
+++ b/packages/core/src/components/card-list/card-list.md
@@ -4,7 +4,7 @@
 It groups cards visually into a list without adding extra visual weight or spacing between them.
 Long lists can be styled with CSS for vertical scrolling.
 
-@## Import
+@## Usage
 
 ```tsx
 import { CardList } from "@blueprintjs/core";


### PR DESCRIPTION
#### Related to [(chore) Enhance Breadcrumbs docs](https://github.com/palantir/blueprint/pull/7824#top)

#### Changes proposed in this pull request:
We want to (a) begin instilling a sense of order/structure in our docs and (b) provide more plentiful examples of how to use the various props in the docs.

The `CardList` docs are already pretty robust, so this is just a very minor structural tweak

#### Reviewers should focus on:
Readability, content, quality of examples.

#### Before
<img width="1363" height="823" alt="Screenshot 2026-03-16 at 12 01 20 PM" src="https://github.com/user-attachments/assets/46c2fd66-11f7-4d0c-a2e9-49b9e7cc722f" />

#### After
<img width="1285" height="838" alt="Screenshot 2026-03-16 at 1 55 00 PM" src="https://github.com/user-attachments/assets/ffd451aa-c9d8-426a-93a5-eb7a48f0206d" />
