### PR TITLE
chore: Migrate tests from Enzyme to RTL

### DIFF
--- a/packages/core/src/components/collapse/collapse.test.tsx
+++ b/packages/core/src/components/collapse/collapse.test.tsx
@@ -14,60 +14,71 @@
  * limitations under the License.
  */
 
-import { mount, shallow } from "enzyme";
+import { render } from "@testing-library/react";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
-import { MenuItem } from "../menu/menuItem";
 
-import { AnimationStates, Collapse } from "./collapse";
+import { Collapse } from "./collapse";
 
 describe("<Collapse>", () => {
     it("has the correct className", () => {
-        const collapse = shallow(<Collapse />);
-        assert.isTrue(collapse.hasClass(Classes.COLLAPSE));
+        const { container } = render(<Collapse />);
+        expect(container.querySelector(`.${Classes.COLLAPSE}`)).toBeInTheDocument();
     });
 
     it("is closed", () => {
-        const collapse = mount(<Collapse isOpen={false}>Body</Collapse>);
-        assert.strictEqual(collapse.state("height"), "0px");
+        const { container } = render(<Collapse isOpen={false}>Body</Collapse>);
+        const collapseBody = assertElement(container, `.${Classes.COLLAPSE_BODY}`);
+        expect(collapseBody).toHaveAttribute("aria-hidden", "true");
+        // children are not rendered when closed
+        expect(container.textContent).not.toContain("Body");
     });
 
     it("is open", () => {
-        const collapse = mount(<Collapse isOpen={true}>Body</Collapse>);
-        assert.strictEqual(collapse.state("height"), "auto");
+        const { container } = render(<Collapse isOpen={true}>Body</Collapse>);
+        const collapse = assertElement(container, `.${Classes.COLLAPSE}`);
+        expect(collapse).toHaveStyle({ height: "auto" });
     });
 
     it("is opening", () => {
-        const collapse = mount(<Collapse isOpen={false}>Body</Collapse>);
-        collapse.setProps({ isOpen: true });
-        assert.strictEqual(collapse.state("animationState"), AnimationStates.OPENING);
+        const { container, rerender } = render(<Collapse isOpen={false}>Body</Collapse>);
+        rerender(<Collapse isOpen={true}>Body</Collapse>);
+        const collapseBody = assertElement(container, `.${Classes.COLLAPSE_BODY}`);
+        // When transitioning to open, children become visible and aria-hidden is removed
+        expect(container.textContent).toContain("Body");
+        expect(collapseBody).toHaveAttribute("aria-hidden", "false");
     });
 
     it("supports custom intrinsic element", () => {
-        assert.isTrue(shallow(<Collapse component="article" />).is("article"));
+        const { container } = render(<Collapse component="article" />);
+        expect(container.querySelector("article")).toHaveClass(Classes.COLLAPSE);
     });
 
     it("supports custom Component", () => {
-        assert.isTrue(shallow(<Collapse component={MenuItem} />).is(MenuItem));
+        // Use a simple custom component to verify the component prop is respected
+        const CustomWrapper = (props: React.HTMLAttributes<HTMLElement>) => <section {...props} />;
+        const { container } = render(<Collapse component={CustomWrapper} />);
+        expect(container.querySelector("section")).toHaveClass(Classes.COLLAPSE);
     });
 
     it("unmounts children by default", () => {
-        const collapse = mount(
+        const { container } = render(
             <Collapse isOpen={false}>
                 <div className="removed-child" />
             </Collapse>,
         );
-        assert.lengthOf(collapse.find(".removed-child"), 0);
+        expect(container.querySelector(".removed-child")).not.toBeInTheDocument();
     });
 
     it("keepChildrenMounted keeps child mounted", () => {
-        const collapse = mount(
+        const { container } = render(
             <Collapse isOpen={false} keepChildrenMounted={true}>
                 <div className="hidden-child" />
             </Collapse>,
         );
-        assert.lengthOf(collapse.find(".hidden-child"), 1);
+        expect(container.querySelector(".hidden-child")).toBeInTheDocument();
     });
 });

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { mount } from "enzyme";
+import { render } from "@testing-library/react";
 
 import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 import { afterEach, beforeAll, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes, Intent } from "../../common";
 
@@ -50,121 +51,110 @@ describe("<Icon>", () => {
         iconLoader?.mockClear();
     });
 
-    it("tagName dictates HTML tag", async () => {
-        const wrapper = mount(<Icon icon="calendar" tagName="i" />);
-        wrapper.update();
-        expect(wrapper.find("i").exists()).toBe(true);
+    it("tagName dictates HTML tag", () => {
+        const { container } = render(<Icon icon="calendar" tagName="i" />);
+        expect(container.querySelector("i")).toBeInTheDocument();
     });
 
-    it("size=16 renders standard size", async () =>
+    it("size=16 renders standard size", () =>
         assertIconSize(<Icon icon="graph" size={IconSize.STANDARD} />, IconSize.STANDARD));
 
-    it("size=20 renders large size", async () =>
+    it("size=20 renders large size", () =>
         assertIconSize(<Icon icon="graph" size={IconSize.LARGE} />, IconSize.LARGE));
 
-    it("renders intent class", async () => {
-        const wrapper = mount(<Icon icon="add" intent={Intent.DANGER} />);
-        expect(wrapper.find(`.${Classes.INTENT_DANGER}`).exists()).toBe(true);
+    it("renders intent class", () => {
+        const { container } = render(<Icon icon="add" intent={Intent.DANGER} />);
+        expect(container.querySelector(`.${Classes.INTENT_DANGER}`)).toBeInTheDocument();
     });
 
-    it.skip("renders icon name", async () => {
+    it.skip("renders icon name", () => {
         assertIconHasPath(<Icon icon="calendar" />, "calendar");
     });
 
-    it("renders icon without color", async () => {
+    it("renders icon without color", () => {
         assertIconColor(<Icon icon="add" />);
     });
 
-    it("renders icon color", async () => {
+    it("renders icon color", () => {
         assertIconColor(<Icon icon="add" color="red" />, "red");
     });
 
-    it("unknown icon name renders blank icon", async () => {
-        const wrapper = mount(<Icon icon={"unknown" as any} />);
-        wrapper.update();
-        expect(wrapper.find("path")).toHaveLength(0);
+    it("unknown icon name renders blank icon", () => {
+        const { container } = render(<Icon icon={"unknown" as any} />);
+        expect(container.querySelectorAll("path")).toHaveLength(0);
     });
 
-    it("prefixed icon renders blank icon", async () => {
-        const wrapper = mount(<Icon icon={Classes.iconClass("airplane") as any} />);
-        wrapper.update();
-        expect(wrapper.find("path")).toHaveLength(0);
+    it("prefixed icon renders blank icon", () => {
+        const { container } = render(<Icon icon={Classes.iconClass("airplane") as any} />);
+        expect(container.querySelectorAll("path")).toHaveLength(0);
     });
 
-    it("icon element passes through unchanged", async () => {
-        // NOTE: This is supported to simplify usage of this component in other
-        // Blueprint components which accept `icon?: IconName | React.JSX.Element`.
-        const onClick = () => true;
-        const wrapper = mount(<Icon icon={<article onClick={onClick} />} />);
-        wrapper.update();
-        expect(wrapper.childAt(0).is("article")).toBe(true);
-        expect(wrapper.find("article").prop("onClick")).toBe(onClick);
+    it("icon element passes through unchanged", () => {
+        const { container } = render(<Icon icon={<article />} />);
+        expect(container.querySelector("article")).toBeInTheDocument();
     });
 
-    it("icon=undefined renders nothing", async () => {
-        const wrapper = mount(<Icon icon={undefined} />);
-        wrapper.update();
-        expect(wrapper.isEmptyRender()).toBe(true);
+    it("icon=undefined renders nothing", () => {
+        const { container } = render(<Icon icon={undefined} />);
+        expect(container.innerHTML).toBe("");
     });
 
-    it("title sets content of <title> element", async () => {
-        const wrapper = mount(<Icon icon="airplane" title="bird" />);
-        wrapper.update();
-        expect(wrapper.find("title").text()).toBe("bird");
+    it("title sets content of <title> element", () => {
+        const { container } = render(<Icon icon="airplane" title="bird" />);
+        expect(container.querySelector("title")).toHaveTextContent("bird");
     });
 
     it("does not add desc if title is not provided", () => {
-        const icon = mount(<Icon icon="airplane" />);
-        expect(icon.find("desc")).toHaveLength(0);
+        const { container } = render(<Icon icon="airplane" />);
+        expect(container.querySelectorAll("desc")).toHaveLength(0);
     });
 
     it("applies aria-hidden=true if title is not defined", () => {
-        const icon = mount(<Icon icon="airplane" />);
-        expect(icon.find(`.${Classes.ICON}`).hostNodes().prop("aria-hidden")).toBe(true);
+        const { container } = render(<Icon icon="airplane" />);
+        expect(container.querySelector(`.${Classes.ICON}`)).toHaveAttribute("aria-hidden", "true");
     });
 
     it("supports mouse event handlers of type React.MouseEventHandler", () => {
         const handleClick: React.MouseEventHandler = () => undefined;
-        mount(<Icon icon="add" onClick={handleClick} />);
+        render(<Icon icon="add" onClick={handleClick} />);
     });
 
     it("accepts HTML attributes", () => {
-        mount(<Icon<HTMLSpanElement> icon="drag-handle-vertical" draggable={false} />);
+        render(<Icon<HTMLSpanElement> icon="drag-handle-vertical" draggable={false} />);
     });
 
     it("accepts generic type param specifying the type of the root element", () => {
         const handleClick: React.MouseEventHandler<HTMLSpanElement> = () => undefined;
-        mount(<Icon<HTMLSpanElement> icon="add" onClick={handleClick} />);
+        render(<Icon<HTMLSpanElement> icon="add" onClick={handleClick} />);
     });
 
     it("allows specifying the root element as <svg> when tagName={null}", () => {
-        const handleClick: React.MouseEventHandler<SVGSVGElement> = () => undefined;
-        const wrapper = mount(<Icon<SVGSVGElement> icon="add" onClick={handleClick} tagName={null} />);
-        expect(wrapper.find("span").exists()).toBe(false);
+        const { container } = render(<Icon<SVGSVGElement> icon="add" onClick={() => undefined} tagName={null} />);
+        expect(container.querySelector("span")).not.toBeInTheDocument();
     });
 
     /** Asserts that rendered icon has an SVG path. */
-    async function assertIconHasPath(icon: React.ReactElement<IconProps>, iconName: IconName) {
-        const wrapper = mount(icon);
-        wrapper.update();
-        expect(wrapper.text()).toBe(iconName);
-        expect(wrapper.find("path").length, "should find at least one path element").toBeGreaterThan(0);
+    function assertIconHasPath(icon: React.ReactElement<IconProps>, _iconName: IconName) {
+        const { container } = render(icon);
+        expect(container.querySelectorAll("path").length, "should find at least one path element").toBeGreaterThan(0);
     }
 
     /** Asserts that rendered icon has width/height equal to size. */
-    async function assertIconSize(icon: React.ReactElement<IconProps>, size: number) {
-        const wrapper = mount(icon);
-        wrapper.update();
-        const svg = wrapper.find("svg");
-        expect(svg.prop("width")).toBe(size);
-        expect(svg.prop("height")).toBe(size);
+    function assertIconSize(icon: React.ReactElement<IconProps>, size: number) {
+        const { container } = render(icon);
+        const svg = assertElement(container, "svg");
+        expect(svg).toHaveAttribute("width", String(size));
+        expect(svg).toHaveAttribute("height", String(size));
     }
 
     /** Asserts that rendered icon has color equal to color. */
-    async function assertIconColor(icon: React.ReactElement<IconProps>, color?: string) {
-        const wrapper = mount(icon);
-        wrapper.update();
-        const svg = wrapper.find("svg");
-        expect(svg.prop("fill")).toEqual(color);
+    function assertIconColor(icon: React.ReactElement<IconProps>, color?: string) {
+        const { container } = render(icon);
+        const svg = assertElement(container, "svg");
+        if (color) {
+            expect(svg).toHaveAttribute("fill", color);
+        } else {
+            expect(svg.getAttribute("fill")).toBeNull();
+        }
     }
 });

--- a/packages/core/src/components/menu/menu.test.tsx
+++ b/packages/core/src/components/menu/menu.test.tsx
@@ -17,6 +17,7 @@
 import { render, within } from "@testing-library/react";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
 
@@ -27,7 +28,7 @@ import { MenuItem } from "./menuItem";
 describe("<MenuDivider>", () => {
     it("React renders MenuDivider", () => {
         const { container } = render(<MenuDivider />);
-        const divider = container.querySelector("li")!;
+        const divider = assertElement(container, "li");
         expect(divider).toHaveClass(Classes.MENU_DIVIDER);
         expect(divider).not.toHaveClass(Classes.MENU_HEADER);
         expect(divider.querySelector("h6")).not.toBeInTheDocument();
@@ -35,7 +36,7 @@ describe("<MenuDivider>", () => {
 
     it("React renders MenuDivider with title", () => {
         const { container } = render(<MenuDivider title="Subject" />);
-        const divider = container.querySelector("li")!;
+        const divider = assertElement(container, "li");
         expect(divider).not.toHaveClass(Classes.MENU_DIVIDER);
         expect(divider).toHaveClass(Classes.MENU_HEADER);
         expect(divider.querySelector("h6")).toBeInTheDocument();
@@ -49,8 +50,7 @@ describe("<Menu>", () => {
                 <MenuItem icon="graph" text="Graph" />
             </Menu>,
         );
-        const menu = container.querySelector(`.${Classes.MENU}`)!;
-        expect(menu).toBeInTheDocument();
-        expect(within(menu as HTMLElement).getAllByRole("menuitem")).toHaveLength(1);
+        const menu = assertElement(container, `.${Classes.MENU}`);
+        expect(within(menu).getAllByRole("menuitem")).toHaveLength(1);
     });
 });

--- a/packages/core/src/components/menu/menu.test.tsx
+++ b/packages/core/src/components/menu/menu.test.tsx
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import { shallow } from "enzyme";
+import { render, within } from "@testing-library/react";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
-import { H6 } from "../html/html";
 
 import { Menu } from "./menu";
 import { MenuDivider } from "./menuDivider";
@@ -27,28 +26,31 @@ import { MenuItem } from "./menuItem";
 
 describe("<MenuDivider>", () => {
     it("React renders MenuDivider", () => {
-        const divider = shallow(<MenuDivider />);
-        assert.isTrue(divider.hasClass(Classes.MENU_DIVIDER));
-        assert.isFalse(divider.hasClass(Classes.MENU_HEADER));
-        assert.isFalse(divider.find(H6).exists());
+        const { container } = render(<MenuDivider />);
+        const divider = container.querySelector("li")!;
+        expect(divider).toHaveClass(Classes.MENU_DIVIDER);
+        expect(divider).not.toHaveClass(Classes.MENU_HEADER);
+        expect(divider.querySelector("h6")).not.toBeInTheDocument();
     });
 
     it("React renders MenuDivider with title", () => {
-        const divider = shallow(<MenuDivider title="Subject" />);
-        assert.isFalse(divider.hasClass(Classes.MENU_DIVIDER));
-        assert.isTrue(divider.hasClass(Classes.MENU_HEADER));
-        assert.isTrue(divider.find(H6).exists());
+        const { container } = render(<MenuDivider title="Subject" />);
+        const divider = container.querySelector("li")!;
+        expect(divider).not.toHaveClass(Classes.MENU_DIVIDER);
+        expect(divider).toHaveClass(Classes.MENU_HEADER);
+        expect(divider.querySelector("h6")).toBeInTheDocument();
     });
 });
 
 describe("<Menu>", () => {
     it("React renders Menu with children", () => {
-        const menu = shallow(
+        const { container } = render(
             <Menu>
                 <MenuItem icon="graph" text="Graph" />
             </Menu>,
         );
-        assert.isTrue(menu.hasClass(Classes.MENU));
-        assert.lengthOf(menu.find(MenuItem), 1);
+        const menu = container.querySelector(`.${Classes.MENU}`)!;
+        expect(menu).toBeInTheDocument();
+        expect(within(menu as HTMLElement).getAllByRole("menuitem")).toHaveLength(1);
     });
 });

--- a/packages/core/src/components/non-ideal-state/nonIdealState.test.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.test.tsx
@@ -17,6 +17,7 @@
 import { render } from "@testing-library/react";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
 
@@ -45,7 +46,7 @@ describe("<NonIdealState>", () => {
 
     it("ensures description is wrapped in an element", () => {
         const { container } = render(<NonIdealState action={<strong />} description="foo" />);
-        const textContainer = container.querySelector(`.${Classes.NON_IDEAL_STATE_TEXT}`)!;
+        const textContainer = assertElement(container, `.${Classes.NON_IDEAL_STATE_TEXT}`);
         const divs = textContainer.querySelectorAll("div");
         expect(divs).toHaveLength(1);
         expect(divs[0].textContent).toBe("foo");

--- a/packages/core/src/components/non-ideal-state/nonIdealState.test.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.test.tsx
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import { shallow } from "enzyme";
+import { render } from "@testing-library/react";
 
-import { assert, describe, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
-import { H4 } from "../html/html";
 
 import { NonIdealState } from "./nonIdealState";
 
 describe("<NonIdealState>", () => {
     it("renders its contents", () => {
-        const wrapper = shallow(
+        const { container } = render(
             <NonIdealState
                 action={<p>More text!</p>}
                 description="An error occurred."
@@ -33,21 +32,22 @@ describe("<NonIdealState>", () => {
                 icon="folder-close"
             />,
         );
-        assert.exists(wrapper.find(H4), "missing H4");
-        [Classes.NON_IDEAL_STATE_VISUAL, Classes.ICON_MUTED, Classes.NON_IDEAL_STATE].forEach(className => {
-            assert.exists(wrapper.find(`.${className}`), `missing ${className}`);
-        });
+        expect(container.querySelector("h4")).toBeInTheDocument();
+        for (const className of [Classes.NON_IDEAL_STATE_VISUAL, Classes.ICON_MUTED, Classes.NON_IDEAL_STATE]) {
+            expect(container.querySelector(`.${className}`)).toBeInTheDocument();
+        }
     });
 
     it("does not apply icon muted style", () => {
-        const wrapper = shallow(<NonIdealState title="ERROR" icon="folder-close" iconMuted={false} />);
-        assert.isFalse(wrapper.find(`.${Classes.ICON_MUTED}`).exists(), `unexpected ${Classes.ICON_MUTED}`);
+        const { container } = render(<NonIdealState title="ERROR" icon="folder-close" iconMuted={false} />);
+        expect(container.querySelector(`.${Classes.ICON_MUTED}`)).not.toBeInTheDocument();
     });
 
     it("ensures description is wrapped in an element", () => {
-        const wrapper = shallow(<NonIdealState action={<strong />} description="foo" />);
-        const div = wrapper.find(`.${Classes.NON_IDEAL_STATE_TEXT}`).children().find("div");
-        assert.lengthOf(div, 1);
-        assert.strictEqual(div.text(), "foo");
+        const { container } = render(<NonIdealState action={<strong />} description="foo" />);
+        const textContainer = container.querySelector(`.${Classes.NON_IDEAL_STATE_TEXT}`)!;
+        const divs = textContainer.querySelectorAll("div");
+        expect(divs).toHaveLength(1);
+        expect(divs[0].textContent).toBe("foo");
     });
 });

--- a/packages/core/src/components/section/section.test.tsx
+++ b/packages/core/src/components/section/section.test.tsx
@@ -18,6 +18,7 @@ import { render, screen } from "@testing-library/react";
 
 import { IconNames } from "@blueprintjs/icons";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
 
@@ -38,8 +39,7 @@ describe("<Section>", () => {
 
     it("supports className", () => {
         const { container } = render(<Section className="foo" />);
-        const section = container.querySelector(`.${Classes.SECTION}`)!;
-        expect(section).toBeInTheDocument();
+        const section = assertElement(container, `.${Classes.SECTION}`);
         expect(section).toHaveClass("foo");
     });
 

--- a/packages/core/src/components/section/section.test.tsx
+++ b/packages/core/src/components/section/section.test.tsx
@@ -14,127 +14,101 @@
  * limitations under the License.
  */
 
-import { mount, type ReactWrapper } from "enzyme";
+import { render, screen } from "@testing-library/react";
 
 import { IconNames } from "@blueprintjs/icons";
-import { afterEach, assert, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
+import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
-import { H5, H6 } from "../html/html";
 
 import { Section } from "./section";
 import { SectionCard } from "./sectionCard";
 
 describe("<Section>", () => {
-    let containerElement: HTMLElement;
-
     const isOpenSelector = `[data-icon="${IconNames.CHEVRON_UP}"]`;
     const isClosedSelector = `[data-icon="${IconNames.CHEVRON_DOWN}"]`;
 
-    const assertIsOpen = (wrapper: ReactWrapper) => {
-        assert.isTrue(wrapper.find(isOpenSelector).exists());
+    const assertIsOpen = (container: HTMLElement) => {
+        expect(container.querySelector(isOpenSelector)).toBeInTheDocument();
     };
 
-    const assertIsClosed = (wrapper: ReactWrapper) => {
-        assert.isTrue(wrapper.find(isClosedSelector).exists());
+    const assertIsClosed = (container: HTMLElement) => {
+        expect(container.querySelector(isClosedSelector)).toBeInTheDocument();
     };
-
-    beforeEach(() => {
-        containerElement = document.createElement("div");
-        document.body.appendChild(containerElement);
-    });
-
-    afterEach(() => {
-        containerElement.remove();
-    });
 
     it("supports className", () => {
-        const wrapper = mount(<Section className="foo" />, {
-            attachTo: containerElement,
-        });
-        assert.isTrue(wrapper.find(`.${Classes.SECTION}`).hostNodes().exists());
-        assert.isTrue(wrapper.find(`.foo`).hostNodes().exists());
+        const { container } = render(<Section className="foo" />);
+        const section = container.querySelector(`.${Classes.SECTION}`)!;
+        expect(section).toBeInTheDocument();
+        expect(section).toHaveClass("foo");
     });
 
     it("supports icon", () => {
-        const wrapper = mount(<Section icon={IconNames.GRAPH} title="title" />, {
-            attachTo: containerElement,
-        });
-        assert.isTrue(wrapper.find(`[data-icon="${IconNames.GRAPH}"]`).exists());
+        const { container } = render(<Section icon={IconNames.GRAPH} title="title" />);
+        expect(container.querySelector(`[data-icon="${IconNames.GRAPH}"]`)).toBeInTheDocument();
     });
 
     it("renders optional title element", () => {
-        const wrapper = mount(<Section title="title" />, {
-            attachTo: containerElement,
-        });
-        assert.isTrue(wrapper.find(H6).exists());
+        const { container } = render(<Section title="title" />);
+        expect(container.querySelector("h6")).toBeInTheDocument();
     });
 
     it("renders optional sub-title element", () => {
-        const wrapper = mount(<Section title="title" subtitle="subtitle" />, {
-            attachTo: containerElement,
-        });
-        assert.isTrue(wrapper.find(`.${Classes.SECTION_HEADER_SUB_TITLE}`).hostNodes().exists());
+        const { container } = render(<Section title="title" subtitle="subtitle" />);
+        expect(container.querySelector(`.${Classes.SECTION_HEADER_SUB_TITLE}`)).toBeInTheDocument();
     });
 
     it("renders custom title element with titleRenderer", () => {
-        const wrapper = mount(<Section title="title" titleRenderer={H5} />, {
-            attachTo: containerElement,
-        });
-        assert.isTrue(wrapper.find(H5).exists());
+        const { container } = render(<Section title="title" titleRenderer="h5" />);
+        expect(container.querySelector("h5")).toBeInTheDocument();
     });
 
     describe("uncontrolled collapse mode", () => {
         it("collapsible is open when defaultIsOpen={undefined}", () => {
-            const wrapper = mount(
+            const { container } = render(
                 <Section collapsible={true} collapseProps={{ defaultIsOpen: undefined }} title="Test">
                     <SectionCard>is open</SectionCard>
                 </Section>,
-                { attachTo: containerElement },
             );
-            assertIsOpen(wrapper);
+            assertIsOpen(container);
         });
 
         it("collapsible is open when defaultIsOpen={true}", () => {
-            const wrapper = mount(
+            const { container } = render(
                 <Section collapsible={true} collapseProps={{ defaultIsOpen: true }} title="Test">
                     <SectionCard>is open</SectionCard>
                 </Section>,
-                { attachTo: containerElement },
             );
-            assertIsOpen(wrapper);
+            assertIsOpen(container);
         });
 
         it("collapsible is closed when defaultIsOpen={false}", () => {
-            const wrapper = mount(
+            const { container } = render(
                 <Section collapsible={true} collapseProps={{ defaultIsOpen: false }} title="Test">
                     <SectionCard>is closed</SectionCard>
                 </Section>,
-                { attachTo: containerElement },
             );
-            assertIsClosed(wrapper);
+            assertIsClosed(container);
         });
     });
 
     describe("controlled collapse mode", () => {
         it("collapsible is open when isOpen={true}", () => {
-            const wrapper = mount(
+            const { container } = render(
                 <Section collapsible={true} collapseProps={{ isOpen: true }} title="Test">
                     <SectionCard>is open</SectionCard>
                 </Section>,
-                { attachTo: containerElement },
             );
-            assertIsOpen(wrapper);
+            assertIsOpen(container);
         });
 
         it("collapsible is closed when isOpen={false}", () => {
-            const wrapper = mount(
+            const { container } = render(
                 <Section collapsible={true} collapseProps={{ isOpen: false }} title="Test">
                     <SectionCard>is closed</SectionCard>
                 </Section>,
-                { attachTo: containerElement },
             );
-            assertIsClosed(wrapper);
+            assertIsClosed(container);
         });
     });
 });

--- a/packages/core/src/components/segmented-control/segmentedControl.test.tsx
+++ b/packages/core/src/components/segmented-control/segmentedControl.test.tsx
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { mount } from "enzyme";
 
 import { IconNames } from "@blueprintjs/icons";
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes, type OptionProps } from "../../common";
 
@@ -53,102 +53,104 @@ describe("<SegmentedControl>", () => {
         containerElement.remove();
     });
 
-    const mountSegmentedControl = (props?: Partial<SegmentedControlProps>) =>
-        mount(<SegmentedControl options={OPTIONS} {...props} />, {
-            attachTo: containerElement,
-        });
+    const renderSegmentedControl = (props?: Partial<SegmentedControlProps>) =>
+        render(<SegmentedControl options={OPTIONS} {...props} />, {
+            container: containerElement,
+        }).container;
 
     it("supports className", () => {
         const testClassName = "test-class-name";
-        const wrapper = mountSegmentedControl({ className: testClassName });
-        assert.isTrue(wrapper.find(`.${Classes.SEGMENTED_CONTROL}`).hostNodes().exists());
-        assert.isTrue(wrapper.find(`.${testClassName}`).hostNodes().exists());
+        const container = renderSegmentedControl({ className: testClassName });
+        expect(container.querySelector(`.${Classes.SEGMENTED_CONTROL}`)).toBeInTheDocument();
+        expect(container.querySelector(`.${testClassName}`)).toBeInTheDocument();
     });
 
     it("supports icon", () => {
-        const wrapper = mountSegmentedControl({ options: [{ icon: IconNames.GRID, value: "grid" }] });
-        assert.isTrue(wrapper.find(`.${Classes.ICON}`).hostNodes().exists());
-        assert.isTrue(wrapper.find(`[data-icon="${IconNames.GRID}"]`).exists());
+        const container = renderSegmentedControl({ options: [{ icon: IconNames.GRID, value: "grid" }] });
+        expect(container.querySelector(`.${Classes.ICON}`)).toBeInTheDocument();
+        expect(container.querySelector(`[data-icon="${IconNames.GRID}"]`)).toBeInTheDocument();
     });
 
     it("button text defaults to value when no label is passed", () => {
-        mountSegmentedControl({ options: [{ value: "val" }] });
-        const optionButtons = containerElement.querySelectorAll("button")!;
-        assert.equal(optionButtons[0].textContent, "val");
+        const container = renderSegmentedControl({ options: [{ value: "val" }] });
+        const optionButtons = container.querySelectorAll("button");
+        expect(optionButtons[0].textContent).toBe("val");
     });
 
     it("when no default value passed, first button gets tabIndex=0, none have aria-checked initially", () => {
-        const wrapper = mountSegmentedControl();
-        assert.lengthOf(wrapper.find("[tabIndex=0]").hostNodes(), 1);
-        assert.lengthOf(wrapper.find("[aria-checked=true]").hostNodes(), 0);
-        const optionButtons = containerElement.querySelectorAll("button")!;
-        assert.equal(optionButtons[0].getAttribute("tabIndex"), "0");
-        assert.equal(optionButtons[0].getAttribute("aria-checked"), "false");
+        const container = renderSegmentedControl();
+        expect(container.querySelectorAll("[tabIndex='0']")).toHaveLength(1);
+        expect(container.querySelectorAll("[aria-checked='true']")).toHaveLength(0);
+        const optionButtons = container.querySelectorAll("button");
+        expect(optionButtons[0].getAttribute("tabIndex")).toBe("0");
+        expect(optionButtons[0].getAttribute("aria-checked")).toBe("false");
     });
 
     it("when defaultValue passed, tabIndex=0 and aria-checked applied to correct option, no others", () => {
-        const wrapper = mountSegmentedControl({ defaultValue: OPTIONS[2].value });
-        assert.lengthOf(wrapper.find("[tabIndex=0]").hostNodes(), 1);
-        assert.lengthOf(wrapper.find("[aria-checked=true]").hostNodes(), 1);
-        const optionButtons = containerElement.querySelectorAll("button")!;
-        assert.equal(optionButtons[2].getAttribute("tabIndex"), "0");
-        assert.equal(optionButtons[2].getAttribute("aria-checked"), "true");
+        const container = renderSegmentedControl({ defaultValue: OPTIONS[2].value });
+        expect(container.querySelectorAll("[tabIndex='0']")).toHaveLength(1);
+        expect(container.querySelectorAll("[aria-checked='true']")).toHaveLength(1);
+        const optionButtons = container.querySelectorAll("button");
+        expect(optionButtons[2].getAttribute("tabIndex")).toBe("0");
+        expect(optionButtons[2].getAttribute("aria-checked")).toBe("true");
     });
 
     it("changes option button focus when arrow keys are pressed", () => {
-        const wrapper = mountSegmentedControl();
-        const radioGroup = wrapper.find('[role="radiogroup"]');
+        const container = renderSegmentedControl();
+        const radioGroup = assertElement(container, '[role="radiogroup"]');
 
-        const optionButtons = containerElement.querySelectorAll<HTMLElement>('[role="radio"]');
+        const optionButtons = container.querySelectorAll<HTMLElement>('[role="radio"]');
         optionButtons[0].focus();
 
-        radioGroup.simulate("keydown", { key: "ArrowRight" });
-        assert.equal(document.activeElement, optionButtons[2], "move right and skip disabled");
-        radioGroup.simulate("keydown", { key: "ArrowRight" });
-        assert.equal(document.activeElement, optionButtons[0], "wrap around to first option");
-        radioGroup.simulate("keydown", { key: "ArrowLeft" });
-        assert.equal(document.activeElement, optionButtons[2], "wrap around to last option");
-        radioGroup.simulate("keydown", { key: "ArrowLeft" });
-        assert.equal(document.activeElement, optionButtons[0], "move left and skip disabled");
+        fireEvent.keyDown(radioGroup, { key: "ArrowRight" });
+        expect(document.activeElement).toBe(optionButtons[2]);
+        fireEvent.keyDown(radioGroup, { key: "ArrowRight" });
+        expect(document.activeElement).toBe(optionButtons[0]);
+        fireEvent.keyDown(radioGroup, { key: "ArrowLeft" });
+        expect(document.activeElement).toBe(optionButtons[2]);
+        fireEvent.keyDown(radioGroup, { key: "ArrowLeft" });
+        expect(document.activeElement).toBe(optionButtons[0]);
     });
 
     it("should select the correct option when clicked", async () => {
         const user = userEvent.setup();
         const onValueChange = vi.fn();
-        render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
-        const listButton = screen.getByRole("radio", { name: /list/i });
+        const { container } = render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
+        const listButton = within(container).getByRole("radio", { name: /list/i });
 
         await user.click(listButton);
 
         expect(onValueChange).toHaveBeenCalled();
-        expect(onValueChange.mock.calls[0][0]).to.equal("list");
-        expect(listButton.getAttribute("aria-checked")).to.equal("true");
+        expect(onValueChange.mock.calls[0][0]).toBe("list");
+        expect(listButton.getAttribute("aria-checked")).toBe("true");
     });
 
     it("should not allow disabled options to be selected", async () => {
         const user = userEvent.setup();
         const onValueChange = vi.fn();
-        render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
-        const gridButton = screen.getByRole("radio", { name: /grid/i });
+        const { container } = render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} />);
+        const gridButton = within(container).getByRole("radio", { name: /grid/i });
 
         await user.click(gridButton);
 
         expect(onValueChange).not.toHaveBeenCalled();
-        expect(gridButton.getAttribute("aria-checked")).to.equal("false");
+        expect(gridButton.getAttribute("aria-checked")).toBe("false");
     });
 
     it("should not allow any options to be selected when disabled", async () => {
         const user = userEvent.setup();
         const onValueChange = vi.fn();
-        render(<SegmentedControl onValueChange={onValueChange} options={OPTIONS} disabled={true} />);
-        const listButton = screen.getByRole("radio", { name: /list/i });
-        const gridButton = screen.getByRole("radio", { name: /grid/i });
+        const { container } = render(
+            <SegmentedControl onValueChange={onValueChange} options={OPTIONS} disabled={true} />,
+        );
+        const listButton = within(container).getByRole("radio", { name: /list/i });
+        const gridButton = within(container).getByRole("radio", { name: /grid/i });
 
         await user.click(listButton);
         await user.click(gridButton);
 
         expect(onValueChange).not.toHaveBeenCalled();
-        expect(listButton.getAttribute("aria-checked")).to.equal("false");
-        expect(gridButton.getAttribute("aria-checked")).to.equal("false");
+        expect(listButton.getAttribute("aria-checked")).toBe("false");
+        expect(gridButton.getAttribute("aria-checked")).toBe("false");
     });
 });

--- a/packages/core/src/components/slider/handle.test.tsx
+++ b/packages/core/src/components/slider/handle.test.tsx
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
-import { mount, type ReactWrapper } from "enzyme";
+import { fireEvent, render } from "@testing-library/react";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
-import { Handle, type HandleState, type InternalHandleProps } from "./handle";
+import { Classes } from "../../common";
+
+import { Handle, type InternalHandleProps } from "./handle";
 import { DRAG_SIZE, simulateMovement } from "./sliderTestUtils";
 
 const HANDLE_PROPS: InternalHandleProps = {
@@ -46,30 +49,36 @@ describe("<Handle>", () => {
 
     it("disabled handle never invokes event handlers", () => {
         const eventSpy = vi.fn();
-        const handle = mountHandle(0, { disabled: true, onChange: eventSpy, onRelease: eventSpy });
-        simulateMovement(handle, { dragTimes: 3 });
-        handle.simulate("keydown", { key: "ArrowUp" });
+        const container = mountHandle(0, { disabled: true, onChange: eventSpy, onRelease: eventSpy });
+        simulateMovement(container, { dragTimes: 3 });
+        const handle = assertElement(container, `.${Classes.SLIDER_HANDLE}`);
+        fireEvent.keyDown(handle, { key: "ArrowUp" });
         expect(eventSpy).not.toHaveBeenCalled();
     });
 
     describe("keyboard events", () => {
         it("pressing arrow key down reduces value by stepSize", () => {
             const onChange = vi.fn();
-            mountHandle(3, { onChange, stepSize: 2 }).simulate("keydown", { key: "ArrowDown" });
+            const container = mountHandle(3, { onChange, stepSize: 2 });
+            const handle = assertElement(container, `.${Classes.SLIDER_HANDLE}`);
+            fireEvent.keyDown(handle, { key: "ArrowDown" });
             expect(onChange).toHaveBeenCalledWith(1);
         });
 
         it("pressing arrow key up increases value by stepSize", () => {
             const onChange = vi.fn();
-            mountHandle(3, { onChange, stepSize: 4 }).simulate("keydown", { key: "ArrowUp" });
+            const container = mountHandle(3, { onChange, stepSize: 4 });
+            const handle = assertElement(container, `.${Classes.SLIDER_HANDLE}`);
+            fireEvent.keyDown(handle, { key: "ArrowUp" });
             expect(onChange).toHaveBeenCalledWith(7);
         });
 
         it("releasing arrow key calls onRelease with value", () => {
             const onRelease = vi.fn();
-            mountHandle(3, { onRelease, stepSize: 4 })
-                .simulate("keydown", { key: "ArrowUp" })
-                .simulate("keyup", { key: "ArrowUp" });
+            const container = mountHandle(3, { onRelease, stepSize: 4 });
+            const handle = assertElement(container, `.${Classes.SLIDER_HANDLE}`);
+            fireEvent.keyDown(handle, { key: "ArrowUp" });
+            fireEvent.keyUp(handle, { key: "ArrowUp" });
             expect(onRelease).toHaveBeenCalledWith(3);
         });
     });
@@ -120,12 +129,9 @@ describe("<Handle>", () => {
         });
     });
 
-    function mountHandle(
-        value: number,
-        props: Partial<InternalHandleProps> = {},
-    ): ReactWrapper<InternalHandleProps, HandleState> {
-        return mount(<Handle {...HANDLE_PROPS} label={value.toString()} value={value} {...props} />, {
-            attachTo: containerElement,
-        });
+    function mountHandle(value: number, props: Partial<InternalHandleProps> = {}): HTMLElement {
+        return render(<Handle {...HANDLE_PROPS} label={value.toString()} value={value} {...props} />, {
+            container: containerElement,
+        }).container;
     }
 });

--- a/packages/core/src/components/slider/rangeSlider.test.tsx
+++ b/packages/core/src/components/slider/rangeSlider.test.tsx
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { mount } from "enzyme";
+import { fireEvent, render } from "@testing-library/react";
 
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
-import { Handle } from "./handle";
 import { RangeSlider } from "./rangeSlider";
 
 const STEP_SIZE = 20;
@@ -40,16 +39,15 @@ describe("<RangeSlider>", () => {
     afterEach(() => containerElement.remove());
 
     it("renders two interactive <Handle>s", () => {
-        const handles = renderSlider(<RangeSlider />).find(Handle);
-        expect(handles).toHaveLength(2);
+        const container = renderSlider(<RangeSlider />);
+        expect(container.querySelectorAll(`.${Classes.SLIDER_HANDLE}`)).toHaveLength(2);
     });
 
     it.skip("renders primary track segment between two values", () => {
-        const track = renderSlider(<RangeSlider value={[2, 5]} />).find(
-            `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
-        );
-        expect(track).toHaveLength(1);
-        expect(track.getDOMNode().getBoundingClientRect().width).toBe(STEP_SIZE * 3);
+        const container = renderSlider(<RangeSlider value={[2, 5]} />);
+        const tracks = container.querySelectorAll(`.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`);
+        expect(tracks).toHaveLength(1);
+        expect(tracks[0].getBoundingClientRect().width).toBe(STEP_SIZE * 3);
     });
 
     it("throws error if range value contains null", () => {
@@ -65,13 +63,14 @@ describe("<RangeSlider>", () => {
 
     it("disabled slider does not respond to key presses", () => {
         const changeSpy = vi.fn();
-        const handles = renderSlider(<RangeSlider disabled={true} onChange={changeSpy} />).find(Handle);
-        handles.first().simulate("keydown", { key: "ArrowDown" });
-        handles.last().simulate("keydown", { key: "ArrowDown" });
+        const container = renderSlider(<RangeSlider disabled={true} onChange={changeSpy} />);
+        const handles = container.querySelectorAll<HTMLElement>(`.${Classes.SLIDER_HANDLE}`);
+        fireEvent.keyDown(handles[0], { key: "ArrowDown" });
+        fireEvent.keyDown(handles[handles.length - 1], { key: "ArrowDown" });
         expect(changeSpy).not.toHaveBeenCalled();
     });
 
     function renderSlider(slider: React.JSX.Element) {
-        return mount(slider, { attachTo: containerElement });
+        return render(slider, { container: containerElement }).container;
     }
 });

--- a/packages/core/src/components/slider/slider.test.tsx
+++ b/packages/core/src/components/slider/slider.test.tsx
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { mount } from "enzyme";
+import { fireEvent, render } from "@testing-library/react";
 
-import { afterEach, assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
 
-import { Handle } from "./handle";
 import { Slider } from "./slider";
 import { simulateMovement } from "./sliderTestUtils";
 
@@ -41,41 +41,43 @@ describe("<Slider>", () => {
     afterEach(() => containerElement.remove());
 
     it("renders one interactive <Handle>", () => {
-        const handles = renderSlider(<Slider />).find(Handle);
-        assert.lengthOf(handles, 1);
+        const container = renderSlider(<Slider />);
+        expect(container.querySelectorAll(`.${Classes.SLIDER_HANDLE}`)).toHaveLength(1);
     });
 
     it.skip("renders primary track segment between initialValue and value", () => {
-        const tracks = renderSlider(<Slider showTrackFill={true} initialValue={2} value={5} />).find(
-            `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
-        );
-        assert.lengthOf(tracks, 1);
-        assert.equal(tracks.getDOMNode().getBoundingClientRect().width, STEP_SIZE * 3);
+        const container = renderSlider(<Slider showTrackFill={true} initialValue={2} value={5} />);
+        const tracks = container.querySelectorAll(`.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`);
+        expect(tracks).toHaveLength(1);
+        expect(tracks[0].getBoundingClientRect().width).toBe(STEP_SIZE * 3);
     });
 
     it.skip("renders primary track segment between initialValue and value when value is less than initial value", () => {
-        const tracks = renderSlider(<Slider showTrackFill={true} initialValue={5} value={2} />).find(
-            `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
-        );
-        assert.lengthOf(tracks, 1);
-        assert.equal(tracks.getDOMNode().getBoundingClientRect().width, STEP_SIZE * 3);
+        const container = renderSlider(<Slider showTrackFill={true} initialValue={5} value={2} />);
+        const tracks = container.querySelectorAll(`.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`);
+        expect(tracks).toHaveLength(1);
+        expect(tracks[0].getBoundingClientRect().width).toBe(STEP_SIZE * 3);
     });
 
     it("renders no primary track segment when value equals initial value", () => {
-        const tracks = renderSlider(<Slider showTrackFill={true} initialValue={2} value={2} min={0} max={5} />).find(
-            `.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`,
+        const container = renderSlider(
+            <Slider showTrackFill={true} initialValue={2} value={2} min={0} max={5} />,
         );
-        assert.lengthOf(tracks, 0);
+        const tracks = container.querySelectorAll(`.${Classes.SLIDER_PROGRESS}.${Classes.INTENT_PRIMARY}`);
+        expect(tracks).toHaveLength(0);
     });
 
     it("renders result of labelRenderer() in each label and differently in handle", () => {
         const labelRenderer = (val: number, opts?: { isHandleTooltip: boolean }) =>
             val + (opts?.isHandleTooltip ? "!" : "#");
-        const wrapper = renderSlider(
+        const container = renderSlider(
             <Slider min={0} max={50} value={10} labelStepSize={10} labelRenderer={labelRenderer} />,
         );
-        assert.strictEqual(wrapper.find(`.${Classes.SLIDER}-axis`).text(), "0#10#20#30#40#50#");
-        assert.strictEqual(wrapper.find(`.${Classes.SLIDER_HANDLE}`).find(`.${Classes.SLIDER_LABEL}`).text(), "10!");
+        const axis = assertElement(container, `.${Classes.SLIDER}-axis`);
+        expect(axis.textContent).toBe("0#10#20#30#40#50#");
+        const sliderHandle = assertElement(container, `.${Classes.SLIDER_HANDLE}`);
+        const sliderLabel = assertElement(sliderHandle, `.${Classes.SLIDER_LABEL}`);
+        expect(sliderLabel.textContent).toBe("10!");
     });
 
     it.skip("moving mouse calls onChange with nearest value", () => {
@@ -101,16 +103,18 @@ describe("<Slider>", () => {
 
     it.skip("disabled slider never invokes event handlers", () => {
         const eventSpy = vi.fn();
-        const slider = renderSlider(<Slider disabled={true} onChange={eventSpy} onRelease={eventSpy} />);
+        const container = renderSlider(<Slider disabled={true} onChange={eventSpy} onRelease={eventSpy} />);
         // handle drag and keys
-        simulateMovement(slider, { dragTimes: 3 });
-        slider.simulate("keydown", { key: "ArrowUp" });
+        simulateMovement(container, { dragTimes: 3 });
+        const handle = assertElement(container, `.${Classes.SLIDER_HANDLE}`);
+        fireEvent.keyDown(handle, { key: "ArrowUp" });
         // track click
-        slider.find(TRACK_SELECTOR).simulate("mousedown", { target: containerElement.querySelector(TRACK_SELECTOR) });
+        const track = assertElement(container, TRACK_SELECTOR);
+        fireEvent.mouseDown(track);
         expect(eventSpy).not.toHaveBeenCalled();
     });
 
     function renderSlider(slider: React.JSX.Element) {
-        return mount(slider, { attachTo: containerElement });
+        return render(slider, { container: containerElement }).container;
     }
 });

--- a/packages/core/src/components/slider/sliderTestUtils.ts
+++ b/packages/core/src/components/slider/sliderTestUtils.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { ReactWrapper } from "enzyme";
+import { act } from "@testing-library/react";
 
 import { dispatchMouseEvent, dispatchTouchEvent } from "@blueprintjs/test-commons/vitest-utils";
 
-import { Handle, type InternalHandleProps } from "./handle";
+import { Classes } from "../../common";
 
 interface MoveOptions {
     /** Size in pixels of one drag event. Direction of drag is determined by `vertical` option. */
@@ -43,21 +43,28 @@ export const DRAG_SIZE = 20;
  * Simulates a full move of a slider handle: engage, move, release.
  * Supports touch and vertical events. Use options to configure exact movement.
  */
-export function simulateMovement(wrapper: ReactWrapper<InternalHandleProps>, options: MoveOptions) {
+export function simulateMovement(container: HTMLElement, options: MoveOptions) {
     const { from = 0, handleIndex = 0, touch = false } = options;
-    const handle = wrapper.find(Handle).at(handleIndex);
-    const eventData =
-        options.vertical !== undefined && options.verticalHeight !== undefined
-            ? { clientY: options.verticalHeight - from }
-            : { clientX: from };
-    if (touch) {
-        handle.simulate("touchstart", { changedTouches: [eventData] });
-    } else {
-        handle.simulate("mousedown", eventData);
+    const handles = container.querySelectorAll<HTMLElement>(`.${Classes.SLIDER_HANDLE}`);
+    if (handles.length <= handleIndex) {
+        throw new Error(`Expected at least ${handleIndex + 1} slider handle(s), found ${handles.length}`);
     }
+    const handle = handles[handleIndex];
+    const isVertical = options.vertical !== undefined && options.verticalHeight !== undefined;
+    const clientX = isVertical ? undefined : from;
+    const clientY = isVertical ? options.verticalHeight! - from : undefined;
+    // Wrap in act() so React flushes the setState({ isMoving: true }) from the
+    // mousedown/touchstart handler before subsequent document-level events fire.
+    act(() => {
+        if (touch) {
+            dispatchTouchEvent(handle, "touchstart", clientX, clientY);
+        } else {
+            dispatchMouseEvent(handle, "mousedown", clientX, clientY);
+        }
+    });
     genericMove(options);
     genericRelease(options);
-    return wrapper;
+    return container;
 }
 
 /** Release the mouse at the given clientX pixel. Useful for ending a drag interaction. */

--- a/packages/core/src/components/tag/compoundTag.test.tsx
+++ b/packages/core/src/components/tag/compoundTag.test.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
-import { mount, shallow } from "enzyme";
+import { fireEvent, render } from "@testing-library/react";
 import { createRef } from "react";
 
 import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
@@ -27,63 +27,61 @@ import { CompoundTag } from "./compoundTag";
 
 describe("<CompoundTag>", () => {
     it("renders its text", () => {
-        expect(
-            shallow(<CompoundTag leftContent="Hello">World</CompoundTag>)
-                .find(`.${Classes.COMPOUND_TAG_RIGHT_CONTENT}`)
-                .prop("children"),
-        ).toBe("World");
+        const { container } = render(<CompoundTag leftContent="Hello">World</CompoundTag>);
+        expect(container.querySelector(`.${Classes.COMPOUND_TAG_RIGHT_CONTENT}`)).toHaveTextContent("World");
     });
 
     it("renders icons", () => {
-        const wrapper = shallow(
+        const { container } = render(
             <CompoundTag icon="tick" endIcon="airplane" leftContent="Hello">
                 World
             </CompoundTag>,
         );
-        expect(wrapper.find(Icon)).toHaveLength(2);
+        expect(container.querySelectorAll(`.${Classes.ICON}`)).toHaveLength(2);
     });
 
     it("prefers endIcon to rightIcon", () => {
         const endIcon = <Icon icon="airplane" data-testid="endIcon" />;
         const rightIcon = <Icon icon="add" data-testid="rightIcon" />;
-        render(
+        const { container } = render(
             // eslint-disable-next-line @typescript-eslint/no-deprecated
             <CompoundTag endIcon={endIcon} rightIcon={rightIcon} leftContent="Hello">
                 World
             </CompoundTag>,
         );
-        expect(screen.getByTestId("endIcon")).to.exist;
-        expect(screen.queryByTestId("rightIcon")).not.toBeInTheDocument();
+        expect(container.querySelector('[data-testid="endIcon"]')).toBeInTheDocument();
+        expect(container.querySelector('[data-testid="rightIcon"]')).not.toBeInTheDocument();
     });
 
     it("renders close button when onRemove is a function", () => {
-        const wrapper = mount(
+        const { container } = render(
             <CompoundTag onRemove={vi.fn()} leftContent="Hello">
                 World
             </CompoundTag>,
         );
-        expect(wrapper.find(`.${Classes.TAG_REMOVE}`)).toHaveLength(1);
+        expect(container.querySelectorAll(`.${Classes.TAG_REMOVE}`)).toHaveLength(1);
     });
 
     it("clicking close button triggers onRemove", () => {
         const handleRemove = vi.fn();
-        mount(
+        const { container } = render(
             <CompoundTag onRemove={handleRemove} leftContent="Hello">
                 World
             </CompoundTag>,
-        )
-            .find(`.${Classes.TAG_REMOVE}`)
-            .simulate("click");
+        );
+        const removeButton = assertElement(container, `.${Classes.TAG_REMOVE}`);
+        fireEvent.click(removeButton);
         expect(handleRemove).toHaveBeenCalledOnce();
     });
 
     it(`passes other props onto .${Classes.COMPOUND_TAG} element`, () => {
-        const element = mount(
+        const { container } = render(
             <CompoundTag title="baz qux" leftContent="Hello">
                 World
             </CompoundTag>,
-        ).find(`.${Classes.COMPOUND_TAG}`);
-        expect(element.prop("title")).toEqual("baz qux");
+        );
+        const element = assertElement(container, `.${Classes.COMPOUND_TAG}`);
+        expect(element).toHaveAttribute("title", "baz qux");
     });
 
     it("passes all props to the onRemove handler", () => {
@@ -96,13 +94,13 @@ describe("<CompoundTag>", () => {
             },
             onRemove: handleRemove,
         };
-        mount(
+        const { container } = render(
             <CompoundTag {...tagProps} leftContent="Hello">
                 World
             </CompoundTag>,
-        )
-            .find(`.${Classes.TAG_REMOVE}`)
-            .simulate("click");
+        );
+        const removeButton = assertElement(container, `.${Classes.TAG_REMOVE}`);
+        fireEvent.click(removeButton);
         expect(handleRemove).toHaveBeenCalledOnce();
         expect(handleRemove).toHaveBeenCalledWith(
             expect.anything(),
@@ -110,17 +108,13 @@ describe("<CompoundTag>", () => {
         );
     });
 
-    it("supports ref objects", async () => {
+    it("supports ref objects", () => {
         const elementRef = createRef<HTMLSpanElement>();
-        const wrapper = mount(
+        const { container } = render(
             <CompoundTag ref={elementRef} leftContent="Hello">
                 World
             </CompoundTag>,
         );
-
-        // wait for the whole lifecycle to run
-        await waitFor(() => {
-            expect(elementRef.current).toBe(wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
-        });
+        expect(elementRef.current).toBe(container.querySelector(`.${Classes.TAG}`));
     });
 });

--- a/packages/core/src/components/tag/tag.test.tsx
+++ b/packages/core/src/components/tag/tag.test.tsx
@@ -14,81 +14,75 @@
  * limitations under the License.
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
-import { mount, shallow } from "enzyme";
+import { fireEvent, render } from "@testing-library/react";
 import { createRef } from "react";
 
 import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { assertElement } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes } from "../../common";
 import { Icon } from "../icon/icon";
-import { Text } from "../text/text";
 
 import { Tag } from "./tag";
 
 describe("<Tag>", () => {
     it("renders its text", () => {
-        expect(
-            shallow(<Tag>Hello</Tag>)
-                .find(Text)
-                .prop("children"),
-        ).toBe("Hello");
+        const { container } = render(<Tag>Hello</Tag>);
+        expect(container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`)).toHaveTextContent("Hello");
     });
 
     it("text is not rendered if omitted", () => {
-        expect(
-            shallow(<Tag icon="tick" />)
-                .find(Text)
-                .exists(),
-        ).toBe(false);
+        const { container } = render(<Tag icon="tick" />);
+        expect(container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`)).not.toBeInTheDocument();
     });
 
     it("renders icons", () => {
-        const wrapper = shallow(<Tag icon="tick" endIcon="airplane" />);
-        expect(wrapper.find(Icon)).toHaveLength(2);
+        const { container } = render(<Tag icon="tick" endIcon="airplane" />);
+        expect(container.querySelectorAll(`.${Classes.ICON}`)).toHaveLength(2);
     });
 
     it("prefers endIcon to rightIcon", () => {
         const endIcon = <Icon icon="airplane" data-testid="endIcon" />;
         const rightIcon = <Icon icon="tick" data-testid="rightIcon" />;
-        render(
+        const { container } = render(
             // eslint-disable-next-line @typescript-eslint/no-deprecated
             <Tag endIcon={endIcon} rightIcon={rightIcon} />,
         );
-        expect(screen.getByTestId("endIcon")).to.exist;
-        expect(screen.queryByTestId("rightIcon")).not.toBeInTheDocument();
+        expect(container.querySelector('[data-testid="endIcon"]')).toBeInTheDocument();
+        expect(container.querySelector('[data-testid="rightIcon"]')).not.toBeInTheDocument();
     });
 
     it("renders close button when onRemove is a function", () => {
-        const wrapper = mount(<Tag onRemove={vi.fn()}>Hello</Tag>);
-        expect(wrapper.find(`.${Classes.TAG_REMOVE}`)).toHaveLength(1);
+        const { container } = render(<Tag onRemove={vi.fn()}>Hello</Tag>);
+        expect(container.querySelectorAll(`.${Classes.TAG_REMOVE}`)).toHaveLength(1);
     });
 
     it("clicking close button triggers onRemove", () => {
         const handleRemove = vi.fn();
-        mount(<Tag onRemove={handleRemove}>Hello</Tag>)
-            .find(`.${Classes.TAG_REMOVE}`)
-            .simulate("click");
+        const { container } = render(<Tag onRemove={handleRemove}>Hello</Tag>);
+        const removeButton = assertElement(container, `.${Classes.TAG_REMOVE}`);
+        fireEvent.click(removeButton);
         expect(handleRemove).toHaveBeenCalledOnce();
     });
 
     it("should be interactive when onClick is provided", () => {
-        const wrapper = mount(<Tag onClick={vi.fn()}>Hello</Tag>);
-        expect(wrapper.find(`.${Classes.INTERACTIVE}`)).toHaveLength(1);
+        const { container } = render(<Tag onClick={vi.fn()}>Hello</Tag>);
+        expect(container.querySelectorAll(`.${Classes.INTERACTIVE}`)).toHaveLength(1);
     });
 
     it("should not be interactive when interactive={false}", () => {
-        const wrapper = mount(
+        const { container } = render(
             <Tag onClick={vi.fn()} interactive={false}>
                 Hello
             </Tag>,
         );
-        expect(wrapper.find(`.${Classes.INTERACTIVE}`)).toHaveLength(0);
+        expect(container.querySelectorAll(`.${Classes.INTERACTIVE}`)).toHaveLength(0);
     });
 
     it(`passes other props onto .${Classes.TAG} element`, () => {
-        const element = shallow(<Tag title="baz qux">Hello</Tag>).find("." + Classes.TAG);
-        expect(element.prop("title")).toEqual("baz qux");
+        const { container } = render(<Tag title="baz qux">Hello</Tag>);
+        const element = assertElement(container, `.${Classes.TAG}`);
+        expect(element).toHaveAttribute("title", "baz qux");
     });
 
     it("passes all props to the onRemove handler", () => {
@@ -101,9 +95,9 @@ describe("<Tag>", () => {
             },
             onRemove: handleRemove,
         };
-        mount(<Tag {...tagProps}>Hello</Tag>)
-            .find(`.${Classes.TAG_REMOVE}`)
-            .simulate("click");
+        const { container } = render(<Tag {...tagProps}>Hello</Tag>);
+        const removeButton = assertElement(container, `.${Classes.TAG_REMOVE}`);
+        fireEvent.click(removeButton);
         expect(handleRemove).toHaveBeenCalledOnce();
         expect(handleRemove).toHaveBeenCalledWith(
             expect.anything(),
@@ -111,13 +105,9 @@ describe("<Tag>", () => {
         );
     });
 
-    it("supports ref objects", async () => {
+    it("supports ref objects", () => {
         const elementRef = createRef<HTMLSpanElement>();
-        const wrapper = mount(<Tag ref={elementRef}>Hello</Tag>);
-
-        // wait for the whole lifecycle to run
-        await waitFor(() => {
-            expect(elementRef.current).toBe(wrapper.find(`.${Classes.TAG}`).getDOMNode<HTMLSpanElement>());
-        });
+        const { container } = render(<Tag ref={elementRef}>Hello</Tag>);
+        expect(elementRef.current).toBe(container.querySelector(`.${Classes.TAG}`));
     });
 });

--- a/packages/core/src/components/toast/toast.test.tsx
+++ b/packages/core/src/components/toast/toast.test.tsx
@@ -14,55 +14,60 @@
  * limitations under the License.
  */
 
-import { mount, shallow } from "enzyme";
+import { fireEvent, render } from "@testing-library/react";
 
-import { assert, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
+import { Classes } from "../../common";
 import { sleep } from "../../common/test-utils";
-import { AnchorButton, Button } from "../button/buttons";
 
 import { Toast } from "./toast";
 
 describe("<Toast>", () => {
     it("renders only dismiss button by default", () => {
-        const { action, dismiss } = wrap(<Toast message="Hello World" />);
-        assert.lengthOf(action, 0);
-        assert.lengthOf(dismiss, 1);
+        const { actionButtons, dismissButtons } = wrap(<Toast message="Hello World" />);
+        expect(actionButtons).toHaveLength(0);
+        expect(dismissButtons).toHaveLength(1);
     });
 
     it("clicking dismiss button triggers onDismiss callback with `false`", () => {
         const handleDismiss = vi.fn();
-        wrap(<Toast message="Hello" onDismiss={handleDismiss} />).dismiss.simulate("click");
+        const { dismissButtons } = wrap(<Toast message="Hello" onDismiss={handleDismiss} />);
+        fireEvent.click(dismissButtons[0]);
         expect(handleDismiss).toHaveBeenCalledOnce();
         expect(handleDismiss).toHaveBeenCalledWith(false);
     });
 
     it("renders action button when action string prop provided", () => {
         // pluralize cuz now there are two buttons
-        const { action } = wrap(<Toast action={{ text: "Undo" }} message="hello world" />);
-        assert.lengthOf(action, 1);
-        assert.equal(action.prop("text"), "Undo");
+        const { actionButtons } = wrap(<Toast action={{ text: "Undo" }} message="hello world" />);
+        expect(actionButtons).toHaveLength(1);
+        expect(actionButtons[0]).toHaveTextContent("Undo");
     });
 
     it("clicking action button triggers onClick callback", () => {
         const onClick = vi.fn();
-        wrap(<Toast action={{ onClick, text: "Undo" }} message="Hello" />).action.simulate("click");
+        const { actionButtons } = wrap(<Toast action={{ onClick, text: "Undo" }} message="Hello" />);
+        fireEvent.click(actionButtons[0]);
         expect(onClick).toHaveBeenCalledOnce();
     });
 
     it("clicking action button also triggers onDismiss callback with `false`", () => {
         const handleDismiss = vi.fn();
-        wrap(<Toast action={{ text: "Undo" }} message="Hello" onDismiss={handleDismiss} />).action.simulate("click");
+        const { actionButtons } = wrap(
+            <Toast action={{ text: "Undo" }} message="Hello" onDismiss={handleDismiss} />,
+        );
+        fireEvent.click(actionButtons[0]);
         expect(handleDismiss).toHaveBeenCalledOnce();
         expect(handleDismiss).toHaveBeenCalledWith(false);
     });
 
     function wrap(toast: React.JSX.Element) {
-        const root = shallow(toast);
+        const { container } = render(toast);
         return {
-            action: root.find(AnchorButton),
-            dismiss: root.find(Button),
-            root,
+            actionButtons: container.querySelectorAll(`a.${Classes.BUTTON}`),
+            dismissButtons: container.querySelectorAll(`button.${Classes.BUTTON}`),
+            container,
         };
     }
 
@@ -71,8 +76,7 @@ describe("<Toast>", () => {
         beforeEach(() => handleDismiss.mockReset());
 
         it("calls onDismiss automatically after timeout expires with `true`", async () => {
-            // mounting for lifecycle methods to start timeout
-            mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />);
+            render(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />);
             await sleep(20);
 
             expect(handleDismiss).toHaveBeenCalledOnce();
@@ -80,17 +84,15 @@ describe("<Toast>", () => {
         });
 
         it("updating with timeout={0} cancels timeout", async () => {
-            mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />).setProps({
-                timeout: 0,
-            });
+            const { rerender } = render(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />);
+            rerender(<Toast message="Hello" onDismiss={handleDismiss} timeout={0} />);
             await sleep(20);
             expect(handleDismiss).not.toHaveBeenCalled();
         });
 
         it("updating timeout={0} with timeout={X} starts timeout", async () => {
-            mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={0} />).setProps({
-                timeout: 20,
-            });
+            const { rerender } = render(<Toast message="Hello" onDismiss={handleDismiss} timeout={0} />);
+            rerender(<Toast message="Hello" onDismiss={handleDismiss} timeout={20} />);
             await sleep(20);
 
             expect(handleDismiss).toHaveBeenCalledOnce();

--- a/packages/test-commons/src/vitest-utils.ts
+++ b/packages/test-commons/src/vitest-utils.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { expect } from "vitest";
+
 /**
  * Test utilities for Vitest + jsdom/happy-dom environments.
  *
@@ -66,4 +68,14 @@ export function createTouchEvent(eventType = "touchstart", clientX = 0, clientY 
 
 export function dispatchTouchEvent(target: EventTarget, eventType = "touchstart", clientX = 0, clientY = 0) {
     target.dispatchEvent(createTouchEvent(eventType, clientX, clientY));
+}
+
+/**
+ * Query a DOM element by CSS selector and assert it exists.
+ * Returns the element as HTMLElement, avoiding bare `!` non-null assertions.
+ */
+export function assertElement(container: HTMLElement, selector: string): HTMLElement {
+    const el = container.querySelector(selector);
+    expect(el).toBeInTheDocument();
+    return el as HTMLElement;
 }


### PR DESCRIPTION
chore: Migrate tests from Enzyme to RTL 

Fixes #7444 

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Drop Enzyme for testing and replace it with RTL.

Fwiw I just want to use blueprint in a React 19 app, this is groundwork for that.

#### Reviewers should focus on:

This changes a lot of code, I know the tests still pass, but I'm not 1000% sure it's still testing the exact same things it was testing. 

#### Notes

- **collapse.test.tsx "is closed" / "is opening"**: The original Enzyme tests asserted on internal component state (`collapse.state("height")` and `collapse.state("animationState")`), which RTL intentionally does not support. The Collapse component's render method maps `animationState === CLOSED` to `height: undefined` (not "0px") in the DOM and unmounts children, so the state value never reaches the DOM directly. The RTL replacements assert on observable behavior instead: children not being rendered and `aria-hidden="true"` on the collapse body for "is closed"; children becoming visible and `aria-hidden="false"` for "is opening". These verify the same CLOSED/OPENING states from the user's perspective.

- **`assertElement` helper in test-commons/vitest-utils**: RTL's `container.querySelector()` returns `Element | null`. Without a guard, tests either use TypeScript's `!` non-null assertion (which silently passes null to the next call, producing confusing errors at runtime) or require a two-line `expect(el).toBeInTheDocument()` + `!` dance at every call site. `assertElement(container, selector)` wraps both into one call: it queries, asserts the element exists with a clear failure message, and returns a typed `HTMLElement`. This keeps tests concise while failing early and descriptively when an element is missing.

#### Screenshot

n/a
