### PR TITLE
[core] Integrating design tokens into dialog

### DIFF
--- a/packages/core/src/components/dialog/Dialog.stories.tsx
+++ b/packages/core/src/components/dialog/Dialog.stories.tsx
@@ -1,0 +1,251 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent } from "../../common";
+import { Button } from "../button/buttons";
+
+import { Dialog } from "./dialog";
+import { DialogBody } from "./dialogBody";
+import { DialogFooter } from "./dialogFooter";
+
+const disabledArgs = ["containerRef", "hasBackdrop", "transitionName"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof Dialog>
+>;
+
+/**
+ * Helper wrapper so that each story can open/close its own Dialog.
+ */
+function DialogDemo({
+    buttonText = "Open Dialog",
+    ...dialogProps
+}: React.ComponentProps<typeof Dialog> & { buttonText?: string }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const handleOpen = useCallback(() => setIsOpen(true), []);
+    const handleClose = useCallback(() => setIsOpen(false), []);
+
+    return (
+        <>
+            <Button text={buttonText} onClick={handleOpen} />
+            <Dialog {...dialogProps} isOpen={isOpen} onClose={handleClose}>
+                {dialogProps.children ?? (
+                    <>
+                        <DialogBody>
+                            <p>
+                                This is a simple dialog body. You can put any content here, including forms, text, or
+                                other components.
+                            </p>
+                        </DialogBody>
+                        <DialogFooter
+                            actions={
+                                <>
+                                    <Button text="Cancel" onClick={handleClose} />
+                                    <Button text="Confirm" intent="primary" onClick={handleClose} />
+                                </>
+                            }
+                        />
+                    </>
+                )}
+            </Dialog>
+        </>
+    );
+}
+
+const meta: Meta<typeof Dialog> = {
+    title: "Core/Overlay/Dialog",
+    component: Dialog,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        title: "Dialog Title",
+        isOpen: false,
+        isCloseButtonShown: true,
+    },
+    argTypes: {
+        icon: { control: "text" },
+        title: { control: "text" },
+        isCloseButtonShown: { control: "boolean" },
+        isOpen: { control: "boolean" },
+        role: { control: "select", options: ["dialog", "alertdialog"] },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => <DialogDemo {...args} title="Dialog Title" />,
+};
+
+export const WithIcon: Story = {
+    name: "With Icon",
+    render: args => <DialogDemo {...args} title="Settings" icon="cog" />,
+};
+
+export const WithScrollableBody: Story = {
+    name: "Scrollable Body",
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <>
+                <Button text="Open Scrollable Dialog" onClick={handleOpen} />
+                <Dialog {...args} title="Scrollable Dialog" isOpen={isOpen} onClose={handleClose}>
+                    <DialogBody useOverflowScrollContainer={true}>
+                        {Array.from({ length: 20 }, (_, i) => (
+                            <p key={i}>
+                                This is paragraph {i + 1} of scrollable content. The dialog body will scroll
+                                independently of the page.
+                            </p>
+                        ))}
+                    </DialogBody>
+                    <DialogFooter
+                        actions={
+                            <>
+                                <Button text="Cancel" onClick={handleClose} />
+                                <Button text="Save" intent="primary" onClick={handleClose} />
+                            </>
+                        }
+                    />
+                </Dialog>
+            </>
+        );
+    },
+};
+
+export const IntentExample: Story = {
+    name: "Intent Footer Actions",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: function Render(args) {
+        const [openIntent, setOpenIntent] = useState<string | null>(null);
+        const handleClose = useCallback(() => setOpenIntent(null), []);
+
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                {Object.values(Intent)
+                    .filter(i => i !== "none")
+                    .map(intent => (
+                        <div key={intent}>
+                            <Button
+                                text={intent.charAt(0).toUpperCase() + intent.slice(1)}
+                                intent={intent}
+                                onClick={() => setOpenIntent(intent)}
+                            />
+                            <Dialog
+                                {...args}
+                                title={`${intent.charAt(0).toUpperCase() + intent.slice(1)} Dialog`}
+                                icon={
+                                    intent === "primary"
+                                        ? "info-sign"
+                                        : intent === "success"
+                                          ? "tick-circle"
+                                          : intent === "warning"
+                                            ? "warning-sign"
+                                            : "error"
+                                }
+                                isOpen={openIntent === intent}
+                                onClose={handleClose}
+                            >
+                                <DialogBody>
+                                    <p>This dialog demonstrates a {intent} intent action.</p>
+                                </DialogBody>
+                                <DialogFooter
+                                    actions={
+                                        <>
+                                            <Button text="Cancel" onClick={handleClose} />
+                                            <Button
+                                                text="Confirm"
+                                                intent={intent}
+                                                onClick={handleClose}
+                                            />
+                                        </>
+                                    }
+                                />
+                            </Dialog>
+                        </div>
+                    ))}
+            </div>
+        );
+    },
+};
+
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <div className="bp6-dark" style={{ padding: 20, background: "#1c2127", borderRadius: 4 }}>
+                <Button text="Open Dark Dialog" onClick={handleOpen} />
+                <Dialog {...args} title="Dark Theme Dialog" icon="moon" isOpen={isOpen} onClose={handleClose}>
+                    <DialogBody>
+                        <p>This dialog is rendered in the dark theme.</p>
+                    </DialogBody>
+                    <DialogFooter
+                        actions={
+                            <>
+                                <Button text="Cancel" onClick={handleClose} />
+                                <Button text="Confirm" intent="primary" onClick={handleClose} />
+                            </>
+                        }
+                    />
+                </Dialog>
+            </div>
+        );
+    },
+};
+
+export const Playground: Story = {
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <>
+                <Button text="Open Dialog" onClick={handleOpen} />
+                <Dialog {...args} isOpen={isOpen} onClose={handleClose}>
+                    <DialogBody>
+                        <p>
+                            Use the Storybook controls panel to adjust the dialog properties. The dialog supports
+                            icons, close buttons, and custom titles.
+                        </p>
+                    </DialogBody>
+                    <DialogFooter
+                        actions={
+                            <>
+                                <Button text="Cancel" onClick={handleClose} />
+                                <Button text="Confirm" intent="primary" onClick={handleClose} />
+                            </>
+                        }
+                    />
+                </Dialog>
+            </>
+        );
+    },
+};

