### PR TITLE
(chore) reverse docs-theme dependency direction

### DIFF
--- a/packages/docs-data/markdownRenderer.mjs
+++ b/packages/docs-data/markdownRenderer.mjs
@@ -8,7 +8,8 @@ import escapeHTML from "escape-html";
 import { marked } from "marked";
 
 import { Classes } from "@blueprintjs/core";
-import { Classes as DocsClasses } from "@blueprintjs/docs-theme";
+
+export const DOCS_CODE_BLOCK = `${Classes.getClassNamespace()}-docs-code-block`;
 
 /**
  * Markdown renderer with some custom logic to handle `<code>` tags.
@@ -42,7 +43,7 @@ renderer.code = (textContent, infostring, isEscaped) => {
             break;
     }
 
-    const pre = `<pre class="${Classes.CODE_BLOCK} ${DocsClasses.DOCS_CODE_BLOCK}" data-lang="${language}">${textContent}</pre>`;
+    const pre = `<pre class="${Classes.CODE_BLOCK} ${DOCS_CODE_BLOCK}" data-lang="${language}">${textContent}</pre>`;
 
     // Wrap code blocks in a container so the docs app can mount a copy button.
     // Triggered by either an explicit `copy` tag in the info string, or code starting with "import ".

--- a/packages/docs-data/navTypes.mts
+++ b/packages/docs-data/navTypes.mts
@@ -81,13 +81,15 @@ export interface DocPage {
     title: string;
     route: string;
     contents: DocContentItem[];
+    metadata: Record<string, any>;
+    sourcePath: string;
 }
 
 /** Fields common to all nav tree nodes. */
 interface NavTreeNodeBase {
     title: string;
     level: number;
-    route: string | undefined;
+    route: string | undefined; //leave undefined
 }
 
 /** A content heading extracted from a page (no children, no reference). */

