### PR TITLE
[core] Integrating design tokens into editable text and link

### DIFF
--- a/packages/core/src/components/editable-text/EditableText.stories.tsx
+++ b/packages/core/src/components/editable-text/EditableText.stories.tsx
@@ -1,0 +1,202 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { EditableText } from "./editableText";
+
+const disabledArgs = ["customInputAttributes", "elementRef", "contentId"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof EditableText>
+>;
+
+const meta: Meta<typeof EditableText> = {
+    title: "Core/EditableText/EditableText",
+    component: EditableText,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        placeholder: "Click to Edit",
+        disabled: false,
+        multiline: false,
+        selectAllOnFocus: false,
+        confirmOnEnterKey: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        disabled: {
+            control: "boolean",
+        },
+        multiline: {
+            control: "boolean",
+        },
+        selectAllOnFocus: {
+            control: "boolean",
+        },
+        confirmOnEnterKey: {
+            control: "boolean",
+        },
+        placeholder: {
+            control: "text",
+        },
+        maxLength: {
+            control: "number",
+        },
+        onCancel: { action: "cancelled" },
+        onChange: { action: "changed" },
+        onConfirm: { action: "confirmed" },
+        onEdit: { action: "editing" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof EditableText>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic editable text field with default styling.
+ */
+export const Default: Story = {
+    args: {
+        placeholder: "Click to Edit",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply semantic color to the editable text.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <EditableText
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        placeholder={intent.charAt(0).toUpperCase() + intent.slice(1)}
+                    />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * EditableText supports `disabled` state where editing is prevented.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <EditableText {...args} placeholder="Click to Edit" />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                <EditableText {...args} disabled={true} placeholder="Disabled" />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `multiline` prop to allow multi-line editing with a textarea.
+ */
+export const Multiline: Story = {
+    argTypes: {
+        multiline: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%", minWidth: "400px" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Single line</span>
+                <EditableText {...args} multiline={false} placeholder="Single line" />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Multiline</span>
+                <EditableText {...args} multiline={true} placeholder="Multiline text" minLines={3} maxLines={6} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * All intents with disabled state shown for visual comparison.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Default</div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {Object.values(Intent).map(intent => (
+                        <EditableText
+                            key={intent}
+                            {...args}
+                            intent={intent}
+                            placeholder={intent === "none" ? "None" : intent}
+                        />
+                    ))}
+                </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Disabled</div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {Object.values(Intent).map(intent => (
+                        <EditableText
+                            key={intent}
+                            {...args}
+                            intent={intent}
+                            disabled={true}
+                            placeholder={intent === "none" ? "None" : intent}
+                        />
+                    ))}
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        placeholder: "Click to Edit",
+        defaultValue: "Hello, world!",
+    },
+};

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -14,18 +14,18 @@
 
   // input styles on the ::before
   &::before {
-    @include position-all(absolute, $pt-spacing * -0.5);
-    border-radius: $pt-border-radius;
+    @include position-all(absolute, calc(var(--bp-surface-spacing) * -0.5));
+    border-radius: var(--bp-surface-border-radius);
     content: "";
     transition:
-      background-color $pt-transition-duration $pt-transition-ease,
-      box-shadow $pt-transition-duration $pt-transition-ease;
+      background-color var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default),
+      box-shadow var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default);
   }
 
   &:hover::before {
     box-shadow:
       input-transition-shadow($input-shadow-color-focus),
-      inset 0 0 0 1px $pt-divider-black;
+      inset 0 0 0 1px var(--bp-surface-border-color-default);
   }
 
   &.#{$ns}-editable-text-editing::before {
@@ -35,29 +35,99 @@
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     &:not(.#{$ns}-disabled)::before {
-      border: 1px solid $pt-high-contrast-mode-border-color;
+      border: 1px solid buttonborder;
     }
   }
 
-  @each $intent, $color in $pt-intent-colors {
-    &.#{$ns}-intent-#{$intent} {
-      .#{$ns}-editable-text-content,
-      .#{$ns}-editable-text-input,
-      .#{$ns}-editable-text-input::placeholder {
-        color: $color;
-      }
+  /* stylelint-disable alpha-value-notation */
+  &.#{$ns}-intent-primary {
+    .#{$ns}-editable-text-content,
+    .#{$ns}-editable-text-input,
+    .#{$ns}-editable-text-input::placeholder {
+      color: var(--bp-intent-primary-rest);
+    }
 
-      &:hover::before {
-        box-shadow:
-          input-transition-shadow($color),
-          inset border-shadow(0.4, $color, 1px);
-      }
+    &:hover::before {
+      box-shadow:
+        0 0 0 0 oklch(from var(--bp-intent-primary-rest) l c h / 0),
+        0 0 0 0 oklch(from var(--bp-intent-primary-rest) l c h / 0),
+        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.4);
+    }
 
