### PR TITLE
[core] Integrating design tokens into form controls

### DIFF
--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -1,0 +1,182 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Checkbox } from "./controls";
+
+const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof Checkbox>
+>;
+
+const meta: Meta<typeof Checkbox> = {
+    title: "Core/Form/Checkbox",
+    component: Checkbox,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Checkbox",
+        disabled: false,
+        inline: false,
+        size: "medium",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["medium", "large"],
+        },
+        disabled: {
+            control: "boolean",
+        },
+        inline: {
+            control: "boolean",
+        },
+        indeterminate: {
+            control: "boolean",
+        },
+        defaultChecked: {
+            control: "boolean",
+        },
+        onChange: { action: "changed" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        label: "Enable notifications",
+    },
+};
+
+export const IntentExample: Story = {
+    name: "Intent",
+    render: args => (
+        <div style={{ display: "flex", gap: 8, flexDirection: "column" }}>
+            <Checkbox {...args} label="Default (no intent)" defaultChecked={true} />
+        </div>
+    ),
+};
+
+export const Size: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            <Checkbox {...args} size="medium" label="Medium" defaultChecked={true} />
+            <Checkbox {...args} size="large" label="Large" defaultChecked={true} />
+        </div>
+    ),
+};
+
+export const State: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Unchecked</div>
+            <div style={{ display: "flex", gap: 16 }}>
+                <Checkbox {...args} label="Default" />
+                <Checkbox {...args} label="Disabled" disabled={true} />
+            </div>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Checked</div>
+            <div style={{ display: "flex", gap: 16 }}>
+                <Checkbox {...args} label="Checked" defaultChecked={true} />
+                <Checkbox {...args} label="Checked Disabled" defaultChecked={true} disabled={true} />
+            </div>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Indeterminate</div>
+            <div style={{ display: "flex", gap: 16 }}>
+                <Checkbox {...args} label="Indeterminate" indeterminate={true} />
+                <Checkbox {...args} label="Indeterminate Disabled" indeterminate={true} disabled={true} />
+            </div>
+        </div>
+    ),
+};
+
+export const Indeterminate: Story = {
+    name: "Indeterminate",
+    argTypes: {
+        indeterminate: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16 }}>
+            <Checkbox {...args} label="Indeterminate" indeterminate={true} />
+            <Checkbox {...args} label="Checked" defaultChecked={true} />
+            <Checkbox {...args} label="Unchecked" />
+        </div>
+    ),
+};
+
+export const Inline: Story = {
+    name: "Inline",
+    argTypes: {
+        inline: { table: { disable: true } },
+    },
+    render: args => (
+        <div>
+            <Checkbox {...args} inline={true} label="Option A" />
+            <Checkbox {...args} inline={true} label="Option B" />
+            <Checkbox {...args} inline={true} label="Option C" />
+        </div>
+    ),
+};
+
+export const AllStates: Story = {
+    name: "All States",
+    render: args => (
+        <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
+            {(["medium", "large"] as const).map(size => (
+                <div key={size}>
+                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8, textTransform: "capitalize" }}>
+                        {size}
+                    </div>
+                    <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+                        <Checkbox {...args} size={size} label="Unchecked" />
+                        <Checkbox {...args} size={size} label="Checked" defaultChecked={true} />
+                        <Checkbox {...args} size={size} label="Indeterminate" indeterminate={true} />
+                        <Checkbox {...args} size={size} label="Disabled" disabled={true} />
+                        <Checkbox {...args} size={size} label="Checked Disabled" defaultChecked={true} disabled={true} />
+                        <Checkbox
+                            {...args}
+                            size={size}
+                            label="Indeterminate Disabled"
+                            indeterminate={true}
+                            disabled={true}
+                        />
+                    </div>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    args: {
+        label: "Enable feature",
+        defaultChecked: false,
+    },
+};

--- a/packages/core/src/components/forms/RadioGroup.stories.tsx
+++ b/packages/core/src/components/forms/RadioGroup.stories.tsx
@@ -1,0 +1,169 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { RadioGroup } from "./radioGroup";
+
+const sampleOptions = [
+    { label: "Option A", value: "a" },
+    { label: "Option B", value: "b" },
+    { label: "Option C", value: "c" },
+];
+
+const meta: Meta<typeof RadioGroup> = {
+    title: "Core/Form/RadioGroup",
+    component: RadioGroup,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Choose an option",
+        options: sampleOptions,
+        disabled: false,
+        inline: false,
+    },
+    argTypes: {
+        disabled: {
+            control: "boolean",
+        },
+        inline: {
+            control: "boolean",
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: function Render(args) {
+        const [selectedValue, setSelectedValue] = useState<string>("a");
+        const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setSelectedValue(e.currentTarget.value);
+            args.onChange?.(e);
+        }, [args]);
+        return <RadioGroup {...args} selectedValue={selectedValue} onChange={handleChange} />;
+    },
+};
+
+export const State: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: function Render(args) {
+        const [value1, setValue1] = useState<string>("a");
+        const [value2, setValue2] = useState<string>("a");
+        const handleChange1 = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setValue1(e.currentTarget.value);
+        }, []);
+        const handleChange2 = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setValue2(e.currentTarget.value);
+        }, []);
+        return (
+            <div style={{ display: "flex", gap: 32 }}>
+                <RadioGroup
+                    {...args}
+                    label="Enabled"
+                    selectedValue={value1}
+                    onChange={handleChange1}
+                />
+                <RadioGroup
+                    {...args}
+                    label="Disabled"
+                    disabled={true}
+                    selectedValue={value2}
+                    onChange={handleChange2}
+                />
+            </div>
+        );
+    },
+};
+
+export const Inline: Story = {
+    name: "Inline",
+    argTypes: {
+        inline: { table: { disable: true } },
+    },
+    render: function Render(args) {
+        const [selectedValue, setSelectedValue] = useState<string>("a");
+        const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setSelectedValue(e.currentTarget.value);
+        }, []);
+        return (
+            <RadioGroup
+                {...args}
+                inline={true}
+                selectedValue={selectedValue}
+                onChange={handleChange}
+            />
+        );
+    },
+};
+
+export const WithLabel: Story = {
+    name: "With Label",
+    render: function Render(args) {
+        const [selectedValue, setSelectedValue] = useState<string>("a");
+        const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setSelectedValue(e.currentTarget.value);
+        }, []);
+        return (
+            <RadioGroup
+                {...args}
+                label="Select your preference"
+                selectedValue={selectedValue}
+                onChange={handleChange}
+            />
+        );
+    },
+};
+
+export const ManyOptions: Story = {
+    name: "Many Options",
+    render: function Render(args) {
+        const [selectedValue, setSelectedValue] = useState<string>("1");
+        const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setSelectedValue(e.currentTarget.value);
+        }, []);
+        const manyOptions = [
+            { label: "Small", value: "1" },
+            { label: "Medium", value: "2" },
+            { label: "Large", value: "3" },
+            { label: "X-Large", value: "4" },
+            { label: "XX-Large", value: "5" },
+        ];
+        return (
+            <RadioGroup
+                {...args}
+                label="Select size"
+                options={manyOptions}
+                selectedValue={selectedValue}
+                onChange={handleChange}
+            />
+        );
+    },
+};
+
+export const Playground: Story = {
+    render: function Render(args) {
+        const [selectedValue, setSelectedValue] = useState<string>("a");
+        const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+            setSelectedValue(e.currentTarget.value);
+            args.onChange?.(e);
+        }, [args]);
+        return <RadioGroup {...args} selectedValue={selectedValue} onChange={handleChange} />;
+    },
+};

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -1,0 +1,176 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Switch } from "./controls";
+
+const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof Switch>
+>;
+
+const meta: Meta<typeof Switch> = {
+    title: "Core/Form/Switch",
+    component: Switch,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Switch",
+        disabled: false,
+        inline: false,
+        size: "medium",
+    },
+    argTypes: {
+        size: {
+            control: "select",
+            options: ["medium", "large"],
+        },
+        disabled: {
+            control: "boolean",
+        },
+        inline: {
+            control: "boolean",
+        },
+        innerLabel: {
+            control: "text",
+        },
+        innerLabelChecked: {
+            control: "text",
+        },
+        defaultChecked: {
+            control: "boolean",
+        },
+        onChange: { action: "changed" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        label: "Enable dark mode",
+    },
+};
+
+export const Size: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            <Switch {...args} size="medium" label="Medium" defaultChecked={true} />
+            <Switch {...args} size="large" label="Large" defaultChecked={true} />
+        </div>
+    ),
+};
+
+export const State: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Unchecked</div>
+            <div style={{ display: "flex", gap: 16 }}>
+                <Switch {...args} label="Default" />
+                <Switch {...args} label="Disabled" disabled={true} />
+            </div>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Checked</div>
+            <div style={{ display: "flex", gap: 16 }}>
+                <Switch {...args} label="Checked" defaultChecked={true} />
+                <Switch {...args} label="Checked Disabled" defaultChecked={true} disabled={true} />
+            </div>
+        </div>
+    ),
+};
+
+export const InnerLabel: Story = {
+    name: "Inner Label",
+    argTypes: {
+        innerLabel: { table: { disable: true } },
+        innerLabelChecked: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+            <Switch {...args} label="With inner labels" innerLabel="Off" innerLabelChecked="On" />
+            <Switch
+                {...args}
+                label="Same label both states"
+                innerLabel="Enabled"
+                defaultChecked={true}
+            />
+        </div>
+    ),
+};
+
+export const Inline: Story = {
+    name: "Inline",
+    argTypes: {
+        inline: { table: { disable: true } },
+    },
+    render: args => (
+        <div>
+            <Switch {...args} inline={true} label="Wi-Fi" defaultChecked={true} />
+            <Switch {...args} inline={true} label="Bluetooth" />
+            <Switch {...args} inline={true} label="Airplane Mode" />
+        </div>
+    ),
+};
+
+export const AllStates: Story = {
+    name: "All States",
+    render: args => (
+        <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
+            {(["medium", "large"] as const).map(size => (
+                <div key={size}>
+                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8, textTransform: "capitalize" }}>
+                        {size}
+                    </div>
+                    <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+                        <Switch {...args} size={size} label="Unchecked" />
+                        <Switch {...args} size={size} label="Checked" defaultChecked={true} />
+                        <Switch {...args} size={size} label="Disabled" disabled={true} />
+                        <Switch {...args} size={size} label="Checked Disabled" defaultChecked={true} disabled={true} />
+                        <Switch
+                            {...args}
+                            size={size}
+                            label="With inner labels"
+                            innerLabel="Off"
+                            innerLabelChecked="On"
+                            defaultChecked={true}
+                        />
+                    </div>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    args: {
+        label: "Enable feature",
+        innerLabel: "Off",
+        innerLabelChecked: "On",
+        defaultChecked: false,
+    },
+};

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -35,7 +35,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   input#{$selector} ~ .#{$ns}-control-indicator {
     background-color: var(--bp-intent-primary-rest);
     /* stylelint-disable-next-line alpha-value-notation */
-    box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-black) l c h / 0.2);
+    box-shadow: inset 0 0 0 var(--bp-surface-border-width) #{"oklch(from var(--bp-palette-black) l c h / 0.2)"};
     color: var(--bp-intent-primary-foreground);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -62,7 +62,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     background: color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent);
     box-shadow: none;
     /* stylelint-disable-next-line alpha-value-notation */
