### PR TITLE
[core] Integrating design tokens into tree

### DIFF
--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -1,0 +1,281 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Classes } from "../../common";
+
+import { Tree } from "./tree";
+import type { TreeNodeInfo } from "./treeTypes";
+
+const SAMPLE_CONTENTS: TreeNodeInfo[] = [
+    {
+        id: 0,
+        hasCaret: true,
+        icon: "folder-close",
+        label: "Folder 0",
+        isExpanded: true,
+        childNodes: [
+            { id: 1, icon: "document", label: "Item 0" },
+            { id: 2, icon: "document", label: "Item 1" },
+            {
+                id: 3,
+                hasCaret: true,
+                icon: "folder-close",
+                label: "Folder 1",
+                isExpanded: false,
+                childNodes: [
+                    { id: 4, icon: "document", label: "Nested Item 0" },
+                    { id: 5, icon: "document", label: "Nested Item 1" },
+                ],
+            },
+        ],
+    },
+    {
+        id: 6,
+        hasCaret: true,
+        icon: "folder-close",
+        label: "Folder 2",
+        isExpanded: false,
+        childNodes: [
+            { id: 7, icon: "document", label: "Item 2" },
+            { id: 8, icon: "document", label: "Item 3" },
+        ],
+    },
+    { id: 9, icon: "document", label: "Item 4" },
+];
+
+const SELECTED_CONTENTS: TreeNodeInfo[] = [
+    {
+        id: 0,
+        hasCaret: true,
+        icon: "folder-close",
+        label: "Folder 0",
+        isExpanded: true,
+        childNodes: [
+            { id: 1, icon: "document", label: "Item 0", isSelected: true },
+            { id: 2, icon: "document", label: "Item 1" },
+        ],
+    },
+    { id: 3, icon: "document", label: "Item 2" },
+];
+
+const DISABLED_CONTENTS: TreeNodeInfo[] = [
+    {
+        id: 0,
+        hasCaret: true,
+        icon: "folder-close",
+        label: "Folder 0 (disabled)",
+        isExpanded: true,
+        disabled: true,
+        childNodes: [
+            { id: 1, icon: "document", label: "Item 0", disabled: true },
+            { id: 2, icon: "document", label: "Item 1", disabled: true },
+        ],
+    },
+    { id: 3, icon: "document", label: "Item 2" },
+];
+
+const SECONDARY_LABEL_CONTENTS: TreeNodeInfo[] = [
+    {
+        id: 0,
+        hasCaret: true,
+        icon: "folder-close",
+        label: "Folder 0",
+        secondaryLabel: "3 items",
+        isExpanded: true,
+        childNodes: [
+            { id: 1, icon: "document", label: "Item 0", secondaryLabel: "2 KB" },
+            { id: 2, icon: "document", label: "Item 1", secondaryLabel: "4 KB" },
+            { id: 3, icon: "document", label: "Item 2", secondaryLabel: "1 KB" },
+        ],
+    },
+];
+
+const meta: Meta<typeof Tree> = {
+    title: "Core/Tree/Tree",
+    component: Tree,
+    decorators: [
+        Story => (
+            <div style={{ minWidth: "350px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        contents: SAMPLE_CONTENTS,
+        compact: false,
+    },
+    argTypes: {
+        compact: { control: "boolean" },
+        onNodeClick: { action: "nodeClick" },
+        onNodeCollapse: { action: "nodeCollapse" },
+        onNodeExpand: { action: "nodeExpand" },
+        onNodeContextMenu: { action: "nodeContextMenu" },
+        onNodeDoubleClick: { action: "nodeDoubleClick" },
+        onNodeMouseEnter: { action: "nodeMouseEnter" },
+        onNodeMouseLeave: { action: "nodeMouseLeave" },
+    },
+} satisfies Meta<typeof Tree>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Selected: Story = {
+    name: "Selected",
+    args: {
+        contents: SELECTED_CONTENTS,
+    },
+};
+
+export const Disabled: Story = {
+    name: "Disabled",
+    args: {
+        contents: DISABLED_CONTENTS,
+    },
+};
+
+export const Compact: Story = {
+    name: "Compact",
+    argTypes: {
+        compact: { table: { disable: true } },
+    },
+    args: {
+        compact: true,
+    },
+};
+
+export const SecondaryLabels: Story = {
+    name: "Secondary Labels",
+    args: {
+        contents: SECONDARY_LABEL_CONTENTS,
+    },
+};
+
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    decorators: [
+        Story => (
+            <div className={Classes.DARK} style={{ minWidth: "350px", padding: 16, background: "#30404d" }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+export const AllStates: Story = {
+    name: "All States",
+    render: args => (
+        <div style={{ display: "flex", gap: 32, flexWrap: "wrap" }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                <div style={{ minWidth: "300px" }}>
+                    <Tree {...args} contents={SAMPLE_CONTENTS} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Selected</div>
+                <div style={{ minWidth: "300px" }}>
+                    <Tree {...args} contents={SELECTED_CONTENTS} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Disabled</div>
+                <div style={{ minWidth: "300px" }}>
+                    <Tree {...args} contents={DISABLED_CONTENTS} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Compact</div>
+                <div style={{ minWidth: "300px" }}>
+                    <Tree {...args} contents={SAMPLE_CONTENTS} compact={true} />
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    render: function Render(args) {
+        const [nodes, setNodes] = useState<TreeNodeInfo[]>(SAMPLE_CONTENTS);
+
+        const forEachNode = useCallback((treeNodes: TreeNodeInfo[], callback: (node: TreeNodeInfo) => void) => {
+            for (const node of treeNodes) {
+                callback(node);
+                if (node.childNodes) {
+                    forEachNode(node.childNodes, callback);
+                }
+            }
+        }, []);
+
+        const handleNodeClick = useCallback(
+            (node: TreeNodeInfo, _nodePath: number[], e: React.MouseEvent<HTMLElement>) => {
+                const originallySelected = node.isSelected;
+                setNodes(prev => {
+                    const newNodes = structuredClone(prev);
+                    if (!e.shiftKey) {
+                        forEachNode(newNodes, n => (n.isSelected = false));
+                    }
+                    const findNode = (items: TreeNodeInfo[]): TreeNodeInfo | undefined => {
+                        for (const item of items) {
+                            if (item.id === node.id) return item;
+                            if (item.childNodes) {
+                                const found = findNode(item.childNodes);
+                                if (found) return found;
+                            }
+                        }
+                        return undefined;
+                    };
+                    const target = findNode(newNodes);
+                    if (target) {
+                        target.isSelected = originallySelected == null ? true : !originallySelected;
+                    }
+                    return newNodes;
+                });
+            },
+            [forEachNode],
+        );
+
+        const handleNodeCollapse = useCallback((_node: TreeNodeInfo, nodePath: number[]) => {
+            setNodes(prev => {
+                const newNodes = structuredClone(prev);
+                let target: TreeNodeInfo = newNodes[nodePath[0]];
+                for (let i = 1; i < nodePath.length; i++) {
+                    target = target.childNodes![nodePath[i]];
+                }
+                target.isExpanded = false;
+                return newNodes;
+            });
+        }, []);
+
+        const handleNodeExpand = useCallback((_node: TreeNodeInfo, nodePath: number[]) => {
+            setNodes(prev => {
+                const newNodes = structuredClone(prev);
+                let target: TreeNodeInfo = newNodes[nodePath[0]];
+                for (let i = 1; i < nodePath.length; i++) {
+                    target = target.childNodes![nodePath[i]];
+                }
+                target.isExpanded = true;
+                return newNodes;
+            });
+        }, []);
+
+        return (
+            <Tree
+                {...args}
+                contents={nodes}
+                onNodeClick={handleNodeClick}
+                onNodeCollapse={handleNodeCollapse}
+                onNodeExpand={handleNodeExpand}
+            />
+        );
+    },
+};

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -72,12 +72,12 @@ $tree-intent-icon-colors: (
 
   &:hover {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.15)"};
   }
 
   &:active {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.3)"};
   }
 }
 
@@ -187,7 +187,7 @@ $tree-intent-icon-colors: (
   .#{$ns}-tree-node-content {
     &:hover {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h / 0.3)"};
+      background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.241) calc(c - 0.016) h / 0.3)"};
     }
   }
 
@@ -196,19 +196,19 @@ $tree-intent-icon-colors: (
       color: var(--bp-typography-color-muted);
 
       &.#{$ns}-intent-primary {
-        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
       }
 
       &.#{$ns}-intent-success {
-        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
+        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"};
       }
 
       &.#{$ns}-intent-warning {
-        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
+        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.112) calc(c + 0.006) h)"};
       }
 
       &.#{$ns}-intent-danger {
