### PR TITLE
[core] Add Storybook stories for form components

### DIFF
--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -139,15 +139,15 @@ export const FillExample: Story = {
     },
     decorators: [
         Story => (
-            <div style={{ width: "500px" }}>
+            <div style={{ width: "400px" }}>
                 <Story />
             </div>
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <FileInput {...args} fill={true} text="Full width..." />
-            <FileInput {...args} fill={false} text="Auto width..." />
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+            <FileInput {...args} fill={true} text="Full Width" />
+            <FileInput {...args} fill={false} text="Auto Width" />
         </div>
     ),
 };

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -9,11 +9,8 @@ import { Size } from "../../common";
 
 import { FileInput } from "./fileInput";
 
-// These props are deprecated on FileInput — hide them from the Storybook controls panel.
-const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof FileInput>>;
-
 const meta: Meta<typeof FileInput> = {
-    title: "Core/Form/FileInput",
+    title: "Core/Form/Inputs/FileInput",
     component: FileInput,
     decorators: [
         Story => (
@@ -63,17 +60,9 @@ const meta: Meta<typeof FileInput> = {
             control: "boolean",
         },
         onInputChange: { action: "inputChanged" },
-        ...disabledArgs.reduce(
-            (acc, argName) => {
-                acc[argName] = {
-                    table: {
-                        disable: true,
-                    },
-                };
-                return acc;
-            },
-            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
-        ),
+        // deprecated props
+        large: { table: { disable: true } },
+        small: { table: { disable: true } },
     },
 } satisfies Meta<typeof FileInput>;
 
@@ -83,11 +72,7 @@ type Story = StoryObj<typeof meta>;
 /**
  * A basic file input with default styling.
  */
-export const Default: Story = {
-    args: {
-        text: "Choose file...",
-    },
-};
+export const Default: Story = {};
 
 /**
  * Use the `size` prop to adjust the file input dimensions.

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useCallback, useState } from "react";
+import { type ChangeEvent, useCallback, useState } from "react";
 
 import { Size } from "../../common";
 
@@ -162,7 +162,7 @@ export const Playground: Story = {
         const [fileName, setFileName] = useState<string | null>(null);
 
         const handleInputChange = useCallback(
-            (e: React.ChangeEvent<HTMLInputElement>) => {
+            (e: ChangeEvent<HTMLInputElement>) => {
                 const file = e.target.files?.[0];
                 setFileName(file?.name ?? null);
                 args.onInputChange?.(e);

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -1,0 +1,206 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Size } from "../../common";
+
+import { FileInput } from "./fileInput";
+
+// These props are deprecated on FileInput — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof FileInput>>;
+
+const meta: Meta<typeof FileInput> = {
+    title: "Core/Form/FileInput",
+    component: FileInput,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 12,
+                    width: "100%",
+                    minWidth: "400px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        text: "Choose file...",
+        buttonText: "Browse",
+        disabled: false,
+        fill: false,
+        hasSelection: false,
+        size: "medium",
+    },
+    argTypes: {
+        text: {
+            control: "text",
+        },
+        buttonText: {
+            control: "text",
+        },
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        disabled: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        hasSelection: {
+            control: "boolean",
+        },
+        onInputChange: { action: "inputChanged" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof FileInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic file input with default styling.
+ */
+export const Default: Story = {
+    args: {
+        text: "Choose file...",
+    },
+};
+
+/**
+ * Use the `size` prop to adjust the file input dimensions.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Size).map(size => (
+                <FileInput
+                    key={size}
+                    {...args}
+                    size={size}
+                    text={`${size.charAt(0).toUpperCase() + size.slice(1)} size`}
+                />
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * FileInput supports `disabled` state and `hasSelection` visual state.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        hasSelection: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <FileInput {...args} text="Choose file..." />
+            <FileInput {...args} hasSelection={true} text="document.pdf" />
+            <FileInput {...args} disabled={true} text="Disabled..." />
+        </div>
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the file input expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <FileInput {...args} fill={true} text="Full width..." />
+            <FileInput {...args} fill={false} text="Auto width..." />
+        </div>
+    ),
+};
+
+/**
+ * Customize the button text with the `buttonText` prop.
+ */
+export const ButtonTextExample: Story = {
+    name: "Button Text",
+    argTypes: {
+        buttonText: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <FileInput {...args} buttonText="Browse" text="Default button text..." />
+            <FileInput {...args} buttonText="Upload" text="Custom button text..." />
+            <FileInput {...args} buttonText="Select" text="Another button text..." />
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with file selection handling.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [fileName, setFileName] = useState<string | null>(null);
+
+        const handleInputChange = useCallback(
+            (e: React.ChangeEvent<HTMLInputElement>) => {
+                const file = e.target.files?.[0];
+                setFileName(file?.name ?? null);
+                args.onInputChange?.(e);
+            },
+            [args],
+        );
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+                <FileInput
+                    buttonText={args.buttonText}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    hasSelection={fileName != null}
+                    onInputChange={handleInputChange}
+                    size={args.size}
+                    text={fileName ?? "Choose file..."}
+                />
+                {fileName != null && <div style={{ fontSize: 12, opacity: 0.6 }}>Selected: {fileName}</div>}
+            </div>
+        );
+    },
+    args: {
+        buttonText: "Browse",
+    },
+};

