### PR TITLE
[core] Integrating design tokens into panel stack

### DIFF
--- a/packages/core/src/components/panel-stack/PanelStack.stories.tsx
+++ b/packages/core/src/components/panel-stack/PanelStack.stories.tsx
@@ -1,0 +1,217 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Button } from "../button/buttons";
+
+import { PanelStack } from "./panelStack";
+import type { Panel, PanelProps } from "./panelTypes";
+
+// ---------------------------------------------------------------------------
+// Sample panel components used across stories
+// ---------------------------------------------------------------------------
+
+interface RootPanelInfo {
+    label: string;
+}
+
+const RootPanel: React.FC<PanelProps<RootPanelInfo>> = ({ openPanel, label }) => {
+    const handleOpen = useCallback(() => {
+        openPanel({
+            renderPanel: DetailPanel,
+            title: "Detail Panel",
+            props: { itemName: "Item A" },
+        });
+    }, [openPanel]);
+
+    return (
+        <div style={{ padding: 16 }}>
+            <p>{label}</p>
+            <Button text="Open detail panel" onClick={handleOpen} />
+        </div>
+    );
+};
+
+interface DetailPanelInfo {
+    itemName: string;
+}
+
+const DetailPanel: React.FC<PanelProps<DetailPanelInfo>> = ({ openPanel, closePanel, itemName }) => {
+    const handleOpen = useCallback(() => {
+        openPanel({
+            renderPanel: LeafPanel,
+            title: "Leaf Panel",
+            props: { message: `Navigated from ${itemName}` },
+        });
+    }, [openPanel, itemName]);
+
+    return (
+        <div style={{ padding: 16 }}>
+            <p>
+                Viewing: <strong>{itemName}</strong>
+            </p>
+            <div style={{ display: "flex", gap: 8 }}>
+                <Button text="Open leaf panel" onClick={handleOpen} />
+                <Button text="Close" variant="minimal" onClick={closePanel} />
+            </div>
+        </div>
+    );
+};
+
+interface LeafPanelInfo {
+    message: string;
+}
+
+const LeafPanel: React.FC<PanelProps<LeafPanelInfo>> = ({ closePanel, message }) => {
+    return (
+        <div style={{ padding: 16 }}>
+            <p>{message}</p>
+            <Button text="Go back" variant="minimal" onClick={closePanel} />
+        </div>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Helper type covering all panels used in these stories
+// ---------------------------------------------------------------------------
+
+type SamplePanel = Panel<RootPanelInfo> | Panel<DetailPanelInfo> | Panel<LeafPanelInfo>;
+
+const INITIAL_PANEL: SamplePanel = {
+    renderPanel: RootPanel,
+    title: "Root Panel",
+    props: { label: "Welcome to PanelStack. Click below to navigate." },
+};
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof PanelStack<SamplePanel>> = {
+    title: "Core/PanelStack",
+    component: PanelStack,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    width: 400,
+                    height: 300,
+                    border: "1px solid var(--pt-divider-black, rgba(17,20,24,0.15))",
+                    borderRadius: 4,
+                    overflow: "hidden",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/**
+ * The default uncontrolled PanelStack with an initial panel. Click through
+ * to push and pop panels on the stack.
+ */
+export const Default: Story = {
+    render: () => <PanelStack<SamplePanel> initialPanel={INITIAL_PANEL} />,
+};
+
+/**
+ * When `showPanelHeader` is `false`, the built-in header with the back button
+ * is hidden. Navigation must be handled entirely within individual panels.
+ */
+export const WithoutHeader: Story = {
+    name: "Without Header",
+    render: () => <PanelStack<SamplePanel> initialPanel={INITIAL_PANEL} showPanelHeader={false} />,
+};
+
+/**
+ * Set `renderActivePanelOnly` to `false` to keep all panels mounted in the
+ * DOM, preserving their React state even when they are not visible.
+ */
+export const RenderAllPanels: Story = {
+    name: "Render All Panels",
+    render: () => <PanelStack<SamplePanel> initialPanel={INITIAL_PANEL} renderActivePanelOnly={false} />,
+};
+
+/**
+ * A controlled PanelStack where the parent component manages the stack array.
+ * Use the buttons below the stack to push and pop panels programmatically.
+ */
+export const Controlled: Story = {
+    render: function Render() {
+        const [stack, setStack] = useState<SamplePanel[]>([INITIAL_PANEL]);
+
+        const handleOpen = useCallback((panel: SamplePanel) => {
+            setStack(prev => [...prev, panel]);
+        }, []);
+
+        const handleClose = useCallback((_panel: SamplePanel) => {
+            setStack(prev => (prev.length > 1 ? prev.slice(0, -1) : prev));
+        }, []);
+
+        const pushPanel = useCallback(() => {
+            setStack(prev => [
+                ...prev,
+                {
+                    renderPanel: LeafPanel,
+                    title: `Panel ${prev.length + 1}`,
+                    props: { message: `This is panel #${prev.length + 1}` },
+                },
+            ]);
+        }, []);
+
+        const popPanel = useCallback(() => {
+            setStack(prev => (prev.length > 1 ? prev.slice(0, -1) : prev));
+        }, []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <PanelStack<SamplePanel> stack={stack} onOpen={handleOpen} onClose={handleClose} />
+                <div style={{ display: "flex", gap: 8, justifyContent: "center" }}>
+                    <Button text="Push panel" icon="add" onClick={pushPanel} size="small" />
+                    <Button
+                        text="Pop panel"
+                        icon="remove"
+                        onClick={popPanel}
+                        size="small"
+                        disabled={stack.length <= 1}
+                    />
+                </div>
+            </div>
+        );
+    },
+};
+
+/**
+ * Interactive playground demonstrating `onOpen` and `onClose` callbacks. Open
+ * the Actions panel in Storybook to see the callbacks fire.
+ */
+export const Playground: Story = {
+    render: function Render() {
+        const [stack, setStack] = useState<SamplePanel[]>([INITIAL_PANEL]);
+
+        const handleOpen = useCallback((panel: SamplePanel) => {
+            setStack(prev => [...prev, panel]);
+        }, []);
+
+        const handleClose = useCallback((_panel: SamplePanel) => {
+            setStack(prev => (prev.length > 1 ? prev.slice(0, -1) : prev));
+        }, []);
+
+        return <PanelStack<SamplePanel> stack={stack} onOpen={handleOpen} onClose={handleClose} />;
+    },
+};

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -12,15 +12,11 @@
 
 .#{$ns}-panel-stack2-header {
   align-items: center;
-  box-shadow: 0 1px $pt-divider-black;
+  box-shadow: 0 1px var(--bp-surface-border-color-default);
   display: flex;
   flex-shrink: 0;
-  height: $pt-spacing * 7.5;
+  height: calc(var(--bp-surface-spacing) * 7.5);
   z-index: 1;
-
-  .#{$ns}-dark & {
-    box-shadow: 0 1px $pt-dark-divider-white;
-  }
 
   // two span children act as spacers to keep the title centered.
   > span {
@@ -30,26 +26,26 @@
   }
 
   .#{$ns}-heading {
-    margin: 0 $pt-spacing;
+    margin: 0 var(--bp-surface-spacing);
   }
 }
 
 .#{$ns}-button.#{$ns}-panel-stack2-header-back {