-        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
+        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.097) calc(c - 0.023) h)"};
       }
     }
   }

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -22,12 +22,22 @@ $tree-intent-icon-colors: (
 
 .#{$ns}-tree {
   #{$icon-classes} {
-    color: $pt-icon-color;
+    color: var(--bp-typography-color-muted);
 
-    @each $intent, $colors in $pt-intent-colors {
-      &.#{$ns}-intent-#{$intent} {
-        @include intent-color($intent);
-      }
+    &.#{$ns}-intent-primary {
+      color: var(--bp-intent-primary-rest);
+    }
+
+    &.#{$ns}-intent-success {
+      color: var(--bp-intent-success-rest);
+    }
+
+    &.#{$ns}-intent-warning {
+      color: var(--bp-intent-warning-rest);
+    }
+
+    &.#{$ns}-intent-danger {
+      color: var(--bp-intent-danger-rest);
     }
   }
 }
@@ -48,7 +58,7 @@ $tree-intent-icon-colors: (
 
 @for $i from 0 through 20 {
   .#{$ns}-tree-node-content-#{$i} {
-    padding-left: ($tree-row-height - $tree-icon-spacing) * $i;
+    padding-left: calc(var(--bp-surface-spacing) * #{5.5 * $i});
   }
 }
 
@@ -56,33 +66,35 @@ $tree-intent-icon-colors: (
   align-items: center;
   background: none;
   display: flex;
-  height: $tree-row-height;
-  padding-right: $pt-spacing;
+  height: calc(var(--bp-surface-spacing) * 7.5);
+  padding-right: var(--bp-surface-spacing);
   width: 100%;
 
   &:hover {
-    background-color: rgba($gray3, 0.15);
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
   }
 
   &:active {
-    background-color: rgba($gray3, 0.3);
+    /* stylelint-disable-next-line alpha-value-notation */
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
   }
 }
 
 .#{$ns}-tree-node-caret,
 .#{$ns}-tree-node-caret-none {
-  min-width: $tree-row-height;
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
 }
 
 .#{$ns}-tree-node-caret {
   @include pt-icon-colors;
   cursor: pointer;
