### PR TITLE
[core] Integrating design tokens into control card

### DIFF
--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -1,0 +1,155 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alignment, Elevation } from "../../common";
+
+import { CheckboxCard } from "./checkboxCard";
+
+const meta: Meta<typeof CheckboxCard> = {
+    title: "Core/ControlCard/CheckboxCard",
+    component: CheckboxCard,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Checkbox option",
+        checked: false,
+        disabled: false,
+        showAsSelectedWhenChecked: true,
+        compact: false,
+        elevation: Elevation.ZERO,
+        alignIndicator: Alignment.START,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        checked: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        showAsSelectedWhenChecked: {
+            control: "boolean",
+        },
+        compact: {
+            control: "boolean",
+        },
+        elevation: {
+            control: "select",
+            options: Object.values(Elevation),
+        },
+        alignIndicator: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof CheckboxCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic checkbox card with default styling.
+ */
+export const Default: Story = {
+    args: {
+        label: "Checkbox option",
+    },
+};
+
+/**
+ * A checked checkbox card.
+ */
+export const Checked: Story = {
+    args: {
+        label: "Enabled feature",
+        checked: true,
+    },
+};
+
+/**
+ * A disabled checkbox card cannot be interacted with.
+ */
+export const Disabled: Story = {
+    args: {
+        label: "Unavailable option",
+        disabled: true,
+    },
+};
+
+/**
+ * A disabled checkbox card that is also checked.
+ */
+export const DisabledChecked: Story = {
+    args: {
+        label: "Locked feature",
+        disabled: true,
+        checked: true,
+    },
+};
+
+/**
+ * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
+ */
+export const NoSelectedStyling: Story = {
+    name: "No selected styling",
+    args: {
+        label: "No highlight when checked",
+        checked: true,
+        showAsSelectedWhenChecked: false,
+    },
+};
+
+/**
+ * Use the `alignIndicator` prop to control the position of the checkbox within the card.
+ */
+export const AlignmentExample: Story = {
+    name: "Alignment",
+    argTypes: {
+        alignIndicator: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <CheckboxCard {...args} alignIndicator={Alignment.START} label="Start (default)" />
+            <CheckboxCard {...args} alignIndicator={Alignment.END} label="End" />
+        </div>
+    ),
+};
+
+/**
+ * Multiple checkbox cards in a group layout.
+ */
+export const Group: Story = {
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <CheckboxCard {...args} label="Wi-Fi" defaultChecked={true} />
+            <CheckboxCard {...args} label="Bluetooth" defaultChecked={false} />
+            <CheckboxCard {...args} label="Location Services" defaultChecked={true} />
+            <CheckboxCard {...args} label="NFC" disabled={true} />
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => <CheckboxCard {...args} />,
+    args: {
+        label: "Playground checkbox card",
+    },
+};

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -1,0 +1,177 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { Alignment, Elevation } from "../../common";
+
+import { RadioCard } from "./radioCard";
+
+const meta: Meta<typeof RadioCard> = {
+    title: "Core/ControlCard/RadioCard",
+    component: RadioCard,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Radio option",
+        checked: false,
+        disabled: false,
+        showAsSelectedWhenChecked: true,
+        compact: false,
+        elevation: Elevation.ZERO,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        checked: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        showAsSelectedWhenChecked: {
+            control: "boolean",
+        },
+        compact: {
+            control: "boolean",
+        },
+        elevation: {
+            control: "select",
+            options: Object.values(Elevation),
+        },
+        alignIndicator: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof RadioCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic radio card with default styling.
+ */
+export const Default: Story = {
+    args: {
+        label: "Radio option",
+    },
+};
+
+/**
+ * A checked radio card.
+ */
+export const Checked: Story = {
+    args: {
+        label: "Selected option",
+        checked: true,
+    },
+};
+
+/**
+ * A disabled radio card cannot be interacted with.
+ */
+export const Disabled: Story = {
+    args: {
+        label: "Unavailable option",
+        disabled: true,
+    },
+};
+
+/**
+ * A disabled radio card that is also checked.
+ */
+export const DisabledChecked: Story = {
+    args: {
+        label: "Locked selection",
+        disabled: true,
+        checked: true,
+    },
+};
+
+/**
+ * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
+ */
+export const NoSelectedStyling: Story = {
+    name: "No selected styling",
+    args: {
+        label: "No highlight when checked",
+        checked: true,
+        showAsSelectedWhenChecked: false,
+    },
+};
+
+/**
+ * Radio cards used in a group to select one option from several.
+ */
+export const Group: Story = {
+    render: function Render(args) {
+        const [selected, setSelected] = useState("monthly");
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                {["monthly", "quarterly", "yearly"].map(value => (
+                    <RadioCard
+                        key={value}
+                        {...args}
+                        label={value.charAt(0).toUpperCase() + value.slice(1)}
+                        value={value}
+                        checked={selected === value}
+                        onChange={() => setSelected(value)}
+                    />
+                ))}
+            </div>
+        );
+    },
+};
+
+/**
+ * A group with one disabled option.
+ */
+export const GroupWithDisabled: Story = {
+    name: "Group with disabled option",
+    render: function Render(args) {
+        const [selected, setSelected] = useState("standard");
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <RadioCard
+                    {...args}
+                    label="Standard"
+                    value="standard"
+                    checked={selected === "standard"}
+                    onChange={() => setSelected("standard")}
+                />
+                <RadioCard
+                    {...args}
+                    label="Premium"
+                    value="premium"
+                    checked={selected === "premium"}
+                    onChange={() => setSelected("premium")}
+                />
+                <RadioCard {...args} label="Enterprise (coming soon)" value="enterprise" disabled={true} />
+            </div>
+        );
+    },
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => <RadioCard {...args} />,
+    args: {
+        label: "Playground radio card",
+    },
+};

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -1,0 +1,149 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alignment, Elevation } from "../../common";
+
+import { SwitchCard } from "./switchCard";
+
+const meta: Meta<typeof SwitchCard> = {
+    title: "Core/ControlCard/SwitchCard",
+    component: SwitchCard,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Switch option",
+        checked: false,
+        disabled: false,
+        showAsSelectedWhenChecked: true,
+        compact: false,
+        elevation: Elevation.ZERO,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        checked: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        showAsSelectedWhenChecked: {
+            control: "boolean",
+        },
+        compact: {
+            control: "boolean",
+        },
+        elevation: {
+            control: "select",
+            options: Object.values(Elevation),
+        },
+        alignIndicator: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof SwitchCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic switch card with default styling.
+ */
+export const Default: Story = {
+    args: {
+        label: "Switch option",
+    },
+};
+
+/**
+ * A checked switch card.
+ */
+export const Checked: Story = {
+    args: {
+        label: "Enabled setting",
+        checked: true,
+    },
+};
+
+/**
+ * A disabled switch card cannot be interacted with.
+ */
+export const Disabled: Story = {
+    args: {
+        label: "Unavailable setting",
+        disabled: true,
+    },
+};
+
+/**
+ * A disabled switch card that is also checked.
+ */
+export const DisabledChecked: Story = {
+    args: {
+        label: "Locked setting",
+        disabled: true,
+        checked: true,
+    },
+};
+
+/**
+ * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
+ */
+export const NoSelectedStyling: Story = {
+    name: "No selected styling",
+    args: {
+        label: "No highlight when checked",
+        checked: true,
+        showAsSelectedWhenChecked: false,
+    },
+};
+
+/**
+ * Multiple switch cards for a settings panel layout.
+ */
+export const SettingsPanel: Story = {
+    name: "Settings panel",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <SwitchCard {...args} label="Dark mode" defaultChecked={true} />
+            <SwitchCard {...args} label="Notifications" defaultChecked={true} />
+            <SwitchCard {...args} label="Auto-save" defaultChecked={false} />
+            <SwitchCard {...args} label="Beta features" disabled={true} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `compact` prop to render a more condensed card.
+ */
+export const Compact: Story = {
+    args: {
+        label: "Compact switch card",
+        compact: true,
+    },
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => <SwitchCard {...args} />,
+    args: {
+        label: "Playground switch card",
+    },
+};

--- a/packages/core/src/components/control-card/_control-card.scss
+++ b/packages/core/src/components/control-card/_control-card.scss
@@ -21,7 +21,7 @@
     // control indicators should be top-aligned
     align-items: flex-start;
     display: flex;
-    gap: $pt-spacing * 2;
+    gap: calc(var(--bp-surface-spacing) * 2);
     margin: 0;
     padding: $card-padding;
     width: calc(100%);


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Control Card component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |

#### Control Card (`_control-card.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Control gap | `$pt-spacing * 2` | `calc(var(--bp-surface-spacing) * 2)` |

No visual differences — single 1:1 spacing token swap. `$card-padding` and `$card-padding-compact` retained as-is (no card padding tokens exist).