-      &.#{$ns}-editable-text-editing::before {
-        box-shadow: input-transition-shadow($color, true), $input-box-shadow-focus;
-      }
+    &.#{$ns}-editable-text-editing::before {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        $input-box-shadow-focus;
     }
   }
+
+  &.#{$ns}-intent-success {
+    .#{$ns}-editable-text-content,
+    .#{$ns}-editable-text-input,
+    .#{$ns}-editable-text-input::placeholder {
+      color: var(--bp-intent-success-rest);
+    }
+
+    &:hover::before {
+      box-shadow:
+        0 0 0 0 oklch(from var(--bp-intent-success-rest) l c h / 0),
+        0 0 0 0 oklch(from var(--bp-intent-success-rest) l c h / 0),
+        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.4);
+    }
+
+    &.#{$ns}-editable-text-editing::before {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        $input-box-shadow-focus;
+    }
+  }
+
+  &.#{$ns}-intent-warning {
+    .#{$ns}-editable-text-content,
+    .#{$ns}-editable-text-input,
+    .#{$ns}-editable-text-input::placeholder {
+      color: var(--bp-intent-warning-rest);
+    }
+
+    &:hover::before {
+      box-shadow:
+        0 0 0 0 oklch(from var(--bp-intent-warning-rest) l c h / 0),
+        0 0 0 0 oklch(from var(--bp-intent-warning-rest) l c h / 0),
+        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.4);
+    }
+
+    &.#{$ns}-editable-text-editing::before {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        $input-box-shadow-focus;
+    }
+  }
+
+  &.#{$ns}-intent-danger {
+    .#{$ns}-editable-text-content,
+    .#{$ns}-editable-text-input,
+    .#{$ns}-editable-text-input::placeholder {
+      color: var(--bp-intent-danger-rest);
+    }
+
+    &:hover::before {
+      box-shadow:
+        0 0 0 0 oklch(from var(--bp-intent-danger-rest) l c h / 0),
+        0 0 0 0 oklch(from var(--bp-intent-danger-rest) l c h / 0),
+        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.4);
+    }
+
+    &.#{$ns}-editable-text-editing::before {
+      box-shadow:
+        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        $input-box-shadow-focus;
+    }
+  }
+  /* stylelint-enable alpha-value-notation */
 
   .#{$ns}-dark & {
     &:hover::before {
@@ -76,25 +146,95 @@
       box-shadow: none;
     }
 
-    @each $intent, $color in $pt-dark-intent-text-colors {
-      &.#{$ns}-intent-#{$intent} {
-        .#{$ns}-editable-text-content,
-        .#{$ns}-editable-text-input,
-        .#{$ns}-editable-text-input::placeholder {
-          color: $color;
-        }
+    /* stylelint-disable alpha-value-notation */
+    &.#{$ns}-intent-primary {
+      .#{$ns}-editable-text-content,
+      .#{$ns}-editable-text-input,
+      .#{$ns}-editable-text-input::placeholder {
+        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      }
 
-        &:hover::before {
-          box-shadow:
-            input-transition-shadow($color),
-            inset border-shadow(0.4, $color, 1px);
-        }
+      &:hover::before {
+        box-shadow:
+          0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0),
+          0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0),
+          inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.4);
+      }
 
-        &.#{$ns}-editable-text-editing::before {
-          box-shadow: input-transition-shadow($color, true), $pt-dark-input-box-shadow;
-        }
+      &.#{$ns}-editable-text-editing::before {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752),
+          $pt-dark-input-box-shadow;
       }
     }