-    color: oklch(from var(--bp-palette-white) l c h / 0.6);
+    color: #{"oklch(from var(--bp-palette-white) l c h / 0.6)"};
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       background-color: graytext;
@@ -73,7 +73,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   .#{$ns}-dark & {
     input#{$selector} ~ .#{$ns}-control-indicator {
       /* stylelint-disable-next-line alpha-value-notation */
-      box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-white) l c h / 0.1);
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) #{"oklch(from var(--bp-palette-white) l c h / 0.1)"};
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
         // Windows High Contrast dark theme
@@ -84,20 +84,20 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     &:hover input#{$selector} ~ .#{$ns}-control-indicator {
       background-color: var(--bp-intent-primary-hover);
       /* stylelint-disable-next-line alpha-value-notation */
-      box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-white) l c h / 0.1);
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) #{"oklch(from var(--bp-palette-white) l c h / 0.1)"};
     }
 
     input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
       background-color: var(--bp-intent-primary-active);
       /* stylelint-disable-next-line alpha-value-notation */
-      box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-white) l c h / 0.1);
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) #{"oklch(from var(--bp-palette-white) l c h / 0.1)"};
     }
 
     input:disabled#{$selector} ~ .#{$ns}-control-indicator {
       background: color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent);
       box-shadow: none;
       /* stylelint-disable-next-line alpha-value-notation */
