### PR TITLE
[core] Add Storybook stories for Breadcrumbs

### DIFF
--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,11 +1,11 @@
-/* !
+/*
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Boundary } from "../../common";
-import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
+import { type BreadcrumbProps } from "./breadcrumb";
 import { Breadcrumbs } from "./breadcrumbs";
 
 const SAMPLE_ITEMS: BreadcrumbProps[] = [
@@ -17,7 +17,7 @@ const SAMPLE_ITEMS: BreadcrumbProps[] = [
 ];
 
 const meta: Meta<typeof Breadcrumbs> = {
-    title: "Core/Breadcrumbs/Breadcrumbs",
+    title: "Core/Breadcrumbs",
     component: Breadcrumbs,
     decorators: [
         Story => (
@@ -48,13 +48,19 @@ const meta: Meta<typeof Breadcrumbs> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * A basic breadcrumbs component with default styling.
+ */
 export const Default: Story = {
     args: {
         items: SAMPLE_ITEMS,
     },
 };
 
-export const CollapseFrom: Story = {
+/**
+ * Use the `collapseFrom` prop to control which end of the breadcrumb trail is collapsed when items overflow.
+ */
+export const CollapseFromExample: Story = {
     name: "Collapse From",
     argTypes: {
         collapseFrom: { table: { disable: true } },
@@ -77,31 +83,10 @@ export const CollapseFrom: Story = {
     ),
 };
 
-export const WithIcons: Story = {
-    name: "With Icons",
-    args: {
-        items: [
-            { text: "Home", href: "#", icon: "home" },
-            { text: "Settings", href: "#", icon: "cog" },
-            { text: "Profile", href: "#", icon: "person" },
-            { text: "Notifications" },
-        ],
-    },
-};
-
-export const DisabledItems: Story = {
-    name: "Disabled Items",
-    args: {
-        items: [
-            { text: "Home", href: "#" },
-            { text: "Archived", href: "#", disabled: true },
-            { text: "Projects", href: "#" },
-            { text: "Current Page" },
-        ],
-    },
-};
-
-export const Overflow: Story = {
+/**
+ * When the breadcrumb trail contains many items, overflow is handled by collapsing items into a dropdown.
+ */
+export const OverflowExample: Story = {
     name: "Overflow",
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
@@ -121,33 +106,9 @@ export const Overflow: Story = {
     ),
 };
 
-export const MinVisibleItems: Story = {
-    name: "Min Visible Items",
-    argTypes: {
-        minVisibleItems: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: 250 }}>
-            {[0, 1, 2, 3].map(minVisibleItems => (
-                <div key={minVisibleItems}>
-                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>
-                        minVisibleItems: {minVisibleItems}
-                    </div>
-                    <Breadcrumbs {...args} minVisibleItems={minVisibleItems} />
-                </div>
-            ))}
-        </div>
-    ),
-};
-
-export const CustomRenderer: Story = {
-    name: "Custom Breadcrumb Renderer",
-    args: {
-        items: SAMPLE_ITEMS,
-        breadcrumbRenderer: (props: BreadcrumbProps) => <Breadcrumb {...props} icon={props.icon ?? "folder-close"} />,
-    },
-};
-
+/**
+ * Interactive playground with all props toggleable via Storybook controls.
+ */
 export const Playground: Story = {
     args: {
         items: SAMPLE_ITEMS,

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import React from "react";
 
 import { Boundary } from "../../common";
 import { type BreadcrumbProps } from "./breadcrumb";
@@ -16,7 +17,10 @@ const SAMPLE_ITEMS: BreadcrumbProps[] = [
     { text: "Breadcrumbs" },
 ];
 
-const meta: Meta<typeof Breadcrumbs> = {
+// Adding extra width arg to showcase Breadcrumbs dynamically
+type StoryArgs = React.ComponentProps<typeof Breadcrumbs> & { width?: number };
+
+const meta: Meta<StoryArgs> = {
     title: "Core/Breadcrumbs",
     component: Breadcrumbs,
     decorators: [
@@ -33,6 +37,7 @@ const meta: Meta<typeof Breadcrumbs> = {
     args: {
         items: SAMPLE_ITEMS,
         collapseFrom: Boundary.START,
+        width: 400,
     },
     argTypes: {
         collapseFrom: {
@@ -42,19 +47,22 @@ const meta: Meta<typeof Breadcrumbs> = {
         minVisibleItems: {
             control: "number",
         },
+        width: { control: { type: "range", min: 100, max: 800, step: 10 } },
     },
-} satisfies Meta<typeof Breadcrumbs>;
+} satisfies Meta<StoryArgs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
- * A basic breadcrumbs component with default styling.
+ * A basic breadcrumbs component with default styling. Adjust the width slider to see overflow behavior.
  */
 export const Default: Story = {
-    args: {
-        items: SAMPLE_ITEMS,
-    },
+    render: ({ width, ...args }) => (
+        <div style={{ width }}>
+            <Breadcrumbs {...args} />
+        </div>
+    ),
 };
 
 /**
@@ -65,19 +73,15 @@ export const CollapseFromExample: Story = {
     argTypes: {
         collapseFrom: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <div>
+    render: ({ width, ...args }) => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "flex-start" }}>
+            <div style={{ width }}>
                 <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from start (default)</div>
-                <div style={{ width: 300 }}>
-                    <Breadcrumbs {...args} collapseFrom={Boundary.START} />
-                </div>
+                <Breadcrumbs {...args} collapseFrom={Boundary.START} />
             </div>
-            <div>
+            <div style={{ width }}>
                 <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from end</div>
-                <div style={{ width: 300 }}>
-                    <Breadcrumbs {...args} collapseFrom={Boundary.END} />
-                </div>
+                <Breadcrumbs {...args} collapseFrom={Boundary.END} />
             </div>
         </div>
     ),
@@ -115,4 +119,9 @@ export const Playground: Story = {
         collapseFrom: Boundary.START,
         minVisibleItems: 0,
     },
+    render: ({ width, ...args }) => (
+        <div style={{ width }}>
+            <Breadcrumbs {...args} />
+        </div>
+    ),
 };

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,0 +1,159 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Boundary } from "../../common";
+import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
+import { Breadcrumbs } from "./breadcrumbs";
+
+const SAMPLE_ITEMS: BreadcrumbProps[] = [
+    { text: "Home", href: "#", icon: "home" },
+    { text: "Projects", href: "#", icon: "projects" },
+    { text: "Blueprint", href: "#" },
+    { text: "Components", href: "#" },
+    { text: "Breadcrumbs" },
+];
+
+const meta: Meta<typeof Breadcrumbs> = {
+    title: "Core/Breadcrumbs/Breadcrumbs",
+    component: Breadcrumbs,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        items: SAMPLE_ITEMS,
+        collapseFrom: Boundary.START,
+    },
+    argTypes: {
+        collapseFrom: {
+            control: "select",
+            options: Object.values(Boundary),
+        },
+        minVisibleItems: {
+            control: "number",
+        },
+    },
+} satisfies Meta<typeof Breadcrumbs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    args: {
+        items: SAMPLE_ITEMS,
+    },
+};
+
+export const CollapseFrom: Story = {
+    name: "Collapse From",
+    argTypes: {
+        collapseFrom: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from start (default)</div>
+                <div style={{ width: 300 }}>
+                    <Breadcrumbs {...args} collapseFrom={Boundary.START} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from end</div>
+                <div style={{ width: 300 }}>
+                    <Breadcrumbs {...args} collapseFrom={Boundary.END} />
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+export const WithIcons: Story = {
+    name: "With Icons",
+    args: {
+        items: [
+            { text: "Home", href: "#", icon: "home" },
+            { text: "Settings", href: "#", icon: "cog" },
+            { text: "Profile", href: "#", icon: "person" },
+            { text: "Notifications" },
+        ],
+    },
+};
+
+export const DisabledItems: Story = {
+    name: "Disabled Items",
+    args: {
+        items: [
+            { text: "Home", href: "#" },
+            { text: "Archived", href: "#", disabled: true },
+            { text: "Projects", href: "#" },
+            { text: "Current Page" },
+        ],
+    },
+};
+
+export const Overflow: Story = {
+    name: "Overflow",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Constrained width (300px)</div>
+                <div style={{ width: 300 }}>
+                    <Breadcrumbs {...args} />
+                </div>
+            </div>
+            <div>
+                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Full width</div>
+                <div style={{ width: 600 }}>
+                    <Breadcrumbs {...args} />
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+export const MinVisibleItems: Story = {
+    name: "Min Visible Items",
+    argTypes: {
+        minVisibleItems: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: 250 }}>
+            {[0, 1, 2, 3].map(minVisibleItems => (
+                <div key={minVisibleItems}>
+                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>
+                        minVisibleItems: {minVisibleItems}
+                    </div>
+                    <Breadcrumbs {...args} minVisibleItems={minVisibleItems} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+export const CustomRenderer: Story = {
+    name: "Custom Breadcrumb Renderer",
+    args: {
+        items: SAMPLE_ITEMS,
+        breadcrumbRenderer: (props: BreadcrumbProps) => (
+            <Breadcrumb {...props} icon={props.icon ?? "folder-close"} />
+        ),
+    },
+};
+
+export const Playground: Story = {
+    args: {
+        items: SAMPLE_ITEMS,
+        collapseFrom: Boundary.START,
+        minVisibleItems: 0,
+    },
+};

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -144,9 +144,7 @@ export const CustomRenderer: Story = {
     name: "Custom Breadcrumb Renderer",
     args: {
         items: SAMPLE_ITEMS,
-        breadcrumbRenderer: (props: BreadcrumbProps) => (
-            <Breadcrumb {...props} icon={props.icon ?? "folder-close"} />
-        ),
+        breadcrumbRenderer: (props: BreadcrumbProps) => <Breadcrumb {...props} icon={props.icon ?? "folder-close"} />,
     },
 };
 

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -5,7 +5,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 
-import { Boundary } from "../../common";
+import { Boundary } from "../../common/boundary";
+
 import { type BreadcrumbProps } from "./breadcrumb";
 import { Breadcrumbs } from "./breadcrumbs";
 


### PR DESCRIPTION
## Summary
- Extracted Storybook stories for Breadcrumbs component
- Stories provide visual regression testing coverage

## Files
- `Breadcrumbs.stories.tsx`

## Test plan
- [ ] Verify stories render correctly in Storybook
- [ ] Check all story variants display properly in light and dark themes

* Note that Breadcrumbs requires a `maxWidth` container to work?

🤖 Generated with [Claude Code](https://claude.com/claude-code)