### PR TITLE
(fix) adjust margin when consecutive CopyableImportButtons are used

### DIFF
--- a/packages/docs-app/src/styles/_copyable-import.scss
+++ b/packages/docs-app/src/styles/_copyable-import.scss
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 .docs-copyable-import {
+  margin: ($pt-spacing * 2) 0;
   position: relative;
 
   > pre {
@@ -11,6 +12,7 @@
 
 .docs-copy-import-btn {
   position: absolute;
+  background-color: var(--bp-surface-background-color-default-rest);
   right: 6px;
   top: 6px;
   z-index: 1;

--- a/packages/docs-app/src/styles/_copyable-import.scss
+++ b/packages/docs-app/src/styles/_copyable-import.scss
@@ -11,8 +11,8 @@
 }
 
 .docs-copy-import-btn {
-  position: absolute;
   background-color: var(--bp-surface-background-color-default-rest);
+  position: absolute;
   right: 6px;
   top: 6px;
   z-index: 1;


### PR DESCRIPTION
#### Addresses [this comment](https://github.com/palantir/blueprint/pull/8015#discussion_r3040864407)

### Why this PR?
Prior to this the `CopyableImportButton` was over-optimized for use where two instances of the component are used in a row, but the second one doesn't have the `copy` keyword.

**This would render normally**

```
'''ts copy
import { Breadcrumbs } from "@blueprintjs/core";
'''

'''tsx
<Breadcrumbs items={[{ text: "Home" }, { text: "Account" }, { text: "Project" }]} />
'''
```

**But this would not**

```
'''ts copy
import { Breadcrumbs } from "@blueprintjs/core";
'''

'''tsx copy <-----
<Breadcrumbs items={[{ text: "Home" }, { text: "Account" }, { text: "Project" }]} />
'''
```

**A local example after the change**
<img width="813" height="323" alt="Screenshot 2026-04-07 at 9 47 54 AM" src="https://github.com/user-attachments/assets/a6682b92-fb33-487f-93ea-24e14cf17c19" />
