### PR TITLE
[core] Integrating design tokens into non-ideal state

### DIFF
--- a/packages/core/src/components/non-ideal-state/NonIdealState.stories.tsx
+++ b/packages/core/src/components/non-ideal-state/NonIdealState.stories.tsx
@@ -1,0 +1,170 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../button/buttons";
+import { NonIdealState, NonIdealStateIconSize } from "./nonIdealState";
+
+const meta: Meta<typeof NonIdealState> = {
+    title: "Core/NonIdealState/NonIdealState",
+    component: NonIdealState,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    justifyContent: "center",
+                    alignItems: "center",
+                    minWidth: "400px",
+                    minHeight: "300px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        icon: "search",
+        title: "No search results",
+        description: "Try a different search query or check your filters.",
+        layout: "vertical",
+        iconMuted: true,
+        iconSize: NonIdealStateIconSize.STANDARD,
+    },
+    argTypes: {
+        icon: {
+            control: "text",
+        },
+        iconSize: {
+            control: "select",
+            options: Object.values(NonIdealStateIconSize).filter(v => typeof v === "number"),
+        },
+        iconMuted: {
+            control: "boolean",
+        },
+        layout: {
+            control: "select",
+            options: ["vertical", "horizontal"],
+        },
+    },
+} satisfies Meta<typeof NonIdealState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic NonIdealState with an icon, title, and description.
+ */
+export const Default: Story = {};
+
+/**
+ * NonIdealState with an action button.
+ */
+export const WithAction: Story = {
+    name: "With Action",
+    args: {
+        icon: "folder-open",
+        title: "This folder is empty",
+        description: "Create a new file to get started.",
+        action: <Button icon="plus" text="Create new file" intent="primary" />,
+    },
+};
+
+/**
+ * Icon size options available for the visual element.
+ */
+export const IconSizes: Story = {
+    name: "Icon Size",
+    argTypes: {
+        iconSize: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 40, alignItems: "flex-start" }}>
+            {(
+                [
+                    { size: NonIdealStateIconSize.EXTRA_SMALL, label: "Extra Small" },
+                    { size: NonIdealStateIconSize.SMALL, label: "Small" },
+                    { size: NonIdealStateIconSize.STANDARD, label: "Standard" },
+                ] as const
+            ).map(({ size, label }) => (
+                <div key={label} style={{ textAlign: "center" }}>
+                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>{label}</div>
+                    <NonIdealState {...args} iconSize={size} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Horizontal vs vertical layout.
+ */
+export const Layout: Story = {
+    argTypes: {
+        layout: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 40, width: "100%" }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Vertical (default)</div>
+                <NonIdealState {...args} layout="vertical" />
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Horizontal</div>
+                <NonIdealState {...args} layout="horizontal" />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Muted vs non-muted icon styling.
+ */
+export const IconMuted: Story = {
+    name: "Icon Muted",
+    argTypes: {
+        iconMuted: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 40, alignItems: "flex-start" }}>
+            <div style={{ textAlign: "center" }}>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Muted (default)</div>
+                <NonIdealState {...args} iconMuted={true} />
+            </div>
+            <div style={{ textAlign: "center" }}>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Not muted</div>
+                <NonIdealState {...args} iconMuted={false} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * NonIdealState with only a title and no icon.
+ */
+export const TitleOnly: Story = {
+    name: "Title Only",
+    args: {
+        icon: undefined,
+        title: "Nothing here yet",
+        description: undefined,
+    },
+};
+
+/**
+ * Interactive playground for experimenting with NonIdealState props.
+ */
+export const Playground: Story = {
+    args: {
+        icon: "search",
+        title: "No search results",
+        description: "Your search didn't match any files. Try searching for something else.",
+        action: <Button icon="refresh" text="Clear search" intent="primary" />,
+    },
+};

--- a/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
+++ b/packages/core/src/components/non-ideal-state/_non-ideal-state.scss
@@ -5,22 +5,22 @@
 @import "../../common/mixins";
 
 .#{$ns}-non-ideal-state {
-  @include pt-flex-container(column, $pt-spacing * 5);
+  @include pt-flex-container(column, calc(var(--bp-surface-spacing) * 5));
   align-items: center;
-  color: $pt-text-color-muted;
+  color: var(--bp-typography-color-muted);
   height: 100%;
   justify-content: center;
   text-align: center;
   width: 100%;
 
   > * {
-    max-width: $pt-spacing * 100;
+    max-width: calc(var(--bp-surface-spacing) * 100);
   }
 
   .#{$ns}-heading {
-    color: $pt-text-color-muted;
-    line-height: $pt-spacing * 5;
-    margin-bottom: $pt-spacing * 2;
+    color: var(--bp-typography-color-muted);
+    line-height: calc(var(--bp-surface-spacing) * 5);
+    margin-bottom: calc(var(--bp-surface-spacing) * 2);
 
     &:only-child {
       margin-bottom: 0;
@@ -28,7 +28,7 @@
   }
 
   &.#{$ns}-non-ideal-state-horizontal {
-    @include pt-flex-container(row, $pt-spacing * 5);
+    @include pt-flex-container(row, calc(var(--bp-surface-spacing) * 5));
     text-align: left;
 
     // We need to override the pt-flex-container() styles on the default vertical layout of this
@@ -38,16 +38,8 @@
       margin-bottom: 0;
     }
   }
-
-  .#{$ns}-dark & {
-    color: $pt-dark-text-color-muted;
-
-    .#{$ns}-heading {
-      color: $pt-dark-text-color-muted;
-    }
-  }
 }
 
 .#{$ns}-non-ideal-state-visual {
-  color: $gray3;
+  color: var(--bp-typography-color-muted);
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Non-Ideal State component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-surface-spacing` | `4px` | `$pt-spacing (4px)` |
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-text-color-muted / $pt-dark-text-color-muted` |

#### `_non-ideal-state.scss`

| Property | Develop | Current |
|----------|---------|---------|
| `color` | `$pt-text-color-muted` | `var(--bp-typography-color-muted)` |
| `max-width` | `$pt-spacing * 100` | `calc(var(--bp-surface-spacing) * 100)` |
| `margi` | `$pt-spacing * 2` | `var(--bp-typography-color-muted)` |
| `color` | `$gray3` | `var(--bp-typography-color-muted)` |

**Differences:**
1. **Spacing is now inline.** Local SCSS variables replaced with `calc(var(--bp-surface-spacing) * N)` expressions.
2. **Redundant dark theme blocks removed.** Typography/intent tokens auto-resolve in `.bp6-dark` contexts.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Spacing inlined | Local SCSS vars replaced with `calc()` expressions |
| 2 | Dark theme consolidation | Tokens auto-resolve, separate `.bp6-dark` blocks removed |

#### Reviewers should focus on:

- Visual parity in all intents and themes
- Dark theme appearance after removing redundant `.bp6-dark` blocks
