### PR TITLE
fix(core): fix OverlayToaster treating empty array children as open overlay

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7884.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7884.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: 'fix(OverlayToaster): treat empty array children the same as null when determining isOpen state'
+  links:
+  - https://github.com/palantir/blueprint/pull/7884

--- a/packages/core/changelog/@unreleased/pr-7884.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7884.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: 'fix(OverlayToaster): treat empty array children the same as null when determining isOpen state'
-  links:
-  - https://github.com/palantir/blueprint/pull/7884

--- a/packages/core/src/components/toast/overlayToaster.test.tsx
+++ b/packages/core/src/components/toast/overlayToaster.test.tsx
@@ -292,6 +292,24 @@ describe("OverlayToaster", () => {
         });
     });
 
+    describe("with empty array children", () => {
+        beforeAll(async () => {
+            containerElement = document.createElement("div");
+            document.documentElement.appendChild(containerElement);
+            toaster = await OverlayToaster.create({ children: [] }, { container: containerElement, domRenderer });
+        });
+
+        afterAll(() => {
+            document.documentElement.removeChild(containerElement);
+        });
+
+        it("does not treat empty array children as open overlay", async () => {
+            await waitFor(() => {
+                assert.isNull(containerElement.querySelector(`.${Classes.TOAST_CONTAINER}.${Classes.OVERLAY_OPEN}`));
+            });
+        });
+    });
+
     describe("validation", () => {
         it("throws an error when max toast is set to a number less than 1", () => {
             expectPropValidationError(OverlayToaster, { maxToasts: 0 }, TOASTER_MAX_TOASTS_INVALID);

--- a/packages/core/src/components/toast/overlayToaster.tsx
+++ b/packages/core/src/components/toast/overlayToaster.tsx
@@ -15,7 +15,7 @@
  */
 
 import classNames from "classnames";
-import { createRef } from "react";
+import { Children, createRef } from "react";
 import { createRoot } from "react-dom/client";
 
 import { AbstractPureComponent, Classes, Position } from "../../common";
@@ -267,7 +267,7 @@ export class OverlayToaster extends AbstractPureComponent<OverlayToasterProps, O
                 childRefs={this.toastRefs}
                 enforceFocus={false}
                 hasBackdrop={false}
-                isOpen={this.state.toasts.length > 0 || this.props.children != null}
+                isOpen={this.state.toasts.length > 0 || Children.count(this.props.children) > 0}
                 onClose={this.handleClose}
                 shouldReturnFocusOnClose={false}
                 // $pt-transition-duration * 3 + $pt-transition-duration / 2


### PR DESCRIPTION
## Problem

  When `OverlayToaster` receives an empty array `[]` as `children`, the overlay
  is incorrectly marked as open because `[] != null` evaluates to `true`. This
  causes the `Overlay2` keydown listener (added in #7594 / #7669) to intercept
  Escape key presses, preventing application-level key handlers from firing.

  In standard React, an empty array renders nothing, the same as `null`, so
  the overlay should not be considered open.

  ## Solution

  Replace `this.props.children != null` with `React.Children.count(this.props.children) > 0`.
  `React.Children.count` returns `0` for `null`, `undefined`, and empty arrays,
  correctly matching React's rendering semantics.

  Fixes #7864