### PR TITLE
[core] Integrating design tokens into spinner and progress bar

### DIFF
--- a/packages/core/src/components/progress-bar/ProgressBar.stories.tsx
+++ b/packages/core/src/components/progress-bar/ProgressBar.stories.tsx
@@ -1,0 +1,155 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { ProgressBar } from "./progressBar";
+
+const meta: Meta<typeof ProgressBar> = {
+    title: "Core/Progress/ProgressBar",
+    component: ProgressBar,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px", width: "100%" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        intent: "none",
+        animate: true,
+        stripes: true,
+        value: undefined,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        animate: {
+            control: "boolean",
+        },
+        stripes: {
+            control: "boolean",
+        },
+        value: {
+            control: { type: "range", min: 0, max: 1, step: 0.05 },
+        },
+    },
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic indeterminate progress bar with default styling.
+ */
+export const Default: Story = {};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the progress bar.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                        <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</span>
+                        <ProgressBar {...args} intent={intent} value={0.6} />
+                    </div>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `value` prop to show determinate progress. Omit it for an indeterminate bar that fills entirely.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        value: { table: { disable: true } },
+        animate: { table: { disable: true } },
+        stripes: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Indeterminate</span>
+                <ProgressBar {...args} value={undefined} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>0%</span>
+                <ProgressBar {...args} value={0} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>50%</span>
+                <ProgressBar {...args} value={0.5} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>100%</span>
+                <ProgressBar {...args} value={1} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>No stripes</span>
+                <ProgressBar {...args} value={0.6} stripes={false} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>No animation</span>
+                <ProgressBar {...args} value={0.6} animate={false} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * All intents showing determinate progress at various levels.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        value: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Default (no intent)</div>
+                <ProgressBar {...args} intent="none" value={0.4} />
+            </div>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                        <div style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</div>
+                        <ProgressBar {...args} intent={intent} value={0.6} />
+                    </div>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        intent: "primary",
+        value: 0.65,
+        animate: true,
+        stripes: true,
+    },
+};

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -10,15 +10,17 @@ $progress-bar-height: $pt-spacing * 2 !default;
 $progress-bar-stripes-size: $pt-spacing * 7.5 !default;
 $progress-bar-border-radius: $pt-spacing * 10 !default;
 
+/* stylelint-disable alpha-value-notation */
 $progress-bar-gradient: linear-gradient(
   -45deg,
-  $progress-bar-stripes-color 25%,
+  #{"oklch(from var(--bp-palette-white) l c h / 0.2)"} 25%,
   transparent 25%,
   transparent 50%,
-  $progress-bar-stripes-color 50%,
-  $progress-bar-stripes-color 75%,
+  #{"oklch(from var(--bp-palette-white) l c h / 0.2)"} 50%,
+  #{"oklch(from var(--bp-palette-white) l c h / 0.2)"} 75%,
   transparent 75%
 ) !default;
