### PR TITLE
fix select not allowing direct selection of last item in scrollable menu

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8023.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8023.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix toast with non-finite timeout values being dismissed immediately
+  links:
+  - https://github.com/palantir/blueprint/pull/8023

--- a/packages/core/src/components/toast/toast.test.tsx
+++ b/packages/core/src/components/toast/toast.test.tsx
@@ -96,5 +96,11 @@ describe("<Toast>", () => {
             expect(handleDismiss).toHaveBeenCalledOnce();
             expect(handleDismiss.mock.calls[0][0]).toBe(true);
         });
+
+        it("does not dismiss toast when timeout={Infinity}", async () => {
+            mount(<Toast message="Hello" onDismiss={handleDismiss} timeout={Infinity} />);
+            await sleep(50);
+            expect(handleDismiss).not.toHaveBeenCalled();
+        });
     });
 });

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -41,7 +41,8 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
     const clearTimeout = useCallback(() => setIsTimeoutStarted(false), []);
 
     // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
-    const isTimeoutEnabled = timeout != null && timeout > 0;
+    // Also guard against Infinity - browsers treat setTimeout(cb, Infinity) as setTimeout(cb, 0).
+    const isTimeoutEnabled = timeout != null && isFinite(timeout) && timeout > 0;
 
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state
     useTimeout(

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -41,8 +41,9 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
     const clearTimeout = useCallback(() => setIsTimeoutStarted(false), []);
 
     // Per docs: "Providing a value less than or equal to 0 will disable the timeout (this is discouraged)."
-    // Also guard against Infinity - browsers treat setTimeout(cb, Infinity) as setTimeout(cb, 0).
-    const isTimeoutEnabled = timeout != null && isFinite(timeout) && timeout > 0;
+    // Also guard against non-finite values like Infinity, which can behave unexpectedly across
+    // runtimes when passed to setTimeout (for example, being clamped or firing immediately).
+    const isTimeoutEnabled = timeout != null && Number.isFinite(timeout) && timeout > 0;
 
     // timeout is triggered & cancelled by updating `isTimeoutStarted` state
     useTimeout(

--- a/packages/core/src/components/toast/toastProps.ts
+++ b/packages/core/src/components/toast/toastProps.ts
@@ -47,7 +47,7 @@ export interface ToastProps extends Props, IntentProps {
 
     /**
      * Milliseconds to wait before automatically dismissing toast.
-     * Providing a value less than or equal to 0 will disable the timeout (this is discouraged).
+     * Providing a value less than or equal to 0 or Infinity will disable the timeout (this is discouraged).
      *
      * @default 5000
      */

--- a/packages/select/changelog/@unreleased/pr-8023.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8023.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix select not allowing direct selection of last item in scrollable menu
+  links:
+  - https://github.com/palantir/blueprint/pull/8023

--- a/packages/select/src/components/query-list/queryList.test.tsx
+++ b/packages/select/src/components/query-list/queryList.test.tsx
@@ -19,7 +19,7 @@ import { act } from "react";
 import sinon from "sinon";
 
 import { Menu } from "@blueprintjs/core";
-import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { type Film, renderFilm, TOP_100_FILMS } from "../../__examples__";
 import type { ItemListRenderer } from "../../common/itemListRenderer";
@@ -229,23 +229,26 @@ describe("<QueryList>", () => {
             } as unknown as HTMLElement;
             Object.defineProperty(fakeParent, "style", { value: {} });
             // stub getComputedStyle to return padding values
-            const originalGetComputedStyle = window.getComputedStyle;
-            window.getComputedStyle = () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
+            const spy = vi.spyOn(window, "getComputedStyle").mockImplementation(
+                () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration,
+            );
 
-            (queryListInstance as any).itemsParentRef = fakeParent;
+            try {
+                (queryListInstance as any).itemsParentRef = fakeParent;
 
-            // mock an active element that is below the visible area
-            const fakeActiveElement = { offsetTop: 350, offsetHeight: 30 };
-            (queryListInstance as any).getActiveElement = () => fakeActiveElement;
+                // mock an active element that is below the visible area
+                const fakeActiveElement = { offsetTop: 350, offsetHeight: 30 };
+                (queryListInstance as any).getActiveElement = () => fakeActiveElement;
 
-            queryListInstance.scrollActiveItemIntoView();
+                queryListInstance.scrollActiveItemIntoView();
 
-            // activeBottomEdge = 350 + 30 + 0 - 0 = 380
-            // expected scrollTop = activeBottomEdge - parentHeight = 380 - 200 = 180
-            // (not 380 + 30 - 200 = 210, which would over-scroll by one item height)
-            expect(fakeParent.scrollTop).toBe(180);
-
-            window.getComputedStyle = originalGetComputedStyle;
+                // activeBottomEdge = 350 + 30 + 0 - 0 = 380
+                // expected scrollTop = activeBottomEdge - parentHeight = 380 - 200 = 180
+                // (not 380 + 30 - 200 = 210, which would over-scroll by one item height)
+                expect(fakeParent.scrollTop).toBe(180);
+            } finally {
+                spy.mockRestore();
+            }
         });
 
         it("scrolls so that top edge of active item aligns with top of container", () => {
@@ -261,23 +264,26 @@ describe("<QueryList>", () => {
                 },
             } as unknown as HTMLElement;
             Object.defineProperty(fakeParent, "style", { value: {} });
-            const originalGetComputedStyle = window.getComputedStyle;
-            window.getComputedStyle = () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
+            const spy = vi.spyOn(window, "getComputedStyle").mockImplementation(
+                () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration,
+            );
 
-            (queryListInstance as any).itemsParentRef = fakeParent;
+            try {
+                (queryListInstance as any).itemsParentRef = fakeParent;
 
-            // mock an active element that is above the visible area
-            const fakeActiveElement = { offsetTop: 50, offsetHeight: 30 };
-            (queryListInstance as any).getActiveElement = () => fakeActiveElement;
+                // mock an active element that is above the visible area
+                const fakeActiveElement = { offsetTop: 50, offsetHeight: 30 };
+                (queryListInstance as any).getActiveElement = () => fakeActiveElement;
 
-            queryListInstance.scrollActiveItemIntoView();
+                queryListInstance.scrollActiveItemIntoView();
 
-            // activeTopEdge = 50 - 0 - 0 = 50
-            // expected scrollTop = activeTopEdge = 50
-            // (not 50 - 30 = 20, which would over-scroll upward by one item height)
-            expect(fakeParent.scrollTop).toBe(50);
-
-            window.getComputedStyle = originalGetComputedStyle;
+                // activeTopEdge = 50 - 0 - 0 = 50
+                // expected scrollTop = activeTopEdge = 50
+                // (not 50 - 30 = 20, which would over-scroll upward by one item height)
+                expect(fakeParent.scrollTop).toBe(50);
+            } finally {
+                spy.mockRestore();
+            }
         });
     });
 

