### PR TITLE
[core] Integrating design tokens into alert

### DIFF
--- a/packages/core/src/components/alert/Alert.stories.tsx
+++ b/packages/core/src/components/alert/Alert.stories.tsx
@@ -1,0 +1,213 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent } from "../../common";
+
+import { Alert } from "./alert";
+
+const meta: Meta<typeof Alert> = {
+    title: "Core/Alert",
+    component: Alert,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        intent: "none",
+        isOpen: true,
+        canEscapeKeyCancel: false,
+        canOutsideClickCancel: false,
+        icon: "info-sign",
+        confirmButtonText: "OK",
+        cancelButtonText: undefined,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        isOpen: {
+            control: "boolean",
+        },
+        canEscapeKeyCancel: {
+            control: "boolean",
+        },
+        canOutsideClickCancel: {
+            control: "boolean",
+        },
+        icon: {
+            control: "text",
+        },
+        confirmButtonText: {
+            control: "text",
+        },
+        cancelButtonText: {
+            control: "text",
+        },
+        loading: {
+            control: "boolean",
+        },
+        onConfirm: { action: "confirmed" },
+        onCancel: { action: "cancelled" },
+        onClose: { action: "closed" },
+    },
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic alert with default styling.
+ */
+export const Default: Story = {
+    args: {
+        children: "Are you sure you want to continue?",
+    },
+};
+
+/**
+ * A primary intent alert for general informational confirmations.
+ */
+export const Primary: Story = {
+    args: {
+        intent: "primary",
+        icon: "info-sign",
+        confirmButtonText: "Got it",
+        children: "This is an informational alert.",
+    },
+};
+
+/**
+ * A success intent alert for confirming successful actions.
+ */
+export const Success: Story = {
+    args: {
+        intent: "success",
+        icon: "tick-circle",
+        confirmButtonText: "Great",
+        children: "The operation completed successfully.",
+    },
+};
+
+/**
+ * A warning intent alert for cautionary messages.
+ */
+export const Warning: Story = {
+    args: {
+        intent: "warning",
+        icon: "warning-sign",
+        confirmButtonText: "I understand",
+        children: "This action may have unintended consequences.",
+    },
+};
+
+/**
+ * A danger intent alert for destructive or irreversible actions.
+ */
+export const Danger: Story = {
+    args: {
+        intent: "danger",
+        icon: "trash",
+        confirmButtonText: "Delete",
+        children: "Are you sure you want to delete this item? This action cannot be undone.",
+    },
+};
+
+/**
+ * An alert with a cancel button, allowing the user to dismiss the alert without confirming.
+ */
+export const WithCancel: Story = {
+    args: {
+        intent: "danger",
+        icon: "trash",
+        confirmButtonText: "Delete",
+        cancelButtonText: "Cancel",
+        canEscapeKeyCancel: true,
+        canOutsideClickCancel: true,
+        children: "Are you sure you want to delete this item? This action cannot be undone.",
+    },
+};
+
+/**
+ * All intents displayed side by side for visual comparison.
+ */
+export const AllIntents: Story = {
+    argTypes: {
+        intent: { table: { disable: true } },
+        icon: { table: { disable: true } },
+    },
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Alert key={intent} isOpen={true} intent={intent} icon="info-sign" confirmButtonText="OK">
+                        This is a <strong>{intent}</strong> alert.
+                    </Alert>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [isOpen, setIsOpen] = useState(true);
+
+        const handleConfirm = useCallback(() => {
+            args.onConfirm?.();
+            setIsOpen(false);
+        }, [args]);
+
+        const handleCancel = useCallback(() => {
+            args.onCancel?.();
+            setIsOpen(false);
+        }, [args]);
+
+        const handleReopen = useCallback(() => setIsOpen(true), []);
+
+        return (
+            <div>
+                <button type="button" onClick={handleReopen}>
+                    Open Alert
+                </button>
+                <Alert
+                    cancelButtonText={args.cancelButtonText}
+                    canEscapeKeyCancel={args.canEscapeKeyCancel}
+                    canOutsideClickCancel={args.canOutsideClickCancel}
+                    confirmButtonText={args.confirmButtonText}
+                    icon={args.icon}
+                    intent={args.intent}
+                    isOpen={isOpen}
+                    loading={args.loading}
+                    onCancel={handleCancel}
+                    onConfirm={handleConfirm}
+                >
+                    This is a playground alert. Use the controls to customize it.
+                </Alert>
+            </div>
+        );
+    },
+    args: {
+        intent: "danger",
+        icon: "trash",
+        confirmButtonText: "Confirm",
+        cancelButtonText: "Cancel",
+        canEscapeKeyCancel: true,
+        canOutsideClickCancel: true,
+        loading: false,
+    },
+};

--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -4,8 +4,8 @@
 @import "../../common/variables";
 
 .#{$ns}-alert {
-  max-width: $pt-spacing * 100;
-  padding: $pt-spacing * 5;
+  max-width: calc(var(--bp-surface-spacing) * 100);
+  padding: calc(var(--bp-surface-spacing) * 5);
 }
 
 .#{$ns}-alert-body {
@@ -13,7 +13,7 @@
 
   .#{$ns}-icon {
     font-size: $pt-icon-size-large * 2;
-    margin-right: $pt-spacing * 5;
+    margin-right: calc(var(--bp-surface-spacing) * 5);
     margin-top: 0;
   }
 }
@@ -25,9 +25,9 @@
 .#{$ns}-alert-footer {
   display: flex;
   flex-direction: row-reverse;
-  margin-top: $pt-spacing * 3;
+  margin-top: calc(var(--bp-surface-spacing) * 3);
 
   .#{$ns}-button {
-    margin-left: $pt-spacing * 2;
+    margin-left: calc(var(--bp-surface-spacing) * 2);
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Alert component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |

#### Alert (`_alert.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Max width | `$pt-spacing * 100` | `calc(var(--bp-surface-spacing) * 100)` |
| Padding | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| Icon margin-right | `$pt-spacing * 5` | `calc(var(--bp-surface-spacing) * 5)` |
| Footer margin-top | `$pt-spacing * 3` | `calc(var(--bp-surface-spacing) * 3)` |
| Button margin-left | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |

No visual differences — all changes are 1:1 spacing token swaps. `$pt-icon-size-large` retained as-is (no icon size token exists).
