### PR TITLE
[core] Integrating design tokens into menu

### DIFF
--- a/packages/core/src/components/menu/Menu.stories.tsx
+++ b/packages/core/src/components/menu/Menu.stories.tsx
@@ -1,0 +1,240 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent, Size } from "../../common";
+
+import { Menu } from "./menu";
+import { MenuDivider } from "./menuDivider";
+import { MenuItem } from "./menuItem";
+
+// These props are deprecated on Menu — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof Menu>
+>;
+
+const meta: Meta<typeof Menu> = {
+    title: "Core/Menu/Menu",
+    component: Menu,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        size: "medium",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Menu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => (
+        <Menu {...args}>
+            <MenuItem icon="new-text-box" text="New text box" />
+            <MenuItem icon="new-object" text="New object" />
+            <MenuItem icon="new-link" text="New link" />
+            <MenuDivider />
+            <MenuItem icon="cog" text="Settings" label="⌘," />
+        </Menu>
+    ),
+};
+
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Menu key={intent} {...args}>
+                        <MenuItem
+                            icon="graph"
+                            text={intent.charAt(0).toUpperCase() + intent.slice(1)}
+                            intent={intent}
+                        />
+                        <MenuItem
+                            icon="notifications"
+                            text="Active"
+                            intent={intent}
+                            active={true}
+                        />
+                    </Menu>
+                ))}
+        </div>
+    ),
+};
+
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+            {Object.values(Size).map(size => (
+                <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                    <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{size}</span>
+                    <Menu {...args} size={size}>
+                        <MenuItem icon="document" text="New file" />
+                        <MenuItem icon="folder-close" text="New folder" />
+                        <MenuDivider />
+                        <MenuItem icon="cog" text="Settings" />
+                    </Menu>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <Menu {...args}>
+                    <MenuItem icon="home" text="Home" />
+                    <MenuItem icon="document" text="Files" />
+                </Menu>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Active</span>
+                <Menu {...args}>
+                    <MenuItem icon="home" text="Home" active={true} />
+                    <MenuItem icon="document" text="Files" />
+                </Menu>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                <Menu {...args}>
+                    <MenuItem icon="home" text="Home" disabled={true} />
+                    <MenuItem icon="document" text="Files" disabled={true} />
+                </Menu>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Selected</span>
+                <Menu {...args}>
+                    <MenuItem icon="home" text="Home" roleStructure="listoption" selected={true} />
+                    <MenuItem icon="document" text="Files" roleStructure="listoption" selected={false} />
+                </Menu>
+            </div>
+        </div>
+    ),
+};
+
+export const IconsExample: Story = {
+    name: "Icons",
+    render: args => (
+        <Menu {...args}>
+            <MenuItem icon="applications" text="With icon" />
+            <MenuItem text="Without icon" />
+            <MenuItem icon="graph" text="With icon and label" label="⌘G" />
+            <MenuItem icon="add" text="With label element" labelElement={<span>Ctrl+N</span>} />
+        </Menu>
+    ),
+};
+
+export const WithDividersAndHeaders: Story = {
+    name: "Dividers & Headers",
+    render: args => (
+        <Menu {...args}>
+            <MenuDivider title="Edit" />
+            <MenuItem icon="cut" text="Cut" label="⌘X" />
+            <MenuItem icon="clipboard" text="Copy" label="⌘C" />
+            <MenuItem icon="duplicate" text="Paste" label="⌘V" />
+            <MenuDivider title="View" />
+            <MenuItem icon="zoom-in" text="Zoom in" />
+            <MenuItem icon="zoom-out" text="Zoom out" />
+        </Menu>
+    ),
+};
+
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                        <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</span>
+                        <Menu {...args}>
+                            <MenuItem icon="graph" text="Default" intent={intent} />
+                            <MenuItem icon="notifications" text="Active" intent={intent} active={true} />
+                            <MenuItem icon="lock" text="Disabled" intent={intent} disabled={true} />
+                        </Menu>
+                    </div>
+                ))}
+        </div>
+    ),
+};
+
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    render: args => (
+        <div className="bp6-dark" style={{ padding: 16, borderRadius: 4 }}>
+            <Menu {...args}>
+                <MenuItem icon="new-text-box" text="New text box" />
+                <MenuItem icon="new-object" text="New object" />
+                <MenuItem icon="new-link" text="New link" />
+                <MenuDivider />
+                <MenuItem icon="cog" text="Settings" label="⌘," />
+                <MenuDivider title="Intent" />
+                <MenuItem icon="graph" text="Primary" intent="primary" />
+                <MenuItem icon="tick" text="Success" intent="success" />
+                <MenuItem icon="warning-sign" text="Warning" intent="warning" />
+                <MenuItem icon="error" text="Danger" intent="danger" />
+            </Menu>
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    render: args => (
+        <Menu {...args}>
+            <MenuDivider title="File" />
+            <MenuItem icon="document" text="New" label="⌘N" />
+            <MenuItem icon="document-open" text="Open" label="⌘O" />
+            <MenuItem icon="floppy-disk" text="Save" label="⌘S" intent="primary" />
+            <MenuDivider title="Edit" />
+            <MenuItem icon="cut" text="Cut" label="⌘X" />
+            <MenuItem icon="clipboard" text="Copy" label="⌘C" />
+            <MenuItem icon="duplicate" text="Paste" label="⌘V" />
+            <MenuDivider />
+            <MenuItem icon="trash" text="Delete" intent="danger" />
+            <MenuItem icon="lock" text="Locked" disabled={true} />
+        </Menu>
+    ),
+};

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -129,7 +129,7 @@ $dark-menu-item-intent-colors: (
   // and mouse interactions.
   &:active {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
 
     .#{$ns}-menu-item-label {
       color: var(--bp-typography-color-default-rest);
@@ -197,7 +197,7 @@ $dark-menu-item-intent-colors: (
   &:active {
     // we can use the same color as light theme due to transparency
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
 
     .#{$ns}-menu-item-label {
       color: var(--bp-typography-color-default-rest);
@@ -228,7 +228,7 @@ $dark-menu-item-intent-colors: (
 
 @mixin menu-item-hover() {
   /* stylelint-disable-next-line alpha-value-notation */
-  background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+  background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
   color: inherit;
   cursor: pointer;
   text-decoration: none;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -35,59 +35,61 @@ $dark-menu-background-color: $dark-gray3 !default;
 $menu-item-color-hover: rgba($gray3, 0.15) !default;
 $menu-item-color-active: rgba($gray3, 0.3) !default;
 
+/* stylelint-disable alpha-value-notation */
 $menu-item-intent-colors: (
   "primary": (
-    /* bg */ $blue3,
-    /* fg */ $blue2,
-    /* fg active */ $blue1,
+    /* bg */ var(--bp-intent-primary-rest),
+    /* fg */ var(--bp-intent-primary-hover),
+    /* fg active */ var(--bp-intent-primary-active),
   ),
   "success": (
-    /* bg */ $green3,
-    /* fg */ $green2,
-    /* fg active */ $green1,
+    /* bg */ var(--bp-intent-success-rest),
+    /* fg */ var(--bp-intent-success-hover),
+    /* fg active */ var(--bp-intent-success-active),
   ),
   "warning": (
-    /* bg */ $orange3,
-    /* fg */ $orange2,
-    /* fg active */ $orange1,
+    /* bg */ var(--bp-intent-warning-rest),
+    /* fg */ var(--bp-intent-warning-hover),
+    /* fg active */ var(--bp-intent-warning-active),
   ),
   "danger": (
-    /* bg */ $red3,
-    /* fg */ $red2,
-    /* fg active */ $red1,
+    /* bg */ var(--bp-intent-danger-rest),
+    /* fg */ var(--bp-intent-danger-hover),
+    /* fg active */ var(--bp-intent-danger-active),
   ),
 ) !default;
 
 $dark-menu-item-intent-colors: (
   "primary": (
-    /* bg */ $blue3,
-    /* fg */ $blue5,
-    /* fg active */ $blue6,
+    /* bg */ var(--bp-intent-primary-rest),
+    /* fg */ #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h)"},
   ),
   "success": (
-    /* bg */ $green3,
-    /* fg */ $green5,
-    /* fg active */ $green6,
+    /* bg */ var(--bp-intent-success-rest),
+    /* fg */ #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h)"},
   ),
   "warning": (
-    /* bg */ $orange3,
-    /* fg */ $orange5,
-    /* fg active */ $orange6,
+    /* bg */ var(--bp-intent-warning-rest),
+    /* fg */ #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h)"},
   ),
   "danger": (
-    /* bg */ $red3,
-    /* fg */ $red5,
-    /* fg active */ $red6,
+    /* bg */ var(--bp-intent-danger-rest),
+    /* fg */ #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h)"},
   ),
 ) !default;
+/* stylelint-enable alpha-value-notation */
 
 @mixin menu-item() {
-  @include pt-flex-container(row, $menu-item-padding);
+  @include pt-flex-container(row, calc(var(--bp-surface-spacing) * 2));
   align-items: flex-start;
-  border-radius: $menu-item-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   color: inherit;
   line-height: $menu-item-line-height;
-  padding: $menu-item-padding-vertical $menu-item-padding;
+  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
   text-decoration: none;
   user-select: none;
 
@@ -103,14 +105,14 @@ $dark-menu-item-intent-colors: (
   }
 
   .#{$ns}-menu-item-label {
-    color: $pt-text-color-muted;
+    color: var(--bp-typography-color-muted);
   }
 
   &::before,
   .#{$ns}-menu-item-icon,
   .#{$ns}-menu-item-selected-icon,
   .#{$ns}-submenu-icon {
-    color: $pt-icon-color;
+    color: var(--bp-typography-color-muted);
   }
 
   &::before,
@@ -126,10 +128,11 @@ $dark-menu-item-intent-colors: (
   // The latter is often used to indicate keyboard navigation, and it's helpful to distinguish between keyboard
   // and mouse interactions.
   &:active {
-    background-color: $menu-item-color-active;
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
 
     .#{$ns}-menu-item-label {
-      color: $pt-text-color;
+      color: var(--bp-typography-color-default-rest);
     }
   }
 
@@ -146,7 +149,7 @@ $dark-menu-item-intent-colors: (
 
     .#{$ns}-menu-item-selected-icon {
       align-self: center;
-      margin: 0 $menu-item-selected-icon-spacing;
+      margin: 0 calc(var(--bp-surface-spacing) * 0.5);
     }
   }
 
@@ -154,7 +157,7 @@ $dark-menu-item-intent-colors: (
   /* stylelint-disable declaration-no-important */
   &.#{$ns}-disabled {
     background-color: inherit !important;
-    color: $pt-text-color-disabled !important;
+    color: var(--bp-typography-color-default-disabled) !important;
     cursor: not-allowed !important;
     // override global a:focus styles
     outline: none !important;
@@ -162,11 +165,11 @@ $dark-menu-item-intent-colors: (
     &::before,
     .#{$ns}-menu-item-icon,
     .#{$ns}-submenu-icon {
-      color: $pt-icon-color-disabled !important;
+      color: var(--bp-typography-color-default-disabled) !important;
     }
 
     .#{$ns}-menu-item-label {
-      color: $pt-text-color-disabled !important;
+      color: var(--bp-typography-color-default-disabled) !important;
     }
   }
   /* stylelint-enable declaration-no-important */
@@ -176,14 +179,14 @@ $dark-menu-item-intent-colors: (
   color: inherit;
 
   .#{$ns}-menu-item-label {
-    color: $pt-dark-text-color-muted;
+    color: var(--bp-typography-color-muted);
   }
 
   &::before,
   .#{$ns}-menu-item-icon,
   .#{$ns}-menu-item-selected-icon,
   .#{$ns}-submenu-icon {
-    color: $pt-dark-icon-color;
+    color: var(--bp-typography-color-muted);
   }
 
   &:hover {
@@ -193,10 +196,11 @@ $dark-menu-item-intent-colors: (
   // N.B. mouse interaction :active appearance is different from the .#{$ns}-active modifier class.
   &:active {
     // we can use the same color as light theme due to transparency
-    background-color: $menu-item-color-active;
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
 
     .#{$ns}-menu-item-label {
-      color: $pt-dark-text-color;
+      color: var(--bp-typography-color-default-rest);
     }
   }
 
@@ -207,23 +211,24 @@ $dark-menu-item-intent-colors: (
   // pt-disable always overrides over styles
   /* stylelint-disable declaration-no-important */
   &.#{$ns}-disabled {
-    color: $pt-dark-text-color-disabled !important;
+    color: var(--bp-typography-color-default-disabled) !important;
 
     &::before,
     .#{$ns}-menu-item-icon,
     .#{$ns}-submenu-icon {
-      color: $pt-dark-icon-color-disabled !important;
+      color: var(--bp-typography-color-default-disabled) !important;
     }
 
     .#{$ns}-menu-item-label {
-      color: $pt-dark-text-color-disabled !important;
+      color: var(--bp-typography-color-default-disabled) !important;
     }
   }
   /* stylelint-enable declaration-no-important */
 }
 
 @mixin menu-item-hover() {
-  background-color: $menu-item-color-hover;
+  /* stylelint-disable-next-line alpha-value-notation */
+  background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
   color: inherit;
   cursor: pointer;
   text-decoration: none;
@@ -235,7 +240,7 @@ $dark-menu-item-intent-colors: (
   // need to override typography styles here
   .#{$ns}-menu-item-icon,
   .#{$ns}-submenu-icon {
-    color: $pt-dark-icon-color;
+    color: var(--bp-typography-color-muted);
   }
 }
 
