### PR TITLE
(chore) Adding support for Chromatic dark snapshots

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -49,7 +49,7 @@ const storybookConfig: StorybookConfig = {
         });
     },
 
-    addons: [getAbsolutePath("@storybook/addon-a11y")],
+    addons: [getAbsolutePath("@storybook/addon-a11y"), getAbsolutePath("@storybook/addon-themes")],
 };
 
 // eslint-disable-next-line import/no-default-export

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,8 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+export const modes = {
+    dark: { backgrounds: { value: "dark" }, theme: "dark" },
+    light: { backgrounds: { value: "light" }, theme: "light" },
+} as const;

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -10,7 +10,7 @@ export const modes = {
         theme: "dark",
     },
     light: {
-        backgrounds: { value: "#ffffff" },
+        backgrounds: { value: Colors.WHITE },
         theme: "light",
     },
 } as const;

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,8 +1,0 @@
-/* !
- * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
- */
-
-export const modes = {
-    dark: { backgrounds: { value: "dark" }, theme: "dark" },
-    light: { backgrounds: { value: "light" }, theme: "light" },
-} as const;

--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,16 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { Colors } from "@blueprintjs/core";
+
+export const modes = {
+    dark: {
+        backgrounds: { value: Colors.BLACK },
+        theme: "dark",
+    },
+    light: {
+        backgrounds: { value: "#ffffff" },
+        theme: "light",
+    },
+} as const;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -27,6 +27,7 @@ import "@blueprintjs/table/lib/css/table.css";
 
 const preview: Preview = {
     parameters: {
+        backgrounds: { disable: true },
         chromatic: {
             modes: {
                 dark: modes.dark,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,8 +9,6 @@ import { BlueprintProvider, Classes, Colors, FocusStyleManager } from "@blueprin
 
 import { Icons } from "../packages/icons/src/iconLoader";
 
-import { modes } from "./modes";
-
 FocusStyleManager.onlyShowFocusOnTabs();
 
 Icons.setLoaderOptions({ loader: "all" });
@@ -27,22 +25,10 @@ import "@blueprintjs/table/lib/css/table.css";
 
 const preview: Preview = {
     parameters: {
-        backgrounds: {
-            options: {
-                dark: {
-                    name: "dark",
-                    value: Colors.BLACK,
-                },
-                light: {
-                    name: "light",
-                    value: "#ffffff",
-                },
-            },
-        },
         chromatic: {
             modes: {
-                dark: modes.dark,
-                light: modes.light,
+                dark: { theme: "dark" },
+                light: { theme: "light" },
             },
         },
         controls: {
@@ -76,7 +62,6 @@ const preview: Preview = {
     ],
 
     initialGlobals: {
-        backgrounds: { value: "light" },
         theme: "light",
     },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -54,7 +54,7 @@ const preview: Preview = {
             const isDark = context.globals?.theme === "dark";
             if (typeof document !== "undefined" && document.body) {
                 // Setting dark background based on class
-                document.body.style.backgroundColor = isDark ? Colors.BLACK : "#ffffff";
+                document.body.style.backgroundColor = isDark ? Colors.BLACK : Colors.WHITE;
             }
             return (
                 <BlueprintProvider>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,11 +2,14 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview } from "@storybook/react-vite";
 
 import { BlueprintProvider, Classes, Colors, FocusStyleManager } from "@blueprintjs/core";
 
 import { Icons } from "../packages/icons/src/iconLoader";
+
+import { modes } from "./modes";
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -26,15 +29,20 @@ const preview: Preview = {
     parameters: {
         backgrounds: {
             options: {
-                light: {
-                    name: "light",
-                    value: "#ffffff",
-                },
-
                 dark: {
                     name: "dark",
                     value: Colors.BLACK,
                 },
+                light: {
+                    name: "light",
+                    value: "#ffffff",
+                },
+            },
+        },
+        chromatic: {
+            modes: {
+                dark: modes.dark,
+                light: modes.light,
             },
         },
         controls: {
@@ -46,16 +54,18 @@ const preview: Preview = {
     },
 
     decorators: [
+        withThemeByClassName({
+            defaultTheme: "light",
+            parentSelector: "body",
+            themes: {
+                dark: Classes.DARK,
+                light: "",
+            },
+        }),
         (Story, context) => {
-            // Toggle Blueprint dark mode via the Backgrounds toolbar (light / dark).
-            const bg = context.globals?.backgrounds;
-            const isDark = bg?.value === Colors.BLACK || bg?.value === "dark" || bg?.name === "dark";
+            const isDark = context.globals?.theme === "dark";
             if (typeof document !== "undefined" && document.body) {
-                if (isDark) {
-                    document.body.classList.add(Classes.DARK);
-                } else {
-                    document.body.classList.remove(Classes.DARK);
-                }
+                document.body.style.backgroundColor = isDark ? Colors.BLACK : "#ffffff";
             }
             return (
                 <BlueprintProvider>
@@ -66,9 +76,8 @@ const preview: Preview = {
     ],
 
     initialGlobals: {
-        backgrounds: {
-            value: "light",
-        },
+        backgrounds: { value: "light" },
+        theme: "light",
     },
 };
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,6 +9,8 @@ import { BlueprintProvider, Classes, Colors, FocusStyleManager } from "@blueprin
 
 import { Icons } from "../packages/icons/src/iconLoader";
 
+import { modes } from "./modes";
+
 FocusStyleManager.onlyShowFocusOnTabs();
 
 Icons.setLoaderOptions({ loader: "all" });
@@ -27,8 +29,8 @@ const preview: Preview = {
     parameters: {
         chromatic: {
             modes: {
-                dark: { theme: "dark" },
-                light: { theme: "light" },
+                dark: modes.dark,
+                light: modes.light,
             },
         },
         controls: {
@@ -51,6 +53,7 @@ const preview: Preview = {
         (Story, context) => {
             const isDark = context.globals?.theme === "dark";
             if (typeof document !== "undefined" && document.body) {
+                // Setting dark background based on class
                 document.body.style.backgroundColor = isDark ? Colors.BLACK : "#ffffff";
             }
             return (

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "@storybook/addon-a11y": "^10.2.14",
+        "@storybook/addon-themes": "^10.2.14",
         "@storybook/icons": "^2.0.1",
         "@storybook/react-dom-shim": "^10.2.14",
         "@storybook/react-vite": "^10.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^10.2.14
         version: 10.3.0(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/addon-themes':
+        specifier: ^10.2.14
+        version: 10.3.4(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/icons':
         specifier: ^2.0.1
         version: 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2893,6 +2896,11 @@ packages:
     resolution: {integrity: sha512-GOQP8kp0Pos3weW00U5FC2azt1zZQOcyihP+tINQO6/MDA3hts0rKMbS5+MyVULX7A5JE5uk7SzcZQj+EZ8Yrg==}
     peerDependencies:
       storybook: ^10.3.0
+
+  '@storybook/addon-themes@10.3.4':
+    resolution: {integrity: sha512-5734o52qtW8svu2vhKPncISWLr1FZrXZoN+u1q0BjTrbL6qTNE1AzIMCBEwn0TNdn16vC3ZsDJOj1dW4dD13cw==}
+    peerDependencies:
+      storybook: ^10.3.4
 
   '@storybook/builder-vite@10.2.14':
     resolution: {integrity: sha512-4b/opKbbTg+npeFXzj4GwZ7SDJdqsJbcJYxFpAznpl9FqMhP+ktH/7QSDs1DtOXpCanKcrmj6UQQgKR8OGypUQ==}
@@ -10342,6 +10350,11 @@ snapshots:
       '@storybook/global': 5.0.0
       axe-core: 4.11.1
       storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  '@storybook/addon-themes@10.3.4(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ts-dedent: 2.2.0
 
   '@storybook/builder-vite@10.2.14(esbuild@0.27.2)(rollup@4.52.5)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.2))':
     dependencies:


### PR DESCRIPTION
#### Changes proposed in this pull request:

Adds `@storybook/addon-themes` to take advantage of the background color changes in snapshots

#### Reviewers should focus on:

Check that Chromatic takes snapshots in both light and dark

