### PR TITLE
[core] Integrating design tokens into tooltip and slider

### DIFF
--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -1,0 +1,252 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent } from "../../common";
+
+import { Slider } from "./slider";
+
+const meta: Meta<typeof Slider> = {
+    title: "Core/Slider/Slider",
+    component: Slider,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    minWidth: "400px",
+                    padding: "40px 20px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        min: 0,
+        max: 10,
+        stepSize: 1,
+        value: 5,
+        disabled: false,
+        vertical: false,
+        showTrackFill: true,
+        intent: "primary",
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        min: {
+            control: "number",
+        },
+        max: {
+            control: "number",
+        },
+        stepSize: {
+            control: "number",
+        },
+        value: {
+            control: "number",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        vertical: {
+            control: "boolean",
+        },
+        showTrackFill: {
+            control: "boolean",
+        },
+        labelRenderer: {
+            control: "boolean",
+        },
+        onChange: { action: "changed" },
+        onRelease: { action: "released" },
+    },
+} satisfies Meta<typeof Slider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic slider with default styling.
+ */
+export const Default: Story = {
+    args: {
+        value: 5,
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the slider track fill.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                        <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</span>
+                        <Slider {...args} intent={intent} value={7} />
+                    </div>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `disabled` prop to render a non-interactive slider.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <Slider {...args} disabled={false} value={5} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                <Slider {...args} disabled={true} value={5} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `vertical` prop to render the slider vertically.
+ */
+export const VerticalExample: Story = {
+    name: "Vertical",
+    argTypes: {
+        vertical: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "flex-start", height: "200px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", gap: 40 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Slider key={intent} {...args} vertical={true} intent={intent} value={7} />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `showTrackFill` prop to control whether the filled portion of the track is visible.
+ */
+export const TrackFillExample: Story = {
+    name: "Track Fill",
+    argTypes: {
+        showTrackFill: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>With track fill</span>
+                <Slider {...args} showTrackFill={true} value={5} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Without track fill</span>
+                <Slider {...args} showTrackFill={false} value={5} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `labelRenderer` prop to customize or hide labels.
+ */
+export const LabelsExample: Story = {
+    name: "Labels",
+    argTypes: {
+        labelRenderer: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>With labels</span>
+                <Slider {...args} labelRenderer={true} value={5} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Without labels</span>
+                <Slider {...args} labelRenderer={false} value={5} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Custom label renderer (percentage)</span>
+                <Slider {...args} labelRenderer={v => `${v * 10}%`} value={5} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * All intents shown together for visual comparison.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Default</div>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Slider key={intent} {...args} intent={intent} value={7} />
+                ))}
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Disabled</div>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Slider key={`disabled-${intent}`} {...args} intent={intent} value={7} disabled={true} />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with full state management.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [value, setValue] = useState(5);
+
+        const handleChange = useCallback((newValue: number) => {
+            setValue(newValue);
+            args.onChange?.(newValue);
+        }, [args]);
+
+        return <Slider {...args} value={value} onChange={handleChange} />;
+    },
+    args: {
+        value: 5,
+    },
+};

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -9,17 +9,18 @@ $track-size: $handle-size - ($pt-spacing * 2.5) !default;
 $label-offset: $handle-size + $pt-spacing !default;
 
 /* stylelint-disable alpha-value-notation */
-$handle-border-shadow: 0 0 0 $button-border-width oklch(from var(--bp-palette-black) l c h / 0.5);
+$handle-border-shadow: 0 0 0 $button-border-width
+  #{"oklch(from var(--bp-palette-black) l c h / 0.5)"};
 $handle-box-shadow:
   $handle-border-shadow,
-  0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.5) !default;
+  0 1px 1px #{"oklch(from var(--bp-palette-black) l c h / 0.5)"} !default;
 $handle-box-shadow-hover:
   $handle-border-shadow,
-  0 1px 2px oklch(from var(--bp-palette-black) l c h / 0.6) !default;
+  0 1px 2px #{"oklch(from var(--bp-palette-black) l c h / 0.6)"} !default;
 $handle-box-shadow-active:
-  inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.1),
+  inset 0 1px 1px #{"oklch(from var(--bp-palette-black) l c h / 0.1)"},
   $handle-border-shadow,
-  0 1px 2px oklch(from var(--bp-palette-black) l c h / 0.2) !default;
+  0 1px 2px #{"oklch(from var(--bp-palette-black) l c h / 0.2)"} !default;
 /* stylelint-enable alpha-value-notation */
 
 // retain legacy variable aliases so as to not break consumers
@@ -64,11 +65,11 @@ $track-height: $track-size !default;
 
 .#{$ns}-slider-progress {
   /* stylelint-disable-next-line alpha-value-notation */
-  background: oklch(from var(--bp-typography-color-muted) l c h / 0.2);
+  background: #{"oklch(from var(--bp-typography-color-muted) l c h / 0.2)"};
 
   .#{$ns}-dark & {
     /* stylelint-disable-next-line alpha-value-notation */
-    background: oklch(from var(--bp-palette-black) l c h / 0.5);
+    background: #{"oklch(from var(--bp-palette-black) l c h / 0.5)"};
   }
 
   &.#{$ns}-intent-primary {
