### PR TITLE
[core] Fix PopoverNext fill class not applied to target wrapper

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -265,6 +265,30 @@ describe("<PopoverNext>", () => {
 
             expect(container.querySelector("[aria-haspopup]")).not.toBeInTheDocument();
         });
+
+        it("applies FILL class to target when fill={true}", () => {
+            const { container } = render(
+                <PopoverNext content="content" fill={true}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+            const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+
+            expect(popoverTarget).toBeInTheDocument();
+            expect(popoverTarget).toHaveClass(Classes.FILL);
+        });
+
+        it("does not apply FILL class to target when fill={false}", () => {
+            const { container } = render(
+                <PopoverNext content="content" fill={false}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+            const popoverTarget = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+
+            expect(popoverTarget).toBeInTheDocument();
+            expect(popoverTarget).not.toHaveClass(Classes.FILL);
+        });
     });
 
     describe("basic functionality", () => {

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -96,6 +96,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
             [Classes.POPOVER_OPEN]: isOpen,
             // this class is mainly useful for button targets
             [Classes.ACTIVE]: isOpen && !isControlled && !isHoverInteractionKind,
+            [Classes.FILL]: fill,
         }),
         ref,
         ...targetEventHandlers,


### PR DESCRIPTION
## Summary

Ports the `fill` class fix from #7635 to `PopoverNext`. The `bp6-fill` class was not being applied to the `.bp6-popover-target` wrapper element, so components like `<Button fill>` inside `<PopoverNext fill>` would not expand to fill their container in flex layouts.

| Before | After |
|--------|--------|
| <img width="1370" height="360" alt="before" src="https://github.com/user-attachments/assets/8b4892b5-9116-4de6-b258-5a29e321decf" /> | <img width="1370" height="360" alt="after" src="https://github.com/user-attachments/assets/462a1d79-820a-4a2c-9e20-460badf5de0f" /> | 

```tsx
<Flex gap={2}>
    <Button fill={true} text="Cancel" />
    <PopoverNext fill={true} content="Popover Content">
        <Button fill={true} intent="primary" text="Submit" />
    </PopoverNext>
</Flex>
```

## Changes

Added `[Classes.FILL]: fill` to the `ownTargetProps` className in `PopoverTarget`. The class was already applied to child targets via `targetModifierClasses`, but the wrapper `div` itself was missing it. Without `width: 100%` on the wrapper, the inner button's `fill` had no effect.

Two tests ported from the `Popover` test suite verify the class is present when `fill={true}` and absent when `fill={false}`.

## Testing

Verified visually in demo-app that `<PopoverNext fill>` now matches `<Popover fill>` layout behavior. New unit tests pass.