+/* stylelint-enable alpha-value-notation */
 
 @keyframes linear-progress-bar-stripes {
   from {
@@ -26,33 +28,35 @@ $progress-bar-gradient: linear-gradient(
   }
 
   to {
-    background-position: $progress-bar-stripes-size 0;
+    background-position: calc(var(--bp-surface-spacing) * 7.5) 0;
   }
 }
 
 .#{$ns}-progress-bar {
-  background: $progress-track-color;
-  border-radius: $progress-bar-border-radius;
+  /* stylelint-disable-next-line alpha-value-notation */
+  background: oklch(from var(--bp-intent-default-rest) l c h / 0.2);
+  border-radius: calc(var(--bp-surface-spacing) * 10);
   display: block;
-  height: $progress-bar-height;
+  height: calc(var(--bp-surface-spacing) * 2);
   overflow: hidden;
   position: relative;
   width: 100%;
 
   .#{$ns}-progress-meter {
     background: $progress-bar-gradient;
-    background-color: $progress-head-color;
-    background-size: $progress-bar-stripes-size $progress-bar-stripes-size;
-    border-radius: $progress-bar-border-radius;
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: oklch(from var(--bp-intent-default-rest) l c h / 0.8);
+    background-size: calc(var(--bp-surface-spacing) * 7.5) calc(var(--bp-surface-spacing) * 7.5);
+    border-radius: calc(var(--bp-surface-spacing) * 10);
     height: 100%;
     position: absolute;
-    transition: width ($pt-transition-duration * 2) $pt-transition-ease;
+    transition: width calc(var(--bp-emphasis-transition-duration) * 2) var(--bp-emphasis-ease-default);
     // initial state is a full bar, a la "indeterminate"
     width: 100%;
   }
 
   &:not(.#{$ns}-no-animation):not(.#{$ns}-no-stripes) .#{$ns}-progress-meter {
-    animation: linear-progress-bar-stripes ($pt-transition-duration * 3) linear infinite reverse;
+    animation: linear-progress-bar-stripes calc(var(--bp-emphasis-transition-duration) * 3) linear infinite reverse;
   }
 
   &.#{$ns}-no-stripes .#{$ns}-progress-meter {
@@ -61,15 +65,26 @@ $progress-bar-gradient: linear-gradient(
 }
 
 .#{$ns}-dark .#{$ns}-progress-bar {
-  background: $dark-progress-track-color;
+  /* stylelint-disable-next-line alpha-value-notation */
+  background: oklch(from var(--bp-palette-black) l c h / 0.5);
 
   .#{$ns}-progress-meter {
-    background-color: $dark-progress-head-color;
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h);
   }
 }
 
-@each $intent, $color in $pt-intent-colors {
-  .#{$ns}-progress-bar.#{$ns}-intent-#{$intent} .#{$ns}-progress-meter {
-    background-color: $color;
-  }
+.#{$ns}-progress-bar.#{$ns}-intent-primary .#{$ns}-progress-meter {
+  background-color: var(--bp-intent-primary-rest);
+}
+
+.#{$ns}-progress-bar.#{$ns}-intent-success .#{$ns}-progress-meter {
+  background-color: var(--bp-intent-success-rest);
+}
+
+.#{$ns}-progress-bar.#{$ns}-intent-warning .#{$ns}-progress-meter {
+  background-color: var(--bp-intent-warning-rest);
+}
+
+.#{$ns}-progress-bar.#{$ns}-intent-danger .#{$ns}-progress-meter {
+  background-color: var(--bp-intent-danger-rest);
 }

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -34,7 +34,7 @@ $progress-bar-gradient: linear-gradient(
 
 .#{$ns}-progress-bar {
   /* stylelint-disable-next-line alpha-value-notation */
-  background: oklch(from var(--bp-intent-default-rest) l c h / 0.2);
+  background: #{"oklch(from var(--bp-intent-default-rest) l c h / 0.2)"};
   border-radius: calc(var(--bp-surface-spacing) * 10);
   display: block;
   height: calc(var(--bp-surface-spacing) * 2);
@@ -45,7 +45,7 @@ $progress-bar-gradient: linear-gradient(
   .#{$ns}-progress-meter {
     background: $progress-bar-gradient;
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) l c h / 0.8);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) l c h / 0.8)"};
     background-size: calc(var(--bp-surface-spacing) * 7.5) calc(var(--bp-surface-spacing) * 7.5);
     border-radius: calc(var(--bp-surface-spacing) * 10);
     height: 100%;
@@ -66,10 +66,10 @@ $progress-bar-gradient: linear-gradient(
 
 .#{$ns}-dark .#{$ns}-progress-bar {
   /* stylelint-disable-next-line alpha-value-notation */
-  background: oklch(from var(--bp-palette-black) l c h / 0.5);
+  background: #{"oklch(from var(--bp-palette-black) l c h / 0.5)"};
 
   .#{$ns}-progress-meter {
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"};
   }
 }
 

