### PR TITLE
[core] Integrating design tokens into toast

### DIFF
--- a/packages/core/src/components/toast/Toast.stories.tsx
+++ b/packages/core/src/components/toast/Toast.stories.tsx
@@ -1,0 +1,182 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Toast } from "./toast";
+
+const meta: Meta<typeof Toast> = {
+    title: "Core/Toast/Toast",
+    component: Toast,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        message: "This is a toast message",
+        intent: "none",
+        icon: undefined,
+        isCloseButtonShown: true,
+        timeout: 0,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        icon: {
+            control: "text",
+        },
+        isCloseButtonShown: {
+            control: "boolean",
+        },
+        timeout: {
+            control: "number",
+        },
+        onDismiss: { action: "dismissed" },
+    },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic toast with default styling and a close button.
+ */
+export const Default: Story = {
+    args: {
+        message: "This is a toast message",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the toast.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Toast
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        message={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent toast`}
+                    />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `icon` prop to render a Blueprint icon before the message.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    argTypes: {
+        icon: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Toast {...args} icon="tick-circle" intent="success" message="File saved successfully" />
+            <Toast {...args} icon="warning-sign" intent="warning" message="Connection is unstable" />
+            <Toast {...args} icon="error" intent="danger" message="Failed to save changes" />
+            <Toast {...args} icon="info-sign" intent="primary" message="New update available" />
+        </div>
+    ),
+};
+
+/**
+ * Toasts can include an action button via the `action` prop.
+ */
+export const WithAction: Story = {
+    name: "With Action",
+    args: {
+        message: "File moved to trash",
+        icon: "trash",
+        action: {
+            text: "Undo",
+        },
+    },
+};
+
+/**
+ * The close button can be hidden with `isCloseButtonShown={false}`.
+ */
+export const CloseButtonHidden: Story = {
+    name: "Close Button Hidden",
+    argTypes: {
+        isCloseButtonShown: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Toast {...args} isCloseButtonShown={true} message="With close button (default)" />
+            <Toast {...args} isCloseButtonShown={false} message="Without close button" />
+        </div>
+    ),
+};
+
+/**
+ * All intents with icons and action buttons for visual regression testing.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        icon: { table: { disable: true } },
+    },
+    render: args => {
+        const intents: Array<{ intent: (typeof Intent)[keyof typeof Intent]; icon: string; message: string }> = [
+            { intent: Intent.NONE, icon: "notifications", message: "You have 3 new notifications" },
+            { intent: Intent.PRIMARY, icon: "info-sign", message: "A new software update is available" },
+            { intent: Intent.SUCCESS, icon: "tick-circle", message: "Changes saved successfully" },
+            { intent: Intent.WARNING, icon: "warning-sign", message: "Your session expires in 5 minutes" },
+            { intent: Intent.DANGER, icon: "error", message: "Network request failed" },
+        ];
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {intents.map(({ intent, icon, message }) => (
+                    <Toast
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        icon={icon}
+                        message={message}
+                        action={{ text: "Action" }}
+                    />
+                ))}
+            </div>
+        );
+    },
+};
+
+/**
+ * Interactive playground for experimenting with toast props.
+ */
+export const Playground: Story = {
+    args: {
+        message: "Playground toast message",
+        icon: "info-sign",
+        intent: "primary",
+        isCloseButtonShown: true,
+        action: {
+            text: "Undo",
+        },
+    },
+};

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -157,7 +157,7 @@ $toast-intent-colors: (
 
   &.#{$ns}-dark,
   .#{$ns}-dark & {
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h)"};
     box-shadow: var(--bp-surface-shadow-3);
 
     > .#{$ns}-icon {
@@ -167,14 +167,14 @@ $toast-intent-colors: (
     // increase contrast for default intent in dark mode
     .#{$ns}-button .#{$ns}-icon {
       /* stylelint-disable-next-line alpha-value-notation */
-      color: oklch(from var(--bp-palette-white) l c h / 0.7);
+      color: #{"oklch(from var(--bp-palette-white) l c h / 0.7)"};
     }
   }
 
   &[class*="#{$ns}-intent-"] {
     a {
       /* stylelint-disable-next-line alpha-value-notation */
-      color: oklch(from var(--bp-palette-white) l c h / 0.7);
+      color: #{"oklch(from var(--bp-palette-white) l c h / 0.7)"};
 
       &:hover {
         color: var(--bp-palette-white);

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -24,10 +24,10 @@ $toast-intent-colors: (
     var(--bp-intent-success-active),
   ),
   "warning": (
-    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
+    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.179) calc(c - 0.01) h)"},
     var(--bp-intent-warning-foreground),
-    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.16) c h)"},
-    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.12) c h)"},
+    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.19) calc(c + 0.031) h)"},
+    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.201) calc(c + 0.045) h)"},
   ),
   "danger": (
     var(--bp-intent-danger-rest),
@@ -157,7 +157,7 @@ $toast-intent-colors: (
 
   &.#{$ns}-dark,
   .#{$ns}-dark & {
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.201) calc(c - 0.015) h)"};
     box-shadow: var(--bp-surface-shadow-3);
 
     > .#{$ns}-icon {

--- a/packages/core/src/components/toast/_toast.scss
+++ b/packages/core/src/components/toast/_toast.scss
@@ -9,32 +9,34 @@ $toast-min-width: $pt-spacing * 75 !default;
 $toast-max-width: $pt-spacing * 125 !default;
 $toast-margin: $pt-spacing * 5 !default;
 
+/* stylelint-disable alpha-value-notation */
 $toast-intent-colors: (
   "primary": (
-    $pt-intent-primary,
-    $white,
-    $blue2,
-    $blue1,
+    var(--bp-intent-primary-rest),
+    var(--bp-intent-primary-foreground),
+    var(--bp-intent-primary-hover),
+    var(--bp-intent-primary-active),
   ),
   "success": (
-    $pt-intent-success,
-    $white,
-    $green2,
-    $green1,
+    var(--bp-intent-success-rest),
+    var(--bp-intent-success-foreground),
+    var(--bp-intent-success-hover),
+    var(--bp-intent-success-active),
   ),
   "warning": (
-    $orange5,
-    $dark-gray1,
-    $orange4,
-    $orange3,
+    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
+    var(--bp-intent-warning-foreground),
+    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.16) c h)"},
+    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.12) c h)"},
   ),
   "danger": (
-    $pt-intent-danger,
-    $white,
-    $red2,
-    $red1,
+    var(--bp-intent-danger-rest),
+    var(--bp-intent-danger-foreground),
+    var(--bp-intent-danger-hover),
+    var(--bp-intent-danger-active),
   ),
 ) !default;
+/* stylelint-enable alpha-value-notation */
 
 @mixin pt-toast-intent(
   $background-color,
@@ -46,7 +48,8 @@ $toast-intent-colors: (
   color: $text-and-focus-color;
 
   .#{$ns}-icon:first-child {
-    color: rgba($text-and-focus-color, 0.7);
+    /* stylelint-disable-next-line alpha-value-notation */
+    color: #{"oklch(from "}#{$text-and-focus-color}#{" l c h / 0.7)"};
   }
 
   // HACKHACK custom colors for buttons on intent background so they always show up nice
@@ -67,11 +70,13 @@ $toast-intent-colors: (
 
     &:focus {
       // blue outline color shows poorly on colored bg
-      outline-color: rgba($text-and-focus-color, 0.75);
+      /* stylelint-disable-next-line alpha-value-notation */
+      outline-color: #{"oklch(from "}#{$text-and-focus-color}#{" l c h / 0.75)"};
     }
 
     &:last-child > .#{$ns}-icon-cross {
-      color: rgba($text-and-focus-color, 0.7) !important;
+      /* stylelint-disable-next-line alpha-value-notation */
+      color: #{"oklch(from "}#{$text-and-focus-color}#{" l c h / 0.7)"} !important;
     }
   }
   /* stylelint-enable declaration-no-important */
@@ -84,7 +89,7 @@ $toast-intent-colors: (
   );
   $leave-blur: (
     opacity: 0 1,
-    filter: blur($pt-spacing * 2) blur(0),
+    filter: blur(calc(var(--bp-surface-spacing) * 2)) blur(0),
   );
 
   // new toasts slide in from the top
@@ -92,16 +97,16 @@ $toast-intent-colors: (
     "#{$ns}-toast",
     "enter",
     $enter-translate,
-    $duration: $pt-transition-duration * 3,
-    $easing: $pt-transition-ease-bounce,
+    $duration: calc(var(--bp-emphasis-transition-duration) * 3),
+    $easing: var(--bp-emphasis-ease-bounce),
     $before: "&"
   );
   @include react-transition-phase(
     "#{$ns}-toast",
     "enter",
     $enter-translate,
-    $duration: $pt-transition-duration * 3,
-    $easing: $pt-transition-ease-bounce,
+    $duration: calc(var(--bp-emphasis-transition-duration) * 3),
+    $easing: var(--bp-emphasis-ease-bounce),
     $before: "&",
     $after: "~ &"
   );
@@ -110,7 +115,7 @@ $toast-intent-colors: (
     "#{$ns}-toast",
     "exit",
     $leave-blur,
-    $duration: $pt-transition-duration * 3,
+    $duration: calc(var(--bp-emphasis-transition-duration) * 3),
     $before: "&"
   );
   // younger siblings of leaving toasts wait a moment before moving to fill gap
@@ -118,18 +123,18 @@ $toast-intent-colors: (
     "#{$ns}-toast",
     "exit",
     $enter-translate,
-    $delay: $pt-transition-duration * 0.5,
+    $delay: calc(var(--bp-emphasis-transition-duration) * 0.5),
     $before: "&",
     $after: "~ &"
   );
   align-items: flex-start;
-  background-color: $white;
-  border-radius: $pt-border-radius;
-  box-shadow: $pt-toast-box-shadow;
+  background-color: var(--bp-palette-white);
+  border-radius: var(--bp-surface-border-radius);
+  box-shadow: var(--bp-surface-shadow-3);
   display: flex;
-  margin: $toast-margin 0 0;
-  max-width: min($toast-max-width, 100%);
-  min-width: min($toast-min-width, 100%);
+  margin: calc(var(--bp-surface-spacing) * 5) 0 0;
+  max-width: min(calc(var(--bp-surface-spacing) * 125), 100%);
+  min-width: min(calc(var(--bp-surface-spacing) * 75), 100%);
 
   // toast is interactive even though container isn't
   pointer-events: all;
@@ -140,42 +145,44 @@ $toast-intent-colors: (
 
   .#{$ns}-button-group {
     flex: 0 0 auto;
-    padding: ($toast-height - $pt-button-height) * 0.5;
+    padding: calc((var(--bp-surface-spacing) * 10 - var(--bp-surface-spacing) * 7.5) * 0.5);
     padding-left: 0;
   }
 
   > .#{$ns}-icon {
-    color: $pt-icon-color;
-    margin: ($toast-height - $pt-icon-size-standard) * 0.5;
+    color: var(--bp-typography-color-muted);
+    margin: calc((var(--bp-surface-spacing) * 10 - var(--bp-surface-spacing) * 4) * 0.5);
     margin-right: 0;
   }
 
   &.#{$ns}-dark,
   .#{$ns}-dark & {
-    background-color: $dark-gray4;
-    box-shadow: $pt-dark-toast-box-shadow;
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h);
+    box-shadow: var(--bp-surface-shadow-3);
 
     > .#{$ns}-icon {
-      color: $pt-dark-icon-color;
+      color: var(--bp-typography-color-muted);
     }
 
     // increase contrast for default intent in dark mode
     .#{$ns}-button .#{$ns}-icon {
-      color: rgba($white, 0.7);
+      /* stylelint-disable-next-line alpha-value-notation */
+      color: oklch(from var(--bp-palette-white) l c h / 0.7);
     }
   }
 
   &[class*="#{$ns}-intent-"] {
     a {
-      color: rgba($white, 0.7);
+      /* stylelint-disable-next-line alpha-value-notation */
+      color: oklch(from var(--bp-palette-white) l c h / 0.7);
 
       &:hover {
-        color: $white;
+        color: var(--bp-palette-white);
       }
     }
 
     > .#{$ns}-icon {
-      color: $white;
+      color: var(--bp-palette-white);
     }
   }
 
@@ -205,7 +212,7 @@ $toast-intent-colors: (
   overflow: hidden;
 
   // ensure there's enough space for full box-shadow
-  padding: 0 $toast-margin $toast-margin;
+  padding: 0 calc(var(--bp-surface-spacing) * 5) calc(var(--bp-surface-spacing) * 5);
 
   // container will not block clicks on elements behind it
   pointer-events: none;
@@ -213,7 +220,7 @@ $toast-intent-colors: (
   right: 0;
 
   // #975 ensure toasts are on top of everything (esp dialogs)
-  z-index: $pt-z-index-overlay * 2;
+  z-index: var(--bp-surface-z-index-4);
 
   &.#{$ns}-toast-container-in-portal {
     position: fixed;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Toast component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-bounce` | `cubic-bezier(0.54, 1.12, 0.38, 1.11)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-intent-danger-active` | `#8e292c` | `$red1` |
| `--bp-intent-danger-foreground` | `#ffffff` | `$white` |
| `--bp-intent-danger-hover` | `#ac2f33` | `$red2` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-primary-active` | `#184a90` | `$blue1` |
| `--bp-intent-primary-foreground` | `#ffffff` | `$white` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue2` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-active` | `#165a36` | `$green1` |
| `--bp-intent-success-foreground` | `#ffffff` | `$white` |
| `--bp-intent-success-hover` | `#1c6e42` | `$green2` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-active` | `#77450d` | `$orange1` |
| `--bp-intent-warning-foreground` | `#111418` | `$pt-text-color` |
| `--bp-intent-warning-hover` | `#935610` | `$orange2` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-shadow-3` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-surface-z-index-4` | `40` | `(see diff)` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_toast.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `filter` | `blur($pt-spacing * 2) blur(0),` | `blur(calc(var(--bp-surface-spacing) * 2)) blur(0),` |
| `box-shadow: $pt-` | `$pt-toast-box-shadow` | `var(--bp-palette-white)` |
| `min-wi` | `min($toast-min-width, 100%)` | `calc(var(--bp-surface-spacing) * 5) 0 0` |
| `padding` | `($toast-height - $pt-button-height) * 0.5` | `calc((var(--bp-surface-spacing) * 10 - var(--bp-surface-spacing) * 7.5) * 0.5)` |
| `color` | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |
| `color` | `$white` | `var(--bp-palette-white)` |
| `color` | `$white` | `var(--bp-palette-white)` |
| `padding` | `0 $toast-margin $toast-margin` | `0 calc(var(--bp-surface-spacing) * 5) calc(var(--bp-surface-spacing) * 5)` |
| `z-index` | `$pt-z-index-overlay * 2` | `var(--bp-surface-z-index-4)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