--- a/packages/core/src/components/dialog/MultistepDialog.stories.tsx
+++ b/packages/core/src/components/dialog/MultistepDialog.stories.tsx
@@ -1,0 +1,210 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Button } from "../button/buttons";
+
+import { DialogBody } from "./dialogBody";
+import { DialogStep } from "./dialogStep";
+import { MultistepDialog } from "./multistepDialog";
+
+const disabledArgs = [
+    "containerRef",
+    "hasBackdrop",
+    "transitionName",
+    "backButtonProps",
+    "closeButtonProps",
+    "finalButtonProps",
+    "nextButtonProps",
+] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof MultistepDialog>>;
+
+function StepPanel({ stepNumber }: { stepNumber: number }) {
+    return (
+        <DialogBody>
+            <p>This is the content for step {stepNumber}.</p>
+            <p>You can place forms, instructions, or any other content here.</p>
+        </DialogBody>
+    );
+}
+
+function MultistepDialogDemo(props: React.ComponentProps<typeof MultistepDialog> & { buttonText?: string }) {
+    const { buttonText = "Open Multistep Dialog", ...dialogProps } = props;
+    const [isOpen, setIsOpen] = useState(false);
+    const handleOpen = useCallback(() => setIsOpen(true), []);
+    const handleClose = useCallback(() => setIsOpen(false), []);
+
+    return (
+        <>
+            <Button text={buttonText} onClick={handleOpen} />
+            <MultistepDialog {...dialogProps} isOpen={isOpen} onClose={handleClose}>
+                {dialogProps.children ?? (
+                    <>
+                        <DialogStep
+                            id="select"
+                            title="Select items"
+                            panel={<StepPanel stepNumber={1} />}
+                        />
+                        <DialogStep
+                            id="confirm"
+                            title="Confirm selection"
+                            panel={<StepPanel stepNumber={2} />}
+                        />
+                        <DialogStep
+                            id="complete"
+                            title="Complete"
+                            panel={<StepPanel stepNumber={3} />}
+                        />
+                    </>
+                )}
+            </MultistepDialog>
+        </>
+    );
+}
+
+const meta: Meta<typeof MultistepDialog> = {
+    title: "Core/Overlay/MultistepDialog",
+    component: MultistepDialog,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        title: "Multistep Dialog",
+        isOpen: false,
+        isCloseButtonShown: true,
+        navigationPosition: "left",
+        resetOnClose: true,
+        showCloseButtonInFooter: false,
+    },
+    argTypes: {
+        icon: { control: "text" },
+        title: { control: "text" },
+        isCloseButtonShown: { control: "boolean" },
+        navigationPosition: { control: "select", options: ["left", "top", "right"] },
+        resetOnClose: { control: "boolean" },
+        showCloseButtonInFooter: { control: "boolean" },
+        initialStepIndex: { control: "number" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof MultistepDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => <MultistepDialogDemo {...args} />,
+};
+
+export const NavigationPosition: Story = {
+    name: "Navigation Position",
+    argTypes: {
+        navigationPosition: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            <MultistepDialogDemo {...args} navigationPosition="left" buttonText="Left (default)" />
+            <MultistepDialogDemo {...args} navigationPosition="top" buttonText="Top" />
+            <MultistepDialogDemo {...args} navigationPosition="right" buttonText="Right" />
+        </div>
+    ),
+};
+
+export const WithIcon: Story = {
+    name: "With Icon",
+    render: args => <MultistepDialogDemo {...args} title="Setup Wizard" icon="build" />,
+};
+
+export const WithCloseInFooter: Story = {
+    name: "Close Button in Footer",
+    render: args => <MultistepDialogDemo {...args} showCloseButtonInFooter={true} />,
+};
+
+export const InitialStep: Story = {
+    name: "Initial Step Index",
+    render: args => <MultistepDialogDemo {...args} initialStepIndex={1} buttonText="Start at Step 2" />,
+};
+
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <div className="bp6-dark" style={{ padding: 20, background: "#1c2127", borderRadius: 4 }}>
+                <Button text="Open Dark Multistep Dialog" onClick={handleOpen} />
+                <MultistepDialog
+                    {...args}
+                    title="Dark Theme Wizard"
+                    icon="moon"
+                    isOpen={isOpen}
+                    onClose={handleClose}
+                >
+                    <DialogStep
+                        id="step1"
+                        title="First Step"
+                        panel={<StepPanel stepNumber={1} />}
+                    />
+                    <DialogStep
+                        id="step2"
+                        title="Second Step"
+                        panel={<StepPanel stepNumber={2} />}
+                    />
+                    <DialogStep
+                        id="step3"
+                        title="Third Step"
+                        panel={<StepPanel stepNumber={3} />}
+                    />
+                </MultistepDialog>
+            </div>
+        );
+    },
+};
+
+export const Playground: Story = {
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <>
+                <Button text="Open Multistep Dialog" onClick={handleOpen} />
+                <MultistepDialog {...args} isOpen={isOpen} onClose={handleClose}>
+                    <DialogStep
+                        id="step1"
+                        title="Select items"
+                        panel={<StepPanel stepNumber={1} />}
+                    />
+                    <DialogStep
+                        id="step2"
+                        title="Confirm selection"
+                        panel={<StepPanel stepNumber={2} />}
+                    />
+                    <DialogStep
+                        id="step3"
+                        title="Complete"
+                        panel={<StepPanel stepNumber={3} />}
+                    />
+                </MultistepDialog>
+            </>
+        );
+    },
+};

