### PR TITLE
Add pnpm supply chain security settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,16 @@
         "overrides": {
             "@types/react": "18.3.12",
             "cheerio": "0.22.0"
-        }
+        },
+        "ignoredBuiltDependencies": [
+            "@parcel/watcher",
+            "@swc/core",
+            "core-js",
+            "core-js-pure",
+            "esbuild",
+            "nx",
+            "ttf2woff2"
+        ]
     },
     "engines": {
         "pnpm": "10.29.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,5 @@ minimumReleaseAge: 4320 # 3 days in minutes
 blockExoticSubdeps: true
 trustPolicy: "no-downgrade"
 trustPolicyIgnoreAfter: 525960 # 1 year in minutes
+trustPolicyExclude:
+  - "@zip.js/zip.js"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,9 @@ catalog:
   vitest: 4.0.7
 
 publishBranch: develop
+
+# Supply chain security
+minimumReleaseAge: 4320 # 3 days in minutes
+blockExoticSubdeps: true
+trustPolicy: "no-downgrade"
+trustPolicyIgnoreAfter: 525960 # 1 year in minutes

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,3 @@ publishBranch: develop
 # Supply chain security
 minimumReleaseAge: 4320 # 3 days in minutes
 blockExoticSubdeps: true
-trustPolicy: "no-downgrade"
-trustPolicyIgnoreAfter: 525960 # 1 year in minutes
-trustPolicyExclude:
-  - "@zip.js/zip.js"


### PR DESCRIPTION
## Description

Based on pnpm's guide on [mitigating supply chain attacks](https://pnpm.io/supply-chain-security). Configures the following supply chain protections:

- [`minimumReleaseAge: 4320`](https://pnpm.io/settings#minimumreleaseage) - 3-day quarantine on newly published packages
- [`blockExoticSubdeps: true`](https://pnpm.io/settings#blockexoticsubdeps) - transitive deps must come from the registry
- [`ignoredBuiltDependencies`](http://pnpm.io/settings#ignoredbuiltdependencies) - explicitly denies all install scripts (all have fallbacks)
- ~~[`trustPolicy: "no-downgrade"`](https://pnpm.io/settings#trustpolicy) - blocks packages whose trust level decreased~~ (removed)