+
+    &.#{$ns}-intent-success {
+      .#{$ns}-editable-text-content,
+      .#{$ns}-editable-text-input,
+      .#{$ns}-editable-text-input::placeholder {
+        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+      }
+
+      &:hover::before {
+        box-shadow:
+          0 0 0 0 oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0),
+          0 0 0 0 oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0),
+          inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.4);
+      }
+
+      &.#{$ns}-editable-text-editing::before {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752),
+          $pt-dark-input-box-shadow;
+      }
+    }
+
+    &.#{$ns}-intent-warning {
+      .#{$ns}-editable-text-content,
+      .#{$ns}-editable-text-input,
+      .#{$ns}-editable-text-input::placeholder {
+        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+      }
+
+      &:hover::before {
+        box-shadow:
+          0 0 0 0 oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0),
+          0 0 0 0 oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0),
+          inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.4);
+      }
+
+      &.#{$ns}-editable-text-editing::before {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752),
+          $pt-dark-input-box-shadow;
+      }
+    }
+
+    &.#{$ns}-intent-danger {
+      .#{$ns}-editable-text-content,
+      .#{$ns}-editable-text-input,
+      .#{$ns}-editable-text-input::placeholder {
+        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
+      }
+
+      &:hover::before {
+        box-shadow:
+          0 0 0 0 oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0),
+          0 0 0 0 oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0),
+          inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.4);
+      }
+
+      &.#{$ns}-editable-text-editing::before {
+        box-shadow:
+          inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752),
+          $pt-dark-input-box-shadow;
+      }
+    }
+    /* stylelint-enable alpha-value-notation */
   }
 
   &.#{$ns}-disabled::before {
@@ -143,7 +283,7 @@
 .#{$ns}-editable-text-content {
   overflow: hidden;
   // magical number to account for slight increase in input width for cursor bar
-  padding-right: $pt-spacing * 0.5;
+  padding-right: calc(var(--bp-surface-spacing) * 0.5);
   text-overflow: ellipsis;
   // preserve so trailing whitespace is included in scrollWidth
   white-space: pre;
@@ -155,11 +295,7 @@
   }
 
   .#{$ns}-editable-text-placeholder > & {
-    color: $input-placeholder-color;
-
-    .#{$ns}-dark & {
-      color: $dark-input-placeholder-color;
-    }
+    color: var(--bp-typography-color-muted);
   }
 }
 

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -49,15 +49,15 @@
 
     &:hover::before {
       box-shadow:
-        0 0 0 0 oklch(from var(--bp-intent-primary-rest) l c h / 0),
-        0 0 0 0 oklch(from var(--bp-intent-primary-rest) l c h / 0),
-        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.4);
+        0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) l c h / 0)"},
+        0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) l c h / 0)"},
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) l c h / 0.4)"};
     }
 
     &.#{$ns}-editable-text-editing::before {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) l c h / 0.752)"},
+        0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) l c h / 0.752)"},
         $input-box-shadow-focus;
     }
   }
@@ -71,15 +71,15 @@
 
     &:hover::before {
       box-shadow:
-        0 0 0 0 oklch(from var(--bp-intent-success-rest) l c h / 0),
-        0 0 0 0 oklch(from var(--bp-intent-success-rest) l c h / 0),
-        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.4);
+        0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) l c h / 0)"},
+        0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) l c h / 0)"},
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) l c h / 0.4)"};
     }
 
     &.#{$ns}-editable-text-editing::before {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) l c h / 0.752)"},
+        0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) l c h / 0.752)"},
         $input-box-shadow-focus;
     }
   }
@@ -93,15 +93,15 @@
 
     &:hover::before {
       box-shadow:
-        0 0 0 0 oklch(from var(--bp-intent-warning-rest) l c h / 0),
-        0 0 0 0 oklch(from var(--bp-intent-warning-rest) l c h / 0),
-        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.4);
+        0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) l c h / 0)"},
+        0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) l c h / 0)"},
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) l c h / 0.4)"};
     }
 
     &.#{$ns}-editable-text-editing::before {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) l c h / 0.752)"},
+        0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) l c h / 0.752)"},
         $input-box-shadow-focus;
     }
   }
@@ -115,15 +115,15 @@
 
     &:hover::before {
       box-shadow:
-        0 0 0 0 oklch(from var(--bp-intent-danger-rest) l c h / 0),
-        0 0 0 0 oklch(from var(--bp-intent-danger-rest) l c h / 0),
-        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.4);
+        0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) l c h / 0)"},
+        0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) l c h / 0)"},
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) l c h / 0.4)"};
     }
 
     &.#{$ns}-editable-text-editing::before {
       box-shadow:
