### PR TITLE
Adding Chromatic to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,14 @@ jobs:
       - store_test_results: { path: ./reports }
       - store_artifacts: { path: ./reports }
 
+  chromatic:
+    docker: *docker-node-image
+    steps:
+      - checkout
+      - attach_workspace: { at: "." }
+      - run: sudo corepack enable
+      - run: npx chromatic --storybook-build-dir storybook-static --exit-zero-on-changes
+
   deploy-preview:
     docker: *docker-node-image
     steps:
@@ -226,6 +234,8 @@ workflows:
           requires: [compile]
       - test-iso-react-18:
           requires: [compile]
+      - chromatic:
+          requires: [dist]
       - deploy-preview:
           requires: [dist]
       - store-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,6 @@ jobs:
     steps:
       - checkout
       - attach_workspace: { at: "." }
-      - run: sudo corepack enable
       - run: npx chromatic --storybook-build-dir storybook-static --exit-zero-on-changes
 
   deploy-preview:


### PR DESCRIPTION
#### Changes proposed in this pull request:

Add chromatic testing to Circle CI, given we have a lot of snapshots this month to test it out
`CHROMATIC_PROJECT_TOKEN` directly added to environment variables in Circle CI already.