### PR TITLE
[core] Integrating design tokens into tabs

### DIFF
--- a/packages/core/src/components/tabs/Tabs.stories.tsx
+++ b/packages/core/src/components/tabs/Tabs.stories.tsx
@@ -1,0 +1,227 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Tab } from "./tab";
+import { Tabs, TabsExpander } from "./tabs";
+
+// These props are deprecated on Tabs — hide them from the Storybook controls panel.
+const disabledArgs = ["large"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof Tabs>>;
+
+const meta: Meta<typeof Tabs> = {
+    title: "Core/Tabs/Tabs",
+    component: Tabs,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        id: "tabs-story",
+        animate: true,
+        vertical: false,
+        fill: false,
+        size: "medium",
+        renderActiveTabPanelOnly: false,
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["medium", "large"],
+        },
+        animate: { control: "boolean" },
+        vertical: { control: "boolean" },
+        fill: { control: "boolean" },
+        renderActiveTabPanelOnly: { control: "boolean" },
+        onChange: { action: "changed" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => (
+        <Tabs {...args}>
+            <Tab id="tab1" title="First" panel={<p>First panel content</p>} />
+            <Tab id="tab2" title="Second" panel={<p>Second panel content</p>} />
+            <Tab id="tab3" title="Third" panel={<p>Third panel content</p>} />
+        </Tabs>
+    ),
+};
+
+export const Vertical: Story = {
+    name: "Vertical",
+    argTypes: {
+        vertical: { table: { disable: true } },
+    },
+    render: args => (
+        <Tabs {...args} vertical={true}>
+            <Tab id="tab1" title="First" panel={<p>First panel content</p>} />
+            <Tab id="tab2" title="Second" panel={<p>Second panel content</p>} />
+            <Tab id="tab3" title="Third" panel={<p>Third panel content</p>} />
+            <Tab id="tab4" title="Disabled" disabled={true} panel={<p>Disabled panel</p>} />
+        </Tabs>
+    ),
+};
+
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24, alignItems: "flex-start" }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Medium</div>
+                <Tabs {...args} id="size-medium" size="medium">
+                    <Tab id="tab1" title="First" panel={<p>First panel</p>} />
+                    <Tab id="tab2" title="Second" panel={<p>Second panel</p>} />
+                    <Tab id="tab3" title="Third" panel={<p>Third panel</p>} />
+                </Tabs>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Large</div>
+                <Tabs {...args} id="size-large" size="large">
+                    <Tab id="tab1" title="First" panel={<p>First panel</p>} />
+                    <Tab id="tab2" title="Second" panel={<p>Second panel</p>} />
+                    <Tab id="tab3" title="Third" panel={<p>Third panel</p>} />
+                </Tabs>
+            </div>
+        </div>
+    ),
+};
+
+export const DisabledTab: Story = {
+    name: "Disabled Tab",
+    render: args => (
+        <Tabs {...args}>
+            <Tab id="tab1" title="Enabled" panel={<p>Enabled panel content</p>} />
+            <Tab id="tab2" title="Disabled" disabled={true} panel={<p>Disabled panel content</p>} />
+            <Tab id="tab3" title="Also Enabled" panel={<p>Also enabled panel content</p>} />
+        </Tabs>
+    ),
+};
+
+export const WithIcons: Story = {
+    name: "With Icons",
+    render: args => (
+        <Tabs {...args}>
+            <Tab id="tab1" title="Home" icon="home" panel={<p>Home panel</p>} />
+            <Tab id="tab2" title="Settings" icon="cog" panel={<p>Settings panel</p>} />
+            <Tab id="tab3" title="Notifications" icon="notifications" panel={<p>Notifications panel</p>} />
+        </Tabs>
+    ),
+};
+
+export const WithTags: Story = {
+    name: "With Tags",
+    render: args => (
+        <Tabs {...args}>
+            <Tab id="tab1" title="Messages" tagContent={5} panel={<p>Messages panel</p>} />
+            <Tab id="tab2" title="Alerts" tagContent={12} panel={<p>Alerts panel</p>} />
+            <Tab id="tab3" title="Archive" panel={<p>Archive panel</p>} />
+        </Tabs>
+    ),
+};
+
+export const FillWidth: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px", height: "200px", border: "1px dashed gray" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <Tabs {...args} fill={true}>
+            <Tab id="tab1" title="First" panel={<p>First panel content</p>} />
+            <Tab id="tab2" title="Second" panel={<p>Second panel content</p>} />
+            <Tab id="tab3" title="Third" panel={<p>Third panel content</p>} />
+        </Tabs>
+    ),
+};
+
+export const WithExpander: Story = {
+    name: "With Expander",
+    decorators: [
+        Story => (
+            <div style={{ width: "600px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <Tabs {...args}>
+            <Tab id="tab1" title="First" panel={<p>First panel content</p>} />
+            <Tab id="tab2" title="Second" panel={<p>Second panel content</p>} />
+            <TabsExpander />
+            <Tab id="tab3" title="Right-aligned" panel={<p>Right-aligned panel content</p>} />
+        </Tabs>
+    ),
+};
+
+export const NoAnimation: Story = {
+    name: "No Animation",
+    argTypes: {
+        animate: { table: { disable: true } },
+    },
+    render: args => (
+        <Tabs {...args} animate={false}>
+            <Tab id="tab1" title="First" panel={<p>First panel content</p>} />
+            <Tab id="tab2" title="Second" panel={<p>Second panel content</p>} />
+            <Tab id="tab3" title="Third" panel={<p>Third panel content</p>} />
+        </Tabs>
+    ),
+};
+
+export const Playground: Story = {
+    render: function Render(args) {
+        const [selectedTabId, setSelectedTabId] = useState<string | number>("tab1");
+        const handleChange = useCallback((newTabId: string | number) => {
+            setSelectedTabId(newTabId);
+        }, []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <Tabs {...args} selectedTabId={selectedTabId} onChange={handleChange}>
+                    <Tab id="tab1" title="React" icon="code" panel={<p>React is a JavaScript library for building user interfaces.</p>} />
+                    <Tab
+                        id="tab2"
+                        title="Angular"
+                        icon="application"
+                        panel={<p>Angular is a platform for building mobile and desktop web applications.</p>}
+                    />
+                    <Tab
+                        id="tab3"
+                        title="Ember"
+                        icon="flame"
+                        panel={<p>Ember.js is a productive, battle-tested JavaScript framework.</p>}
+                    />
+                    <Tab id="tab4" title="Backbone" disabled={true} icon="disable" panel={<p>Backbone panel</p>} />
+                </Tabs>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Selected tab: {selectedTabId}</div>
+            </div>
+        );
+    },
+};

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -29,25 +29,27 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 
     .#{$ns}-tab {
       align-items: center;
-      border-radius: $pt-border-radius;
+      border-radius: var(--bp-surface-border-radius);
       display: flex;
-      padding: 0 ($pt-spacing * 2);
+      padding: 0 calc(var(--bp-surface-spacing) * 2);
       width: 100%;
 
       &[aria-selected="true"] {
-        background-color: rgba($pt-intent-primary, 0.2);
+        /* stylelint-disable-next-line alpha-value-notation */
+        background-color: oklch(from var(--bp-intent-primary-rest) l c h / 0.2);
         box-shadow: none;
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
-          background-color: $pt-high-contrast-mode-active-background-color;
-          color: $black;
+          background-color: highlight;
+          color: black;
         }
       }
     }
 
     .#{$ns}-tab-indicator-wrapper .#{$ns}-tab-indicator {
-      background-color: rgba($pt-intent-primary, 0.2);
-      border-radius: $pt-border-radius;
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: oklch(from var(--bp-intent-primary-rest) l c h / 0.2);
+      border-radius: var(--bp-surface-border-radius);
       height: auto;
       inset: 0;
     }