--- a/packages/core/src/components/dialog/_dialog-body.scss
+++ b/packages/core/src/components/dialog/_dialog-body.scss
@@ -6,7 +6,7 @@
   // We'd like to use padding instead of margin here to be consistent with the -dialog-body-scroll-container class,
   // but we need to keep this margin style for backwards-compatibility. This may change in a future major version.
   // TODO(adahiya): migrate from margin to padding style (CSS breaking change)
-  margin: $dialog-padding;
+  margin: calc(var(--bp-surface-spacing) * 4);
 }
 
 // modifier for -dialog-body class, works similarly to -overlay-scroll-container
@@ -14,5 +14,5 @@
   margin: 0;
   max-height: 70vh;
   overflow: auto;
-  padding: $dialog-padding;
+  padding: calc(var(--bp-surface-spacing) * 4);
 }

--- a/packages/core/src/components/dialog/_dialog-footer.scss
+++ b/packages/core/src/components/dialog/_dialog-footer.scss
@@ -6,23 +6,23 @@
   // We'd like to use padding instead of margin here to be consistent with the -dialog-footer-fixed class,
   // but we need to keep this margin style for backwards-compatibility. This may change in a future major version.
   // TODO(adahiya): migrate from margin to padding style (CSS breaking change)
-  margin: $dialog-padding;
+  margin: calc(var(--bp-surface-spacing) * 4);
 }
 
 .#{$ns}-dialog-footer-fixed {
   align-items: center;
