### PR TITLE
[core] Integrating design tokens into hotkeys

### DIFF
--- a/packages/core/src/components/hotkeys/Hotkeys.stories.tsx
+++ b/packages/core/src/components/hotkeys/Hotkeys.stories.tsx
@@ -1,0 +1,204 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import type { HotkeyConfig } from "../../hooks";
+
+import { Hotkey } from "./hotkey";
+import { Hotkeys } from "./hotkeys";
+import { HotkeysDialog } from "./hotkeysDialog";
+import { KeyComboTag } from "./keyComboTag";
+
+const SAMPLE_HOTKEYS: HotkeyConfig[] = [
+    { combo: "cmd + s", label: "Save", global: true },
+    { combo: "cmd + shift + s", label: "Save as...", global: true },
+    { combo: "cmd + z", label: "Undo", global: true },
+    { combo: "cmd + shift + z", label: "Redo", global: true },
+    { combo: "cmd + c", label: "Copy", group: "Editing" },
+    { combo: "cmd + v", label: "Paste", group: "Editing" },
+    { combo: "cmd + x", label: "Cut", group: "Editing" },
+    { combo: "cmd + f", label: "Find", group: "Navigation" },
+    { combo: "cmd + p", label: "Quick open", group: "Navigation" },
+];
+
+const meta: Meta<typeof KeyComboTag> = {
+    title: "Core/Hotkeys",
+    component: KeyComboTag,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        combo: "cmd + s",
+        minimal: false,
+    },
+    argTypes: {
+        combo: {
+            control: "text",
+        },
+        minimal: {
+            control: "boolean",
+        },
+    },
+} satisfies Meta<typeof KeyComboTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic KeyComboTag rendering a key combination.
+ */
+export const Default: Story = {
+    args: {
+        combo: "cmd + s",
+    },
+};
+
+/**
+ * KeyComboTag supports a `minimal` rendering mode where keys are shown without wrapper `<kbd>` styles.
+ */
+export const MinimalExample: Story = {
+    name: "Minimal",
+    argTypes: {
+        minimal: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "center" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <KeyComboTag {...args} minimal={false} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <KeyComboTag {...args} minimal={true} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Various key combinations demonstrating different modifier keys and special keys.
+ */
+export const KeyCombinations: Story = {
+    name: "Key Combinations",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+            <KeyComboTag {...args} combo="cmd + s" />
+            <KeyComboTag {...args} combo="ctrl + shift + k" />
+            <KeyComboTag {...args} combo="alt + enter" />
+            <KeyComboTag {...args} combo="shift + delete" />
+            <KeyComboTag {...args} combo="mod + z" />
+            <KeyComboTag {...args} combo="up" />
+            <KeyComboTag {...args} combo="shift + ?" />
+        </div>
+    ),
+};
+
+/**
+ * Arrow key combinations shown in both default and minimal styles.
+ */
+export const ArrowKeys: Story = {
+    name: "Arrow Keys",
+    render: args => (
+        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <div style={{ display: "flex", gap: 8 }}>
+                    <KeyComboTag {...args} combo="up" minimal={false} />
+                    <KeyComboTag {...args} combo="down" minimal={false} />
+                    <KeyComboTag {...args} combo="left" minimal={false} />
+                    <KeyComboTag {...args} combo="right" minimal={false} />
+                </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <div style={{ display: "flex", gap: 8 }}>
+                    <KeyComboTag {...args} combo="up" minimal={true} />
+                    <KeyComboTag {...args} combo="down" minimal={true} />
+                    <KeyComboTag {...args} combo="left" minimal={true} />
+                    <KeyComboTag {...args} combo="right" minimal={true} />
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * A single Hotkey component displaying a label alongside its key combination.
+ */
+export const SingleHotkey: Story = {
+    name: "Single Hotkey",
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: "300px" }}>
+            <Hotkey combo="cmd + s" label="Save" global={true} group="Global" />
+            <Hotkey combo="cmd + shift + f" label="Find in files" global={true} group="Global" />
+            <Hotkey combo="ctrl + shift + k" label="Delete line" global={false} group="Editing" />
+        </div>
+    ),
+};
+
+/**
+ * The Hotkeys component renders a grouped and sorted list of hotkey definitions.
+ */
+export const GroupedHotkeys: Story = {
+    name: "Grouped Hotkeys",
+    render: () => (
+        <div style={{ minWidth: "400px" }}>
+            <Hotkeys>
+                <Hotkey combo="cmd + s" label="Save" global={true} group="Global" />
+                <Hotkey combo="cmd + z" label="Undo" global={true} group="Global" />
+                <Hotkey combo="cmd + c" label="Copy" global={false} group="Editing" />
+                <Hotkey combo="cmd + v" label="Paste" global={false} group="Editing" />
+                <Hotkey combo="cmd + f" label="Find" global={false} group="Navigation" />
+                <Hotkey combo="cmd + p" label="Quick open" global={false} group="Navigation" />
+            </Hotkeys>
+        </div>
+    ),
+};
+
+/**
+ * HotkeysDialog displays hotkey definitions inside a dialog, grouped by category.
+ * Click "Open dialog" to toggle the dialog.
+ */
+export const DialogExample: Story = {
+    name: "Hotkeys Dialog",
+    render: function Render() {
+        const [isOpen, setIsOpen] = useState(true);
+        return (
+            <div>
+                <button type="button" onClick={() => setIsOpen(true)}>
+                    Open dialog
+                </button>
+                <HotkeysDialog
+                    isOpen={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    hotkeys={SAMPLE_HOTKEYS}
+                    globalGroupName="Global"
+                />
+            </div>
+        );
+    },
+};
+
+/**
+ * Interactive playground for KeyComboTag with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        return <KeyComboTag combo={args.combo} minimal={args.minimal} />;
+    },
+    args: {
+        combo: "cmd + shift + p",
+        minimal: false,
+    },
+};

--- a/packages/core/src/components/hotkeys/_hotkeys.scss
+++ b/packages/core/src/components/hotkeys/_hotkeys.scss
@@ -7,7 +7,7 @@
   align-items: center;
 
   &:not(.#{$ns}-minimal) {
-    @include pt-flex-container(row, $pt-spacing);
+    @include pt-flex-container(row, var(--bp-surface-spacing));
   }
 
   &.#{$ns}-minimal {
@@ -17,7 +17,7 @@
 
 .#{$ns}-hotkey-dialog {
   padding-bottom: 0;
-  top: $pt-spacing * 10;
+  top: calc(var(--bp-surface-spacing) * 10);
 
   .#{$ns}-dialog-body {
     margin: 0;
@@ -31,13 +31,13 @@
 
 .#{$ns}-hotkey-column {
   margin: auto;
-  padding: $pt-spacing * 7.5;
+  padding: calc(var(--bp-surface-spacing) * 7.5);
 
   .#{$ns}-heading {
-    margin-bottom: $pt-spacing * 5;
+    margin-bottom: calc(var(--bp-surface-spacing) * 5);
 
     &:not(:first-child) {
-      margin-top: $pt-spacing * 10;
+      margin-top: calc(var(--bp-surface-spacing) * 10);
     }
   }
 }
@@ -50,6 +50,6 @@
   margin-right: 0;
 
   &:not(:last-child) {
-    margin-bottom: $pt-spacing * 2;
+    margin-bottom: calc(var(--bp-surface-spacing) * 2);
   }
 }

--- a/packages/core/src/components/html-select/HTMLSelect.stories.tsx
+++ b/packages/core/src/components/html-select/HTMLSelect.stories.tsx
@@ -1,0 +1,164 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { HTMLSelectIconName } from "./htmlSelect";
+import { HTMLSelect } from "./htmlSelect";
+
+const SAMPLE_OPTIONS = [
+    { label: "Option 1", value: "1" },
+    { label: "Option 2", value: "2" },
+    { label: "Option 3", value: "3" },
+    { label: "Option 4", value: "4" },
+    { label: "Option 5", value: "5" },
+];
+
+const meta: Meta<typeof HTMLSelect> = {
+    title: "Core/HTMLSelect",
+    component: HTMLSelect,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        options: SAMPLE_OPTIONS,
+        fill: false,
+        large: false,
+        minimal: false,
+        disabled: false,
+        iconName: "double-caret-vertical",
+    },
+    argTypes: {
+        fill: {
+            control: "boolean",
+        },
+        large: {
+            control: "boolean",
+        },
+        minimal: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        iconName: {
+            control: "select",
+            options: ["double-caret-vertical", "caret-down"] satisfies HTMLSelectIconName[],
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof HTMLSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic HTML select with default styling.
+ */
+export const Default: Story = {};
+
+/**
+ * Use the `fill` prop to make the select expand to the full width of its container.
+ */
+export const Fill: Story = {
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <HTMLSelect {...args} fill={true} />
+            <HTMLSelect {...args} fill={false} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `disabled` prop to make the select non-interactive.
+ */
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+    },
+};
+
+/**
+ * Use the `large` prop to render a larger select element.
+ */
+export const Sizes: Story = {
+    argTypes: {
+        large: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <HTMLSelect {...args} large={false} />
+            <HTMLSelect {...args} large={true} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `iconName` prop to change the icon displayed on the right side of the select.
+ */
+export const WithIcon: Story = {
+    argTypes: {
+        iconName: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <HTMLSelect {...args} iconName="double-caret-vertical" />
+            <HTMLSelect {...args} iconName="caret-down" />
+        </div>
+    ),
+};
+
+/**
+ * All size and style combinations displayed together.
+ */
+export const AllSizes: Story = {
+    argTypes: {
+        large: { table: { disable: true } },
+        minimal: { table: { disable: true } },
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Default</div>
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <HTMLSelect {...args} large={false} />
+                    <HTMLSelect {...args} large={true} />
+                </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Minimal</div>
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <HTMLSelect {...args} minimal={true} large={false} />
+                    <HTMLSelect {...args} minimal={true} large={true} />
+                </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Disabled</div>
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <HTMLSelect {...args} disabled={true} large={false} />
+                    <HTMLSelect {...args} disabled={true} large={true} />
+                </div>
+            </div>
+        </div>
+    ),
+};

--- a/packages/core/src/components/html-select/_common.scss
+++ b/packages/core/src/components/html-select/_common.scss
@@ -10,7 +10,7 @@
   /* stylelint-disable property-no-vendor-prefix */
   -moz-appearance: none;
   -webkit-appearance: none;
-  border-radius: $pt-border-radius;
+  border-radius: var(--bp-surface-border-radius);
   height: $pt-button-height;
   padding: 0 ($input-padding-horizontal * 3) 0 $input-padding-horizontal;
   // fill parent container
@@ -23,7 +23,7 @@
 }
 
 %pt-select-large {
-  font-size: $pt-font-size-large;
+  font-size: var(--bp-typography-size-body-large);
   height: $pt-button-height-large;
   padding-right: $input-padding-horizontal * 3.5;
 }
@@ -40,15 +40,15 @@
 }
 
 %pt-select-icon {
-  color: $pt-icon-color;
+  color: var(--bp-typography-color-muted);
   pointer-events: none;
   position: absolute;
   // N.B. it's more important for the icon to vertically align with button end icons rather than
   // input right padding, see https://github.com/palantir/blueprint/issues/6184
-  right: $pt-spacing * 2;
+  right: calc(var(--bp-surface-spacing) * 2);
   top: ($pt-button-height - $pt-icon-size-standard) * 0.5;
 
   &.#{$ns}-disabled {
-    color: $pt-icon-color-disabled;
+    color: var(--bp-typography-color-default-disabled);
   }
 }

