### PR TITLE
[core] Integrating design tokens into html table

### DIFF
--- a/packages/core/src/components/html-table/HTMLTable.stories.tsx
+++ b/packages/core/src/components/html-table/HTMLTable.stories.tsx
@@ -1,0 +1,195 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { HTMLTable } from "./htmlTable";
+
+const sampleRows = [
+    { name: "Blueprint", role: "UI Framework", location: "GitHub" },
+    { name: "TSX", role: "Type-safe JSX", location: "TypeScript" },
+    { name: "Sass", role: "CSS Preprocessor", location: "Node" },
+    { name: "Storybook", role: "Component Explorer", location: "Browser" },
+    { name: "React", role: "View Library", location: "npm" },
+];
+
+function renderTable(props: React.ComponentProps<typeof HTMLTable>) {
+    return (
+        <HTMLTable {...props}>
+            <thead>
+                <tr>
+                    <th>Project</th>
+                    <th>Role</th>
+                    <th>Location</th>
+                </tr>
+            </thead>
+            <tbody>
+                {sampleRows.map(row => (
+                    <tr key={row.name}>
+                        <td>{row.name}</td>
+                        <td>{row.role}</td>
+                        <td>{row.location}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </HTMLTable>
+    );
+}
+
+const meta: Meta<typeof HTMLTable> = {
+    title: "Core/HTMLTable/HTMLTable",
+    component: HTMLTable,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        bordered: false,
+        compact: false,
+        interactive: false,
+        striped: false,
+    },
+    argTypes: {
+        bordered: { control: "boolean" },
+        compact: { control: "boolean" },
+        interactive: { control: "boolean" },
+        striped: { control: "boolean" },
+    },
+} satisfies Meta<typeof HTMLTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => renderTable(args),
+};
+
+export const Bordered: Story = {
+    name: "Bordered",
+    argTypes: {
+        bordered: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                {renderTable({ ...args, bordered: false })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Bordered</div>
+                {renderTable({ ...args, bordered: true })}
+            </div>
+        </div>
+    ),
+};
+
+export const Compact: Story = {
+    name: "Compact",
+    argTypes: {
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                {renderTable({ ...args, compact: false })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Compact</div>
+                {renderTable({ ...args, compact: true })}
+            </div>
+        </div>
+    ),
+};
+
+export const Striped: Story = {
+    name: "Striped",
+    argTypes: {
+        striped: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                {renderTable({ ...args, striped: false })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Striped</div>
+                {renderTable({ ...args, striped: true })}
+            </div>
+        </div>
+    ),
+};
+
+export const Interactive: Story = {
+    name: "Interactive",
+    argTypes: {
+        interactive: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                {renderTable({ ...args, interactive: false })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Interactive (hover rows)</div>
+                {renderTable({ ...args, interactive: true })}
+            </div>
+        </div>
+    ),
+};
+
+export const AllCombinations: Story = {
+    name: "All Combinations",
+    argTypes: {
+        bordered: { table: { disable: true } },
+        compact: { table: { disable: true } },
+        interactive: { table: { disable: true } },
+        striped: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                {renderTable(args)}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Bordered + Striped</div>
+                {renderTable({ ...args, bordered: true, striped: true })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Bordered + Compact</div>
+                {renderTable({ ...args, bordered: true, compact: true })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Bordered + Striped + Interactive</div>
+                {renderTable({ ...args, bordered: true, striped: true, interactive: true })}
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>
+                    Bordered + Striped + Compact + Interactive
+                </div>
+                {renderTable({ ...args, bordered: true, striped: true, compact: true, interactive: true })}
+            </div>
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    args: {
+        bordered: true,
+        compact: false,
+        interactive: true,
+        striped: true,
+    },
+    render: args => renderTable(args),
+};

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -55,7 +55,7 @@ table.#{$ns}-html-table {
   &.#{$ns}-html-table-striped {
     tbody tr:nth-child(odd) td {
       /* stylelint-disable-next-line alpha-value-notation */
-      background: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+      background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
     }
   }
 
@@ -102,7 +102,7 @@ table.#{$ns}-html-table {
     tbody tr {
       &:hover td {
         /* stylelint-disable-next-line alpha-value-notation */
-        background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
+        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
         cursor: pointer;
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -112,7 +112,7 @@ table.#{$ns}-html-table {
 
       &:active td {
         /* stylelint-disable-next-line alpha-value-notation */
-        background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.35);
+        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.35)"};
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           background-color: highlight;

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -55,7 +55,7 @@ table.#{$ns}-html-table {
   &.#{$ns}-html-table-striped {
     tbody tr:nth-child(odd) td {
       /* stylelint-disable-next-line alpha-value-notation */
-      background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+      background: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.15)"};
     }
   }
 
@@ -102,7 +102,7 @@ table.#{$ns}-html-table {
     tbody tr {
       &:hover td {
         /* stylelint-disable-next-line alpha-value-notation */
-        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3)"};
+        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.3)"};
         cursor: pointer;
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -112,7 +112,7 @@ table.#{$ns}-html-table {
 
       &:active td {
         /* stylelint-disable-next-line alpha-value-notation */
-        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.35)"};
+        background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.24) calc(c - 0.011) h / 0.35)"};
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
           background-color: highlight;

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -12,7 +12,7 @@ $dark-table-border-color: $pt-dark-divider-white !default;
 // placeholder for extending inside running-text (see typography)
 %html-table {
   border-spacing: 0;
-  font-size: $pt-font-size;
+  font-size: var(--bp-typography-size-body-medium);
 
   th,
   td {
@@ -22,42 +22,21 @@ $dark-table-border-color: $pt-dark-divider-white !default;
   }
 
   th {
-    color: $pt-heading-color;
+    color: var(--bp-typography-color-default-rest);
     font-weight: 600;
   }
 
   td {
-    color: $pt-text-color;
+    color: var(--bp-typography-color-default-rest);
   }
 
   tbody tr:first-child,
   tfoot tr:first-child {
     th,
     td {
-      box-shadow: inset 0 $table-border-width 0 0 $table-border-color;
+      box-shadow: inset 0 $table-border-width 0 0 var(--bp-surface-border-color-default);
     }
   }
-
-  // a bunch of deep compound selectors ahead, but there's not really a better way to do this right now
-  /* stylelint-disable selector-max-compound-selectors */
-  .#{$ns}-dark & {
-    th {
-      color: $pt-dark-heading-color;
-    }
-
-    td {
-      color: $pt-dark-text-color;
-    }
-
-    tbody tr:first-child,
-    tfoot tr:first-child {
-      th,
-      td {
-        box-shadow: inset 0 $table-border-width 0 0 $dark-table-border-color;
-      }
-    }
-  }
-  /* stylelint-enable selector-max-compound-selectors */
 }
 
 table.#{$ns}-html-table {
@@ -75,35 +54,36 @@ table.#{$ns}-html-table {
 
   &.#{$ns}-html-table-striped {
     tbody tr:nth-child(odd) td {
-      background: rgba($gray3, 0.15);
+      /* stylelint-disable-next-line alpha-value-notation */
+      background: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
     }
   }
 
   // Borders are applied as box-shadows (at the top and left borders of a cell) for better color control.
   &.#{$ns}-html-table-bordered {
     th:not(:first-child) {
-      box-shadow: inset $table-border-width 0 0 0 $table-border-color;
+      box-shadow: inset $table-border-width 0 0 0 var(--bp-surface-border-color-default);
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        border-left: 1px solid $pt-high-contrast-mode-border-color;
+        border-left: 1px solid buttonborder;
       }
     }
 
     tbody tr td,
     tfoot tr td {
-      box-shadow: inset 0 $table-border-width 0 0 $table-border-color;
+      box-shadow: inset 0 $table-border-width 0 0 var(--bp-surface-border-color-default);
 
       &:not(:first-child) {
-        box-shadow: inset $table-border-width $table-border-width 0 0 $table-border-color;
+        box-shadow: inset $table-border-width $table-border-width 0 0 var(--bp-surface-border-color-default);
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
-          border-left: 1px solid $pt-high-contrast-mode-border-color;
-          border-top: 1px solid $pt-high-contrast-mode-border-color;
+          border-left: 1px solid buttonborder;
+          border-top: 1px solid buttonborder;
         }
       }
 
       @media (forced-colors: active) and (prefers-color-scheme: dark) {
-        border-top: 1px solid $pt-high-contrast-mode-border-color;
+        border-top: 1px solid buttonborder;
       }
     }
 