-  background-color: $white;
-  border-radius: 0 0 $dialog-border-radius $dialog-border-radius;
-  border-top: 1px solid $pt-divider-black;
+  background-color: var(--bp-palette-white);
+  border-radius: 0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius);
+  border-top: 1px solid var(--bp-surface-border-color-default);
   display: flex;
-  gap: $dialog-padding;
+  gap: calc(var(--bp-surface-spacing) * 4);
   justify-content: space-between;
   margin: 0;
-  padding: ($pt-spacing * 2) ($pt-spacing * 2) ($pt-spacing * 2) $dialog-padding;
+  padding: calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 2) calc(var(--bp-surface-spacing) * 4);
 
   .#{$ns}-dark & {
-    background: $dark-gray4;
-    border-top: 1px solid $pt-dark-divider-white;
+    background: var(--bp-palette-dark-gray-4);
+    border-top: 1px solid var(--bp-surface-border-color-default);
   }
 }
 
@@ -35,6 +35,6 @@
   justify-content: flex-end;
 
   .#{$ns}-button {
-    margin-left: $pt-spacing * 2;
+    margin-left: calc(var(--bp-surface-spacing) * 2);
   }
 }

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -42,29 +42,22 @@ $dialog-padding: $pt-spacing * 4 !default;
 }
 
 .#{$ns}-dialog {
-  background: $dialog-background-color;
-  border-radius: $dialog-border-radius;
-  box-shadow: $pt-dialog-box-shadow;
+  background: var(--bp-surface-background-color-default-rest);
+  border-radius: var(--bp-surface-border-radius);
+  box-shadow: var(--bp-surface-shadow-3);
   display: flex;
   flex-direction: column;
-  margin: $dialog-margin;
+  margin: calc(var(--bp-surface-spacing) * 8) 0;
   pointer-events: all;
   user-select: text;
-  width: $pt-spacing * 125;
+  width: calc(var(--bp-surface-spacing) * 125);
 
   &:focus {
     outline: 0;
   }
 
-  &.#{$ns}-dark,
-  .#{$ns}-dark & {
-    background: $pt-dark-app-background-color;
-    box-shadow: $pt-dark-dialog-box-shadow;
-    color: $pt-dark-text-color;
-  }
-
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
   }
 }
 
@@ -72,54 +65,46 @@ $dialog-header-padding: $pt-spacing;
 
 .#{$ns}-dialog-header {
   align-items: center;
-  background: $white;
-  border-radius: $dialog-border-radius $dialog-border-radius 0 0;
-  box-shadow: 0 1px 0 $pt-divider-black;
+  background: var(--bp-palette-white);
+  border-radius: var(--bp-surface-border-radius) var(--bp-surface-border-radius) 0 0;
+  box-shadow: 0 1px 0 var(--bp-surface-border-color-default);
   display: flex;
   flex: 0 0 auto;
