### PR TITLE
[Storybook] Add Icon Gallery stories

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -82,6 +82,7 @@
         "@types/culori": "^4.0.1",
         "@types/use-sync-external-store": "0.0.6",
         "@vitejs/plugin-react": "catalog:",
+        "change-case": "^4.1.2",
         "culori": "^4.0.2",
         "enzyme": "catalog:",
         "jsdom": "catalog:",

--- a/packages/core/src/components/icon/IconGallery.stories.tsx
+++ b/packages/core/src/components/icon/IconGallery.stories.tsx
@@ -42,7 +42,7 @@ const ICON_NAMES = sortedUniqueIconNames();
 // -----------------------------------------------------------------------------
 // Storybook meta & stories
 
-const meta: Meta = {
+const meta = {
     title: "Icons/Icon Gallery",
     decorators: [galleryLayoutDecorator],
     parameters: {
@@ -51,11 +51,11 @@ const meta: Meta = {
         controls: { disable: true },
         interactions: { disable: true },
     },
-};
+} satisfies Meta;
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj<typeof meta>;
 
 export const Static: Story = {
     render: () => <IconGallery renderIcon={renderStaticGalleryIcon} />,

--- a/packages/core/src/components/icon/IconGallery.stories.tsx
+++ b/packages/core/src/components/icon/IconGallery.stories.tsx
@@ -1,0 +1,166 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { type Meta, type StoryObj } from "@storybook/react-vite";
+// eslint-disable-next-line import/no-extraneous-dependencies -- Storybook-only; mirrors icons package generator casing
+import { pascalCase } from "change-case";
+import classNames from "classnames";
+import React, { type ComponentType, type ReactElement } from "react";
+
+import type { IconName } from "@blueprintjs/icons";
+import * as BlueprintIcons from "@blueprintjs/icons";
+import "@blueprintjs/icons/lib/css/blueprint-icons.css";
+
+import { Classes } from "../../common";
+import { Card } from "../card/card";
+import { H4 } from "../html/html";
+
+import { Icon } from "./icon";
+
+// -----------------------------------------------------------------------------
+// Constants & data
+
+const GALLERY_MAX_WIDTH = 1024;
+
+const DISPLAY_ICON_SIZE_SMALL = 16;
+const DISPLAY_ICON_SIZE_LARGE = 20;
+
+const ICON_FONT_FAMILY_STANDARD = '"blueprint-icons-16", sans-serif';
+const ICON_FONT_FAMILY_LARGE = '"blueprint-icons-20", sans-serif';
+
+const ICON_GRID_CARD_STYLE: React.CSSProperties = {
+    alignItems: "center",
+    aspectRatio: "1 / 1",
+    display: "flex",
+    justifyContent: "center",
+    minWidth: 72,
+};
+
+const ICON_NAMES = sortedUniqueIconNames();
+
+// -----------------------------------------------------------------------------
+// Storybook meta & stories
+
+const meta: Meta = {
+    title: "Icons/Icon Gallery",
+    decorators: [galleryLayoutDecorator],
+    parameters: {
+        layout: "centered",
+        actions: { disable: true },
+        controls: { disable: true },
+        interactions: { disable: true },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Static: Story = {
+    render: () => <IconGallery renderIcon={renderStaticGalleryIcon} />,
+};
+
+export const Dynamic: Story = {
+    render: () => <IconGallery renderIcon={renderDynamicGalleryIcon} />,
+};
+
+export const CSSIconFont: Story = {
+    parameters: {
+        chromatic: {
+            delay: 250,
+        },
+    },
+    play: async () => {
+        if (document.fonts != null) {
+            await document.fonts.ready;
+        }
+        await new Promise(resolve => window.setTimeout(resolve, 250));
+    },
+    render: () => <IconGallery renderIcon={renderCssFontGalleryIcon} />,
+};
+
+// -----------------------------------------------------------------------------
+// Layout (Storybook decorator + gallery shell)
+
+function galleryLayoutDecorator(Story: ComponentType) {
+    return (
+        <div style={{ maxWidth: GALLERY_MAX_WIDTH }}>
+            <Story />
+        </div>
+    );
+}
+
+type GalleryRenderIcon = (iconName: IconName, pixelSize: number) => ReactElement;
+
+function IconGallery({ renderIcon }: { renderIcon: GalleryRenderIcon }) {
+    return (
+        <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+            <section>
+                <H4>Small (16px)</H4>
+                <IconGrid pixelSize={DISPLAY_ICON_SIZE_SMALL} renderIcon={renderIcon} />
+            </section>
+            <section>
+                <H4>Large (20px)</H4>
+                <IconGrid pixelSize={DISPLAY_ICON_SIZE_LARGE} renderIcon={renderIcon} />
+            </section>
+        </div>
+    );
+}
+
+function IconGrid({ pixelSize, renderIcon }: { pixelSize: number; renderIcon: GalleryRenderIcon }) {
+    return (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {ICON_NAMES.map(iconName => (
+                <Card key={iconName} title={`${iconName} (${pixelSize}px)`} style={ICON_GRID_CARD_STYLE}>
+                    {renderIcon(iconName, pixelSize)}
+                </Card>
+            ))}
+        </div>
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Per-mode icon cells
+
+function renderStaticGalleryIcon(iconName: IconName, pixelSize: number) {
+    return <StaticIcon iconName={iconName} size={pixelSize} />;
+}
+
+function renderDynamicGalleryIcon(iconName: IconName, pixelSize: number) {
+    return <Icon icon={iconName} size={pixelSize} />;
+}
+
+function renderCssFontGalleryIcon(iconName: IconName, pixelSize: number) {
+    return <FontIcon iconName={iconName} size={pixelSize} />;
+}
+
+function StaticIcon({ iconName, size }: { iconName: IconName; size: number }) {
+    const name = pascalCase(iconName);
+    const IconComponent = (BlueprintIcons as unknown as Record<string, ComponentType<{ size?: number }>>)[name];
+    if (IconComponent == null) {
+        return <span />;
+    }
+    return <IconComponent size={size} />;
+}
+
+function FontIcon({ iconName, size }: { iconName: IconName; size: number }) {
+    const sizeClass = size === DISPLAY_ICON_SIZE_SMALL ? Classes.ICON_STANDARD : Classes.ICON_LARGE;
+    // `span.#{$ns}-icon:empty` in core forces the 20px face; override so standard uses blueprint-icons-16.
+    const fontFamily = sizeClass === Classes.ICON_STANDARD ? ICON_FONT_FAMILY_STANDARD : ICON_FONT_FAMILY_LARGE;
+    return (
+        <span
+            className={classNames(Classes.ICON, sizeClass, Classes.iconClass(iconName))}
+            style={{ fontFamily, fontSize: size, height: size, width: size }}
+        />
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Data
+
+function sortedUniqueIconNames(): IconName[] {
+    return Array.from(new Set(Object.values(BlueprintIcons.IconNames)))
+        .filter(name => name !== BlueprintIcons.IconNames.Blank)
+        .sort();
+}

--- a/packages/core/src/components/icon/IconGallery.stories.tsx
+++ b/packages/core/src/components/icon/IconGallery.stories.tsx
@@ -75,7 +75,6 @@ export const CSSIconFont: Story = {
         if (document.fonts != null) {
             await document.fonts.ready;
         }
-        await new Promise(resolve => window.setTimeout(resolve, 250));
     },
     render: () => <IconGallery renderIcon={renderCssFontGalleryIcon} />,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 5.1.0(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      change-case:
+        specifier: ^4.1.2
+        version: 4.1.2
       culori:
         specifier: ^4.0.2
         version: 4.0.2


### PR DESCRIPTION
## Summary

Add exhaustive `Icons/Icon Gallery` stories (static components, `<Icon />` string names, CSS icon font) for visual regression testing in Storybook/Chromatic.

<img width="3454" height="1604" alt="Screenshot 2026-04-09 at 10 27 39@2x" src="https://github.com/user-attachments/assets/c2c2cd78-6a6d-493e-bcb7-dbddc33c6188" />