### PR TITLE
[core] fix: Restore minimal default tag text contrast in dark mode

### DIFF
--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -232,7 +232,7 @@ $minimal-dark-tag-intent-colors: (
 
       /* stylelint-disable-next-line alpha-value-notation */
       background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
-      color: var(--bp-typography-color-default-rest);
+      color: var(--bp-palette-light-gray-5);
 
       .#{$ns}-tag-remove {
         color: var(--bp-typography-color-muted);

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -232,7 +232,7 @@ $minimal-dark-tag-intent-colors: (
 
       /* stylelint-disable-next-line alpha-value-notation */
       background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
-      color: var(--bp-palette-light-gray-5);
+      color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.24) c h)"};
 
       .#{$ns}-tag-remove {
         color: var(--bp-typography-color-muted);


### PR DESCRIPTION
## Description

### Issue

#7817 replaced `$pt-dark-text-color` (`$light-gray5` / `#f6f7f9`) with `var(--bp-typography-color-default-rest)` as part of the design token migration for tags. In dark mode, this token resolves to `#a5aab3` (oklch L ≈ 0.736), which is significantly dimmer than the original `#f6f7f9` (oklch L ≈ 0.975), resulting in noticeably reduced foreground contrast for minimal default tags.

| Before | After |
|--------|--------|
| <img width="3456" height="1672" alt="before" src="https://github.com/user-attachments/assets/e9a16a5e-9999-43c9-8e86-a2bbe641e1bc" /> | <img width="3456" height="1672" alt="after" src="https://github.com/user-attachments/assets/53de11cf-5630-4928-bf12-42d79eb8636e" /> | 
| <img width="916" height="700" alt="before" src="https://github.com/user-attachments/assets/681a2e8f-f40f-4a5f-9957-850b59b649e8" /> | <img width="916" height="700" alt="after" src="https://github.com/user-attachments/assets/bcba0c7b-6383-44e9-8347-ed735b77ba45" /> | 

### Fix

Instead of falling back to a raw palette value, the fix derives the text color from the existing typography token with an oklch lightness offset: `oklch(from var(--bp-typography-color-default-rest) calc(l + 0.24) c h)`. This produces `#f2f7ff`, close to the original `#f6f7f9`, and stays consistent with the oklch derivation pattern used in the rest of the tag token migration.

## Test plan
- [ ] Verify minimal default tags in dark mode have high-contrast text matching `#f6f7f9`
- [ ] Verify minimal default tags in light mode are unaffected
- [ ] Verify minimal intent tags (primary, success, warning, danger) in both themes are unaffected
