### PR TITLE
[chore] Replace mocha with vitest in eslint-plugin

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,7 +8,7 @@
         "compile": "tsc -p src/",
         "lint": "es-lint",
         "lint-fix": "es-lint --fix",
-        "test": "SWC_NODE_PROJECT=./tsconfig.test.json mocha --require @swc-node/register,test/setup.ts --watch-extensions ts,tsx 'test/**/*.{ts,tsx}'"
+        "test": "vitest run"
     },
     "dependencies": {
         "@typescript-eslint/utils": "^8.56.1",
@@ -19,12 +19,10 @@
     },
     "devDependencies": {
         "@blueprintjs/node-build-scripts": "workspace:^",
-        "@swc-node/register": "^1.6.8",
-        "@swc/core": "^1.3.105",
         "@types/dedent": "~0.7.2",
         "@typescript-eslint/rule-tester": "^8.56.1",
         "dedent": "^1.5.1",
-        "mocha": "^10.2.0",
+        "vitest": "catalog:",
         "typescript": "~5.9.3"
     },
     "repository": {

--- a/packages/eslint-plugin/vitest.config.mts
+++ b/packages/eslint-plugin/vitest.config.mts
@@ -1,0 +1,15 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        name: "eslint-plugin",
+        environment: "node",
+        include: ["test/**/*.test.{ts,tsx}"],
+        // required: @typescript-eslint/rule-tester auto-detects describe/it/afterAll from globals
+        globals: true,
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,12 +755,6 @@ importers:
       '@blueprintjs/node-build-scripts':
         specifier: workspace:^
         version: link:../node-build-scripts
-      '@swc-node/register':
-        specifier: ^1.6.8
-        version: 1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3)
-      '@swc/core':
-        specifier: ^1.3.105
-        version: 1.13.20
       '@types/dedent':
         specifier: ~0.7.2
         version: 0.7.2
@@ -770,12 +764,12 @@ importers:
       dedent:
         specifier: ^1.5.1
         version: 1.7.0
-      mocha:
-        specifier: ^10.2.0
-        version: 10.8.2
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.7(@types/node@24.10.0)(jiti@2.6.1)(jsdom@27.1.0)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
 
   packages/icons:
     dependencies:
@@ -10415,6 +10409,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.13.20
       '@swc/types': 0.1.25
+    optional: true
 
   '@swc-node/register@1.11.1(@swc/core@1.13.20)(@swc/types@0.1.25)(typescript@5.9.3)':
     dependencies:
@@ -10430,11 +10425,13 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/types'
       - supports-color
+    optional: true
 
   '@swc-node/sourcemap-support@0.6.1':
     dependencies:
       source-map-support: 0.5.21
       tslib: 2.8.1
+    optional: true
 
   '@swc/core-darwin-arm64@1.13.20':
     optional: true
@@ -14820,6 +14817,7 @@ snapshots:
       '@oxc-resolver/binding-win32-arm64-msvc': 11.11.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.11.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.11.1
+    optional: true
 
   p-limit@2.3.0:
     dependencies:
@@ -15009,7 +15007,8 @@ snapshots:
 
   pify@6.1.0: {}
 
-  pirates@4.0.7: {}
+  pirates@4.0.7:
+    optional: true
 
   pkg-dir@4.2.0:
     dependencies:

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -14,6 +14,7 @@ export default defineConfig({
             "packages/core/vitest.config.mts",
             "packages/datetime/vitest.config.mts",
             "packages/docs-data/vitest.config.mts",
+            "packages/eslint-plugin/vitest.config.mts",
             "packages/labs/vitest.config.mts",
             "packages/node-build-scripts/vitest.config.mts",
             "packages/select/vitest.config.mts",


### PR DESCRIPTION
## Summary

- Replaced Mocha with Vitest as the test runner for `@blueprintjs/eslint-plugin`
- Deleted `test/setup.ts` (mocha bridge for RuleTester) - with `globals: true` in the vitest config, `@typescript-eslint/rule-tester` auto-detects `describe`/`it`/`afterAll` from the global scope
- Removed `@swc-node/register` and `@swc/core` devDependencies (vitest handles TypeScript natively)
- Test files themselves needed no changes - they only use `RuleTester.run()`

## Test plan

- [x] `pnpm --filter @blueprintjs/eslint-plugin test`