@@ -142,7 +143,7 @@ $track-height: $track-size !default;
       background-color: var(--bp-palette-gray-2);
       box-shadow:
         /* stylelint-disable-next-line alpha-value-notation */
-        inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.1),
+        inset 0 1px 1px #{"oklch(from var(--bp-palette-black) l c h / 0.1)"},
         $dark-button-box-shadow-active;
     }
   }

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -8,17 +8,19 @@ $handle-size: $pt-icon-size-standard !default;
 $track-size: $handle-size - ($pt-spacing * 2.5) !default;
 $label-offset: $handle-size + $pt-spacing !default;
 
-$handle-border-shadow: 0 0 0 $button-border-width rgba($black, 0.5);
+/* stylelint-disable alpha-value-notation */
+$handle-border-shadow: 0 0 0 $button-border-width oklch(from var(--bp-palette-black) l c h / 0.5);
 $handle-box-shadow:
   $handle-border-shadow,
-  0 1px 1px rgba($black, 0.5) !default;
+  0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.5) !default;
 $handle-box-shadow-hover:
   $handle-border-shadow,
-  0 1px 2px rgba($black, 0.6) !default;
+  0 1px 2px oklch(from var(--bp-palette-black) l c h / 0.6) !default;
 $handle-box-shadow-active:
-  inset 0 1px 1px rgba($black, 0.1),
+  inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.1),
   $handle-border-shadow,
-  0 1px 2px rgba($black, 0.2) !default;
+  0 1px 2px oklch(from var(--bp-palette-black) l c h / 0.2) !default;
+/* stylelint-enable alpha-value-notation */
 
 // retain legacy variable aliases so as to not break consumers
 $handle-height: $handle-size !default;
@@ -45,7 +47,7 @@ $track-height: $track-size !default;
   }
 
   &.#{$ns}-slider-unlabeled {
-    height: $handle-size;
+    height: calc(var(--bp-surface-spacing) * 4);
   }
 }
 
@@ -56,21 +58,33 @@ $track-height: $track-size !default;
 }
 
 .#{$ns}-slider-track {
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   overflow: hidden;
 }
 
 .#{$ns}-slider-progress {
-  background: rgba($gray1, 0.2);
+  /* stylelint-disable-next-line alpha-value-notation */
+  background: oklch(from var(--bp-typography-color-muted) l c h / 0.2);
 
   .#{$ns}-dark & {
-    background: rgba($black, 0.5);
+    /* stylelint-disable-next-line alpha-value-notation */
+    background: oklch(from var(--bp-palette-black) l c h / 0.5);
   }
 