@@ -252,7 +257,8 @@ $dark-menu-item-intent-colors: (
     }
   }
 
-  background-color: rgba(list.nth(map.get($intent-colors, "primary"), 1), $background-alpha);
+  /* stylelint-disable alpha-value-notation */
+  background-color: #{"oklch(from "}#{list.nth(map.get($intent-colors, "primary"), 1)}#{" l c h / "}#{$background-alpha}#{")"};
   color: list.nth(map.get($intent-colors, "primary"), 2);
 
   &::before,
@@ -264,7 +270,7 @@ $dark-menu-item-intent-colors: (
 
   @each $intent in ("success", "warning", "danger") {
     &.#{$ns}-intent-#{$intent} {
-      background-color: rgba(list.nth(map.get($intent-colors, $intent), 1), $background-alpha);
+      background-color: #{"oklch(from "}#{list.nth(map.get($intent-colors, $intent), 1)}#{" l c h / "}#{$background-alpha}#{")"};
       color: list.nth(map.get($intent-colors, $intent), 2);
 
       &::before,
@@ -274,10 +280,11 @@ $dark-menu-item-intent-colors: (
       }
     }
   }
+  /* stylelint-enable alpha-value-notation */
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
-    background-color: $pt-high-contrast-mode-active-background-color;
+    background-color: highlight;
   }
 }
 
