### PR TITLE
fix toast with timeout 0 being dismissed early

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8022.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8022.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix toast with non-finite timeout values being dismissed immediately
+  links:
+  - https://github.com/palantir/blueprint/pull/8022

--- a/packages/core/src/components/toast/toast.test.tsx
+++ b/packages/core/src/components/toast/toast.test.tsx
@@ -96,5 +96,11 @@ describe("<Toast>", () => {
             expect(handleDismiss).toHaveBeenCalledOnce();
             expect(handleDismiss.mock.calls[0][0]).toBe(true);
         });
+
+        it("does not dismiss toast when timeout={Infinity}", async () => {
+            mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={Infinity} />);
+            await sleep(50);
+            expect(handleDismiss).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -40,9 +40,9 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
     const startTimeout = useCallback(() => setIsTimeoutStarted(true), []);
     const clearTimeout = useCallback(() => setIsTimeoutStarted(false), []);
 
-    // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
-    // Also guard against Infinity - browsers treat setTimeout(cb, Infinity) as setTimeout(cb, 0).
-    const isTimeoutEnabled = timeout != null && isFinite(timeout) && timeout > 0;
+    // Per docs: "Providing a value less than or equal to 0 or a non-finite value will disable the timeout."
+    // Guard against Infinity/NaN - browsers treat setTimeout(cb, Infinity) as setTimeout(cb, 0).
+    const isTimeoutEnabled = timeout != null && Number.isFinite(timeout) && timeout > 0;
 
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state
     useTimeout(

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -41,7 +41,8 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
     const clearTimeout = useCallback(() => setIsTimeoutStarted(false), []);
 
     // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
-    const isTimeoutEnabled = timeout != null && timeout > 0;
+    // Also guard against Infinity - browsers treat setTimeout(cb, Infinity) as setTimeout(cb, 0).
+    const isTimeoutEnabled = timeout != null && isFinite(timeout) && timeout > 0;
 
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state
     useTimeout(

--- a/packages/core/src/components/toast/toastProps.ts
+++ b/packages/core/src/components/toast/toastProps.ts
@@ -47,7 +47,7 @@ export interface ToastProps extends Props, IntentProps {
 
     /**
      * Milliseconds to wait before automatically dismissing toast.
-     * Providing a value less than or equal to 0 will disable the timeout (this is discouraged).
+     * Providing a value less than or equal to 0 or Infinity will disable the timeout (this is discouraged).
      *
      * @default 5000
      */

--- a/packages/core/src/components/toast/toastProps.ts
+++ b/packages/core/src/components/toast/toastProps.ts
@@ -47,7 +47,7 @@ export interface ToastProps extends Props, IntentProps {
 
     /**
      * Milliseconds to wait before automatically dismissing toast.
-     * Providing a value less than or equal to 0 or Infinity will disable the timeout (this is discouraged).
+     * Providing a value less than or equal to 0, or a non-finite value (e.g. Infinity), will disable the timeout.
      *
      * @default 5000
      */


### PR DESCRIPTION
## summary
- fix toast with timeout=0 or timeout=Infinity being dismissed instead of persisting indefinitely
- the `isTimeoutEnabled` check only tested `timeout > 0`, which is true for `Infinity` - browsers coerce `setTimeout(cb, Infinity)` to ~0ms delay, causing immediate dismissal
- added `isFinite(timeout)` guard so non-finite values disable auto-dismiss just like timeout <= 0

## test plan
- added test for timeout=Infinity case
- verified existing tests for timeout=0 still pass
- manually confirmed setTimeout(cb, Infinity) fires in ~1ms in node/browsers

fixes #6742