-  min-height: $pt-button-height + $dialog-header-padding * 2;
-  padding: $dialog-header-padding;
-  padding-left: $dialog-padding;
+  min-height: calc(var(--bp-surface-spacing) * 8);
+  padding: var(--bp-surface-spacing);
+  padding-left: calc(var(--bp-surface-spacing) * 4);
   z-index: 0;
 
   .#{$ns}-icon-large,
   .#{$ns}-icon {
     flex: 0 0 auto;
-    margin-left: -$pt-spacing;
-    margin-right: $dialog-padding * 0.5;
+    margin-left: calc(var(--bp-surface-spacing) * -1);
+    margin-right: calc(var(--bp-surface-spacing) * 2);
 
     // only apply light color to icons that are not intent-specific
     &:not([class*="#{$ns}-intent"]) {
-      color: $pt-icon-color;
+      color: var(--bp-typography-color-muted);
     }
   }
 
   .#{$ns}-heading {
     @include overflow-ellipsis;
     flex: 1 1 auto;
-    font-size: 14px;
+    font-size: var(--bp-typography-size-body-medium);
     line-height: inherit;
     margin: 0;
 
     &:last-child {
-      margin-right: $dialog-padding;
+      margin-right: calc(var(--bp-surface-spacing) * 4);
     }
   }
 
   .#{$ns}-dark & {
-    background: $dark-gray3;
-    box-shadow: inset 0 0 0 1px $pt-dark-divider-white;
-
-    // only apply dark color to icons that are not intent-specific
-    :not([class*="#{$ns}-intent"]) {
-      &.#{$ns}-icon-large,
-      &.#{$ns}-icon {
-        color: $pt-dark-icon-color;
-      }
-    }
+    background: var(--bp-palette-dark-gray-3);
+    box-shadow: inset 0 0 0 1px var(--bp-surface-border-color-default);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border-bottom: 1px solid $pt-high-contrast-mode-border-color;
+    border-bottom: 1px solid buttonborder;
   }
 }

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -204,7 +204,7 @@ $step-radius: $pt-border-radius !default;
     color: var(--bp-intent-primary-rest);
 
     .#{$ns}-dark & {
-      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.003) h)"};
     }
   }
 

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -204,7 +204,7 @@ $step-radius: $pt-border-radius !default;
     color: var(--bp-intent-primary-rest);
 
     .#{$ns}-dark & {
-      color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
+      color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
     }
   }
 

--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -16,11 +16,11 @@ $step-radius: $pt-border-radius !default;
   // borders needs to be rounded.
   &:first-child {
     .#{$ns}-dialog-step-container:first-child {
-      border-radius: $dialog-border-radius 0 0 0;
+      border-radius: var(--bp-surface-border-radius) 0 0 0;
     }
 
     .#{$ns}-multistep-dialog-right-panel {
-      border-top-right-radius: $dialog-border-radius;
+      border-top-right-radius: var(--bp-surface-border-radius);
     }
   }
 
@@ -30,11 +30,11 @@ $step-radius: $pt-border-radius !default;
     // Handle case where title it not rendered.
     &:first-child {
       .#{$ns}-dialog-step-container:first-child {
-        border-radius: $dialog-border-radius 0 0 0;
+        border-radius: var(--bp-surface-border-radius) 0 0 0;
       }
 
       .#{$ns}-dialog-step-container:last-child {
-        border-radius: 0 $dialog-border-radius 0 0;
+        border-radius: 0 var(--bp-surface-border-radius) 0 0;
       }
     }
 
@@ -46,11 +46,7 @@ $step-radius: $pt-border-radius !default;
       flex-grow: 1;
 
       &:not(:first-child) {
-        border-left: 1px solid $pt-divider-black;
-      }
-
-      .#{$ns}-dark & {
-        border-color: $pt-dark-divider-black;
+        border-left: 1px solid var(--bp-surface-border-color-default);
       }
     }
 
@@ -60,7 +56,7 @@ $step-radius: $pt-border-radius !default;
 
     .#{$ns}-multistep-dialog-right-panel,
     .#{$ns}-multistep-dialog-footer {