-  margin-left: $pt-spacing;
+  margin-left: var(--bp-surface-spacing);
   padding-left: 0;
   white-space: nowrap;
 
   .#{$ns}-icon {
     // reduce margins around icon so it fits better in tight header
-    margin: 0 ($pt-spacing * 0.5);
+    margin: 0 calc(var(--bp-surface-spacing) * 0.5);
   }
 }
 
 .#{$ns}-panel-stack2-view {
   @include position-all(absolute, 0);
 
-  background-color: $card-background-color;
-  border-right: 1px solid $pt-divider-black;
+  background-color: var(--bp-surface-background-color-default-rest);
+  border-right: 1px solid var(--bp-surface-border-color-default);
   display: flex;
   flex-direction: column;
 
@@ -57,10 +53,6 @@
   margin-right: -1px;
   overflow-y: auto;
   z-index: 1;
-
-  .#{$ns}-dark & {
-    background-color: $dark-card-background-color;
-  }
 
   &:nth-last-child(n + 4) {
     display: none;


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Panel Stack component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |
| `--bp-surface-border-color-default` | `oklch(... / 0.12)` | `$pt-divider-black` |
| `--bp-surface-background-color-default-rest` | `#ffffff` | `$card-background-color` (`$white`) |

#### Panel Stack Header (`_panel-stack.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Header box-shadow | `0 1px $pt-divider-black` | `0 1px var(--bp-surface-border-color-default)` |
| Header height | `$pt-spacing * 7.5` | `calc(var(--bp-surface-spacing) * 7.5)` |
| Heading margin | `0 $pt-spacing` | `0 var(--bp-surface-spacing)` |
| Back button margin-left | `$pt-spacing` | `var(--bp-surface-spacing)` |
| Back icon margin | `$pt-spacing * 0.5` | `calc(var(--bp-surface-spacing) * 0.5)` |

#### Panel Stack View

| Property | Develop | Current |
|----------|---------|---------|
| Background color | `$card-background-color` | `var(--bp-surface-background-color-default-rest)` |
| Border | `1px solid $pt-divider-black` | `1px solid var(--bp-surface-border-color-default)` |

**Differences:**
1. **Dark theme blocks removed.** The `.bp6-dark &` overrides for `box-shadow` and `background-color` have been removed because `--bp-surface-border-color-default` and `--bp-surface-background-color-default-rest` auto-resolve in dark theme.
2. **Divider color token.** `$pt-divider-black` (`rgba($black, 0.15)`) is replaced by `--bp-surface-border-color-default` which uses `oklch(... / 0.12)` — slightly different alpha and color space.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Dark theme blocks removed | Tokens auto-resolve in `.bp6-dark` context |
| 2 | Divider color | `--bp-surface-border-color-default` has `oklch(... / 0.12)` vs `rgba($black, 0.15)` |

#### Reviewers should focus on:

- Panel header divider line appearance (border-color token uses 12% opacity vs legacy 15%)
- Dark mode panel stack appearance (tokens auto-resolve, dedicated dark blocks removed)
