### PR TITLE
[core] Integrating design tokens into callout

### DIFF
--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -1,0 +1,225 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Callout } from "./callout";
+
+const meta: Meta<typeof Callout> = {
+    title: "Core/Callout/Callout",
+    component: Callout,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        children: "This is a callout with some informational content.",
+        intent: undefined,
+        icon: undefined,
+        title: undefined,
+        compact: false,
+        minimal: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: [undefined, ...Object.values(Intent).filter(i => i !== "none")],
+        },
+        icon: {
+            control: "text",
+        },
+        compact: {
+            control: "boolean",
+        },
+        minimal: {
+            control: "boolean",
+        },
+        title: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Callout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic callout with default styling.
+ */
+export const Default: Story = {
+    args: {
+        children: "This is a callout with some informational content.",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the callout.
+ * When an intent is set, a default icon is also rendered.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Callout key={intent} {...args} intent={intent}>
+                        {intent.charAt(0).toUpperCase() + intent.slice(1)} intent callout.
+                    </Callout>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `minimal` prop to render a callout without a background color fill.
+ */
+export const VariantExample: Story = {
+    name: "Variant",
+    argTypes: {
+        minimal: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <Callout {...args} minimal={false}>
+                    Default callout with background fill.
+                </Callout>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <Callout {...args} minimal={true}>
+                    Minimal callout without background fill.
+                </Callout>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `compact` prop to reduce the visual padding around callout content.
+ */
+export const CompactExample: Story = {
+    name: "Compact",
+    argTypes: {
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <Callout {...args} compact={false}>
+                    Default padding callout.
+                </Callout>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Compact</span>
+                <Callout {...args} compact={true}>
+                    Compact padding callout.
+                </Callout>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `icon` prop to render an icon on the left side. If omitted, the intent prop determines a default icon.
+ * Set `icon={null}` to explicitly hide the icon.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    argTypes: {
+        icon: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Callout {...args} icon="home">
+                Custom icon callout.
+            </Callout>
+            <Callout {...args} intent="primary">
+                Intent-driven default icon.
+            </Callout>
+            <Callout {...args} intent="primary" icon={null}>
+                Intent with icon explicitly hidden.
+            </Callout>
+        </div>
+    ),
+};
+
+/**
+ * Use the `title` prop to add a heading to the callout.
+ */
+export const TitleExample: Story = {
+    name: "Title",
+    argTypes: {
+        title: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Callout {...args} title="Callout title">
+                Callout with a title and body content.
+            </Callout>
+            <Callout {...args} title="Title only" children={undefined} />
+            <Callout {...args} intent="primary" title="Primary callout">
+                An intent callout with a title and body content.
+            </Callout>
+        </div>
+    ),
+};
+
+/**
+ * All intents across default and minimal variants.
+ */
+export const AllIntentsAllVariants: Story = {
+    argTypes: {
+        intent: { table: { disable: true } },
+        minimal: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {[false, true].map(minimal => (
+                <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <div style={{ fontSize: 12, opacity: 0.6 }}>{minimal ? "Minimal" : "Default"}</div>
+                    <Callout {...args} minimal={minimal}>
+                        No intent callout.
+                    </Callout>
+                    {Object.values(Intent)
+                        .filter(i => i !== "none")
+                        .map(intent => (
+                            <Callout key={intent} {...args} minimal={minimal} intent={intent} title={intent}>
+                                {intent.charAt(0).toUpperCase() + intent.slice(1)} intent callout content.
+                            </Callout>
+                        ))}
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        children: "Adjust the controls to customize this callout.",
+        intent: "primary",
+        title: "Playground Callout",
+        icon: undefined,
+        compact: false,
+        minimal: false,
+    },
+};

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -17,7 +17,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
   &:not(.#{$ns}-minimal) {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.15)"};
   }
 
   // CSS API support

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -10,133 +10,158 @@ $callout-padding-compact: $pt-spacing * 2;
 
 .#{$ns}-callout {
   @include running-typography;
-  border-radius: $pt-border-radius;
-  padding: $callout-padding;
+  border-radius: var(--bp-surface-border-radius);
+  padding: calc(var(--bp-surface-spacing) * 4);
   position: relative;
   width: 100%;
 
   &:not(.#{$ns}-minimal) {
-    background-color: rgba($gray3, 0.15);
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
   }
 
   // CSS API support
   &[class*="#{$ns}-icon-"] {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 2);
+    padding-left: calc(var(--bp-surface-spacing) * 10);
 
     &::before {
       @include pt-icon($pt-icon-size-standard);
-      color: $pt-icon-color;
-      left: $callout-padding;
+      color: var(--bp-typography-color-muted);
+      left: calc(var(--bp-surface-spacing) * 4);
       position: absolute;
-      top: $callout-padding + $callout-header-margin-top;
+      top: calc(var(--bp-surface-spacing) * 4.5);
     }
   }
 
   // High contrast mode hides backgrounds, so we need to use a border instead
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
   }
 
   &.#{$ns}-callout-icon {
-    padding-left: $callout-padding + $pt-icon-size-standard + ($pt-spacing * 2);
+    padding-left: calc(var(--bp-surface-spacing) * 10);
 
     > .#{$ns}-icon:first-child {
-      color: $pt-icon-color;
-      left: $callout-padding;
+      color: var(--bp-typography-color-muted);
+      left: calc(var(--bp-surface-spacing) * 4);
       position: absolute;
-      top: $callout-padding + $callout-header-margin-top;
+      top: calc(var(--bp-surface-spacing) * 4.5);
     }
   }
 
   .#{$ns}-heading {
-    line-height: $pt-icon-size-standard;
+    line-height: calc(var(--bp-surface-spacing) * 4);
     margin-bottom: 0;
-    margin-top: $callout-header-margin-top;
+    margin-top: calc(var(--bp-surface-spacing) * 0.5);
   }
 
   &.#{$ns}-callout-has-body-content {
     .#{$ns}-heading {
-      margin-bottom: $pt-spacing;
+      margin-bottom: var(--bp-surface-spacing);
     }
   }
 
   &.#{$ns}-compact {
-    padding: $callout-padding-compact;
+    padding: calc(var(--bp-surface-spacing) * 2);
 
     &.#{$ns}-callout-icon {
-      padding-left: $callout-padding-compact + $pt-icon-size-standard + ($pt-spacing * 2);
+      padding-left: calc(var(--bp-surface-spacing) * 8);
 
       > .#{$ns}-icon:first-child {
-        left: $callout-padding-compact;
-        top: $callout-padding-compact + $callout-header-margin-top;
+        left: calc(var(--bp-surface-spacing) * 2);
+        top: calc(var(--bp-surface-spacing) * 2.5);
       }
     }
   }
 
