### PR TITLE
[core] Integrating design tokens into control group

### DIFF
--- a/packages/core/src/components/forms/ControlGroup.stories.tsx
+++ b/packages/core/src/components/forms/ControlGroup.stories.tsx
@@ -1,0 +1,105 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../button/buttons";
+import { InputGroup } from "./inputGroup";
+
+import { ControlGroup } from "./controlGroup";
+
+const meta: Meta<typeof ControlGroup> = {
+    title: "Core/ControlGroup",
+    component: ControlGroup,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        fill: false,
+        vertical: false,
+    },
+    argTypes: {
+        fill: {
+            control: "boolean",
+        },
+        vertical: {
+            control: "boolean",
+        },
+    },
+} satisfies Meta<typeof ControlGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic control group with default styling containing an input and a button.
+ */
+export const Default: Story = {
+    render: args => (
+        <ControlGroup {...args}>
+            <InputGroup placeholder="Enter text..." />
+            <Button text="Submit" />
+        </ControlGroup>
+    ),
+};
+
+/**
+ * Use the `vertical` prop to stack controls vertically instead of horizontally.
+ */
+export const Vertical: Story = {
+    args: {
+        vertical: true,
+    },
+    render: args => (
+        <ControlGroup {...args}>
+            <InputGroup placeholder="First input" />
+            <InputGroup placeholder="Second input" />
+            <Button text="Submit" />
+        </ControlGroup>
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the control group expand to the full width of its container.
+ */
+export const Fill: Story = {
+    args: {
+        fill: true,
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <ControlGroup {...args}>
+            <InputGroup placeholder="Full width input" />
+            <Button text="Submit" />
+        </ControlGroup>
+    ),
+};
+
+/**
+ * A control group with multiple controls showing a combination of buttons and inputs.
+ */
+export const WithMultipleControls: Story = {
+    render: args => (
+        <ControlGroup {...args}>
+            <Button text="Action" icon="search" />
+            <InputGroup placeholder="Search..." />
+            <Button text="Go" intent="primary" />
+            <Button icon="arrow-right" />
+        </ControlGroup>
+    ),
+};

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -131,7 +131,7 @@
 
   &:not(.#{$ns}-vertical) {
     > :not(:last-child) {
-      margin-right: $pt-spacing * 0.5;
+      margin-right: calc(var(--bp-surface-spacing) * 0.5);
     }
   }
 
@@ -157,7 +157,7 @@
     flex-direction: column;
 
     > :not(:last-child) {
-      margin-bottom: $pt-spacing * 0.5;
+      margin-bottom: calc(var(--bp-surface-spacing) * 0.5);
     }
   }
 }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Control Group component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |

#### Control Group (`_control-group.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Horizontal child margin | `$pt-spacing * 0.5` | `calc(var(--bp-surface-spacing) * 0.5)` |
| Vertical child margin | `$pt-spacing * 0.5` | `calc(var(--bp-surface-spacing) * 0.5)` |

No visual differences — all changes are 1:1 spacing token swaps. Z-index management via `$control-group-stack` retained as-is.
