### PR TITLE
Integrating design tokens into divider

### DIFF
--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -1,0 +1,198 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Divider } from "./divider";
+
+const meta: Meta<typeof Divider> = {
+    title: "Core/Components/Divider",
+    component: Divider,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        compact: false,
+        tagName: "div",
+    },
+    argTypes: {
+        compact: {
+            control: "boolean",
+        },
+        tagName: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Divider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic horizontal divider rendered inside a column flex container.
+ */
+export const Default: Story = {
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", flexDirection: "column", width: "300px" }}>
+                <span>Content above</span>
+                <Story />
+                <span>Content below</span>
+            </div>
+        ),
+    ],
+};
+
+/**
+ * When placed inside a flex row container, the Divider renders as a vertical line.
+ */
+export const Vertical: Story = {
+    name: "Vertical",
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", flexDirection: "row", alignItems: "center", height: "40px" }}>
+                <span>Left</span>
+                <Story />
+                <span>Right</span>
+            </div>
+        ),
+    ],
+};
+
+/**
+ * Use the `compact` prop to remove the default margin around the Divider,
+ * making it flush with adjacent content.
+ */
+export const CompactExample: Story = {
+    name: "Compact",
+    argTypes: {
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 0, width: "300px" }}>
+            <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
+                <span style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Default (with margin)</span>
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        border: "1px dashed rgba(0,0,0,0.2)",
+                        padding: 8,
+                    }}
+                >
+                    <span>Above</span>
+                    <Divider {...args} compact={false} />
+                    <span>Below</span>
+                </div>
+            </div>
+            <div style={{ marginTop: 16, display: "flex", flexDirection: "column", width: "100%" }}>
+                <span style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Compact (no margin)</span>
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        border: "1px dashed rgba(0,0,0,0.2)",
+                        padding: 8,
+                    }}
+                >
+                    <span>Above</span>
+                    <Divider {...args} compact={true} />
+                    <span>Below</span>
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * The Divider adapts its orientation based on the flex direction of its parent container.
+ * In a row layout it renders as a vertical separator; in a column layout as a horizontal rule.
+ */
+export const Orientation: Story = {
+    name: "Orientation",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "300px" }}>
+            <div>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Horizontal (column container)</span>
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <span>Above</span>
+                    <Divider {...args} />
+                    <span>Below</span>
+                </div>
+            </div>
+            <div>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Vertical (row container)</span>
+                <div style={{ display: "flex", flexDirection: "row", alignItems: "center", height: "40px" }}>
+                    <span>Left</span>
+                    <Divider {...args} />
+                    <span>Right</span>
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * The `tagName` prop allows rendering the Divider as a different HTML element.
+ */
+export const TagNameExample: Story = {
+    name: "Tag Name",
+    argTypes: {
+        tagName: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "300px" }}>
+            <div>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>div (default)</span>
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <span>Above</span>
+                    <Divider {...args} tagName="div" />
+                    <span>Below</span>
+                </div>
+            </div>
+            <div>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>hr</span>
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <span>Above</span>
+                    <Divider {...args} tagName="hr" />
+                    <span>Below</span>
+                </div>
+            </div>
+            <div>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>span</span>
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <span>Above</span>
+                    <Divider {...args} tagName="span" />
+                    <span>Below</span>
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all Divider props available via Storybook controls.
+ */
+export const Playground: Story = {
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", flexDirection: "column", width: "300px" }}>
+                <span>Content above</span>
+                <Story />
+                <span>Content below</span>
+            </div>
+        ),
+    ],
+    args: {
+        compact: false,
+    },
+};

--- a/packages/core/src/components/divider/_divider.scss
+++ b/packages/core/src/components/divider/_divider.scss
@@ -6,15 +6,11 @@
 $divider-margin: $pt-spacing !default;
 
 .#{$ns}-divider {
-  border-bottom: 1px solid $pt-divider-black;
+  border-bottom: 1px solid var(--bp-surface-border-color-default);
   // since the element is empty, it will occupy minimal space and only show
   // the appropriate border based on direction of container.
-  border-right: 1px solid $pt-divider-black;
-  margin: $divider-margin;
-
-  .#{$ns}-dark & {
-    border-color: $pt-dark-divider-white;
-  }
+  border-right: 1px solid var(--bp-surface-border-color-default);
+  margin: var(--bp-surface-spacing);
 
   &.#{$ns}-compact {
     margin: 0;


### PR DESCRIPTION
#### Checklist

-   [ ] Includes tests
-   [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request

Migrates the Divider component from SCSS palette variables to CSS design tokens.

#### Token-to-Palette Reference

| Token | Hex | Sass equivalent |
|-------|-----|-----------------|
| `--bp-surface-border-color-default` | `#5f6b7c1f` (light), `oklch(from --bp-intent-default-rest l c h / 0.12)` (dark) | `$pt-divider-black` (light) / `$pt-dark-divider-white` (dark) |
| `--bp-surface-spacing` | `4px` | `$pt-spacing` |

#### Divider (`.bp5-divider`)

| Property | Develop | Current |
|----------|---------|---------|
| Border color (light) | `$pt-divider-black` (`rgba($black, 0.15)`) | `var(--bp-surface-border-color-default)` (`#5f6b7c1f`) |
| Border color (dark) | `$pt-dark-divider-white` (`rgba($white, 0.2)`) | `var(--bp-surface-border-color-default)` (auto-resolves via token) |
| Margin | `$divider-margin` (→ `$pt-spacing` = `4px`) | `var(--bp-surface-spacing)` (`4px`) |

**Differences:**
1. **Dark theme override removed.** The `.#{$ns}-dark &` block that set `border-color: $pt-dark-divider-white` has been removed entirely. The `--bp-surface-border-color-default` token auto-resolves to the appropriate value in dark theme contexts, so the explicit override is no longer needed.
2. **Border color value differs slightly.** The old light-theme value was `rgba($black, 0.15)` (= `rgba(0, 0, 0, 0.15)`). The new token value `#5f6b7c1f` is a semi-transparent hex derived from `$gray1` at ~12% opacity, which will produce a slightly different tint — gray-toned rather than pure black transparency. Similarly, the old dark-theme value `rgba($white, 0.2)` is replaced with an oklch-based expression `oklch(from --bp-intent-default-rest l c h / 0.12)` at 12% opacity, which is a different opacity and color space.
3. **Local `$divider-margin` variable bypassed.** The margin now reads directly from `var(--bp-surface-spacing)` instead of the local `$divider-margin` SCSS variable. The `$divider-margin: $pt-spacing !default;` definition is retained in the file for backward compatibility but is no longer used by the component itself.

#### Summary of All Differences

| # | Category | Root cause |
|---|----------|------------|
| 1 | Dark override removed | Token auto-resolves across themes; explicit `.bp5-dark` block eliminated |
| 2 | Border color tint | `rgba($black, 0.15)` → `#5f6b7c1f` (gray-tinted semi-transparent vs pure black semi-transparent) |
| 3 | Local var bypassed | `$divider-margin` still defined but no longer consumed |

#### Reviewers should focus on:

- **Border color appearance in light theme** — the shift from `rgba(0,0,0,0.15)` (pure black at 15% opacity) to `#5f6b7c1f` (gray1 at ~12% opacity) is the most visually noticeable change; divider lines may appear slightly lighter/warmer.
- **Dark theme border color** — the old value `rgba(255,255,255,0.2)` is replaced by an oklch expression at 12% opacity from a different base color, which changes both the opacity and color space.