-      color: oklch(from var(--bp-palette-white) l c h / 0.6);
+      color: #{"oklch(from var(--bp-palette-white) l c h / 0.6)"};
     }
   }
 }
@@ -408,6 +408,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       }
     }
 
+    /* stylelint-disable alpha-value-notation */
     @include indicator-colors(
       "",
       var(--bp-typography-color-default-rest),
@@ -416,7 +417,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       color-mix(in srgb, var(--bp-intent-default-disabled) 50%, transparent),
       var(--bp-typography-color-default-disabled),
       color-mix(in srgb, var(--bp-intent-default-disabled) 15%, transparent),
-      oklch(from var(--bp-palette-white) calc(l - 0.03) c h / 0.8)
+      #{"oklch(from var(--bp-palette-white) calc(l - 0.03) c h / 0.8)"}
     );
     @include indicator-colors(
       ":checked",
@@ -424,10 +425,11 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       var(--bp-intent-primary-rest),
       var(--bp-intent-primary-hover),
       var(--bp-intent-primary-active),
-      oklch(from var(--bp-palette-white) l c h / 0.6),
+      #{"oklch(from var(--bp-palette-white) l c h / 0.6)"},
       color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent),
-      oklch(from var(--bp-palette-white) l c h / 0.5)
+      #{"oklch(from var(--bp-palette-white) l c h / 0.5)"}
     );
