### PR TITLE
feat(core): add bordered prop to Section component

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7890.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-7890.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add bordered prop to Section component.
+  links:
+  - https://github.com/palantir/blueprint/pull/7890

--- a/packages/core/src/common/classes.ts
+++ b/packages/core/src/common/classes.ts
@@ -247,6 +247,7 @@ export const MULTISTEP_DIALOG_NAV_TOP = `${MULTISTEP_DIALOG}-nav-top`;
 export const MULTISTEP_DIALOG_NAV_RIGHT = `${MULTISTEP_DIALOG}-nav-right`;
 
 export const SECTION = `${NS}-section`;
+export const SECTION_BORDERED = `${SECTION}-bordered`;
 export const SECTION_COLLAPSED = `${SECTION}-collapsed`;
 export const SECTION_HEADER = `${SECTION}-header`;
 export const SECTION_HEADER_LEFT = `${SECTION_HEADER}-left`;

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -10,6 +10,7 @@ $section-min-height-compact: $pt-spacing * 10 !default;
 $section-padding-compact-vertical: $pt-spacing * 2 !default;
 $section-padding-compact-horizontal: $pt-spacing * 4 !default;
 $section-card-padding-compact: $pt-spacing * 4 !default;
+$section-unbordered-gap: 15px !default;
 
 .#{$ns}-section {
   overflow: hidden;
@@ -118,6 +119,22 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
 
     .#{$ns}-section-card.#{$ns}-padded {
       padding: $section-card-padding-compact;
+    }
+  }
+
+  &:not(.#{$ns}-section-bordered) {
+    .#{$ns}-section-header {
+      border-bottom: none;
+    }
+
+    .#{$ns}-section-card {
+      &:not(:last-child) {
+        border-bottom: none;
+      }
+
+      &.#{$ns}-padded {
+        padding-top: $section-unbordered-gap;
+      }
     }
   }
 }

--- a/packages/core/src/components/section/section.test.tsx
+++ b/packages/core/src/components/section/section.test.tsx
@@ -56,6 +56,20 @@ describe("<Section>", () => {
         assert.isTrue(wrapper.find(`.foo`).hostNodes().exists());
     });
 
+    it("renders with bordered styles by default", () => {
+        const wrapper = mount(<Section title="title" />, {
+            attachTo: containerElement,
+        });
+        assert.isTrue(wrapper.find(`.${Classes.SECTION_BORDERED}`).hostNodes().exists());
+    });
+
+    it("renders without bordered styles when bordered={false}", () => {
+        const wrapper = mount(<Section bordered={false} title="title" />, {
+            attachTo: containerElement,
+        });
+        assert.isFalse(wrapper.find(`.${Classes.SECTION_BORDERED}`).hostNodes().exists());
+    });
+
     it("supports icon", () => {
         const wrapper = mount(<Section icon={IconNames.GRAPH} title="title" />, {
             attachTo: containerElement,

--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -75,6 +75,16 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
     collapseProps?: SectionCollapseProps;
 
     /**
+     * Whether this section should have visual borders.
+     *
+     * Set this to `false` to remove the header border and section card dividers.
+     * When `false`, the gap between the title and body is also reduced to 15px.
+     *
+     * @default true
+     */
+    bordered?: boolean;
+
+    /**
      * Whether this section should use compact styles.
      *
      * @default false
@@ -129,6 +139,7 @@ export interface SectionProps extends Props, Omit<HTMLDivProps, "title">, React.
  */
 export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
     const {
+        bordered = true,
         children,
         className,
         collapseProps,
@@ -166,6 +177,7 @@ export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
     return (
         <Card
             className={classNames(className, Classes.SECTION, {
+                [Classes.SECTION_BORDERED]: bordered,
                 [Classes.COMPACT]: compact,
                 [Classes.SECTION_COLLAPSED]: (collapsible && isCollapsed) || Utils.isReactNodeEmpty(children),
             })}

--- a/packages/docs-app/changelog/@unreleased/pr-7890.v2.yml
+++ b/packages/docs-app/changelog/@unreleased/pr-7890.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add bordered prop to Section component.
+  links:
+  - https://github.com/palantir/blueprint/pull/7890

--- a/packages/docs-app/src/examples/core-examples/sectionExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/sectionExample.tsx
@@ -34,6 +34,7 @@ import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/do
 import { IconNames } from "@blueprintjs/icons";
 
 export interface SectionExampleState {
+    bordered: boolean;
     collapsible: boolean;
     defaultIsOpen: boolean;
     elevation: SectionElevation;
@@ -55,6 +56,7 @@ const BASIL_DESCRIPTION_TEXT = dedent`
 `;
 
 export const SectionExample: React.FC<ExampleProps> = props => {
+    const [bordered, setBordered] = useState(true);
     const [collapsible, setCollapsible] = useState(false);
     const [defaultIsOpen, setDefaultIsOpen] = useState(true);
     const [elevation, setElevation] = useState<SectionElevation>(Elevation.ZERO);
@@ -82,6 +84,11 @@ export const SectionExample: React.FC<ExampleProps> = props => {
         <>
             <div>
                 <H5>Section Props</H5>
+                <Switch
+                    checked={bordered}
+                    label="Bordered"
+                    onChange={handleBooleanChange(setBordered)}
+                />
                 <Switch
                     checked={isCompact}
                     label="Compact"
@@ -164,6 +171,7 @@ export const SectionExample: React.FC<ExampleProps> = props => {
                 // the local state in the `Collapse` component is not
                 // updated.
                 key={String(defaultIsOpen)}
+                bordered={bordered}
                 collapsible={collapsible}
                 collapseProps={collapseProps}
                 compact={isCompact}


### PR DESCRIPTION
## Summary
Fixes #6577

Adds a \ordered\ prop to the Section component (similar to CardList) that allows consumers to control whether borders are rendered.

## Changes
- **section.tsx**: Added \ordered\ prop (default: \	rue\) to SectionProps
- **classes.ts**: Added \SECTION_BORDERED\ class constant
- **_section.scss**: When \ordered={false}\:
  - Removes header border-bottom
  - Removes section card dividers
  - Reduces gap between title and body to 15px
- **section.test.tsx**: Added tests for bordered prop
- **sectionExample.tsx**: Added Bordered switch to the docs example

## Testing
- Added unit tests for bordered/default and bordered=false cases
- Updated docs example with interactive Bordered toggle

Made with [Cursor](https://cursor.com)