### PR TITLE
(chore) Remove karma reference from datetime gitignore

### DIFF
--- a/packages/datetime/.npmignore
+++ b/packages/datetime/.npmignore
@@ -1,5 +1,4 @@
 coverage/
 test/
 webpack.config.js
-karma.conf.js
 .npmrc


### PR DESCRIPTION
#### FLUP to these
- [(chore) Migrate /datetime to vitest pt2 - vitest usage](https://github.com/palantir/blueprint/pull/7825#top)
- [(chore) Migrate /datetime to vitest pt3 - sinon mocks conversion](https://github.com/palantir/blueprint/pull/7828#top)
- [(chore) Migrate /datetime to vitest pt4 - migrate from assert to expect](https://github.com/palantir/blueprint/pull/7831#top)
- [(chore) Migrate /datetime to vitest pt5 - migrate to BDD style assertions](https://github.com/palantir/blueprint/pull/7845#top)

#### Core goal
Remove now unnecessary reference to `karma`