-  @each $intent, $color in $pt-intent-colors {
-    &.#{$ns}-intent-#{$intent} {
-      background-color: $color;
-    }
+  &.#{$ns}-intent-primary {
+    background-color: var(--bp-intent-primary-rest);
+  }
+
+  &.#{$ns}-intent-success {
+    background-color: var(--bp-intent-success-rest);
+  }
+
+  &.#{$ns}-intent-warning {
+    background-color: var(--bp-intent-warning-rest);
+  }
+
+  &.#{$ns}-intent-danger {
+    background-color: var(--bp-intent-danger-rest);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -80,14 +94,14 @@ $track-height: $track-size !default;
 
 .#{$ns}-slider-handle {
   @include pt-button;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   box-shadow: $handle-box-shadow;
   cursor: pointer;
-  height: $handle-size;
+  height: calc(var(--bp-surface-spacing) * 4);
   left: 0;
   position: absolute;
   top: 0;
-  width: $handle-size;
+  width: calc(var(--bp-surface-spacing) * 4);
 
   // ensure target handle's label always covers neighbors
   &:focus {
@@ -108,7 +122,7 @@ $track-height: $track-size !default;
   }
 
   .#{$ns}-disabled & {
-    background: $gray5;
+    background: var(--bp-palette-gray-5);
     box-shadow: none;
     // easy way to avoid lots of special cases to ignore mouse states when disabled:
     pointer-events: none;
@@ -116,39 +130,40 @@ $track-height: $track-size !default;
 
   .#{$ns}-dark & {
     // don't use pt-dark-button() here, since we want to appear more like a light theme button
-    background-color: $gray4;
+    background-color: var(--bp-palette-gray-4);
     box-shadow: $dark-button-box-shadow;
 
     &:hover {
-      background-color: $gray3;
+      background-color: var(--bp-palette-gray-3);
       box-shadow: $dark-button-box-shadow-active;
     }
 
     &.#{$ns}-active {
-      background-color: $gray2;
+      background-color: var(--bp-palette-gray-2);
       box-shadow:
-        inset 0 1px 1px rgba($black, 0.1),
+        /* stylelint-disable-next-line alpha-value-notation */
+        inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.1),
         $dark-button-box-shadow-active;
     }
   }
 
   .#{$ns}-dark .#{$ns}-disabled & {
-    background: $gray1;
-    border-color: $gray1;
+    background: var(--bp-palette-gray-1);
+    border-color: var(--bp-palette-gray-1);
     box-shadow: none;
   }
 
   .#{$ns}-slider-label {
-    background: $tooltip-background-color;
-    border-radius: $pt-border-radius;
-    box-shadow: $pt-tooltip-box-shadow;
-    color: $tooltip-text-color;
+    background: var(--bp-palette-dark-gray-5);
+    border-radius: var(--bp-surface-border-radius);
+    box-shadow: var(--bp-surface-shadow-3);
+    color: var(--bp-palette-light-gray-5);
     margin-left: $handle-size * 0.5;
 
     .#{$ns}-dark & {
-      background: $dark-tooltip-background-color;
-      box-shadow: $pt-dark-tooltip-box-shadow;
-      color: $dark-tooltip-text-color;
+      background: var(--bp-palette-light-gray-3);
+      box-shadow: var(--bp-surface-shadow-3);
+      color: var(--bp-palette-dark-gray-5);
     }
 
     .#{$ns}-disabled & {
@@ -180,9 +195,9 @@ $track-height: $track-size !default;
 .#{$ns}-slider-label {
   @include slider-label-orientation($label-offset);
   display: inline-block;
-  font-size: $pt-font-size-small;
+  font-size: var(--bp-typography-size-body-small);
   line-height: 1;
-  padding: ($pt-spacing * 0.5) $pt-spacing;
+  padding: calc(var(--bp-surface-spacing) * 0.5) var(--bp-surface-spacing);
   position: absolute;
   vertical-align: top;
 }
@@ -219,7 +234,7 @@ $track-height: $track-size !default;
     }
 
     &.#{$ns}-start {