@@ -293,30 +300,32 @@ $dark-menu-item-intent-colors: (
       color: inherit;
     }
 
+    /* stylelint-disable alpha-value-notation */
     &:hover {
       @if $is-dark {
-        background-color: rgba($bg-color, 0.2);
+        background-color: #{"oklch(from "}#{$bg-color}#{" l c h / 0.2)"};
       } @else {
-        background-color: rgba($bg-color, 0.1);
+        background-color: #{"oklch(from "}#{$bg-color}#{" l c h / 0.1)"};
       }
     }
 
     &:active,
     &.#{$ns}-active {
       @if $is-dark {
-        background-color: rgba($bg-color, 0.3);
+        background-color: #{"oklch(from "}#{$bg-color}#{" l c h / 0.3)"};
       } @else {
-        background-color: rgba($bg-color, 0.2);
+        background-color: #{"oklch(from "}#{$bg-color}#{" l c h / 0.2)"};
       }
       color: $fg-color-active;
     }
+    /* stylelint-enable alpha-value-notation */
   }
 }
 
 @mixin menu-item-large() {
-  font-size: $pt-font-size-large;
-  padding-bottom: $menu-item-padding-vertical-large;
-  padding-top: $menu-item-padding-vertical-large;
+  font-size: var(--bp-typography-size-body-large);
+  padding-bottom: calc(var(--bp-surface-spacing) * 2.25);
+  padding-top: calc(var(--bp-surface-spacing) * 2.25);
 
   .#{$ns}-menu-item-icon {
     height: $menu-item-line-height;
@@ -331,8 +340,8 @@ $dark-menu-item-intent-colors: (
 
 @mixin menu-item-small() {
   line-height: $menu-item-line-height-small;
-  padding-bottom: $menu-item-padding-vertical-small;
-  padding-top: $menu-item-padding-vertical-small;
+  padding-bottom: calc(var(--bp-surface-spacing) * 0.5);
+  padding-top: calc(var(--bp-surface-spacing) * 0.5);
 
   .#{$ns}-menu-item-icon {
     height: $menu-item-line-height-small;
@@ -340,20 +349,21 @@ $dark-menu-item-intent-colors: (
 }
 
 @mixin menu-divider() {
-  border-top: 1px solid $pt-divider-black;
+  border-top: 1px solid var(--bp-surface-border-color-default);
   display: block;
   // use negative margin to make dividers take up full menu width
-  margin: $pt-spacing (-$pt-spacing);
+  margin: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * -1);
 
   .#{$ns}-dark & {
-    border-top-color: $pt-dark-divider-white;
+    border-top-color: var(--bp-surface-border-color-default);
   }
 }
 
 @mixin menu-header($heading-selector: null) {
   @include menu-divider;
   cursor: default;
-  padding-left: $menu-item-padding - $pt-spacing;
+  // $menu-item-padding (8px) - $pt-spacing (4px) = 4px = 1 spacing unit
+  padding-left: var(--bp-surface-spacing);
 
   @if $heading-selector != null {
     &:first-of-type {
@@ -374,16 +384,16 @@ $dark-menu-item-intent-colors: (
   @include heading-typography;
   @include overflow-ellipsis;
   // a little extra space to avoid clipping descenders (because overflow hidden)
-  line-height: $pt-icon-size-standard + 1px;
+  line-height: calc(var(--bp-surface-spacing) * 4 + 1px);
   margin: 0;
-  padding: ($pt-spacing * 2) $menu-item-padding 0 ($pt-spacing * 2);
+  padding: calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 2) 0;
 }
 
 @mixin menu-header-large($heading-selector) {
   #{$heading-selector} {
-    font-size: $pt-spacing * 4.5;
-    padding-bottom: $pt-spacing;
-    padding-top: $pt-spacing * 4;
+    font-size: calc(var(--bp-surface-spacing) * 4.5);
+    padding-bottom: var(--bp-surface-spacing);
+    padding-top: calc(var(--bp-surface-spacing) * 4);
   }
 
   &:first-of-type #{$heading-selector} {

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -62,23 +62,23 @@ $menu-item-intent-colors: (
 $dark-menu-item-intent-colors: (
   "primary": (
     /* bg */ var(--bp-intent-primary-rest),
-    /* fg */ #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"},
-    /* fg active */ #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h)"},
+    /* fg */ #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.05) h)"},
   ),
   "success": (
     /* bg */ var(--bp-intent-success-rest),
-    /* fg */ #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"},
-    /* fg active */ #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h)"},
+    /* fg */ #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.223) calc(c - 0.012) h)"},
   ),
   "warning": (
     /* bg */ var(--bp-intent-warning-rest),
-    /* fg */ #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"},
-    /* fg active */ #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h)"},
+    /* fg */ #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.179) calc(c - 0.01) h)"},
   ),
   "danger": (
     /* bg */ var(--bp-intent-danger-rest),
-    /* fg */ #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"},
-    /* fg active */ #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h)"},
+    /* fg */ #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h)"},
+    /* fg active */ #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.204) calc(c - 0.062) h)"},
   ),
 ) !default;
 /* stylelint-enable alpha-value-notation */
@@ -129,7 +129,7 @@ $dark-menu-item-intent-colors: (
   // and mouse interactions.
   &:active {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.3)"};
 
     .#{$ns}-menu-item-label {
       color: var(--bp-typography-color-default-rest);
@@ -197,7 +197,7 @@ $dark-menu-item-intent-colors: (
   &:active {
     // we can use the same color as light theme due to transparency
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.3)"};
 
     .#{$ns}-menu-item-label {
       color: var(--bp-typography-color-default-rest);
@@ -228,7 +228,7 @@ $dark-menu-item-intent-colors: (
 
 @mixin menu-item-hover() {
   /* stylelint-disable-next-line alpha-value-notation */
-  background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+  background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.15)"};
   color: inherit;
   cursor: pointer;
   text-decoration: none;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -68,7 +68,7 @@ button.#{$ns}-menu-item {
 // dark theme
 .#{$ns}-dark {
   .#{$ns}-menu {
-    background: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h)"};
+    background: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.241) calc(c - 0.016) h)"};
     color: var(--bp-typography-color-default-rest);
   }
 

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -9,13 +9,13 @@
 @import "./submenu";
 
 .#{$ns}-menu {
-  background: $menu-background-color;
-  border-radius: $pt-border-radius;
-  color: $pt-text-color;
+  background: var(--bp-palette-white);
+  border-radius: var(--bp-surface-border-radius);
+  color: var(--bp-typography-color-default-rest);
   list-style: none;
   margin: 0;
-  min-width: $menu-min-width;
-  padding: $pt-spacing;
+  min-width: calc(var(--bp-surface-spacing) * 45);
+  padding: var(--bp-surface-spacing);
   text-align: left;
 }
 
@@ -33,7 +33,7 @@
   &::before {
     // support pt-icon-* classes directly on this element
     @include pt-icon;
-    margin-right: $menu-item-padding;
+    margin-right: calc(var(--bp-surface-spacing) * 2);
   }
 
   .#{$ns}-large & {
@@ -41,7 +41,7 @@
 
     &::before {
       @include pt-icon($pt-icon-size-large);
-      margin-right: $menu-item-padding-large;
+      margin-right: calc(var(--bp-surface-spacing) * 2);
     }
   }
 
@@ -68,8 +68,8 @@ button.#{$ns}-menu-item {
 // dark theme
 .#{$ns}-dark {
   .#{$ns}-menu {
-    background: $dark-menu-background-color;
-    color: $pt-dark-text-color;
+    background: oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h);
+    color: var(--bp-typography-color-default-rest);
   }
 
   .#{$ns}-menu-item {
