### PR TITLE
(chore) Enhance Divider docs

### DIFF
--- a/packages/core/src/components/divider/divider.md
+++ b/packages/core/src/components/divider/divider.md
@@ -10,13 +10,21 @@ additional styles. Otherwise, a **Divider** will appear as a full-width 1px-high
 import { Divider } from "@blueprintjs/core";
 ```
 
-@## Usage
+```tsx
+Option 1
+<Divider />
+Option 2
+```
+
+@## Examples
+
+@### Basic
 
 Use **Divider** to separate blocks of content within a page or container. By default, it spans the full width of its container.
 
 @reactCodeExample DividerBasicExample
 
-@## Compact
+@### Compact
 
 The `compact` prop removes the margin from the divider, making it flush with adjacent content.
 
@@ -24,7 +32,7 @@ The `compact` prop removes the margin from the divider, making it flush with adj
 <Divider compact />
 ```
 
-@## Vertical
+@### Vertical
 
 When used inside a flex container, **Divider** adapts to the layout's direction. It becomes a vertical divider when placed between flex items.
 

--- a/packages/core/src/components/divider/divider.md
+++ b/packages/core/src/components/divider/divider.md
@@ -4,7 +4,7 @@
 It works best in flex layouts where they will adapt to orientation without
 additional styles. Otherwise, a **Divider** will appear as a full-width 1px-high block element.
 
-@## Import
+@## Usage
 
 ```tsx
 import { Divider } from "@blueprintjs/core";


### PR DESCRIPTION
#### Related to [(chore) Enhance Breadcrumbs docs](https://github.com/palantir/blueprint/pull/7824#top)

#### Changes proposed in this pull request:
We want to (a) begin instilling a sense of order/structure in our docs and (b) provide more plentiful examples of how to use the various props in the docs.

The `Divider` docs are already pretty robust, so this is just a very minor structural tweak

#### Reviewers should focus on:
Readability, content, quality of examples.

#### Before
<img width="836" height="710" alt="Screenshot 2026-03-16 at 2 24 59 PM" src="https://github.com/user-attachments/assets/dc5e29ee-c737-4e11-ae42-299626c2341b" />
