### PR TITLE
(chore) Update outdated Node.js and pnpm versions in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 ## Architecture
 
 - **Monorepo** using pnpm workspaces + Nx task runner
-- **Package manager**: pnpm v10.18.3 (strict dependency resolution)
+- **Package manager**: pnpm v10.29.3 (strict dependency resolution)
 - **Packages**: Core UI components in `packages/` - core, datetime, select, table, icons, colors
 - **Apps**: docs-app (blueprintjs.com), demo-app, table-dev-app for development
 - **Build tools**: karma-build-scripts, node-build-scripts, webpack-build-scripts

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ then [check out the "help wanted" label](https://github.com/palantir/blueprint/l
 Builds are orchestrated via [Nx's task runner](https://nx.dev/getting-started/intro) and NPM scripts.
 [Lerna-Lite](https://github.com/lerna-lite/lerna-lite) is used to prepare releases.
 
-**Prerequisites**: Node.js v20.11+ (see version specified in `.nvmrc`), pnpm v10.x (see version specified in `package.json`)
+**Prerequisites**: Node.js v24.11+ (see version specified in `.nvmrc`), pnpm v10.x (see version specified in `package.json`)
 
 ### One-time setup
 


### PR DESCRIPTION
The prerequisites section in README.md still referenced Node.js v20.11, 
but .nvmrc and package.json both specify v24.11. Similarly, AGENTS.md 
listed pnpm v10.18.3 while package.json specifies v10.29.3.