@@ -112,7 +92,7 @@ table.#{$ns}-html-table {
         box-shadow: none;
 
         &:not(:first-child) {
-          box-shadow: inset $table-border-width 0 0 0 $table-border-color;
+          box-shadow: inset $table-border-width 0 0 0 var(--bp-surface-border-color-default);
         }
       }
     }
@@ -121,72 +101,23 @@ table.#{$ns}-html-table {
   &.#{$ns}-interactive {
     tbody tr {
       &:hover td {
-        background-color: rgba($gray3, 0.3);
+        /* stylelint-disable-next-line alpha-value-notation */
+        background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.3);
         cursor: pointer;
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
-          background-color: $pt-high-contrast-mode-active-background-color;
+          background-color: highlight;
         }
       }
 
       &:active td {
-        background-color: rgba($gray3, 0.35);
+        /* stylelint-disable-next-line alpha-value-notation */
+        background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.35);
 
         @media (forced-colors: active) and (prefers-color-scheme: dark) {
-          background-color: $pt-high-contrast-mode-active-background-color;
+          background-color: highlight;
         }
       }
     }
-  }
-
-  .#{$ns}-dark & {
-    /* stylelint-disable selector-max-compound-selectors */
-    &.#{$ns}-html-table-striped {
-      tbody tr:nth-child(odd) td {
-        background: rgba($gray1, 0.15);
-      }
-    }
-
-    // Borders are applied as box-shadows (at the top and left borders of a cell) for better color control.
-    &.#{$ns}-html-table-bordered {
-      th:not(:first-child) {
-        box-shadow: inset $table-border-width 0 0 0 $dark-table-border-color;
-      }
-
-      tbody tr td,
-      tfoot tr td {
-        box-shadow: inset 0 $table-border-width 0 0 $dark-table-border-color;
-
-        &:not(:first-child) {
-          box-shadow: inset $table-border-width $table-border-width 0 0 $dark-table-border-color;
-        }
-      }
-
-      &.#{$ns}-html-table-striped {
-        tbody tr:not(:first-child) td {
-          box-shadow: inset $table-border-width 0 0 0 $dark-table-border-color;
-
-          // easier than the alternative...
-          /* stylelint-disable max-nesting-depth */
-          &:first-child {
-            box-shadow: none;
-          }
-        }
-      }
-    }
-
-    &.#{$ns}-interactive {
-      tbody tr {
-        &:hover td {
-          background-color: rgba($gray1, 0.3);
-          cursor: pointer;
-        }
-
-        &:active td {
-          background-color: rgba($gray1, 0.4);
-        }
-      }
-    }
-    /* stylelint-enable selector-max-compound-selectors */
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the HTML Table component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-intent-default-rest` | `#5f6b7c` | `$gray1` |
| `--bp-surface-border-color-default` | `#5f6b7c1f` | `$pt-divider-black` |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-text-color / $pt-dark-text-color` |
| `--bp-typography-size-body-medium` | `14px` | `$pt-font-size` |

#### `_html-table.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `font-size` | `$pt-font-size` | `var(--bp-typography-size-body-medium)` |
| `color` | `$pt-heading-color` | `var(--bp-typography-color-default-rest)` |
| `color` | `$pt-text-color` | `var(--bp-typography-color-default-rest)` |
| `box-shadow` | `inset 0 $table-border-width 0 0 $table-border-color` | `inset 0 $table-border-width 0 0 var(--bp-surface-border-color-default)` |
| `box-shadow` | `inset $table-border-width 0 0 0 $table-border-color` | `inset $table-border-width 0 0 0 var(--bp-surface-border-color-default)` |
| `border-left` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `box-shadow` | `inset 0 $table-border-width 0 0 $table-border-color` | `inset 0 $table-border-width 0 0 var(--bp-surface-border-color-default)` |
| `border-top` | `1px solid $pt-high-contrast-mode-border-color` | `1px solid buttonborder` |
| `box-shadow` | `inset $table-border-width 0 0 0 $table-border-color` | `inset $table-border-width 0 0 0 var(--bp-surface-border-color-default)` |
| `background-color` | `$pt-high-contrast-mode-active-background-color` | `highlight` |
| `background-color` | `$pt-high-contrast-mode-active-background-color` | `highlight` |

**Differences:**
1. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.
2. **`rgba()` → `oklch()` for transparency.** Same alpha percentages but different color space interpolation; may produce very subtle visual differences.
3. **High contrast uses native CSS system colors.** `buttonborder` replaces SCSS variable.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |
| 2 | Transparency color space | `oklch()` instead of `rgba()` — different color space |
| 3 | High contrast | Native CSS system color instead of SCSS variable |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- oklch vs rgba differences in semi-transparent areas
- Dark theme appearance after removing redundant `.bp6-dark` blocks
