### PR TITLE
[core] Integrating design tokens into breadcrumbs

### DIFF
--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,159 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Boundary } from "../../common";
+import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
+import { Breadcrumbs } from "./breadcrumbs";
+
+const SAMPLE_ITEMS: BreadcrumbProps[] = [
+    { text: "Home", href: "#", icon: "home" },
+    { text: "Projects", href: "#", icon: "projects" },
+    { text: "Blueprint", href: "#" },
+    { text: "Components", href: "#" },
+    { text: "Breadcrumbs" },
+];
+
+const meta: Meta<typeof Breadcrumbs> = {
+    title: "Core/Breadcrumbs/Breadcrumbs",
+    component: Breadcrumbs,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        items: SAMPLE_ITEMS,
+        collapseFrom: Boundary.START,
+    },
+    argTypes: {
+        collapseFrom: {
+            control: "select",
+            options: Object.values(Boundary),
+        },
+        minVisibleItems: {
+            control: "number",
+        },
+    },
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        items: SAMPLE_ITEMS,
+    },
+};
+
+export const CollapseFrom: Story = {
+    name: "Collapse From",
+    argTypes: {
+        collapseFrom: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from start (default)</div>
+                <div style={{ width: 300 }}>
+                    <Breadcrumbs {...args} collapseFrom={Boundary.START} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from end</div>
+                <div style={{ width: 300 }}>
+                    <Breadcrumbs {...args} collapseFrom={Boundary.END} />
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+export const WithIcons: Story = {
+    name: "With Icons",
+    args: {
+        items: [
+            { text: "Home", href: "#", icon: "home" },
+            { text: "Settings", href: "#", icon: "cog" },
+            { text: "Profile", href: "#", icon: "person" },
+            { text: "Notifications" },
+        ],
+    },
+};
+
+export const DisabledItems: Story = {
+    name: "Disabled Items",
+    args: {
+        items: [
+            { text: "Home", href: "#" },
+            { text: "Archived", href: "#", disabled: true },
+            { text: "Projects", href: "#" },
+            { text: "Current Page" },
+        ],
+    },
+};
+
+export const Overflow: Story = {
+    name: "Overflow",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Constrained width (300px)</div>
+                <div style={{ width: 300 }}>
+                    <Breadcrumbs {...args} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Full width</div>
+                <div style={{ width: 600 }}>
+                    <Breadcrumbs {...args} />
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+export const MinVisibleItems: Story = {
+    name: "Min Visible Items",
+    argTypes: {
+        minVisibleItems: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: 250 }}>
+            {[0, 1, 2, 3].map(minVisibleItems => (
+                <div key={minVisibleItems}>
+                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>
+                        minVisibleItems: {minVisibleItems}
+                    </div>
+                    <Breadcrumbs {...args} minVisibleItems={minVisibleItems} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+export const CustomRenderer: Story = {
+    name: "Custom Breadcrumb Renderer",
+    args: {
+        items: SAMPLE_ITEMS,
+        breadcrumbRenderer: (props: BreadcrumbProps) => (
+            <Breadcrumb {...props} icon={props.icon ?? "folder-close"} />
+        ),
+    },
+};
+
+export const Playground: Story = {
+    args: {
+        items: SAMPLE_ITEMS,
+        collapseFrom: Boundary.START,
+        minVisibleItems: 0,
+    },
+};

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -9,7 +9,7 @@
   cursor: default;
   display: flex;
   flex-wrap: wrap;
-  height: $pt-input-height;
+  height: calc(var(--bp-surface-spacing) * 7.5);
   list-style: none;
   // unstyled inline list reset
   margin: 0;
@@ -31,9 +31,9 @@
       );
       content: "";
       display: block;
-      height: $pt-icon-size-standard;
-      margin: 0 $pt-spacing;
-      width: $pt-icon-size-standard;
+      height: calc(var(--bp-surface-spacing) * 4);
+      margin: 0 var(--bp-surface-spacing);
+      width: calc(var(--bp-surface-spacing) * 4);
     }
 
     &:last-of-type::after {
@@ -47,12 +47,12 @@
 .#{$ns}-breadcrumbs-collapsed {
   align-items: center;
   display: inline-flex;
-  font-size: $pt-font-size-large;
+  font-size: var(--bp-typography-size-body-large);
 }
 
 .#{$ns}-breadcrumb,
 .#{$ns}-breadcrumbs-collapsed {
-  color: $pt-text-color-muted;
+  color: var(--bp-typography-color-muted);
 }
 
 .#{$ns}-breadcrumb {
@@ -61,12 +61,12 @@
   }
 
   &.#{$ns}-disabled {
-    color: $pt-text-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
     cursor: not-allowed;
   }
 
   .#{$ns}-icon {
-    margin-right: $pt-spacing;
+    margin-right: var(--bp-surface-spacing);
   }
 }
 