+    /* stylelint-enable alpha-value-notation */
     // convert em variable to px value
     @include indicator-position(math.div($switch-width, 1em) * $control-indicator-size);
 
@@ -469,7 +471,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
         background: var(--bp-palette-white);
         border-radius: 50%;
         /* stylelint-disable-next-line alpha-value-notation */
-        box-shadow: 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-black) l c h / 0.5);
+        box-shadow: 0 0 0 var(--bp-surface-border-width) #{"oklch(from var(--bp-palette-black) l c h / 0.5)"};
         height: $switch-indicator-size;
         left: calc(var(--bp-surface-spacing) * 0.5);
         position: absolute;
@@ -501,6 +503,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     }
 
     .#{$ns}-dark & {
+      /* stylelint-disable alpha-value-notation */
       @include indicator-colors(
         "",
         var(--bp-typography-color-default-rest),
@@ -509,7 +512,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
         color-mix(in srgb, var(--bp-intent-default-disabled) 50%, transparent),
         var(--bp-typography-color-default-disabled),
         color-mix(in srgb, var(--bp-intent-default-disabled) 15%, transparent),
-        oklch(from var(--bp-palette-white) calc(l - 0.03) c h / 0.8)
+        #{"oklch(from var(--bp-palette-white) calc(l - 0.03) c h / 0.8)"}
       );
       @include indicator-colors(
         ":checked",
@@ -519,8 +522,9 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
         var(--bp-intent-primary-active),
         var(--bp-typography-color-default-disabled),
         color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent),
-        oklch(from var(--bp-palette-white) l c h / 0.5)
+        #{"oklch(from var(--bp-palette-white) l c h / 0.5)"}
       );
+      /* stylelint-enable alpha-value-notation */
 
       // Add Windows high contrast mode styles
       @media (forced-colors: active) and (prefers-color-scheme: dark) {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -33,65 +33,71 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
 @mixin control-checked-colors($selector: ":checked") {
   input#{$selector} ~ .#{$ns}-control-indicator {
-    background-color: $control-checked-background-color;
-    box-shadow: $control-checked-box-shadow;
-    color: $white;
+    background-color: var(--bp-intent-primary-rest);
+    /* stylelint-disable-next-line alpha-value-notation */
+    box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-black) l c h / 0.2);
+    color: var(--bp-intent-primary-foreground);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      background-color: $pt-high-contrast-mode-active-background-color;
+      background-color: highlight;
       // Windows High Contrast dark theme
-      border: 1px solid $pt-high-contrast-mode-active-background-color;
+      border: 1px solid highlight;
     }
   }
 
   &:hover input#{$selector} ~ .#{$ns}-control-indicator {
-    background-color: $control-checked-background-color-hover;
+    background-color: var(--bp-intent-primary-hover);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
-      background-color: $pt-high-contrast-mode-active-background-color;
+      background-color: highlight;
     }
   }
 
   input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
-    background: $control-checked-background-color-active;
+    background: var(--bp-intent-primary-active);
   }
 
   input:disabled#{$selector} ~ .#{$ns}-control-indicator {
-    background: $control-checked-background-color-disabled;
+    background: color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent);
     box-shadow: none;
-    color: rgba($white, 0.6);
+    /* stylelint-disable-next-line alpha-value-notation */
+    color: oklch(from var(--bp-palette-white) l c h / 0.6);
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      background-color: $pt-high-contrast-mode-disabled-border-color;
-      border-color: $pt-high-contrast-mode-disabled-border-color;
+      background-color: graytext;
+      border-color: graytext;
     }
   }
 
   .#{$ns}-dark & {
     input#{$selector} ~ .#{$ns}-control-indicator {
-      box-shadow: $dark-control-checked-box-shadow;
+      /* stylelint-disable-next-line alpha-value-notation */
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-white) l c h / 0.1);
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
         // Windows High Contrast dark theme
-        border: 1px solid $pt-high-contrast-mode-border-color;
+        border: 1px solid buttonborder;
       }
     }
 
     &:hover input#{$selector} ~ .#{$ns}-control-indicator {