-        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
-        0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) l c h / 0.752)"},
+        0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) l c h / 0.752)"},
         $input-box-shadow-focus;
     }
   }
@@ -151,20 +151,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0),
-          0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0),
-          inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.4);
+          0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752),
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }
@@ -173,20 +173,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0),
-          0 0 0 0 oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0),
-          inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.4);
+          0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752),
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }
@@ -195,20 +195,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0),
-          0 0 0 0 oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0),
-          inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.4);
+          0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752),
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }
@@ -217,20 +217,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
+        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0),
-          0 0 0 0 oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0),
-          inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.4);
+          0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752),
-          0 0 0 1px oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752),
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }

--- a/packages/core/src/components/editable-text/_editable-text.scss
+++ b/packages/core/src/components/editable-text/_editable-text.scss
@@ -151,20 +151,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0)"},
-          0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0)"},
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.4)"};
+          0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752)"},
-          0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h / 0.752)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }
@@ -173,20 +173,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
+        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0)"},
-          0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0)"},
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.4)"};
+          0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752)"},
-          0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h / 0.752)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }
@@ -195,20 +195,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
+        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0)"},
-          0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0)"},
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.4)"};
+          0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752)"},
-          0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h / 0.752)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }
@@ -217,20 +217,20 @@
       .#{$ns}-editable-text-content,
       .#{$ns}-editable-text-input,
       .#{$ns}-editable-text-input::placeholder {
-        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
+        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h)"};
       }
 
       &:hover::before {
         box-shadow:
-          0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0)"},
-          0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0)"},
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.4)"};
+          0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h / 0)"},
+          0 0 0 0 #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h / 0)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h / 0.4)"};
       }
 
       &.#{$ns}-editable-text-editing::before {
         box-shadow:
-          inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752)"},
-          0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h / 0.752)"},
+          inset 0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h / 0.752)"},
+          0 0 0 1px #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h / 0.752)"},
           $pt-dark-input-box-shadow;
       }
     }

--- a/packages/core/src/components/link/Link.stories.tsx
+++ b/packages/core/src/components/link/Link.stories.tsx
@@ -1,0 +1,156 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Link } from "./link";
+
+const meta: Meta<typeof Link> = {
+    title: "Core/Link/Link",
+    component: Link,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        children: "Blueprint Link",
+        href: "#",
+        underline: "always",
+        color: Intent.PRIMARY,
+    },
+    argTypes: {
+        underline: {
+            control: "select",
+            options: ["always", "hover", "none"],
+        },
+        color: {
+            control: "select",
+            options: [...Object.values(Intent).filter(i => i !== "none"), "inherit"],
+        },
+        href: {
+            control: "text",
+        },
+        onClick: { action: "clicked" },
+    },
+} satisfies Meta<typeof Link>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic link with default styling.
+ */
+export const Default: Story = {
+    args: {
+        children: "Blueprint Link",
+    },
+};
+
+/**
+ * Use the `color` prop to apply intent-based colors to the link.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        color: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Link key={intent} {...args} color={intent}>
+                        {intent.charAt(0).toUpperCase() + intent.slice(1)}
+                    </Link>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `underline` prop to control when the link underline appears.
+ */
+export const UnderlineExample: Story = {
+    name: "Underline",
+    argTypes: {
+        underline: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16 }}>
+            {(["always", "hover", "none"] as const).map(underline => (
+                <div key={underline} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                    <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{underline}</span>
+                    <Link {...args} underline={underline}>
+                        Link
+                    </Link>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Use `color="inherit"` to make the link inherit the surrounding text color.
+ */
+export const ColorInherit: Story = {
+    name: "Color Inherit",
+    argTypes: {
+        color: { table: { disable: true } },
+    },
+    render: args => (
+        <p style={{ color: "#5f6b7c" }}>
+            This paragraph contains a <Link {...args} color="inherit">link that inherits</Link> the text color.
+        </p>
+    ),
+};
+
+/**
+ * All intent colors across all underline styles.
+ */
+export const AllIntentsAllUnderlines: Story = {
+    argTypes: {
+        color: { table: { disable: true } },
+        underline: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {(["always", "hover", "none"] as const).map(underline => (
+                <div key={underline} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <div style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{underline}</div>
+                    <div style={{ display: "flex", gap: 16 }}>
+                        {Object.values(Intent)
+                            .filter(i => i !== "none")
+                            .map(intent => (
+                                <Link key={intent} {...args} color={intent} underline={underline}>
+                                    {intent.charAt(0).toUpperCase() + intent.slice(1)}
+                                </Link>
+                            ))}
+                        <Link {...args} color="inherit" underline={underline}>
+                            Inherit
+                        </Link>
+                    </div>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        children: "Click this link",
+        href: "#",
+    },
+};

--- a/packages/core/src/components/link/_link.scss
+++ b/packages/core/src/components/link/_link.scss
@@ -7,7 +7,7 @@
 .#{$ns}-link {
   cursor: pointer;
   display: inline-flex;
-  gap: $pt-spacing;
+  gap: var(--bp-surface-spacing);
   text-underline-offset: 17.5%;
   text-underline-position: from-font;
 
@@ -35,22 +35,44 @@
     color: inherit;
   }
 
-  @each $intent, $color in $pt-intent-text-colors {
-    &.#{$ns}-intent-#{$intent} {
-      color: $color;
-    }
+  &.#{$ns}-intent-primary {
+    color: var(--bp-intent-primary-hover);
+  }
+
+  &.#{$ns}-intent-success {
+    color: var(--bp-intent-success-hover);
+  }
+
+  &.#{$ns}-intent-warning {
+    color: var(--bp-intent-warning-hover);
+  }
+
+  &.#{$ns}-intent-danger {
+    color: var(--bp-intent-danger-hover);
   }
 
   // Dark theme
+  /* stylelint-disable alpha-value-notation */
   .#{$ns}-dark & {
     &.#{$ns}-link-color-inherit {
       color: inherit;
     }
 
