### PR TITLE
[core] Integrating design tokens into segmented control

### DIFF
--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -1,0 +1,247 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent, Size } from "../../common";
+
+import { SegmentedControl } from "./segmentedControl";
+
+const DEFAULT_OPTIONS = [
+    { label: "List", value: "list" },
+    { label: "Grid", value: "grid" },
+    { label: "Gallery", value: "gallery" },
+];
+
+const ICON_OPTIONS = [
+    { label: "List", value: "list", icon: "list" as const },
+    { label: "Grid", value: "grid", icon: "grid-view" as const },
+    { label: "Gallery", value: "gallery", icon: "media" as const },
+];
+
+// These props are deprecated on SegmentedControl — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof SegmentedControl>
+>;
+
+const meta: Meta<typeof SegmentedControl> = {
+    title: "Core/Components/SegmentedControl",
+    component: SegmentedControl,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        options: DEFAULT_OPTIONS,
+        defaultValue: "list",
+        intent: "none",
+        size: "medium",
+        disabled: false,
+        fill: false,
+        inline: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: [Intent.NONE, Intent.PRIMARY],
+        },
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        disabled: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        inline: {
+            control: "boolean",
+        },
+        onValueChange: { action: "valueChanged" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof SegmentedControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic segmented control with default styling.
+ */
+export const Default: Story = {};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the selected segment.
+ * SegmentedControl supports `"none"` (default) and `"primary"`.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>None</span>
+                <SegmentedControl {...args} intent={Intent.NONE} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Primary</span>
+                <SegmentedControl {...args} intent={Intent.PRIMARY} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the control dimensions.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+            {Object.values(Size).map(size => (
+                <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                    <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{size}</span>
+                    <SegmentedControl {...args} size={size} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * The disabled state prevents user interaction with the control.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <SegmentedControl {...args} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                <SegmentedControl {...args} disabled={true} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Options can include icons alongside labels.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    render: args => (
+        <SegmentedControl {...args} options={ICON_OPTIONS} />
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the control expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Fill</span>
+                <SegmentedControl {...args} fill={true} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Auto Width</span>
+                <SegmentedControl {...args} fill={false} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * All intents across all sizes and states.
+ */
+export const AllIntentsAllSizes: Story = {
+    name: "All Intents & Sizes",
+    argTypes: {
+        intent: { table: { disable: true } },
+        size: { table: { disable: true } },
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {[Intent.NONE, Intent.PRIMARY].map(intent => (
+                <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <div style={{ fontSize: 12, opacity: 0.6 }}>
+                        Intent: {intent === Intent.NONE ? "none" : "primary"}
+                    </div>
+                    {Object.values(Size).map(size => (
+                        <SegmentedControl key={size} {...args} intent={intent} size={size} />
+                    ))}
+                    <SegmentedControl {...args} intent={intent} disabled={true} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground demonstrating controlled value state.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [value, setValue] = useState("list");
+
+        const handleValueChange = useCallback((newValue: string) => {
+            setValue(newValue);
+        }, []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+                <SegmentedControl
+                    {...args}
+                    options={ICON_OPTIONS}
+                    value={value}
+                    onValueChange={handleValueChange}
+                />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Selected: {value}</span>
+            </div>
+        );
+    },
+};

--- a/packages/core/src/components/segmented-control/_segmented-control.scss
+++ b/packages/core/src/components/segmented-control/_segmented-control.scss
@@ -2,11 +2,11 @@
 @import "../../common/variables";
 
 .#{$ns}-segmented-control {
-  background-color: $light-gray5;
-  border-radius: $pt-border-radius;
+  background-color: var(--bp-surface-background-color-default-rest);
+  border-radius: var(--bp-surface-border-radius);
   display: flex;
-  gap: $pt-spacing * 0.5;
-  padding: $pt-spacing * 0.5;
+  gap: calc(var(--bp-surface-spacing) * 0.5);
+  padding: calc(var(--bp-surface-spacing) * 0.5);
 
   &.#{$ns}-inline {
     display: inline-flex;
@@ -22,31 +22,19 @@
 
   > .#{$ns}-button:not(.#{$ns}-minimal) {
     &:not(.#{$ns}-intent-primary) {
-      background-color: $white;
+      background-color: var(--bp-palette-white);
 
       .#{$ns}-dark & {
-        background-color: $dark-gray5;
+        background-color: var(--bp-palette-dark-gray-5);
       }
     }
   }
 
   > .#{$ns}-button.#{$ns}-minimal {
-    color: $pt-text-color-muted;
-
-    .#{$ns}-dark & {
-      color: $pt-dark-text-color-muted;
-    }
+    color: var(--bp-typography-color-muted);
   }
 
   > .#{$ns}-button.#{$ns}-minimal:disabled {
-    color: $pt-text-color-disabled;
-
-    .#{$ns}-dark & {
-      color: $pt-dark-text-color-disabled;
-    }
-  }
-
-  .#{$ns}-dark & {
-    background-color: $dark-gray2;
+    color: var(--bp-typography-color-default-disabled);
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Segmented Control component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-palette-dark-gray-5` | `#404854` | `(see diff)` |
| `--bp-palette-white` | `#ffffff` | `$white` |
| `--bp-surface-background-color-default-rest` | `#ffffff` | `(see diff)` |
| `--bp-surface-border-radius` | `4px` | `$pt-border-radius` |
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-default-disabled` | `#8f99a8` | `(see diff)` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_segmented-control.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `background-color` | `$white` | `var(--bp-palette-white)` |
| `background-color` | `$dark-gray5` | `var(--bp-palette-dark-gray-5)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- Dark theme appearance after removing redundant `.bp6-dark` blocks
