### PR TITLE
[chore] Update pnpm from `10.29.3` to `10.33.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "description": "A React UI toolkit for the web.",
-    "packageManager": "pnpm@10.29.3",
+    "packageManager": "pnpm@10.33.0",
     "workspaces": [
         "packages/*"
     ],
@@ -74,7 +74,7 @@
         }
     },
     "engines": {
-        "pnpm": "10.29.3",
+        "pnpm": "10.33.0",
         "node": ">=24.11.0"
     },
     "repository": {


### PR DESCRIPTION
## Summary

Bump the pnpm package manager version from [`10.29.3`](https://github.com/pnpm/pnpm/releases/tag/v10.29.3) to [`10.33.0`](https://github.com/pnpm/pnpm/releases/tag/v10.33.0).