@@ -82,15 +82,15 @@ button.#{$ns}-menu-item {
 
   .#{$ns}-menu-divider,
   .#{$ns}-menu-header {
-    border-color: $pt-dark-divider-white;
+    border-color: var(--bp-surface-border-color-default);
   }
 
   .#{$ns}-menu-header > h6 {
-    color: $pt-dark-heading-color;
+    color: var(--bp-typography-color-default-rest);
   }
 }
 
 // #402 support menu inside label
 .#{$ns}-label .#{$ns}-menu {
-  margin-top: $pt-spacing;
+  margin-top: var(--bp-surface-spacing);
 }

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -68,7 +68,7 @@ button.#{$ns}-menu-item {
 // dark theme
 .#{$ns}-dark {
   .#{$ns}-menu {
-    background: oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h);
+    background: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h)"};
     color: var(--bp-typography-color-default-rest);
   }
 

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -41,10 +41,10 @@
   &.#{$ns}-popover {
     box-shadow: none;
     // horizontal padding leaves some space from parent menu item, and extends mouse zone
-    padding: 0 $pt-spacing;
+    padding: 0 var(--bp-surface-spacing);
 
     > .#{$ns}-popover-content {
-      box-shadow: $pt-popover-box-shadow;
+      box-shadow: var(--bp-surface-shadow-3);
     }
 
     .#{$ns}-dark &,


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Menu component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-danger-active` | `#8e292c` | `$red1` |
| `--bp-intent-danger-hover` | `#ac2f33` | `$red2` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-primary-active` | `#184a90` | `$blue1` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue2` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-active` | `#165a36` | `$green1` |
| `--bp-intent-success-hover` | `#1c6e42` | `$green2` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-active` | `#77450d` | `$orange1` |
| `--bp-intent-warning-hover` | `#935610` | `$orange2` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-border-color-default` | `#5f6b7c1f` | `$pt-divider-black` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-shadow-3` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |
| `--bp-typography-size-body-large` | `16px` | `(see diff)` |