--- a/packages/docs-data/navTypes.mts
+++ b/packages/docs-data/navTypes.mts
@@ -89,7 +89,7 @@ export interface DocPage {
 interface NavTreeNodeBase {
     title: string;
     level: number;
-    route: string | undefined; //leave undefined
+    route: string;
 }
 
 /** A content heading extracted from a page (no children, no reference). */

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@blueprintjs/core": "workspace:^",
-        "@blueprintjs/docs-theme": "workspace:^",
+        "@documentalist/client": "^5.0.0",
         "@documentalist/compiler": "^5.0.0",
         "escape-html": "^1.0.3",
         "marked": "^9.1.6",

--- a/packages/docs-data/src/index.d.ts
+++ b/packages/docs-data/src/index.d.ts
@@ -2,14 +2,22 @@
  * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
  */
 
-import { MarkdownPluginData, KssPluginData, TypescriptPluginData } from "@documentalist/client";
+import { KssPluginData, TypescriptPluginData } from "@documentalist/client";
 
-export type DocsCompleteData = MarkdownPluginData & KssPluginData & TypescriptPluginData;
+import type { DocPage, NavTreeNode } from "../navTypes.mts";
+
+export interface MdxPluginData {
+    nav: NavTreeNode[];
+    pages: Record<string, DocPage>;
+}
+
+export type DocsCompleteData = MdxPluginData & KssPluginData & TypescriptPluginData;
 
 export const docsData: DocsCompleteData;
 
 export { PACKAGES, SECTIONS } from "../navTypes.mts";
-export type { Package, Section } from "../navTypes.mts";
+export { slugify } from "../navHelpers.mts";
+export type { DocPage, NavTreeHeading, NavTreeNode, NavTreePage, Package, Section } from "../navTypes.mts";
 
 export interface NpmPackageInfo {
     name: string;
@@ -21,14 +29,3 @@ export interface NpmPackageInfo {
 export type NpmData = Record<string, NpmPackageInfo>;
 
 export const npmData: NpmData;
-
-export interface HeadingNode {
-    route: string;
-    level: number;
-    title: string;
-}
-
-export interface PageNode extends HeadingNode {
-    children: Array<PageNode | HeadingNode>;
-    reference: string;
-}

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -34,6 +34,7 @@
     "dependencies": {
         "@blueprintjs/colors": "workspace:^",
         "@blueprintjs/core": "workspace:^",
+        "@blueprintjs/docs-data": "workspace:^",
         "@blueprintjs/icons": "workspace:^",
         "@blueprintjs/select": "workspace:^",
         "@documentalist/client": "^5.0.0",

--- a/packages/docs-theme/src/common/context.ts
+++ b/packages/docs-theme/src/common/context.ts
@@ -14,19 +14,21 @@
  * limitations under the License.
  */
 
-import type { Block, KssPluginData, MarkdownPluginData, TsDocBase, TypescriptPluginData } from "@documentalist/client";
+import type { Block, KssPluginData, TsDocBase, TypescriptPluginData } from "@documentalist/client";
 import { createContext, type ReactNode } from "react";
 
+import type { MdxPluginData } from "@blueprintjs/docs-data";
+
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-/** This docs theme requires Markdown data and optionally supports Typescript and KSS data. */
-export type DocsData = MarkdownPluginData & (TypescriptPluginData | {}) & (KssPluginData | {});
+/** This docs theme requires MDX page data and optionally supports Typescript and KSS data. */
+export type DocsData = MdxPluginData & (TypescriptPluginData | {}) & (KssPluginData | {});
 /* eslint-enable @typescript-eslint/no-empty-object-type */
 
-export function hasTypescriptData(docs: DocsData): docs is MarkdownPluginData & TypescriptPluginData {
+export function hasTypescriptData(docs: DocsData): docs is MdxPluginData & TypescriptPluginData {
     return docs != null && (docs as TypescriptPluginData).typescript != null;
 }
 
-export function hasKssData(docs: DocsData): docs is MarkdownPluginData & KssPluginData {
+export function hasKssData(docs: DocsData): docs is MdxPluginData & KssPluginData {
     return docs != null && (docs as KssPluginData).css != null;
 }
 

--- a/packages/docs-theme/src/common/documentalistUtils.ts
+++ b/packages/docs-theme/src/common/documentalistUtils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// TBD
 import { type HeadingNode, isPageNode, type PageNode } from "@documentalist/client";
 
 /**

--- a/packages/docs-theme/src/common/documentalistUtils.ts
+++ b/packages/docs-theme/src/common/documentalistUtils.ts
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-// TBD
-import { type HeadingNode, isPageNode, type PageNode } from "@documentalist/client";
+import type { NavTreeNode, NavTreePage } from "@blueprintjs/docs-data";
+
+export function isPageNode(node: NavTreeNode): node is NavTreePage {
+    return node.type === "page";
+}
 
 /**
  * Performs an in-order traversal of the layout tree, invoking the callback for each node.
  * Callback receives an array of ancestors with direct parent first in the list.
  */
 export function eachLayoutNode(
-    layout: Array<HeadingNode | PageNode>,
-    callback: (node: HeadingNode | PageNode, parents: PageNode[]) => void,
-    parents: PageNode[] = [],
+    layout: NavTreeNode[],
+    callback: (node: NavTreeNode, parents: NavTreePage[]) => void,
+    parents: NavTreePage[] = [],
 ) {
     layout.forEach(node => {
         callback(node, parents);

--- a/packages/docs-theme/src/common/index.ts
+++ b/packages/docs-theme/src/common/index.ts
@@ -20,5 +20,7 @@ export { Classes };
 export * from "./constants";
 export * from "./documentalistUtils";
 export * from "./eventHandlerUtils";
-export * from "./stringUtils";
+export type { NavTreeHeading, NavTreeNode, NavTreePage, DocPage, MdxPluginData } from "@blueprintjs/docs-data";
+export { slugify } from "@blueprintjs/docs-data";
+export { smartSearch } from "./stringUtils";
 export * from "./themeContext";

--- a/packages/docs-theme/src/components/block.tsx
+++ b/packages/docs-theme/src/components/block.tsx
@@ -20,11 +20,12 @@ import { createElement } from "react";
 
 import { Classes, Code, H3 } from "@blueprintjs/core";
 
+import type { DocPage } from "../common";
 import type { TagRendererMap } from "../tags";
 
 export function renderBlock(
     /** the block to render */
-    block: Block | undefined,
+    block: Block | DocPage | undefined,
     /** known tag renderers */
     tagRenderers: TagRendererMap,
     /** class names to apply to element wrapping string content. */
@@ -35,6 +36,9 @@ export function renderBlock(
     }
     const textClasses = classNames(Classes.RUNNING_TEXT, textClassName);
     const contents = block.contents.map((node, i) => {
+        if (node == null) {
+            return null;
+        }
         if (typeof node === "string") {
             return <div className={textClasses} key={i} dangerouslySetInnerHTML={{ __html: node }} />;
         }

--- a/packages/docs-theme/src/components/documentation.tsx
+++ b/packages/docs-theme/src/components/documentation.tsx
@@ -14,27 +14,21 @@
  * limitations under the License.
  */
 
-import {
-    type HeadingNode,
-    isPageNode,
-    linkify,
-    type PageData,
-    type PageNode,
-    type TsDocBase,
-} from "@documentalist/client";
+import { linkify, type TsDocBase } from "@documentalist/client";
 import classNames from "classnames";
 import { PureComponent } from "react";
 
 import { Classes, Drawer, FocusStyleManager, HotkeysTarget, type Props } from "@blueprintjs/core";
 import { Search } from "@blueprintjs/icons";
 
+import type { DocPage, NavTreeNode } from "../common";
 import {
     type DocsData,
     DocumentationContext,
     type DocumentationContextApi,
     hasTypescriptData,
 } from "../common/context";
-import { eachLayoutNode } from "../common/documentalistUtils";
+import { eachLayoutNode, isPageNode } from "../common/documentalistUtils";
 import { type TagRendererMap, TypescriptExample } from "../tags";
 
 import { renderBlock } from "./block";
@@ -82,7 +76,7 @@ export interface DocumentationProps extends Props {
      * searchable in the navigator. Returning `true` will exclude the item from
      * the navigator search results.
      */
-    navigatorExclude?: (node: PageNode | HeadingNode) => boolean;
+    navigatorExclude?: (node: NavTreeNode) => boolean;
 
     /**
      * Callback invoked whenever the component props or state change (specifically,
@@ -109,7 +103,7 @@ export interface DocumentationProps extends Props {
      * Callback invoked to render actions for a documentation page.
      * Actions appear in an element in the upper-right corner of the page.
      */
-    renderPageActions?: (page: PageData) => React.ReactNode;
+    renderPageActions?: (page: DocPage) => React.ReactNode;
 
     /**
      * HTML element to use as the scroll parent. By default `document.documentElement` is assumed to be the scroll container.

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -18,8 +18,7 @@ import classNames from "classnames";
 
 import { Classes, type Props } from "@blueprintjs/core";
 
-import type { NavTreeNode } from "../common";
-import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
+import { COMPONENT_DISPLAY_NAMESPACE, type NavTreeNode } from "../common";
 import { isPageNode } from "../common/documentalistUtils";
 
 import { NavMenuItem, type NavMenuItemProps } from "./navMenuItem";

--- a/packages/docs-theme/src/components/navMenu.tsx
+++ b/packages/docs-theme/src/components/navMenu.tsx
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { type HeadingNode, isPageNode, type PageNode } from "@documentalist/client";
 import classNames from "classnames";
 
 import { Classes, type Props } from "@blueprintjs/core";
 
+import type { NavTreeNode } from "../common";
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
+import { isPageNode } from "../common/documentalistUtils";
 
 import { NavMenuItem, type NavMenuItemProps } from "./navMenuItem";
 
@@ -28,7 +29,7 @@ export interface NavMenuProps extends Props {
     activeSectionId: string;
     level: number;
     onItemClick: (reference: string) => void;
-    items: Array<PageNode | HeadingNode>;
+    items: NavTreeNode[];
     renderNavMenuItem?: (props: NavMenuItemProps) => React.JSX.Element;
 }
 

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import type { HeadingNode, PageNode } from "@documentalist/client";
 import classNames from "classnames";
 
 import { Classes } from "@blueprintjs/core";
 
+import type { NavTreeNode } from "../common";
 import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
 
 export interface NavMenuItemProps {
@@ -40,7 +40,7 @@ export interface NavMenuItemProps {
     onClick: () => void;
 
     /** The section for this menu item, either a page or a heading node. */
-    section: PageNode | HeadingNode;
+    section: NavTreeNode;
 }
 
 export const NavMenuItem: React.FC<NavMenuItemProps> = props => {

--- a/packages/docs-theme/src/components/navMenuItem.tsx
+++ b/packages/docs-theme/src/components/navMenuItem.tsx
@@ -18,8 +18,7 @@ import classNames from "classnames";
 
 import { Classes } from "@blueprintjs/core";
 
-import type { NavTreeNode } from "../common";
-import { COMPONENT_DISPLAY_NAMESPACE } from "../common";
+import { COMPONENT_DISPLAY_NAMESPACE, type NavTreeNode } from "../common";
 
 export interface NavMenuItemProps {
     children?: React.ReactNode;

--- a/packages/docs-theme/src/components/navigator.tsx
+++ b/packages/docs-theme/src/components/navigator.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { HeadingNode, PageNode } from "@documentalist/client";
 import classNames from "classnames";
 import { filter } from "fuzzaldrin-plus";
 import { PureComponent } from "react";
@@ -23,6 +22,7 @@ import { Classes, MenuItem } from "@blueprintjs/core";
 import { CaretRight } from "@blueprintjs/icons";
 import { type ItemListPredicate, type ItemRenderer, Omnibar } from "@blueprintjs/select";
 
+import type { NavTreeNode } from "../common";
 import { eachLayoutNode } from "../common/documentalistUtils";
 
 export interface NavigatorProps {
@@ -30,10 +30,10 @@ export interface NavigatorProps {
     isOpen: boolean;
 
     /** All potentially navigable items. */
-    items: Array<PageNode | HeadingNode>;
+    items: NavTreeNode[];
 
     /** Callback to determine if a given item should be excluded. */
-    itemExclude?: (node: PageNode | HeadingNode) => boolean;
+    itemExclude?: (node: NavTreeNode) => boolean;
 
     /**
      * Callback invoked when the navigator is closed. Navigation is performed by

--- a/packages/docs-theme/src/components/page.tsx
+++ b/packages/docs-theme/src/components/page.tsx
@@ -14,17 +14,16 @@
  * limitations under the License.
  */
 
-import type { PageData } from "@documentalist/client";
-
 import { Classes } from "@blueprintjs/core";
 
+import type { DocPage } from "../common";
 import type { TagRendererMap } from "../tags";
 
 import { renderBlock } from "./block";
 
 export interface PageProps {
-    page: PageData;
-    renderActions?: (page: PageData) => React.ReactNode;
+    page: DocPage;
+    renderActions?: (page: DocPage) => React.ReactNode;
     tagRenderers: TagRendererMap;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,9 +607,9 @@ importers:
       '@blueprintjs/core':
         specifier: workspace:^
         version: link:../core
-      '@blueprintjs/docs-theme':
-        specifier: workspace:^
-        version: link:../docs-theme
+      '@documentalist/client':
+        specifier: ^5.0.0
+        version: 5.0.0
       '@documentalist/compiler':
         specifier: ^5.0.0
         version: 5.0.0(chokidar@3.6.0)(typescript@5.9.3)
@@ -641,6 +641,9 @@ importers:
       '@blueprintjs/core':
         specifier: workspace:^
         version: link:../core
+      '@blueprintjs/docs-data':
+        specifier: workspace:^
+        version: link:../docs-data
       '@blueprintjs/icons':
         specifier: workspace:^
         version: link:../icons


### PR DESCRIPTION
#### Changes proposed in this pull request:                                                                                      
  - Reverse the dependency direction between `docs-data` and `docs-theme`
  - Export nav tree `types`, `slugify`, and `MdxPluginData` from `docs-data`
  - Define `MdxPluginData` in `docs-data` as the replacement for `MarkdownPluginData` from `@documentalist/client`, using our own `NavTreeNode[]` and `DocPage` types                                                                                                   
  - Migrate all `nav tree` type usage in `docs-theme` components from `@documentalist/client's` to `docs-data`
  - Add a local `isPageNode` type guard in `documentalistUtils.ts` to replace the one from `@documentalist/client`
  - Inline the `DOCS_CODE_BLOCK` class constant in `markdownRenderer.mjs` to remove the `docs-theme` import from `docs-data`