-      border-radius: 0 0 $dialog-border-radius $dialog-border-radius;
+      border-radius: 0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius);
     }
   }
 
@@ -70,25 +66,25 @@ $step-radius: $pt-border-radius !default;
     // Handle case where title it not rendered.
     &:first-child {
       .#{$ns}-multistep-dialog-right-panel {
-        border-radius: $dialog-border-radius 0 0 $dialog-border-radius;
+        border-radius: var(--bp-surface-border-radius) 0 0 var(--bp-surface-border-radius);
       }
 
       .#{$ns}-dialog-step-container:first-child {
-        border-radius: 0 $dialog-border-radius 0 0;
+        border-radius: 0 var(--bp-surface-border-radius) 0 0;
       }
     }
 
     .#{$ns}-multistep-dialog-left-panel {
-      border-radius: 0 0 $dialog-border-radius;
+      border-radius: 0 0 var(--bp-surface-border-radius);
     }
 
     .#{$ns}-multistep-dialog-right-panel {
       border-left: none;
-      border-radius: $dialog-border-radius 0 0 $dialog-border-radius;
-      border-right: 1px solid $pt-divider-black;
+      border-radius: var(--bp-surface-border-radius) 0 0 var(--bp-surface-border-radius);
+      border-right: 1px solid var(--bp-surface-border-color-default);
 
       .#{$ns}-dark & {
-        border-color: $pt-dark-divider-black;
+        border-color: var(--bp-surface-border-color-default);
       }
     }
 
@@ -104,26 +100,26 @@ $step-radius: $pt-border-radius !default;
   flex-direction: column;
 
   .#{$ns}-dark & {
-    background: $dark-gray2;
-    border-bottom: 1px solid $pt-dark-divider-white;
-    border-bottom-left-radius: $dialog-border-radius;
-    border-left: 1px solid $pt-dark-divider-white;
+    background: var(--bp-palette-dark-gray-2);
+    border-bottom: 1px solid var(--bp-surface-border-color-default);
+    border-bottom-left-radius: var(--bp-surface-border-radius);
+    border-left: 1px solid var(--bp-surface-border-color-default);
   }
 }
 
 .#{$ns}-multistep-dialog-right-panel {
-  background-color: $light-gray5;
-  border-left: 1px solid $pt-divider-black;
-  border-radius: 0 0 $dialog-border-radius;
+  background-color: var(--bp-surface-background-color-default-rest);
+  border-left: 1px solid var(--bp-surface-border-color-default);
+  border-radius: 0 0 var(--bp-surface-border-radius);
   flex: 3;
   min-width: 0;
 
   .#{$ns}-dark & {
-    background-color: $dark-gray3;
-    border-bottom: 1px solid $pt-dark-divider-white;
-    border-bottom-right-radius: $dialog-border-radius;
-    border-left: 1px solid $pt-dark-divider-white;
-    border-right: 1px solid $pt-dark-divider-white;
+    background-color: var(--bp-palette-dark-gray-3);
+    border-bottom: 1px solid var(--bp-surface-border-color-default);
+    border-bottom-right-radius: var(--bp-surface-border-radius);
+    border-left: 1px solid var(--bp-surface-border-color-default);
+    border-right: 1px solid var(--bp-surface-border-color-default);
   }
 }
 
@@ -132,99 +128,87 @@ $step-radius: $pt-border-radius !default;
 }
 
 .#{$ns}-dialog-step-container {
-  background-color: $light-gray5;
-  border-bottom: 1px solid $pt-divider-black;
+  background-color: var(--bp-surface-background-color-default-rest);
+  border-bottom: 1px solid var(--bp-surface-border-color-default);
 
   .#{$ns}-dark & {
-    background: $dark-gray3;
-    border-bottom: 1px solid $pt-dark-divider-white;
+    background: var(--bp-palette-dark-gray-3);
+    border-bottom: 1px solid var(--bp-surface-border-color-default);
   }
 
   &.#{$ns}-dialog-step-viewed {