@@ -82,12 +82,13 @@
 }
 
 .#{$ns}-breadcrumbs-collapsed {
-  background: rgba($gray3, 0.15);
+  /* stylelint-disable-next-line alpha-value-notation */
+  background: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
   border: none;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   cursor: pointer;
-  margin-right: $pt-spacing * 0.5;
-  padding: 1px $pt-spacing;
+  margin-right: calc(var(--bp-surface-spacing) * 0.5);
+  padding: 1px var(--bp-surface-spacing);
   vertical-align: text-bottom;
 
   &::before {
@@ -102,23 +103,19 @@
       center no-repeat;
     content: "";
     display: block;
-    height: $pt-icon-size-standard;
-    width: $pt-icon-size-standard;
+    height: calc(var(--bp-surface-spacing) * 4);
+    width: calc(var(--bp-surface-spacing) * 4);
   }
 
   &:hover {
-    background: rgba($gray3, 0.3);
-    color: $pt-text-color;
+    /* stylelint-disable-next-line alpha-value-notation */
+    background: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
+    color: var(--bp-typography-color-default-rest);
     text-decoration: none;
   }
 }
 
 .#{$ns}-dark {
-  .#{$ns}-breadcrumb,
-  .#{$ns}-breadcrumbs-collapsed {
-    color: $pt-dark-text-color-muted;
-  }
-
   .#{$ns}-breadcrumbs > li::after {
     background: svg-icon(
       "16px/chevron-right.svg",
@@ -128,20 +125,9 @@
         ),
       )
     );
-    color: $pt-dark-icon-color;
-  }
-
-  .#{$ns}-breadcrumb.#{$ns}-disabled {
-    color: $pt-dark-text-color-disabled;
-  }
-
-  .#{$ns}-breadcrumb-current {
-    color: $pt-dark-text-color;
   }
 
   .#{$ns}-breadcrumbs-collapsed {
-    background: rgba($gray3, 0.2);
-
     &::before {
       background: svg-icon(
           "16px/more.svg",
@@ -152,11 +138,6 @@
           )
         )
         center no-repeat;
-    }
-
-    &:hover {
-      background: rgba($gray3, 0.3);
-      color: $pt-dark-text-color;
     }
   }
 }

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -83,7 +83,7 @@
 
 .#{$ns}-breadcrumbs-collapsed {
   /* stylelint-disable-next-line alpha-value-notation */
-  background: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+  background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
   border: none;
   border-radius: var(--bp-surface-border-radius);
   cursor: pointer;
@@ -109,7 +109,7 @@
 
   &:hover {
     /* stylelint-disable-next-line alpha-value-notation */
-    background: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
+    background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
     color: var(--bp-typography-color-default-rest);
     text-decoration: none;
   }

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -83,7 +83,7 @@
 
 .#{$ns}-breadcrumbs-collapsed {
   /* stylelint-disable-next-line alpha-value-notation */
-  background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+  background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.15)"};
   border: none;
   border-radius: var(--bp-surface-border-radius);
   cursor: pointer;
@@ -109,7 +109,7 @@
 
   &:hover {
     /* stylelint-disable-next-line alpha-value-notation */
-    background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
+    background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.3)"};
     color: var(--bp-typography-color-default-rest);
     text-decoration: none;
   }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Breadcrumbs component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |
| `--bp-typography-size-body-large` | `16px` | `(see diff)` |

#### `_breadcrumbs.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `height` | `$pt-input-height` | `calc(var(--bp-surface-spacing) * 7.5)` |
| `width:` | `$pt-icon-size-standard` | `calc(var(--bp-surface-spacing) * 4)` |
| `font-size` | `$pt-font-size-large` | `var(--bp-typography-size-body-large)` |
| `color` | `$pt-text-color-muted` | `var(--bp-typography-color-muted)` |
| `color` | `$pt-text-color-disabled` | `var(--bp-typography-color-default-disabled)` |
| `margin-right` | `$pt-spacing` | `var(--bp-surface-spacing)` |
| `border-radius` | `$pt-border-radius` | `var(--bp-surface-border-radius)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
