### PR TITLE
[eslint-plugin] Flag Popover as deprecated in favor of PopoverNext

### DIFF
--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -44,6 +44,7 @@ export const PopoverExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Popover" subLabel="Text content" width={200}>
+                {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                 <Popover
                     content={
                         <div style={{ minWidth: 100 }}>
@@ -59,6 +60,7 @@ export const PopoverExample = memo(() => {
                 </Popover>
             </ExampleCard>
             <ExampleCard label="Popover" subLabel="Dropdown menu" width={200}>
+                {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                 <Popover content={textEditorMenu} fill={true} placement="bottom-start" minimal={true}>
                     <Button fill={true} text="Click to open" endIcon="caret-down" />
                 </Popover>

--- a/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverDismissExample.tsx
@@ -44,6 +44,7 @@ export const PopoverDismissExample: React.FC<ExampleProps> = props => {
 
     return (
         <Example options={false} {...props}>
+            {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
             <Popover
                 // don't autofocus or enforce focus because it is open by default on the page,
                 // and that will make unexpectedly users scroll to this example
@@ -58,6 +59,7 @@ export const PopoverDismissExample: React.FC<ExampleProps> = props => {
                                 label="Capture dismiss"
                                 onChange={handleDismissChange}
                             />
+                            {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                             <Popover
                                 autoFocus={false}
                                 captureDismiss={captureDismiss}

--- a/packages/docs-app/src/examples/core-examples/popoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverExample.tsx
@@ -330,6 +330,7 @@ export const PopoverExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={options} {...props}>
             <div className="docs-popover-example-scroll" ref={centerScroll}>
+                {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                 <Popover
                     boundary={
                         boundary === "scrollParent"

--- a/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverInteractionKindExample.tsx
@@ -34,6 +34,7 @@ export const PopoverInteractionKindExample: React.FC<ExampleProps> = props => {
                     // MenuItem's default shouldDismissPopover={true} behavior is confusing
                     // in this example, since it introduces an additional way popovers can
                     // close. set it to false here for clarity.
+                    // eslint-disable-next-line @blueprintjs/no-deprecated-components
                     <Popover
                         key={interactionKind}
                         content={<FileMenu shouldDismissPopover={false} />}

--- a/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverMinimalExample.tsx
@@ -21,6 +21,7 @@ import { FileMenu } from "../core-examples/common/fileMenu";
 
 export const PopoverMinimalExample: React.FC<ExampleProps> = props => (
     <Example options={false} {...props}>
+        {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
         <Popover
             content={<FileMenu />}
             minimal={true}
@@ -29,6 +30,7 @@ export const PopoverMinimalExample: React.FC<ExampleProps> = props => (
                 <Button {...rest} active={isOpen} intent={Intent.PRIMARY} text="Minimal" />
             )}
         />
+        {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
         <Popover
             content={<FileMenu />}
             placement="bottom-end"

--- a/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPlacementExample.tsx
@@ -101,6 +101,7 @@ const PlacementPopover: React.FC<{ placement: Placement }> = ({ placement }) => 
     );
 
     return (
+        // eslint-disable-next-line @blueprintjs/no-deprecated-components
         <Popover
             content={content}
             placement={placement}

--- a/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverPortalExample.tsx
@@ -97,6 +97,7 @@ export const PopoverPortalExample: React.FC<ExampleProps> = props => {
                 ref={scrollContainerLeftRef}
             >
                 <div className="docs-popover-portal-example-scroll-content">
+                    {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                     <Popover
                         {...POPOVER_PROPS}
                         content="I am in a Portal (default)."
@@ -114,6 +115,7 @@ export const PopoverPortalExample: React.FC<ExampleProps> = props => {
                 ref={scrollContainerRightRef}
             >
                 <div className="docs-popover-portal-example-scroll-content">
+                    {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                     <Popover
                         {...POPOVER_PROPS}
                         content="I am an inline popover."

--- a/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/popoverSizingExample.tsx
@@ -22,6 +22,7 @@ import { FileMenu } from "./common/fileMenu";
 export const PopoverSizingExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={false} {...props}>
+            {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
             <Popover
                 content={<FileMenu className="docs-popover-sizing-example" />}
                 placement="bottom-end"

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
@@ -4,11 +4,12 @@
 
 import type { TSESLint } from "@typescript-eslint/utils";
 
-import { createNoDeprecatedComponentsRule } from "./createNoDeprecatedComponentsRule";
+import { createNoDeprecatedComponentsRule, type DeprecatedComponentsConfig } from "./createNoDeprecatedComponentsRule";
 
-export const coreComponentsMigrationMapping = {
+export const coreComponentsMigrationMapping: DeprecatedComponentsConfig = {
     // TODO(@adidahiya): Blueprint v6
     // PanelStack: "PanelStack2",
+    Popover: "PopoverNext",
 };
 
 /**

--- a/packages/eslint-plugin/test/no-deprecated-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-components.test.ts
@@ -30,7 +30,40 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run("no-deprecated-components", noDeprecatedComponentsRule, {
-    invalid: [],
+    invalid: [
+        {
+            code: dedent`
+                import { Popover } from "@blueprintjs/core";
+
+                return <Popover />;
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Popover",
+                        newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+        {
+            code: dedent`
+                import * as Blueprint from "@blueprintjs/core";
+
+                return <Blueprint.Popover />;
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Popover",
+                        newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+    ],
     valid: [
         {
             code: dedent`

--- a/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
@@ -32,7 +32,40 @@ const ruleTester = new RuleTester({
 ruleTester.run("no-deprecated-core-components", noDeprecatedCoreComponentsRule, {
     // N.B. most other deprecated components are tested by no-deprecated-components.test.ts, this suite just tests
     // for more specific violations which involve certain deprecated props
-    invalid: [],
+    invalid: [
+        {
+            code: dedent`
+                import { Popover } from "@blueprintjs/core";
+
+                return <Popover />;
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Popover",
+                        newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+        {
+            code: dedent`
+                import * as Blueprint from "@blueprintjs/core";
+
+                return <Blueprint.Popover />;
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Popover",
+                        newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+    ],
     valid: [
         {
             code: dedent`


### PR DESCRIPTION
## Summary

Adds `Popover` to the `no-deprecated-core-components` and `no-deprecated-components` ESLint rules, suggesting migration to `PopoverNext`. This complements the JSDoc `@deprecated` annotation added in #8006.

The mapping uses the same-package string format since both components live in `@blueprintjs/core`. Test cases cover named imports and namespace imports.
