### PR TITLE
[eslint] fix: Add tslib as a dependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,7 +11,8 @@
         "test": "SWC_NODE_PROJECT=./tsconfig.test.json mocha --require @swc-node/register,test/setup.ts --watch-extensions ts,tsx 'test/**/*.{ts,tsx}'"
     },
     "dependencies": {
-        "@typescript-eslint/utils": "^8.56.1"
+        "@typescript-eslint/utils": "^8.56.1",
+        "tslib": "catalog:"
     },
     "peerDependencies": {
         "eslint": "^8.57 || ^9.0.0"
@@ -24,7 +25,6 @@
         "@typescript-eslint/rule-tester": "^8.56.1",
         "dedent": "^1.5.1",
         "mocha": "^10.2.0",
-        "tslib": "catalog:",
         "typescript": "~5.9.3"
     },
     "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
       eslint:
         specifier: ^8.57 || ^9.0.0
         version: 9.38.0(jiti@2.6.1)
+      tslib:
+        specifier: 'catalog:'
+        version: 2.6.3
     devDependencies:
       '@blueprintjs/node-build-scripts':
         specifier: workspace:^
@@ -767,9 +770,6 @@ importers:
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
-      tslib:
-        specifier: 'catalog:'
-        version: 2.6.3
       typescript:
         specifier: ~5.9.3
         version: 5.9.3


### PR DESCRIPTION
#### Problem

`tslib` is imported in the index but it is listed as a dev dependency. Thank you @gluxon for flagging this for us!

#### Changes proposed in this pull request:

Move `tslib` to a dependency.

#### Reviewers should focus on:

Compiles okay

#### Screenshot

<img width="3104" height="2024" alt="Screenshot 2026-03-20 at 12 17 47 PM" src="https://github.com/user-attachments/assets/2fc850b8-ca19-4518-96f9-80d0b860e898" />
