### PR TITLE
(chore) replace @ns with bp6 in .mdx docs files

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -14,12 +14,12 @@ Headings
 
 Markup:
 <div>
-  <h1 class="@ns-heading {{.modifier}}">H1 heading</h1>
-  <h2 class="@ns-heading {{.modifier}}">H2 heading</h2>
-  <h3 class="@ns-heading {{.modifier}}">H3 heading</h3>
-  <h4 class="@ns-heading {{.modifier}}">H4 heading</h4>
-  <h5 class="@ns-heading {{.modifier}}">H5 heading</h5>
-  <h6 class="@ns-heading {{.modifier}}">H6 heading</h6>
+  <h1 class="bp6-heading {{.modifier}}">H1 heading</h1>
+  <h2 class="bp6-heading {{.modifier}}">H2 heading</h2>
+  <h3 class="bp6-heading {{.modifier}}">H3 heading</h3>
+  <h4 class="bp6-heading {{.modifier}}">H4 heading</h4>
+  <h5 class="bp6-heading {{.modifier}}">H5 heading</h5>
+  <h6 class="bp6-heading {{.modifier}}">H6 heading</h6>
 </div>
 
 .#{$ns}-text-muted - Change text color to a gentler gray.
@@ -113,7 +113,7 @@ Styleguide ui-text
 Running text
 
 Markup:
-<div class="@ns-running-text {{.modifier}}">
+<div class="bp6-running-text {{.modifier}}">
   <p>
     We build products that make people better at their most important
     work — the kind of work you read about on the front page of the
@@ -186,15 +186,15 @@ Styleguide running-text
   }
 }
 
-// NOTE: these must be defined after .@ns-running-text in order to override font-size.
+// NOTE: these must be defined after .bp6-running-text in order to override font-size.
 .#{$ns}-text-large {
   font-size: $pt-font-size-large;
-  // line-height comes from .@ns-(ui|running)-text
+  // line-height comes from .bp6-(ui|running)-text
 }
 
 .#{$ns}-text-small {
   font-size: $pt-font-size-small;