#### `_common.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border-radius` | `$menu-item-border-radius` | `var(--bp-surface-border-radius)` |
| `padding` | `$menu-item-padding-vertical $menu-item-padding` | `var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2)` |
| `color` | `$pt-text-color-muted` | `var(--bp-typography-color-muted)` |
| `color` | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| `color` | `$pt-text-color` | `var(--bp-typography-color-default-rest)` |
| `margin` | `0 $menu-item-selected-icon-spacing` | `0 calc(var(--bp-surface-spacing) * 0.5)` |
| `color` | `$pt-text-color-disabled !important` | `var(--bp-typography-color-default-disabled) !important` |
| `color` | `$pt-icon-color-disabled !important` | `var(--bp-typography-color-default-disabled) !important` |
| `color` | `$pt-text-color-disabled !important` | `var(--bp-typography-color-default-disabled) !important` |
| `color` | `$pt-dark-text-color-muted` | `var(--bp-typography-color-muted)` |
| `color` | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |
| `color` | `$pt-dark-text-color` | `var(--bp-typography-color-default-rest)` |
| `color` | `$pt-dark-text-color-disabled !important` | `var(--bp-typography-color-default-disabled) !important` |
| `color` | `$pt-dark-icon-color-disabled !important` | `var(--bp-typography-color-default-disabled) !important` |
| `color` | `$pt-dark-text-color-disabled !important` | `var(--bp-typography-color-default-disabled) !important` |
| `color` | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |
| `background-color` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `background-color` | `rgba($bg-color, 0.2)` | `#{"oklch(from "}#{$bg-color}#{" l c h / 0.2)"}` |
| `background-color` | `rgba($bg-color, 0.1)` | `#{"oklch(from "}#{$bg-color}#{" l c h / 0.1)"}` |
| `background-color` | `rgba($bg-color, 0.3)` | `#{"oklch(from "}#{$bg-color}#{" l c h / 0.3)"}` |
| `background-color` | `rgba($bg-color, 0.2)` | `#{"oklch(from "}#{$bg-color}#{" l c h / 0.2)"}` |
| `padding-t` | `$menu-item-padding-vertical-large` | `var(--bp-typography-size-body-large)` |
| `border-top` | `1px solid $pt-divider-black` | `1px solid var(--bp-surface-border-color-default)` |
| `margin` | `$pt-spacing (-$pt-spacing)` | `var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * -1)` |
| `border-top-color` | `$pt-dark-divider-white` | `var(--bp-surface-border-color-default)` |
| `line-height` | `$pt-icon-size-standard + 1px` | `calc(var(--bp-surface-spacing) * 4 + 1px)` |
| `padding` | `($pt-spacing * 2) $menu-item-padding 0 ($pt-spacing * 2)` | `calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 2) 0` |
| `padding-t` | `$pt-spacing * 4` | `calc(var(--bp-surface-spacing) * 4.5)` |
#### `_menu.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `color: $pt` | `$pt-text-color` | `var(--bp-palette-white)` |
| `margin-right` | `$menu-item-padding` | `calc(var(--bp-surface-spacing) * 2)` |
| `margin-right` | `$menu-item-padding-large` | `calc(var(--bp-surface-spacing) * 2)` |
| `border-color` | `$pt-dark-divider-white` | `var(--bp-surface-border-color-default)` |
| `color` | `$pt-dark-heading-color` | `var(--bp-typography-color-default-rest)` |
| `margin-top` | `$pt-spacing` | `var(--bp-surface-spacing)` |
#### `_submenu.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `padding` | `0 $pt-spacing` | `0 var(--bp-surface-spacing)` |
| `box-shadow` | `$pt-popover-box-shadow` | `var(--bp-surface-shadow-3)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
3. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 3 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