-      border-bottom-right-radius: $pt-border-radius;
+      border-bottom-right-radius: var(--bp-surface-border-radius);
       border-top-left-radius: 0;
 
       .#{$ns}-slider-label {
@@ -230,7 +245,7 @@ $track-height: $track-size !default;
     &.#{$ns}-end {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      border-top-left-radius: $pt-border-radius;
+      border-top-left-radius: var(--bp-surface-border-radius);
       margin-bottom: $handle-size * 0.5;
     }
   }

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,190 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Tooltip } from "./tooltip";
+
+const meta: Meta<typeof Tooltip> = {
+    title: "Core/Tooltip/Tooltip",
+    component: Tooltip,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        content: "This is a tooltip",
+        intent: "none",
+        compact: false,
+        minimal: false,
+        disabled: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        compact: {
+            control: "boolean",
+        },
+        minimal: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        content: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic tooltip that appears on hover.
+ */
+export const Default: Story = {
+    args: {
+        content: "This is a tooltip",
+        isOpen: true,
+        children: <span>Hover me</span>,
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the tooltip background.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
+                        <span>{intent.charAt(0).toUpperCase() + intent.slice(1)}</span>
+                    </Tooltip>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `compact` prop for a more condensed tooltip appearance.
+ */
+export const CompactExample: Story = {
+    name: "Compact",
+    argTypes: {
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <Tooltip {...args} compact={false} isOpen={true}>
+                <span>Default</span>
+            </Tooltip>
+            <Tooltip {...args} compact={true} isOpen={true}>
+                <span>Compact</span>
+            </Tooltip>
+        </div>
+    ),
+};
+
+/**
+ * Use the `minimal` prop to render the tooltip without an arrow.
+ */
+export const MinimalExample: Story = {
+    name: "Minimal",
+    argTypes: {
+        minimal: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <Tooltip {...args} minimal={false} isOpen={true}>
+                <span>With arrow</span>
+            </Tooltip>
+            <Tooltip {...args} minimal={true} isOpen={true}>
+                <span>No arrow</span>
+            </Tooltip>
+        </div>
+    ),
+};
+
+/**
+ * Use the `disabled` prop to prevent the tooltip from appearing.
+ */
+export const DisabledExample: Story = {
+    name: "Disabled",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <Tooltip {...args} disabled={false} isOpen={true}>
+                <span>Enabled</span>
+            </Tooltip>
+            <Tooltip {...args} disabled={true}>
+                <span>Disabled</span>
+            </Tooltip>
+        </div>
+    ),
+};
+
+/**
+ * All intents displayed together for visual comparison.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 40 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Default</div>
+                <div style={{ display: "flex", gap: 24 }}>
+                    {Object.values(Intent).map(intent => (
+                        <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
+                            <span style={{ textTransform: "capitalize" }}>{intent === "none" ? "none" : intent}</span>
+                        </Tooltip>
+                    ))}
+                </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Compact</div>
+                <div style={{ display: "flex", gap: 24 }}>
+                    {Object.values(Intent).map(intent => (
+                        <Tooltip key={intent} {...args} intent={intent} compact={true} isOpen={true}>
+                            <span style={{ textTransform: "capitalize" }}>{intent === "none" ? "none" : intent}</span>
+                        </Tooltip>
+                    ))}
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        content: "Tooltip content",
+        children: <span>Hover over me</span>,
+    },
+};

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -19,9 +19,9 @@ $tooltip-padding-compact-horizontal: $pt-spacing * 2 !default;
     $arrow-target-offset: -$pt-spacing
   );
   @include popover-appearance(
-    $tooltip-background-color,
-    $tooltip-text-color,
-    $pt-tooltip-box-shadow,
+    var(--bp-palette-dark-gray-5),
+    var(--bp-palette-light-gray-5),
+    var(--bp-surface-shadow-3),
     $tooltip-arrow-box-shadow,
     $pt-border-shadow-opacity
   );
@@ -38,13 +38,13 @@ $tooltip-padding-compact-horizontal: $pt-spacing * 2 !default;
   @include pt-dark-typography-colors;
 
   .#{$ns}-popover-content {
-    padding: $tooltip-padding-vertical $tooltip-padding-horizontal;
+    padding: calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 3);
   }
 
   &.#{$ns}-compact {
     .#{$ns}-popover-content {
       line-height: 1rem; // ensure a consistent line height
-      padding: $tooltip-padding-compact-vertical $tooltip-padding-compact-horizontal;
+      padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
     }
 
     // Compact tooltip content is usually just a single line with default line-height, where the slight vertical
@@ -58,24 +58,24 @@ $tooltip-padding-compact-horizontal: $pt-spacing * 2 !default;
 
   // need to adjust arrow placement a little bit for tooltips
   &.#{$ns}-popover-placement-top .#{$ns}-popover-arrow {
-    transform: translateY($pt-spacing * -0.75);
+    transform: translateY(calc(var(--bp-surface-spacing) * -0.75));
   }
   &.#{$ns}-popover-placement-left .#{$ns}-popover-arrow {
-    transform: translateX($pt-spacing * -0.75);
+    transform: translateX(calc(var(--bp-surface-spacing) * -0.75));
   }
   &.#{$ns}-popover-placement-bottom .#{$ns}-popover-arrow {
-    transform: translateY($pt-spacing * 0.75);
+    transform: translateY(calc(var(--bp-surface-spacing) * 0.75));
   }
   &.#{$ns}-popover-placement-right .#{$ns}-popover-arrow {
-    transform: translateX($pt-spacing * 0.75);
+    transform: translateX(calc(var(--bp-surface-spacing) * 0.75));
   }
 
   &.#{$ns}-dark,
   .#{$ns}-dark & {
     @include popover-appearance(
-      $dark-tooltip-background-color,
-      $dark-tooltip-text-color,
-      $pt-dark-tooltip-box-shadow,
+      var(--bp-palette-light-gray-3),
+      var(--bp-palette-dark-gray-5),
+      var(--bp-surface-shadow-3),
       $dark-tooltip-arrow-box-shadow,
       $pt-dark-border-shadow-opacity
     );
@@ -83,20 +83,63 @@ $tooltip-padding-compact-horizontal: $pt-spacing * 2 !default;
     @include pt-typography-colors;
   }
 
-  @each $intent, $color in $pt-intent-colors {
-    &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-popover-content {
-        background: $color;
-        color: $white;
+  &.#{$ns}-intent-primary {
+    .#{$ns}-popover-content {
+      background: var(--bp-intent-primary-rest);
+      color: var(--bp-intent-primary-foreground);
+    }
+
+    .#{$ns}-popover-arrow-fill {
+      fill: var(--bp-intent-primary-rest);
+
+      @media (forced-colors: active) and (prefers-color-scheme: dark) {
+        // In Windows high contrast mode, just force the color to be the same as the border.
+        fill: buttonborder;
       }
+    }
+  }
 
-      .#{$ns}-popover-arrow-fill {
-        fill: $color;
+  &.#{$ns}-intent-success {
+    .#{$ns}-popover-content {
+      background: var(--bp-intent-success-rest);
+      color: var(--bp-intent-success-foreground);
+    }
 
-        @media (forced-colors: active) and (prefers-color-scheme: dark) {
-          // In Windows high contrast mode, just force the color to be the same as the border.
-          fill: $pt-high-contrast-mode-border-color;
-        }
+    .#{$ns}-popover-arrow-fill {
+      fill: var(--bp-intent-success-rest);
+
+      @media (forced-colors: active) and (prefers-color-scheme: dark) {
+        fill: buttonborder;
+      }
+    }
+  }
+
+  &.#{$ns}-intent-warning {
+    .#{$ns}-popover-content {
+      background: var(--bp-intent-warning-rest);
+      color: var(--bp-intent-warning-foreground);
+    }
+
+    .#{$ns}-popover-arrow-fill {
+      fill: var(--bp-intent-warning-rest);
+
+      @media (forced-colors: active) and (prefers-color-scheme: dark) {
+        fill: buttonborder;
+      }
+    }
+  }
+
+  &.#{$ns}-intent-danger {
+    .#{$ns}-popover-content {
+      background: var(--bp-intent-danger-rest);
+      color: var(--bp-intent-danger-foreground);
+    }
+
+    .#{$ns}-popover-arrow-fill {
+      fill: var(--bp-intent-danger-rest);
+
+      @media (forced-colors: active) and (prefers-color-scheme: dark) {
+        fill: buttonborder;
       }
     }
   }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Tooltip and Slider component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-danger-foreground` | `#ffffff` | `$white` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-primary-foreground` | `#ffffff` | `$white` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-foreground` | `#ffffff` | `$white` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-foreground` | `#111418` | `$pt-text-color` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-palette-black` | `#111418` | `$black` |
| `--bp-palette-dark-gray-5` | `#404854` | `(see diff)` |
| `--bp-palette-gray-1` | `#5f6b7c` | `(see diff)` |
| `--bp-palette-gray-2` | `#738091` | `(see diff)` |
| `--bp-palette-gray-3` | `#8f99a8` | `(see diff)` |
| `--bp-palette-gray-4` | `#abb3bf` | `(see diff)` |
| `--bp-palette-gray-5` | `#c5cbd3` | `(see diff)` |
| `--bp-palette-light-gray-3` | `#e5e8eb` | `(see diff)` |
| `--bp-palette-light-gray-5` | `#f6f7f9` | `(see diff)` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-shadow-3` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |
| `--bp-typography-size-body-small` | `12px` | `$pt-font-size-small` |

#### `_tooltip.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `padding` | `$tooltip-padding-vertical $tooltip-padding-horizontal` | `calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 3)` |
| `padding` | `$tooltip-padding-compact-vertical $tooltip-padding-compact-horizontal` | `var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2)` |
| `transform` | `translateY($pt-spacing * -0.75)` | `translateY(calc(var(--bp-surface-spacing) * -0.75))` |
| `transform` | `translateX($pt-spacing * -0.75)` | `translateX(calc(var(--bp-surface-spacing) * -0.75))` |
| `transform` | `translateY($pt-spacing * 0.75)` | `translateY(calc(var(--bp-surface-spacing) * 0.75))` |
| `transform` | `translateX($pt-spacing * 0.75)` | `translateX(calc(var(--bp-surface-spacing) * 0.75))` |
#### `_slider.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `height` | `$handle-size` | `calc(var(--bp-surface-spacing) * 4)` |
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `height` | `$handle-size` | `calc(var(--bp-surface-spacing) * 4)` |
| `width` | `$handle-size` | `calc(var(--bp-surface-spacing) * 4)` |
| `background` | `$gray5` | `var(--bp-palette-gray-5)` |
| `background-color` | `$gray4` | `var(--bp-palette-gray-4)` |
| `background-color` | `$gray3` | `var(--bp-palette-gray-3)` |
| `background-color` | `$gray2` | `var(--bp-palette-gray-2)` |
| `color: $da` | `$dark-tooltip-text-color` | `var(--bp-palette-light-gray-3)` |
| `font-size` | `$pt-font-size-small` | `var(--bp-typography-size-body-small)` |
| `padding` | `($pt-spacing * 0.5) $pt-spacing` | `calc(var(--bp-surface-spacing) * 0.5) var(--bp-surface-spacing)` |
| `border-bottom-right-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `border-top-left-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`@each` intent loops expanded.** Loops over `$pt-intent-colors` replaced with explicit per-intent blocks for CSS custom property compatibility.
3. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
4. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Loop expansion | `@each` over SCSS map → explicit per-intent rules |
| 3 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 4 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Intent styles after expanding `@each` loops
