### PR TITLE
[core] Integrating design tokens into drawer

### DIFF
--- a/packages/core/src/components/drawer/Drawer.stories.tsx
+++ b/packages/core/src/components/drawer/Drawer.stories.tsx
@@ -1,0 +1,255 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Position } from "../../common";
+import { Button } from "../button/buttons";
+
+import { Drawer, DrawerSize } from "./drawer";
+
+const meta: Meta<typeof Drawer> = {
+    title: "Core/Overlays/Drawer",
+    component: Drawer,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        isOpen: true,
+        title: "Drawer Title",
+        position: "right",
+        size: DrawerSize.SMALL,
+        isCloseButtonShown: true,
+        hasBackdrop: true,
+    },
+    argTypes: {
+        position: {
+            control: "select",
+            options: [Position.TOP, Position.BOTTOM, Position.LEFT, Position.RIGHT],
+        },
+        size: {
+            control: "select",
+            options: [DrawerSize.SMALL, DrawerSize.STANDARD, DrawerSize.LARGE],
+        },
+        isOpen: {
+            control: "boolean",
+        },
+        isCloseButtonShown: {
+            control: "boolean",
+        },
+        hasBackdrop: {
+            control: "boolean",
+        },
+        onClose: { action: "closed" },
+    },
+} satisfies Meta<typeof Drawer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic drawer opening from the right side.
+ */
+export const Default: Story = {
+    args: {
+        title: "Drawer Title",
+        children: (
+            <div style={{ padding: 20 }}>
+                <p>Drawer content goes here.</p>
+            </div>
+        ),
+    },
+};
+
+/**
+ * Drawers can open from any of the four edges of the screen.
+ */
+export const PositionExample: Story = {
+    name: "Position",
+    argTypes: {
+        position: { table: { disable: true } },
+    },
+    render: function Render(args) {
+        const [openPosition, setOpenPosition] = useState<string | null>(null);
+        const positions = [Position.TOP, Position.BOTTOM, Position.LEFT, Position.RIGHT] as const;
+
+        const handleClose = useCallback(() => setOpenPosition(null), []);
+
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                {positions.map(pos => (
+                    <Button key={pos} onClick={() => setOpenPosition(pos)}>
+                        {pos.charAt(0).toUpperCase() + pos.slice(1)}
+                    </Button>
+                ))}
+                <Drawer
+                    {...args}
+                    isOpen={openPosition !== null}
+                    position={openPosition ?? "right"}
+                    onClose={handleClose}
+                    title={`Drawer (${openPosition})`}
+                >
+                    <div style={{ padding: 20 }}>
+                        <p>This drawer opens from the {openPosition} edge.</p>
+                    </div>
+                </Drawer>
+            </div>
+        );
+    },
+};
+
+/**
+ * Drawers come in three predefined sizes: Small (360px), Standard (50%), and Large (90%).
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: function Render(args) {
+        const [openSize, setOpenSize] = useState<string | null>(null);
+        const sizes = [
+            { label: "Small", value: DrawerSize.SMALL },
+            { label: "Standard", value: DrawerSize.STANDARD },
+            { label: "Large", value: DrawerSize.LARGE },
+        ];
+
+        const handleClose = useCallback(() => setOpenSize(null), []);
+
+        return (
+            <div style={{ display: "flex", gap: 8 }}>
+                {sizes.map(({ label, value }) => (
+                    <Button key={label} onClick={() => setOpenSize(value)}>
+                        {label}
+                    </Button>
+                ))}
+                <Drawer
+                    {...args}
+                    isOpen={openSize !== null}
+                    size={openSize ?? DrawerSize.SMALL}
+                    onClose={handleClose}
+                    title={`${sizes.find(s => s.value === openSize)?.label ?? ""} Drawer`}
+                >
+                    <div style={{ padding: 20 }}>
+                        <p>This drawer uses the {openSize} size.</p>
+                    </div>
+                </Drawer>
+            </div>
+        );
+    },
+};
+
+/**
+ * Drawers can display a header with a title, icon, and close button.
+ */
+export const WithIcon: Story = {
+    name: "With Icon",
+    args: {
+        title: "Settings",
+        icon: "cog",
+        children: (
+            <div style={{ padding: 20 }}>
+                <p>Drawer with an icon in the header.</p>
+            </div>
+        ),
+    },
+};
+
+/**
+ * The close button in the header can be hidden.
+ */
+export const NoCloseButton: Story = {
+    name: "No Close Button",
+    args: {
+        title: "Persistent Drawer",
+        isCloseButtonShown: false,
+        children: (
+            <div style={{ padding: 20 }}>
+                <p>This drawer has no close button in the header.</p>
+            </div>
+        ),
+    },
+    argTypes: {
+        isCloseButtonShown: { table: { disable: true } },
+    },
+};
+
+/**
+ * A drawer without a title will not render a header.
+ */
+export const NoHeader: Story = {
+    name: "No Header",
+    args: {
+        title: undefined,
+        children: (
+            <div style={{ padding: 20 }}>
+                <p>This drawer has no header because no title was provided.</p>
+            </div>
+        ),
+    },
+};
+
+/**
+ * Drawers support header, body, and footer sections for structured content.
+ */
+export const WithFooter: Story = {
+    name: "With Footer",
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <>
+                <Button onClick={handleOpen}>Open Drawer</Button>
+                <Drawer {...args} isOpen={isOpen} onClose={handleClose} title="Confirm Action">
+                    <div className="bp6-drawer-body">
+                        <div style={{ padding: 20 }}>
+                            <p>Are you sure you want to proceed?</p>
+                        </div>
+                    </div>
+                    <div className="bp6-drawer-footer">
+                        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                            <Button onClick={handleClose}>Cancel</Button>
+                            <Button intent="primary" onClick={handleClose}>
+                                Confirm
+                            </Button>
+                        </div>
+                    </div>
+                </Drawer>
+            </>
+        );
+    },
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+        const handleOpen = useCallback(() => setIsOpen(true), []);
+        const handleClose = useCallback(() => setIsOpen(false), []);
+
+        return (
+            <>
+                <Button onClick={handleOpen}>Open Drawer</Button>
+                <Drawer {...args} isOpen={isOpen} onClose={handleClose}>
+                    <div className="bp6-drawer-body">
+                        <div style={{ padding: 20 }}>
+                            <p>Drawer body content. Use the Storybook controls to adjust props.</p>
+                        </div>
+                    </div>
+                    <div className="bp6-drawer-footer">
+                        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                            <Button onClick={handleClose}>Close</Button>
+                        </div>
+                    </div>
+                </Drawer>
+            </>
+        );
+    },
+};