@@ -58,14 +60,14 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
   // vertical tab component
   > .#{$ns}-tab-panel {
     margin-top: 0;
-    padding-left: $pt-spacing * 5;
+    padding-left: calc(var(--bp-surface-spacing) * 5);
   }
 }
 
 .#{$ns}-tab-list {
   align-items: flex-end;
   border: none;
-  column-gap: $pt-spacing * 5;
+  column-gap: calc(var(--bp-surface-spacing) * 5);
   display: flex;
   flex: 0 0 auto;
   list-style: none;
@@ -77,7 +79,7 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
     // offset column-gap from parent component above
     // since flex-expander is taking up _available_ space, we don't want to add a double gap
     // between the elements before and after the expander
-    margin-right: $pt-spacing * -5;
+    margin-right: calc(var(--bp-surface-spacing) * -5);
   }
 }
 
@@ -85,12 +87,12 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
   @include overflow-ellipsis;
   align-items: center;
   align-self: stretch;
-  color: $pt-text-color;
+  color: var(--bp-typography-color-default-rest);
   cursor: pointer;
   display: flex;
   flex: 0 0 auto;
-  font-size: $pt-font-size;
-  line-height: $pt-button-height;
+  font-size: var(--bp-typography-size-body-medium);
+  line-height: calc(var(--bp-surface-spacing) * 7.5);
   max-width: 100%;
   position: relative;
   vertical-align: top;
