### PR TITLE
[core] Fix PopoverNext outside-click detection for nested overlays

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -9,7 +9,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/tes
 
 import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
-import { Button, PopupKind, Tooltip } from "../../components";
+import { Button, Dialog, DialogBody, PopupKind, Tooltip } from "../../components";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
 
 import { PopoverNext } from "./popoverNext";
@@ -871,6 +871,34 @@ describe("<PopoverNext>", () => {
 
                 expect(onInteraction).toHaveBeenCalledOnce();
                 expect(onInteraction).toHaveBeenCalledWith(false, expect.anything());
+            });
+
+            it("is not invoked when clicking inside a child Dialog rendered in popover content", async () => {
+                const user = userEvent.setup();
+                const onInteraction = vi.fn();
+                render(
+                    <PopoverNext
+                        content={
+                            <Dialog isOpen={true} title="Child dialog" usePortal={true}>
+                                <DialogBody>
+                                    <Button text="dialog button" />
+                                </DialogBody>
+                            </Dialog>
+                        }
+                        isOpen={true}
+                        onInteraction={onInteraction}
+                    >
+                        <Button text="target" />
+                    </PopoverNext>,
+                );
+
+                await waitFor(() => expect(screen.getByRole("button", { name: "dialog button" })).toBeInTheDocument());
+
+                onInteraction.mockClear();
+
+                await user.click(screen.getByRole("button", { name: "dialog button" }));
+
+                expect(onInteraction).not.toHaveBeenCalledWith(false, expect.anything());
             });
         });
 

--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -115,7 +115,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
             backdropClassName={Classes.POPOVER_BACKDROP}
             backdropProps={backdropProps}
             canEscapeKeyClose={canEscapeKeyClose}
-            canOutsideClickClose={interactionKind === PopoverInteractionKind.CLICK && hasBackdrop}
+            canOutsideClickClose={interactionKind === PopoverInteractionKind.CLICK}
             childRef={transitionContainerElement}
             enforceFocus={enforceFocus}
             hasBackdrop={hasBackdrop}

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -106,11 +106,12 @@ export function usePopover({
     });
     const dismiss = useDismiss(context, {
         escapeKey: canEscapeKeyClose,
-        // For CLICK interactions, delegate outside-click detection to Overlay2's stack-aware
-        // handler (getThisOverlayAndDescendants) so that clicks inside child overlays like
-        // Dialog don't incorrectly close the popover. Floating UI's useDismiss is not aware
-        // of Blueprint's overlay stack and treats clicks in portaled child overlays as
-        // "outside" clicks.
+        // Disable Floating UI outside-press in two cases:
+        // 1. CLICK interactions: delegate to Overlay2's stack-aware handler
+        //    (getThisOverlayAndDescendants) so clicks inside child overlays like Dialog
+        //    don't incorrectly close the popover. useDismiss is not overlay-stack-aware
+        //    and treats clicks in portaled child overlays as "outside" clicks.
+        // 2. hasBackdrop: Overlay2 handles backdrop clicks and outside-click detection.
         outsidePress:
             interactionKind !== PopoverInteractionKind.CLICK_TARGET_ONLY &&
             interactionKind !== PopoverInteractionKind.CLICK &&

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -106,8 +106,15 @@ export function usePopover({
     });
     const dismiss = useDismiss(context, {
         escapeKey: canEscapeKeyClose,
-        // Disable outside press when hasBackdrop=true since Overlay2 handles backdrop clicks
-        outsidePress: interactionKind !== PopoverInteractionKind.CLICK_TARGET_ONLY && !hasBackdrop,
+        // For CLICK interactions, delegate outside-click detection to Overlay2's stack-aware
+        // handler (getThisOverlayAndDescendants) so that clicks inside child overlays like
+        // Dialog don't incorrectly close the popover. Floating UI's useDismiss is not aware
+        // of Blueprint's overlay stack and treats clicks in portaled child overlays as
+        // "outside" clicks.
+        outsidePress:
+            interactionKind !== PopoverInteractionKind.CLICK_TARGET_ONLY &&
+            interactionKind !== PopoverInteractionKind.CLICK &&
+            !hasBackdrop,
     });
 
     const interactions = useInteractions([click, dismiss]);


### PR DESCRIPTION
## Problem

If you render a `Dialog` (or any portaled overlay) inside `PopoverNext`'s content, clicking anywhere in the dialog closes the popover. The popover should stay open while interacting with a child overlay.

This is because `PopoverNext` uses Floating UI's `useDismiss` for outside-click detection on CLICK-interaction popovers. `useDismiss` doesn't know about Blueprint's overlay stack, so when a `Dialog` portals its content to `document.body`, those clicks look like "outside" clicks to Floating UI.

The old `Popover` didn't have this problem. It used `Overlay2` with `canOutsideClickClose={true}` for CLICK interactions, and `Overlay2`'s `handleDocumentMousedown` calls `getThisOverlayAndDescendants()` to check if the click landed in a child overlay before closing.

## Fix

Two changes:

- `usePopover.ts`: Disable `useDismiss`'s `outsidePress` for CLICK interactions
- `popoverPopup.tsx`: Set `canOutsideClickClose={interactionKind === PopoverInteractionKind.CLICK}` (matching old `Popover`)

This hands outside-click detection back to `Overlay2` for the CLICK case, where the overlay stack handles nested overlays correctly. HOVER interactions are unaffected (still use Floating UI).

## Demo

**Minimal repro:** a `PopoverNext` with a `Dialog` inside its content

```tsx
const [isPopoverOpen, setIsPopoverOpen] = useState(false);
const [isDialogOpen, setIsDialogOpen] = useState(false);

<PopoverNext
    isOpen={isPopoverOpen}
    onInteraction={setIsPopoverOpen}
    placement="right"
    content={
        <div style={{ padding: 10 }}>
            <Menu>
                <MenuItem icon="document" text="New file" />
                <MenuItem icon="folder-new" text="New folder" />
            </Menu>
            <Button icon="info-sign" text="Open dialog" onClick={() => setIsDialogOpen(true)} />
            <Dialog isOpen={isDialogOpen} onClose={() => setIsDialogOpen(false)} title="Dialog inside PopoverNext">
                <DialogBody>Clicking here should not close the PopoverNext.</DialogBody>
            </Dialog>
        </div>
    }
>
    <Button text="Open popover" icon="menu" />
</PopoverNext>;
```

### Before

https://github.com/user-attachments/assets/1a2e17a9-d1d2-47a9-b439-3cc5ca244871

### After

https://github.com/user-attachments/assets/07114f25-9001-4a45-a283-3dd0dc64ac3f