--- a/packages/core/src/components/drawer/_drawer.scss
+++ b/packages/core/src/components/drawer/_drawer.scss
@@ -15,8 +15,8 @@ $drawer-background-color: $white !default;
 $dark-drawer-background-color: $dark-gray3 !default;
 
 .#{$ns}-drawer {
-  background: $drawer-background-color;
-  box-shadow: $pt-elevation-shadow-4;
+  background: var(--bp-surface-color-default);
+  box-shadow: var(--bp-surface-shadow-4);
   display: flex;
   flex-direction: column;
   margin: 0;
@@ -36,8 +36,8 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateY(0),
         ),
       ),
-      $pt-transition-duration * 2,
-      $pt-transition-ease,
+      calc(var(--bp-emphasis-transition-duration) * 2),
+      var(--bp-emphasis-ease-default),
       $before: "&"
     );
     @include react-transition-phase(
@@ -49,7 +49,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateY(0),
         ),
       ),
-      $pt-transition-duration,
+      var(--bp-emphasis-transition-duration),
       $before: "&"
     );
     height: $drawer-default-size;
@@ -59,7 +59,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
     top: 0;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      border-bottom: 1px solid $pt-high-contrast-mode-border-color;
+      border-bottom: 1px solid buttonborder;
     }
   }
 
@@ -73,8 +73,8 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateY(0),
         ),
       ),
-      $pt-transition-duration * 2,
-      $pt-transition-ease,
+      calc(var(--bp-emphasis-transition-duration) * 2),
+      var(--bp-emphasis-ease-default),
       $before: "&"
     );
     @include react-transition-phase(
@@ -86,7 +86,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateY(0),
         ),
       ),
-      $pt-transition-duration,
+      var(--bp-emphasis-transition-duration),
       $before: "&"
     );
     bottom: 0;
@@ -96,7 +96,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
     right: 0;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      border-top: 1px solid $pt-high-contrast-mode-border-color;
+      border-top: 1px solid buttonborder;
     }
   }
 
@@ -110,8 +110,8 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateX(0),
         ),
       ),
-      $pt-transition-duration * 2,
-      $pt-transition-ease,
+      calc(var(--bp-emphasis-transition-duration) * 2),
+      var(--bp-emphasis-ease-default),
       $before: "&"
     );
     @include react-transition-phase(
@@ -123,7 +123,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateX(0),
         ),
       ),
-      $pt-transition-duration,
+      var(--bp-emphasis-transition-duration),
       $before: "&"
     );
     bottom: 0;
@@ -133,7 +133,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
     width: $drawer-default-size;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      border-right: 1px solid $pt-high-contrast-mode-border-color;
+      border-right: 1px solid buttonborder;
     }
   }
 
@@ -147,8 +147,8 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateX(0),
         ),
       ),
-      $pt-transition-duration * 2,
-      $pt-transition-ease,
+      calc(var(--bp-emphasis-transition-duration) * 2),
+      var(--bp-emphasis-ease-default),
       $before: "&"
     );
     @include react-transition-phase(
@@ -160,7 +160,7 @@ $dark-drawer-background-color: $dark-gray3 !default;
           translateX(0),
         ),
       ),
-      $pt-transition-duration,
+      var(--bp-emphasis-transition-duration),
       $before: "&"
     );
     bottom: 0;
@@ -170,38 +170,38 @@ $dark-drawer-background-color: $dark-gray3 !default;
     width: $drawer-default-size;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