@@ -112,27 +114,27 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
   }
 
   &[aria-disabled="true"] {
-    color: $pt-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
-      color: $pt-high-contrast-mode-disabled-text-color;
+      color: graytext;
     }
   }
 
   &[aria-selected="true"] {
     border-radius: 0;
-    box-shadow: inset 0 (-$tab-indicator-width) 0 $tab-color-selected;
+    box-shadow: inset 0 calc(var(--bp-surface-spacing) * -0.75) 0 var(--bp-intent-primary-hover);
   }
 
   &[aria-selected="true"],
   &:not([aria-disabled="true"]):hover {
-    color: $tab-color-selected;
+    color: var(--bp-intent-primary-hover);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
-      color: $pt-high-contrast-mode-active-text-color;
+      color: highlight;
     }
   }
 
@@ -141,13 +143,13 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
   }
 
   .#{$ns}-large > & {
-    font-size: $pt-font-size-large;
-    line-height: $pt-button-height-large;
+    font-size: var(--bp-typography-size-body-large);
+    line-height: calc(var(--bp-surface-spacing) * 10);
   }
 }
 
 .#{$ns}-tab-panel {
-  margin-top: $pt-spacing * 5;
+  margin-top: calc(var(--bp-surface-spacing) * 5);
 
   &[aria-hidden="true"] {
     display: none;
@@ -155,11 +157,11 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 }
 
 .#{$ns}-tab-icon {
-  margin-right: $pt-spacing * 2;
+  margin-right: calc(var(--bp-surface-spacing) * 2);
 }
 
 .#{$ns}-tab-tag {
-  margin-left: $pt-spacing * 2;
+  margin-left: calc(var(--bp-surface-spacing) * 2);
 }
 
 .#{$ns}-tab-indicator-wrapper {
@@ -169,20 +171,20 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
   top: 0;
   transform: translateX(0), translateY(0);
   transition: height, transform, width;
-  transition-duration: $pt-transition-duration * 2;
-  transition-timing-function: $pt-transition-ease;
+  transition-duration: calc(var(--bp-emphasis-transition-duration) * 2);
+  transition-timing-function: var(--bp-emphasis-ease-default);
 
   .#{$ns}-tab-indicator {
-    background-color: $tab-color-selected;
+    background-color: var(--bp-intent-primary-hover);
     bottom: 0;
-    height: $tab-indicator-width;
+    height: calc(var(--bp-surface-spacing) * 0.75);
     left: 0;
     position: absolute;
     right: 0;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
-      background-color: $pt-high-contrast-mode-active-background-color;
+      background-color: highlight;
     }
   }
 
@@ -197,39 +199,18 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 
 .#{$ns}-dark {
   .#{$ns}-tab {