--- a/packages/select/src/components/query-list/queryList.test.tsx
+++ b/packages/select/src/components/query-list/queryList.test.tsx
@@ -230,8 +230,7 @@ describe("<QueryList>", () => {
             Object.defineProperty(fakeParent, "style", { value: {} });
             // stub getComputedStyle to return padding values
             const originalGetComputedStyle = window.getComputedStyle;
-            window.getComputedStyle = () =>
-                ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
+            window.getComputedStyle = () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
 
             (queryListInstance as any).itemsParentRef = fakeParent;
 
@@ -263,8 +262,7 @@ describe("<QueryList>", () => {
             } as unknown as HTMLElement;
             Object.defineProperty(fakeParent, "style", { value: {} });
             const originalGetComputedStyle = window.getComputedStyle;
-            window.getComputedStyle = () =>
-                ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
+            window.getComputedStyle = () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
 
             (queryListInstance as any).itemsParentRef = fakeParent;
 

--- a/packages/select/src/components/query-list/queryList.test.tsx
+++ b/packages/select/src/components/query-list/queryList.test.tsx
@@ -220,24 +220,24 @@ describe("<QueryList>", () => {
 
             // mock the items parent ref with a fake scrollable container
             const fakeParent = {
-                offsetTop: 0,
-                scrollTop: 0,
-                clientHeight: 200,
                 children: {
                     item: () => null,
                 },
+                clientHeight: 200,
+                offsetTop: 0,
+                scrollTop: 0,
             } as unknown as HTMLElement;
             Object.defineProperty(fakeParent, "style", { value: {} });
             // stub getComputedStyle to return padding values
-            const spy = vi.spyOn(window, "getComputedStyle").mockImplementation(
-                () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration,
-            );
+            const spy = vi
+                .spyOn(window, "getComputedStyle")
+                .mockImplementation(() => ({ paddingBottom: "0px", paddingTop: "0px" }) as CSSStyleDeclaration);
 
             try {
                 (queryListInstance as any).itemsParentRef = fakeParent;
 
                 // mock an active element that is below the visible area
-                const fakeActiveElement = { offsetTop: 350, offsetHeight: 30 };
+                const fakeActiveElement = { offsetHeight: 30, offsetTop: 350 };
                 (queryListInstance as any).getActiveElement = () => fakeActiveElement;
 
                 queryListInstance.scrollActiveItemIntoView();
@@ -256,23 +256,23 @@ describe("<QueryList>", () => {
             const queryListInstance = filmQueryList.instance() as QueryList<Film>;
 
             const fakeParent = {
-                offsetTop: 0,
-                scrollTop: 300,
-                clientHeight: 200,
                 children: {
                     item: () => null,
                 },
+                clientHeight: 200,
+                offsetTop: 0,
+                scrollTop: 300,
             } as unknown as HTMLElement;
             Object.defineProperty(fakeParent, "style", { value: {} });
-            const spy = vi.spyOn(window, "getComputedStyle").mockImplementation(
-                () => ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration,
-            );
+            const spy = vi
+                .spyOn(window, "getComputedStyle")
+                .mockImplementation(() => ({ paddingBottom: "0px", paddingTop: "0px" }) as CSSStyleDeclaration);
 
             try {
                 (queryListInstance as any).itemsParentRef = fakeParent;
 
                 // mock an active element that is above the visible area
-                const fakeActiveElement = { offsetTop: 50, offsetHeight: 30 };
+                const fakeActiveElement = { offsetHeight: 30, offsetTop: 50 };
                 (queryListInstance as any).getActiveElement = () => fakeActiveElement;
 
                 queryListInstance.scrollActiveItemIntoView();

--- a/packages/select/src/components/query-list/queryList.test.tsx
+++ b/packages/select/src/components/query-list/queryList.test.tsx
@@ -213,6 +213,74 @@ describe("<QueryList>", () => {
 
     describe("scrolling", () => {
         it("brings active item into view");
+
+        it("scrolls so that bottom edge of active item aligns with bottom of container", () => {
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...testProps} />);
+            const queryListInstance = filmQueryList.instance() as QueryList<Film>;
+
+            // mock the items parent ref with a fake scrollable container
+            const fakeParent = {
+                offsetTop: 0,
+                scrollTop: 0,
+                clientHeight: 200,
+                children: {
+                    item: () => null,
+                },
+            } as unknown as HTMLElement;
+            Object.defineProperty(fakeParent, "style", { value: {} });
+            // stub getComputedStyle to return padding values
+            const originalGetComputedStyle = window.getComputedStyle;
+            window.getComputedStyle = () =>
+                ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
+
+            (queryListInstance as any).itemsParentRef = fakeParent;
+
+            // mock an active element that is below the visible area
+            const fakeActiveElement = { offsetTop: 350, offsetHeight: 30 };
+            (queryListInstance as any).getActiveElement = () => fakeActiveElement;
+
+            queryListInstance.scrollActiveItemIntoView();
+
+            // activeBottomEdge = 350 + 30 + 0 - 0 = 380
+            // expected scrollTop = activeBottomEdge - parentHeight = 380 - 200 = 180
+            // (not 380 + 30 - 200 = 210, which would over-scroll by one item height)
+            expect(fakeParent.scrollTop).toBe(180);
+
+            window.getComputedStyle = originalGetComputedStyle;
+        });
+
+        it("scrolls so that top edge of active item aligns with top of container", () => {
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...testProps} />);
+            const queryListInstance = filmQueryList.instance() as QueryList<Film>;
+
+            const fakeParent = {
+                offsetTop: 0,
+                scrollTop: 300,
+                clientHeight: 200,
+                children: {
+                    item: () => null,
+                },
+            } as unknown as HTMLElement;
+            Object.defineProperty(fakeParent, "style", { value: {} });
+            const originalGetComputedStyle = window.getComputedStyle;
+            window.getComputedStyle = () =>
+                ({ paddingTop: "0px", paddingBottom: "0px" }) as CSSStyleDeclaration;
+
+            (queryListInstance as any).itemsParentRef = fakeParent;
+
+            // mock an active element that is above the visible area
+            const fakeActiveElement = { offsetTop: 50, offsetHeight: 30 };
+            (queryListInstance as any).getActiveElement = () => fakeActiveElement;
+
+            queryListInstance.scrollActiveItemIntoView();
+
+            // activeTopEdge = 50 - 0 - 0 = 50
+            // expected scrollTop = activeTopEdge = 50
+            // (not 50 - 30 = 20, which would over-scroll upward by one item height)
+            expect(fakeParent.scrollTop).toBe(50);
+
+            window.getComputedStyle = originalGetComputedStyle;
+        });
     });
 
     describe("pasting", () => {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -323,10 +323,10 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
 
             if (activeBottomEdge >= parentScrollTop + parentHeight) {
                 // offscreen bottom: align bottom of item with bottom of viewport
-                this.itemsParentRef.scrollTop = activeBottomEdge + activeHeight - parentHeight;
+                this.itemsParentRef.scrollTop = activeBottomEdge - parentHeight;
             } else if (activeTopEdge <= parentScrollTop) {
                 // offscreen top: align top of item with top of viewport
-                this.itemsParentRef.scrollTop = activeTopEdge - activeHeight;
+                this.itemsParentRef.scrollTop = activeTopEdge;
             }
         }
     }


### PR DESCRIPTION
## summary
- fix select component not allowing direct selection of last item in scrollable menu
- the `scrollActiveItemIntoView` method in `QueryList` was over-scrolling by one item height in both directions - when scrolling down it added `activeHeight` twice to compute the new `scrollTop`, and when scrolling up it subtracted an extra `activeHeight`. this caused the menu to shift under the cursor during click interactions on boundary items (first/last visible), preventing the click from registering on the intended item.
- also fix toast with `Infinity` timeout being dismissed early by guarding with `Number.isFinite`

## test plan
- added tests for scroll-to-bottom and scroll-to-top alignment in `queryList.test.tsx`
- verified existing select and query-list tests still pass

fixes #6655