### PR TITLE
[core] Add Storybook stories for Tooltip

### DIFF
--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -73,13 +73,11 @@ export const IntentExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", gap: 24 }}>
-            {Object.values(Intent)
-                .filter(i => i !== "none")
-                .map(intent => (
-                    <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
-                        <span>{intent.charAt(0).toUpperCase() + intent.slice(1)}</span>
-                    </Tooltip>
-                ))}
+            {Object.values(Intent).map(intent => (
+                <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
+                    <span>{intent.charAt(0).toUpperCase() + intent.slice(1)}</span>
+                </Tooltip>
+            ))}
         </div>
     ),
 };

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -112,41 +112,6 @@ export const VariantExample: Story = {
 };
 
 /**
- * All intents displayed together for visual comparison, in both default and compact variants.
- */
-export const AllIntents: Story = {
-    name: "All Intents",
-    argTypes: {
-        intent: { table: { disable: true } },
-        compact: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 40 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <div style={{ fontSize: 12, opacity: 0.6 }}>Default</div>
-                <div style={{ display: "flex", gap: 24 }}>
-                    {Object.values(Intent).map(intent => (
-                        <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
-                            <span style={{ textTransform: "capitalize" }}>{intent === "none" ? "none" : intent}</span>
-                        </Tooltip>
-                    ))}
-                </div>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <div style={{ fontSize: 12, opacity: 0.6 }}>Compact</div>
-                <div style={{ display: "flex", gap: 24 }}>
-                    {Object.values(Intent).map(intent => (
-                        <Tooltip key={intent} {...args} intent={intent} compact={true} isOpen={true}>
-                            <span style={{ textTransform: "capitalize" }}>{intent === "none" ? "none" : intent}</span>
-                        </Tooltip>
-                    ))}
-                </div>
-            </div>
-        </div>
-    ),
-};
-
-/**
  * Interactive playground with all props togglable via Storybook controls.
  */
 export const Playground: Story = {

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -11,7 +11,7 @@ import { Button } from "../button/buttons";
 import { Tooltip } from "./tooltip";
 
 const meta: Meta<typeof Tooltip> = {
-    title: "Core/Tooltip",
+    title: "Core/Overlays/Tooltip",
     component: Tooltip,
     decorators: [
         Story => (
@@ -26,7 +26,7 @@ const meta: Meta<typeof Tooltip> = {
     tags: ["autodocs"],
     args: {
         content: "This is a tooltip",
-        intent: "none",
+        intent: Intent.NONE,
         compact: false,
         minimal: false,
         disabled: false,
@@ -61,7 +61,7 @@ export const Default: Story = {
     args: {
         content: "This is a tooltip",
         isOpen: true,
-        children: <span>Hover me</span>,
+        children: <Button>Hover me</Button>,
     },
 };
 
@@ -77,7 +77,7 @@ export const IntentExample: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 108 }}>
             {Object.values(Intent).map(intent => (
                 <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
-                    <span>{intent.charAt(0).toUpperCase() + intent.slice(1)}</span>
+                    <Button>{intent.charAt(0).toUpperCase() + intent.slice(1)}</Button>
                 </Tooltip>
             ))}
         </div>
@@ -96,16 +96,16 @@ export const VariantExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 108 }}>
             <Tooltip {...args} compact={false} minimal={false} isOpen={true}>
-                <span>Default</span>
+                <Button>Default</Button>
             </Tooltip>
             <Tooltip {...args} compact={true} minimal={false} isOpen={true}>
-                <span>Compact</span>
+                <Button>Compact</Button>
             </Tooltip>
             <Tooltip {...args} compact={false} minimal={true} isOpen={true}>
-                <span>Minimal</span>
+                <Button>Minimal</Button>
             </Tooltip>
             <Tooltip {...args} compact={true} minimal={true} isOpen={true}>
-                <span>Compact + Minimal</span>
+                <Button>Compact + Minimal</Button>
             </Tooltip>
         </div>
     ),
@@ -117,7 +117,7 @@ export const VariantExample: Story = {
 export const Playground: Story = {
     args: {
         content: "Tooltip content",
-        children: <span>Hover over me</span>,
+        children: <Button>Hover over me</Button>,
     },
 };
 
@@ -205,6 +205,10 @@ export const HoverOpenDelay: Story = {
             const target = canvas.getByRole("button", { name: "500ms delay" });
             await userEvent.hover(target);
             await expect(screen.queryByText("Delayed tooltip")).not.toBeInTheDocument();
+        });
+
+        await step("Wait for delay — tooltip becomes visible", async () => {
+            await waitFor(() => expect(screen.getByText("Delayed tooltip")).toBeVisible());
         });
     },
 };

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -3,8 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, screen, waitFor } from "storybook/test";
 
 import { Intent } from "../../common";
+import { Button } from "../button/buttons";
 
 import { Tooltip } from "./tooltip";
 