-    color: $pt-dark-text-color;
-
-    &[aria-disabled="true"] {
-      color: $pt-dark-text-color-disabled;
-
-      @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        // Windows High Contrast dark theme
-        color: $pt-high-contrast-mode-disabled-text-color;
-      }
-    }
-
     &[aria-selected="true"] {
-      box-shadow: inset 0 (-$tab-indicator-width) 0 $dark-tab-color-selected;
+      box-shadow: inset 0 calc(var(--bp-surface-spacing) * -0.75) 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
     }
 
     &[aria-selected="true"],
     &:not([aria-disabled="true"]):hover {
-      color: $dark-tab-color-selected;
-
-      @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        // Windows High Contrast dark theme
-        color: $pt-high-contrast-mode-active-text-color;
-      }
+      color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
     }
   }
 
   .#{$ns}-tab-indicator {
-    background-color: $dark-tab-color-selected;
-
-    @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      // Windows High Contrast dark theme
-      background-color: $pt-high-contrast-mode-active-background-color;
-    }
+    background-color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
   }
 }
 

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -36,7 +36,7 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 
       &[aria-selected="true"] {
         /* stylelint-disable-next-line alpha-value-notation */
-        background-color: oklch(from var(--bp-intent-primary-rest) l c h / 0.2);
+        background-color: #{"oklch(from var(--bp-intent-primary-rest) l c h / 0.2)"};
         box-shadow: none;
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -48,7 +48,7 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 
     .#{$ns}-tab-indicator-wrapper .#{$ns}-tab-indicator {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-primary-rest) l c h / 0.2);
+      background-color: #{"oklch(from var(--bp-intent-primary-rest) l c h / 0.2)"};
       border-radius: var(--bp-surface-border-radius);
       height: auto;
       inset: 0;
@@ -200,17 +200,17 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 .#{$ns}-dark {
   .#{$ns}-tab {
     &[aria-selected="true"] {
-      box-shadow: inset 0 calc(var(--bp-surface-spacing) * -0.75) 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      box-shadow: inset 0 calc(var(--bp-surface-spacing) * -0.75) 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
     }
 
     &[aria-selected="true"],
     &:not([aria-disabled="true"]):hover {
-      color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
     }
   }
 
   .#{$ns}-tab-indicator {
-    background-color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+    background-color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
   }
 }
 

--- a/packages/core/src/components/tabs/_tabs.scss
+++ b/packages/core/src/components/tabs/_tabs.scss
@@ -200,17 +200,17 @@ $tab-indicator-width: $pt-spacing * 0.75 !default;
 .#{$ns}-dark {
   .#{$ns}-tab {
     &[aria-selected="true"] {
-      box-shadow: inset 0 calc(var(--bp-surface-spacing) * -0.75) 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+      box-shadow: inset 0 calc(var(--bp-surface-spacing) * -0.75) 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
     }
 
     &[aria-selected="true"],
     &:not([aria-disabled="true"]):hover {
-      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
     }
   }
 
   .#{$ns}-tab-indicator {
-    background-color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+    background-color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
   }
 }
 


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Tabs component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-default` | `cubic-bezier(0.4, 1, 0.75, 0.9)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue2` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-size-body-large` | `16px` | `(see diff)` |
| `--bp-typography-size-body-medium` | `14px` | `$pt-font-size` |

#### `_tabs.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `padding` | `0 ($pt-spacing * 2)` | `0 calc(var(--bp-surface-spacing) * 2)` |
| `padding-left` | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| `column-gap` | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| `margin-right` | `$pt-spacing * -5` | `calc(var(--bp-surface-spacing) * -5)` |
| `color` | `$pt-text-color` | `var(--bp-typography-color-default-rest)` |
| `color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `color` | `$pt-high-contrast-mode-disabled-text-color` | `graytext` |
| `color` | `$tab-color-selected` | `var(--bp-intent-primary-hover)` |
| `color` | `$pt-high-contrast-mode-active-text-color` | `highlight` |
| `margin-top` | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| `margin-right` | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |
| `margin-left` | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |
| `background-color` | `$tab-color-selected` | `var(--bp-intent-primary-hover)` |
| `height` | `$tab-indicator-width` | `calc(var(--bp-surface-spacing) * 0.75)` |
| `background-color` | `$pt-high-contrast-mode-active-background-color` | `highlight` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
3. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 3 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