-  padding: $tree-icon-spacing;
+  padding: calc(var(--bp-surface-spacing) * 2);
   transform: rotate(0deg);
-  transition: transform ($pt-transition-duration * 2) $pt-transition-ease;
+  transition: transform calc(var(--bp-emphasis-transition-duration) * 2) var(--bp-emphasis-ease-default);
 
   &:hover {
-    color: $pt-text-color;
+    color: var(--bp-typography-color-default-rest);
   }
 
   &.#{$ns}-tree-node-caret-open {
@@ -96,7 +108,7 @@ $tree-intent-icon-colors: (
 }
 
 .#{$ns}-tree-node-icon {
-  margin-right: $tree-icon-spacing;
+  margin-right: calc(var(--bp-surface-spacing) * 2);
   position: relative;
 }
 
@@ -113,7 +125,7 @@ $tree-intent-icon-colors: (
 }
 
 .#{$ns}-tree-node-secondary-label {
-  padding: 0 $pt-spacing;
+  padding: 0 var(--bp-surface-spacing);
   user-select: none;
 
   .#{$ns}-popover-wrapper,
@@ -126,32 +138,33 @@ $tree-intent-icon-colors: (
 .#{$ns}-tree-node.#{$ns}-disabled {
   .#{$ns}-tree-node-content {
     background-color: inherit;
-    color: $pt-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
   }
 
   .#{$ns}-tree-node-caret,
   .#{$ns}-tree-node-icon {
-    color: $pt-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
   }
 }
 
 .#{$ns}-tree-node.#{$ns}-tree-node-selected > .#{$ns}-tree-node-content {
-  background-color: $pt-intent-primary;
+  background-color: var(--bp-intent-primary-rest);
 
   &,
   #{$icon-classes} {
-    color: $white;
+    color: var(--bp-intent-primary-foreground);
   }
 
   .#{$ns}-tree-node-caret {
     &::before {
-      color: rgba($white, 0.7);
+      /* stylelint-disable-next-line alpha-value-notation */
+      color: oklch(from var(--bp-intent-primary-foreground) l c h / 0.7);
     }
 
     &:hover::before {
-      color: $white;
+      color: var(--bp-intent-primary-foreground);
     }
   }
 }
@@ -159,13 +172,13 @@ $tree-intent-icon-colors: (
 // Variant: compact
 .#{$ns}-tree.#{$ns}-compact {
   .#{$ns}-tree-node-content {
-    height: $tree-row-height-compact;
+    height: calc(var(--bp-surface-spacing) * 6);
   }
 
   .#{$ns}-tree-node-caret {
-    margin-right: $pt-spacing * 0.75;
-    min-width: $tree-row-height-compact;
-    padding: $tree-icon-spacing-compact;
+    margin-right: calc(var(--bp-surface-spacing) * 0.75);
+    min-width: calc(var(--bp-surface-spacing) * 6);
+    padding: calc(var(--bp-surface-spacing) * 1);
   }
 }
 
@@ -173,18 +186,29 @@ $tree-intent-icon-colors: (
 .#{$ns}-dark {
   .#{$ns}-tree-node-content {
     &:hover {
-      background-color: rgba($gray1, 0.3);
+      /* stylelint-disable-next-line alpha-value-notation */
+      background-color: oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h / 0.3);
     }
   }
 
   .#{$ns}-tree {
     #{$icon-classes} {
