### PR TITLE
[core] Integrating design tokens into skeleton

### DIFF
--- a/packages/core/src/components/skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/components/skeleton/Skeleton.stories.tsx
@@ -1,0 +1,131 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Classes } from "../../common";
+import { Button } from "../button/buttons";
+import { Card } from "../card/card";
+
+interface SkeletonStoryProps {
+    /** Whether the skeleton class is applied */
+    skeleton: boolean;
+}
+
+const SkeletonDemo: React.FC<SkeletonStoryProps> = ({ skeleton }) => (
+    <Card>
+        <h5 className={`${Classes.HEADING} ${skeleton ? Classes.SKELETON : ""}`}>
+            <a href="#" tabIndex={-1}>
+                Card heading
+            </a>
+        </h5>
+        <p className={skeleton ? Classes.SKELETON : ""}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eget tortor felis. Fusce dapibus metus in
+            dapibus mollis. Quisque eget ex diam.
+        </p>
+        <Button className={skeleton ? Classes.SKELETON : ""} icon="add" text="Submit" tabIndex={-1} />
+    </Card>
+);
+
+const meta: Meta<typeof SkeletonDemo> = {
+    title: "Core/Skeleton",
+    component: SkeletonDemo,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        skeleton: true,
+    },
+    argTypes: {
+        skeleton: {
+            control: "boolean",
+        },
+    },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A card with the `.bp5-skeleton` class applied to its content elements, showing the default loading state.
+ */
+export const Default: Story = {
+    args: {
+        skeleton: true,
+    },
+};
+
+/**
+ * Compare the skeleton loading state with the loaded content side by side.
+ */
+export const ComparisonExample: Story = {
+    name: "Comparison",
+    render: () => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Loading</span>
+                <SkeletonDemo skeleton={true} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Loaded</span>
+                <SkeletonDemo skeleton={false} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * The skeleton class can be applied to various HTML elements, inheriting their dimensions.
+ */
+export const VariousElementsExample: Story = {
+    name: "Various Elements",
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: 300 }}>
+            <h3 className={Classes.SKELETON}>Heading element</h3>
+            <p className={Classes.SKELETON}>Paragraph element with some placeholder text content.</p>
+            <span className={Classes.SKELETON} style={{ display: "inline-block", width: 200, height: 20 }}>
+                Inline block element
+            </span>
+            <Button className={Classes.SKELETON} text="Button element" tabIndex={-1} />
+            <input className={Classes.SKELETON} type="text" placeholder="Input element" tabIndex={-1} />
+        </div>
+    ),
+};
+
+/**
+ * Multiple skeleton rows simulating a list loading state.
+ */
+export const ListExample: Story = {
+    name: "List",
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 400 }}>
+            {Array.from({ length: 5 }, (_, i) => (
+                <div key={i} style={{ display: "flex", gap: 12, alignItems: "center" }}>
+                    <div
+                        className={Classes.SKELETON}
+                        style={{ width: 32, height: 32, borderRadius: "50%", flexShrink: 0 }}
+                    >
+                        &nbsp;
+                    </div>
+                    <div style={{ flex: 1, display: "flex", flexDirection: "column", gap: 4 }}>
+                        <div className={Classes.SKELETON} style={{ height: 16, width: `${70 + ((i * 13) % 30)}%` }}>
+                            &nbsp;
+                        </div>
+                        <div className={Classes.SKELETON} style={{ height: 12, width: `${50 + ((i * 17) % 40)}%` }}>
+                            &nbsp;
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    ),
+};

--- a/packages/core/src/components/skeleton/_common.scss
+++ b/packages/core/src/components/skeleton/_common.scss
@@ -3,5 +3,7 @@
 @import "../../common/variables";
 
 $skeleton-animation: ($pt-transition-duration * 10) linear infinite alternate skeleton-glow !default;
-$skeleton-color-start: rgba($light-gray1, 0.2) !default;
-$skeleton-color-end: rgba($gray1, 0.2) !default;
+/* stylelint-disable alpha-value-notation */
+$skeleton-color-start: #{"oklch(from var(--bp-palette-light-gray-1) l c h / 0.2)"} !default;
+$skeleton-color-end: #{"oklch(from var(--bp-palette-gray-1) l c h / 0.2)"} !default;
+/* stylelint-enable alpha-value-notation */

--- a/packages/core/src/components/skeleton/_skeleton.scss
+++ b/packages/core/src/components/skeleton/_skeleton.scss
@@ -45,7 +45,7 @@ Styleguide skeleton
   // Prevent background color from extending to the border and overlappping
   background-clip: padding-box !important;
   border-color: $skeleton-color-start !important;
-  border-radius: $pt-spacing * 0.5;
+  border-radius: calc(var(--bp-surface-spacing) * 0.5);
   box-shadow: none !important;
 
   // Transparent text will occupy space but be invisible to the user


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Skeleton component from SCSS palette variables to CSS design tokens.

> [!NOTE]
> All `rgba()` transparency calls have been replaced with `oklch()` relative color syntax. The percentages are identical but the color space differs, which may produce very subtle visual differences in semi-transparent overlays.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |
| `--bp-palette-light-gray-1` | `#d3d8de` | `$light-gray1` |
| `--bp-palette-gray-1` | `#5f6b7c` | `$gray1` |

#### Skeleton Common (`_common.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Color start | `rgba($light-gray1, 0.2)` | `oklch(from var(--bp-palette-light-gray-1) l c h / 0.2)` |
| Color end | `rgba($gray1, 0.2)` | `oklch(from var(--bp-palette-gray-1) l c h / 0.2)` |

#### Skeleton (`_skeleton.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Border radius | `$pt-spacing * 0.5` | `calc(var(--bp-surface-spacing) * 0.5)` |

**Differences:**
1. **Transparency color space.** `oklch()` replaces `rgba()` for skeleton glow colors. Same alpha values but different color space may produce subtle visual difference in the animation.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Transparency color space | `oklch()` instead of `rgba()` — different color space |

#### Reviewers should focus on:

- Skeleton glow animation appearance (oklch vs rgba color space difference at 20% opacity)