-    background-color: $white;
+    background-color: var(--bp-palette-white);
     .#{$ns}-dark & {
-      background: $dark-gray4;
+      background: var(--bp-palette-dark-gray-4);
     }
   }
 }
 
 .#{$ns}-dialog-step {
   align-items: center;
-  border-radius: $step-radius;
+  border-radius: var(--bp-surface-border-radius);
   cursor: not-allowed;
   display: flex;
-  margin: $pt-spacing;
-  padding: ($pt-spacing * 1.5) ($pt-spacing * 3.5);
+  margin: var(--bp-surface-spacing);
+  padding: calc(var(--bp-surface-spacing) * 1.5) calc(var(--bp-surface-spacing) * 3.5);
 
   .#{$ns}-dark & {
-    background: $dark-gray3;
+    background: var(--bp-palette-dark-gray-3);
   }
 
   // by default, steps are inactive until they are visited
   .#{$ns}-dialog-step-viewed & {
-    background-color: $white;
+    background-color: var(--bp-palette-white);
     cursor: pointer;
 
     .#{$ns}-dark & {
-      background: $dark-gray4;
+      background: var(--bp-palette-dark-gray-4);
     }
   }
 
   &:hover {
-    background-color: $light-gray5;
+    background-color: var(--bp-surface-background-color-default-rest);
 
     .#{$ns}-dark & {
-      background: $dark-gray3;
+      background: var(--bp-palette-dark-gray-3);
     }
   }
 }
 
 .#{$ns}-dialog-step-icon {
   align-items: center;
-  background-color: $pt-text-color-disabled;
+  background-color: var(--bp-typography-color-default-disabled);
   border-radius: 50%;
-  color: $white;
+  color: var(--bp-palette-white);
   display: flex;
-  height: $pt-spacing * 6;
+  height: calc(var(--bp-surface-spacing) * 6);
   justify-content: center;
-  width: $pt-spacing * 6;
-
-  .#{$ns}-dark & {
-    background-color: $pt-dark-icon-color-disabled;
-  }
+  width: calc(var(--bp-surface-spacing) * 6);
 
   .#{$ns}-active.#{$ns}-dialog-step-viewed & {
-    background-color: $blue3;
+    background-color: var(--bp-intent-primary-rest);
   }
 
   .#{$ns}-dialog-step-viewed & {
-    background-color: $gray3;
+    background-color: var(--bp-intent-default-disabled);
   }
 }
 
 .#{$ns}-dialog-step-title {
-  color: $pt-text-color-disabled;
+  color: var(--bp-typography-color-default-disabled);
   flex: 1;
-  padding-left: $pt-spacing * 2;
-
-  .#{$ns}-dark & {
-    color: $pt-dark-text-color-disabled;
-  }
+  padding-left: calc(var(--bp-surface-spacing) * 2);
 
   // step title is active only when the step is selected
   .#{$ns}-active.#{$ns}-dialog-step-viewed & {
-    color: $blue3;
+    color: var(--bp-intent-primary-rest);
 
     .#{$ns}-dark & {
-      color: $blue5;
+      color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
     }
   }
 
   .#{$ns}-dialog-step-viewed:not(.#{$ns}-active) & {
