### PR TITLE
[chore] Adding chromatic setup for blueprint

### DIFF
--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,0 +1,6 @@
+{
+    "buildScriptName": "build-storybook",
+    "autoAcceptChanges": "develop",
+    "exitZeroOnChanges": true,
+    "exitOnceUploaded": true
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "verify": "npm-run-all -s compile dist -p test lint format-check",
         "storybook": "storybook dev -p 6006",
         "build-storybook": "storybook build",
-        "chromatic": "npx chromatic"
+        "chromatic": "chromatic"
     },
     "dependencies": {
         "@lerna-lite/cli": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         "test": "nx run-many -t test",
         "verify": "npm-run-all -s compile dist -p test lint format-check",
         "storybook": "storybook dev -p 6006",
-        "build-storybook": "storybook build"
+        "build-storybook": "storybook build",
+        "chromatic": "npx chromatic"
     },
     "dependencies": {
         "@lerna-lite/cli": "^3.11.0",
@@ -90,6 +91,7 @@
         "@storybook/icons": "^2.0.1",
         "@storybook/react-dom-shim": "^10.2.14",
         "@storybook/react-vite": "^10.2.14",
+        "chromatic": "^16.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "storybook": "^10.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@storybook/react-vite':
         specifier: ^10.2.14
         version: 10.2.14(esbuild@0.27.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))
+      chromatic:
+        specifier: ^16.0.0
+        version: 16.0.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -4394,6 +4397,18 @@ packages:
 
   chroma-js@2.6.0:
     resolution: {integrity: sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==}
+
+  chromatic@16.0.0:
+    resolution: {integrity: sha512-O81RVGDXXoreNeG894hjaUx08xep+C/BA6aJNMZkwSjH7Lln8IweZekBpBEoQPNNpjmHyZvcTIwN/aGitdK53Q==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -13081,6 +13096,8 @@ snapshots:
   chownr@2.0.0: {}
 
   chroma-js@2.6.0: {}
+
+  chromatic@16.0.0: {}
 
   chrome-trace-event@1.0.4: {}
 


### PR DESCRIPTION
#### Problem

Blueprint does not have an automated visual regression testing pipeline. This will allow us to test using Chromatic (https://www.chromatic.com/) for that process

#### Changes proposed in this pull request:

* Adding a `chromatic.config.json` to run chromatic.
* Adding chromatic to `package.json` as a `devDependency`

#### Reviewers should focus on:

* [ ] Try running `npx chromatic --project-token=TOKEN` to see if this runs properly

#### Screenshot

<img width="1567" height="1053" alt="chromatic" src="https://github.com/user-attachments/assets/5ce0b547-7524-41b9-b553-882c915fdef5" />
<img width="1070" height="519" alt="chromatic component changed" src="https://github.com/user-attachments/assets/052e6f74-6de9-4fb7-a70e-94729916412e" />