@@ -72,7 +74,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 24 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 108 }}>
             {Object.values(Intent).map(intent => (
                 <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
                     <span>{intent.charAt(0).toUpperCase() + intent.slice(1)}</span>
@@ -92,7 +94,7 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 32 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 108 }}>
             <Tooltip {...args} compact={false} minimal={false} isOpen={true}>
                 <span>Default</span>
             </Tooltip>
@@ -116,5 +118,93 @@ export const Playground: Story = {
     args: {
         content: "Tooltip content",
         children: <span>Hover over me</span>,
+    },
+};
+
+/**
+ * Demonstrates the tooltip appearing on hover. The `play` function simulates
+ * a user hovering over the target, causing the tooltip to open.
+ */
+export const HoverOpen: Story = {
+    name: "Hover Open",
+    args: {
+        content: "I appeared on hover!",
+        hoverOpenDelay: 0,
+        children: <Button>Hover me</Button>,
+    },
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Hover target to open tooltip", async () => {
+            const target = canvas.getByRole("button", { name: "Hover me" });
+            await userEvent.hover(target);
+            await waitFor(() => expect(screen.getByText("I appeared on hover!")).toBeVisible());
+        });
+    },
+};
+
+/**
+ * Demonstrates the tooltip closing when the user moves the cursor away.
+ * After hovering to open, the cursor is moved off and the tooltip disappears.
+ */
+export const HoverClose: Story = {
+    name: "Hover Close",
+    args: {
+        content: "Now you see me",
+        hoverOpenDelay: 0,
+        hoverCloseDelay: 0,
+        transitionDuration: 0,
+        children: <Button>Hover then leave</Button>,
+    },
+    play: async ({ canvas, userEvent, step }) => {
+        const target = canvas.getByRole("button", { name: "Hover then leave" });
+
+        await step("Hover to open tooltip", async () => {
+            await userEvent.hover(target);
+            await waitFor(() => expect(screen.getByText("Now you see me")).toBeVisible());
+        });
+
+        await step("Unhover to close tooltip", async () => {
+            await userEvent.unhover(target);
+            await waitFor(() => expect(screen.queryByText("Now you see me")).not.toBeInTheDocument());
+        });
+    },
+};
+
+/**
+ * When `disabled` is true, hovering over the target does not open the tooltip.
+ */
+export const HoverDisabled: Story = {
+    name: "Hover Disabled",
+    args: {
+        content: "You should not see this",
+        disabled: true,
+        hoverOpenDelay: 0,
+        children: <Button>Tooltip is disabled</Button>,
+    },
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Hover disabled tooltip — nothing appears", async () => {
+            const target = canvas.getByRole("button", { name: "Tooltip is disabled" });
+            await userEvent.hover(target);
+            await expect(screen.queryByText("You should not see this")).not.toBeInTheDocument();
+        });
+    },
+};
+
+/**
+ * Demonstrates `hoverOpenDelay` — the tooltip waits before appearing.
+ * With a 500ms delay, the tooltip is not yet visible immediately after hover.
+ */
+export const HoverOpenDelay: Story = {
+    name: "Hover Open Delay",
+    args: {
+        content: "Delayed tooltip",
+        hoverOpenDelay: 500,
+        children: <Button>500ms delay</Button>,
+    },
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Hover — tooltip not visible immediately due to delay", async () => {
+            const target = canvas.getByRole("button", { name: "500ms delay" });
+            await userEvent.hover(target);
+            await expect(screen.queryByText("Delayed tooltip")).not.toBeInTheDocument();
+        });
     },
 };

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-/* !
+/*
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
@@ -9,7 +9,7 @@ import { Intent } from "../../common";
 import { Tooltip } from "./tooltip";
 
 const meta: Meta<typeof Tooltip> = {
-    title: "Core/Tooltip/Tooltip",
+    title: "Core/Tooltip",
     component: Tooltip,
     decorators: [
         Story => (
@@ -85,67 +85,34 @@ export const IntentExample: Story = {
 };
 
 /**
- * Use the `compact` prop for a more condensed tooltip appearance.
+ * The `compact` prop renders a more condensed tooltip, and the `minimal` prop removes the arrow.
  */
