### PR TITLE
(chore) Enhance Collapse docs

### DIFF
--- a/packages/core/src/components/collapse/collapse.md
+++ b/packages/core/src/components/collapse/collapse.md
@@ -3,13 +3,21 @@
 The **Collapse** component reveals and hides content with a smooth sliding animation.
 It is commonly used to create expandable sections, like settings panels, sub-sections, or FAQs.
 
-@## Import
+@## Usage
 
 ```tsx
 import { Collapse } from "@blueprintjs/core";
 ```
 
-@## Usage
+```tsx
+<Collapse isOpen={isOpen}>
+    <p>This is an example of collapsible content.</p>
+</Collapse>
+```
+
+@## Examples
+
+@### Basic
 
 The **Collapse** component wraps its children and toggles their visibility with a sliding animation.
 The `isOpen` prop controls whether the content is visible. Content must be in the normal document
@@ -17,7 +25,7 @@ flow (i.e., avoid `position: absolute;`), as **Collapse** calculates height to a
 
 @reactCodeExample CollapseBasicExample
 
-@## Keeping children mounted
+@### Keeping children mounted
 
 By default, **Collapse** removes its children from the DOM when the collapse is closed.
 This improves performance, especially when there are many collapsible elements on a page.


### PR DESCRIPTION
#### Related to [(chore) Enhance Breadcrumbs docs](https://github.com/palantir/blueprint/pull/7824#top)

#### Changes proposed in this pull request:
We want to begin instilling a sense of order/structure in our docs

#### Reviewers should focus on:
Readability, content, quality of examples.

#### Before
<img width="1331" height="790" alt="Screenshot 2026-03-17 at 1 23 51 PM" src="https://github.com/user-attachments/assets/2a798e5e-8c34-46e6-9eb9-c8fb3057ab8b" />

#### After
<img width="1305" height="638" alt="Screenshot 2026-03-17 at 1 24 04 PM" src="https://github.com/user-attachments/assets/b9eb8041-e689-42b9-b397-14a9a357eaf5" />