-      background-color: $control-checked-background-color-hover;
-      box-shadow: $dark-control-checked-box-shadow;
+      background-color: var(--bp-intent-primary-hover);
+      /* stylelint-disable-next-line alpha-value-notation */
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-white) l c h / 0.1);
     }
 
     input:not(:disabled):active#{$selector} ~ .#{$ns}-control-indicator {
-      background-color: $control-checked-background-color-active;
-      box-shadow: $dark-control-checked-box-shadow;
+      background-color: var(--bp-intent-primary-active);
+      /* stylelint-disable-next-line alpha-value-notation */
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-white) l c h / 0.1);
     }
 
     input:disabled#{$selector} ~ .#{$ns}-control-indicator {
-      background: $control-checked-background-color-disabled;
+      background: color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent);
       box-shadow: none;
-      color: rgba($white, 0.6);
+      /* stylelint-disable-next-line alpha-value-notation */
+      color: oklch(from var(--bp-palette-white) l c h / 0.6);
     }
   }
 }
@@ -132,18 +138,18 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   cursor: pointer;
 
   display: block;
-  margin-bottom: $pt-spacing * 2;
+  margin-bottom: calc(var(--bp-surface-spacing) * 2);
   position: relative;
   text-transform: none;
 
   &.#{$ns}-disabled {
-    color: $pt-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
   }
 
   &.#{$ns}-inline {
     display: inline-block;
-    margin-inline-end: $pt-spacing * 5;
+    margin-inline-end: calc(var(--bp-surface-spacing) * 5);
   }
 
   .#{$ns}-control-input {
@@ -156,17 +162,17 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
   .#{$ns}-control-indicator {
     background-clip: padding-box;
-    background-color: $control-background-color;
+    background-color: transparent;
     border: none;
-    box-shadow: $control-box-shadow;
+    box-shadow: inset 0 0 0 var(--bp-surface-border-width) var(--bp-palette-gray-2);
     cursor: pointer;
     display: inline-block;
     // font-size is used to size indicator for all control types,
     // to reduce property changes needed across types and sizes (large).
-    font-size: $control-indicator-size;
+    font-size: calc(var(--bp-surface-spacing) * 4);
     height: 1em;
-    margin-inline-end: $control-indicator-spacing;
-    margin-top: $pt-spacing * -0.75;
+    margin-inline-end: calc(var(--bp-surface-spacing) * 2);
+    margin-top: calc(var(--bp-surface-spacing) * -0.75);
     position: relative;
     user-select: none;
     vertical-align: middle;
@@ -181,7 +187,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
-      border: 1px solid $pt-high-contrast-mode-border-color;
+      border: 1px solid buttonborder;
 
       &::before {
         // Because we're using a border in high contrast mode, we need to adjust the margins
@@ -193,16 +199,19 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   }
 
   &:hover .#{$ns}-control-indicator {
-    background-color: $control-background-color-hover;
+    // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+    background-color: color-mix(in srgb, var(--bp-intent-default-hover) 8%, transparent);
   }
 
   input:not(:disabled):active ~ .#{$ns}-control-indicator {
-    background: $control-background-color-active;
-    box-shadow: $control-box-shadow;
+    // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+    background: color-mix(in srgb, var(--bp-intent-default-active) 16%, transparent);
+    box-shadow: inset 0 0 0 var(--bp-surface-border-width) var(--bp-palette-gray-2);
   }
 
   input:disabled ~ .#{$ns}-control-indicator {
-    background: $control-background-color-disabled;
+    // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+    background: color-mix(in srgb, var(--bp-intent-default-hover) 8%, transparent);
     box-shadow: none;
     cursor: not-allowed;
   }
@@ -214,7 +223,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   // right-aligned indicator is glued to the right side of the container
   &.#{$ns}-align-right .#{$ns}-control-indicator {
     float: right;
-    margin-left: $control-indicator-spacing;
+    margin-left: calc(var(--bp-surface-spacing) * 2);
     margin-top: 1px;
   }
 
@@ -226,11 +235,11 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   &.#{$ns}-large {
     @include indicator-position($control-indicator-size-large);
     // larger text
-    font-size: $pt-font-size-large;
+    font-size: var(--bp-typography-size-body-large);
 
     .#{$ns}-control-indicator {
       // em-based sizing
-      font-size: $control-indicator-size-large;
+      font-size: calc(var(--bp-surface-spacing) * 5);
     }
 
     &.#{$ns}-align-right .#{$ns}-control-indicator {
