### PR TITLE
[core] Integrating design tokens into icon

### DIFF
--- a/packages/core/src/components/icon/Icon.stories.tsx
+++ b/packages/core/src/components/icon/Icon.stories.tsx
@@ -1,0 +1,132 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Icon, IconSize } from "./icon";
+
+const meta: Meta<typeof Icon> = {
+    title: "Core/Icon",
+    component: Icon,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        icon: "home",
+        size: IconSize.STANDARD,
+        intent: "none",
+        color: undefined,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "select",
+            options: [IconSize.STANDARD, IconSize.LARGE],
+        },
+        icon: {
+            control: "text",
+        },
+        color: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic icon with default styling.
+ */
+export const Default: Story = {
+    args: {
+        icon: "home",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the icon.
+ */
+export const WithIntent: Story = {
+    name: "With Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Icon key={intent} {...args} intent={intent} />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the icon dimensions. Icon supports `STANDARD` (16px) and `LARGE` (20px).
+ */
+export const Sizes: Story = {
+    name: "Sizes",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Icon {...args} size={IconSize.STANDARD} />
+            <Icon {...args} size={IconSize.LARGE} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `color` prop to apply a custom color to the icon.
+ */
+export const CustomColor: Story = {
+    name: "Custom Color",
+    argTypes: {
+        color: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            <Icon {...args} color="#D63384" />
+            <Icon {...args} color="#0D6EFD" />
+            <Icon {...args} color="#198754" />
+            <Icon {...args} color="#FFC107" />
+        </div>
+    ),
+};
+
+/**
+ * All intents displayed together for visual comparison.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 8 }}>
+            {Object.values(Intent).map(intent => (
+                <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                    <Icon {...args} intent={intent} />
+                    <span style={{ fontSize: 10, opacity: 0.6 }}>{intent === "none" ? "none" : intent}</span>
+                </div>
+            ))}
+        </div>
+    ),
+};

--- a/packages/core/src/components/icon/_icon-mixins.scss
+++ b/packages/core/src/components/icon/_icon-mixins.scss
@@ -25,18 +25,10 @@
 }
 
 @mixin pt-icon-colors() {
-  color: $pt-icon-color;
+  color: var(--bp-typography-color-muted);
 
   &:hover {
-    color: $pt-icon-color-hover;
-  }
-
-  .#{$ns}-dark & {
-    color: $pt-dark-icon-color;
-
-    &:hover {
-      color: $pt-dark-icon-color-hover;
-    }
+    color: var(--bp-typography-color-default-rest);
   }
 }
 

--- a/packages/core/src/components/icon/_icon.scss
+++ b/packages/core/src/components/icon/_icon.scss
@@ -42,7 +42,7 @@
     overflow: visible;
 
     path {
-      stroke: $gray3;
+      stroke: var(--bp-palette-gray-3);
       stroke-opacity: 0.5;
       stroke-width: 0.5px;
     }


### PR DESCRIPTION
#### Fixes #0000

#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Icon component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Value | Sass equivalent |
|-------|-------|-----------------| 
| `--bp-typography-color-muted` | `#5f6b7c` | `$pt-icon-color` (`$pt-text-color-muted` = `$gray1`) |
| `--bp-typography-color-default-rest` | `#1c2127` | `$pt-icon-color-hover` (`$pt-text-color` = `$dark-gray1`) |
| `--bp-palette-gray-3` | `#8f99a8` | `$gray3` |

#### Icon Mixins (`_icon-mixins.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Icon color (rest) | `$pt-icon-color` | `var(--bp-typography-color-muted)` |
| Icon color (hover) | `$pt-icon-color-hover` | `var(--bp-typography-color-default-rest)` |

#### Icon (`_icon.scss`)

| Property | Develop | Current |
|----------|---------|---------|
| Muted icon stroke | `$gray3` | `var(--bp-palette-gray-3)` |

**Differences:**
1. **Dark theme block removed from `pt-icon-colors()` mixin.** The `.bp6-dark &` overrides for `$pt-dark-icon-color` and `$pt-dark-icon-color-hover` have been removed because `--bp-typography-color-muted` and `--bp-typography-color-default-rest` auto-resolve in dark theme contexts.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Dark theme block removed | Typography tokens auto-resolve in `.bp6-dark` context |

#### Reviewers should focus on:

- Icon colors in dark mode (tokens auto-resolve, `pt-icon-colors()` mixin no longer has a `.bp6-dark` override)