-  .#{$ns}-dark & {
+  // Intent styles — expanded from @each over $pt-intent-colors
+  &.#{$ns}-intent-primary {
+    color: var(--bp-intent-primary-rest);
+
     &:not(.#{$ns}-minimal) {
-      background-color: rgba($gray3, 0.2);
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: oklch(from var(--bp-intent-primary-rest) l c h / 0.1);
+    }
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+      border: 1px solid buttonborder;
     }
 
     &[class*="#{$ns}-icon-"]::before,
-    &.#{$ns}-callout-icon > .#{$ns}-icon:first-child {
-      color: $pt-dark-icon-color;
+    > .#{$ns}-icon:first-child,
+    .#{$ns}-heading {
+      color: var(--bp-intent-primary-rest);
     }
-  }
 
-  @each $intent, $color in $pt-intent-colors {
-    &.#{$ns}-intent-#{$intent} {
-      color: map.get($pt-intent-text-colors, $intent);
-
-      &:not(.#{$ns}-minimal) {
-        background-color: rgba($color, 0.1);
-      }
-
-      @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        border: 1px solid $pt-high-contrast-mode-border-color;
-      }
-
-      &[class*="#{$ns}-icon-"]::before,
-      > .#{$ns}-icon:first-child,
-      .#{$ns}-heading {
-        color: map.get($pt-intent-text-colors, $intent);
-      }
-
-      .#{$ns}-dark & {
-        color: map.get($pt-dark-intent-text-colors, $intent);
-
-        &:not(.#{$ns}-minimal) {
-          background-color: rgba($color, 0.2);
-        }
-
-        &[class*="#{$ns}-icon-"]::before,
-        > .#{$ns}-icon:first-child,
-        .#{$ns}-heading {
-          color: map.get($pt-dark-intent-text-colors, $intent);
-        }
-      }
-    }
-  }
-
-  &.#{$ns}-intent-primary {
     // special case for links inside primary intent callouts, which would otherwise not have any indication
     // that they are clickable links; see https://github.com/palantir/blueprint/issues/5853
     a {
       text-decoration: underline;
 
       &:hover {
-        color: $blue1;
-      }
-    }
-
-    .#{$ns}-dark & {
-      a:hover {
-        color: $blue6;
+        color: var(--bp-intent-primary-hover);
       }
     }
   }
 
