### PR TITLE
[chore] Bump change-case to `^5.4.4` (icons + core)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
         "@tokens-studio/sd-transforms": "^2.0.3",
         "@types/culori": "^4.0.1",
         "@vitejs/plugin-react": "catalog:",
-        "change-case": "^4.1.2",
+        "change-case": "^5.4.4",
         "culori": "^4.0.2",
         "enzyme": "catalog:",
         "jsdom": "catalog:",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -41,7 +41,7 @@
         "verify": "npm-run-all compile -p dist test lint"
     },
     "dependencies": {
-        "change-case": "^4.1.2",
+        "change-case": "^5.4.4",
         "classnames": "catalog:",
         "tslib": "catalog:"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ importers:
         specifier: 'catalog:'
         version: 5.1.0(vite@7.1.12(@types/node@24.10.0)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       change-case:
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^5.4.4
+        version: 5.4.4
       culori:
         specifier: ^4.0.2
         version: 4.0.2
@@ -765,8 +765,8 @@ importers:
         specifier: 18.3.12
         version: 18.3.12
       change-case:
-        specifier: ^4.1.2
-        version: 4.1.2
+        specifier: ^5.4.4
+        version: 5.4.4
       classnames:
         specifier: 'catalog:'
         version: 2.5.1


### PR DESCRIPTION
## Summary

Upgrade `change-case` from `^4.1.2` to `^5.4.4` in `@blueprintjs/icons` and `@blueprintjs/core`

https://github.com/blakeembrey/change-case/releases

## Testing
Build should pass.