### PR TITLE
[core] Integrating design tokens into popover

### DIFF
--- a/packages/core/src/components/popover/Popover.stories.tsx
+++ b/packages/core/src/components/popover/Popover.stories.tsx
@@ -1,0 +1,271 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Button, Menu, MenuItem } from "../..";
+
+import { Popover } from "./popover";
+import { PopoverInteractionKind } from "./popoverProps";
+
+const disabledArgs = [
+    "boundary",
+    "captureDismiss",
+    "modifiers",
+    "modifiersCustom",
+    "popoverRef",
+    "renderTarget",
+    "rootBoundary",
+    "targetProps",
+    "targetTagName",
+] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof Popover>>;
+
+const sampleMenu = (
+    <Menu>
+        <MenuItem text="New file" icon="document" />
+        <MenuItem text="New folder" icon="folder-new" />
+        <MenuItem text="Settings" icon="cog" />
+    </Menu>
+);
+
+const meta: Meta<typeof Popover> = {
+    title: "Core/Overlay/Popover",
+    component: Popover,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        content: sampleMenu,
+        interactionKind: "click",
+        placement: "bottom",
+        minimal: false,
+        disabled: false,
+        fill: false,
+        usePortal: true,
+    },
+    argTypes: {
+        interactionKind: {
+            control: "select",
+            options: Object.values(PopoverInteractionKind),
+        },
+        placement: {
+            control: "select",
+            options: [
+                "auto",
+                "auto-start",
+                "auto-end",
+                "top",
+                "top-start",
+                "top-end",
+                "bottom",
+                "bottom-start",
+                "bottom-end",
+                "left",
+                "left-start",
+                "left-end",
+                "right",
+                "right-start",
+                "right-end",
+            ],
+        },
+        minimal: { control: "boolean" },
+        disabled: { control: "boolean" },
+        fill: { control: "boolean" },
+        hasBackdrop: { control: "boolean" },
+        usePortal: { control: "boolean" },
+        matchTargetWidth: { control: "boolean" },
+        onInteraction: { action: "interaction" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic popover triggered by a button click, displaying a menu.
+ */
+export const Default: Story = {
+    args: {
+        children: <Button text="Open popover" />,
+    },
+};
+
+/**
+ * Popover interaction kinds determine how the popover opens and closes.
+ */
+export const InteractionKindExample: Story = {
+    name: "Interaction Kind",
+    argTypes: {
+        interactionKind: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            <Popover {...args} interactionKind="click">
+                <Button text="Click" />
+            </Popover>
+            <Popover {...args} interactionKind="hover">
+                <Button text="Hover" />
+            </Popover>
+            <Popover {...args} interactionKind="hover-target">
+                <Button text="Hover target only" />
+            </Popover>
+        </div>
+    ),
+};
+
+/**
+ * Use `minimal` to render the popover without an arrow and with a subtler animation.
+ */
+export const VariantExample: Story = {
+    name: "Variant",
+    argTypes: {
+        minimal: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 16 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <Popover {...args} minimal={false}>
+                    <Button text="With arrow" />
+                </Popover>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <Popover {...args} minimal={true}>
+                    <Button text="No arrow" />
+                </Popover>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `placement` prop to control where the popover appears relative to the target.
+ */
+export const PlacementExample: Story = {
+    name: "Placement",
+    argTypes: {
+        placement: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            {(["top", "bottom", "left", "right"] as const).map(placement => (
+                <Popover key={placement} {...args} placement={placement}>
+                    <Button text={placement} />
+                </Popover>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Popover supports disabled and backdrop states.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        hasBackdrop: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            <Popover {...args}>
+                <Button text="Default" />
+            </Popover>
+            <Popover {...args} disabled={true}>
+                <Button text="Disabled" disabled={true} />
+            </Popover>
+            <Popover {...args} hasBackdrop={true}>
+                <Button text="With backdrop" />
+            </Popover>
+        </div>
+    ),
+};
+
+/**
+ * Use `fill` to make the popover target expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Popover {...args} fill={true}>
+                <Button text="Full width" fill={true} />
+            </Popover>
+            <Popover {...args} fill={false}>
+                <Button text="Auto width" />
+            </Popover>
+        </div>
+    ),
+};
+
+/**
+ * Use `matchTargetWidth` to make the popover content match the width of the target.
+ */
+export const MatchTargetWidthExample: Story = {
+    name: "Match Target Width",
+    argTypes: {
+        matchTargetWidth: { table: { disable: true } },
+    },
+    render: args => (
+        <Popover {...args} matchTargetWidth={true} fill={true}>
+            <Button text="Popover matches this button's width" fill={true} />
+        </Popover>
+    ),
+    decorators: [
+        Story => (
+            <div style={{ width: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+/**
+ * Interactive playground with a controlled popover and all props togglable.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(false);
+
+        const handleInteraction = useCallback((nextOpenState: boolean) => {
+            setIsOpen(nextOpenState);
+        }, []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+                <Popover {...args} isOpen={isOpen} onInteraction={handleInteraction}>
+                    <Button text={isOpen ? "Close popover" : "Open popover"} intent={isOpen ? "danger" : "primary"} />
+                </Popover>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Popover is {isOpen ? "open" : "closed"}</span>
+            </div>
+        );
+    },
+};

--- a/packages/core/src/components/popover/_common.scss
+++ b/packages/core/src/components/popover/_common.scss
@@ -68,7 +68,7 @@ $pt-dark-popover-background-color: $dark-gray3 !default;
   }
 
   .#{$ns}-popover-arrow-border {
-    fill: $black;
+    fill: var(--bp-palette-black);
     fill-opacity: $arrow-border-fill-opacity;
   }
 
@@ -77,13 +77,13 @@ $pt-dark-popover-background-color: $dark-gray3 !default;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       // Windows High Contrast dark theme
-      fill: $pt-high-contrast-mode-border-color;
+      fill: buttonborder;
     }
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
     // Windows High Contrast dark theme
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
   }
 }
 
@@ -103,8 +103,8 @@ $pt-dark-popover-background-color: $dark-gray3 !default;
     (
       transform: scale(0.3) scale(1),
     ),
-    $duration: $pt-transition-duration * 3,
-    $easing: $pt-transition-ease-bounce,
+    $duration: calc(var(--bp-emphasis-transition-duration) * 3),
+    $easing: var(--bp-emphasis-ease-bounce),
     $after: "> &"
   );
 }

--- a/packages/core/src/components/popover/_popover-in-button-group.scss
+++ b/packages/core/src/components/popover/_popover-in-button-group.scss
@@ -27,11 +27,11 @@
   &.#{$ns}-vertical {
     &:not(.#{$ns}-minimal) {
       > .#{$ns}-popover-target:first-child .#{$ns}-button {
-        border-radius: $pt-border-radius $pt-border-radius 0 0;
+        border-radius: var(--bp-surface-border-radius) var(--bp-surface-border-radius) 0 0;
       }
 
       > .#{$ns}-popover-target:last-child .#{$ns}-button {
-        border-radius: 0 0 $pt-border-radius $pt-border-radius;
+        border-radius: 0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius);
       }
 
       > .#{$ns}-popover-target:not(:last-child) .#{$ns}-button {

--- a/packages/core/src/components/popover/_popover-in-label.scss
+++ b/packages/core/src/components/popover/_popover-in-label.scss
@@ -6,7 +6,7 @@
 label.#{$ns}-label {
   .#{$ns}-popover-target {
     display: block;
-    margin-top: $pt-spacing;
+    margin-top: var(--bp-surface-spacing);
     text-transform: none;
   }
 }

--- a/packages/core/src/components/popover/_popover-in-submenu.scss
+++ b/packages/core/src/components/popover/_popover-in-submenu.scss
@@ -12,10 +12,10 @@
   &.#{$ns}-popover {
     box-shadow: none;
     // horizontal padding leaves some space from parent menu item, and extends mouse zone
-    padding: 0 $pt-spacing;
+    padding: 0 var(--bp-surface-spacing);
 
     > .#{$ns}-popover-content {
-      box-shadow: $pt-popover-box-shadow;
+      box-shadow: var(--bp-surface-shadow-3);
     }
 
     .#{$ns}-dark &,

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -18,6 +18,17 @@ $dark-popover-arrow-box-shadow:
   0 0 0 1px color.adjust($pt-dark-popover-border-color, $lightness: 10%),
   1px 1px 6px rgba($black, $pt-dark-drop-shadow-opacity) !default;
 
+// Token-based arrow box shadows
+// $pt-drop-shadow-opacity (0.2) → oklch alpha
+/* stylelint-disable alpha-value-notation */
+$popover-arrow-box-shadow-token: 1px 1px 6px oklch(from var(--bp-palette-black) l c h / 0.2);
+// color.adjust($pt-dark-popover-border-color, $lightness: 10%) ≈ hsl(215deg, 3%, 48%)
+// $pt-dark-drop-shadow-opacity (0.4) → oklch alpha
+$dark-popover-arrow-box-shadow-token:
+  0 0 0 1px hsl(215deg, 3%, 48%),
+  1px 1px 6px oklch(from var(--bp-palette-black) l c h / 0.4);
+/* stylelint-enable alpha-value-notation */
+
 .#{$ns}-popover {
   @include popover-sizing(
     $arrow-square-size: $pt-spacing * 7.5,
@@ -25,33 +36,33 @@ $dark-popover-arrow-box-shadow:
     $arrow-target-offset: -$pt-spacing
   );
   @include popover-appearance(
-    $pt-popover-background-color,
+    var(--bp-palette-white),
     inherit,
-    $pt-popover-box-shadow,
-    $popover-arrow-box-shadow,
+    var(--bp-surface-shadow-3),
+    $popover-arrow-box-shadow-token,
     $pt-border-shadow-opacity
   );
   @include scale-transition;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   display: inline-block;
-  z-index: $pt-z-index-overlay;
+  z-index: var(--bp-surface-z-index-2);
 
   .#{$ns}-popover-content {
-    border-radius: $pt-border-radius;
+    border-radius: var(--bp-surface-border-radius);
     position: relative;
   }
 
   &.#{$ns}-popover-content-sizing {
     .#{$ns}-popover-content {
-      max-width: $popover-width;
-      padding: $pt-spacing * 5;
+      max-width: calc(var(--bp-surface-spacing) * 87.5);
+      padding: calc(var(--bp-surface-spacing) * 5);
     }
 
     // only inline popovers get a width if this class is applied.
     // note that an inline overlay will be an immediate next sibling
     // of the popover target as of Blueprint 2.0.
     .#{$ns}-popover-target + .#{$ns}-overlay & {
-      width: $popover-width;
+      width: calc(var(--bp-surface-spacing) * 87.5);
     }
   }
 
@@ -73,7 +84,7 @@ $dark-popover-arrow-box-shadow:
         (
           transform: scale(1) scale(1),
         ),
-        $duration: $pt-transition-duration,
+        $duration: var(--bp-emphasis-transition-duration),
         $after: "> &"
       );
     }
@@ -88,16 +99,16 @@ $dark-popover-arrow-box-shadow:
   &.#{$ns}-dark,
   .#{$ns}-dark & {
     @include popover-appearance(
-      $pt-dark-popover-background-color,
+      var(--bp-palette-dark-gray-3),
       inherit,
       $pt-dark-popover-box-shadow,
-      $dark-popover-arrow-box-shadow,
+      $dark-popover-arrow-box-shadow-token,
       $pt-dark-border-shadow-opacity
     );
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
     // Windows High Contrast dark theme
     box-shadow: none;
   }
@@ -113,7 +124,8 @@ $dark-popover-arrow-box-shadow:
 }
 
 .#{$ns}-overlay-backdrop.#{$ns}-popover-backdrop {
-  background: rgba($white, 0);
+  /* stylelint-disable-next-line alpha-value-notation */
+  background: oklch(from var(--bp-palette-white) l c h / 0);
 }
 
 .#{$ns}-popover-transition-container {
@@ -122,7 +134,7 @@ $dark-popover-arrow-box-shadow:
   // ensure element size exactly equals its children, no edge-case 4px spacing!
   // (try removing this property with Slider content in example)
   display: flex;
-  z-index: $pt-z-index-overlay;
+  z-index: var(--bp-surface-z-index-2);
 
   &:focus {
     outline: none;

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -21,12 +21,12 @@ $dark-popover-arrow-box-shadow:
 // Token-based arrow box shadows
 // $pt-drop-shadow-opacity (0.2) → oklch alpha
 /* stylelint-disable alpha-value-notation */
-$popover-arrow-box-shadow-token: 1px 1px 6px oklch(from var(--bp-palette-black) l c h / 0.2);
+$popover-arrow-box-shadow-token: 1px 1px 6px #{"oklch(from var(--bp-palette-black) l c h / 0.2)"};
 // color.adjust($pt-dark-popover-border-color, $lightness: 10%) ≈ hsl(215deg, 3%, 48%)
 // $pt-dark-drop-shadow-opacity (0.4) → oklch alpha
 $dark-popover-arrow-box-shadow-token:
   0 0 0 1px hsl(215deg, 3%, 48%),
-  1px 1px 6px oklch(from var(--bp-palette-black) l c h / 0.4);
+  1px 1px 6px #{"oklch(from var(--bp-palette-black) l c h / 0.4)"};
 /* stylelint-enable alpha-value-notation */
 
 .#{$ns}-popover {
@@ -125,7 +125,7 @@ $dark-popover-arrow-box-shadow-token:
 
 .#{$ns}-overlay-backdrop.#{$ns}-popover-backdrop {
   /* stylelint-disable-next-line alpha-value-notation */
-  background: oklch(from var(--bp-palette-white) l c h / 0);
+  background: #{"oklch(from var(--bp-palette-white) l c h / 0)"};
 }
 
 .#{$ns}-popover-transition-container {


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Popover component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-emphasis-ease-bounce` | `cubic-bezier(0.54, 1.12, 0.38, 1.11)` | `(see diff)` |
| `--bp-emphasis-transition-duration` | `100ms` | `(see diff)` |
| `--bp-palette-black` | `#111418` | `$black` |
| `--bp-palette-dark-gray-3` | `#2f343c` | `(see diff)` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-shadow-3` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-surface-z-index-2` | `20` | `(see diff)` |

#### `_common.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `fill` | `$black` | `var(--bp-palette-black)` |
| `fill` | `$pt-high-contrast-mode-border-color` | `buttonborder` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
#### `_popover.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `z-index` | `$pt-z-index-overlay` | `var(--bp-surface-z-index-2)` |
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |
| `width` | `$popover-width` | `calc(var(--bp-surface-spacing) * 87.5)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `z-index` | `$pt-z-index-overlay` | `var(--bp-surface-z-index-2)` |
#### `_popover-in-button-group.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `border-radius` | `$pt-border-radius $pt-border-radius 0 0` | `var(--bp-surface-border-radius) var(--bp-surface-border-radius) 0 0` |
| `border-radius` | `0 0 $pt-border-radius $pt-border-radius` | `0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius)` |
#### `_popover-in-label.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `margin-top` | `$pt-spacing` | `var(--bp-surface-spacing)` |
#### `_popover-in-submenu.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `padding` | `0 $pt-spacing` | `0 var(--bp-surface-spacing)` |
| `box-shadow` | `$pt-popover-box-shadow` | `var(--bp-surface-shadow-3)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
3. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.
4. **Sass color functions replaced.** `color.adjust()`/`color.change()` replaced with `oklch()` relative color syntax.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 3 | High contrast | Native CSS system color instead of SCSS variable |
| 4 | Sass color functions | `color.adjust()` → `oklch()` relative color syntax |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
