### PR TITLE
(chore) Remove showClearButton from intentSelect

### DIFF
--- a/packages/docs-app/src/examples/core-examples/calloutPlaygroundExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/calloutPlaygroundExample.tsx
@@ -55,7 +55,7 @@ export const CalloutPlaygroundExample: React.FC<DocsExampleProps> = props => {
             />
             <Switch checked={compact} label="Compact" onChange={handleBooleanChange(setCompact)} />
             <Switch checked={minimal} label="Minimal" onChange={handleBooleanChange(setMinimal)} />
-            <IntentSelect intent={intent} onChange={setIntent} showClearButton={true} />
+            <IntentSelect intent={intent} onChange={setIntent} />
             <IconSelect iconName={icon} onChange={setIcon} />
             <H5>Children</H5>
             <Label>

--- a/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
+++ b/packages/docs-app/src/examples/core-examples/common/intentSelect.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { useCallback } from "react";
-
-import { Button, ControlGroup, FormGroup, HTMLSelect, Intent } from "@blueprintjs/core";
+import { ControlGroup, FormGroup, HTMLSelect, Intent } from "@blueprintjs/core";
 import { handleValueChange } from "@blueprintjs/docs-theme";
 
 const INTENTS = [
@@ -31,30 +29,18 @@ export interface IntentSelectProps {
     intent: Intent;
     label?: React.ReactNode;
     onChange: (intent: Intent) => void;
-    /** @default false */
-    showClearButton?: boolean;
 }
 
 export const IntentSelect: React.FC<IntentSelectProps> = ({
     label = "Intent",
     intent,
-    showClearButton,
     onChange,
 }) => {
     const handleChange = handleValueChange(onChange);
-    const handleClear = useCallback(() => onChange("none"), [onChange]);
     return (
         <FormGroup label={label}>
             <ControlGroup>
                 <HTMLSelect value={intent} onChange={handleChange} options={INTENTS} fill={true} />
-                {showClearButton && (
-                    <Button
-                        aria-label="Clear"
-                        disabled={intent === "none"}
-                        icon="cross"
-                        onClick={handleClear}
-                    />
-                )}
             </ControlGroup>
         </FormGroup>
     );

--- a/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/formGroupExample.tsx
@@ -91,12 +91,7 @@ export const FormGroupExample: React.FC<ExampleProps> = props => {
                 onChange={handleBooleanChange(setSubLabel)}
             />
             <Divider />
-            <IntentSelect
-                intent={intent}
-                label={intentLabelInfo}
-                onChange={setIntent}
-                showClearButton={true}
-            />
+            <IntentSelect intent={intent} label={intentLabelInfo} onChange={setIntent} />
         </>
     );
 

--- a/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/menuItemExample.tsx
@@ -88,7 +88,7 @@ export function MenuItemExample(props: ExampleProps) {
                 checked={submenuEnabled}
                 onChange={handleBooleanChange(setSubmenuEnabled)}
             />
-            <IntentSelect intent={intent} onChange={setIntent} showClearButton={true} />
+            <IntentSelect intent={intent} onChange={setIntent} />
             <FormGroup label="Role structure">
                 <SegmentedControl
                     options={[{ value: "menuitem" }, { value: "listoption" }]}


### PR DESCRIPTION
### What this PR does
As I was working through various PRs for Docs I recently noticed that `showClearButton` was only present for three examples. I feel that this is an inconsistency that isn't needed and for a frequent docs visitor is a departure from a standard.

There are **16 uses of IntentSelect** and only **3 of them** were using this prop

### What is the issue?
<img width="991" height="508" alt="Screenshot 2026-04-03 at 4 44 42 PM" src="https://github.com/user-attachments/assets/3351f879-5070-40b3-bcbd-ff7003d7f6f0" />


### Where is was used
`<Callout />`

<img width="991" height="508" alt="Screenshot 2026-04-03 at 4 44 42 PM" src="https://github.com/user-attachments/assets/f7483267-74e0-49c1-98dd-2e87b27adc12" />


`<FormGroup />`

<img width="989" height="713" alt="Screenshot 2026-04-03 at 4 44 58 PM" src="https://github.com/user-attachments/assets/ed26cce3-5608-4923-86ac-96bd025dfaaa" />


`<MenuItem />`

<img width="991" height="651" alt="Screenshot 2026-04-03 at 4 44 17 PM" src="https://github.com/user-attachments/assets/5c00fdbc-2ed6-4de3-b4be-f5fd0028a37a" />