@@ -243,7 +252,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   }
 
   &.#{$ns}-checkbox {
-    @mixin indicator-inline-icon($icon, $fill-color: $white) {
+    @mixin indicator-inline-icon($icon, $fill-color: var(--bp-palette-white)) {
       &::before {
         // embed SVG icon image as backgroud-image above gradient.
         // the SVG image content is inlined into the CSS, so use this sparingly.
@@ -262,7 +271,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     @include control-checked-colors(":indeterminate");
 
     .#{$ns}-control-indicator {
-      border-radius: $pt-border-radius;
+      border-radius: var(--bp-surface-border-radius);
     }
 
     input:checked ~ .#{$ns}-control-indicator {
@@ -287,7 +296,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       }
 
       input:disabled ~ .#{$ns}-control-indicator {
-        border-color: $pt-high-contrast-mode-disabled-border-color;
+        border-color: graytext;
       }
     }
   }
@@ -298,11 +307,11 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator::before {
-      background-image: radial-gradient($white, $white 28%, transparent 32%);
+      background-image: radial-gradient(var(--bp-palette-white), var(--bp-palette-white) 28%, transparent 32%);
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
         // Windows High Contrast dark theme
-        background: $pt-high-contrast-mode-active-background-color;
+        background: highlight;
         // Subtract border on either end, and then an extra 2px for space between the border
         height: $control-indicator-size - $pt-spacing;
         margin-left: 1px;
@@ -315,7 +324,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       opacity: 0.5;
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        background: $pt-high-contrast-mode-disabled-background-color;
+        background: graytext;
       }
     }
 
@@ -325,7 +334,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       input:disabled ~ .#{$ns}-control-indicator {
-        border-color: $pt-high-contrast-mode-disabled-border-color;
+        border-color: graytext;
       }
     }
   }
@@ -401,23 +410,23 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     @include indicator-colors(
       "",
-      $switch-text-color,
-      $switch-background-color,
-      $switch-background-color-hover,
-      $switch-background-color-active,
-      $switch-text-color-disabled,
-      $switch-background-color-disabled,
-      $switch-indicator-background-color-disabled
+      var(--bp-typography-color-default-rest),
+      color-mix(in srgb, var(--bp-intent-default-disabled) 30%, transparent),
+      color-mix(in srgb, var(--bp-intent-default-disabled) 40%, transparent),
+      color-mix(in srgb, var(--bp-intent-default-disabled) 50%, transparent),
+      var(--bp-typography-color-default-disabled),
+      color-mix(in srgb, var(--bp-intent-default-disabled) 15%, transparent),
+      oklch(from var(--bp-palette-white) calc(l - 0.03) c h / 0.8)
     );
     @include indicator-colors(
       ":checked",
-      $switch-checked-text-color,
-      $switch-checked-background-color,
-      $switch-checked-background-color-hover,
-      $switch-checked-background-color-active,
-      $switch-checked-text-color-disabled,
-      $switch-checked-background-color-disabled,
-      $switch-checked-indicator-background-color-disabled
+      var(--bp-intent-primary-foreground),
+      var(--bp-intent-primary-rest),
+      var(--bp-intent-primary-hover),
+      var(--bp-intent-primary-active),
+      oklch(from var(--bp-palette-white) l c h / 0.6),
+      color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent),
+      oklch(from var(--bp-palette-white) l c h / 0.5)
     );
     // convert em variable to px value
     @include indicator-position(math.div($switch-width, 1em) * $control-indicator-size);
@@ -425,24 +434,24 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     // Add Windows high contrast mode styles
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       input:checked ~ .#{$ns}-control-indicator {
-        background: $pt-high-contrast-mode-active-background-color;
-        border: 1px solid $pt-high-contrast-mode-border-color;
+        background: highlight;
+        border: 1px solid buttonborder;
       }
 
       input:checked:disabled ~ .#{$ns}-control-indicator {
-        background-color: $pt-high-contrast-mode-disabled-background-color;
+        background-color: graytext;
       }
 
       input:not(:checked):disabled ~ .#{$ns}-control-indicator {
-        border-color: $pt-high-contrast-mode-disabled-border-color;
+        border-color: graytext;
 
         &::before {
-          border-color: $pt-high-contrast-mode-disabled-border-color;
+          border-color: graytext;
         }
       }
 
       &:hover input:checked ~ .#{$ns}-control-indicator {
-        background: $pt-high-contrast-mode-active-background-color;
+        background: highlight;
       }
     }
 
@@ -453,31 +462,32 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       /* stylelint-disable-next-line declaration-no-important */
       box-shadow: none !important;
       min-width: $switch-width;