-      color: $pt-dark-icon-color;
+      color: var(--bp-typography-color-muted);
 
-      @each $intent, $color in $tree-intent-icon-colors {
-        &.#{$ns}-intent-#{$intent} {
-          color: $color;
-        }
+      &.#{$ns}-intent-primary {
+        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      }
+
+      &.#{$ns}-intent-success {
+        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+      }
+
+      &.#{$ns}-intent-warning {
+        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+      }
+
+      &.#{$ns}-intent-danger {
+        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
       }
     }
   }
@@ -192,15 +216,15 @@ $tree-intent-icon-colors: (
   .#{$ns}-tree-node {
     &:not(.#{$ns}-disabled) {
       .#{$ns}-tree-node-caret:hover {
-        color: $pt-dark-text-color;
+        color: var(--bp-typography-color-default-rest);
       }
     }
 
     &.#{$ns}-tree-node-selected > .#{$ns}-tree-node-content {
-      background-color: $pt-intent-primary;
+      background-color: var(--bp-intent-primary-rest);
 
       #{$icon-classes} {
-        color: $white;
+        color: var(--bp-intent-primary-foreground);
       }
     }
   }

--- a/packages/core/src/components/tree/_tree.scss
+++ b/packages/core/src/components/tree/_tree.scss
@@ -72,12 +72,12 @@ $tree-intent-icon-colors: (
 
   &:hover {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
   }
 
   &:active {
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
+    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
   }
 }
 
@@ -160,7 +160,7 @@ $tree-intent-icon-colors: (
   .#{$ns}-tree-node-caret {
     &::before {
       /* stylelint-disable-next-line alpha-value-notation */
-      color: oklch(from var(--bp-intent-primary-foreground) l c h / 0.7);
+      color: #{"oklch(from var(--bp-intent-primary-foreground) l c h / 0.7)"};
     }
 
     &:hover::before {
@@ -187,7 +187,7 @@ $tree-intent-icon-colors: (
   .#{$ns}-tree-node-content {
     &:hover {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h / 0.3);
+      background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.2) c h / 0.3)"};
     }
   }
 
@@ -196,19 +196,19 @@ $tree-intent-icon-colors: (
       color: var(--bp-typography-color-muted);
 
       &.#{$ns}-intent-primary {
-        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
       }
 
       &.#{$ns}-intent-success {
-        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
+        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
       }
 
       &.#{$ns}-intent-warning {
-        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
+        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
       }
 
       &.#{$ns}-intent-danger {
-        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
+        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
       }
     }
   }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Tree component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-default` | `cubic-bezier(0.4, 1, 0.75, 0.9)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-intent-danger-rest` | `#cd4246` | `$pt-intent-danger / $red3` |
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-intent-primary-foreground` | `#ffffff` | `$white` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-intent-success-rest` | `#238551` | `$pt-intent-success / $green3` |
| `--bp-intent-warning-rest` | `#c87619` | `$pt-intent-warning / $orange3` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_tree.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `color` | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| `padding-left` | `($tree-row-height - $tree-icon-spacing) * $i` | `calc(var(--bp-surface-spacing) * #{5.5 * $i})` |
| `min-width` | `$tree-row-height` | `calc(var(--bp-surface-spacing) * 7.5)` |
| `padding` | `$tree-icon-spacing` | `calc(var(--bp-surface-spacing) * 2)` |
| `color` | `$pt-text-color` | `var(--bp-typography-color-default-rest)` |
| `margin-right` | `$tree-icon-spacing` | `calc(var(--bp-surface-spacing) * 2)` |
| `padding` | `0 $pt-spacing` | `0 var(--bp-surface-spacing)` |
| `color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `background-color` | `$pt-intent-primary` | `var(--bp-intent-primary-rest)` |
| `color` | `$white` | `var(--bp-intent-primary-foreground)` |
| `color` | `$white` | `var(--bp-intent-primary-foreground)` |
| `height` | `$tree-row-height-compact` | `calc(var(--bp-surface-spacing) * 6)` |
| `padding: $tr` | `$tree-icon-spacing-compact` | `calc(var(--bp-surface-spacing) * 0.75)` |
| `color` | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |
| `color` | `$pt-dark-text-color` | `var(--bp-typography-color-default-rest)` |
| `background-color` | `$pt-intent-primary` | `var(--bp-intent-primary-rest)` |
| `color` | `$white` | `var(--bp-intent-primary-foreground)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`@each` intent loops expanded.** Loops over `$pt-intent-colors` replaced with explicit per-intent blocks for CSS custom property compatibility.
3. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Loop expansion | `@each` over SCSS map → explicit per-intent rules |
| 3 | Transparency color space | `oklch()` instead of `rgba()` — different color space |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Intent styles after expanding `@each` loops
