### PR TITLE
[chore] Fix test flake in select tests

### DIFF
--- a/packages/select/src/components/select/selectComponentTestUtils.tsx
+++ b/packages/select/src/components/select/selectComponentTestUtils.tsx
@@ -18,7 +18,7 @@ import type { ReactWrapper } from "enzyme";
 import sinon from "sinon";
 
 import { Classes, type HTMLInputProps } from "@blueprintjs/core";
-import { beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import {
     areFilmsEqual,
@@ -48,11 +48,30 @@ export function selectComponentSuite<P extends ListItemsProps<Film>, S>(
         query: "19",
     };
 
+    let mountedWrappers: Array<ReactWrapper<P, S>> = [];
+    const originalRender = render;
+    render = (props: ListItemsProps<Film>) => {
+        const wrapper = originalRender(props);
+        mountedWrappers.push(wrapper);
+        return wrapper;
+    };
+
     beforeEach(() => {
         testProps.itemRenderer.resetHistory();
         testProps.onActiveItemChange.resetHistory();
         testProps.onItemSelect.resetHistory();
         testProps.onQueryChange.resetHistory();
+    });
+
+    afterEach(() => {
+        for (const wrapper of mountedWrappers) {
+            try {
+                wrapper.unmount();
+            } catch {
+                // best-effort
+            }
+        }
+        mountedWrappers = [];
     });
 
     describe("common behavior", () => {


### PR DESCRIPTION
## Summary

A few CI builds have been failing intermittently on `test-react-18` with `ReferenceError: window is not defined` from `omnibar.test.tsx`. The errors come from `react-dom` and `react-transition-group` trying to access `window` after jsdom has been torn down.

`selectComponentSuite` mounts Enzyme wrappers in each test but never unmounts them. After the test file finishes and jsdom cleans up, React 18 still has pending async work (transitions from `Overlay2`'s use of `react-transition-group`) that fires against a destroyed environment. This adds wrapper tracking and `afterEach` cleanup inside `selectComponentSuite` so all its consumers (Omnibar, MultiSelect, etc.) get proper teardown.


### Examples of failing builds

- https://app.circleci.com/pipelines/github/palantir/blueprint/11145/workflows/476535a8-ed75-43e3-9c44-3cbdb7ca45e5/jobs/138035
- https://app.circleci.com/pipelines/github/palantir/blueprint/11126/workflows/2cee1155-67a1-4d41-b272-f4bb754af2c9/jobs/137819
- https://app.circleci.com/pipelines/github/palantir/blueprint/11133/workflows/a8159809-1c4e-4037-b1ba-d415e9d692df/jobs/137894



