### PR TITLE
[core] Add Storybook stories for Navbar

### DIFF
--- a/packages/core/src/components/navbar/Navbar.stories.tsx
+++ b/packages/core/src/components/navbar/Navbar.stories.tsx
@@ -17,7 +17,7 @@ type NavbarStoryArgs = React.ComponentProps<typeof Navbar> & {
 };
 
 const meta: Meta<NavbarStoryArgs> = {
-    title: "Core/Navbar and NavbarGroup",
+    title: "Core/Navbar",
     component: Navbar,
     subcomponents: { NavbarGroup },
     parameters: {
@@ -45,6 +45,30 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     argTypes: {
         align: { table: { disable: true } },
+    },
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+            <NavbarGroup align={Alignment.END}>
+                <Button variant="minimal" icon="notifications" />
+                <Button variant="minimal" icon="cog" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const FixedToTop: Story = {
+    args: {
+        fixedToTop: true,
+    },
+    argTypes: {
+        align: { table: { disable: true } },
+        fixedToTop: { table: { disable: true } },
     },
     render: args => (
         <Navbar {...args}>

--- a/packages/core/src/components/navbar/Navbar.stories.tsx
+++ b/packages/core/src/components/navbar/Navbar.stories.tsx
@@ -1,0 +1,115 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alignment } from "../../common";
+import { Button } from "../button/buttons";
+
+import { Navbar } from "./navbar";
+import { NavbarDivider } from "./navbarDivider";
+import { NavbarGroup } from "./navbarGroup";
+import { NavbarHeading } from "./navbarHeading";
+
+const meta: Meta<typeof Navbar> = {
+    title: "Core/Components/Navbar",
+    component: Navbar,
+    parameters: {
+        layout: "padded",
+    },
+    tags: ["autodocs"],
+    args: {
+        fixedToTop: false,
+    },
+    argTypes: {
+        fixedToTop: { control: "boolean" },
+    },
+} satisfies Meta<typeof Navbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const WithLeftAndRightGroups: Story = {
+    name: "Left & Right Groups",
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+            <NavbarGroup align={Alignment.END}>
+                <Button variant="minimal" icon="notifications" />
+                <Button variant="minimal" icon="cog" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const WithDividers: Story = {
+    name: "With Dividers",
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>App</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+                <NavbarDivider />
+                <Button variant="minimal" icon="cog" text="Settings" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};
+
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    render: args => (
+        <div className="bp6-dark">
+            <Navbar {...args}>
+                <NavbarGroup align={Alignment.START}>
+                    <NavbarHeading>Blueprint</NavbarHeading>
+                    <NavbarDivider />
+                    <Button variant="minimal" icon="home" text="Home" />
+                    <Button variant="minimal" icon="document" text="Files" />
+                </NavbarGroup>
+                <NavbarGroup align={Alignment.END}>
+                    <Button variant="minimal" icon="notifications" />
+                    <Button variant="minimal" icon="cog" />
+                </NavbarGroup>
+            </Navbar>
+        </div>
+    ),
+};
+
+export const Playground: Story = {
+    render: args => (
+        <Navbar {...args}>
+            <NavbarGroup align={Alignment.START}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
+            </NavbarGroup>
+            <NavbarGroup align={Alignment.END}>
+                <Button variant="minimal" icon="notifications" />
+                <Button variant="minimal" icon="cog" />
+            </NavbarGroup>
+        </Navbar>
+    ),
+};

--- a/packages/core/src/components/navbar/Navbar.stories.tsx
+++ b/packages/core/src/components/navbar/Navbar.stories.tsx
@@ -12,25 +12,40 @@ import { NavbarDivider } from "./navbarDivider";
 import { NavbarGroup } from "./navbarGroup";
 import { NavbarHeading } from "./navbarHeading";
 
-const meta: Meta<typeof Navbar> = {
-    title: "Core/Navbar",
+type NavbarStoryArgs = React.ComponentProps<typeof Navbar> & {
+    align: NonNullable<React.ComponentProps<typeof NavbarGroup>["align"]>;
+};
+
+const meta: Meta<NavbarStoryArgs> = {
+    title: "Core/Navbar and NavbarGroup",
     component: Navbar,
+    subcomponents: { NavbarGroup },
     parameters: {
         layout: "padded",
     },
     tags: ["autodocs"],
     args: {
         fixedToTop: false,
+        align: Alignment.START,
     },
     argTypes: {
-        fixedToTop: { control: "boolean" },
+        fixedToTop: { control: "boolean", table: { category: "Navbar" } },
+        align: {
+            control: "select",
+            options: Object.values(Alignment).filter(option => option !== "center"),
+            description: "`NavbarGroup` alignment",
+            table: { category: "NavbarGroup" },
+        },
     },
-} satisfies Meta<typeof Navbar>;
+} satisfies Meta<NavbarStoryArgs>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+    argTypes: {
+        align: { table: { disable: true } },
+    },
     render: args => (
         <Navbar {...args}>
             <NavbarGroup align={Alignment.START}>
@@ -47,18 +62,30 @@ export const Default: Story = {
     ),
 };
 
-export const Playground: Story = {
-    render: args => (
+export const AlignEnd: Story = {
+    argTypes: {
+        align: { table: { disable: true } },
+    },
+    render: ({ align, ...args }) => (
         <Navbar {...args}>
-            <NavbarGroup align={Alignment.START}>
+            <NavbarGroup align={Alignment.END}>
                 <NavbarHeading>Blueprint</NavbarHeading>
                 <NavbarDivider />
                 <Button variant="minimal" icon="home" text="Home" />
                 <Button variant="minimal" icon="document" text="Files" />
             </NavbarGroup>
-            <NavbarGroup align={Alignment.END}>
-                <Button variant="minimal" icon="notifications" />
-                <Button variant="minimal" icon="cog" />
+        </Navbar>
+    ),
+};
+
+export const Playground: Story = {
+    render: ({ align, ...args }) => (
+        <Navbar {...args}>
+            <NavbarGroup align={align}>
+                <NavbarHeading>Blueprint</NavbarHeading>
+                <NavbarDivider />
+                <Button variant="minimal" icon="home" text="Home" />
+                <Button variant="minimal" icon="document" text="Files" />
             </NavbarGroup>
         </Navbar>
     ),

--- a/packages/core/src/components/navbar/Navbar.stories.tsx
+++ b/packages/core/src/components/navbar/Navbar.stories.tsx
@@ -13,7 +13,7 @@ import { NavbarGroup } from "./navbarGroup";
 import { NavbarHeading } from "./navbarHeading";
 
 const meta: Meta<typeof Navbar> = {
-    title: "Core/Components/Navbar",
+    title: "Core/Navbar",
     component: Navbar,
     parameters: {
         layout: "padded",
@@ -39,61 +39,11 @@ export const Default: Story = {
                 <Button variant="minimal" icon="home" text="Home" />
                 <Button variant="minimal" icon="document" text="Files" />
             </NavbarGroup>
-        </Navbar>
-    ),
-};
-
-export const WithLeftAndRightGroups: Story = {
-    name: "Left & Right Groups",
-    render: args => (
-        <Navbar {...args}>
-            <NavbarGroup align={Alignment.START}>
-                <NavbarHeading>Blueprint</NavbarHeading>
-                <NavbarDivider />
-                <Button variant="minimal" icon="home" text="Home" />
-                <Button variant="minimal" icon="document" text="Files" />
-            </NavbarGroup>
             <NavbarGroup align={Alignment.END}>
                 <Button variant="minimal" icon="notifications" />
                 <Button variant="minimal" icon="cog" />
             </NavbarGroup>
         </Navbar>
-    ),
-};
-
-export const WithDividers: Story = {
-    name: "With Dividers",
-    render: args => (
-        <Navbar {...args}>
-            <NavbarGroup align={Alignment.START}>
-                <NavbarHeading>App</NavbarHeading>
-                <NavbarDivider />
-                <Button variant="minimal" icon="home" text="Home" />
-                <Button variant="minimal" icon="document" text="Files" />
-                <NavbarDivider />
-                <Button variant="minimal" icon="cog" text="Settings" />
-            </NavbarGroup>
-        </Navbar>
-    ),
-};
-
-export const DarkTheme: Story = {
-    name: "Dark Theme",
-    render: args => (
-        <div className="bp6-dark">
-            <Navbar {...args}>
-                <NavbarGroup align={Alignment.START}>
-                    <NavbarHeading>Blueprint</NavbarHeading>
-                    <NavbarDivider />
-                    <Button variant="minimal" icon="home" text="Home" />
-                    <Button variant="minimal" icon="document" text="Files" />
-                </NavbarGroup>
-                <NavbarGroup align={Alignment.END}>
-                    <Button variant="minimal" icon="notifications" />
-                    <Button variant="minimal" icon="cog" />
-                </NavbarGroup>
-            </Navbar>
-        </div>
     ),
 };
 


### PR DESCRIPTION
## Summary
- Extracted Storybook stories for Navbar component and NavbarGroup subcomponent. NavbarDivider and NavbarHeading do not have props, so are not separately tested here.
- Stories provide visual regression testing coverage

## Files
- `Navbar.stories.tsx`

## Test plan
- [ ] `pnpm install && pnpm -w run storybook`
- [ ] Verify stories render correctly in Storybook
- [ ] Check all story variants display properly in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)