### PR TITLE
(chore) add Package Download component

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -32,6 +32,7 @@ import {
 import { highlightCodeBlocks } from "../styles/syntaxHighlighting";
 
 import { addCopyButtonsToImportBlocks } from "./copyableImportButton";
+import { mountPackageDownloadOptions } from "./mountPackageDownloadOptions";
 import { NavHeader } from "./navHeader";
 import { NavIcon } from "./navIcons";
 
@@ -209,6 +210,7 @@ export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: st
 
         await highlightCodeBlocks();
         addCopyButtonsToImportBlocks();
+        mountPackageDownloadOptions();
     };
 
     private handleToggleDark = async (useDark: boolean) => {
@@ -218,5 +220,6 @@ export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: st
 
         await highlightCodeBlocks();
         addCopyButtonsToImportBlocks();
+        mountPackageDownloadOptions();
     };
 }

--- a/packages/docs-app/src/components/mountPackageDownloadOptions.tsx
+++ b/packages/docs-app/src/components/mountPackageDownloadOptions.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRoot, type Root } from "react-dom/client";
+
+import { PackageDownloadOptions, parseBlueprintPackage } from "./packageDownloadOptions";
+
+const roots: Array<{ root: Root; container: HTMLElement }> = [];
+
+/**
+ * Find all `.docs-package-install` containers in the DOM and mount a
+ * {@link PackageDownloadOptions} component into each one. Follows the same
+ * post-render enhancement pattern as {@link addCopyButtonsToImportBlocks}.
+ */
+export function mountPackageDownloadOptions() {
+    // Clean up previously mounted roots
+    for (const { root } of roots) {
+        root.unmount();
+    }
+    roots.length = 0;
+
+    const containers = document.querySelectorAll<HTMLElement>(".docs-package-install");
+    for (const container of Array.from(containers)) {
+        const pre = container.querySelector("pre");
+        if (pre == null) {
+            continue;
+        }
+
+        const pkg = parseBlueprintPackage(pre.textContent ?? "");
+        if (pkg == null) {
+            continue;
+        }
+
+        // Clear the container (removes the original <pre>) and mount the React component
+        container.innerHTML = "";
+        const root = createRoot(container);
+        root.render(<PackageDownloadOptions package={pkg} />);
+        roots.push({ root, container });
+    }
+}

--- a/packages/docs-app/src/components/packageDownloadOptions.tsx
+++ b/packages/docs-app/src/components/packageDownloadOptions.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useCallback, useContext, useSyncExternalStore } from "react";
+
+import { Button, ButtonGroup, Card, Code } from "@blueprintjs/core";
+import { CopyToClipboardButton } from "@blueprintjs/docs-theme";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+export type BlueprintPackage = "core" | "colors" | "datetime" | "icons" | "labs" | "select" | "table";
+
+const BLUEPRINT_PACKAGES: ReadonlySet<string> = new Set<BlueprintPackage>([
+    "core",
+    "colors",
+    "datetime",
+    "icons",
+    "labs",
+    "select",
+    "table",
+]);
+
+const PACKAGE_MANAGERS: readonly PackageManager[] = ["npm", "pnpm", "yarn", "bun"];
+
+// ---------------------------------------------------------------------------
+// parseBlueprintPackage
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a valid {@link BlueprintPackage} name from an install command string
+ * such as `npm install --save @blueprintjs/core`. Returns `undefined` when no
+ * recognised package is found.
+ */
+export function parseBlueprintPackage(text: string): BlueprintPackage | undefined {
+    const match = text.match(/@blueprintjs\/([\w-]+)/);
+    if (match != null && BLUEPRINT_PACKAGES.has(match[1])) {
+        return match[1] as BlueprintPackage;
+    }
+    return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Install-command generation
+// ---------------------------------------------------------------------------
+
+function getInstallCommand(pm: PackageManager, pkg: BlueprintPackage): string {
+    const fullName = `@blueprintjs/${pkg}`;
+    switch (pm) {
+        case "npm":
+            return `npm install --save ${fullName}`;
+        case "pnpm":
+            return `pnpm add ${fullName}`;
+        case "yarn":
+            return `yarn add ${fullName}`;
+        case "bun":
+            return `bun add ${fullName}`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// External store (shared across independent React roots)
+// ---------------------------------------------------------------------------
+
+type Listener = () => void;
+
+let currentPackageManager: PackageManager = "npm";
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+}
+
+function getSnapshot(): PackageManager {
+    return currentPackageManager;
+}
+
+function setPackageManagerExternal(pm: PackageManager) {
+    if (pm !== currentPackageManager) {
+        currentPackageManager = pm;
+        for (const listener of listeners) {
+            listener();
+        }
+    }
+}
+
+/**
+ * Hook that returns the shared package-manager selection and a setter.
+ * Works across independent React roots via `useSyncExternalStore`.
+ */
+export function useSharedPackageManager(): [PackageManager, (pm: PackageManager) => void] {
+    const pm = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+    return [pm, setPackageManagerExternal];
+}
+
+// ---------------------------------------------------------------------------
+// React context (for future single-tree rendering)
+// ---------------------------------------------------------------------------
+
+export interface PackageManagerContextValue {
+    packageManager: PackageManager;
+    setPackageManager: (pm: PackageManager) => void;
+}
+
+const PackageManagerContext = createContext<PackageManagerContextValue | null>(null);
+
+export const PackageManagerProvider = PackageManagerContext.Provider;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface PackageDownloadOptionsProps {
+    package: BlueprintPackage;
+}
+
+export function PackageDownloadOptions({ package: pkg }: PackageDownloadOptionsProps) {
+    const ctxValue = useContext(PackageManagerContext);
+
+    // Prefer context if available; otherwise fall back to the external store.
+    const [storePm, setStorePm] = useSharedPackageManager();
+    const pm = ctxValue?.packageManager ?? storePm;
+    const setPm = ctxValue?.setPackageManager ?? setStorePm;
+
+    const command = getInstallCommand(pm, pkg);
+
+    const handleClick = useCallback(
+        (selected: PackageManager) => () => {
+            setPm(selected);
+        },
+        [setPm],
+    );
+
+    return (
+        <Card compact={true} className="docs-package-download-options">
+            <ButtonGroup variant="minimal">
+                {PACKAGE_MANAGERS.map(name => (
+                    <Button key={name} active={pm === name} text={name} onClick={handleClick(name)} />
+                ))}
+            </ButtonGroup>
+            <CopyToClipboardButton text={command} variant="outlined" />
+            <Code className="docs-package-download-command">{command}</Code>
+        </Card>
+    );
+}

--- a/packages/docs-app/src/index.scss
+++ b/packages/docs-app/src/index.scss
@@ -22,6 +22,7 @@ Licensed under the Apache License, Version 2.0.
 // then our own styles
 @import "styles/colors";
 @import "styles/copyable-import";
+@import "styles/packageDownloadOptions";
 @import "styles/examples";
 @import "styles/icons";
 @import "styles/nav";

--- a/packages/docs-app/src/styles/_packageDownloadOptions.scss
+++ b/packages/docs-app/src/styles/_packageDownloadOptions.scss
@@ -1,0 +1,32 @@
+// Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+.docs-package-download-options {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0 $pt-grid-size;
+
+    &.#{$ns}-card {
+        padding: ($pt-grid-size * 0.5) ($pt-grid-size * 0.5) ($pt-grid-size * 0.5) $pt-grid-size;
+    }
+
+    .#{$ns}-button-group {
+        flex: 0 0 auto;
+    }
+
+    > .#{$ns}-popover-target {
+        flex: 0 0 auto;
+        margin-left: auto;
+    }
+
+    .docs-package-download-command {
+        flex: 1 0 100%;
+        background: none;
+        box-shadow: none;
+        font-size: $pt-font-size;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+}

