### PR TITLE
Adds new docs content instead of completely overwriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "copy:ci-config": "mkdir -p site/.circleci && cp .circleci/config-gh-pages.yml site/.circleci/config.yml",
         "copy:docs-app": "cp -rf packages/docs-app/dist/ site/docs",
         "copy:landing-app": "cp -rf packages/landing-app/dist/ site",
-        "deploy:site": "gh-pages -d site -b gh-pages",
+        "deploy:site": "gh-pages -d site -b gh-pages --add",
         "dev": "nx run-many -t dev --exclude @blueprintjs/landing-app @blueprintjs/table-dev-app",
         "dev:core": "nx run-many -t dev -p @blueprintjs/core @blueprintjs/icons @blueprintjs/docs-app",
         "dev:docs": "nx run-many -t dev -p @blueprintjs/docs-app @blueprintjs/docs-theme",


### PR DESCRIPTION
#### Fixes
Allows `pnpm deploy:site` to deploy without erasing previous versions

#### Checklist

- [ ] Includes tests
- [X] Update documentation (already updated in our release process)

#### Changes proposed in this pull request:

Instead of copying over generated site docs using the previous process, follow the current release process of:

1. `pnpm clean && pnpm nx clear-cache && pnpm compile && pnpm dist`
2. `pnpm site` to do a local test
3. `pnpm deploy:site`

>[!NOTE]
> To add a commit message (such as `docs v...`), you can use `pnpm deploy:site -- -m "docs vx.xx.x"`, so `pnpm deploy:site -- -m "docs v6.10.0"` in this case

Previous process was:

```
1. After a [successful publish to NPM](https://www.npmjs.com/~blueprintjs) (can also check [`core` package directly here](https://www.npmjs.com/package/@blueprintjs/core), or follow the CI job on the "Publish" commit), run the following on `develop` to produce a clean build:
    ```sh
    pnpm clean && pnpm nx clear-cache && pnpm compile && pnpm dist
    ```

2. Run the docs preparation task to copy assets to the `site/` directory and launch a local HTTP server:

    ```sh
    pnpm site
    ```

3. Do a spot check on the local server to confirm that the site is in order and the version numbers you just released appear in the sidebar.
5. (If you haven't already) Create a second local check-out of the blueprint git repository at `../blueprint-gh-pages` which is checked out at the `gh-pages` branch
6. Copy the locally-built docs site to your second git repo checkout:

    ```sh
    cp -r site/docs/ ../blueprint-gh-pages/docs/
    ```

7. Create a commit for the docs update:
    ```sh
    cd ../blueprint-gh-pages
    git add .
    git commit -m "docs v6.x" # replace this with the version of @blueprintjs/core just released
    ````
8. Push to the `gh-pages` branch:
    ```sh
    git push origin gh-pages
    ````
```

#### Reviewers should focus on:

- [ ] Docs site is up and running, as well as previous versions

#### Screenshot

N/A
