### PR TITLE
Fix Collapse clipping content when initially open

### DIFF
--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -216,8 +216,16 @@ export const Collapse: React.FC<CollapseProps> = ({
         contents.current = element;
         if (contents.current != null) {
             const contentHeight = contents.current.clientHeight;
-            setAnimationState(isOpenRef.current ? AnimationStates.OPEN : AnimationStates.CLOSED);
-            setHeight(contentHeight === 0 ? undefined : `${contentHeight}px`);
+            if (isOpenRef.current) {
+                // When initially open, keep height as "auto" so overflow-y stays "visible"
+                // and content is never clipped. Only record the measured height for future
+                // close animations.
+                setAnimationState(AnimationStates.OPEN);
+                setHeight("auto");
+            } else {
+                setAnimationState(AnimationStates.CLOSED);
+                setHeight(contentHeight === 0 ? undefined : `${contentHeight}px`);
+            }
             setHeightWhenOpen(contentHeight === 0 ? undefined : contentHeight);
         }
     }, []);

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -216,16 +216,8 @@ export const Collapse: React.FC<CollapseProps> = ({
         contents.current = element;
         if (contents.current != null) {
             const contentHeight = contents.current.clientHeight;
-            if (isOpenRef.current) {
-                // Keep height "auto" on mount — converting to a fixed pixel value here
-                // causes clipping during initial layout. The measured height is still
-                // recorded in heightWhenOpen for close animations.
-                setAnimationState(AnimationStates.OPEN);
-                setHeight("auto");
-            } else {
-                setAnimationState(AnimationStates.CLOSED);
-                setHeight(contentHeight === 0 ? undefined : `${contentHeight}px`);
-            }
+            setAnimationState(isOpenRef.current ? AnimationStates.OPEN : AnimationStates.CLOSED);
+            setHeight(contentHeight === 0 ? undefined : `${contentHeight}px`);
             setHeightWhenOpen(contentHeight === 0 ? undefined : contentHeight);
         }
     }, []);
@@ -233,10 +225,14 @@ export const Collapse: React.FC<CollapseProps> = ({
     const isContentVisible = animationState !== AnimationStates.CLOSED;
     const shouldRenderChildren = isContentVisible || keepChildrenMounted;
     const displayWithTransform = isContentVisible && animationState !== AnimationStates.CLOSING;
-    const isAutoHeight = height === "auto";
+    // When fully open, always use "auto" height so content is never clipped — the ref
+    // callback may have stored a measured pixel value, but that's only needed for close
+    // animations, not for the resting open state.
+    const effectiveHeight = animationState === AnimationStates.OPEN ? "auto" : height;
+    const isAutoHeight = effectiveHeight === "auto";
 
     const containerStyle = {
-        height: isContentVisible ? height : undefined,
+        height: isContentVisible ? effectiveHeight : undefined,
         overflowY: isAutoHeight ? "visible" : undefined,
         // transitions don't work with height: auto
         transition: isAutoHeight ? "none" : undefined,

--- a/packages/core/src/components/collapse/collapse.tsx
+++ b/packages/core/src/components/collapse/collapse.tsx
@@ -217,9 +217,9 @@ export const Collapse: React.FC<CollapseProps> = ({
         if (contents.current != null) {
             const contentHeight = contents.current.clientHeight;
             if (isOpenRef.current) {
-                // When initially open, keep height as "auto" so overflow-y stays "visible"
-                // and content is never clipped. Only record the measured height for future
-                // close animations.
+                // Keep height "auto" on mount — converting to a fixed pixel value here
+                // causes clipping during initial layout. The measured height is still
+                // recorded in heightWhenOpen for close animations.
                 setAnimationState(AnimationStates.OPEN);
                 setHeight("auto");
             } else {

--- a/packages/demo-app/src/examples/CollapseExample.tsx
+++ b/packages/demo-app/src/examples/CollapseExample.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useState } from "react";
+
+import { Button, Card, Collapse } from "@blueprintjs/core";
+
+import { ExampleCard } from "./ExampleCard";
+
+export const CollapseExample: React.FC = () => {
+    const [isOpen, setIsOpen] = useState(true);
+    const handleToggle = useCallback(() => setIsOpen(prev => !prev), []);
+
+    return (
+        <ExampleCard label="Collapse">
+            <Button onClick={handleToggle}>{isOpen ? "Hide" : "Show"}</Button>
+            <Collapse isOpen={isOpen}>
+                <Card style={{ marginTop: 10 }}>
+                    <p>This content starts open and can be toggled.</p>
+                </Card>
+            </Collapse>
+        </ExampleCard>
+    );
+};
+
+CollapseExample.displayName = "DemoApp.CollapseExample";

--- a/packages/demo-app/src/examples/Examples.tsx
+++ b/packages/demo-app/src/examples/Examples.tsx
@@ -24,6 +24,7 @@ import { ButtonExample } from "./ButtonExample";
 import { ButtonGroupExample } from "./ButtonGroupExample";
 import { CalloutExample } from "./CalloutExample";
 import { CheckboxRadioExample } from "./CheckboxRadioExample";
+import { CollapseExample } from "./CollapseExample";
 import { DatePickerExample } from "./DatePickerExample";
 import { DateRangePickerExample } from "./DateRangePickerExample";
 import { DialogExample } from "./DialogExample";
@@ -68,6 +69,7 @@ const ExamplesContainer: React.FC<{ isDark?: boolean }> = ({ isDark = false }) =
             <ButtonExample />
             <ButtonGroupExample />
             <CalloutExample />
+            <CollapseExample />
             <CheckboxRadioExample />
             <DatePickerExample />
             <DateRangePickerExample />


### PR DESCRIPTION
## Summary
- Fixes a regression from #7437: `Collapse` with `isOpen={true}` clips content at the bottom on initial render
- `contentsRefHandler` was replacing `height: "auto"` with a fixed pixel value at mount, so `overflow-y: hidden` kicked in and clipped the overflow
- Now we keep `height: "auto"` when mounting already-open, and only store the measured height for close animations

| Before | After | Diff |
|--------|--------|--------|
| <img width="1520" height="920" alt="before" src="https://github.com/user-attachments/assets/06ae80aa-c0f9-445a-a64f-bdbc8c166d45" /> | <img width="1520" height="920" alt="after" src="https://github.com/user-attachments/assets/6f529914-8727-405f-b692-d4ed3fd78bfc" /> | ![diff](https://github.com/user-attachments/assets/16ae39fa-96cb-4cff-880b-6263035b1291) | 

![Screenshot 2026-03-31 at 19 00 34](https://github.com/user-attachments/assets/c35a8f29-4ef2-4332-9dd7-ac289a266dc6)

## Test plan
- [x] Render `Collapse` with `isOpen={true}`, content should be fully visible, no clipping
- [ ] Toggle closed and back open, animation still works
- [ ] Render `Collapse` with `isOpen={false}`, then open, animates normally