-    @each $intent, $color in $pt-dark-intent-text-colors {
-      &.#{$ns}-intent-#{$intent} {
-        color: $color;
-      }
+    &.#{$ns}-intent-primary {
+      color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+    }
+
+    &.#{$ns}-intent-success {
+      color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+    }
+
+    &.#{$ns}-intent-warning {
+      color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+    }
+
+    &.#{$ns}-intent-danger {
+      color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
     }
   }
+  /* stylelint-enable alpha-value-notation */
 }

--- a/packages/core/src/components/link/_link.scss
+++ b/packages/core/src/components/link/_link.scss
@@ -59,19 +59,19 @@
     }
 
     &.#{$ns}-intent-primary {
-      color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
     }
 
     &.#{$ns}-intent-success {
-      color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+      color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
     }
 
     &.#{$ns}-intent-warning {
-      color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+      color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
     }
 
     &.#{$ns}-intent-danger {
-      color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
+      color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
     }
   }
   /* stylelint-enable alpha-value-notation */

--- a/packages/core/src/components/link/_link.scss
+++ b/packages/core/src/components/link/_link.scss
@@ -59,19 +59,19 @@
     }
 
     &.#{$ns}-intent-primary {
-      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
     }
 
     &.#{$ns}-intent-success {
-      color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
+      color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"};
     }
 
     &.#{$ns}-intent-warning {
-      color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
+      color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h)"};
     }
 
     &.#{$ns}-intent-danger {
-      color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
+      color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h)"};
     }
   }
   /* stylelint-enable alpha-value-notation */


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Editable Text and Link component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-default` | `cubic-bezier(0.4, 1, 0.75, 0.9)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-intent-danger-hover` | `#ac2f33` | `$red2` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue2` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-hover` | `#1c6e42` | `$green2` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-hover` | `#935610` | `$orange2` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-surface-border-color-default` | `#5f6b7c1f` | `$pt-divider-black` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_editable-text.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `padding-right` | `$pt-spacing * 0.5` | `calc(var(--bp-surface-spacing) * 0.5)` |
#### `_link.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `gap` | `$pt-spacing` | `var(--bp-surface-spacing)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`@each` intent loops expanded.** Loops over `$pt-intent-colors` replaced with explicit per-intent blocks for CSS custom property compatibility.
3. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.
4. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
5. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Loop expansion | `@each` over SCSS map → explicit per-intent rules |
| 3 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |
| 4 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 5 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Dark theme appearance after removing redundant `.bp6-dark` blocks
- Intent styles after expanding `@each` loops