-      border-left: 1px solid $pt-high-contrast-mode-border-color;
+      border-left: 1px solid buttonborder;
     }
   }
 
   &.#{$ns}-dark,
   .#{$ns}-dark & {
-    background: $dark-drawer-background-color;
-    box-shadow: $pt-dark-dialog-box-shadow;
-    color: $pt-dark-text-color;
+    background: var(--bp-surface-color-default);
+    box-shadow: var(--bp-surface-shadow-4);
+    color: var(--bp-typography-color-default-rest);
   }
 }
 
 .#{$ns}-drawer-header {
   align-items: center;
   border-radius: 0;
-  box-shadow: 0 1px 0 $pt-divider-black;
+  box-shadow: 0 1px 0 var(--bp-surface-border-color-default);
   display: flex;
   flex: 0 0 auto;
-  min-height: $pt-icon-size-large + $drawer-padding;
-  padding: $drawer-padding * 0.25;
-  padding-left: $drawer-padding;
+  min-height: calc(var(--bp-surface-spacing) * 10);
+  padding: calc(var(--bp-surface-spacing) * 1.25);
+  padding-left: calc(var(--bp-surface-spacing) * 5);
   position: relative;
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border-bottom: 1px solid $pt-high-contrast-mode-border-color;
+    border-bottom: 1px solid buttonborder;
   }
 
   .#{$ns}-icon-large,
   .#{$ns}-icon {
-    color: $pt-icon-color;
+    color: var(--bp-typography-color-muted);
     flex: 0 0 auto;
-    margin-right: $drawer-padding * 0.5;
+    margin-right: calc(var(--bp-surface-spacing) * 2.5);
   }
 
   .#{$ns}-heading {
@@ -211,33 +211,33 @@ $dark-drawer-background-color: $dark-gray3 !default;
     margin: 0;
 
     &:last-child {
-      margin-right: $drawer-padding;
+      margin-right: calc(var(--bp-surface-spacing) * 5);
     }
   }
 
   .#{$ns}-dark & {
-    box-shadow: 0 1px 0 $pt-dark-divider-black;
+    box-shadow: 0 1px 0 var(--bp-surface-border-color-default);
 
     .#{$ns}-icon-large,
     .#{$ns}-icon {
-      color: $pt-dark-icon-color;
+      color: var(--bp-typography-color-muted);
     }
   }
 }
 
 .#{$ns}-drawer-body {
   flex: 1 1 auto;
-  line-height: $pt-spacing * 4.5;
+  line-height: calc(var(--bp-surface-spacing) * 4.5);
   overflow: auto;
 }
 
 .#{$ns}-drawer-footer {
-  box-shadow: inset 0 1px 0 $pt-divider-black;
+  box-shadow: inset 0 1px 0 var(--bp-surface-border-color-default);
   flex: 0 0 auto;
-  padding: $drawer-padding * 0.5 $drawer-padding;
+  padding: calc(var(--bp-surface-spacing) * 2.5) calc(var(--bp-surface-spacing) * 5);
   position: relative;
 
   .#{$ns}-dark & {
-    box-shadow: inset 0 1px 0 $pt-dark-divider-black;
+    box-shadow: inset 0 1px 0 var(--bp-surface-border-color-default);
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Drawer component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-default` | `cubic-bezier(0.4, 1, 0.75, 0.9)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-surface-border-color-default` | `#5f6b7c1f` | `$pt-divider-black` |
| `--bp-surface-color-default` | `(derived)` | `$white / $dark-gray*` |
| `--bp-surface-shadow-4` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_drawer.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border-bottom` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `border-top` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `border-right` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `border-left` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `color: $pt` | `$pt-dark-text-color` | `var(--bp-surface-color-default)` |
| `box-shadow` | `0 1px 0 $pt-divider-black` | `0 1px 0 var(--bp-surface-border-color-default)` |
| `padding-le` | `$drawer-padding` | `calc(var(--bp-surface-spacing) * 10)` |
| `border-bottom` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `color` | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| `margin-right` | `$drawer-padding * 0.5` | `calc(var(--bp-surface-spacing) * 2.5)` |
| `margin-right` | `$drawer-padding` | `calc(var(--bp-surface-spacing) * 5)` |
| `box-shadow` | `0 1px 0 $pt-dark-divider-black` | `0 1px 0 var(--bp-surface-border-color-default)` |
| `color` | `$pt-dark-icon-color` | `var(--bp-typography-color-muted)` |
| `line-height` | `$pt-spacing * 4.5` | `calc(var(--bp-surface-spacing) * 4.5)` |
| `box-shadow` | `inset 0 1px 0 $pt-divider-black` | `inset 0 1px 0 var(--bp-surface-border-color-default)` |
| `padding` | `$drawer-padding * 0.5 $drawer-padding` | `calc(var(--bp-surface-spacing) * 2.5) calc(var(--bp-surface-spacing) * 5)` |
| `box-shadow` | `inset 0 1px 0 $pt-dark-divider-black` | `inset 0 1px 0 var(--bp-surface-border-color-default)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
