### PR TITLE
Prevent forced reflow in `MultiSlider`

### DIFF
--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -223,7 +223,11 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
 
     public componentDidUpdate(prevProps: MultiSliderProps, prevState: SliderState) {
         super.componentDidUpdate(prevProps, prevState);
-        if (prevProps.min !== this.props.min || prevProps.max !== this.props.max || prevProps.vertical !== this.props.vertical) {
+        if (
+            prevProps.min !== this.props.min ||
+            prevProps.max !== this.props.max ||
+            prevProps.vertical !== this.props.vertical
+        ) {
             this.updateTickSize();
         }
     }

--- a/packages/core/src/components/slider/multiSlider.tsx
+++ b/packages/core/src/components/slider/multiSlider.tsx
@@ -223,7 +223,9 @@ export class MultiSlider extends AbstractPureComponent<MultiSliderProps, SliderS
 
     public componentDidUpdate(prevProps: MultiSliderProps, prevState: SliderState) {
         super.componentDidUpdate(prevProps, prevState);
-        this.updateTickSize();
+        if (prevProps.min !== this.props.min || prevProps.max !== this.props.max || prevProps.vertical !== this.props.vertical) {
+            this.updateTickSize();
+        }
     }
 
     protected validateProps(props: React.PropsWithChildren<MultiSliderProps>) {


### PR DESCRIPTION
This can be substantial for frequently updating values. 

<img width="576" height="139" alt="image" src="https://github.com/user-attachments/assets/95f88c19-d5cf-4b5f-81d9-c4d644d2f253" />