--- a/packages/core/src/components/forms/FormGroup.stories.tsx
+++ b/packages/core/src/components/forms/FormGroup.stories.tsx
@@ -1,0 +1,275 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Intent } from "../../common";
+
+import { FormGroup } from "./formGroup";
+import { InputGroup } from "./inputGroup";
+
+const meta: Meta<typeof FormGroup> = {
+    title: "Core/Form/FormGroup",
+    component: FormGroup,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 12,
+                    width: "100%",
+                    minWidth: "400px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        label: "Label",
+        helperText: undefined,
+        labelInfo: undefined,
+        subLabel: undefined,
+        intent: "none",
+        disabled: false,
+        fill: false,
+        inline: false,
+    },
+    argTypes: {
+        label: {
+            control: "text",
+        },
+        helperText: {
+            control: "text",
+        },
+        labelInfo: {
+            control: "text",
+        },
+        subLabel: {
+            control: "text",
+        },
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        disabled: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        inline: {
+            control: "boolean",
+        },
+    },
+} satisfies Meta<typeof FormGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic form group with a label and input.
+ */
+export const Default: Story = {
+    args: {
+        label: "Label",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <InputGroup placeholder="Enter value..." />
+        </FormGroup>
+    ),
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color to the helper text and sub label.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <FormGroup
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        label={intent.charAt(0).toUpperCase() + intent.slice(1)}
+                        helperText={`This is ${intent} helper text`}
+                    >
+                        <InputGroup intent={intent} placeholder={`${intent} input...`} />
+                    </FormGroup>
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * FormGroup supports `disabled` state which visually dims the label and helper text.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <FormGroup {...args} label="Enabled" helperText="This field is enabled">
+                <InputGroup placeholder="Enabled input..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} label="Disabled" helperText="This field is disabled">
+                <InputGroup disabled={true} placeholder="Disabled input..." />
+            </FormGroup>
+        </div>
+    ),
+};
+
+/**
+ * Use `helperText`, `labelInfo`, and `subLabel` to add additional context to the form group.
+ */
+export const LabelsExample: Story = {
+    name: "Labels & Helper Text",
+    argTypes: {
+        helperText: { table: { disable: true } },
+        labelInfo: { table: { disable: true } },
+        subLabel: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <FormGroup {...args} label="Basic label">
+                <InputGroup placeholder="Basic..." />
+            </FormGroup>
+            <FormGroup {...args} label="With helper text" helperText="This is a helpful description">
+                <InputGroup placeholder="With helper..." />
+            </FormGroup>
+            <FormGroup {...args} label="With label info" labelInfo="(required)">
+                <InputGroup placeholder="Required field..." />
+            </FormGroup>
+            <FormGroup {...args} label="With sub label" subLabel="Additional context below the label">
+                <InputGroup placeholder="With sub label..." />
+            </FormGroup>
+            <FormGroup
+                {...args}
+                label="All label options"
+                labelInfo="(optional)"
+                subLabel="More details about this field"
+                helperText="This helper text provides further guidance"
+            >
+                <InputGroup placeholder="Full example..." />
+            </FormGroup>
+        </div>
+    ),
+};
+
+/**
+ * Use the `inline` prop to render the label and input on a single line.
+ */
+export const InlineExample: Story = {
+    name: "Inline",
+    argTypes: {
+        inline: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <FormGroup {...args} inline={false} label="Stacked (default)" helperText="Label above input">
+                <InputGroup placeholder="Stacked layout..." />
+            </FormGroup>
+            <FormGroup {...args} inline={true} label="Inline" helperText="Label beside input">
+                <InputGroup placeholder="Inline layout..." />
+            </FormGroup>
+        </div>
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the form group expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <FormGroup {...args} fill={true} label="Full width">
+                <InputGroup fill={true} placeholder="Full width input..." />
+            </FormGroup>
+            <FormGroup {...args} fill={false} label="Auto width">
+                <InputGroup placeholder="Auto width input..." />
+            </FormGroup>
+        </div>
+    ),
+};
+
+/**
+ * All intents with helper text for visual comparison.
+ */
+export const AllIntents: Story = {
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            {Object.values(Intent).map(intent => (
+                <FormGroup
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    label={intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)}
+                    helperText={`Helper text with ${intent} intent`}
+                >
+                    <InputGroup intent={intent} placeholder={`${intent} intent...`} />
+                </FormGroup>
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: args => (
+        <FormGroup
+            disabled={args.disabled}
+            fill={args.fill}
+            helperText={args.helperText}
+            inline={args.inline}
+            intent={args.intent}
+            label={args.label}
+            labelFor="playground-input"
+            labelInfo={args.labelInfo}
+            subLabel={args.subLabel}
+        >
+            <InputGroup
+                id="playground-input"
+                intent={args.intent}
+                disabled={args.disabled}
+                placeholder="Enter value..."
+            />
+        </FormGroup>
+    ),
+    args: {
+        label: "Full Name",
+        helperText: "Enter your full legal name",
+        labelInfo: "(required)",
+        intent: "none",
+    },
+};

--- a/packages/core/src/components/forms/FormGroup.stories.tsx
+++ b/packages/core/src/components/forms/FormGroup.stories.tsx
@@ -17,8 +17,7 @@ import { NumericInput } from "./numericInput";
 import { RadioGroup } from "./radioGroup";
 import { TextArea } from "./textArea";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const NOOP = () => {};
+const NOOP = () => undefined;
 
 const meta: Meta<typeof FormGroup> = {
     title: "Core/Form/FormGroup",
@@ -44,9 +43,9 @@ const meta: Meta<typeof FormGroup> = {
     tags: ["autodocs"],
     args: {
         label: "Label",
-        helperText: undefined,
-        labelInfo: undefined,
-        subLabel: undefined,
+        helperText: "",
+        labelInfo: "",
+        subLabel: "",
         intent: "none",
         disabled: false,
         fill: false,
@@ -135,8 +134,9 @@ export const WithNumericInput: Story = {
         helperText: "Enter a number between 1 and 100",
     },
     render: args => (
-        <FormGroup {...args}>
+        <FormGroup {...args} labelFor="numeric-input">
             <NumericInput
+                id="numeric-input"
                 intent={args.intent}
                 disabled={args.disabled}
                 fill={args.fill}
@@ -642,60 +642,6 @@ export const FillExample: Story = {
 // ---------------------------------------------------------------------------
 // Comprehensive comparisons
 // ---------------------------------------------------------------------------
-
-/**
- * All intents with helper text for visual comparison, shown with various form controls.
- */
-export const AllIntents: Story = {
-    args: {
-        label: "Label",
-        helperText: "Helper text with intent",
-    },
-    argTypes: {
-        intent: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <FormGroup {...args} intent="none" labelInfo="(none, text input)" labelFor="all-intents-none-input">
-                <InputGroup
-                    id="all-intents-none-input"
-                    disabled={args.disabled}
-                    fill={args.fill}
-                    placeholder="None intent..."
-                />
-            </FormGroup>
-            <FormGroup
-                {...args}
-                intent="primary"
-                labelInfo="(primary, text area)"
-                labelFor="all-intents-primary-textarea"
-            >
-                <TextArea
-                    id="all-intents-primary-textarea"
-                    intent="primary"
-                    disabled={args.disabled}
-                    fill={args.fill}
-                    placeholder="Primary intent..."
-                />
-            </FormGroup>
-            <FormGroup {...args} intent="success" labelInfo="(success, numeric input)">
-                <NumericInput
-                    intent="success"
-                    disabled={args.disabled}
-                    fill={args.fill}
-                    placeholder="Success intent..."
-                />
-            </FormGroup>
-            <FormGroup {...args} intent="warning" labelInfo="(warning, switch)">
-                <Switch label="Warning toggle" disabled={args.disabled} />
-            </FormGroup>
-            <FormGroup {...args} intent="danger" labelInfo="(danger, checkbox)">
-                <Checkbox label="Danger option A" disabled={args.disabled} />
-                <Checkbox label="Danger option B" disabled={args.disabled} />
-            </FormGroup>
-        </div>
-    ),
-};
 
 /**
  * All form controls in their enabled and disabled states within FormGroups.

--- a/packages/core/src/components/forms/FormGroup.stories.tsx
+++ b/packages/core/src/components/forms/FormGroup.stories.tsx
@@ -201,18 +201,18 @@ export const FillExample: Story = {
     },
     decorators: [
         Story => (
-            <div style={{ width: "500px" }}>
+            <div style={{ width: "400px" }}>
                 <Story />
             </div>
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <FormGroup {...args} fill={true} label="Full width">
-                <InputGroup fill={true} placeholder="Full width input..." />
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+            <FormGroup {...args} fill={true} label="Full Width">
+                <InputGroup fill={true} placeholder="Full Width" />
             </FormGroup>
-            <FormGroup {...args} fill={false} label="Auto width">
-                <InputGroup placeholder="Auto width input..." />
+            <FormGroup {...args} fill={false} label="Auto Width">
+                <InputGroup placeholder="Auto Width" />
             </FormGroup>
         </div>
     ),

--- a/packages/core/src/components/forms/FormGroup.stories.tsx
+++ b/packages/core/src/components/forms/FormGroup.stories.tsx
@@ -5,9 +5,20 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Intent } from "../../common";
+import { HTMLSelect } from "../html-select/htmlSelect";
+import { SegmentedControl } from "../segmented-control/segmentedControl";
+import { Slider } from "../slider/slider";
 
+import { Checkbox, Radio, Switch } from "./controls";
+import { FileInput } from "./fileInput";
 import { FormGroup } from "./formGroup";
 import { InputGroup } from "./inputGroup";
+import { NumericInput } from "./numericInput";
+import { RadioGroup } from "./radioGroup";
+import { TextArea } from "./textArea";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const NOOP = () => {};
 
 const meta: Meta<typeof FormGroup> = {
     title: "Core/Form/FormGroup",
@@ -73,62 +84,343 @@ const meta: Meta<typeof FormGroup> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// ---------------------------------------------------------------------------
+// Individual control stories
+// ---------------------------------------------------------------------------
+
 /**
- * A basic form group with a label and input.
+ * A basic form group with a text input.
  */
 export const Default: Story = {
-    args: {
-        label: "Label",
-    },
     render: args => (
-        <FormGroup {...args}>
-            <InputGroup placeholder="Enter value..." />
+        <FormGroup {...args} labelFor="default-input">
+            <InputGroup
+                id="default-input"
+                intent={args.intent}
+                disabled={args.disabled}
+                fill={args.fill}
+                placeholder="Enter value..."
+            />
         </FormGroup>
     ),
 };
 
 /**
+ * FormGroup works with TextArea for multi-line text input.
+ */
+export const WithTextArea: Story = {
+    args: {
+        label: "Description",
+        helperText: "Provide a detailed description",
+    },
+    render: args => (
+        <FormGroup {...args} labelFor="textarea-input">
+            <TextArea
+                id="textarea-input"
+                intent={args.intent}
+                disabled={args.disabled}
+                fill={args.fill}
+                placeholder="Enter description..."
+            />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with NumericInput for numeric values.
+ */
+export const WithNumericInput: Story = {
+    args: {
+        label: "Quantity",
+        helperText: "Enter a number between 1 and 100",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <NumericInput
+                intent={args.intent}
+                disabled={args.disabled}
+                fill={args.fill}
+                min={1}
+                max={100}
+                placeholder="Enter quantity..."
+            />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with HTMLSelect for dropdown selections.
+ */
+export const WithHTMLSelect: Story = {
+    args: {
+        label: "Country",
+        helperText: "Select your country of residence",
+    },
+    render: args => (
+        <FormGroup {...args} labelFor="select-input">
+            <HTMLSelect
+                id="select-input"
+                disabled={args.disabled}
+                fill={args.fill}
+                options={["United States", "Canada", "United Kingdom", "Germany", "France", "Japan"]}
+            />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with FileInput for file uploads.
+ */
+export const WithFileInput: Story = {
+    args: {
+        label: "Attachment",
+        helperText: "Upload a PDF or image file",
+    },
+    render: args => (
+        <FormGroup {...args} labelFor="file-input">
+            <FileInput
+                inputProps={{ id: "file-input" }}
+                disabled={args.disabled}
+                fill={args.fill}
+                text="Choose file..."
+            />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with Switch for toggling a boolean setting.
+ */
+export const WithSwitch: Story = {
+    args: {
+        label: "Notifications",
+        helperText: "Enable or disable email notifications",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <Switch label="Email notifications" disabled={args.disabled} />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with Checkbox for single or multiple boolean selections.
+ */
+export const WithCheckboxes: Story = {
+    args: {
+        label: "Interests",
+        helperText: "Select all that apply",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <Checkbox label="Engineering" disabled={args.disabled} />
+            <Checkbox label="Design" disabled={args.disabled} />
+            <Checkbox label="Marketing" disabled={args.disabled} />
+            <Checkbox label="Sales" disabled={args.disabled} />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with RadioGroup for mutually exclusive selections.
+ */
+export const WithRadioGroup: Story = {
+    args: {
+        label: "Priority",
+        helperText: "Select the task priority",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <RadioGroup
+                disabled={args.disabled}
+                onChange={NOOP}
+                selectedValue="medium"
+                options={[
+                    { label: "Low", value: "low" },
+                    { label: "Medium", value: "medium" },
+                    { label: "High", value: "high" },
+                    { label: "Critical", value: "critical" },
+                ]}
+            />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with Slider for selecting a value in a range.
+ */
+export const WithSlider: Story = {
+    args: {
+        label: "Volume",
+        helperText: "Adjust the output volume",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <Slider
+                intent={args.intent}
+                disabled={args.disabled}
+                min={0}
+                max={100}
+                stepSize={1}
+                value={50}
+                labelStepSize={25}
+            />
+        </FormGroup>
+    ),
+};
+
+/**
+ * FormGroup works with SegmentedControl for selecting one of a few options.
+ */
+export const WithSegmentedControl: Story = {
+    args: {
+        label: "View mode",
+        helperText: "Choose how items are displayed",
+    },
+    render: args => (
+        <FormGroup {...args}>
+            <SegmentedControl
+                disabled={args.disabled}
+                fill={args.fill}
+                options={[
+                    { label: "List", value: "list" },
+                    { label: "Grid", value: "grid" },
+                    { label: "Table", value: "table" },
+                ]}
+            />
+        </FormGroup>
+    ),
+};
+
+// ---------------------------------------------------------------------------
+// FormGroup prop demonstrations
+// ---------------------------------------------------------------------------
+
+/**
  * Use the `intent` prop to apply a semantic color to the helper text and sub label.
+ * Shown here with various form controls.
  */
 export const IntentExample: Story = {
     name: "Intent",
+    args: {
+        label: "Label",
+        helperText: "Helper text styled by intent",
+    },
     argTypes: {
         intent: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
-            {Object.values(Intent)
-                .filter(i => i !== "none")
-                .map(intent => (
-                    <FormGroup
-                        key={intent}
-                        {...args}
-                        intent={intent}
-                        label={intent.charAt(0).toUpperCase() + intent.slice(1)}
-                        helperText={`This is ${intent} helper text`}
-                    >
-                        <InputGroup intent={intent} placeholder={`${intent} input...`} />
-                    </FormGroup>
-                ))}
+            <FormGroup {...args} intent="primary" labelInfo="(text input)" labelFor="intent-primary-input">
+                <InputGroup
+                    id="intent-primary-input"
+                    intent="primary"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Primary input..."
+                />
+            </FormGroup>
+            <FormGroup {...args} intent="success" labelInfo="(text area)" labelFor="intent-success-textarea">
+                <TextArea
+                    id="intent-success-textarea"
+                    intent="success"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Success textarea..."
+                />
+            </FormGroup>
+            <FormGroup {...args} intent="warning" labelInfo="(numeric input)">
+                <NumericInput
+                    intent="warning"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Warning numeric..."
+                />
+            </FormGroup>
+            <FormGroup {...args} intent="danger" labelInfo="(select)" labelFor="intent-danger-select">
+                <HTMLSelect
+                    id="intent-danger-select"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    options={["Option A", "Option B", "Option C"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} intent="primary" labelInfo="(checkbox)">
+                <Checkbox label="Option one" disabled={args.disabled} />
+                <Checkbox label="Option two" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} intent="success" labelInfo="(switch)">
+                <Switch label="Enable feature" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} intent="warning" labelInfo="(radio group)">
+                <RadioGroup
+                    disabled={args.disabled}
+                    onChange={NOOP}
+                    selectedValue="a"
+                    options={[
+                        { label: "Option A", value: "a" },
+                        { label: "Option B", value: "b" },
+                    ]}
+                />
+            </FormGroup>
         </div>
     ),
 };
 
 /**
  * FormGroup supports `disabled` state which visually dims the label and helper text.
+ * Shown here with various form controls in enabled and disabled states.
  */
 export const StateExample: Story = {
     name: "State",
+    args: {
+        label: "Label",
+        helperText: "Helper text for this field",
+    },
     argTypes: {
         disabled: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
-            <FormGroup {...args} label="Enabled" helperText="This field is enabled">
-                <InputGroup placeholder="Enabled input..." />
+            <FormGroup {...args} labelInfo="(text input, enabled)" labelFor="state-enabled-input">
+                <InputGroup
+                    id="state-enabled-input"
+                    intent={args.intent}
+                    fill={args.fill}
+                    placeholder="Enabled input..."
+                />
             </FormGroup>
-            <FormGroup {...args} disabled={true} label="Disabled" helperText="This field is disabled">
-                <InputGroup disabled={true} placeholder="Disabled input..." />
+            <FormGroup {...args} disabled={true} labelInfo="(text input, disabled)" labelFor="state-disabled-input">
+                <InputGroup
+                    id="state-disabled-input"
+                    disabled={true}
+                    intent={args.intent}
+                    fill={args.fill}
+                    placeholder="Disabled input..."
+                />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(switch, enabled)">
+                <Switch label="Notifications" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(switch, disabled)">
+                <Switch disabled={true} label="Notifications" />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(checkbox, enabled)">
+                <Checkbox label="Accept terms" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(checkbox, disabled)">
+                <Checkbox disabled={true} label="Accept terms" />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(select, enabled)" labelFor="state-enabled-select">
+                <HTMLSelect id="state-enabled-select" fill={args.fill} options={["Option A", "Option B"]} />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(select, disabled)" labelFor="state-disabled-select">
+                <HTMLSelect
+                    id="state-disabled-select"
+                    disabled={true}
+                    fill={args.fill}
+                    options={["Option A", "Option B"]}
+                />
             </FormGroup>
         </div>
     ),
@@ -136,6 +428,7 @@ export const StateExample: Story = {
 
 /**
  * Use `helperText`, `labelInfo`, and `subLabel` to add additional context to the form group.
+ * Shown here with various form controls.
  */
 export const LabelsExample: Story = {
     name: "Labels & Helper Text",
@@ -146,26 +439,74 @@ export const LabelsExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
-            <FormGroup {...args} label="Basic label">
-                <InputGroup placeholder="Basic..." />
-            </FormGroup>
-            <FormGroup {...args} label="With helper text" helperText="This is a helpful description">
-                <InputGroup placeholder="With helper..." />
-            </FormGroup>
-            <FormGroup {...args} label="With label info" labelInfo="(required)">
-                <InputGroup placeholder="Required field..." />
-            </FormGroup>
-            <FormGroup {...args} label="With sub label" subLabel="Additional context below the label">
-                <InputGroup placeholder="With sub label..." />
+            <FormGroup {...args} label="Text input" labelFor="labels-basic-input">
+                <InputGroup
+                    id="labels-basic-input"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Basic..."
+                />
             </FormGroup>
             <FormGroup
                 {...args}
-                label="All label options"
-                labelInfo="(optional)"
-                subLabel="More details about this field"
-                helperText="This helper text provides further guidance"
+                label="Text area"
+                labelFor="labels-textarea"
+                helperText="Helper text appears below the control"
             >
-                <InputGroup placeholder="Full example..." />
+                <TextArea
+                    id="labels-textarea"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="With helper..."
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Numeric input" labelInfo="(required)">
+                <NumericInput
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Required field..."
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Select" labelFor="labels-select" subLabel="Additional context below the label">
+                <HTMLSelect
+                    id="labels-select"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    options={["Option A", "Option B", "Option C"]}
+                />
+            </FormGroup>
+            <FormGroup
+                {...args}
+                label="Checkbox group"
+                labelInfo="(optional)"
+                subLabel="Select your preferences"
+                helperText="You may choose more than one"
+            >
+                <Checkbox label="Option one" disabled={args.disabled} />
+                <Checkbox label="Option two" disabled={args.disabled} />
+                <Checkbox label="Option three" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup
+                {...args}
+                label="Switch"
+                subLabel="Toggle this setting on or off"
+                helperText="Changes take effect immediately"
+            >
+                <Switch label="Dark mode" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} label="Radio group" labelInfo="(required)" helperText="Choose exactly one option">
+                <RadioGroup
+                    disabled={args.disabled}
+                    onChange={NOOP}
+                    selectedValue="a"
+                    options={[
+                        { label: "Option A", value: "a" },
+                        { label: "Option B", value: "b" },
+                    ]}
+                />
             </FormGroup>
         </div>
     ),
@@ -173,6 +514,7 @@ export const LabelsExample: Story = {
 
 /**
  * Use the `inline` prop to render the label and input on a single line.
+ * Shown here with various form controls.
  */
 export const InlineExample: Story = {
     name: "Inline",
@@ -181,11 +523,40 @@ export const InlineExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
-            <FormGroup {...args} inline={false} label="Stacked (default)" helperText="Label above input">
-                <InputGroup placeholder="Stacked layout..." />
+            <FormGroup {...args} inline={true} labelInfo="(text input)" labelFor="inline-name-input">
+                <InputGroup
+                    id="inline-name-input"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Enter name..."
+                />
             </FormGroup>
-            <FormGroup {...args} inline={true} label="Inline" helperText="Label beside input">
-                <InputGroup placeholder="Inline layout..." />
+            <FormGroup {...args} inline={true} labelInfo="(text area)" labelFor="inline-textarea">
+                <TextArea
+                    id="inline-textarea"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Enter description..."
+                />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(numeric input)">
+                <NumericInput intent={args.intent} disabled={args.disabled} fill={args.fill} placeholder="0" />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(select)" labelFor="inline-select">
+                <HTMLSelect
+                    id="inline-select"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    options={["United States", "Canada", "United Kingdom"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(switch)">
+                <Switch label="Toggle" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(checkbox)">
+                <Checkbox label="I accept the terms" disabled={args.disabled} />
             </FormGroup>
         </div>
     ),
@@ -193,6 +564,7 @@ export const InlineExample: Story = {
 
 /**
  * Use the `fill` prop to make the form group expand to the full width of its container.
+ * Shown here with various form controls.
  */
 export const FillExample: Story = {
     name: "Fill",
@@ -207,37 +579,454 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
-            <FormGroup {...args} fill={true} label="Full Width">
-                <InputGroup fill={true} placeholder="Full Width" />
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "flex-start" }}>
+            <FormGroup {...args} fill={true} labelInfo="(text input, fill)" labelFor="fill-full-input">
+                <InputGroup
+                    id="fill-full-input"
+                    fill={true}
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    placeholder="Full width input..."
+                />
             </FormGroup>
-            <FormGroup {...args} fill={false} label="Auto Width">
-                <InputGroup placeholder="Auto Width" />
+            <FormGroup {...args} fill={false} labelInfo="(text input, auto)" labelFor="fill-auto-input">
+                <InputGroup
+                    id="fill-auto-input"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    placeholder="Auto width input..."
+                />
+            </FormGroup>
+            <FormGroup {...args} fill={true} labelInfo="(text area, fill)" labelFor="fill-textarea">
+                <TextArea
+                    id="fill-textarea"
+                    fill={true}
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    placeholder="Full width textarea..."
+                />
+            </FormGroup>
+            <FormGroup {...args} fill={true} labelInfo="(select, fill)" labelFor="fill-select">
+                <HTMLSelect
+                    id="fill-select"
+                    fill={true}
+                    disabled={args.disabled}
+                    options={["Option A", "Option B", "Option C"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} fill={false} labelInfo="(select, auto)" labelFor="fill-select-auto">
+                <HTMLSelect
+                    id="fill-select-auto"
+                    disabled={args.disabled}
+                    options={["Option A", "Option B", "Option C"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} fill={true} labelInfo="(switch, fill)">
+                <Switch label="Enable feature" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} fill={true} labelInfo="(segmented control, fill)">
+                <SegmentedControl
+                    fill={true}
+                    disabled={args.disabled}
+                    options={[
+                        { label: "List", value: "list" },
+                        { label: "Grid", value: "grid" },
+                        { label: "Table", value: "table" },
+                    ]}
+                />
+            </FormGroup>
+        </div>
+    ),
+};
+
+// ---------------------------------------------------------------------------
+// Comprehensive comparisons
+// ---------------------------------------------------------------------------
+
+/**
+ * All intents with helper text for visual comparison, shown with various form controls.
+ */
+export const AllIntents: Story = {
+    args: {
+        label: "Label",
+        helperText: "Helper text with intent",
+    },
+    argTypes: {
+        intent: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <FormGroup {...args} intent="none" labelInfo="(none, text input)" labelFor="all-intents-none-input">
+                <InputGroup
+                    id="all-intents-none-input"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="None intent..."
+                />
+            </FormGroup>
+            <FormGroup
+                {...args}
+                intent="primary"
+                labelInfo="(primary, text area)"
+                labelFor="all-intents-primary-textarea"
+            >
+                <TextArea
+                    id="all-intents-primary-textarea"
+                    intent="primary"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Primary intent..."
+                />
+            </FormGroup>
+            <FormGroup {...args} intent="success" labelInfo="(success, numeric input)">
+                <NumericInput
+                    intent="success"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Success intent..."
+                />
+            </FormGroup>
+            <FormGroup {...args} intent="warning" labelInfo="(warning, switch)">
+                <Switch label="Warning toggle" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} intent="danger" labelInfo="(danger, checkbox)">
+                <Checkbox label="Danger option A" disabled={args.disabled} />
+                <Checkbox label="Danger option B" disabled={args.disabled} />
             </FormGroup>
         </div>
     ),
 };
 
 /**
- * All intents with helper text for visual comparison.
+ * All form controls in their enabled and disabled states within FormGroups.
  */
-export const AllIntents: Story = {
+export const AllStates: Story = {
+    args: {
+        label: "Label",
+        helperText: "Helper text for this field",
+    },
     argTypes: {
-        intent: { table: { disable: true } },
+        disabled: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            {Object.values(Intent).map(intent => (
-                <FormGroup
-                    key={intent}
-                    {...args}
-                    intent={intent}
-                    label={intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)}
-                    helperText={`Helper text with ${intent} intent`}
-                >
-                    <InputGroup intent={intent} placeholder={`${intent} intent...`} />
-                </FormGroup>
-            ))}
+            <FormGroup {...args} labelInfo="(text input, enabled)" labelFor="allstates-input">
+                <InputGroup id="allstates-input" intent={args.intent} fill={args.fill} placeholder="Enter value..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(text input, disabled)" labelFor="allstates-input-dis">
+                <InputGroup
+                    id="allstates-input-dis"
+                    disabled={true}
+                    intent={args.intent}
+                    fill={args.fill}
+                    placeholder="Enter value..."
+                />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(text area, enabled)" labelFor="allstates-textarea">
+                <TextArea id="allstates-textarea" intent={args.intent} fill={args.fill} placeholder="Enter text..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(text area, disabled)" labelFor="allstates-textarea-dis">
+                <TextArea
+                    id="allstates-textarea-dis"
+                    disabled={true}
+                    intent={args.intent}
+                    fill={args.fill}
+                    placeholder="Enter text..."
+                />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(numeric input, enabled)">
+                <NumericInput intent={args.intent} fill={args.fill} placeholder="0" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(numeric input, disabled)">
+                <NumericInput disabled={true} intent={args.intent} fill={args.fill} placeholder="0" />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(select, enabled)" labelFor="allstates-select">
+                <HTMLSelect id="allstates-select" fill={args.fill} options={["Option A", "Option B"]} />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(select, disabled)" labelFor="allstates-select-dis">
+                <HTMLSelect
+                    id="allstates-select-dis"
+                    disabled={true}
+                    fill={args.fill}
+                    options={["Option A", "Option B"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(file input, enabled)" labelFor="allstates-file">
+                <FileInput inputProps={{ id: "allstates-file" }} fill={args.fill} text="Choose file..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(file input, disabled)" labelFor="allstates-file-dis">
+                <FileInput
+                    inputProps={{ id: "allstates-file-dis" }}
+                    disabled={true}
+                    fill={args.fill}
+                    text="Choose file..."
+                />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(switch, enabled)">
+                <Switch label="Toggle" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(switch, disabled)">
+                <Switch disabled={true} label="Toggle" />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(checkbox, enabled)">
+                <Checkbox label="Accept terms" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(checkbox, disabled)">
+                <Checkbox disabled={true} label="Accept terms" />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(radio group, enabled)">
+                <RadioGroup
+                    onChange={NOOP}
+                    selectedValue="a"
+                    options={[
+                        { label: "Option A", value: "a" },
+                        { label: "Option B", value: "b" },
+                    ]}
+                />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(radio group, disabled)">
+                <RadioGroup
+                    disabled={true}
+                    onChange={NOOP}
+                    selectedValue="a"
+                    options={[
+                        { label: "Option A", value: "a" },
+                        { label: "Option B", value: "b" },
+                    ]}
+                />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(slider, enabled)">
+                <Slider intent={args.intent} min={0} max={10} value={5} />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(slider, disabled)">
+                <Slider disabled={true} intent={args.intent} min={0} max={10} value={5} />
+            </FormGroup>
+            <FormGroup {...args} labelInfo="(segmented control, enabled)">
+                <SegmentedControl
+                    fill={args.fill}
+                    options={[
+                        { label: "A", value: "a" },
+                        { label: "B", value: "b" },
+                    ]}
+                />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(segmented control, disabled)">
+                <SegmentedControl
+                    disabled={true}
+                    fill={args.fill}
+                    options={[
+                        { label: "A", value: "a" },
+                        { label: "B", value: "b" },
+                    ]}
+                />
+            </FormGroup>
+        </div>
+    ),
+};
+
+/**
+ * All form controls in their disabled state within FormGroups.
+ */
+export const AllControlsDisabled: Story = {
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <FormGroup {...args} disabled={true} labelInfo="(text input)" labelFor="disabled-text">
+                <InputGroup id="disabled-text" disabled={true} intent={args.intent} placeholder="Disabled input..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(text area)" labelFor="disabled-textarea">
+                <TextArea
+                    id="disabled-textarea"
+                    disabled={true}
+                    intent={args.intent}
+                    placeholder="Disabled textarea..."
+                    fill={true}
+                />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(numeric input)">
+                <NumericInput disabled={true} intent={args.intent} placeholder="Disabled..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(select)" labelFor="disabled-select">
+                <HTMLSelect id="disabled-select" disabled={true} options={["Option A", "Option B"]} />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(file input)" labelFor="disabled-file">
+                <FileInput inputProps={{ id: "disabled-file" }} disabled={true} text="Choose file..." />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(switch)">
+                <Switch disabled={true} label="Disabled switch" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(checkbox)">
+                <Checkbox disabled={true} label="Disabled checkbox" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(radio)">
+                <Radio disabled={true} label="Disabled radio" />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(slider)">
+                <Slider disabled={true} intent={args.intent} value={30} />
+            </FormGroup>
+            <FormGroup {...args} disabled={true} labelInfo="(segmented control)">
+                <SegmentedControl
+                    disabled={true}
+                    options={[
+                        { label: "A", value: "a" },
+                        { label: "B", value: "b" },
+                    ]}
+                />
+            </FormGroup>
+        </div>
+    ),
+};
+
+/**
+ * All form controls rendered inline within FormGroups.
+ */
+export const InlineControls: Story = {
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <FormGroup {...args} inline={true} labelInfo="(text input)" labelFor="inline-name">
+                <InputGroup
+                    id="inline-name"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Enter name..."
+                />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(numeric input)">
+                <NumericInput intent={args.intent} disabled={args.disabled} fill={args.fill} placeholder="0" />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(select)" labelFor="inline-country">
+                <HTMLSelect
+                    id="inline-country"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    options={["United States", "Canada", "United Kingdom"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(switch)">
+                <Switch disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} inline={true} labelInfo="(checkbox)">
+                <Checkbox label="I accept the terms" disabled={args.disabled} />
+            </FormGroup>
+        </div>
+    ),
+};
+
+// ---------------------------------------------------------------------------
+// Composite examples
+// ---------------------------------------------------------------------------
+
+/**
+ * A realistic form combining multiple input types within FormGroups.
+ */
+export const MixedForm: Story = {
+    decorators: [
+        Story => (
+            <div style={{ width: "100%", minWidth: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <FormGroup {...args} label="Full name" labelFor="mixed-name" labelInfo="(required)">
+                <InputGroup
+                    id="mixed-name"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Jane Doe"
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Email" labelFor="mixed-email" labelInfo="(required)">
+                <InputGroup
+                    id="mixed-email"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="jane@example.com"
+                    type="email"
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Bio" labelFor="mixed-bio" helperText="Brief description of yourself">
+                <TextArea
+                    id="mixed-bio"
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    placeholder="Tell us about yourself..."
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Age">
+                <NumericInput
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    min={0}
+                    max={150}
+                    placeholder="Enter age..."
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Country" labelFor="mixed-country">
+                <HTMLSelect
+                    id="mixed-country"
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    options={["", "United States", "Canada", "United Kingdom", "Germany"]}
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Resume" labelFor="mixed-resume" helperText="PDF format preferred">
+                <FileInput
+                    inputProps={{ id: "mixed-resume" }}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    text="Choose file..."
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Role">
+                <RadioGroup
+                    disabled={args.disabled}
+                    onChange={NOOP}
+                    selectedValue="engineer"
+                    options={[
+                        { label: "Engineer", value: "engineer" },
+                        { label: "Designer", value: "designer" },
+                        { label: "Manager", value: "manager" },
+                    ]}
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Skills" helperText="Select all that apply">
+                <Checkbox label="JavaScript" disabled={args.disabled} />
+                <Checkbox label="TypeScript" disabled={args.disabled} />
+                <Checkbox label="React" disabled={args.disabled} />
+                <Checkbox label="Node.js" disabled={args.disabled} />
+            </FormGroup>
+            <FormGroup {...args} label="Experience level">
+                <Slider
+                    intent={args.intent}
+                    disabled={args.disabled}
+                    min={0}
+                    max={10}
+                    stepSize={1}
+                    value={3}
+                    labelStepSize={5}
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Employment type">
+                <SegmentedControl
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    options={[
+                        { label: "Full-time", value: "full" },
+                        { label: "Part-time", value: "part" },
+                        { label: "Contract", value: "contract" },
+                    ]}
+                />
+            </FormGroup>
+            <FormGroup {...args} label="Preferences">
+                <Switch label="Subscribe to newsletter" disabled={args.disabled} />
+                <Switch label="Allow data collection" disabled={args.disabled} />
+            </FormGroup>
         </div>
     ),
 };
@@ -262,6 +1051,7 @@ export const Playground: Story = {
                 id="playground-input"
                 intent={args.intent}
                 disabled={args.disabled}
+                fill={args.fill}
                 placeholder="Enter value..."
             />
         </FormGroup>

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -1,0 +1,305 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent, Size } from "../../common";
+import { Button } from "../button/buttons";
+import { Icon } from "../icon/icon";
+
+import { InputGroup } from "./inputGroup";
+
+// These props are deprecated on InputGroup — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof InputGroup>>;
+
+const meta: Meta<typeof InputGroup> = {
+    title: "Core/Form/InputGroup",
+    component: InputGroup,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 12,
+                    width: "100%",
+                    minWidth: "400px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        intent: "none",
+        size: "medium",
+        placeholder: "Enter text...",
+        disabled: false,
+        readOnly: false,
+        fill: false,
+        round: false,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        placeholder: {
+            control: "text",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        readOnly: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        round: {
+            control: "boolean",
+        },
+        leftIcon: {
+            control: "text",
+        },
+        onChange: { action: "changed" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof InputGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic input group with default styling.
+ */
+export const Default: Story = {
+    args: {
+        placeholder: "Enter text...",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the input.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <InputGroup
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
+                    />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the input dimensions.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Size).map(size => (
+                <InputGroup
+                    key={size}
+                    {...args}
+                    size={size}
+                    placeholder={`${size.charAt(0).toUpperCase() + size.slice(1)} size...`}
+                />
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * InputGroup supports `disabled` and `readOnly` states.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        readOnly: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <InputGroup {...args} placeholder="Enabled..." />
+            <InputGroup {...args} disabled={true} placeholder="Disabled..." />
+            <InputGroup {...args} readOnly={true} defaultValue="Read only" />
+        </div>
+    ),
+};
+
+/**
+ * Use `leftIcon`, `leftElement`, and `rightElement` to add content around the input.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    argTypes: {
+        leftIcon: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <InputGroup {...args} leftIcon="search" placeholder="Search..." />
+            <InputGroup {...args} leftIcon="user" placeholder="Username..." />
+            <InputGroup
+                {...args}
+                leftIcon="lock"
+                rightElement={<Button icon="eye-open" variant="minimal" size="small" />}
+                placeholder="Password..."
+                type="password"
+            />
+            <InputGroup
+                {...args}
+                rightElement={<Icon icon="key-tab" style={{ padding: "0 8px", opacity: 0.5 }} />}
+                placeholder="With right element..."
+            />
+        </div>
+    ),
+};
+
+/**
+ * Use the `round` prop to render the input with rounded caps.
+ */
+export const RoundExample: Story = {
+    name: "Round",
+    argTypes: {
+        round: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <InputGroup {...args} round={false} placeholder="Default shape..." />
+            <InputGroup {...args} round={true} placeholder="Round shape..." />
+            <InputGroup {...args} round={true} leftIcon="search" placeholder="Round with icon..." />
+        </div>
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the input expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <InputGroup {...args} fill={true} placeholder="Full width..." />
+            <InputGroup {...args} fill={false} placeholder="Auto width..." />
+        </div>
+    ),
+};
+
+/**
+ * All intents shown together for visual comparison.
+ */
+export const AllIntents: Story = {
+    argTypes: {
+        intent: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {Object.values(Intent).map(intent => (
+                <InputGroup
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    placeholder={`${intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
+                />
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [value, setValue] = useState("");
+
+        const handleChange = useCallback(
+            (e: React.ChangeEvent<HTMLInputElement>) => {
+                setValue(e.target.value);
+                args.onChange?.(e);
+            },
+            [args],
+        );
+
+        const handleClear = useCallback(() => setValue(""), []);
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+                <InputGroup
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    intent={args.intent}
+                    leftIcon={args.leftIcon}
+                    onChange={handleChange}
+                    placeholder={args.placeholder}
+                    readOnly={args.readOnly}
+                    rightElement={
+                        value.length > 0 ? (
+                            <Button icon="cross" variant="minimal" size="small" onClick={handleClear} />
+                        ) : undefined
+                    }
+                    round={args.round}
+                    size={args.size}
+                    value={value}
+                />
+            </div>
+        );
+    },
+    args: {
+        leftIcon: "search",
+        placeholder: "Type to search...",
+    },
+};

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -224,15 +224,15 @@ export const FillExample: Story = {
     },
     decorators: [
         Story => (
-            <div style={{ width: "500px" }}>
+            <div style={{ width: "400px" }}>
                 <Story />
             </div>
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <InputGroup {...args} fill={true} placeholder="Full width..." />
-            <InputGroup {...args} fill={false} placeholder="Auto width..." />
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+            <InputGroup {...args} fill={true} placeholder="Full Width" />
+            <InputGroup {...args} fill={false} placeholder="Auto Width" />
         </div>
     ),
 };

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -11,11 +11,8 @@ import { Icon } from "../icon/icon";
 
 import { InputGroup } from "./inputGroup";
 
-// These props are deprecated on InputGroup — hide them from the Storybook controls panel.
-const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof InputGroup>>;
-
 const meta: Meta<typeof InputGroup> = {
-    title: "Core/Form/InputGroup",
+    title: "Core/Form/Inputs/InputGroup",
     component: InputGroup,
     decorators: [
         Story => (
@@ -73,17 +70,9 @@ const meta: Meta<typeof InputGroup> = {
             control: "text",
         },
         onChange: { action: "changed" },
-        ...disabledArgs.reduce(
-            (acc, argName) => {
-                acc[argName] = {
-                    table: {
-                        disable: true,
-                    },
-                };
-                return acc;
-            },
-            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
-        ),
+        // deprecated props
+        large: { table: { disable: true } },
+        small: { table: { disable: true } },
     },
 } satisfies Meta<typeof InputGroup>;
 
@@ -93,11 +82,7 @@ type Story = StoryObj<typeof meta>;
 /**
  * A basic input group with default styling.
  */
-export const Default: Story = {
-    args: {
-        placeholder: "Enter text...",
-    },
-};
+export const Default: Story = {};
 
 /**
  * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the input.
@@ -106,7 +91,6 @@ export const IntentExample: Story = {
     name: "Intent",
     argTypes: {
         intent: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -131,7 +115,6 @@ export const SizeExample: Story = {
     name: "Size",
     argTypes: {
         size: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -155,7 +138,6 @@ export const StateExample: Story = {
     argTypes: {
         disabled: { table: { disable: true } },
         readOnly: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -173,7 +155,6 @@ export const IconExample: Story = {
     name: "Icons",
     argTypes: {
         leftIcon: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -202,7 +183,6 @@ export const RoundExample: Story = {
     name: "Round",
     argTypes: {
         round: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -220,7 +200,6 @@ export const FillExample: Story = {
     name: "Fill",
     argTypes: {
         fill: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     decorators: [
         Story => (
@@ -243,7 +222,6 @@ export const FillExample: Story = {
 export const AllIntents: Story = {
     argTypes: {
         intent: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -3,11 +3,11 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useCallback, useState } from "react";
+import { type ChangeEvent, useCallback, useState } from "react";
 
 import { Intent, Size } from "../../common";
 import { Button } from "../button/buttons";
-import { Icon } from "../icon/icon";
+import { Tag } from "../tag/tag";
 
 import { InputGroup } from "./inputGroup";
 
@@ -94,16 +94,14 @@ export const IntentExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-            {Object.values(Intent)
-                .filter(i => i !== "none")
-                .map(intent => (
-                    <InputGroup
-                        key={intent}
-                        {...args}
-                        intent={intent}
-                        placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
-                    />
-                ))}
+            {Object.values(Intent).map(intent => (
+                <InputGroup
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
+                />
+            ))}
         </div>
     ),
 };
@@ -167,9 +165,31 @@ export const IconExample: Story = {
                 placeholder="Password..."
                 type="password"
             />
+        </div>
+    ),
+};
+
+/**
+ * Use `leftElement`, and `rightElement` to add content around the input.
+ */
+export const LeftRightElementsExample: Story = {
+    name: "Left & Right Elements",
+    argTypes: {
+        leftElement: { table: { disable: true } },
+        rightElement: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <InputGroup {...args} leftElement={<Tag interactive={true}>Left</Tag>} placeholder="Search..." />
             <InputGroup
                 {...args}
-                rightElement={<Icon icon="key-tab" style={{ padding: "0 8px", opacity: 0.5 }} />}
+                leftElement={<Tag interactive={true}>Left</Tag>}
+                rightElement={<Tag interactive={true}>Right</Tag>}
+                placeholder="Search..."
+            />
+            <InputGroup
+                {...args}
+                rightElement={<Tag interactive={true}>Right</Tag>}
                 placeholder="With right element..."
             />
         </div>
@@ -217,27 +237,6 @@ export const FillExample: Story = {
 };
 
 /**
- * All intents shown together for visual comparison.
- */
-export const AllIntents: Story = {
-    argTypes: {
-        intent: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            {Object.values(Intent).map(intent => (
-                <InputGroup
-                    key={intent}
-                    {...args}
-                    intent={intent}
-                    placeholder={`${intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
-                />
-            ))}
-        </div>
-    ),
-};
-
-/**
  * Interactive playground with all props togglable via Storybook controls.
  */
 export const Playground: Story = {
@@ -245,7 +244,7 @@ export const Playground: Story = {
         const [value, setValue] = useState("");
 
         const handleChange = useCallback(
-            (e: React.ChangeEvent<HTMLInputElement>) => {
+            (e: ChangeEvent<HTMLInputElement>) => {
                 setValue(e.target.value);
                 args.onChange?.(e);
             },

--- a/packages/core/src/components/forms/Label.stories.tsx
+++ b/packages/core/src/components/forms/Label.stories.tsx
@@ -49,15 +49,14 @@ export const Default: Story = {
  */
 export const WithInput: Story = {
     name: "With Input",
-    render: () => (
+    args: {
+        children: "Label text",
+    },
+    render: ({ children, ...args }) => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
             <Label>
-                Username
-                <InputGroup placeholder="Enter username..." />
-            </Label>
-            <Label>
-                Email
-                <InputGroup placeholder="Enter email..." type="email" />
+                {children}
+                <InputGroup placeholder="Placeholder..." />
             </Label>
         </div>
     ),
@@ -86,8 +85,9 @@ export const StateExample: Story = {
  * Interactive playground.
  */
 export const Playground: Story = {
-    render: args => (
+    render: ({ children, ...args }) => (
         <Label {...args}>
+            {children}
             <InputGroup placeholder="Enter value..." />
         </Label>
     ),

--- a/packages/core/src/components/forms/Label.stories.tsx
+++ b/packages/core/src/components/forms/Label.stories.tsx
@@ -54,7 +54,7 @@ export const WithInput: Story = {
     },
     render: ({ children, ...args }) => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
-            <Label>
+            <Label {...args}>
                 {children}
                 <InputGroup placeholder="Placeholder..." />
             </Label>
@@ -73,7 +73,7 @@ export const StateExample: Story = {
                 Enabled label
                 <InputGroup placeholder="Enabled..." />
             </Label>
-            <Label className="bp5-disabled">
+            <Label disabled={true}>
                 Disabled label
                 <InputGroup disabled={true} placeholder="Disabled..." />
             </Label>

--- a/packages/core/src/components/forms/Label.stories.tsx
+++ b/packages/core/src/components/forms/Label.stories.tsx
@@ -1,0 +1,97 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Label } from "../html/html";
+
+import { InputGroup } from "./inputGroup";
+
+const meta: Meta<typeof Label> = {
+    title: "Core/Form/Label",
+    component: Label,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 12,
+                    width: "100%",
+                    minWidth: "400px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic label with text content.
+ */
+export const Default: Story = {
+    args: {
+        children: "Label text",
+    },
+};
+
+/**
+ * Labels are commonly used alongside input elements.
+ */
+export const WithInput: Story = {
+    name: "With Input",
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <Label>
+                Username
+                <InputGroup placeholder="Enter username..." />
+            </Label>
+            <Label>
+                Email
+                <InputGroup placeholder="Enter email..." type="email" />
+            </Label>
+        </div>
+    ),
+};
+
+/**
+ * Labels support disabled styling through the `bp-disabled` class.
+ */
+export const StateExample: Story = {
+    name: "State",
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+            <Label>
+                Enabled label
+                <InputGroup placeholder="Enabled..." />
+            </Label>
+            <Label className="bp5-disabled">
+                Disabled label
+                <InputGroup disabled={true} placeholder="Disabled..." />
+            </Label>
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground.
+ */
+export const Playground: Story = {
+    render: args => (
+        <Label {...args}>
+            <InputGroup placeholder="Enter value..." />
+        </Label>
+    ),
+    args: {
+        children: "Field label",
+    },
+};

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -104,16 +104,14 @@ export const IntentExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-            {Object.values(Intent)
-                .filter(i => i !== "none")
-                .map(intent => (
-                    <NumericInput
-                        key={intent}
-                        {...args}
-                        intent={intent}
-                        placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
-                    />
-                ))}
+            {Object.values(Intent).map(intent => (
+                <NumericInput
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
+                />
+            ))}
         </div>
     ),
 };
@@ -213,27 +211,6 @@ export const FillExample: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
             <NumericInput {...args} fill={true} placeholder="Full Width" />
             <NumericInput {...args} fill={false} placeholder="Auto Width" />
-        </div>
-    ),
-};
-
-/**
- * All intents shown together for visual comparison.
- */
-export const AllIntents: Story = {
-    argTypes: {
-        intent: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            {Object.values(Intent).map(intent => (
-                <NumericInput
-                    key={intent}
-                    {...args}
-                    intent={intent}
-                    placeholder={`${intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
-                />
-            ))}
         </div>
     ),
 };

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -1,0 +1,308 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useCallback, useState } from "react";
+
+import { Intent, Position, Size } from "../../common";
+
+import { NumericInput } from "./numericInput";
+
+// These props are deprecated on NumericInput — hide them from the Storybook controls panel.
+const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
+    keyof React.ComponentProps<typeof NumericInput>
+>;
+
+const meta: Meta<typeof NumericInput> = {
+    title: "Core/Form/NumericInput",
+    component: NumericInput,
+    decorators: [
+        Story => (
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 12,
+                    width: "100%",
+                    minWidth: "400px",
+                }}
+            >
+                <Story />
+            </div>
+        ),
+    ],
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    args: {
+        intent: "none",
+        size: "medium",
+        placeholder: "Enter a number...",
+        disabled: false,
+        readOnly: false,
+        fill: false,
+        min: 0,
+        max: 100,
+        stepSize: 1,
+    },
+    argTypes: {
+        intent: {
+            control: "select",
+            options: Object.values(Intent),
+        },
+        size: {
+            control: "select",
+            options: Object.values(Size),
+        },
+        placeholder: {
+            control: "text",
+        },
+        disabled: {
+            control: "boolean",
+        },
+        readOnly: {
+            control: "boolean",
+        },
+        fill: {
+            control: "boolean",
+        },
+        min: {
+            control: "number",
+        },
+        max: {
+            control: "number",
+        },
+        stepSize: {
+            control: "number",
+        },
+        buttonPosition: {
+            control: "select",
+            options: [Position.LEFT, Position.RIGHT, "none"],
+        },
+        leftIcon: {
+            control: "text",
+        },
+        onValueChange: { action: "valueChanged" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = {
+                    table: {
+                        disable: true,
+                    },
+                };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof NumericInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic numeric input with default styling and increment/decrement buttons.
+ */
+export const Default: Story = {
+    args: {
+        placeholder: "Enter a number...",
+    },
+};
+
+/**
+ * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the input.
+ */
+export const IntentExample: Story = {
+    name: "Intent",
+    argTypes: {
+        intent: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Intent)
+                .filter(i => i !== "none")
+                .map(intent => (
+                    <NumericInput
+                        key={intent}
+                        {...args}
+                        intent={intent}
+                        placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
+                    />
+                ))}
+        </div>
+    ),
+};
+
+/**
+ * Use the `size` prop to adjust the input dimensions.
+ */
+export const SizeExample: Story = {
+    name: "Size",
+    argTypes: {
+        size: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            {Object.values(Size).map(size => (
+                <NumericInput
+                    key={size}
+                    {...args}
+                    size={size}
+                    placeholder={`${size.charAt(0).toUpperCase() + size.slice(1)} size...`}
+                />
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * NumericInput supports `disabled` and `readOnly` states.
+ */
+export const StateExample: Story = {
+    name: "State",
+    argTypes: {
+        disabled: { table: { disable: true } },
+        readOnly: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <NumericInput {...args} placeholder="Enabled..." />
+            <NumericInput {...args} disabled={true} placeholder="Disabled..." />
+            <NumericInput {...args} readOnly={true} value={42} />
+        </div>
+    ),
+};
+
+/**
+ * Use `buttonPosition` to control the placement of increment/decrement buttons.
+ */
+export const ButtonPositionExample: Story = {
+    name: "Button Position",
+    argTypes: {
+        buttonPosition: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Right (default)</div>
+            <NumericInput {...args} buttonPosition={Position.RIGHT} placeholder="Buttons right..." />
+            <div style={{ fontSize: 12, opacity: 0.6 }}>Left</div>
+            <NumericInput {...args} buttonPosition={Position.LEFT} placeholder="Buttons left..." />
+            <div style={{ fontSize: 12, opacity: 0.6 }}>None</div>
+            <NumericInput {...args} buttonPosition="none" placeholder="No buttons..." />
+        </div>
+    ),
+};
+
+/**
+ * Use `leftIcon` to add an icon to the left side of the input.
+ */
+export const IconExample: Story = {
+    name: "Icons",
+    argTypes: {
+        leftIcon: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+            <NumericInput {...args} leftIcon="dollar" placeholder="Price..." />
+            <NumericInput {...args} leftIcon="percentage" placeholder="Percentage..." min={0} max={100} />
+        </div>
+    ),
+};
+
+/**
+ * Use the `fill` prop to make the input expand to the full width of its container.
+ */
+export const FillExample: Story = {
+    name: "Fill",
+    argTypes: {
+        fill: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    decorators: [
+        Story => (
+            <div style={{ width: "500px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <NumericInput {...args} fill={true} placeholder="Full width..." />
+            <NumericInput {...args} fill={false} placeholder="Auto width..." />
+        </div>
+    ),
+};
+
+/**
+ * All intents shown together for visual comparison.
+ */
+export const AllIntents: Story = {
+    argTypes: {
+        intent: { table: { disable: true } },
+        placeholder: { table: { disable: true } },
+    },
+    render: args => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {Object.values(Intent).map(intent => (
+                <NumericInput
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    placeholder={`${intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
+                />
+            ))}
+        </div>
+    ),
+};
+
+/**
+ * Interactive playground with all props togglable via Storybook controls.
+ */
+export const Playground: Story = {
+    render: function Render(args) {
+        const [value, setValue] = useState<string>("0");
+
+        const handleValueChange = useCallback(
+            (_valueAsNumber: number, valueAsString: string) => {
+                setValue(valueAsString);
+                args.onValueChange?.(_valueAsNumber, valueAsString, null);
+            },
+            [args],
+        );
+
+        return (
+            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+                <NumericInput
+                    buttonPosition={args.buttonPosition}
+                    disabled={args.disabled}
+                    fill={args.fill}
+                    intent={args.intent}
+                    leftIcon={args.leftIcon}
+                    max={args.max}
+                    min={args.min}
+                    onValueChange={handleValueChange}
+                    placeholder={args.placeholder}
+                    readOnly={args.readOnly}
+                    size={args.size}
+                    stepSize={args.stepSize}
+                    value={value}
+                />
+                <div style={{ fontSize: 12, opacity: 0.6 }}>Current value: {value}</div>
+            </div>
+        );
+    },
+    args: {
+        leftIcon: "dollar",
+        placeholder: "Enter amount...",
+        min: 0,
+        max: 1000,
+        stepSize: 1,
+    },
+};

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -9,13 +9,8 @@ import { Intent, Position, Size } from "../../common";
 
 import { NumericInput } from "./numericInput";
 
-// These props are deprecated on NumericInput — hide them from the Storybook controls panel.
-const disabledArgs = ["large", "small"] as const satisfies ReadonlyArray<
-    keyof React.ComponentProps<typeof NumericInput>
->;
-
 const meta: Meta<typeof NumericInput> = {
-    title: "Core/Form/NumericInput",
+    title: "Core/Form/Inputs/NumericInput",
     component: NumericInput,
     decorators: [
         Story => (
@@ -85,17 +80,9 @@ const meta: Meta<typeof NumericInput> = {
             control: "text",
         },
         onValueChange: { action: "valueChanged" },
-        ...disabledArgs.reduce(
-            (acc, argName) => {
-                acc[argName] = {
-                    table: {
-                        disable: true,
-                    },
-                };
-                return acc;
-            },
-            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
-        ),
+        // deprecated props
+        large: { table: { disable: true } },
+        small: { table: { disable: true } },
     },
 } satisfies Meta<typeof NumericInput>;
 
@@ -105,11 +92,7 @@ type Story = StoryObj<typeof meta>;
 /**
  * A basic numeric input with default styling and increment/decrement buttons.
  */
-export const Default: Story = {
-    args: {
-        placeholder: "Enter a number...",
-    },
-};
+export const Default: Story = {};
 
 /**
  * Use the `intent` prop to apply a semantic color that conveys the purpose or status of the input.
@@ -118,7 +101,6 @@ export const IntentExample: Story = {
     name: "Intent",
     argTypes: {
         intent: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -143,7 +125,6 @@ export const SizeExample: Story = {
     name: "Size",
     argTypes: {
         size: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -167,7 +148,6 @@ export const StateExample: Story = {
     argTypes: {
         disabled: { table: { disable: true } },
         readOnly: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -185,7 +165,6 @@ export const ButtonPositionExample: Story = {
     name: "Button Position",
     argTypes: {
         buttonPosition: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -206,7 +185,6 @@ export const IconExample: Story = {
     name: "Icons",
     argTypes: {
         leftIcon: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
@@ -223,7 +201,6 @@ export const FillExample: Story = {
     name: "Fill",
     argTypes: {
         fill: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     decorators: [
         Story => (
@@ -246,7 +223,6 @@ export const FillExample: Story = {
 export const AllIntents: Story = {
     argTypes: {
         intent: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -227,15 +227,15 @@ export const FillExample: Story = {
     },
     decorators: [
         Story => (
-            <div style={{ width: "500px" }}>
+            <div style={{ width: "400px" }}>
                 <Story />
             </div>
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <NumericInput {...args} fill={true} placeholder="Full width..." />
-            <NumericInput {...args} fill={false} placeholder="Auto width..." />
+        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+            <NumericInput {...args} fill={true} placeholder="Full Width" />
+            <NumericInput {...args} fill={false} placeholder="Auto Width" />
         </div>
     ),
 };

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -108,17 +108,15 @@ export const IntentExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-            {Object.values(Intent)
-                .filter(i => i !== "none")
-                .map(intent => (
-                    <TagInput
-                        key={intent}
-                        {...args}
-                        intent={intent}
-                        values={[intent.charAt(0).toUpperCase() + intent.slice(1)]}
-                        placeholder={`${intent} intent...`}
-                    />
-                ))}
+            {Object.values(Intent).map(intent => (
+                <TagInput
+                    key={intent}
+                    {...args}
+                    intent={intent}
+                    values={[intent.charAt(0).toUpperCase() + intent.slice(1)]}
+                    placeholder={`${intent} intent...`}
+                />
+            ))}
         </div>
     ),
 };
@@ -222,32 +220,6 @@ export const AutoResizeExample: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <TagInput {...args} autoResize={true} values={["Auto Resize"]} placeholder="Type to resize..." />
             <TagInput {...args} autoResize={false} values={["Fixed Width"]} placeholder="Fixed input width..." />
-        </div>
-    ),
-};
-
-/**
- * All intents shown together for visual comparison.
- */
-export const AllIntents: Story = {
-    argTypes: {
-        intent: { table: { disable: true } },
-        values: { table: { disable: true } },
-        placeholder: { table: { disable: true } },
-        rightElement: { table: { disable: true } },
-        separator: { table: { disable: true } },
-    },
-    render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            {Object.values(Intent).map(intent => (
-                <TagInput
-                    key={intent}
-                    {...args}
-                    intent={intent}
-                    values={[intent === "none" ? "None" : intent.charAt(0).toUpperCase() + intent.slice(1)]}
-                    placeholder={`${intent} intent...`}
-                />
-            ))}
         </div>
     ),
 };

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -18,7 +18,7 @@ const disabledArgs = ["large", "children"] as const satisfies ReadonlyArray<
 const INITIAL_VALUES = ["London", "New York", "San Francisco"];
 
 const meta: Meta<typeof TagInput> = {
-    title: "Core/TagInput",
+    title: "Core/Form/Inputs/TagInput",
     component: TagInput,
     decorators: [
         Story => (


### PR DESCRIPTION
## Summary
- Add Storybook stories for InputGroup, NumericInput, FileInput, FormGroup, and Label
- Each story file covers: Default, Intent, Size, State, Icons, Fill, AllIntents, and Playground variations
- Follows established pattern from Button, Tag, TagInput, and Card stories
- Supports visual regression testing for design token migration PR #7865

## Test plan
- [ ] Verify each story renders correctly in Storybook
- [ ] Check intent colors match across all form components
- [ ] Verify size variants display correctly
- [ ] Test disabled/readOnly states render properly
- [ ] Compare against existing SCSS styles from PR #7865

🤖 Generated with [Claude Code](https://claude.com/claude-code)