### PR TITLE
[core] Integrating design tokens into navbar

### DIFF
--- a/packages/core/src/components/navbar/Navbar.stories.tsx
+++ b/packages/core/src/components/navbar/Navbar.stories.tsx
@@ -1,0 +1,115 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alignment } from "../../common";
+import { Button } from "../button/buttons";
+
+import { Navbar } from "./navbar";
+import { NavbarDivider } from "./navbarDivider";
+import { NavbarGroup } from "./navbarGroup";
+import { NavbarHeading } from "./navbarHeading";
+
+const meta: Meta<typeof Navbar> = {
+    title: "Core/Components/Navbar",
+    component: Navbar,
+    parameters: {
+        layout: "padded",
+    },
+    tags: ["autodocs"],
+    args: {
+        fixedToTop: false,
+    },
+    argTypes: {
+        fixedToTop: { control: "boolean" },
+    },
+} satisfies Meta<typeof Navbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const WithLeftAndRightGroups: Story = {
+    name: "Left & Right Groups",
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+            <NavbarGroup align={Alignment.END}>
+                <Button variant="minimal" icon="notifications" />
+                <Button variant="minimal" icon="cog" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const WithDividers: Story = {
+    name: "With Dividers",
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>App</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+                <NavbarDivider />
+                <Button variant="minimal" icon="cog" text="Settings" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    render: args => (
+        <div className="bp6-dark">
+            <Navbar {...args}>
+                <NavbarGroup align={Alignment.START}>
+                    <NavbarHeading>Blueprint</NavbarHeading>
+                    <NavbarDivider />
+                    <Button variant="minimal" icon="home" text="Home" />
+                    <Button variant="minimal" icon="document" text="Files" />
+                </NavbarGroup>
+                <NavbarGroup align={Alignment.END}>
+                    <Button variant="minimal" icon="notifications" />
+                    <Button variant="minimal" icon="cog" />
+                </NavbarGroup>
+            </Navbar>
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+            <NavbarGroup align={Alignment.END}>
+                <Button variant="minimal" icon="notifications" />
+                <Button variant="minimal" icon="cog" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};

--- a/packages/core/src/components/navbar/_navbar.scss
+++ b/packages/core/src/components/navbar/_navbar.scss
@@ -10,27 +10,22 @@ $navbar-background-color: $card-background-color !default;
 $dark-navbar-background-color: $dark-card-background-color !default;
 
 .#{$ns}-navbar {
-  background-color: $navbar-background-color;
-  box-shadow: $pt-elevation-shadow-1;
-  height: $pt-navbar-height;
-  padding: 0 $navbar-padding;
+  background-color: var(--bp-surface-background-color-default-rest);
+  box-shadow: var(--bp-surface-shadow-1);
+  height: calc(var(--bp-surface-spacing) * 12.5);
+  padding: 0 calc(var(--bp-surface-spacing) * 4);
   position: relative;
   width: 100%;
-  z-index: $pt-z-index-content;
-
-  &.#{$ns}-dark,
-  .#{$ns}-dark & {
-    background-color: $dark-navbar-background-color;
-  }
+  z-index: var(--bp-surface-z-index-1);
 
   // shadow for dark navbar in light theme apps
   &.#{$ns}-dark {
-    box-shadow: inset $pt-dark-elevation-shadow-1;
+    box-shadow: inset var(--bp-surface-shadow-1);
   }
 
   // shadow for dark navbar in dark theme apps
   .#{$ns}-dark & {
-    box-shadow: $pt-dark-elevation-shadow-1;
+    box-shadow: var(--bp-surface-shadow-1);
   }
 
   &.#{$ns}-fixed-top {
@@ -41,19 +36,19 @@ $dark-navbar-background-color: $dark-card-background-color !default;
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    border: 1px solid $pt-high-contrast-mode-border-color;
+    border: 1px solid buttonborder;
   }
 }
 
 .#{$ns}-navbar-heading {
-  font-size: $pt-font-size-large;
-  margin-right: $navbar-padding;
+  font-size: var(--bp-typography-size-body-large);
+  margin-right: calc(var(--bp-surface-spacing) * 4);
 }
 
 .#{$ns}-navbar-group {
   align-items: center;
   display: flex;
-  height: $pt-navbar-height;
+  height: calc(var(--bp-surface-spacing) * 12.5);
 
   &.#{$ns}-align-left {
     float: left;
@@ -65,11 +60,7 @@ $dark-navbar-background-color: $dark-card-background-color !default;
 }
 
 .#{$ns}-navbar-divider {
-  border-left: 1px solid $pt-divider-black;
-  height: $pt-navbar-height - $pt-spacing * 7.5;
-  margin: 0 ($pt-spacing * 2);
-
-  .#{$ns}-dark & {
-    border-left-color: $pt-dark-divider-white;
-  }
+  border-left: 1px solid var(--bp-surface-border-color-default);
+  height: calc(var(--bp-surface-spacing) * 5);
+  margin: 0 calc(var(--bp-surface-spacing) * 2);
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Navbar component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-surface-background-color-default-rest` | `#ffffff` | `(see diff)` |
| `--bp-surface-border-color-default` | `#5f6b7c1f` | `$pt-divider-black` |
| `--bp-surface-shadow-1` | `0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px ` | `$pt-elevation-shadow-*` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-surface-z-index-1` | `10` | `(see diff)` |
| `--bp-typography-size-body-large` | `16px` | `(see diff)` |

#### `_navbar.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `box-shadow` | `inset $pt-dark-elevation-shadow-1` | `inset var(--bp-surface-shadow-1)` |
| `box-shadow` | `$pt-dark-elevation-shadow-1` | `var(--bp-surface-shadow-1)` |
| `border` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `height` | `$pt-navbar-height` | `calc(var(--bp-surface-spacing) * 12.5)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.
3. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |
| 3 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- Dark theme appearance after removing redundant `.bp6-dark` blocks