-      transition: background-color $pt-transition-duration $pt-transition-ease;
+      transition: background-color var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default);
       width: auto;
 
       &::before {
-        background: $white;
+        background: var(--bp-palette-white);
         border-radius: 50%;
-        box-shadow: $switch-indicator-box-shadow;
+        /* stylelint-disable-next-line alpha-value-notation */
+        box-shadow: 0 0 0 var(--bp-surface-border-width) oklch(from var(--bp-palette-black) l c h / 0.5);
         height: $switch-indicator-size;
-        left: $switch-indicator-margin;
+        left: calc(var(--bp-surface-spacing) * 0.5);
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
-        transition: left $pt-transition-duration $pt-transition-ease;
+        transition: left var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default);
         width: $switch-indicator-size;
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           // Windows High Contrast dark theme
-          border: 1px solid $pt-high-contrast-mode-border-color;
+          border: 1px solid buttonborder;
           // Because we're using a border for the outline, we need to decrease the top margin
           margin-top: $switch-indicator-margin - 1px;
         }
       }
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        border: 1px solid $pt-high-contrast-mode-border-color;
+        border: 1px solid buttonborder;
       }
     }
 
@@ -493,47 +503,47 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     .#{$ns}-dark & {
       @include indicator-colors(
         "",
-        $dark-switch-text-color,
-        $switch-background-color,
-        $switch-background-color-hover,
-        $switch-background-color-active,
-        $dark-switch-text-color-disabled,
-        $switch-background-color-disabled,
-        $switch-indicator-background-color-disabled
+        var(--bp-typography-color-default-rest),
+        color-mix(in srgb, var(--bp-intent-default-disabled) 30%, transparent),
+        color-mix(in srgb, var(--bp-intent-default-disabled) 40%, transparent),
+        color-mix(in srgb, var(--bp-intent-default-disabled) 50%, transparent),
+        var(--bp-typography-color-default-disabled),
+        color-mix(in srgb, var(--bp-intent-default-disabled) 15%, transparent),
+        oklch(from var(--bp-palette-white) calc(l - 0.03) c h / 0.8)
       );
       @include indicator-colors(
         ":checked",
-        $dark-switch-checked-text-color,
-        $switch-checked-background-color,
-        $switch-checked-background-color-hover,
-        $switch-checked-background-color-active,
-        $dark-switch-checked-text-color-disabled,
-        $switch-checked-background-color-disabled,
-        $switch-checked-indicator-background-color-disabled
+        var(--bp-intent-primary-foreground),
+        var(--bp-intent-primary-rest),
+        var(--bp-intent-primary-hover),
+        var(--bp-intent-primary-active),
+        var(--bp-typography-color-default-disabled),
+        color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent),
+        oklch(from var(--bp-palette-white) l c h / 0.5)
       );
 
       // Add Windows high contrast mode styles
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
         input:checked ~ .#{$ns}-control-indicator {
-          background: $pt-high-contrast-mode-active-background-color;
-          border: 1px solid $pt-high-contrast-mode-border-color;
+          background: highlight;
+          border: 1px solid buttonborder;
         }
 
         input:checked:disabled ~ .#{$ns}-control-indicator {
-          background-color: $pt-high-contrast-mode-disabled-background-color;
+          background-color: graytext;
         }
 
         input:not(:checked):disabled ~ .#{$ns}-control-indicator {
-          border-color: $pt-high-contrast-mode-disabled-border-color;
+          border-color: graytext;
 
           // stylelint-disable-next-line max-nesting-depth
           &::before {
-            border-color: $pt-high-contrast-mode-disabled-border-color;
+            border-color: graytext;
           }
         }
 
         &:hover input:checked ~ .#{$ns}-control-indicator {
-          background: $pt-high-contrast-mode-active-background-color;
+          background: highlight;
         }
       }
     }
@@ -573,28 +583,31 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
   }
 
   .#{$ns}-dark & {
-    color: $pt-dark-text-color;
+    color: var(--bp-typography-color-default-rest);
 
     &.#{$ns}-disabled {
-      color: $pt-dark-text-color-disabled;
+      color: var(--bp-typography-color-default-disabled);
     }
 
     .#{$ns}-control-indicator {
-      background-color: $dark-control-background-color;
-      box-shadow: $dark-control-box-shadow;
+      background-color: transparent;
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) var(--bp-palette-gray-3);
     }
 
     &:hover .#{$ns}-control-indicator {
