### PR TITLE
[core] Add Storybook stories for Control Card

### DIFF
--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -72,74 +72,37 @@ export const Default: Story = {
 };
 
 /**
- * A checked checkbox card.
+ * Use the `size` prop to render a medium or large checkbox card.
  */
-export const Checked: Story = {
-    args: {
-        label: "Enabled feature",
-        checked: true,
-    },
-};
-
-/**
- * A disabled checkbox card cannot be interacted with.
- */
-export const Disabled: Story = {
-    args: {
-        label: "Unavailable option",
-        disabled: true,
-    },
-};
-
-/**
- * A disabled checkbox card that is also checked.
- */
-export const DisabledChecked: Story = {
-    args: {
-        label: "Locked feature",
-        disabled: true,
-        checked: true,
-    },
-};
-
-/**
- * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
- */
-export const NoSelectedStyling: Story = {
-    name: "No selected styling",
-    args: {
-        label: "No highlight when checked",
-        checked: true,
-        showAsSelectedWhenChecked: false,
-    },
-};
-
-/**
- * Use the `alignIndicator` prop to control the position of the checkbox within the card.
- */
-export const AlignmentExample: Story = {
-    name: "Alignment",
+export const SizeExample: Story = {
+    name: "Size",
     argTypes: {
-        alignIndicator: { table: { disable: true } },
+        compact: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <CheckboxCard {...args} alignIndicator={Alignment.START} label="Start (default)" />
-            <CheckboxCard {...args} alignIndicator={Alignment.END} label="End" />
+            <CheckboxCard {...args} compact={false} label="Default" defaultChecked={true} />
+            <CheckboxCard {...args} compact={true} label="Compact" defaultChecked={true} />
         </div>
     ),
 };
 
 /**
- * Multiple checkbox cards in a group layout.
+ * Checkbox cards support `disabled`, `checked`, and `selected` states.
  */
-export const Group: Story = {
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        checked: { table: { disable: true } },
+    },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <CheckboxCard {...args} label="Wi-Fi" defaultChecked={true} />
-            <CheckboxCard {...args} label="Bluetooth" defaultChecked={false} />
-            <CheckboxCard {...args} label="Location Services" defaultChecked={true} />
-            <CheckboxCard {...args} label="NFC" disabled={true} />
+            <CheckboxCard {...args} label="Default" />
+            <CheckboxCard {...args} label="Checked" checked={true} />
+            <CheckboxCard {...args} label="Disabled" disabled={true} />
+            <CheckboxCard {...args} label="Disabled Checked" disabled={true} checked={true} />
+            <CheckboxCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
         </div>
     ),
 };