+  &.#{$ns}-intent-success {
+    color: var(--bp-intent-success-rest);
+
+    &:not(.#{$ns}-minimal) {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: oklch(from var(--bp-intent-success-rest) l c h / 0.1);
+    }
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+      border: 1px solid buttonborder;
+    }
+
+    &[class*="#{$ns}-icon-"]::before,
+    > .#{$ns}-icon:first-child,
+    .#{$ns}-heading {
+      color: var(--bp-intent-success-rest);
+    }
+  }
+
+  &.#{$ns}-intent-warning {
+    color: var(--bp-intent-warning-rest);
+
+    &:not(.#{$ns}-minimal) {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: oklch(from var(--bp-intent-warning-rest) l c h / 0.1);
+    }
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+      border: 1px solid buttonborder;
+    }
+
+    &[class*="#{$ns}-icon-"]::before,
+    > .#{$ns}-icon:first-child,
+    .#{$ns}-heading {
+      color: var(--bp-intent-warning-rest);
+    }
+  }
+
+  &.#{$ns}-intent-danger {
+    color: var(--bp-intent-danger-rest);
+
+    &:not(.#{$ns}-minimal) {
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: oklch(from var(--bp-intent-danger-rest) l c h / 0.1);
+    }
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+      border: 1px solid buttonborder;
+    }
+
+    &[class*="#{$ns}-icon-"]::before,
+    > .#{$ns}-icon:first-child,
+    .#{$ns}-heading {
+      color: var(--bp-intent-danger-rest);
+    }
+  }
+
   .#{$ns}-running-text & {
-    margin: ($pt-spacing * 5) 0;
+    margin: calc(var(--bp-surface-spacing) * 5) 0;
   }
 }

--- a/packages/core/src/components/callout/_callout.scss
+++ b/packages/core/src/components/callout/_callout.scss
@@ -17,7 +17,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
   &:not(.#{$ns}-minimal) {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
   }
 
   // CSS API support
@@ -80,7 +80,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
     &:not(.#{$ns}-minimal) {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-primary-rest) l c h / 0.1);
+      background-color: #{"oklch(from var(--bp-intent-primary-rest) l c h / 0.1)"};
     }
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -109,7 +109,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
     &:not(.#{$ns}-minimal) {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-success-rest) l c h / 0.1);
+      background-color: #{"oklch(from var(--bp-intent-success-rest) l c h / 0.1)"};
     }
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -128,7 +128,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
     &:not(.#{$ns}-minimal) {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-warning-rest) l c h / 0.1);
+      background-color: #{"oklch(from var(--bp-intent-warning-rest) l c h / 0.1)"};
     }
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -147,7 +147,7 @@ $callout-padding-compact: $pt-spacing * 2;
 
     &:not(.#{$ns}-minimal) {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-danger-rest) l c h / 0.1);
+      background-color: #{"oklch(from var(--bp-intent-danger-rest) l c h / 0.1)"};
     }
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Callout component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue2` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_callout.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `padding-left` | `$callout-padding + $pt-icon-size-standard + ($pt-spacing * 2)` | `calc(var(--bp-surface-spacing) * 10)` |
| `top` | `$callout-padding + $callout-header-margin-top` | `calc(var(--bp-surface-spacing) * 4.5)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `padding-left` | `$callout-padding + $pt-icon-size-standard + ($pt-spacing * 2)` | `calc(var(--bp-surface-spacing) * 10)` |
| `top` | `$callout-padding + $callout-header-margin-top` | `calc(var(--bp-surface-spacing) * 4.5)` |
| `line-height` | `$pt-icon-size-standard` | `calc(var(--bp-surface-spacing) * 4)` |
| `margin-top` | `$callout-header-margin-top` | `calc(var(--bp-surface-spacing) * 0.5)` |
| `margin-bottom` | `$pt-spacing` | `var(--bp-surface-spacing)` |
| `padding` | `$callout-padding-compact` | `calc(var(--bp-surface-spacing) * 2)` |
| `padding-left` | `$callout-padding-compact + $pt-icon-size-standard + ($pt-spacing * 2)` | `calc(var(--bp-surface-spacing) * 8)` |
| `color` | `$blue1` | `var(--bp-intent-primary-hover)` |
| `margin` | `($pt-spacing * 5) 0` | `calc(var(--bp-surface-spacing) * 5) 0` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`@each` intent loops expanded.** Loops over `$pt-intent-colors` replaced with explicit per-intent blocks for CSS custom property compatibility.
3. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.
4. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
5. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Loop expansion | `@each` over SCSS map → explicit per-intent rules |
| 3 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |
| 4 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 5 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Dark theme appearance after removing redundant `.bp6-dark` blocks
- Intent styles after expanding `@each` loops
