### PR TITLE
[core] Add Storybook stories for Segmented Control

### DIFF
--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -27,7 +27,7 @@ const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
 >;
 
 const meta: Meta<typeof SegmentedControl> = {
-    title: "Core/Components/SegmentedControl",
+    title: "Core/SegmentedControl",
     component: SegmentedControl,
     decorators: [
         Story => (
@@ -153,14 +153,6 @@ export const StateExample: Story = {
             </div>
         </div>
     ),
-};
-
-/**
- * Options can include icons alongside labels.
- */
-export const IconExample: Story = {
-    name: "Icons",
-    render: args => <SegmentedControl {...args} options={ICON_OPTIONS} />,
 };
 
 /**

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -1,4 +1,4 @@
-/* !
+/*
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
@@ -27,7 +27,7 @@ const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
 >;
 
 const meta: Meta<typeof SegmentedControl> = {
-    title: "Core/SegmentedControl",
+    title: "Core/Form/Controls/SegmentedControl",
     component: SegmentedControl,
     decorators: [
         Story => (
@@ -43,7 +43,7 @@ const meta: Meta<typeof SegmentedControl> = {
     args: {
         options: DEFAULT_OPTIONS,
         defaultValue: "list",
-        intent: "none",
+        intent: Intent.NONE,
         size: "medium",
         disabled: false,
         fill: false,
@@ -185,6 +185,40 @@ export const FillExample: Story = {
 };
 
 /**
+ * Each option can include an `icon` prop to display an icon alongside the label.
+ */
+export const WithIcons: Story = {
+    name: "With Icons",
+    args: {
+        options: ICON_OPTIONS,
+    },
+};
+
+/**
+ * Use `aria-label` on the container and `role` to control the ARIA semantics.
+ * The component supports `"radiogroup"` (default), `"group"`, `"toolbar"`, and `"menu"` roles.
+ */
+export const AriaLabels: Story = {
+    name: "Aria Labels",
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>role="radiogroup" (default) + aria-label</span>
+                <SegmentedControl {...args} aria-label="View mode" />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>role="toolbar" + aria-label</span>
+                <SegmentedControl {...args} role="toolbar" aria-label="View mode toolbar" />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>role="group" + aria-label</span>
+                <SegmentedControl {...args} role="group" aria-label="View mode group" />
+            </div>
+        </div>
+    ),
+};
+
+/**
  * All intents across all sizes and states.
  */
 export const AllIntentsAllSizes: Story = {
@@ -198,9 +232,7 @@ export const AllIntentsAllSizes: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {[Intent.NONE, Intent.PRIMARY].map(intent => (
                 <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <div style={{ fontSize: 12, opacity: 0.6 }}>
-                        Intent: {intent === Intent.NONE ? "none" : "primary"}
-                    </div>
+                    <div style={{ fontSize: 12, opacity: 0.6 }}>Intent: {intent}</div>
                     {Object.values(Size).map(size => (
                         <SegmentedControl key={size} {...args} intent={intent} size={size} />
                     ))}

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -1,0 +1,247 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent, Size } from "../../common";
+
+import { SegmentedControl } from "./segmentedControl";
+
+const DEFAULT_OPTIONS = [
+    { label: "List", value: "list" },
+    { label: "Grid", value: "grid" },
+    { label: "Gallery", value: "gallery" },
+];
+
+const ICON_OPTIONS = [
+    { label: "List", value: "list", icon: "list" as const },
+    { label: "Grid", value: "grid", icon: "grid-view" as const },
+    { label: "Gallery", value: "gallery", icon: "media" as const },
+];
+
+// These props are deprecated on SegmentedControl — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof SegmentedControl>
+>;
+
+const meta: Meta<typeof SegmentedControl> = {
+    title: "Core/Components/SegmentedControl",
+    component: SegmentedControl,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        options: DEFAULT_OPTIONS,
+        defaultValue: "list",
+        intent: "none",
+        size: "medium",
+        disabled: false,
+        fill: false,
+        inline: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: [Intent.NONE, Intent.PRIMARY],
+        },
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        disabled: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        inline: {
+            control: "boolean",
+        },
+        onValueChange: { action: "valueChanged" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof SegmentedControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic segmented control with default styling.
+ */
+export const Default: Story = {};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the selected segment.
+ * SegmentedControl supports `"none"` (default) and `"primary"`.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>None</span>
+                <SegmentedControl {...args} intent={Intent.NONE} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Primary</span>
+                <SegmentedControl {...args} intent={Intent.PRIMARY} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the control dimensions.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+            {Object.values(Size).map(size => (
+                <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                    <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{size}</span>
+                    <SegmentedControl {...args} size={size} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * The disabled state prevents user interaction with the control.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <SegmentedControl {...args} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                <SegmentedControl {...args} disabled={true} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Options can include icons alongside labels.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    render: args => (
+        <SegmentedControl {...args} options={ICON_OPTIONS} />
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the control expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Fill</span>
+                <SegmentedControl {...args} fill={true} />
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Auto Width</span>
+                <SegmentedControl {...args} fill={false} />
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * All intents across all sizes and states.
+ */
+export const AllIntentsAllSizes: Story = {
+    name: "All Intents & Sizes",
+    argTypes: {
+        intent: { table: { disable: true } },
+        size: { table: { disable: true } },
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {[Intent.NONE, Intent.PRIMARY].map(intent => (
+                <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <div style={{ fontSize: 12, opacity: 0.6 }}>
+                        Intent: {intent === Intent.NONE ? "none" : "primary"}
+                    </div>
+                    {Object.values(Size).map(size => (
+                        <SegmentedControl key={size} {...args} intent={intent} size={size} />
+                    ))}
+                    <SegmentedControl {...args} intent={intent} disabled={true} />
+                </div>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground demonstrating controlled value state.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [value, setValue] = useState("list");
+
+        const handleValueChange = useCallback((newValue: string) => {
+            setValue(newValue);
+        }, []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+                <SegmentedControl
+                    {...args}
+                    options={ICON_OPTIONS}
+                    value={value}
+                    onValueChange={handleValueChange}
+                />
+                <span style={{ fontSize: 12, opacity: 0.6 }}>Selected: {value}</span>
+            </div>
+        );
+    },
+};

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -160,9 +160,7 @@ export const StateExample: Story = {
  */
 export const IconExample: Story = {
     name: "Icons",
-    render: args => (
-        <SegmentedControl {...args} options={ICON_OPTIONS} />
-    ),
+    render: args => <SegmentedControl {...args} options={ICON_OPTIONS} />,
 };
 
 /**
@@ -234,12 +232,7 @@ export const Playground: Story = {
 
         return (
             <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
-                <SegmentedControl
-                    {...args}
-                    options={ICON_OPTIONS}
-                    value={value}
-                    onValueChange={handleValueChange}
-                />
+                <SegmentedControl {...args} options={ICON_OPTIONS} value={value} onValueChange={handleValueChange} />
                 <span style={{ fontSize: 12, opacity: 0.6 }}>Selected: {value}</span>
             </div>
         );


### PR DESCRIPTION
## Summary
- Extracted Storybook stories for Segmented Control component
- Stories provide visual regression testing coverage

## Files
- `SegmentedControl.stories.tsx`

## Test plan
- [ ] Verify stories render correctly in Storybook
- [ ] Check all story variants display properly in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)