--- a/packages/core/src/components/html-select/_html-select.scss
+++ b/packages/core/src/components/html-select/_html-select.scss
@@ -36,7 +36,7 @@
 
     &::after, // CSS support
     .#{$ns}-icon {
-      right: $pt-spacing * 3;
+      right: calc(var(--bp-surface-spacing) * 3);
       top: ($pt-button-height-large - $pt-icon-size-standard) * 0.5;
     }
   }
@@ -55,15 +55,15 @@
 
     option {
       background-color: $pt-dark-popover-background-color;
-      color: $pt-dark-text-color;
+      color: var(--bp-typography-color-default-rest);
     }
 
     option:disabled {
-      color: $pt-dark-text-color-disabled;
+      color: var(--bp-typography-color-default-disabled);
     }
 
     &::after {
-      color: $pt-dark-icon-color;
+      color: var(--bp-typography-color-muted);
     }
   }
 }

--- a/packages/core/src/components/icon/Icon.stories.tsx
+++ b/packages/core/src/components/icon/Icon.stories.tsx
@@ -1,0 +1,132 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Icon, IconSize } from "./icon";
+
+const meta: Meta<typeof Icon> = {
+    title: "Core/Icon",
+    component: Icon,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        icon: "home",
+        size: IconSize.STANDARD,
+        intent: "none",
+        color: undefined,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "select",
+            options: [IconSize.STANDARD, IconSize.LARGE],
+        },
+        icon: {
+            control: "text",
+        },
+        color: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic icon with default styling.
+ */
+export const Default: Story = {
+    args: {
+        icon: "home",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the icon.
+ */
+export const WithIntent: Story = {
+    name: "With Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Icon key={intent} {...args} intent={intent} />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the icon dimensions. Icon supports `STANDARD` (16px) and `LARGE` (20px).
+ */
+export const Sizes: Story = {
+    name: "Sizes",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Icon {...args} size={IconSize.STANDARD} />
+            <Icon {...args} size={IconSize.LARGE} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `color` prop to apply a custom color to the icon.
+ */
+export const CustomColor: Story = {
+    name: "Custom Color",
+    argTypes: {
+        color: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            <Icon {...args} color="#D63384" />
+            <Icon {...args} color="#0D6EFD" />
+            <Icon {...args} color="#198754" />
+            <Icon {...args} color="#FFC107" />
+        </div>
+    ),
+};
+
+/**
+ * All intents displayed together for visual comparison.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            {Object.values(Intent).map(intent => (
+                <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                    <Icon {...args} intent={intent} />
+                    <span style={{ fontSize: 10, opacity: 0.6 }}>{intent === "none" ? "none" : intent}</span>
+                </div>
+            ))}
+        </div>
+    ),
+};


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Hotkeys component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |

#### Hotkeys (`_hotkeys.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Key combo gap | `$pt-spacing` | `var(--bp-surface-spacing)` |
| Dialog top | `$pt-spacing * 10` | `calc(var(--bp-surface-spacing) * 10)` |
| Column padding | `$pt-spacing * 7.5` | `calc(var(--bp-surface-spacing) * 7.5)` |
| Heading margin-bottom | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| Heading margin-top | `$pt-spacing * 10` | `calc(var(--bp-surface-spacing) * 10)` |
| Hotkey margin-bottom | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |

No visual differences — all changes are 1:1 spacing token swaps.