-export const CompactExample: Story = {
-    name: "Compact",
+export const VariantExample: Story = {
+    name: "Variant",
     argTypes: {
         compact: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", gap: 24 }}>
-            <Tooltip {...args} compact={false} isOpen={true}>
-                <span>Default</span>
-            </Tooltip>
-            <Tooltip {...args} compact={true} isOpen={true}>
-                <span>Compact</span>
-            </Tooltip>
-        </div>
-    ),
-};
-
-/**
- * Use the `minimal` prop to render the tooltip without an arrow.
- */
-export const MinimalExample: Story = {
-    name: "Minimal",
-    argTypes: {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 24 }}>
-            <Tooltip {...args} minimal={false} isOpen={true}>
-                <span>With arrow</span>
+        <div style={{ display: "flex", gap: 32 }}>
+            <Tooltip {...args} compact={false} minimal={false} isOpen={true}>
+                <span>Default</span>
             </Tooltip>
-            <Tooltip {...args} minimal={true} isOpen={true}>
-                <span>No arrow</span>
+            <Tooltip {...args} compact={true} minimal={false} isOpen={true}>
+                <span>Compact</span>
             </Tooltip>
-        </div>
-    ),
-};
-
-/**
- * Use the `disabled` prop to prevent the tooltip from appearing.
- */
-export const DisabledExample: Story = {
-    name: "Disabled",
-    argTypes: {
-        disabled: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", gap: 24 }}>
-            <Tooltip {...args} disabled={false} isOpen={true}>
-                <span>Enabled</span>
+            <Tooltip {...args} compact={false} minimal={true} isOpen={true}>
+                <span>Minimal</span>
             </Tooltip>
-            <Tooltip {...args} disabled={true}>
-                <span>Disabled</span>
+            <Tooltip {...args} compact={true} minimal={true} isOpen={true}>
+                <span>Compact + Minimal</span>
             </Tooltip>
         </div>
     ),
 };
 
 /**
- * All intents displayed together for visual comparison.
+ * All intents displayed together for visual comparison, in both default and compact variants.
  */
 export const AllIntents: Story = {
     name: "All Intents",

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,190 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { Tooltip } from "./tooltip";
+
+const meta: Meta<typeof Tooltip> = {
+    title: "Core/Tooltip/Tooltip",
+    component: Tooltip,
+    decorators: [
+        Story => (
+            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        content: "This is a tooltip",
+        intent: "none",
+        compact: false,
+        minimal: false,
+        disabled: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        compact: {
+            control: "boolean",
+        },
+        minimal: {
+            control: "boolean",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        content: {
+            control: "text",
+        },
+    },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic tooltip that appears on hover.
+ */
+export const Default: Story = {
+    args: {
+        content: "This is a tooltip",
+        isOpen: true,
+        children: <span>Hover me</span>,
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the tooltip background.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
+                        <span>{intent.charAt(0).toUpperCase() + intent.slice(1)}</span>
+                    </Tooltip>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `compact` prop for a more condensed tooltip appearance.
+ */
+export const CompactExample: Story = {
+    name: "Compact",
+    argTypes: {
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <Tooltip {...args} compact={false} isOpen={true}>
+                <span>Default</span>
+            </Tooltip>
+            <Tooltip {...args} compact={true} isOpen={true}>
+                <span>Compact</span>
+            </Tooltip>
+        </div>
+    ),
+};
+
+/**
+ * Use the `minimal` prop to render the tooltip without an arrow.
+ */
+export const MinimalExample: Story = {
+    name: "Minimal",
+    argTypes: {
+        minimal: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <Tooltip {...args} minimal={false} isOpen={true}>
+                <span>With arrow</span>
+            </Tooltip>
+            <Tooltip {...args} minimal={true} isOpen={true}>
+                <span>No arrow</span>
+            </Tooltip>
+        </div>
+    ),
+};
+
+/**
+ * Use the `disabled` prop to prevent the tooltip from appearing.
+ */
+export const DisabledExample: Story = {
+    name: "Disabled",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", gap: 24 }}>
+            <Tooltip {...args} disabled={false} isOpen={true}>
+                <span>Enabled</span>
+            </Tooltip>
+            <Tooltip {...args} disabled={true}>
+                <span>Disabled</span>
+            </Tooltip>
+        </div>
+    ),
+};
+
+/**
+ * All intents displayed together for visual comparison.
+ */
+export const AllIntents: Story = {
+    name: "All Intents",
+    argTypes: {
+        intent: { table: { disable: true } },
+        compact: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 40 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Default</div>
+                <div style={{ display: "flex", gap: 24 }}>
+                    {Object.values(Intent).map(intent => (
+                        <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
+                            <span style={{ textTransform: "capitalize" }}>{intent === "none" ? "none" : intent}</span>
+                        </Tooltip>
+                    ))}
+                </div>
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Compact</div>
+                <div style={{ display: "flex", gap: 24 }}>
+                    {Object.values(Intent).map(intent => (
+                        <Tooltip key={intent} {...args} intent={intent} compact={true} isOpen={true}>
+                            <span style={{ textTransform: "capitalize" }}>{intent === "none" ? "none" : intent}</span>
+                        </Tooltip>
+                    ))}
+                </div>
+            </div>
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    args: {
+        content: "Tooltip content",
+        children: <span>Hover over me</span>,
+    },
+};


### PR DESCRIPTION
## Summary
- Extracted Storybook stories for Tooltip component
- Stories provide visual regression testing coverage

## Files
- `Tooltip.stories.tsx`

## Test plan
- [ ] Verify stories render correctly in Storybook
- [ ] Check all story variants display properly in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)