### PR TITLE
Make Breadcrumbs items prop optional to fix FC regression

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -26,6 +26,8 @@ import type { PopoverProps } from "../popover/popoverProps";
 
 import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
 
+const EMPTY_ITEMS: readonly BreadcrumbProps[] = [];
+
 export interface BreadcrumbsProps extends Props {
     /**
      * Callback invoked to render visible breadcrumbs. Best practice is to
@@ -100,7 +102,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
         className,
         collapseFrom = Boundary.START,
         currentBreadcrumbRenderer,
-        items = [],
+        items = EMPTY_ITEMS,
         minVisibleItems = 0,
         overflowButtonProps,
         overflowListProps = {},

--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -55,8 +55,10 @@ export interface BreadcrumbsProps extends Props {
     /**
      * All breadcrumbs to display. Breadcrumbs that do not fit in the container
      * will be rendered in an overflow menu instead.
+     *
+     * @default []
      */
-    items: readonly BreadcrumbProps[];
+    items?: readonly BreadcrumbProps[];
 
     /**
      * The minimum number of visible breadcrumbs that should never collapse into
@@ -98,7 +100,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
         className,
         collapseFrom = Boundary.START,
         currentBreadcrumbRenderer,
-        items,
+        items = [],
         minVisibleItems = 0,
         overflowButtonProps,
         overflowListProps = {},


### PR DESCRIPTION
## Summary
The refactor in #7236 made the items prop of `Breadcrumbs` strictly required. The old class component typed defaultProps as `Partial<BreadcrumbsProps>`, which made TypeScript treat every prop as potentially defaulted, including `items`. Code like this no longer compiles:

```tsx
const items: BreadcrumbProps[] | undefined = props.items;
<Breadcrumbs items={items} />
//           ^^^^^ Type 'undefined' is not assignable to type 'readonly BreadcrumbProps[]'
```
- Makes `items` optional with a default of `[]`, matching the previous behavior.

## Why

The old class component typed `defaultProps` as `Partial<BreadcrumbsProps>`. TypeScript can't tell from that type which props actually have defaults, so it treats them all as optional in JSX, including `items`. Consumers could pass undefined without error. The FC refactor removed `defaultProps`, making `items` strictly required for the first time. Making it explicitly optional with a stable empty-array default matches the behavior consumers relied on.

## Test plan
- [ ] Existing Breadcrumbs unit tests pass
- [ ] Verify in a downstream consumer that previously had the type error