### PR TITLE
(chore) Improve Tag Interactive Playground

### DIFF
--- a/packages/docs-app/src/examples/core-examples/compoundTagPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/compoundTagPlaygroundExample.tsx
@@ -47,7 +47,6 @@ export const CompoundTagPlaygroundExample: React.FC<ExampleProps> = props => {
     const options = (
         <>
             <H5>Props</H5>
-            <Switch label="Active" checked={active} onChange={handleBooleanChange(setActive)} />
             <Switch label="Fill" checked={fill} onChange={handleBooleanChange(setFill)} />
             <Switch label="Large" checked={large} onChange={handleBooleanChange(setLarge)} />
             <Switch label="Minimal" checked={minimal} onChange={handleBooleanChange(setMinimal)} />
@@ -55,6 +54,12 @@ export const CompoundTagPlaygroundExample: React.FC<ExampleProps> = props => {
                 label="Interactive"
                 checked={interactive}
                 onChange={handleBooleanChange(setInteractive)}
+            />
+            <Switch
+                label="Active"
+                checked={active}
+                disabled={!interactive}
+                onChange={handleBooleanChange(setActive)}
             />
             <Switch
                 label="Removable"

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useState } from "react";
 
-import { Button, H5, Intent, Switch, Tag } from "@blueprintjs/core";
+import { Button, H5, Intent, Switch, Tag, Tooltip } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -25,6 +25,7 @@ const INITIAL_TAGS = ["London", "New York", "San Francisco", "Seattle"];
 
 export const TagExample: React.FC<ExampleProps> = props => {
     const [active, setActive] = useState(false);
+    const [activeTags, setActiveTags] = useState<string[]>([]);
     const [fill, setFill] = useState(false);
     const [icon, setIcon] = useState(false);
     const [intent, setIntent] = useState<Intent>(Intent.NONE);
@@ -41,12 +42,21 @@ export const TagExample: React.FC<ExampleProps> = props => {
         [tags],
     );
 
-    const handleReset = useCallback(() => setTags(INITIAL_TAGS), []);
+    const handleTagClick = useCallback(
+        (tag: string) => () => {
+            setActiveTags([...activeTags, tag]);
+        },
+        [activeTags],
+    );
+
+    const handleReset = useCallback(() => {
+        setTags(INITIAL_TAGS);
+        setActiveTags([]);
+    }, []);
 
     const options = (
         <>
             <H5>Props</H5>
-            <Switch label="Active" checked={active} onChange={handleBooleanChange(setActive)} />
             <Switch label="Fill" checked={fill} onChange={handleBooleanChange(setFill)} />
             <Switch label="Large" checked={large} onChange={handleBooleanChange(setLarge)} />
             <Switch label="Minimal" checked={minimal} onChange={handleBooleanChange(setMinimal)} />
@@ -55,6 +65,18 @@ export const TagExample: React.FC<ExampleProps> = props => {
                 checked={interactive}
                 onChange={handleBooleanChange(setInteractive)}
             />
+            <Tooltip
+                content="Enable interactivity to use active"
+                disabled={interactive}
+                placement="left"
+            >
+                <Switch
+                    label="Active"
+                    disabled={!interactive}
+                    checked={active}
+                    onChange={handleBooleanChange(setActive)}
+                />
+            </Tooltip>
             <Switch
                 label="Removable"
                 checked={removable}
@@ -74,7 +96,7 @@ export const TagExample: React.FC<ExampleProps> = props => {
             {tags.map(tag => (
                 <Tag
                     key={tag}
-                    active={active}
+                    active={activeTags.includes(tag)}
                     endIcon={endIcon ? "map" : undefined}
                     fill={fill}
                     icon={icon ? "home" : undefined}
@@ -84,10 +106,12 @@ export const TagExample: React.FC<ExampleProps> = props => {
                     onRemove={removable ? handleRemove(tag) : undefined}
                     round={round}
                     size={large ? "large" : undefined}
+                    onClick={handleTagClick(tag)}
                 >
                     {tag}
                 </Tag>
             ))}
+            {active && <p>click a tag to show in an active state</p>}
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -44,9 +44,11 @@ export const TagExample: React.FC<ExampleProps> = props => {
 
     const handleTagClick = useCallback(
         (tag: string) => () => {
-            setActiveTags([...activeTags, tag]);
+            setActiveTags(prev =>
+                prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag],
+            );
         },
-        [activeTags],
+        [],
     );
 
     const handleReset = useCallback(() => {

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useState } from "react";
 
-import { Button, H5, Intent, Switch, Tag, Tooltip } from "@blueprintjs/core";
+import { Button, H5, Intent, Switch, Tag } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
 import { IntentSelect } from "./common/intentSelect";
@@ -67,18 +67,7 @@ export const TagExample: React.FC<ExampleProps> = props => {
                 checked={interactive}
                 onChange={handleBooleanChange(setInteractive)}
             />
-            <Tooltip
-                content="Enable interactivity to use active"
-                disabled={interactive}
-                placement="left"
-            >
-                <Switch
-                    label="Active"
-                    disabled={!interactive}
-                    checked={active}
-                    onChange={handleBooleanChange(setActive)}
-                />
-            </Tooltip>
+            <Switch label="Active" checked={active} onChange={handleBooleanChange(setActive)} />
             <Switch
                 label="Removable"
                 checked={removable}
@@ -98,7 +87,7 @@ export const TagExample: React.FC<ExampleProps> = props => {
             {tags.map(tag => (
                 <Tag
                     key={tag}
-                    active={activeTags.includes(tag)}
+                    active={active || (interactive && activeTags.includes(tag))}
                     endIcon={endIcon ? "map" : undefined}
                     fill={fill}
                     icon={icon ? "home" : undefined}
@@ -113,7 +102,6 @@ export const TagExample: React.FC<ExampleProps> = props => {
                     {tag}
                 </Tag>
             ))}
-            {active && <p>click a tag to show in an active state</p>}
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/tagExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tagExample.tsx
@@ -25,7 +25,6 @@ const INITIAL_TAGS = ["London", "New York", "San Francisco", "Seattle"];
 
 export const TagExample: React.FC<ExampleProps> = props => {
     const [active, setActive] = useState(false);
-    const [activeTags, setActiveTags] = useState<string[]>([]);
     const [fill, setFill] = useState(false);
     const [icon, setIcon] = useState(false);
     const [intent, setIntent] = useState<Intent>(Intent.NONE);
@@ -42,19 +41,7 @@ export const TagExample: React.FC<ExampleProps> = props => {
         [tags],
     );
 
-    const handleTagClick = useCallback(
-        (tag: string) => () => {
-            setActiveTags(prev =>
-                prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag],
-            );
-        },
-        [],
-    );
-
-    const handleReset = useCallback(() => {
-        setTags(INITIAL_TAGS);
-        setActiveTags([]);
-    }, []);
+    const handleReset = useCallback(() => setTags(INITIAL_TAGS), []);
 
     const options = (
         <>
@@ -67,7 +54,12 @@ export const TagExample: React.FC<ExampleProps> = props => {
                 checked={interactive}
                 onChange={handleBooleanChange(setInteractive)}
             />
-            <Switch label="Active" checked={active} onChange={handleBooleanChange(setActive)} />
+            <Switch
+                label="Active"
+                checked={active}
+                disabled={!interactive}
+                onChange={handleBooleanChange(setActive)}
+            />
             <Switch
                 label="Removable"
                 checked={removable}
@@ -87,7 +79,7 @@ export const TagExample: React.FC<ExampleProps> = props => {
             {tags.map(tag => (
                 <Tag
                     key={tag}
-                    active={active || (interactive && activeTags.includes(tag))}
+                    active={active}
                     endIcon={endIcon ? "map" : undefined}
                     fill={fill}
                     icon={icon ? "home" : undefined}
@@ -97,7 +89,6 @@ export const TagExample: React.FC<ExampleProps> = props => {
                     onRemove={removable ? handleRemove(tag) : undefined}
                     round={round}
                     size={large ? "large" : undefined}
-                    onClick={handleTagClick(tag)}
                 >
                     {tag}
                 </Tag>


### PR DESCRIPTION
#### Why make these changes
While reviewing https://github.com/palantir/blueprint/pull/7817 I noticed that the `active` switch (see below) doesn't really do what it's meant to do. (A) it only works if `interactive` is also selected and (B) that doesn't then actually allow the user to _interact_ and basically toggle the active state. Not only is this kind of unexpected behavior, but it doesn't allow you to contrast the `active` state against the `default` state.

<img width="782" height="505" alt="Screenshot 2026-03-19 at 2 04 53 PM" src="https://github.com/user-attachments/assets/d32ea82e-2203-4af5-bbde-209b05ca9fe9" />

_this is from develop^^_

#### Goal
Allow `interactive` to actually create an `interactive` experience