-    color: $pt-text-color;
-
-    .#{$ns}-dark & {
-      color: $pt-dark-text-color;
-    }
+    color: var(--bp-typography-color-default-rest);
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Dialog and Multistep Dialog component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-intent-primary-rest` | `#2d72d2` | `$pt-intent-primary / $blue3` |
| `--bp-palette-dark-gray-2` | `#252a31` | `(see diff)` |
| `--bp-palette-dark-gray-3` | `#2f343c` | `(see diff)` |
| `--bp-palette-dark-gray-4` | `#383e47` | `(see diff)` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-background-color-default-rest` | `#ffffff` | `(see diff)` |
| `--bp-surface-border-color-default` | `#5f6b7c1f` | `$pt-divider-black` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-shadow-3` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |
| `--bp-typography-size-body-medium` | `14px` | `$pt-font-size` |

#### `_dialog.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `box-shadow` | `$pt-dialog-box-shadow` | `var(--bp-surface-background-color-default-rest)` |
| `margin` | `$dialog-margin` | `calc(var(--bp-surface-spacing) * 8) 0` |
| `width` | `$pt-spacing * 125` | `calc(var(--bp-surface-spacing) * 125)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `box-shadow` | `0 1px 0 $pt-divider-black` | `var(--bp-palette-white)` |
| `padding-le` | `$dialog-padding` | `calc(var(--bp-surface-spacing) * 8)` |
| `color` | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| `font-size` | `14px` | `var(--bp-typography-size-body-medium)` |
| `margin-right` | `$dialog-padding` | `calc(var(--bp-surface-spacing) * 4)` |
| `border-bottom` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
#### `_dialog-body.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `margin` | `$dialog-padding` | `calc(var(--bp-surface-spacing) * 4)` |
| `padding` | `$dialog-padding` | `calc(var(--bp-surface-spacing) * 4)` |
#### `_dialog-footer.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `margin` | `$dialog-padding` | `calc(var(--bp-surface-spacing) * 4)` |
| `border-top: 1px ` | `1px solid $pt-divider-black` | `var(--bp-palette-white)` |
| `gap` | `$dialog-padding` | `calc(var(--bp-surface-spacing) * 4)` |
| `margin-left` | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |
#### `_multistep-dialog.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border-radius` | `$dialog-border-radius 0 0 0` | `var(--bp-surface-border-radius) 0 0 0` |
| `border-top-right-radius` | `$dialog-border-radius` | `var(--bp-surface-border-radius)` |
| `border-radius` | `$dialog-border-radius 0 0 0` | `var(--bp-surface-border-radius) 0 0 0` |
| `border-radius` | `0 $dialog-border-radius 0 0` | `0 var(--bp-surface-border-radius) 0 0` |
| `border-radius` | `0 0 $dialog-border-radius $dialog-border-radius` | `0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius)` |
| `border-radius` | `$dialog-border-radius 0 0 $dialog-border-radius` | `var(--bp-surface-border-radius) 0 0 var(--bp-surface-border-radius)` |
| `border-radius` | `0 $dialog-border-radius 0 0` | `0 var(--bp-surface-border-radius) 0 0` |
| `border-radius` | `0 0 $dialog-border-radius` | `0 0 var(--bp-surface-border-radius)` |
| `border-color` | `$pt-dark-divider-black` | `var(--bp-surface-border-color-default)` |
| `border-radius: 0` | `0 0 $dialog-border-radius` | `var(--bp-surface-background-color-default-rest)` |
| `border-right: 1p` | `1px solid $pt-dark-divider-white` | `var(--bp-palette-dark-gray-3)` |
| `background-color` | `$white` | `var(--bp-palette-white)` |
| `background` | `$dark-gray4` | `var(--bp-palette-dark-gray-4)` |
| `border-radius` | `$step-radius` | `var(--bp-surface-border-radius)` |
| `background` | `$dark-gray3` | `var(--bp-palette-dark-gray-3)` |
| `background-color` | `$white` | `var(--bp-palette-white)` |
| `background` | `$dark-gray4` | `var(--bp-palette-dark-gray-4)` |
| `background-color` | `$light-gray5` | `var(--bp-surface-background-color-default-rest)` |
| `background` | `$dark-gray3` | `var(--bp-palette-dark-gray-3)` |
| `background-color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `color` | `$white` | `var(--bp-palette-white)` |
| `height` | `$pt-spacing * 6` | `calc(var(--bp-surface-spacing) * 6)` |
| `background-color` | `$blue3` | `var(--bp-intent-primary-rest)` |
| `background-color` | `$gray3` | `var(--bp-intent-default-disabled)` |
| `color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `color` | `$blue3` | `var(--bp-intent-primary-rest)` |
| `color` | `$blue5` | `oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.
3. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
4. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |
| 3 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 4 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Dark theme appearance after removing redundant `.bp6-dark` blocks
