### PR TITLE
Publish to npm with OIDC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,12 @@ jobs:
       - checkout
       - attach_workspace: { at: "." }
       - run: sudo corepack enable
-      - run: ./scripts/publish-npm-semver-tagged
+      - run:
+          command: |
+            # From https://docs.npmjs.com/trusted-publishers#circleci-configuration
+            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            export NPM_ID_TOKEN
+            ./scripts/publish-npm-semver-tagged
 
 workflows:
   compile_lint_test_dist_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,8 +214,7 @@ jobs:
       - run:
           command: |
             # From https://docs.npmjs.com/trusted-publishers#circleci-configuration
-            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-            export NPM_ID_TOKEN
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
             ./scripts/publish-npm-semver-tagged
 
 workflows:

--- a/scripts/publish-npm-semver-tagged
+++ b/scripts/publish-npm-semver-tagged
@@ -14,14 +14,6 @@ if [ -z "$publishable_paths" ]; then
     exit 0
 fi
 
-if [ -z "${NPM_AUTH_TOKEN}" ]; then
-    echo "No NPM auth token available. Check the \$NPM_AUTH_TOKEN environment variable."
-    exit 1
-fi
-
-# see https://pnpm.io/cli/config
-pnpm config set //registry.npmjs.org/:_authToken "${NPM_AUTH_TOKEN}"
-
 for path in $publishable_paths; do
     pushd "$path"
     echo "Attempting to publish package at path '$path'"


### PR DESCRIPTION
#### Changes proposed in this pull request:

Publishes to npm with OIDC trusted publishing.
Follows precedents:
* https://github.com/palantir/conjure-typescript/pull/381
* https://github.com/palantir/stylelint-config-palantir/pull/100/
* https://github.com/palantir/conjure-typescript-runtime/pull/194

#### Reviewers should focus on:

Trying to publish to npm with this.