--- a/packages/docs-data/markdownRenderer.mjs
+++ b/packages/docs-data/markdownRenderer.mjs
@@ -44,10 +44,13 @@ renderer.code = (textContent, infostring, isEscaped) => {
 
     const pre = `<pre class="${Classes.CODE_BLOCK} ${DocsClasses.DOCS_CODE_BLOCK}" data-lang="${language}">${textContent}</pre>`;
 
-    // Wrap code blocks in a container so the docs app can mount a copy button.
-    // Triggered by either an explicit `copy` tag in the info string, or code starting with "import ".
+    // Wrap code blocks in a container so the docs app can mount interactive components.
+    // Shell install commands for @blueprintjs/ packages get a package-manager switcher;
+    // all other `copy`-tagged blocks get a simple copy button.
     if (hasCopyTag) {
-        return `<div class="docs-copyable-import">${pre}</div>`;
+        const isPackageInstall = language === "sh" && /@blueprintjs\//.test(textContent);
+        const wrapperClass = isPackageInstall ? "docs-package-install" : "docs-copyable-import";
+        return `<div class="${wrapperClass}">${pre}</div>`;
     }
 
     return pre;


### PR DESCRIPTION
#### Motivation
All of our peers, in the open-source component-library world, offer various ways to download their packages. Below you'll see an example from `Shadcn`. This is not a feature we've ever offered.

<img width="684" height="111" alt="Screenshot 2026-03-17 at 5 46 35 PM" src="https://github.com/user-attachments/assets/256fd311-3cd2-4782-b077-06c8a3a8e2bf" />

#### What this PR does
Building off of the work in https://github.com/palantir/blueprint/pull/7871, this PR implements a similar functionality, that is copyable.

#### Whats important to know
As soon as we move to `mdx` formatting, this probably shouldn't be done in a compilation step. For that reason, I will likely hold off until [Documentalist Migration pt3 - migrate from .md to .mdx format](https://github.com/palantir/blueprint/pull/7796#top) merges, before resuming this work. 

Structurally, we'll be gaining the ability to drop react components into the `.mdx` files and get full component rendering support. I think that very likely means we can fully remove:
- packages/docs-app/src/components/mountPackageDownloadOptions.tsx
- both `addCopyButtonsToImportBlocks()` and `mountPackageDownloadOptions()`
- the drop-in steps in packages/docs-data/markdownRenderer.mjs

#### TBD
Should this live in `docs-theme` or `docs-app`