-      background-color: $dark-control-background-color-hover;
+      // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+      background-color: color-mix(in srgb, var(--bp-intent-default-hover) 8%, transparent);
     }
 
     input:not(:disabled):active ~ .#{$ns}-control-indicator {
-      background: $dark-control-background-color-active;
-      box-shadow: $dark-control-box-shadow;
+      // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+      background: color-mix(in srgb, var(--bp-intent-default-active) 16%, transparent);
+      box-shadow: inset 0 0 0 var(--bp-surface-border-width) var(--bp-palette-gray-3);
     }
 
     input:disabled ~ .#{$ns}-control-indicator {
-      background: $dark-control-background-color-disabled;
+      // Use srgb instead of oklch to avoid hue shift with near-neutral colors
+      background: color-mix(in srgb, var(--bp-intent-default-hover) 8%, transparent);
       box-shadow: none;
       cursor: not-allowed;
     }
@@ -603,7 +616,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
       &:checked,
       &:indeterminate {
         ~ .#{$ns}-control-indicator {
-          background: $control-checked-background-color-disabled;
+          background: color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent);
         }
       }
     }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Form Controls (Checkbox, Radio, Switch) component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-default` | `cubic-bezier(0.4, 1, 0.75, 0.9)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-intent-default-active` | `#383e47` | `$dark-gray4` |
| `--bp-intent-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-intent-default-hover` | `#404854` | `$dark-gray5` |
| `--bp-intent-primary-active` | `#184a90` | `$blue1` |
| `--bp-intent-primary-foreground` | `#ffffff` | `$white` |
| `--bp-intent-primary-hover` | `#215db0` | `$blue2` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-palette-black` | `#111418` | `$black` |
| `--bp-palette-gray-2` | `#738091` | `(see diff)` |
| `--bp-palette-gray-3` | `#8f99a8` | `(see diff)` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-border-width` | `1px` | `(see diff)` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-size-body-large` | `16px` | `(see diff)` |

#### `_controls.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `color: $white;` | `$white` | `var(--bp-intent-primary-rest)` |
| `background-color` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `border` | `1px solid $pt-high-contrast-mode-active-background-color` | `1px solid highlight` |
| `background-color` | `$control-checked-background-color-hover` | `var(--bp-intent-primary-hover)` |
| `background-color` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `background` | `$control-checked-background-color-active` | `var(--bp-intent-primary-active)` |
| `background` | `$control-checked-background-color-disabled` | `color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `background` | `$control-checked-background-color-disabled` | `color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent)` |
| `margin-bottom` | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |
| `color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `margin-inline-end` | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| `background-color` | `$control-background-color` | `transparent` |
| `box-shadow` | `$control-box-shadow` | `inset 0 0 0 var(--bp-surface-border-width) var(--bp-palette-gray-2)` |
| `font-size` | `$control-indicator-size` | `calc(var(--bp-surface-spacing) * 4)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `margin-left` | `$control-indicator-spacing` | `calc(var(--bp-surface-spacing) * 2)` |
| `font-size` | `$pt-font-size-large` | `var(--bp-typography-size-body-large)` |
| `font-size` | `$control-indicator-size-large` | `calc(var(--bp-surface-spacing) * 5)` |
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `border-color` | `$pt-high-contrast-mode-disabled-border-color` | `graytext` |
| `background` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `background` | `$pt-high-contrast-mode-disabled-background-color` | `graytext` |
| `border-color` | `$pt-high-contrast-mode-disabled-border-color` | `graytext` |
| `background-color` | `$pt-high-contrast-mode-disabled-background-color` | `graytext` |
| `border-color` | `$pt-high-contrast-mode-disabled-border-color` | `graytext` |
| `border-color` | `$pt-high-contrast-mode-disabled-border-color` | `graytext` |
| `background` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `background` | `$white` | `var(--bp-palette-white)` |
| `left` | `$switch-indicator-margin` | `calc(var(--bp-surface-spacing) * 0.5)` |
| `transition` | `left $pt-transition-duration $pt-transition-ease` | `left var(--bp-emphasis-transition-duration) var(--bp-emphasis-ease-default)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `background-color` | `$pt-high-contrast-mode-disabled-background-color` | `graytext` |
| `border-color` | `$pt-high-contrast-mode-disabled-border-color` | `graytext` |
| `border-color` | `$pt-high-contrast-mode-disabled-border-color` | `graytext` |
| `background` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `color` | `$pt-dark-text-color` | `var(--bp-typography-color-default-rest)` |
| `color` | `$pt-dark-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `background` | `$control-checked-background-color-disabled` | `color-mix(in oklch, var(--bp-intent-primary-rest) 50%, transparent)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
3. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 3 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
