### PR TITLE
(chore) Explicitly defining changelog directories in lerna monorepo

### DIFF
--- a/.palantir/changelog.yml
+++ b/.palantir/changelog.yml
@@ -1,3 +1,17 @@
-# Excavator auto-updates this file. Please contribute improvements to the central template.
-
-# This file is intentionally empty. The file's existence enables changelog-app and is empty to use the default configuration.
+repo-type:
+  type: lernaMonoRepo
+  lernaMonoRepo:
+    changelogDirectories:
+      - packages/colors
+      - packages/core
+      - packages/datetime
+      - packages/datetime2
+      - packages/docs-theme
+      - packages/eslint-config
+      - packages/eslint-plugin
+      - packages/icons
+      - packages/labs
+      - packages/node-build-scripts
+      - packages/select
+      - packages/stylelint-plugin
+      - packages/table


### PR DESCRIPTION
#### Issue

We removed the changelog directories in https://github.com/palantir/blueprint/pull/7986, and now on autorelease changes are not showing.

#### Changes proposed in this pull request:

Adding explicitly named directories to `changelog.yml` in order to allow autorelease to pick up changes.
Choosing this route instead of re-adding the directories (see https://github.com/palantir/blueprint/pull/7993) so that we know what to expect in autorelease.

#### Reviewers should focus on:

- [ ] These packages are the only public packages in our repo, and thus the only ones whose versions we release

#### Screenshot

<img width="1392" height="1522" alt="autorelease" src="https://github.com/user-attachments/assets/0f0741fd-c68e-493d-b4da-c401ebf4172e" />