--- a/packages/core/src/components/progress-bar/_progress-bar.scss
+++ b/packages/core/src/components/progress-bar/_progress-bar.scss
@@ -69,7 +69,7 @@ $progress-bar-gradient: linear-gradient(
   background: #{"oklch(from var(--bp-palette-black) l c h / 0.5)"};
 
   .#{$ns}-progress-meter {
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h)"};
   }
 }
 

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -1,0 +1,175 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Spinner, SpinnerSize } from "./spinner";
+
+const meta: Meta<typeof Spinner> = {
+    title: "Core/Spinner/Spinner",
+    component: Spinner,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        intent: "none",
+        size: SpinnerSize.STANDARD,
+        value: undefined,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "number",
+        },
+        value: {
+            control: { type: "range", min: 0, max: 1, step: 0.05 },
+        },
+        tagName: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Spinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic spinner with default styling (indeterminate).
+ */
+export const Default: Story = {};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the spinner.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <div
+                        key={intent}
+                        style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}
+                    >
+                        <Spinner {...args} intent={intent} size={SpinnerSize.STANDARD} />
+                        <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</span>
+                    </div>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to control the spinner dimensions. Common sizes are available as `SpinnerSize` constants.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} size={SpinnerSize.SMALL} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Small (20px)</span>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} size={SpinnerSize.STANDARD} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Standard (50px)</span>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} size={SpinnerSize.LARGE} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Large (100px)</span>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `value` prop to show determinate progress. Omit it for an indeterminate spinner.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        value: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} value={undefined} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Indeterminate</span>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} value={0} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>0%</span>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} value={0.5} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>50%</span>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Spinner {...args} value={1} />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>100%</span>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * All intents across all sizes.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            {[SpinnerSize.SMALL, SpinnerSize.STANDARD, SpinnerSize.LARGE].map(size => (
+                <div key={size} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <div style={{ fontSize: 12, opacity: 0.6 }}>
+                        {size === SpinnerSize.SMALL ? "Small" : size === SpinnerSize.STANDARD ? "Standard" : "Large"}
+                    </div>
+                    <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+                        <Spinner {...args} size={size} intent="none" />
+                        {Object.values(Intent)
+                            .filter(i => i !== "none")
+                            .map(intent => (
+                                <Spinner key={intent} {...args} size={size} intent={intent} />
+                            ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        intent: "primary",
+        size: SpinnerSize.STANDARD,
+        value: 0.7,
+    },
+};

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -34,7 +34,7 @@
 
   .#{$ns}-spinner-head {
     /* stylelint-disable-next-line alpha-value-notation */
-    stroke: oklch(from var(--bp-intent-default-rest) l c h / 0.8);
+    stroke: #{"oklch(from var(--bp-intent-default-rest) l c h / 0.8)"};
     stroke-linecap: round;
     transform-origin: center;
     transition: stroke-dashoffset calc(var(--bp-emphasis-transition-duration) * 2) var(--bp-emphasis-ease-default);
@@ -42,7 +42,7 @@
 
   .#{$ns}-spinner-track {
     /* stylelint-disable-next-line alpha-value-notation */
-    stroke: oklch(from var(--bp-intent-default-rest) l c h / 0.2);
+    stroke: #{"oklch(from var(--bp-intent-default-rest) l c h / 0.2)"};
   }
 }
 
@@ -57,12 +57,12 @@
 
 .#{$ns}-dark .#{$ns}-spinner {
   .#{$ns}-spinner-head {
-    stroke: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h);
+    stroke: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"};
   }
 
   .#{$ns}-spinner-track {
     /* stylelint-disable-next-line alpha-value-notation */
-    stroke: oklch(from var(--bp-palette-black) l c h / 0.5);
+    stroke: #{"oklch(from var(--bp-palette-black) l c h / 0.5)"};
   }
 }
 

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -33,20 +33,22 @@
   }
 
   .#{$ns}-spinner-head {
