### PR TITLE
[bug] Fix PopoverNext eating Space key in typeable target children

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -9,7 +9,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/tes
 
 import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
-import { Button, Dialog, DialogBody, PopupKind, Tooltip } from "../../components";
+import { Button, Dialog, DialogBody, InputGroup, PopupKind, Tooltip } from "../../components";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
 
 import { PopoverNext } from "./popoverNext";
@@ -1509,6 +1509,29 @@ describe("<PopoverNext>", () => {
 
             await waitFor(() => expect(screen.queryByRole("button", { name: "dismiss" })).not.toBeInTheDocument());
             await waitFor(() => expect(screen.queryByRole("button", { name: "inner target" })).not.toBeInTheDocument());
+        });
+    });
+
+    describe("key interactions on InputGroup target", () => {
+        it("Space key inserts a space character instead of being swallowed", async () => {
+            const handleChange = vi.fn();
+            const user = userEvent.setup();
+            render(
+                <PopoverNext
+                    content="popover content"
+                    autoFocus={false}
+                    enforceFocus={false}
+                    usePortal={false}
+                >
+                    <InputGroup placeholder="Search..." onChange={handleChange} />
+                </PopoverNext>,
+            );
+            const input = screen.getByPlaceholderText("Search...");
+
+            await user.click(input);
+            await user.type(input, "lorem ipsum");
+
+            expect(input).toHaveValue("lorem ipsum");
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -1517,12 +1517,7 @@ describe("<PopoverNext>", () => {
             const handleChange = vi.fn();
             const user = userEvent.setup();
             render(
-                <PopoverNext
-                    content="popover content"
-                    autoFocus={false}
-                    enforceFocus={false}
-                    usePortal={false}
-                >
+                <PopoverNext content="popover content" autoFocus={false} enforceFocus={false} usePortal={false}>
                     <InputGroup placeholder="Search..." onChange={handleChange} />
                 </PopoverNext>,
             );

--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -1524,9 +1524,13 @@ describe("<PopoverNext>", () => {
             const input = screen.getByPlaceholderText("Search...");
 
             await user.click(input);
+            await waitFor(() => expect(screen.getByText("popover content")).toBeInTheDocument());
+
             await user.type(input, "lorem ipsum");
 
             expect(input).toHaveValue("lorem ipsum");
+            // Popover should stay open; Space must not toggle it
+            expect(screen.getByText("popover content")).toBeInTheDocument();
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -3,7 +3,7 @@
  */
 
 import classNames from "classnames";
-import { Children, cloneElement, createElement, forwardRef } from "react";
+import { Children, cloneElement, createElement, forwardRef, useCallback } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Utils } from "../../common";
 import { PopoverInteractionKind } from "../popover/popoverProps";
@@ -38,6 +38,38 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     const { isOpen } = floatingData;
 
     const ref = mergeRefs(floatingData.refs.setReference, targetRef);
+
+    // Custom keyboard click handler for the reference element. Floating UI's useClick hook
+    // has its keyboardHandlers disabled because it calls `preventDefault()` on Space keydown,
+    // which prevents space characters from being typed in <input>/<textarea> target children.
+    // This handler replicates keyboard-to-click behavior while preserving typeable element input.
+    const handleReferenceKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
+        if (!Utils.isKeyboardClick(event)) {
+            return;
+        }
+
+        const eventTarget = event.target as HTMLElement;
+
+        if (event.key === " ") {
+            // Don't intercept Space in typeable elements — let the character be typed
+            if (isTypeableElement(eventTarget)) {
+                return;
+            }
+            // Buttons handle Space natively (fire click on keyup), skip to avoid double-toggle
+            if (eventTarget.closest("button") != null) {
+                return;
+            }
+        } else if (event.key === "Enter") {
+            // Buttons and anchors fire native click on Enter, skip to avoid double-toggle
+            if (eventTarget.closest("button, a") != null) {
+                return;
+            }
+        }
+
+        // For non-typeable, non-natively-clickable targets (e.g. <span>, <div>),
+        // simulate a click so that useClick's onClick handler toggles the popover
+        event.currentTarget.click();
+    }, []);
 
     const targetEventHandlers: PopoverHoverTargetHandlers | PopoverClickTargetHandlers = isHoverInteractionKind
         ? {
@@ -81,7 +113,9 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     let target: React.JSX.Element | undefined;
 
     if (renderTarget !== undefined) {
-        const floatingProps = floatingData.getReferenceProps();
+        const floatingProps = floatingData.getReferenceProps({
+            onKeyDown: handleReferenceKeyDown,
+        });
 
         // When using renderTarget, if the consumer renders a tooltip target, it's their responsibility
         // to disable that tooltip when this popover is open
@@ -113,7 +147,9 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
                 ...ownTargetProps,
                 ...targetProps,
                 // Apply Floating UI's interaction props to the wrapper element (same element that has the ref)
-                ...floatingData.getReferenceProps(),
+                ...floatingData.getReferenceProps({
+                    onKeyDown: handleReferenceKeyDown,
+                }),
             },
             clonedTarget,
         );
@@ -137,4 +173,13 @@ function isTooltipElement(element: React.ReactElement): boolean {
         "displayName" in element.type &&
         element.type.displayName === `${DISPLAYNAME_PREFIX}.Tooltip`
     );
+}
+
+/**
+ * Check if an element accepts keyboard text input (i.e., Space should insert a character,
+ * not be interpreted as a click).
+ */
+function isTypeableElement(element: HTMLElement): boolean {
+    const tagName = element.tagName;
+    return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT" || element.isContentEditable;
 }

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -44,7 +44,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     // which prevents space characters from being typed in <input>/<textarea> target children.
     // This handler replicates keyboard-to-click behavior while preserving typeable element input.
     const handleReferenceKeyDown = useCallback((event: React.KeyboardEvent<HTMLElement>) => {
-        if (!Utils.isKeyboardClick(event)) {
+        if (!Utils.isKeyboardClick(event) || event.repeat) {
             return;
         }
 

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -50,15 +50,19 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
 
         const eventTarget = event.target as HTMLElement;
 
+        // Don't intercept keyboard events on typeable elements — let them handle
+        // Space (character input) and Enter (form submission) normally
+        if (isTypeableElement(eventTarget)) {
+            return;
+        }
+
         if (event.key === " ") {
-            // Don't intercept Space in typeable elements — let the character be typed
-            if (isTypeableElement(eventTarget)) {
-                return;
-            }
             // Buttons handle Space natively (fire click on keyup), skip to avoid double-toggle
             if (eventTarget.closest("button") != null) {
                 return;
             }
+            // Prevent page scroll for non-typeable, non-button targets
+            event.preventDefault();
         } else if (event.key === "Enter") {
             // Buttons and anchors fire native click on Enter, skip to avoid double-toggle
             if (eventTarget.closest("button, a") != null) {

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -103,6 +103,16 @@ export function usePopover({
 
     const click = useClick(context, {
         enabled: !disabled,
+        // Disable Floating UI's built-in Space/Enter keyboard handlers because they
+        // call `preventDefault()` on the Space keydown event to prevent page scrolling.
+        // This also prevents space characters from being typed in <input>/<textarea>
+        // elements that are children of the target wrapper element.
+        // See: https://github.com/palantir/blueprint/issues/XXXX
+        //
+        // PopoverTarget provides its own keyboard click handling that avoids this issue
+        // by skipping typeable elements while still maintaining keyboard accessibility
+        // for non-typeable targets.
+        keyboardHandlers: false,
     });
     const dismiss = useDismiss(context, {
         escapeKey: canEscapeKeyClose,

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -107,7 +107,7 @@ export function usePopover({
         // call `preventDefault()` on the Space keydown event to prevent page scrolling.
         // This also prevents space characters from being typed in <input>/<textarea>
         // elements that are children of the target wrapper element.
-        // See: https://github.com/palantir/blueprint/issues/XXXX
+        // See: https://github.com/palantir/blueprint/pull/7997
         //
         // PopoverTarget provides its own keyboard click handling that avoids this issue
         // by skipping typeable elements while still maintaining keyboard accessibility


### PR DESCRIPTION
## Summary

When a text input is the trigger for a PopoverNext (like a search box that opens a dropdown), pressing the spacebar doesn't type a space. Typing "lorem ipsum" only produces "lorem", the space gets swallowed, and repeated presses produce a "." artifact as the popover toggles open and closed.

PopoverNext uses Floating UI's `useClick` hook to handle opening/closing. That hook intercepts the Space key on the target element and calls `preventDefault()`, which was meant to stop the page from scrolling when you press Space on a button. But it decides whether to do this by checking if the *wrapper element* (a `<span>`) is a text input. It's not, it's a `<span>`, so it always blocks the Space key, even when the actual thing you're typing in is an `<input>` nested inside that `<span>`. On keyup, it also toggles the popover state, which is where the "." artifact comes from.

The fix turns off Floating UI's keyboard handling (`keyboardHandlers: false`) and adds a custom `onKeyDown` in `PopoverTarget` that checks what element you're actually typing in:
- Input, textarea, or other typeable element: leave the key alone
- Button or link: let the browser handle it natively (they already fire click events on Space/Enter)
- Everything else (`<span>`, `<div>`, etc.): simulate a click to toggle the popover and call `preventDefault()` to block scrolling

## Test plan

- [x] Existing PopoverNext tests pass
- [x] Open a PopoverNext with an `<InputGroup>` as a child target, type "lorem ipsum", space characters are inserted correctly (similar to example below)

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/components/popover-next/usePopover.ts` | Set `keyboardHandlers: false` on `useClick` |
| `packages/core/src/components/popover-next/popoverTarget.tsx` | Add `handleReferenceKeyDown` + `isTypeableElement` helper |

## Behavior

https://github.com/user-attachments/assets/34af9ce7-9834-46a6-8703-9f3800f218b3

https://github.com/user-attachments/assets/380ecab5-7f6c-4fa8-aa93-cc5b87a1c9e5

```tsx
import { useCallback, useState } from "react";

import { InputGroup, Menu, MenuItem, PopoverNext } from "@blueprintjs/core";
import { Flex } from "@blueprintjs/labs";

const COUNTRIES = ["South Africa", "South Korea", "South Sudan", "French Southern Territories"];

export function PopoverNextDemo() {
    const [query, setQuery] = useState("");
    const [isOpen, setIsOpen] = useState(false);

    const handleQueryChange = useCallback(
        (e: React.ChangeEvent<HTMLInputElement>) => {
            setQuery(e.target.value);
            if (!isOpen) {
                setIsOpen(true);
            }
        },
        [isOpen],
    );

    const handleInteraction = useCallback((nextOpen: boolean) => setIsOpen(nextOpen), []);

    const filtered = COUNTRIES.filter(c => c.toLowerCase().includes(query.toLowerCase()));

    return (
        <Flex padding={5} alignItems="center" justifyContent="center">
            <div style={{ width: 300 }}>
                <p style={{ marginBottom: 4 }}>Country is</p>
                <PopoverNext
                    animation="minimal"
                    autoFocus={false}
                    enforceFocus={false}
                    isOpen={isOpen}
                    onInteraction={handleInteraction}
                    matchTargetWidth={true}
                    placement="bottom"
                    content={
                        <Menu>
                            <MenuItem text={`Add "${query} "`} labelElement="↵" />
                            {filtered.map(c => (
                                <MenuItem key={c} text={c} />
                            ))}
                        </Menu>
                    }
                >
                    <InputGroup
                        size="small"
                        placeholder="Search value..."
                        value={query}
                        onChange={handleQueryChange}
                    />
                </PopoverNext>
            </div>
        </Flex>
    );
}
```