-  // line-height comes from .@ns-(ui|running)-text
+  // line-height comes from .bp6-(ui|running)-text
 }
 
 /*
@@ -222,9 +222,9 @@ Preformatted text
 
 Markup:
 <div>
-  <p>Use the <code class="@ns-code">&lt;code></code> tag for snippets of code.</p>
-  <pre class="@ns-code-block">Use the &lt;pre> tag for blocks of code.</pre>
-  <pre class="@ns-code-block"><code>// code sample
+  <p>Use the <code class="bp6-code">&lt;code></code> tag for snippets of code.</p>
+  <pre class="bp6-code-block">Use the &lt;pre> tag for blocks of code.</pre>
+  <pre class="bp6-code-block"><code>// code sample
 export function hasModifier(
   modifiers: ts.ModifiersArray,
   ...modifierKinds: ts.SyntaxKind[],
@@ -297,7 +297,7 @@ Styleguide preformatted
 Block quotes
 
 Markup:
-<blockquote class="@ns-blockquote">
+<blockquote class="bp6-blockquote">
   Premium Aerotec is a key supplier for Airbus, producing 30 million parts per year,
   which is huge complexity. Skywise helps us manage all the production steps.
   It gives Airbus much better visibility into where the product is in the supply chain,
@@ -376,13 +376,13 @@ Styleguide lists
 Right-to-left text
 
 Markup:
-<h5 class="@ns-heading">Arabic:</h5>
-<p class="@ns-rtl">
+<h5 class="bp6-heading">Arabic:</h5>
+<p class="bp6-rtl">
   لكل لأداء بمحاولة من. مدينة الواقعة يبق أي, وإعلان وقوعها، حول كل, حدى عجّل مشروط الخاسرة قد.
   من الذود تكبّد بين, و لها واحدة الأراضي. عل الصفحة والروسية يتم, أي للحكومة استعملت شيء. أم وصل زهاء اليا
 </p>
-<h5 class="@ns-heading">Hebrew:</h5>
-<p class="@ns-rtl">
+<h5 class="bp6-heading">Hebrew:</h5>
+<p class="bp6-rtl">
   כדי על עזרה יידיש הבהרה, מלא באגים טכניים דת. תנך או ברית ביולי. כתב בה הטבע למנוע, דת כלים פיסיקה החופשית זכר.
   מתן החלל מאמרשיחהצפה ב. הספרות אנציקלופדיה אם זכר, על שימושי שימושיים תאולוגיה עזה
 </p>

--- a/packages/core/src/components/button/button-group.mdx
+++ b/packages/core/src/components/button/button-group.mdx
@@ -45,8 +45,8 @@ Use the `variant` prop to change the visual style of button child elements withi
 
 ### Outlined and minimal
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign">
+    <h5 class="bp6-heading">
 
 Deprecated: use [`variant`](#core/components/buttons.variant) instead
 

--- a/packages/core/src/components/button/buttons.mdx
+++ b/packages/core/src/components/button/buttons.mdx
@@ -47,8 +47,8 @@ Buttons come in three different variants that support different use cases:
 
 ### Minimal
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign">
+    <h5 class="bp6-heading">
 
 Deprecated: use [`variant`](#core/components/buttons.variant) instead
 
@@ -62,8 +62,8 @@ The `minimal` prop offers a button without borders or background, ideal for subt
 
 ### Outlined
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign">
+    <h5 class="bp6-heading">
 
 Deprecated: use [`variant`](#core/components/buttons.variant) instead
 
@@ -127,13 +127,13 @@ The **AnchorButton** component behaves like an anchor (`<a>` tag) and is useful 
 
 @reactCodeExample ButtonAnchorButtonExample
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Disabled Button elements prevent all interaction</h5>
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Disabled Button elements prevent all interaction</h5>
 
 Use **AnchorButton** if you need mouse interaction events (such as hovering) on a disabled button.
 
 **Button** uses the native `disabled` attribute on the `<button>` tag so the browser disables all interactions.
-**AnchorButton** uses the class `.@ns-disabled` because `<a>` tags do not support the `disabled` attribute. As a result,
+**AnchorButton** uses the class `.bp6-disabled` because `<a>` tags do not support the `disabled` attribute. As a result,
 the **AnchorButton** component will prevent _only_ the `onClick` handler when disabled but permit other events.
 
 </div>

--- a/packages/core/src/components/context-menu/context-menu-popover.mdx
+++ b/packages/core/src/components/context-menu/context-menu-popover.mdx
@@ -4,8 +4,8 @@ title: Context Menu Popover
 
 # Context Menu Popover
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Consider [Context Menu](#core/components/context-menu) first
 

--- a/packages/core/src/components/dialog/dialog.mdx
+++ b/packages/core/src/components/dialog/dialog.mdx
@@ -13,8 +13,8 @@ The **Dialog** component presents content overlaid over other parts of the UI vi
 import { Dialog } from "@blueprintjs/core";
 ```
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Terminology note</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Terminology note</h5>
 
 The term "modal" is sometimes used to mean "dialog," but this is a misnomer.
 _Modal_ is an adjective that describes parts of a UI. An element is considered to be "modal" if it
@@ -34,8 +34,8 @@ Blueprint provides two types of dialogs:
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 [OverlaysProvider](#core/context/overlays-provider) recommended
 

--- a/packages/core/src/components/drawer/drawer.mdx
+++ b/packages/core/src/components/drawer/drawer.mdx
@@ -17,8 +17,8 @@ import { Drawer } from "@blueprintjs/core";
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 [OverlaysProvider](#core/context/overlays-provider) recommended
 

--- a/packages/core/src/components/editable-text/editable-text.mdx
+++ b/packages/core/src/components/editable-text/editable-text.mdx
@@ -35,8 +35,8 @@ invoked if the value is unchanged.
 
 @reactCodeExample EditableTextBasicExample
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Centering EditableText</h5>
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Centering EditableText</h5>
 
 **Do not center this component** using `text-align: center`, as it will cause an infinite loop
 in the browser ([more details](https://github.com/JedWatson/react-select/issues/540)). Instead,

--- a/packages/core/src/components/forms/control-group.mdx
+++ b/packages/core/src/components/forms/control-group.mdx
@@ -7,8 +7,8 @@ title: Control group
 A **ControlGroup** renders multiple distinct form controls as one unit, with a small margin between elements. It
 supports any number of buttons, text inputs, input groups, numeric inputs, and HTML selects as direct children.
 
-<div class="@ns-callout @ns-intent-success @ns-icon-comparison @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Control group vs. input group</h5>
+<div class="bp6-callout bp6-intent-success bp6-icon-comparison bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Control group vs. input group</h5>
 
 Both components group multiple elements into a single unit, but their usage patterns are quite different.
 

--- a/packages/core/src/components/forms/file-input.mdx
+++ b/packages/core/src/components/forms/file-input.mdx
@@ -20,8 +20,8 @@ import { FileInput } from "@blueprintjs/core";
 <FileInput disabled={true} text="Choose file..." onInputChange={...} />
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Static file name</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Static file name</h5>
 
 File name does not automatically update after a user selects a file.
 To get this behavior, you must update the `text` prop.

--- a/packages/core/src/components/forms/label.mdx
+++ b/packages/core/src/components/forms/label.mdx
@@ -9,8 +9,8 @@ title: Label
 Wrapping a `<label>` element around a form input effectively increases the area where the user can click to activate
 the control. Notice how in the examples below, clicking a label focuses its `<input>`.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Prefer form groups over labels</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Prefer form groups over labels</h5>
 
 The [**FormGroup** component](#core/components/form-group) provides additional functionality such as helper text and
 modifier props as well as full label support. **FormGroup** supports both simple and complex use cases, therefore we

--- a/packages/core/src/components/forms/numeric-input.mdx
+++ b/packages/core/src/components/forms/numeric-input.mdx
@@ -48,7 +48,7 @@ These special-case inputs are evaluated when `Enter` is pressed (via a custom `o
 loses focus (via a custom `onBlur` callback). If the input is invalid when either of these callbacks is trigged, the
 field will be cleared.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 This example contains non-core functionality that is meant to demonstrate the extensibility of the **NumericInput**
 component. The correctness of the custom evaluation code has not been tested robustly.
@@ -98,7 +98,7 @@ Exceptions to this rule may occur if your input only supports _positive integers
 have any non-numeric characters. See the [precision section](#core/components/numeric-input.numeric-precision)
 to learn how to enforce this kind of constraint.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign">
 
 When handling changes in controlled mode, always use the _second_ parameter of the `onValueChange` callback, which
 provides the value as a string. This allows users to type non-numeric characters like decimal points (".") without the

--- a/packages/core/src/components/hotkeys/hotkeys-target.mdx
+++ b/packages/core/src/components/hotkeys/hotkeys-target.mdx
@@ -72,7 +72,7 @@ event handlers with the `handleKeyDown` and `handleKeyUp` functions in the child
 you will likely have to set a non-negative `tabIndex` on the DOM node to which these local event handlers are
 bound for them to work correctly.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 See the [useHotkeys hook documentation](#core/hooks/use-hotkeys.key-combos) to understand the semantics of "key combos":
 how they are configured and how they will appear in the global dialog.

--- a/packages/core/src/components/html-select/html-select.mdx
+++ b/packages/core/src/components/html-select/html-select.mdx
@@ -7,7 +7,7 @@ title: HTML select
 Styling HTML `<select>` tags requires a wrapper element to customize the dropdown caret, so Blueprint provides
 a **HTMLSelect** component to streamline this process.
 
-<div class="@ns-callout @ns-intent-success @ns-icon-info-sign @ns-callout-has-body-content">
+<div class="bp6-callout bp6-intent-success bp6-icon-info-sign bp6-callout-has-body-content">
 
 The [**Select**](#select/select-component) component in the [**@blueprintjs/select**](#select)
 package provides a more full-features alternative to the native HTML `<select>` tag. Notably, it

--- a/packages/core/src/components/html-table/html-table.mdx
+++ b/packages/core/src/components/html-table/html-table.mdx
@@ -6,8 +6,8 @@ title: HTML table
 
 **HTMLTable** provides Blueprint styling to native HTML tables.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">This is not @blueprintjs/table</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">This is not @blueprintjs/table</h5>
 
 This component is a simple CSS-only skin for HTML `<table>` elements.
 It is ideal for basic static tables. If you're looking for more complex

--- a/packages/core/src/components/icon/icon.mdx
+++ b/packages/core/src/components/icon/icon.mdx
@@ -4,7 +4,7 @@ title: Icon
 
 # Icon
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 See the [**Icons package**](#icons) for a searchable list of all available UI icons.
 
@@ -35,7 +35,7 @@ prop is typed such that editors can offer autocomplete for known icon names. The
 optional `size` prop determines the exact width and height of the icon
 image; the icon element itself can be also be sized using CSS.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 Icons may be configured to load in various ways, see ["Loading icons"](#icons/loading-icons).
 
@@ -75,7 +75,7 @@ Custom sizes are supported. The following React element:
 ...renders this HTML markup:
 
 ```xml
-<span class="@ns-icon @ns-icon-globe" aria-hidden="true">
+<span class="bp6-icon bp6-icon-globe" aria-hidden="true">
     <svg data-icon="globe" width="30" height="30" viewBox="0 0 20 20" role="img">
         <path d="..."></path>
     </svg>
@@ -148,23 +148,23 @@ preferred over icon SVGs.
 
 To use Blueprint UI icons via CSS, you must apply two classes to a `<span>` element:
 
-- a **sizing class**, either `@ns-icon-standard` (16px) or `@ns-icon-large` (20px)
-- an **icon name class**, such as `@ns-icon-projects`
+- a **sizing class**, either `bp6-icon-standard` (16px) or `bp6-icon-large` (20px)
+- an **icon name class**, such as `bp6-icon-projects`
 
-Icon classes also support the four `.@ns-intent-*` modifiers to color the image.
+Icon classes also support the four `.bp6-intent-*` modifiers to color the image.
 
 ```html
-<span class="@ns-icon-{{size}} @ns-icon-{{name}}"></span>
+<span class="bp6-icon-{{size}} bp6-icon-{{name}}"></span>
 
-<span class="@ns-icon-standard @ns-icon-projects"></span>
-<span class="@ns-icon-large @ns-icon-geosearch @ns-intent-success"></span>
+<span class="bp6-icon-standard bp6-icon-projects"></span>
+<span class="bp6-icon-large bp6-icon-geosearch bp6-intent-success"></span>
 ```
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Non-standard sizes</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Non-standard sizes</h5>
 
 Generally, font icons should only be used at either 16px or 20px. However, if a non-standard size is
 necessary, set a `font-size` that is whole multiple of 16 or 20 with the relevant size class.
-You can instead use the class `@ns-icon` to make the icon inherit its size from surrounding text.
+You can instead use the class `bp6-icon` to make the icon inherit its size from surrounding text.
 
 </div>

--- a/packages/core/src/components/navbar/navbar.mdx
+++ b/packages/core/src/components/navbar/navbar.mdx
@@ -23,8 +23,8 @@ The **Navbar** API includes four stateless React components:
 - **NavbarHeading** (aliased as `Navbar.Heading`)
 - **NavbarDivider** (aliased as `Navbar.Divider`)
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
     Nested components are deprecated
 
 </h5>
@@ -42,8 +42,8 @@ DOM attributes.
     <NavbarGroup align={Alignment.START}>
         <NavbarHeading>Blueprint</NavbarHeading>
         <NavbarDivider />
-        <Button className="@ns-minimal" icon="home" text="Home" />
-        <Button className="@ns-minimal" icon="document" text="Files" />
+        <Button className="bp6-minimal" icon="home" text="Home" />
+        <Button className="bp6-minimal" icon="document" text="Files" />
     </NavbarGroup>
 </Navbar>
 ```
@@ -55,8 +55,8 @@ so-called "sticky" behavior: the navbar stays at the top of the screen as the us
 
 This modifier is not illustrated here because it breaks the document flow.
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Body padding required</h5>
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Body padding required</h5>
 
 The fixed navbar will lie on top of your other content unless you add padding to the top of the `<body>` element equal
 to the height of the navbar. Use the `$pt-navbar-height` Sass variable.

--- a/packages/core/src/components/overlay/overlay.mdx
+++ b/packages/core/src/components/overlay/overlay.mdx
@@ -3,11 +3,10 @@ title: Overlay
 tag: deprecated
 ---
 
-
 # Overlay
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Deprecated: use [**Overlay2**](#core/components/overlay2)
 
@@ -48,8 +47,8 @@ will be inserted before the children if `hasBackdrop={true}`.
 The `onClose` callback prop is invoked when user interaction causes the overlay to close, but your application is
 responsible for updating the state that actually closes the overlay.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">A note about overlay content positioning</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">A note about overlay content positioning</h5>
 
 When rendered inline, content will automatically be set to `position: absolute` to respect
 document flow. Otherwise, content will be set to `position: fixed` to cover the entire viewport.

--- a/packages/core/src/components/overlay2/overlay2.mdx
+++ b/packages/core/src/components/overlay2/overlay2.mdx
@@ -4,8 +4,8 @@ title: Overlay2
 
 # Overlay2
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Migrating from [Overlay](#core/components/overlay)?
 
@@ -77,8 +77,8 @@ function Example() {
 
 ## DOM layout
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">A note about overlay content positioning</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">A note about overlay content positioning</h5>
 
 When rendered inline, content will automatically be set to `position: absolute` to respect
 document flow. Otherwise, content will be set to `position: fixed` to cover the entire viewport.
@@ -99,8 +99,8 @@ this modifier class automatically.
 
 ## Child refs
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">DOM ref(s) required</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">DOM ref(s) required</h5>
 
 Overlay2 needs to be able to attach DOM refs to its child elements, so the children of this
 component _must be a native DOM element_ or utilize

--- a/packages/core/src/components/popover-next/popover-next.mdx
+++ b/packages/core/src/components/popover-next/popover-next.mdx
@@ -3,7 +3,6 @@ title: PopoverNext
 tag: new
 ---
 
-
 # PopoverNext
 
 PopoverNext displays floating content next to a target element.
@@ -21,8 +20,8 @@ import { PopoverNext } from "@blueprintjs/core";
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 [OverlaysProvider](#core/context/overlays-provider) recommended
 
@@ -61,7 +60,7 @@ In Floating UI terms, this is the "reference" element. There are two ways to ren
 in different DOM layout depending on your application's needs:
 
 - The simplest way to specify a target is via `children`. Provide a single React child to
-  `<PopoverNext>` and the component will render that child wrapped in a `@ns-popover-target` HTML element.
+  `<PopoverNext>` and the component will render that child wrapped in a `bp6-popover-target` HTML element.
   This wrapper is configured with event handling logic necessary for the PopoverNext to function. Its tag name
   (e.g. `div`, `span`) and props can be customized with the `targetTagName` and `targetProps` props, respectively.
 
@@ -79,8 +78,8 @@ The **content** will be shown inside the popover itself. When opened, the popove
 positioned on the page next to the target; the `placement` prop determines its relative placement (on
 which side of the target).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Button targets</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Button targets</h5>
 
 Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
 events, which interferes with the popover functioning. If you need to disable a button which
@@ -93,7 +92,7 @@ See the [callout here](#core/components/button.props) for more details.
 import { Button, Classes, PopoverNext } from "@blueprintjs/core";
 
 export const PopoverNextExample: React.FC = () => {
-    // popover content gets no padding by default; add the "@ns-popover-content-sizing"
+    // popover content gets no padding by default; add the "bp6-popover-content-sizing"
     // class to the popover to set nice padding between its border and content.
     return (
         <PopoverNext
@@ -159,7 +158,7 @@ The following example shows how each placement value behaves in practice:
 
 If a `placement` prop is not specified (default behavior), PopoverNext will use automatic placement to choose the side with the best available space and continually update the position to avoid overflowing the boundary element (when scrolling within it, for instance).
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 You can also specify a specific initial placement (e.g. `"left"`, `"bottom-start"`) and still allow PopoverNext to update its position automatically when there isn't enough space. [See below](#core/components/popover-next.middleware) for information about customizing positioning behavior.
 
@@ -171,8 +170,8 @@ Middleware allow us to customize Floating UI's positioning behavior. **PopoverNe
 
 You may override the default middleware with the `middleware` prop, which is an object with key-value pairs representing the middleware name and its options object, respectively. See the [Floating UI middleware docs page](https://floating-ui.com/docs/middleware) for more info.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Auto placement requires autoPlacement or flip middleware</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Auto placement requires autoPlacement or flip middleware</h5>
 
 Be careful when disabling the "autoPlacement" or "flip" middleware, since automatic placement relies on them. If you _do_ decide to disable these middleware, be sure to also specify a placement which is specific (not automatic).
 
@@ -219,8 +218,8 @@ It is important to pay attention to the value of the `nextOpenState` parameter a
 in your application logic whether you should care about a particular invocation (for instance,
 if the `nextOpenState` is not the same as the **PopoverNext**'s current state).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Disabling controlled popovers</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Disabling controlled popovers</h5>
 
 If `disabled={true}`, a controlled popover will remain closed even if `isOpen={true}`.
 The popover will re-open when `disabled` is set to `false`.
@@ -283,8 +282,8 @@ The following example demonstrates the various interaction kinds (note: these Po
 
 @reactExample PopoverNextInteractionKindExample
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Conditionally styling popover targets</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Conditionally styling popover targets</h5>
 
 When a popover is open, `Classes.POPOVER_OPEN` is applied to the target.
 You can use this to style the target differently when the popover is open.
@@ -312,13 +311,13 @@ An error is thrown if used otherwise.
 #### Styling the backdrop
 
 By default, the popover backdrop is invisible, but you can easily add your own styles to
-`.@ns-popover-backdrop` to customize the appearance of the backdrop (for example, you could give it
+`.bp6-popover-backdrop` to customize the appearance of the backdrop (for example, you could give it
 a translucent background color, like the backdrop for the [`Dialog`](#core/components/dialog) component).
 
 The backdrop element has the same opacity-fade transition as the `Dialog` backdrop.
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Dangerous edge case</h5>
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Dangerous edge case</h5>
 
 Rendering a `<PopoverNext isOpen={true} hasBackdrop={true}>` outside the viewport bounds can easily break your application
 by covering the UI with an invisible non-interactive backdrop. This edge case must be handled by your application code
@@ -344,9 +343,9 @@ everything else on the page without needing to manually adjust z-indices, and Fl
 
 ### Dark theme
 
-**PopoverNext** automatically detects whether its trigger is nested inside a `.@ns-dark` container and applies the
+**PopoverNext** automatically detects whether its trigger is nested inside a `.bp6-dark` container and applies the
 same class to itself. You can also explicitly apply the dark theme to the React component by providing the prop
-`popoverClassName="@ns-dark"`.
+`popoverClassName="bp6-dark"`.
 
 As a result, any component that you place inside a **PopoverNext** (such as a `Menu`) automatically inherits the dark theme
 styles. Note that [`Tooltip`](#core/components/tooltip) uses **PopoverNext** internally, so it also benefits from this

--- a/packages/core/src/components/popover/popover.mdx
+++ b/packages/core/src/components/popover/popover.mdx
@@ -3,11 +3,10 @@ title: Popover
 tag: deprecated
 ---
 
-
 # Popover
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Deprecated: use [**PopoverNext**](#core/components/popover-next)
 
@@ -32,8 +31,8 @@ import { Popover } from "@blueprintjs/core";
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 [OverlaysProvider](#core/context/overlays-provider) recommended
 
@@ -72,7 +71,7 @@ In Popper.js terms, this is the popper "reference". There are two ways to render
 in different DOM layout depending on your application's needs:
 
 - The simplest way to specify a target is via `children`. Provide a single React child to
-  `<Popover>` and the component will render that child wrapped in a `@ns-popover-target` HTML element.
+  `<Popover>` and the component will render that child wrapped in a `bp6-popover-target` HTML element.
   This wrapper is configured with event handling logic necessary for the Popover to function. Its tag name
   (e.g. `div`, `span`) and props can be customized with the `targetTagName` and `targetProps` props, respectively.
 
@@ -91,8 +90,8 @@ The **content** will be shown inside the popover itself. When opened, the popove
 positioned on the page next to the target; the `placement` prop determines its relative placement (on
 which side of the target).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Button targets</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Button targets</h5>
 
 Buttons make great popover targets, but the `disabled` attribute on a `<button>` blocks all
 events, which interferes with the popover functioning. If you need to disable a button which
@@ -106,7 +105,7 @@ import { Button, Classes, Popover } from "@blueprintjs/core";
 
 export class PopoverExample extends React.PureComponent {
     public render() {
-        // popover content gets no padding by default; add the "@ns-popover-content-sizing"
+        // popover content gets no padding by default; add the "bp6-popover-content-sizing"
         // class to the popover to set nice padding between its border and content.
         return (
             <Popover
@@ -169,7 +168,7 @@ The options differ in how they handle <span class="docs-popover-placement-label-
 - In `"auto-start"` mode, the Popover will align itself to the `start` of the target (i.e., the top edge when the popover is on the left or right, or the left edge when the popover is on the top or bottom).
 - In `"auto-end"` mode, the Popover will align itself to the `end` of the target (i.e., the bottom edge when the popover is on the left or right, or the right edge when the popover is on the top or bottom).
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 You can also specify a specific initial placement (e.g. `"left"`, `"bottom-start"`) and still update the Popover's position
 automatically by enabling the modifiers `flip` and `preventOverflow`.
@@ -186,8 +185,8 @@ You may override the default modifiers with the `modifiers` prop, which is an ob
 the modifier name and its options object, respectively. See the
 [Popper.js modifiers docs page](https://popper.js.org/docs/v2/modifiers/) for more info.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Auto placement requires flip modifier</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Auto placement requires flip modifier</h5>
 
 Be careful when disabling the "flip" modifier, since the default "auto" placement relies on it. If you _do_ decide
 to disable this modifier, be sure to also specify a placement which is not "auto".
@@ -212,8 +211,8 @@ It is important to pay attention to the value of the `nextOpenState` parameter a
 in your application logic whether you should care about a particular invocation (for instance,
 if the `nextOpenState` is not the same as the **Popover**'s current state).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Disabling controlled popovers</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Disabling controlled popovers</h5>
 
 If `disabled={true}`, a controlled popover will remain closed even if `isOpen={true}`.
 The popover will re-open when `disabled` is set to `false`.
@@ -277,8 +276,8 @@ The following example demonstrates the various interaction kinds (note: these Po
 
 @reactExample PopoverInteractionKindExample
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Conditionally styling popover targets</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Conditionally styling popover targets</h5>
 
 When a popover is open, `Classes.POPOVER_OPEN` is applied to the target.
 You can use this to style the target differently when the popover is open.
@@ -316,7 +315,7 @@ any submenu item will close all submenus, which is desirable behavior for a menu
 
 @reactExample PopoverDismissExample
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 Dismiss elements won't have any effect in a popover with `interactionKind="hover-target"` because there is no way to
 interact with the popover content itself: the popover is dismissed the moment the user mouses away from the target.
@@ -344,13 +343,13 @@ An error is thrown if used otherwise.
 #### Styling the backdrop
 
 By default, the popover backdrop is invisible, but you can easily add your own styles to
-`.@ns-popover-backdrop` to customize the appearance of the backdrop (for example, you could give it
+`.bp6-popover-backdrop` to customize the appearance of the backdrop (for example, you could give it
 a translucent background color, like the backdrop for the [`Dialog`](#core/components/dialog) component).
 
 The backdrop element has the same opacity-fade transition as the `Dialog` backdrop.
 
-<div class="@ns-callout @ns-intent-danger @ns-icon-error @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Dangerous edge case</h5>
+<div class="bp6-callout bp6-intent-danger bp6-icon-error bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Dangerous edge case</h5>
 
 Rendering a `<Popover isOpen={true} hasBackdrop={true}>` outside the viewport bounds can easily break your application
 by covering the UI with an invisible non-interactive backdrop. This edge case must be handled by your application code
@@ -376,9 +375,9 @@ everything else on the page without needing to manually adjust z-indices, and Po
 
 ### Dark theme
 
-**Popover** automatically detects whether its trigger is nested inside a `.@ns-dark` container and applies the
+**Popover** automatically detects whether its trigger is nested inside a `.bp6-dark` container and applies the
 same class to itself. You can also explicitly apply the dark theme to the React component by providing the prop
-`popoverClassName="@ns-dark"`.
+`popoverClassName="bp6-dark"`.
 
 As a result, any component that you place inside a **Popover** (such as a `Menu`) automatically inherits the dark theme
 styles. Note that [`Tooltip`](#core/components/tooltip) uses **Popover** internally, so it also benefits from this
@@ -421,7 +420,7 @@ documentation.
 
 ## Testing
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 Your best resource for strategies in popover testing is
 [its own unit test suite.](https://github.com/palantir/blueprint/blob/develop/packages/core/test/popover/popoverTests.tsx)
@@ -476,7 +475,7 @@ setTimeout(() => {
 #### Element refs
 
 If `usePortal={false}` rendering is not an option, **Popover** instances expose `popoverElement` and `targetElement`
-refs of the actual DOM elements. Importantly, `popoverElement` points to the `.@ns-popover` element inside the
+refs of the actual DOM elements. Importantly, `popoverElement` points to the `.bp6-popover` element inside the
 **Portal** so you can use it to easily query popover contents without knowing precisely where they are in the DOM.
 These properties exist primarily to simplify testing; do not rely on them for feature work.
 
@@ -484,6 +483,6 @@ These properties exist primarily to simplify testing; do not rely on them for fe
 // using mount() from enzyme
 const wrapper = mount(<Popover content={<div className="test">test</div>} />);
 const { popoverElement } = wrapper.instance();
-// popoverElement is the parent element of .@ns-popover
+// popoverElement is the parent element of .bp6-popover
 popoverElement.querySelector(".test").textContent; // "test"
 ```

--- a/packages/core/src/components/portal/portal.mdx
+++ b/packages/core/src/components/portal/portal.mdx
@@ -26,8 +26,8 @@ import { Portal } from "@blueprintjs/core";
 **Portal** is used inside [Overlay2](#core/components/overlay2) to actually overlay the content on the
 application.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-move @ns-callout-has-body-content">
-    <h5 class="@ns-heading">A note about responsive layouts</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-move bp6-callout-has-body-content">
+    <h5 class="bp6-heading">A note about responsive layouts</h5>
 
 For a single-page app, if the `<body>` is styled with `width: 100%` and `height: 100%`, a `Portal`
 may take up extra whitespace and cause the window to undesirably scroll. To fix this, instead

--- a/packages/core/src/components/resize-sensor/resize-sensor.mdx
+++ b/packages/core/src/components/resize-sensor/resize-sensor.mdx
@@ -9,8 +9,8 @@ It is a thin wrapper around [`ResizeObserver`][resizeobserver] to provide React 
 
 [resizeobserver]: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">DOM ref required</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">DOM ref required</h5>
 
 ResizeSensor's implementation relies on a React ref being attached to a DOM element,
 so the child of this component _must be a native DOM element_ or utilize
@@ -50,8 +50,8 @@ const myRef = React.createRef();
 </ResizeSensor>;
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Asynchronous behavior</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Asynchronous behavior</h5>
 
 The `onResize` callback is invoked asynchronously after a resize is detected
 and typically happens at the end of a frame (after layout, before paint).

--- a/packages/core/src/components/skeleton/skeleton.mdx
+++ b/packages/core/src/components/skeleton/skeleton.mdx
@@ -15,13 +15,13 @@ to, so you should supply a placeholder while awaiting real content.
 
 ## CSS
 
-Apply the class `.@ns-skeleton` to elements that you would like to cover up with
+Apply the class `.bp6-skeleton` to elements that you would like to cover up with
 a loading animation.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Manually disable focusable elements</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Manually disable focusable elements</h5>
 
-When using the `.@ns-skeleton` class on focusable elements such as inputs and buttons, be sure to disable the element,
+When using the `.bp6-skeleton` class on focusable elements such as inputs and buttons, be sure to disable the element,
 via either the `disabled` or `tabindex="-1"` attributes. Failing to do so will allow these skeleton elements to be
 focused when they shouldn't be.
 

--- a/packages/core/src/components/tabs/tabs.mdx
+++ b/packages/core/src/components/tabs/tabs.mdx
@@ -32,7 +32,7 @@ import { Tab, Tabs } from "@blueprintjs/core";
     <Tab id="rx" title="React" panel={<ReactPanel />} />
     <Tab id="bb" disabled title="Backbone" panel={<BackbonePanel />} />
     <TabsExpander />
-    <input className="@ns-input" type="text" placeholder="Search..." />
+    <input className="bp6-input" type="text" placeholder="Search..." />
 </Tabs>;
 ```
 

--- a/packages/core/src/components/tag-input/tag-input.mdx
+++ b/packages/core/src/components/tag-input/tag-input.mdx
@@ -16,8 +16,8 @@ import { TagInput } from "@blueprintjs/core";
 
 @reactExample TagInputExample
 
-<div class="@ns-callout @ns-intent-success @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Looking for a dropdown menu?</h5>
+<div class="bp6-callout bp6-intent-success bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Looking for a dropdown menu?</h5>
 
 [The **MultiSelect** component in the **@blueprintjs/select** package](#select/multi-select)
 composes this component with a dropdown menu.
@@ -31,7 +31,7 @@ Typing in the input and pressing <kbd>Enter</kbd> will **add new items** by invo
 set to `true`, clicking outside of the component will also trigger the callback to add new items. A `separator` prop is
 supported to allow multiple items to be added at once; the default splits on commas and newlines.
 
-**Tags** may be removed by clicking their <span class="@ns-icon-standard @ns-icon-cross"></span> buttons or by pressing
+**Tags** may be removed by clicking their <span class="bp6-icon-standard bp6-icon-cross"></span> buttons or by pressing
 either <kbd>backspace</kbd> or <kbd>delete</kbd> repeatedly. Pressing <kbd>delete</kbd> mimics the behavior of deleting
 in a text editor, where trying to delete at the end of the line will do nothing. Arrow keys can also be used to focus
 on a particular tag before removing it. The cursor must be at the beginning of the text input for these interactions.
@@ -47,8 +47,8 @@ updated `values` array, with new items appended to the end and removed items fil
 The `<input>` element can be controlled directly via the `inputValue` and `onInputChange` props. Additional properties
 (such as custom event handlers) can be forwarded to the input via `inputProps`.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Handling long words</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Handling long words</h5>
 
 Set an explicit `width` on the container element to cause long tags to wrap onto multiple lines.
 Either supply a specific pixel value, or use `<TagInput className={Classes.FILL}>`
@@ -56,8 +56,8 @@ to fill its container's width (try this in the example above).
 
 </div>
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Disabling a tag input</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Disabling a tag input</h5>
 
 Disabling this component requires setting the `disabled` prop to `true`
 and separately disabling the component's `rightElement` as appropriate

--- a/packages/core/src/components/toast/toast.mdx
+++ b/packages/core/src/components/toast/toast.mdx
@@ -72,16 +72,16 @@ There are three ways to use **OverlayToaster**:
     myToaster.current?.show({ ...toastOptions });
     ```
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Working with multiple toasters</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Working with multiple toasters</h5>
 
 You can have multiple toasters in a single application, but you must ensure that each has a unique
 `position` to prevent overlap.
 
 </div>
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Toaster focus</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Toaster focus</h5>
 
 **OverlayToaster** always disables Overlay2's `enforceFocus` behavior (meaning that you're not blocked
 from accessing other parts of the application while a toast is active), and by default also
@@ -126,8 +126,8 @@ function synchronousFn() {
 Note that `OverlayToaster.create()` will throw an error if invoked inside a component lifecycle
 method, as `ReactDOM.render()` will return `null` resulting in an inaccessible toaster instance.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Beware of memory leaks</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Beware of memory leaks</h5>
 
 The static `create` method creates a new `OverlayToaster` instance for the full lifetime of your
 application. Since there's no React parent component, this method creates a new DOM node as a container for the

--- a/packages/core/src/components/tooltip/tooltip.mdx
+++ b/packages/core/src/components/tooltip/tooltip.mdx
@@ -27,8 +27,8 @@ The **content** will be shown inside the tooltip itself. When opened, the toolti
 positioned on the page next to the target; the `placement` prop determines its relative placement (on
 which side of the target).
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Button targets</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Button targets</h5>
 
 Buttons make great tooltip targets, but the `disabled` attribute will prevent all
 events so the enclosing **Tooltip** will not know when to respond.

--- a/packages/core/src/context/hotkeys/hotkeys-provider.mdx
+++ b/packages/core/src/context/hotkeys/hotkeys-provider.mdx
@@ -12,8 +12,8 @@ by navigating around and triggering the dialog with the <kbd>?</kbd> key.
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Consider [**BlueprintProvider**](#core/context/blueprint-provider)
 

--- a/packages/core/src/context/overlays/overlays-provider.mdx
+++ b/packages/core/src/context/overlays/overlays-provider.mdx
@@ -4,8 +4,8 @@ title: OverlaysProvider
 
 # OverlaysProvider
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Migrating from [Overlay](#core/components/overlay)?
 
@@ -25,8 +25,8 @@ specifically the stack of all overlays which are currently open. It provides the
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Consider [**BlueprintProvider**](#core/context/blueprint-provider)
 

--- a/packages/core/src/context/portal/portal-provider.mdx
+++ b/packages/core/src/context/portal/portal-provider.mdx
@@ -9,8 +9,8 @@ options. It uses the [React context API](https://reactjs.org/docs/context.html).
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Consider [**BlueprintProvider**](#core/context/blueprint-provider)
 

--- a/packages/core/src/docs/classes.mdx
+++ b/packages/core/src/docs/classes.mdx
@@ -14,7 +14,7 @@ downstream users (although in practice this happens very rarely).
 
 ```tsx
 // Don't do this! Avoid hardcoding Blueprint class names.
-<button className="@ns-button @ns-large">Don't do this!</button>
+<button className="bp6-button bp6-large">Don't do this!</button>
 ```
 
 The **best practice** is to add your own class to an element and then reference
@@ -73,7 +73,7 @@ by a descendant.
 
 All Blueprint CSS classes begin with a namespace prefix to isolate our styles
 from other frameworks: `.button` is a very common name, but only Blueprint
-defines `.@ns-button`.
+defines `.bp6-button`.
 
 This CSS namespace is versioned by major version of the library so two major versions of Blueprint
 can be used together on a single page.

--- a/packages/core/src/docs/typography.mdx
+++ b/packages/core/src/docs/typography.mdx
@@ -10,7 +10,7 @@ Keep in mind these general web typography guidelines when building your applicat
 
 - The default text color in all components is compliant with the recommended [WCAG 2.0](https://www.w3.org/TR/WCAG20/) minimum contrast ratio.
 - If you choose to go with a custom text color, make sure the background behind it provides proper contrast.
-- Try not to explicitly write pixel values for your font-size or line-height CSS rules. Instead, reference the classes and variables we provide in Blueprint (`.@ns-ui-text`, `$@ns-font-size-large`, etc.).
+- Try not to explicitly write pixel values for your font-size or line-height CSS rules. Instead, reference the classes and variables we provide in Blueprint (`.bp6-ui-text`, `$bp6-font-size-large`, etc.).
 
 ## UI text
 
@@ -19,7 +19,7 @@ A handful of utility CSS classes can be combined freely to further customize a b
 
 The base font size for Blueprint web applications is 14px. This should be the default type size
 for most short strings of text which are not headings or titles. If you wish to reset some
-element's font size and line height to the default base styles, use the `.@ns-ui-text` class.
+element's font size and line height to the default base styles, use the `.bp6-ui-text` class.
 
 For longer blocks of running text, such as articles or documents, see [running text styles](#core/typography.running-text).
 
@@ -28,17 +28,17 @@ For longer blocks of running text, such as articles or documents, see [running t
 ## Running text
 
 Longform text, such as rendered Markdown documents, benefit from increased spacing and support for unclassed textual elements.
-Apply `.@ns-running-text` to the parent element to apply the following styles to all children:
+Apply `.bp6-running-text` to the parent element to apply the following styles to all children:
 
 - `<h*>`, `<ul>`, `<ol>`, `<blockquote>`, `<code>`, `<pre>`, `<kbd>` tags do not require additional CSS classes for styles. This is great for rendered Markdown documents.
 - `<h*>` tag margins are adjusted to provide clear separation between sections in a document.
-- `<ul>` and `<ol>` tags receive [`.@ns-list`](#core/typography.lists) styles for legibility.
+- `<ul>` and `<ol>` tags receive [`.bp6-list`](#core/typography.lists) styles for legibility.
 
 @css running-text
 
 ## Headings
 
-Apply the `.@ns-heading` class to one of the six `<h*>` tags (or nest them inside a `.@ns-running-text` container)
+Apply the `.bp6-heading` class to one of the six `<h*>` tags (or nest them inside a `.bp6-running-text` container)
 to adjust font size and line height.
 
 @css headings
@@ -52,11 +52,11 @@ Putting an icon inside a link will cause it to inherit the link's text color.
 
 ## Preformatted text
 
-Use `.@ns-code` for inline code elements (typically with the `<code>` tag).
-Use `.@ns-code-block` for mulitline blocks of code (typically on a `<pre>` tag).
+Use `.bp6-code` for inline code elements (typically with the `<code>` tag).
+Use `.bp6-code-block` for mulitline blocks of code (typically on a `<pre>` tag).
 Note that `<pre>` blocks will retain _all_ whitespace so you'll have to format the content accordingly.
 
-When nested inside a `.@ns-running-text` container, use the `<pre>` or `<code>` tags directly without CSS classes.
+When nested inside a `.bp6-running-text` container, use the `<pre>` or `<code>` tags directly without CSS classes.
 
 @css preformatted
 
@@ -64,7 +64,7 @@ When nested inside a `.@ns-running-text` container, use the `<pre>` or `<code>` 
 
 Block quotes receive a left border and padding to distinguish them from body text.
 
-Use the `.@ns-blockquote` class or nest a `<blockquote>` element inside a `.@ns-running-text` container.
+Use the `.bp6-blockquote` class or nest a `<blockquote>` element inside a `.bp6-running-text` container.
 
 @css blockquote
 
@@ -72,10 +72,10 @@ Use the `.@ns-blockquote` class or nest a `<blockquote>` element inside a `.@ns-
 
 Blueprint provides a small amount of global styling and a few modifier classes for list elements.
 
-`<ul>` and `<ol>` elements in blocks with the `.@ns-running-text` modifier class will
-automatically assume the `.@ns-list` styles to promote readability.
+`<ul>` and `<ol>` elements in blocks with the `.bp6-running-text` modifier class will
+automatically assume the `.bp6-list` styles to promote readability.
 
-Use `.@ns-list-unstyled` to remove list item decorations and margins and padding.
+Use `.bp6-list-unstyled` to remove list item decorations and margins and padding.
 
 Note that these classes must be applied to each nested `<ul>` or `<ol>` element in a tree.
 
@@ -101,29 +101,29 @@ For example, a [`<Checkbox>`](#core/components/checkbox) component with `alignIn
 
 #### CSS Utility Classes
 
-Use the utility class `.@ns-rtl` to apply right alignment to an element to support RTL text.
+Use the utility class `.bp6-rtl` to apply right alignment to an element to support RTL text.
 
 @css rtl
 
 ## Dark theme
 
 Blueprint provides two UI color themes: light and dark. The light theme is active by default. The
-dark theme can be applied by adding the class `@ns-dark` to a container element to theme all nested
+dark theme can be applied by adding the class `bp6-dark` to a container element to theme all nested
 elements.
 
-Once applied, the dark theme will cascade to nested `.@ns-*` elements inside a `.@ns-dark` container.
+Once applied, the dark theme will cascade to nested `.bp6-*` elements inside a `.bp6-dark` container.
 There is no way to nest light-themed elements inside a dark container.
 
-Most elements only support the dark theme when nested inside a `.@ns-dark` container because it does
+Most elements only support the dark theme when nested inside a `.bp6-dark` container because it does
 not make sense to mark individual elements as dark. The dark container is therefore responsible for
 setting a dark background color.
 
-The following elements and components support the `.@ns-dark` class directly (i.e, `.@ns-card.@ns-dark`)
+The following elements and components support the `.bp6-dark` class directly (i.e, `.bp6-card.bp6-dark`)
 and can be used as a container for nested dark children:
 
 - `Card`
 - Overlays: `Dialog`, `Popover`, `Tooltip`, `Toast`
-- `Popover` and `Tooltip` will automatically detect when their trigger is inside a `.@ns-dark` container and add the same class to themselves.
+- `Popover` and `Tooltip` will automatically detect when their trigger is inside a `.bp6-dark` container and add the same class to themselves.
 
 Rather than illustrating dark components inline, this documentation site provides a site-wide switch
 in the sidebar to enable the dark theme. Try it out as you read the docs.

--- a/packages/core/src/docs/variables.mdx
+++ b/packages/core/src/docs/variables.mdx
@@ -39,7 +39,7 @@ Most icons should be displayed using the `<Icon>` component from `@blueprintjs/i
 of rendering SVGs directly onto the page.
 
 In some cases you may use the icon fonts instead with the CSS API targeting selectors of the kind
-`span.@ns-icon-*` (be sure to include `.@ns-icon-standard` or `.@ns-icon-large` as well).
+`span.bp6-icon-*` (be sure to include `.bp6-icon-standard` or `.bp6-icon-large` as well).
 
 In rare cases, you may need direct access to the code points the icon font. Blueprint provides these
 variables in Sass as a map and in TypeScript as an object (see the [Icons section](#icons) for the
@@ -162,7 +162,7 @@ These variables are semantic aliases of our [colors](#core/colors).
 They are used throughout Blueprint itself to ensure consistent color usage across components
 and are available in the Sass or Less variables files.
 
-<table class="@ns-html-table docs-color-aliases-table">
+<table class="bp6-html-table docs-color-aliases-table">
     <thead>
         <tr>
             <th></th>

--- a/packages/core/src/hooks/overlays/use-overlay-stack.mdx
+++ b/packages/core/src/hooks/overlays/use-overlay-stack.mdx
@@ -4,8 +4,8 @@ title: useOverlayStack
 
 # useOverlayStack
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Internal API</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Internal API</h5>
 
 This hook is mainly intended to be an internal Blueprint API used by the **Overlay2** component.
 Its usage outside of `@blueprintjs/` packages is not fully supported.

--- a/packages/datetime/src/components/date-picker/date-picker.mdx
+++ b/packages/datetime/src/components/date-picker/date-picker.mdx
@@ -129,8 +129,8 @@ function Example() {
 }
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 Localizing shortcuts
 

--- a/packages/datetime/src/components/timezone-select/timezone-select.mdx
+++ b/packages/datetime/src/components/timezone-select/timezone-select.mdx
@@ -49,8 +49,8 @@ in this case, all button-specific props will be ignored:
 </TimezonePicker>
 ```
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Local timezone detection</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Local timezone detection</h5>
 
 **TimezoneSelect** detects the local timezone using the
 [i18n API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions)

--- a/packages/docs-app/src/blueprint.mdx
+++ b/packages/docs-app/src/blueprint.mdx
@@ -10,8 +10,8 @@ It is optimized for building complex data-dense interfaces for desktop applicati
 
 @reactDocs Welcome
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-star @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Blueprint v6.x is now available</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-star bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Blueprint v6.x is now available</h5>
 
 Check out the [migration guides to upgrade from v5.x &rarr;](https://github.com/palantir/blueprint/wiki/Blueprint-6.0)
 

--- a/packages/docs-app/src/getting-started.mdx
+++ b/packages/docs-app/src/getting-started.mdx
@@ -97,7 +97,7 @@ imports/exports). We strive to be compatible with most TypeScript versions, but 
 which can create compiler incompatibilities if you are using a `tsc` version different from the one used to build
 Blueprint (see the current version in [`package.json`](https://github.com/palantir/blueprint/blob/develop/package.json)).
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 For more information, see [Understanding TypeScript](#blueprint/reading-the-docs.understanding-typescript).
 

--- a/packages/docs-app/src/reading-the-docs.mdx
+++ b/packages/docs-app/src/reading-the-docs.mdx
@@ -37,7 +37,7 @@ const option: Option = { label: "Name", value: "Gilad" };
 Simply ignoring the type annotations (any italics in code blocks) will produce valid ES2015 code.
 Familiarity with the syntax is suggested so you can follow our examples source code.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 For more information, see the TypeScript Handbook for [basic types][basic-types]
 and [consuming declaration files][decl-files].

--- a/packages/docs-data/compile-docs-data.test.ts
+++ b/packages/docs-data/compile-docs-data.test.ts
@@ -21,8 +21,8 @@ import { interpolateClassNamespace, sortMajorVersions, transformDocumentalistDat
 describe("interpolateClassNamespace", () => {
     it("replaces #{$ns} and @ns with the default class namespace", () => {
         expect(interpolateClassNamespace("#{$ns}-button")).toBe("bp6-button");
-        expect(interpolateClassNamespace("@ns-icon")).toBe("bp6-icon");
-        expect(interpolateClassNamespace("#{$ns}-card @ns-elevation")).toBe("bp6-card bp6-elevation");
+        expect(interpolateClassNamespace("bp6-icon")).toBe("bp6-icon");
+        expect(interpolateClassNamespace("#{$ns}-card bp6-elevation")).toBe("bp6-card bp6-elevation");
     });
 });
 

--- a/packages/icons/src/icons-list.mdx
+++ b/packages/icons/src/icons-list.mdx
@@ -8,7 +8,7 @@ Blueprint provides over 500 vector UI icons in two sizes (16px and 20px) and two
 Be sure to check out the docs on [loading icons](#icons/loading-icons) and how to use their
 [React and CSS APIs](#core/components/icon).
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 See the [**`Icon` component documentation**](#core/components/icon) (in the `@blueprintjs/core` package) for React API details.
 

--- a/packages/icons/src/index.mdx
+++ b/packages/icons/src/index.mdx
@@ -8,7 +8,7 @@ reference: icons
 The [**@blueprintjs/icons** NPM package](https://www.npmjs.com/package/@blueprintjs/icons)
 provides over 500 vector UI icons in two sizes (16px and 20px) and two formats (SVG and fonts).
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 See the [**`Icon` component documentation**](#core/components/icon) (in the `@blueprintjs/core` package) for React API details.
 

--- a/packages/icons/src/loading-icons.mdx
+++ b/packages/icons/src/loading-icons.mdx
@@ -8,7 +8,7 @@ As of Blueprint v5.0, icons are no longer loaded by default through the main pac
 to bundle only the icons you use in your application. There are a few different ways to load icons, and you may mix some of the
 approaches.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 See the [**`Icon` component documentation**](#core/components/icon) (in the `@blueprintjs/core` package) for React API details.
 

--- a/packages/labs/src/index.mdx
+++ b/packages/labs/src/index.mdx
@@ -3,11 +3,10 @@ title: Labs
 reference: labs
 ---
 
-
 # Labs
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
-    <h5 class="@ns-heading">Under construction</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign">
+    <h5 class="bp6-heading">Under construction</h5>
 </div>
 
 The **[@blueprintjs/labs](https://www.npmjs.com/package/@blueprintjs/labs)** NPM package contains **unstable React components under active development by team members**. We're excited for this space to be used for experimentation of components that can help us augment the current Blueprint offerings, and support a faster iteration cycle with early feedback.

--- a/packages/select/src/components/multi-select/multi-select.mdx
+++ b/packages/select/src/components/multi-select/multi-select.mdx
@@ -19,8 +19,8 @@ You may react to user interactions with the `onItemSelect` and `onRemove` callba
 
 @reactExample MultiSelectExample
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">Generic components and custom filtering</h5>
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">Generic components and custom filtering</h5>
 
 For more information on controlled usage, generic components, creating new items, and custom filtering,
 please visit the documentation for [**Select**](#select/select-component).

--- a/packages/select/src/components/omnibar/omnibar.mdx
+++ b/packages/select/src/components/omnibar/omnibar.mdx
@@ -20,8 +20,8 @@ The following example responds to a button and a hotkey.
 
 ## Usage
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
-    <h5 class="@ns-heading">
+<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign bp6-callout-has-body-content">
+    <h5 class="bp6-heading">
 
 [OverlaysProvider](#core/context/overlays-provider) recommended
 

--- a/packages/select/src/components/select/select-component.mdx
+++ b/packages/select/src/components/select/select-component.mdx
@@ -205,7 +205,7 @@ const FilmSelect: React.FC = () => (
 This controlled usage allows you to implement all sorts of advanced behavior on top of the basic **Select**
 interactions, such as windowed filtering for large data sets.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 To control the active item when a "Create Item" option is present, See
 [Controlling the active item](#select/select-component.controlling-the-active-item) in the "Creating new items"
@@ -224,8 +224,8 @@ string. Use `createNewItemFromQuery` and `createNewItemRenderer` to enable this:
   selected via click or `Enter`, this element will invoke `onItemSelect` with the item returned from
   `createNewItemFromQuery`.
 
-<div class="@ns-callout @ns-intent-warning @ns-icon-info-sign">
-    <h5 class="@ns-heading">Avoiding type conflicts</h5>
+<div class="bp6-callout bp6-intent-warning bp6-icon-info-sign">
+    <h5 class="bp6-heading">Avoiding type conflicts</h5>
 
 The "Create Item" option is represented by the reserved type `CreateNewItem` exported from this package. It is
 exceedingly unlikely but technically possible for your custom type `<T>` to conflict with this type. If your type
@@ -407,7 +407,7 @@ const FilmSelect: React.FC = () => (
 This package also exports a `renderFilteredItems()` helper function for custom item list rendering. It handles the
 `noResults` and `initialContent` states automatically.
 
-<div class="@ns-callout @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-intent-primary bp6-icon-info-sign">
 
 `renderFilteredItems()` calls `renderItem()` for each filtered item, so you don't need to map through
 `filteredItems` yourself.

--- a/packages/table/src/docs/table-features.mdx
+++ b/packages/table/src/docs/table-features.mdx
@@ -3,7 +3,6 @@ title: Table features
 reference: features
 ---
 
-
 # Table features
 
 ## Sorting
@@ -19,7 +18,7 @@ In the table below, try:
 - Sorting with the menu in each column header
 - Selecting cells and copying with the right-click context menu or with <kbd>Cmd/Ctrl</kbd> + <kbd>C</kbd> hotkeys
 
-<div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-large bp6-intent-primary bp6-icon-info-sign">
 
 This example utilizes `cellRendererDependencies`; [see why in the section below](#table/features.re-rendering-cells).
 

--- a/packages/table/src/docs/table.mdx
+++ b/packages/table/src/docs/table.mdx
@@ -7,7 +7,7 @@ title: Table
 The [**@blueprintjs/table** package](https://www.npmjs.com/package/@blueprintjs/table) provides components
 to build a highly interactive table or spreadsheet UI.
 
-<div class="@ns-callout @ns-large @ns-intent-primary @ns-icon-info-sign">
+<div class="bp6-callout bp6-large bp6-intent-primary bp6-icon-info-sign">
 
 If you are looking for the simpler Blueprint-styled HTML `<table>` instead, see
 [**HTMLTable**](#core/components/html-table).


### PR DESCRIPTION
#### FLUP to [Documentalist Migration pt2 - remove @documentalist from docs-data](https://github.com/palantir/blueprint/pull/7774#top)

### What this PR does
Simply removes the prior Documentalist syntax of `@ns-`
```tsx
<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign">
    <h5 class="@ns-heading">
       Deprecated: use [`variant`](#core/components/buttons.variant) instead
    </h5>
</div>
```

with `bp6-`
```tsx
<div class="bp6-callout bp6-intent-warning bp6-icon-warning-sign">
    <h5 class="bp6-heading">
       Deprecated: use [`variant`](#core/components/buttons.variant) instead
    </h5>
</div>
```

### How/what to test
Refer to docs pages where this change takes place and confirm no visual regression. `Button` and `ButtonGroup` are good examples.