-    stroke: $progress-head-color;
+    /* stylelint-disable-next-line alpha-value-notation */
+    stroke: oklch(from var(--bp-intent-default-rest) l c h / 0.8);
     stroke-linecap: round;
     transform-origin: center;
-    transition: stroke-dashoffset ($pt-transition-duration * 2) $pt-transition-ease;
+    transition: stroke-dashoffset calc(var(--bp-emphasis-transition-duration) * 2) var(--bp-emphasis-ease-default);
   }
 
   .#{$ns}-spinner-track {
-    stroke: $progress-track-color;
+    /* stylelint-disable-next-line alpha-value-notation */
+    stroke: oklch(from var(--bp-intent-default-rest) l c h / 0.2);
   }
 }
 
 // put the animation on a child HTML element to isolate it from display of parent
 .#{$ns}-spinner-animation {
-  animation: pt-spinner-animation ($pt-transition-duration * 5) linear infinite;
+  animation: pt-spinner-animation calc(var(--bp-emphasis-transition-duration) * 5) linear infinite;
 
   .#{$ns}-no-spin > & {
     animation: none;
@@ -55,16 +57,27 @@
 
 .#{$ns}-dark .#{$ns}-spinner {
   .#{$ns}-spinner-head {
-    stroke: $dark-progress-head-color;
+    stroke: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h);
   }
 
   .#{$ns}-spinner-track {
-    stroke: $dark-progress-track-color;
+    /* stylelint-disable-next-line alpha-value-notation */
+    stroke: oklch(from var(--bp-palette-black) l c h / 0.5);
   }
 }
 
-@each $intent, $color in $pt-intent-colors {
-  .#{$ns}-spinner.#{$ns}-intent-#{$intent} .#{$ns}-spinner-head {
-    stroke: $color;
-  }
+.#{$ns}-spinner.#{$ns}-intent-primary .#{$ns}-spinner-head {
+  stroke: var(--bp-intent-primary-rest);
+}
+
+.#{$ns}-spinner.#{$ns}-intent-success .#{$ns}-spinner-head {
+  stroke: var(--bp-intent-success-rest);
+}
+
+.#{$ns}-spinner.#{$ns}-intent-warning .#{$ns}-spinner-head {
+  stroke: var(--bp-intent-warning-rest);
+}
+
+.#{$ns}-spinner.#{$ns}-intent-danger .#{$ns}-spinner-head {
+  stroke: var(--bp-intent-danger-rest);
 }

--- a/packages/core/src/components/spinner/_spinner.scss
+++ b/packages/core/src/components/spinner/_spinner.scss
@@ -57,7 +57,7 @@
 
 .#{$ns}-dark .#{$ns}-spinner {
   .#{$ns}-spinner-head {
-    stroke: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"};
+    stroke: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h)"};
   }
 
   .#{$ns}-spinner-track {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Spinner and Progress Bar component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-default` | `cubic-bezier(0.4, 1, 0.75, 0.9)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-palette-black` | `#111418` | `$black` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |

#### `_spinner.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `stroke` | `$dark-progress-head-color` | `oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)` |
#### `_progress-bar.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `background-position` | `$progress-bar-stripes-size 0` | `calc(var(--bp-surface-spacing) * 7.5) 0` |
| `height` | `$progress-bar-height` | `calc(var(--bp-surface-spacing) * 2)` |
| `background-color` | `$dark-progress-head-color` | `oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`@each` intent loops expanded.** Loops over `$pt-intent-colors` replaced with explicit per-intent blocks for CSS custom property compatibility.
3. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Loop expansion | `@each` over SCSS map → explicit per-intent rules |
| 3 | Transparency color space | `oklch()` instead of `rgba()` — different color space |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Intent styles after expanding `@each` loops
