### PR TITLE
(chore) Updating to check for a project token before running chromatic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,15 @@ jobs:
     steps:
       - checkout
       - attach_workspace: { at: "." }
-      - run: pnpm exec chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --only-changed
+      - run:
+          # Checks for the project token for Chromatic, which is not available to forked repos
+          name: Check chromatic project token available
+          command: |
+            if [ -z "$CHROMATIC_PROJECT_TOKEN" ]; then
+              echo "Skipping Chromatic (no project token — likely a fork build)"
+              exit 0
+            fi
+            pnpm exec chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --only-changed
 
   deploy-preview:
     docker: *docker-node-image


### PR DESCRIPTION
#### Changes proposed in this pull request:

* Checks for project token for chromatic, and if unavailable, skips the chromatic step.

#### Reviewers should focus on:

* Runs on forked repos to allow builds.

Note that in the future, we could consider exposing `projectToken` to run builds in the future (https://www.chromatic.com/docs/github-actions/#forked-repositories) should we need that capability. For now, this makes sense.