### PR TITLE
(chore) Limit chromatic to run by default only for develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,9 @@ workflows:
           requires: [compile]
       - chromatic:
           requires: [dist]
+          filters:
+            branches:
+              only: develop
       - deploy-preview:
           requires: [dist]
       - store-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+parameters:
+  run-chromatic:
+    type: boolean
+    default: false
+
 orbs:
   browser-tools: circleci/browser-tools@2.4.0
 
@@ -258,3 +263,13 @@ workflows:
                 - develop
                 - next
                 - /^release\/.*/
+  chromatic-on-demand:
+    when: << pipeline.parameters.run-chromatic >>
+    jobs:
+      - checkout-code
+      - compile:
+          requires: [checkout-code]
+      - dist:
+          requires: [compile]
+      - chromatic:
+          requires: [dist]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,7 @@ jobs:
 
 workflows:
   compile_lint_test_dist_deploy:
+    unless: << pipeline.parameters.run-chromatic >>
     jobs:
       - checkout-code
       - clean-lockfile:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ jobs:
               echo "Skipping Chromatic (no project token — likely a fork build)"
               exit 0
             fi
-            pnpm exec chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --only-changed
+            pnpm exec chromatic --storybook-build-dir storybook-static --exit-zero-on-changes --only-changed --trace-changed
 
   deploy-preview:
     docker: *docker-node-image


### PR DESCRIPTION
#### Changes proposed in this pull request:

In CI, only run chromatic on develop. Individual runs can still be done locally when needed, or there is an additional pipeline that can be triggered via Circle CI.

Also adds `--trace-changed` for more insight into chromatic changes.

#### Reviewers should focus on:

Chromatic should not run UI tests on commits by default.

Triggering a pipeline allows you to set the parameter, as shown here:

<img width="1272" height="1090" alt="Screenshot 2026-04-09 at 15 51 18" src="https://github.com/user-attachments/assets/1ed778f6-fbe8-440d-bb81-d4dca34ee366" />