### PR TITLE
[core] fix: Dark mode surface tokens updates, fix for hover and active derive from dark

### DIFF
--- a/packages/core/src/design-tokens/tokens/themes/dark/surface.tokens.json
+++ b/packages/core/src/design-tokens/tokens/themes/dark/surface.tokens.json
@@ -155,23 +155,39 @@
             "default": {
                 "rest": {
                     "$value": "{intent.default.rest}",
-                    "$extensions": { "com.blueprint.derive": { "lightnessScale": 0.248, "chromaScale": 0.487 } }
+                    "$extensions": {
+                        "com.blueprint.derive": { "lightnessScale": 0.362, "chromaScale": 0.308, "hueOffset": -1.44 }
+                    }
                 },
                 "hover": {
                     "$value": "{intent.default.hover}",
                     "$extensions": {
-                        "com.blueprint.derive": { "lightnessScale": 0.279, "chromaScale": 1.379, "hueOffset": 0.3 }
+                        "com.blueprint.derive": {
+                            "lightnessOffset": null,
+                            "chromaOffset": null,
+                            "lightnessScale": 0.615,
+                            "chromaScale": 0.597,
+                            "hueOffset": -5.29
+                        }
                     }
                 },
                 "active": {
                     "$value": "{intent.default.active}",
                     "$extensions": {
-                        "com.blueprint.derive": { "lightnessScale": 0.313, "chromaScale": 1.825, "hueOffset": 2.9 }
+                        "com.blueprint.derive": {
+                            "lightnessOffset": null,
+                            "chromaOffset": null,
+                            "lightnessScale": 0.782,
+                            "chromaScale": 0.84,
+                            "hueOffset": -1.58
+                        }
                     }
                 },
                 "disabled": {
                     "$value": "{intent.default.disabled}",
-                    "$extensions": { "com.blueprint.derive": { "lightnessScale": 0.319, "chromaScale": 0.312 } }
+                    "$extensions": {
+                        "com.blueprint.derive": { "lightnessScale": 0.279, "chromaScale": 0.377, "hueOffset": -2.74 }
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Fix the dark mode surface tokens
- Explicitly nullify light mode values in extension to derive from dark properly

Note that disabled + rest colors are the same for now. TODO: Check that we need a disabled state for surfaces.

Following up the experimental phase, we will add tests to validate what we expect for token outputs.

#### Reviewers should focus on:

- [ ] Correct dark token outputs

#### Screenshot

| Before | After |
| ----- | ----- |
| <img width="694" height="344" alt="derived from light" src="https://github.com/user-attachments/assets/316c4262-b8d0-4f50-9e24-8985e064b183" /> | <img width="645" height="329" alt="dark" src="https://github.com/user-attachments/assets/d66a32e7-b4d1-4c70-8302-fd643b3b1fca" /> |