--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -1,0 +1,155 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alignment, Elevation } from "../../common";
+
+import { CheckboxCard } from "./checkboxCard";
+
+const meta: Meta<typeof CheckboxCard> = {
+    title: "Core/ControlCard/CheckboxCard",
+    component: CheckboxCard,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Checkbox option",
+        checked: false,
+        disabled: false,
+        showAsSelectedWhenChecked: true,
+        compact: false,
+        elevation: Elevation.ZERO,
+        alignIndicator: Alignment.START,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        checked: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        showAsSelectedWhenChecked: {
+            control: "boolean",
+        },
+        compact: {
+            control: "boolean",
+        },
+        elevation: {
+            control: "select",
+            options: Object.values(Elevation),
+        },
+        alignIndicator: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof CheckboxCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic checkbox card with default styling.
+ */
+export const Default: Story = {
+    args: {
+        label: "Checkbox option",
+    },
+};
+
+/**
+ * A checked checkbox card.
+ */
+export const Checked: Story = {
+    args: {
+        label: "Enabled feature",
+        checked: true,
+    },
+};
+
+/**
+ * A disabled checkbox card cannot be interacted with.
+ */
+export const Disabled: Story = {
+    args: {
+        label: "Unavailable option",
+        disabled: true,
+    },
+};
+
+/**
+ * A disabled checkbox card that is also checked.
+ */
+export const DisabledChecked: Story = {
+    args: {
+        label: "Locked feature",
+        disabled: true,
+        checked: true,
+    },
+};
+
+/**
+ * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
+ */
+export const NoSelectedStyling: Story = {
+    name: "No selected styling",
+    args: {
+        label: "No highlight when checked",
+        checked: true,
+        showAsSelectedWhenChecked: false,
+    },
+};
+
+/**
+ * Use the `alignIndicator` prop to control the position of the checkbox within the card.
+ */
+export const AlignmentExample: Story = {
+    name: "Alignment",
+    argTypes: {
+        alignIndicator: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <CheckboxCard {...args} alignIndicator={Alignment.START} label="Start (default)" />
+            <CheckboxCard {...args} alignIndicator={Alignment.END} label="End" />
+        </div>
+    ),
+};
+
+/**
+ * Multiple checkbox cards in a group layout.
+ */
+export const Group: Story = {
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <CheckboxCard {...args} label="Wi-Fi" defaultChecked={true} />
+            <CheckboxCard {...args} label="Bluetooth" defaultChecked={false} />
+            <CheckboxCard {...args} label="Location Services" defaultChecked={true} />
+            <CheckboxCard {...args} label="NFC" disabled={true} />
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => <CheckboxCard {...args} />,
+    args: {
+        label: "Playground checkbox card",
+    },
+};

--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs, useCallback } from "storybook/preview-api";
 
 import { Alignment, Elevation } from "../../common";
 
@@ -69,19 +70,24 @@ export const Default: Story = {
     args: {
         label: "Checkbox option",
     },
+    render: function Render(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+        return <CheckboxCard {...args} onChange={handleChange} />;
+    },
 };
 
 /**
- * Use the `size` prop to render a medium or large checkbox card.
+ * Use the `compact` prop to render a medium or large checkbox card.
  */
