### PR TITLE
(chore) Switch to pnpm exec from npx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace: { at: "." }
-      - run: npx chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --only-changed
+      - run: pnpm exec chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --only-changed
 
   deploy-preview:
     docker: *docker-node-image


### PR DESCRIPTION
#### Changes proposed in this pull request:

FLUP on the following:
* #8017 

Uses `pnpm exec` instead of `npx` to use pinned version 

#### Reviewers should focus on:

Make sure this runs chromatic with pinned version.