-export const SizeExample: Story = {
-    name: "Size",
+export const CompactExample: Story = {
+    name: "Compact",
     argTypes: {
         compact: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <CheckboxCard {...args} compact={false} label="Default" defaultChecked={true} />
+            <CheckboxCard {...args} label="Default" defaultChecked={true} />
             <CheckboxCard {...args} compact={true} label="Compact" defaultChecked={true} />
         </div>
     ),
@@ -108,11 +114,31 @@ export const StateExample: Story = {
 };
 
 /**
- * Interactive playground with all props togglable via Storybook controls.
+ * Use the `alignIndicator` prop to render start or end-aligned.
+ */
+export const AlignIndicatorExample: Story = {
+    name: "Align Indicator",
+    argTypes: {
+        alignIndicator: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <CheckboxCard {...args} alignIndicator={Alignment.START} label="Align start" defaultChecked={true} />
+            <CheckboxCard {...args} alignIndicator={Alignment.END} label="Align end" defaultChecked={true} />
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props toggleable via Storybook controls.
  */
 export const Playground: Story = {
-    render: args => <CheckboxCard {...args} />,
     args: {
         label: "Playground checkbox card",
+    },
+    render: function Render(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+        return <CheckboxCard {...args} onChange={handleChange} />;
     },
 };

--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -10,7 +10,7 @@ import { Alignment, Elevation } from "../../common";
 import { CheckboxCard } from "./checkboxCard";
 
 const meta: Meta<typeof CheckboxCard> = {
-    title: "Core/ControlCard/CheckboxCard",
+    title: "Core/Control Card/CheckboxCard",
     component: CheckboxCard,
     decorators: [
         Story => (
@@ -70,7 +70,7 @@ export const Default: Story = {
     args: {
         label: "Checkbox option",
     },
-    render: function Render(args) {
+    render: function RenderDefault(args) {
         const [, updateArgs] = useArgs();
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
         return <CheckboxCard {...args} onChange={handleChange} />;
@@ -85,12 +85,17 @@ export const CompactExample: Story = {
     argTypes: {
         compact: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <CheckboxCard {...args} label="Default" defaultChecked={true} />
-            <CheckboxCard {...args} compact={true} label="Compact" defaultChecked={true} />
-        </div>
-    ),
+    render: function RenderCompact(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <CheckboxCard {...args} label="Default" defaultChecked={true} onChange={handleChange} />
+                <CheckboxCard {...args} compact={true} label="Compact" defaultChecked={true} onChange={handleChange} />
+            </div>
+        );
+    },
 };
 
 /**
@@ -102,15 +107,26 @@ export const StateExample: Story = {
         disabled: { table: { disable: true } },
         checked: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <CheckboxCard {...args} label="Default" />
-            <CheckboxCard {...args} label="Checked" checked={true} />
-            <CheckboxCard {...args} label="Disabled" disabled={true} />
-            <CheckboxCard {...args} label="Disabled Checked" disabled={true} checked={true} />
-            <CheckboxCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
-        </div>
-    ),
+    render: function RenderState(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <CheckboxCard {...args} label="Default" onChange={handleChange} />
+                <CheckboxCard {...args} label="Checked" checked={true} onChange={handleChange} />
+                <CheckboxCard {...args} label="Disabled" disabled={true} />
+                <CheckboxCard {...args} label="Disabled Checked" disabled={true} checked={true} />
+                <CheckboxCard
+                    {...args}
+                    label="No selected styling"
+                    checked={true}
+                    showAsSelectedWhenChecked={false}
+                    onChange={handleChange}
+                />
+            </div>
+        );
+    },
 };
 
 /**
@@ -121,12 +137,29 @@ export const AlignIndicatorExample: Story = {
     argTypes: {
         alignIndicator: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <CheckboxCard {...args} alignIndicator={Alignment.START} label="Align start" defaultChecked={true} />
-            <CheckboxCard {...args} alignIndicator={Alignment.END} label="Align end" defaultChecked={true} />
-        </div>
-    ),
+    render: function RenderAlignIndicator(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <CheckboxCard
+                    {...args}
+                    alignIndicator={Alignment.START}
+                    label="Align start"
+                    defaultChecked={true}
+                    onChange={handleChange}
+                />
+                <CheckboxCard
+                    {...args}
+                    alignIndicator={Alignment.END}
+                    label="Align end"
+                    defaultChecked={true}
+                    onChange={handleChange}
+                />
+            </div>
+        );
+    },
 };
 
 /**
@@ -136,7 +169,7 @@ export const Playground: Story = {
     args: {
         label: "Playground checkbox card",
     },
-    render: function Render(args) {
+    render: function RenderPlayground(args) {
         const [, updateArgs] = useArgs();
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
         return <CheckboxCard {...args} onChange={handleChange} />;

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -1,0 +1,177 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { Alignment, Elevation } from "../../common";
+
+import { RadioCard } from "./radioCard";
+
+const meta: Meta<typeof RadioCard> = {
+    title: "Core/ControlCard/RadioCard",
+    component: RadioCard,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Radio option",
+        checked: false,
+        disabled: false,
+        showAsSelectedWhenChecked: true,
+        compact: false,
+        elevation: Elevation.ZERO,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        checked: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        showAsSelectedWhenChecked: {
+            control: "boolean",
+        },
+        compact: {
+            control: "boolean",
+        },
+        elevation: {
+            control: "select",
+            options: Object.values(Elevation),
+        },
+        alignIndicator: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof RadioCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic radio card with default styling.
+ */
+export const Default: Story = {
+    args: {
+        label: "Radio option",
+    },
+};
+
+/**
+ * A checked radio card.
+ */
+export const Checked: Story = {
+    args: {
+        label: "Selected option",
+        checked: true,
+    },
+};
+
+/**
+ * A disabled radio card cannot be interacted with.
+ */
+export const Disabled: Story = {
+    args: {
+        label: "Unavailable option",
+        disabled: true,
+    },
+};
+
+/**
+ * A disabled radio card that is also checked.
+ */
+export const DisabledChecked: Story = {
+    args: {
+        label: "Locked selection",
+        disabled: true,
+        checked: true,
+    },
+};
+
+/**
+ * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
+ */
+export const NoSelectedStyling: Story = {
+    name: "No selected styling",
+    args: {
+        label: "No highlight when checked",
+        checked: true,
+        showAsSelectedWhenChecked: false,
+    },
+};
+
+/**
+ * Radio cards used in a group to select one option from several.
+ */
+export const Group: Story = {
+    render: function Render(args) {
+        const [selected, setSelected] = useState("monthly");
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                {["monthly", "quarterly", "yearly"].map(value => (
+                    <RadioCard
+                        key={value}
+                        {...args}
+                        label={value.charAt(0).toUpperCase() + value.slice(1)}
+                        value={value}
+                        checked={selected === value}
+                        onChange={() => setSelected(value)}
+                    />
+                ))}
+            </div>
+        );
+    },
+};
+
+/**
+ * A group with one disabled option.
+ */
+export const GroupWithDisabled: Story = {
+    name: "Group with disabled option",
+    render: function Render(args) {
+        const [selected, setSelected] = useState("standard");
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <RadioCard
+                    {...args}
+                    label="Standard"
+                    value="standard"
+                    checked={selected === "standard"}
+                    onChange={() => setSelected("standard")}
+                />
+                <RadioCard
+                    {...args}
+                    label="Premium"
+                    value="premium"
+                    checked={selected === "premium"}
+                    onChange={() => setSelected("premium")}
+                />
+                <RadioCard {...args} label="Enterprise (coming soon)" value="enterprise" disabled={true} />
+            </div>
+        );
+    },
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => <RadioCard {...args} />,
+    args: {
+        label: "Playground radio card",
+    },
+};

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -3,7 +3,6 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useState } from "react";
 
 import { Alignment, Elevation } from "../../common";
 
@@ -72,98 +71,39 @@ export const Default: Story = {
 };
 
 /**
- * A checked radio card.
+ * Use the `compact` prop to render a more condensed radio card.
  */
-export const Checked: Story = {
-    args: {
-        label: "Selected option",
-        checked: true,
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        compact: { table: { disable: true } },
     },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <RadioCard {...args} compact={false} label="Default" defaultChecked={true} />
+            <RadioCard {...args} compact={true} label="Compact" defaultChecked={true} />
+        </div>
+    ),
 };
 
 /**
- * A disabled radio card cannot be interacted with.
+ * Radio cards support `disabled`, `checked`, and `selected` states.
  */
-export const Disabled: Story = {
-    args: {
-        label: "Unavailable option",
-        disabled: true,
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        checked: { table: { disable: true } },
     },
-};
-
-/**
- * A disabled radio card that is also checked.
- */
-export const DisabledChecked: Story = {
-    args: {
-        label: "Locked selection",
-        disabled: true,
-        checked: true,
-    },
-};
-
-/**
- * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
- */
-export const NoSelectedStyling: Story = {
-    name: "No selected styling",
-    args: {
-        label: "No highlight when checked",
-        checked: true,
-        showAsSelectedWhenChecked: false,
-    },
-};
-
-/**
- * Radio cards used in a group to select one option from several.
- */
-export const Group: Story = {
-    render: function Render(args) {
-        const [selected, setSelected] = useState("monthly");
-        return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-                {["monthly", "quarterly", "yearly"].map(value => (
-                    <RadioCard
-                        key={value}
-                        {...args}
-                        label={value.charAt(0).toUpperCase() + value.slice(1)}
-                        value={value}
-                        checked={selected === value}
-                        onChange={() => setSelected(value)}
-                    />
-                ))}
-            </div>
-        );
-    },
-};
-
-/**
- * A group with one disabled option.
- */
-export const GroupWithDisabled: Story = {
-    name: "Group with disabled option",
-    render: function Render(args) {
-        const [selected, setSelected] = useState("standard");
-        return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-                <RadioCard
-                    {...args}
-                    label="Standard"
-                    value="standard"
-                    checked={selected === "standard"}
-                    onChange={() => setSelected("standard")}
-                />
-                <RadioCard
-                    {...args}
-                    label="Premium"
-                    value="premium"
-                    checked={selected === "premium"}
-                    onChange={() => setSelected("premium")}
-                />
-                <RadioCard {...args} label="Enterprise (coming soon)" value="enterprise" disabled={true} />
-            </div>
-        );
-    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <RadioCard {...args} label="Default" />
+            <RadioCard {...args} label="Checked" checked={true} />
+            <RadioCard {...args} label="Disabled" disabled={true} />
+            <RadioCard {...args} label="Disabled Checked" disabled={true} checked={true} />
+            <RadioCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
+        </div>
+    ),
 };
 
 /**

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -10,7 +10,7 @@ import { Alignment, Elevation } from "../../common";
 import { RadioCard } from "./radioCard";
 
 const meta: Meta<typeof RadioCard> = {
-    title: "Core/ControlCard/RadioCard",
+    title: "Core/Control Card/RadioCard",
     component: RadioCard,
     decorators: [
         Story => (
@@ -69,7 +69,7 @@ export const Default: Story = {
     args: {
         label: "Radio option",
     },
-    render: function Render(args) {
+    render: function RenderDefault(args) {
         const [, updateArgs] = useArgs();
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
         return <RadioCard {...args} onChange={handleChange} />;
@@ -84,12 +84,17 @@ export const CompactExample: Story = {
     argTypes: {
         compact: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <RadioCard {...args} compact={false} label="Default" defaultChecked={true} />
-            <RadioCard {...args} compact={true} label="Compact" defaultChecked={true} />
-        </div>
-    ),
+    render: function RenderCompact(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <RadioCard {...args} label="Default" defaultChecked={true} onChange={handleChange} />
+                <RadioCard {...args} compact={true} label="Compact" defaultChecked={true} onChange={handleChange} />
+            </div>
+        );
+    },
 };
 
 /**
@@ -101,15 +106,17 @@ export const StateExample: Story = {
         disabled: { table: { disable: true } },
         checked: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <RadioCard {...args} label="Default" />
-            <RadioCard {...args} label="Checked" checked={true} />
-            <RadioCard {...args} label="Disabled" disabled={true} />
-            <RadioCard {...args} label="Disabled Checked" disabled={true} checked={true} />
-            <RadioCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
-        </div>
-    ),
+    render: function RenderState(args) {
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <RadioCard {...args} label="Default" />
+                <RadioCard {...args} label="Checked" checked={true} />
+                <RadioCard {...args} label="Disabled" disabled={true} />
+                <RadioCard {...args} label="Disabled Checked" disabled={true} checked={true} />
+                <RadioCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
+            </div>
+        );
+    },
 };
 
 /**
@@ -120,12 +127,29 @@ export const AlignIndicatorExample: Story = {
     argTypes: {
         alignIndicator: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <RadioCard {...args} alignIndicator={Alignment.START} label="Align start" defaultChecked={true} />
-            <RadioCard {...args} alignIndicator={Alignment.END} label="Align end" defaultChecked={true} />
-        </div>
-    ),
+    render: function RenderAlignIndicator(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <RadioCard
+                    {...args}
+                    alignIndicator={Alignment.START}
+                    label="Align start"
+                    defaultChecked={true}
+                    onChange={handleChange}
+                />
+                <RadioCard
+                    {...args}
+                    alignIndicator={Alignment.END}
+                    label="Align end"
+                    defaultChecked={true}
+                    onChange={handleChange}
+                />
+            </div>
+        );
+    },
 };
 
 /**
@@ -135,7 +159,7 @@ export const Playground: Story = {
     args: {
         label: "Playground radio card",
     },
-    render: function Render(args) {
+    render: function RenderPlayground(args) {
         const [, updateArgs] = useArgs();
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
         return <RadioCard {...args} onChange={handleChange} />;

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs, useCallback } from "storybook/preview-api";
 
 import { Alignment, Elevation } from "../../common";
 
@@ -68,13 +69,18 @@ export const Default: Story = {
     args: {
         label: "Radio option",
     },
+    render: function Render(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+        return <RadioCard {...args} onChange={handleChange} />;
+    },
 };
 
 /**
  * Use the `compact` prop to render a more condensed radio card.
  */
-export const SizeExample: Story = {
-    name: "Size",
+export const CompactExample: Story = {
+    name: "Compact",
     argTypes: {
         compact: { table: { disable: true } },
     },
@@ -107,11 +113,31 @@ export const StateExample: Story = {
 };
 
 /**
- * Interactive playground with all props togglable via Storybook controls.
+ * Use the `alignIndicator` prop to render start or end-aligned.
+ */
+export const AlignIndicatorExample: Story = {
+    name: "Align Indicator",
+    argTypes: {
+        alignIndicator: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <RadioCard {...args} alignIndicator={Alignment.START} label="Align start" defaultChecked={true} />
+            <RadioCard {...args} alignIndicator={Alignment.END} label="Align end" defaultChecked={true} />
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props toggleable via Storybook controls.
  */
 export const Playground: Story = {
-    render: args => <RadioCard {...args} />,
     args: {
         label: "Playground radio card",
+    },
+    render: function Render(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+        return <RadioCard {...args} onChange={handleChange} />;
     },
 };

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -1,0 +1,149 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alignment, Elevation } from "../../common";
+
+import { SwitchCard } from "./switchCard";
+
+const meta: Meta<typeof SwitchCard> = {
+    title: "Core/ControlCard/SwitchCard",
+    component: SwitchCard,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "400px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Switch option",
+        checked: false,
+        disabled: false,
+        showAsSelectedWhenChecked: true,
+        compact: false,
+        elevation: Elevation.ZERO,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        checked: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        showAsSelectedWhenChecked: {
+            control: "boolean",
+        },
+        compact: {
+            control: "boolean",
+        },
+        elevation: {
+            control: "select",
+            options: Object.values(Elevation),
+        },
+        alignIndicator: {
+            control: "select",
+            options: Object.values(Alignment),
+        },
+        onChange: { action: "changed" },
+    },
+} satisfies Meta<typeof SwitchCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic switch card with default styling.
+ */
+export const Default: Story = {
+    args: {
+        label: "Switch option",
+    },
+};
+
+/**
+ * A checked switch card.
+ */
+export const Checked: Story = {
+    args: {
+        label: "Enabled setting",
+        checked: true,
+    },
+};
+
+/**
+ * A disabled switch card cannot be interacted with.
+ */
+export const Disabled: Story = {
+    args: {
+        label: "Unavailable setting",
+        disabled: true,
+    },
+};
+
+/**
+ * A disabled switch card that is also checked.
+ */
+export const DisabledChecked: Story = {
+    args: {
+        label: "Locked setting",
+        disabled: true,
+        checked: true,
+    },
+};
+
+/**
+ * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
+ */
+export const NoSelectedStyling: Story = {
+    name: "No selected styling",
+    args: {
+        label: "No highlight when checked",
+        checked: true,
+        showAsSelectedWhenChecked: false,
+    },
+};
+
+/**
+ * Multiple switch cards for a settings panel layout.
+ */
+export const SettingsPanel: Story = {
+    name: "Settings panel",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <SwitchCard {...args} label="Dark mode" defaultChecked={true} />
+            <SwitchCard {...args} label="Notifications" defaultChecked={true} />
+            <SwitchCard {...args} label="Auto-save" defaultChecked={false} />
+            <SwitchCard {...args} label="Beta features" disabled={true} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `compact` prop to render a more condensed card.
+ */
+export const Compact: Story = {
+    args: {
+        label: "Compact switch card",
+        compact: true,
+    },
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => <SwitchCard {...args} />,
+    args: {
+        label: "Playground switch card",
+    },
+};

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -71,71 +71,39 @@ export const Default: Story = {
 };
 
 /**
- * A checked switch card.
+ * Use the `compact` prop to render a more condensed switch card.
  */
-export const Checked: Story = {
-    args: {
-        label: "Enabled setting",
-        checked: true,
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        compact: { table: { disable: true } },
     },
-};
-
-/**
- * A disabled switch card cannot be interacted with.
- */
-export const Disabled: Story = {
-    args: {
-        label: "Unavailable setting",
-        disabled: true,
-    },
-};
-
-/**
- * A disabled switch card that is also checked.
- */
-export const DisabledChecked: Story = {
-    args: {
-        label: "Locked setting",
-        disabled: true,
-        checked: true,
-    },
-};
-
-/**
- * Use `showAsSelectedWhenChecked={false}` to prevent "selected" card styling when checked.
- */
-export const NoSelectedStyling: Story = {
-    name: "No selected styling",
-    args: {
-        label: "No highlight when checked",
-        checked: true,
-        showAsSelectedWhenChecked: false,
-    },
-};
-
-/**
- * Multiple switch cards for a settings panel layout.
- */
-export const SettingsPanel: Story = {
-    name: "Settings panel",
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <SwitchCard {...args} label="Dark mode" defaultChecked={true} />
-            <SwitchCard {...args} label="Notifications" defaultChecked={true} />
-            <SwitchCard {...args} label="Auto-save" defaultChecked={false} />
-            <SwitchCard {...args} label="Beta features" disabled={true} />
+            <SwitchCard {...args} compact={false} label="Default" defaultChecked={true} />
+            <SwitchCard {...args} compact={true} label="Compact" defaultChecked={true} />
         </div>
     ),
 };
 
 /**
- * Use the `compact` prop to render a more condensed card.
+ * Switch cards support `disabled`, `checked`, and `selected` states.
  */
-export const Compact: Story = {
-    args: {
-        label: "Compact switch card",
-        compact: true,
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        checked: { table: { disable: true } },
     },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <SwitchCard {...args} label="Default" />
+            <SwitchCard {...args} label="Checked" checked={true} />
+            <SwitchCard {...args} label="Disabled" disabled={true} />
+            <SwitchCard {...args} label="Disabled Checked" disabled={true} checked={true} />
+            <SwitchCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
+        </div>
+    ),
 };
 
 /**

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs, useCallback } from "storybook/preview-api";
 
 import { Alignment, Elevation } from "../../common";
 
@@ -68,13 +69,18 @@ export const Default: Story = {
     args: {
         label: "Switch option",
     },
+    render: function Render(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+        return <SwitchCard {...args} onChange={handleChange} />;
+    },
 };
 
 /**
  * Use the `compact` prop to render a more condensed switch card.
  */
-export const SizeExample: Story = {
-    name: "Size",
+export const CompactExample: Story = {
+    name: "Compact",
     argTypes: {
         compact: { table: { disable: true } },
     },
@@ -107,11 +113,31 @@ export const StateExample: Story = {
 };
 
 /**
- * Interactive playground with all props togglable via Storybook controls.
+ * Use the `alignIndicator` prop to render start or end-aligned.
+ */
+export const AlignIndicatorExample: Story = {
+    name: "Align Indicator",
+    argTypes: {
+        alignIndicator: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <SwitchCard {...args} alignIndicator={Alignment.START} label="Align start" defaultChecked={true} />
+            <SwitchCard {...args} alignIndicator={Alignment.END} label="Align end" defaultChecked={true} />
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props toggleable via Storybook controls.
  */
 export const Playground: Story = {
-    render: args => <SwitchCard {...args} />,
     args: {
         label: "Playground switch card",
+    },
+    render: function Render(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+        return <SwitchCard {...args} onChange={handleChange} />;
     },
 };

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -10,7 +10,7 @@ import { Alignment, Elevation } from "../../common";
 import { SwitchCard } from "./switchCard";
 
 const meta: Meta<typeof SwitchCard> = {
-    title: "Core/ControlCard/SwitchCard",
+    title: "Core/Control Card/SwitchCard",
     component: SwitchCard,
     decorators: [
         Story => (
@@ -69,7 +69,7 @@ export const Default: Story = {
     args: {
         label: "Switch option",
     },
-    render: function Render(args) {
+    render: function RenderDefault(args) {
         const [, updateArgs] = useArgs();
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
         return <SwitchCard {...args} onChange={handleChange} />;
@@ -84,12 +84,17 @@ export const CompactExample: Story = {
     argTypes: {
         compact: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <SwitchCard {...args} compact={false} label="Default" defaultChecked={true} />
-            <SwitchCard {...args} compact={true} label="Compact" defaultChecked={true} />
-        </div>
-    ),
+    render: function RenderCompact(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <SwitchCard {...args} label="Default" defaultChecked={true} onChange={handleChange} />
+                <SwitchCard {...args} compact={true} label="Compact" defaultChecked={true} onChange={handleChange} />
+            </div>
+        );
+    },
 };
 
 /**
@@ -101,15 +106,26 @@ export const StateExample: Story = {
         disabled: { table: { disable: true } },
         checked: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <SwitchCard {...args} label="Default" />
-            <SwitchCard {...args} label="Checked" checked={true} />
-            <SwitchCard {...args} label="Disabled" disabled={true} />
-            <SwitchCard {...args} label="Disabled Checked" disabled={true} checked={true} />
-            <SwitchCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
-        </div>
-    ),
+    render: function RenderState(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <SwitchCard {...args} label="Default" onChange={handleChange} />
+                <SwitchCard {...args} label="Checked" checked={true} onChange={handleChange} />
+                <SwitchCard {...args} label="Disabled" disabled={true} />
+                <SwitchCard {...args} label="Disabled Checked" disabled={true} checked={true} />
+                <SwitchCard
+                    {...args}
+                    label="No selected styling"
+                    checked={true}
+                    showAsSelectedWhenChecked={false}
+                    onChange={handleChange}
+                />
+            </div>
+        );
+    },
 };
 
 /**
@@ -120,12 +136,29 @@ export const AlignIndicatorExample: Story = {
     argTypes: {
         alignIndicator: { table: { disable: true } },
     },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
-            <SwitchCard {...args} alignIndicator={Alignment.START} label="Align start" defaultChecked={true} />
-            <SwitchCard {...args} alignIndicator={Alignment.END} label="Align end" defaultChecked={true} />
-        </div>
-    ),
+    render: function RenderAlignIndicator(args) {
+        const [, updateArgs] = useArgs();
+        const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+                <SwitchCard
+                    {...args}
+                    alignIndicator={Alignment.START}
+                    label="Align start"
+                    defaultChecked={true}
+                    onChange={handleChange}
+                />
+                <SwitchCard
+                    {...args}
+                    alignIndicator={Alignment.END}
+                    label="Align end"
+                    defaultChecked={true}
+                    onChange={handleChange}
+                />
+            </div>
+        );
+    },
 };
 
 /**
@@ -135,7 +168,7 @@ export const Playground: Story = {
     args: {
         label: "Playground switch card",
     },
-    render: function Render(args) {
+    render: function RenderPlayground(args) {
         const [, updateArgs] = useArgs();
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
         return <SwitchCard {...args} onChange={handleChange} />;


### PR DESCRIPTION
## Summary
- Extracted Storybook stories for Control Card component
- Stories provide visual regression testing coverage

## Files
- `CheckboxCard.stories.tsx`
- `RadioCard.stories.tsx`
- `SwitchCard.stories.tsx`

## Test plan
- [ ] Verify stories render correctly in Storybook
- [ ] Check all story variants display properly in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)