### PR TITLE
(chore) add StoryLabel component for Storybook testing

### DIFF
--- a/.storybook/common.tsx
+++ b/.storybook/common.tsx
@@ -2,7 +2,6 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
-import * as React from "react";
 
 export interface StoryLabelProps {
     title: React.ReactNode;

--- a/.storybook/common.tsx
+++ b/.storybook/common.tsx
@@ -2,7 +2,6 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
-
 export interface StoryLabelProps {
     title: React.ReactNode;
 }

--- a/.storybook/common.tsx
+++ b/.storybook/common.tsx
@@ -2,10 +2,10 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
-import type { ReactNode } from "react";
+import * as React from "react";
 
 export interface StoryLabelProps {
-    title: ReactNode;
+    title: React.ReactNode;
 }
 
 /**

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -34,6 +34,7 @@ const storybookConfig: StorybookConfig = {
                 // Blueprint workspace packages: use package names so preview and stories share one copy.
                 // Array form so order is guaranteed: more specific (core/lib) must match before core.
                 alias: [
+                    { find: "@storybook-common", replacement: resolve(rootDir, ".storybook/common") },
                     { find: "@blueprintjs/core/lib", replacement: resolve(rootDir, "packages/core/lib") },
                     { find: "@blueprintjs/core", replacement: resolve(rootDir, "packages/core/src") },
                     { find: "@blueprintjs/datetime", replacement: resolve(rootDir, "packages/datetime") },

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -8,6 +8,7 @@
         "moduleResolution": "bundler",
         "skipLibCheck": true,
         "paths": {
+            "@storybook-common": ["./common"],
             "@blueprintjs/core": ["../packages/core/src"],
             "@blueprintjs/datetime": ["../packages/datetime/src"],
             "@blueprintjs/icons": ["../packages/icons/src"],

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import React from "react";
 
 import { Boundary } from "../../common/boundary";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { type BreadcrumbProps } from "./breadcrumb";
 import { Breadcrumbs } from "./breadcrumbs";

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -6,10 +6,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 
 import { Boundary } from "../../common/boundary";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { type BreadcrumbProps } from "./breadcrumb";
 import { Breadcrumbs } from "./breadcrumbs";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const SAMPLE_ITEMS: BreadcrumbProps[] = [
     { text: "Home", href: "#", icon: "home" },

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -9,6 +9,7 @@ import { Boundary } from "../../common/boundary";
 
 import { type BreadcrumbProps } from "./breadcrumb";
 import { Breadcrumbs } from "./breadcrumbs";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const SAMPLE_ITEMS: BreadcrumbProps[] = [
     { text: "Home", href: "#", icon: "home" },
@@ -77,11 +78,11 @@ export const CollapseFromExample: Story = {
     render: ({ width, ...args }) => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "flex-start" }}>
             <div style={{ width }}>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from start (default)</div>
+                <StoryLabel title="Collapse from start (default)" />
                 <Breadcrumbs {...args} collapseFrom={Boundary.START} />
             </div>
             <div style={{ width }}>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Collapse from end</div>
+                <StoryLabel title="Collapse from end" />
                 <Breadcrumbs {...args} collapseFrom={Boundary.END} />
             </div>
         </div>
@@ -96,13 +97,13 @@ export const OverflowExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Constrained width (300px)</div>
+                <StoryLabel title="Constrained width (300px)" />
                 <div style={{ width: 300 }}>
                     <Breadcrumbs {...args} />
                 </div>
             </div>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Full width</div>
+                <StoryLabel title="Full width" />
                 <div style={{ width: 600 }}>
                     <Breadcrumbs {...args} />
                 </div>

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -281,7 +281,7 @@ export const AllIntentsAllVariants: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {Object.values(ButtonVariant).map(variant => (
                 <div key={variant} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <StoryLabel title={variant} capitalize />
+                    <StoryLabel title={variant} />
                     <div style={{ display: "flex", gap: 8 }}>
                         {Object.values(Intent).map(intent => (
                             <Button key={intent} {...args} variant={variant} intent={intent} text={intent} />

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -5,9 +5,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Button } from "./buttons";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 // These props are deprecated on Button — hide them from the Storybook controls panel.
 const disabledArgs = [

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -3,9 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Button } from "./buttons";
 

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
 
 import { Button } from "./buttons";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 // These props are deprecated on Button — hide them from the Storybook controls panel.
 const disabledArgs = [
@@ -280,7 +281,7 @@ export const AllIntentsAllVariants: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {Object.values(ButtonVariant).map(variant => (
                 <div key={variant} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <div style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{variant}</div>
+                    <StoryLabel title={variant} capitalize />
                     <div style={{ display: "flex", gap: 8 }}>
                         {Object.values(Intent).map(intent => (
                             <Button key={intent} {...args} variant={variant} intent={intent} text={intent} />

--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -3,9 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 
 import { Intent } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Callout } from "./callout";
 

--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -5,9 +5,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Intent } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Callout } from "./callout";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Callout> = {
     title: "Core/Callout",

--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Intent } from "../../common";
 
 import { Callout } from "./callout";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Callout> = {
     title: "Core/Callout",
@@ -93,13 +94,13 @@ export const VariantExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <StoryLabel title="Default" />
                 <Callout {...args} minimal={false}>
                     Default callout with background fill.
                 </Callout>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <StoryLabel title="Minimal" />
                 <Callout {...args} minimal={true}>
                     Minimal callout without background fill.
                 </Callout>
@@ -119,13 +120,13 @@ export const CompactExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <StoryLabel title="Default" />
                 <Callout {...args} compact={false}>
                     Default padding callout.
                 </Callout>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Compact</span>
+                <StoryLabel title="Compact" />
                 <Callout {...args} compact={true}>
                     Compact padding callout.
                 </Callout>
@@ -170,7 +171,7 @@ export const AllIntentsAllVariants: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {[false, true].map(minimal => (
                 <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <div style={{ fontSize: 12, opacity: 0.6 }}>{minimal ? "Minimal" : "Default"}</div>
+                    <StoryLabel title={minimal ? "Minimal" : "Default"} />
                     <Callout {...args} minimal={minimal}>
                         No intent callout.
                     </Callout>

--- a/packages/core/src/components/card-list/CardList.stories.tsx
+++ b/packages/core/src/components/card-list/CardList.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useArgs, useCallback } from "storybook/preview-api";
 
 import { Card } from "../card/card";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { CardList } from "./cardList";
 
@@ -65,7 +66,7 @@ export const StateExample: Story = {
     render: args => (
         <div style={{ display: "flex", gap: 24 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Bordered</span>
+                <StoryLabel title="Bordered" />
                 <CardList {...args} bordered={true} compact={false}>
                     <Card>Plain</Card>
                     <Card interactive={true}>Interactive</Card>
@@ -73,7 +74,7 @@ export const StateExample: Story = {
                 </CardList>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Compact</span>
+                <StoryLabel title="Compact" />
                 <CardList {...args} bordered={true} compact={true}>
                     <Card>Plain</Card>
                     <Card interactive={true}>Interactive</Card>
@@ -81,7 +82,7 @@ export const StateExample: Story = {
                 </CardList>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Not bordered</span>
+                <StoryLabel title="Not bordered" />
                 <CardList {...args} bordered={false} compact={false}>
                     <Card>Plain</Card>
                     <Card interactive={true}>Interactive</Card>
@@ -104,7 +105,7 @@ export const AllConfigurations: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
             {[false, true].map(compact => (
                 <div key={String(compact)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <div style={{ fontSize: 12, opacity: 0.6 }}>{compact ? "Compact" : "Default"}</div>
+                    <StoryLabel title={compact ? "Compact" : "Default"} />
                     <div style={{ display: "flex", gap: 16 }}>
                         {[true, false].map(bordered => (
                             <CardList key={String(bordered)} bordered={bordered} compact={compact}>

--- a/packages/core/src/components/card-list/CardList.stories.tsx
+++ b/packages/core/src/components/card-list/CardList.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { useArgs, useCallback } from "storybook/preview-api";
 
 import { Card } from "../card/card";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { CardList } from "./cardList";
 

--- a/packages/core/src/components/card/Card.stories.tsx
+++ b/packages/core/src/components/card/Card.stories.tsx
@@ -6,9 +6,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Elevation } from "../../common";
 import { H3 } from "../html/html";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Card } from "./card";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Card> = {
     title: "Core/Card",

--- a/packages/core/src/components/card/Card.stories.tsx
+++ b/packages/core/src/components/card/Card.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 
 import { Elevation } from "../../common";
 import { H3 } from "../html/html";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Card } from "./card";
 

--- a/packages/core/src/components/card/Card.stories.tsx
+++ b/packages/core/src/components/card/Card.stories.tsx
@@ -8,6 +8,7 @@ import { Elevation } from "../../common";
 import { H3 } from "../html/html";
 
 import { Card } from "./card";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Card> = {
     title: "Core/Card",
@@ -72,7 +73,7 @@ export const ElevationExample: Story = {
         <div style={{ display: "flex", gap: 16 }}>
             {Object.values(Elevation).map(elevation => (
                 <Card key={elevation} {...args} elevation={elevation} style={{ width: 140, padding: 16 }}>
-                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 4 }}>Elevation</div>
+                    <StoryLabel title="Elevation" />
                     {elevation}
                 </Card>
             ))}
@@ -149,7 +150,7 @@ export const AllElevationsAllStates: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {(["Default", "Interactive", "Selected", "Compact"] as const).map(state => (
                 <div key={state}>
-                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>{state}</div>
+                    <StoryLabel title={state} />
                     <div style={{ display: "flex", gap: 16 }}>
                         {Object.values(Elevation).map(elevation => (
                             <Card

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Divider } from "./divider";
 import { StoryLabel } from "../storybook-components/StoryLabel";
+
+import { Divider } from "./divider";
 
 const meta: Meta<typeof Divider> = {
     title: "Core/Divider",

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -3,8 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
-import { StoryLabel } from "../storybook-components/StoryLabel";
+import { StoryLabel } from "@storybook-common";
 
 import { Divider } from "./divider";
 

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -5,6 +5,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Divider } from "./divider";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Divider> = {
     title: "Core/Divider",
@@ -92,13 +93,13 @@ export const CompactExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: "3em" }}>
             <div style={{ display: "flex", flexDirection: "column", textAlign: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <StoryLabel title="Default" />
                 Above
                 <Divider {...args} compact={false} />
                 Below
             </div>
             <div style={{ display: "flex", flexDirection: "column", textAlign: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Compact</span>
+                <StoryLabel title="Compact" />
                 Above
                 <Divider {...args} compact={true} />
                 Below

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -3,9 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 
 import { Intent } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Checkbox } from "./controls";
 

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -5,9 +5,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Intent } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Checkbox } from "./controls";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<
     keyof React.ComponentProps<typeof Checkbox>

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -135,7 +135,7 @@ export const AllStatesAllSizes: Story = {
         <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
             {(["medium", "large"] as const).map(size => (
                 <div key={size}>
-                    <StoryLabel title={size} capitalize />
+                    <StoryLabel title={size} />
                     <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
                         <Checkbox {...args} size={size} label="Unchecked" />
                         <Checkbox {...args} size={size} label="Checked" defaultChecked={true} />

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Intent } from "../../common";
 
 import { Checkbox } from "./controls";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<
     keyof React.ComponentProps<typeof Checkbox>
@@ -100,22 +101,22 @@ export const StateExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Unchecked</div>
+            <StoryLabel title="Unchecked" />
             <div style={{ display: "flex", gap: 16 }}>
                 <Checkbox {...args} label="Default" />
                 <Checkbox {...args} label="Disabled" disabled={true} />
             </div>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Checked</div>
+            <StoryLabel title="Checked" />
             <div style={{ display: "flex", gap: 16 }}>
                 <Checkbox {...args} label="Checked" defaultChecked={true} />
                 <Checkbox {...args} label="Checked Disabled" defaultChecked={true} disabled={true} />
             </div>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Indeterminate</div>
+            <StoryLabel title="Indeterminate" />
             <div style={{ display: "flex", gap: 16 }}>
                 <Checkbox {...args} label="Indeterminate" indeterminate={true} />
                 <Checkbox {...args} label="Indeterminate Disabled" indeterminate={true} disabled={true} />
             </div>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Inline</div>
+            <StoryLabel title="Inline" />
             <div>
                 <Checkbox {...args} inline={true} label="Option A" />
                 <Checkbox {...args} inline={true} label="Option B" />
@@ -134,9 +135,7 @@ export const AllStatesAllSizes: Story = {
         <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
             {(["medium", "large"] as const).map(size => (
                 <div key={size}>
-                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8, textTransform: "capitalize" }}>
-                        {size}
-                    </div>
+                    <StoryLabel title={size} capitalize />
                     <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
                         <Checkbox {...args} size={size} label="Unchecked" />
                         <Checkbox {...args} size={size} label="Checked" defaultChecked={true} />

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { type ChangeEvent, useCallback, useState } from "react";
 
 import { Size } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { FileInput } from "./fileInput";
 

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -8,6 +8,7 @@ import { type ChangeEvent, useCallback, useState } from "react";
 import { Size } from "../../common";
 
 import { FileInput } from "./fileInput";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof FileInput> = {
     title: "Core/Form/Inputs/FileInput",
@@ -181,7 +182,7 @@ export const Playground: Story = {
                     size={args.size}
                     text={fileName ?? "Choose file..."}
                 />
-                {fileName != null && <div style={{ fontSize: 12, opacity: 0.6 }}>Selected: {fileName}</div>}
+                {fileName != null && <StoryLabel title={`Selected: ${fileName}`} />}
             </div>
         );
     },

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -6,9 +6,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ChangeEvent, useCallback, useState } from "react";
 
 import { Size } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { FileInput } from "./fileInput";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof FileInput> = {
     title: "Core/Form/Inputs/FileInput",

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from "react";
 import { Intent, Position, Size } from "../../common";
 
 import { NumericInput } from "./numericInput";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof NumericInput> = {
     title: "Core/Form/Inputs/NumericInput",
@@ -166,11 +167,11 @@ export const ButtonPositionExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Right (default)</div>
+            <StoryLabel title="Right (default)" />
             <NumericInput {...args} buttonPosition={Position.RIGHT} placeholder="Buttons right..." />
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Left</div>
+            <StoryLabel title="Left" />
             <NumericInput {...args} buttonPosition={Position.LEFT} placeholder="Buttons left..." />
-            <div style={{ fontSize: 12, opacity: 0.6 }}>None</div>
+            <StoryLabel title="None" />
             <NumericInput {...args} buttonPosition="none" placeholder="No buttons..." />
         </div>
     ),
@@ -247,7 +248,7 @@ export const Playground: Story = {
                     stepSize={args.stepSize}
                     value={value}
                 />
-                <div style={{ fontSize: 12, opacity: 0.6 }}>Current value: {value}</div>
+                <StoryLabel title={`Current value: ${value}`} />
             </div>
         );
     },

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { useCallback, useState } from "react";
 
 import { Intent, Position, Size } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { NumericInput } from "./numericInput";
 

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -6,9 +6,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useState } from "react";
 
 import { Intent, Position, Size } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { NumericInput } from "./numericInput";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof NumericInput> = {
     title: "Core/Form/Inputs/NumericInput",

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -6,7 +6,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
 import { type ComponentProps } from "react";
 
-
 import { Switch } from "./controls";
 
 const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ComponentProps } from "react";
 
 import { Switch } from "./controls";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<
     keyof ComponentProps<typeof Switch>
@@ -102,17 +103,17 @@ export const StateExample: Story = {
     },
     render: args => (
         <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Unchecked</div>
+            <StoryLabel title="Unchecked" />
             <div style={{ display: "flex", gap: 16 }}>
                 <Switch {...args} label="Default" />
                 <Switch {...args} label="Disabled" disabled={true} />
             </div>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Checked</div>
+            <StoryLabel title="Checked" />
             <div style={{ display: "flex", gap: 16 }}>
                 <Switch {...args} label="Checked" defaultChecked={true} />
                 <Switch {...args} label="Checked Disabled" defaultChecked={true} disabled={true} />
             </div>
-            <div style={{ fontSize: 12, opacity: 0.6 }}>Inline</div>
+            <StoryLabel title="Inline" />
             <div>
                 <Switch {...args} inline={true} label="Wi-Fi" defaultChecked={true} />
                 <Switch {...args} inline={true} label="Bluetooth" />
@@ -131,9 +132,7 @@ export const AllStates: Story = {
         <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
             {(["medium", "large"] as const).map(size => (
                 <div key={size}>
-                    <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8, textTransform: "capitalize" }}>
-                        {size}
-                    </div>
+                    <StoryLabel title={size} capitalize />
                     <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
                         <Switch {...args} size={size} label="Unchecked" />
                         <Switch {...args} size={size} label="Checked" defaultChecked={true} />

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -5,8 +5,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ComponentProps } from "react";
 
-import { Switch } from "./controls";
 import { StoryLabel } from "../storybook-components/StoryLabel";
+
+import { Switch } from "./controls";
 
 const disabledArgs = ["large", "tagName", "labelElement", "inputRef"] as const satisfies ReadonlyArray<
     keyof ComponentProps<typeof Switch>

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -132,7 +132,7 @@ export const AllStates: Story = {
         <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
             {(["medium", "large"] as const).map(size => (
                 <div key={size}>
-                    <StoryLabel title={size} capitalize />
+                    <StoryLabel title={size} />
                     <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
                         <Switch {...args} size={size} label="Unchecked" />
                         <Switch {...args} size={size} label="Checked" defaultChecked={true} />

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -3,9 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { type ComponentProps } from "react";
 
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Switch } from "./controls";
 

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -126,7 +126,7 @@ export const SizeExample: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
             {Object.values(Size).map(size => (
                 <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                    <StoryLabel title={size} capitalize />
+                    <StoryLabel title={size} />
                     <SegmentedControl {...args} size={size} />
                 </div>
             ))}

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from "react";
 import { Intent, Size } from "../../common";
 
 import { SegmentedControl } from "./segmentedControl";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const DEFAULT_OPTIONS = [
     { label: "List", value: "list" },
@@ -102,11 +103,11 @@ export const IntentExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>None</span>
+                <StoryLabel title="None" />
                 <SegmentedControl {...args} intent={Intent.NONE} />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Primary</span>
+                <StoryLabel title="Primary" />
                 <SegmentedControl {...args} intent={Intent.PRIMARY} />
             </div>
         </div>
@@ -125,7 +126,7 @@ export const SizeExample: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
             {Object.values(Size).map(size => (
                 <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                    <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{size}</span>
+                    <StoryLabel title={size} capitalize />
                     <SegmentedControl {...args} size={size} />
                 </div>
             ))}
@@ -144,11 +145,11 @@ export const StateExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <StoryLabel title="Default" />
                 <SegmentedControl {...args} />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                <StoryLabel title="Disabled" />
                 <SegmentedControl {...args} disabled={true} />
             </div>
         </div>
@@ -173,11 +174,11 @@ export const FillExample: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Fill</span>
+                <StoryLabel title="Fill" />
                 <SegmentedControl {...args} fill={true} />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Auto Width</span>
+                <StoryLabel title="Auto Width" />
                 <SegmentedControl {...args} fill={false} />
             </div>
         </div>
@@ -203,15 +204,15 @@ export const AriaLabels: Story = {
     render: args => (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>role="radiogroup" (default) + aria-label</span>
+                <StoryLabel title={'role="radiogroup" (default) + aria-label'} />
                 <SegmentedControl {...args} aria-label="View mode" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>role="toolbar" + aria-label</span>
+                <StoryLabel title={'role="toolbar" + aria-label'} />
                 <SegmentedControl {...args} role="toolbar" aria-label="View mode toolbar" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>role="group" + aria-label</span>
+                <StoryLabel title={'role="group" + aria-label'} />
                 <SegmentedControl {...args} role="group" aria-label="View mode group" />
             </div>
         </div>
@@ -232,7 +233,7 @@ export const AllIntentsAllSizes: Story = {
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
             {[Intent.NONE, Intent.PRIMARY].map(intent => (
                 <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <div style={{ fontSize: 12, opacity: 0.6 }}>Intent: {intent}</div>
+                    <StoryLabel title={`Intent: ${intent}`} />
                     {Object.values(Size).map(size => (
                         <SegmentedControl key={size} {...args} intent={intent} size={size} />
                     ))}
@@ -257,7 +258,7 @@ export const Playground: Story = {
         return (
             <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
                 <SegmentedControl {...args} options={ICON_OPTIONS} value={value} onValueChange={handleValueChange} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Selected: {value}</span>
+                <StoryLabel title={`Selected: ${value}`} />
             </div>
         );
     },

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { useCallback, useState } from "react";
 
 import { Intent, Size } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { SegmentedControl } from "./segmentedControl";
 

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -6,9 +6,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useState } from "react";
 
 import { Intent, Size } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { SegmentedControl } from "./segmentedControl";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const DEFAULT_OPTIONS = [
     { label: "List", value: "list" },

--- a/packages/core/src/components/skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/components/skeleton/Skeleton.stories.tsx
@@ -8,6 +8,7 @@ import { Classes } from "../../common";
 import { Button } from "../button/buttons";
 import { Card } from "../card/card";
 import { H5 } from "../html/html";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 interface SkeletonStoryProps {
     /** Whether the skeleton class is applied */
@@ -77,11 +78,11 @@ export const ComparisonExample: Story = {
     render: () => (
         <div style={{ display: "flex", gap: 24 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Loading</span>
+                <StoryLabel title="Loading" />
                 <SkeletonDemo skeleton={true} />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Loaded</span>
+                <StoryLabel title="Loaded" />
                 <SkeletonDemo skeleton={false} />
             </div>
         </div>

--- a/packages/core/src/components/skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/components/skeleton/Skeleton.stories.tsx
@@ -3,12 +3,12 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 
 import { Classes } from "../../common";
 import { Button } from "../button/buttons";
 import { Card } from "../card/card";
 import { H5 } from "../html/html";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 interface SkeletonStoryProps {
     /** Whether the skeleton class is applied */

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -7,9 +7,9 @@ import { useCallback } from "react";
 import { useArgs } from "storybook/preview-api";
 
 import { Intent } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Slider } from "./slider";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Slider> = {
     title: "Core/Slider",

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -9,6 +9,7 @@ import { useArgs } from "storybook/preview-api";
 import { Intent } from "../../common";
 
 import { Slider } from "./slider";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Slider> = {
     title: "Core/Slider",
@@ -121,7 +122,7 @@ export const IntentExample: Story = {
             <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
                 {Object.values(Intent).map(intent => (
                     <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                        <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</span>
+                        <StoryLabel title={intent} capitalize />
                         <Slider
                             {...args}
                             intent={intent}
@@ -152,7 +153,7 @@ export const StateExample: Story = {
         return (
             <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
                 <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                    <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                    <StoryLabel title="Default" />
                     <Slider
                         {...args}
                         disabled={false}
@@ -162,7 +163,7 @@ export const StateExample: Story = {
                     />
                 </div>
                 <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                    <span style={{ fontSize: 12, opacity: 0.6 }}>Disabled</span>
+                    <StoryLabel title="Disabled" />
                     <Slider
                         {...args}
                         disabled={true}
@@ -172,7 +173,7 @@ export const StateExample: Story = {
                     />
                 </div>
                 <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                    <span style={{ fontSize: 12, opacity: 0.6 }}>Vertical</span>
+                    <StoryLabel title="Vertical" />
                     <Slider
                         {...args}
                         vertical={true}

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -3,11 +3,11 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { useCallback } from "react";
 import { useArgs } from "storybook/preview-api";
 
 import { Intent } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Slider } from "./slider";
 

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -122,7 +122,7 @@ export const IntentExample: Story = {
             <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
                 {Object.values(Intent).map(intent => (
                     <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                        <StoryLabel title={intent} capitalize />
+                        <StoryLabel title={intent} />
                         <Slider
                             {...args}
                             intent={intent}

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -3,9 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 
 import { Intent } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Spinner, SpinnerSize } from "./spinner";
 

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -65,7 +65,7 @@ export const IntentExample: Story = {
             {Object.values(Intent).map(intent => (
                 <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                     <Spinner {...args} intent={intent} size={SpinnerSize.STANDARD} />
-                    <StoryLabel title={intent} capitalize />
+                    <StoryLabel title={intent} />
                 </div>
             ))}
         </div>

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -5,9 +5,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Intent } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Spinner, SpinnerSize } from "./spinner";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Spinner> = {
     title: "Core/Spinner",

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Intent } from "../../common";
 
 import { Spinner, SpinnerSize } from "./spinner";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 const meta: Meta<typeof Spinner> = {
     title: "Core/Spinner",
@@ -64,7 +65,7 @@ export const IntentExample: Story = {
             {Object.values(Intent).map(intent => (
                 <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                     <Spinner {...args} intent={intent} size={SpinnerSize.STANDARD} />
-                    <span style={{ fontSize: 12, opacity: 0.6, textTransform: "capitalize" }}>{intent}</span>
+                    <StoryLabel title={intent} capitalize />
                 </div>
             ))}
         </div>
@@ -83,15 +84,15 @@ export const SizeExample: Story = {
         <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} size={SpinnerSize.SMALL} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Small (20px)</span>
+                <StoryLabel title="Small (20px)" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} size={SpinnerSize.STANDARD} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Standard (50px)</span>
+                <StoryLabel title="Standard (50px)" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} size={SpinnerSize.LARGE} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Large (100px)</span>
+                <StoryLabel title="Large (100px)" />
             </div>
         </div>
     ),
@@ -109,19 +110,19 @@ export const StateExample: Story = {
         <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} value={undefined} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Indeterminate</span>
+                <StoryLabel title="Indeterminate" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} value={0} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>0%</span>
+                <StoryLabel title="0%" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} value={0.5} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>50%</span>
+                <StoryLabel title="50%" />
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
                 <Spinner {...args} value={1} />
-                <span style={{ fontSize: 12, opacity: 0.6 }}>100%</span>
+                <StoryLabel title="100%" />
             </div>
         </div>
     ),

--- a/packages/core/src/components/storybook-components/StoryLabel.tsx
+++ b/packages/core/src/components/storybook-components/StoryLabel.tsx
@@ -1,0 +1,21 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { ReactNode } from "react";
+
+export interface StoryLabelProps {
+    title: ReactNode;
+    capitalize?: boolean;
+}
+
+/**
+ * Small, muted label used in Storybook stories to annotate variants, states, etc.
+ */
+export function StoryLabel({ title, capitalize }: StoryLabelProps) {
+    return (
+        <span style={{ fontSize: 12, opacity: 0.6, marginBottom: 4, textTransform: capitalize ? "capitalize" : undefined }}>
+            {title}
+        </span>
+    );
+}

--- a/packages/core/src/components/storybook-components/StoryLabel.tsx
+++ b/packages/core/src/components/storybook-components/StoryLabel.tsx
@@ -12,5 +12,5 @@ export interface StoryLabelProps {
  * Small, muted label used in Storybook stories to annotate variants, states, etc.
  */
 export function StoryLabel({ title }: StoryLabelProps) {
-    return <span style={{ fontSize: 12, opacity: 0.6, marginBottom: 4, textTransform: "capitalize" }}>{title}</span>;
+    return <span style={{ fontSize: 12, marginBottom: 4, opacity: 0.6, textTransform: "capitalize" }}>{title}</span>;
 }

--- a/packages/core/src/components/storybook-components/StoryLabel.tsx
+++ b/packages/core/src/components/storybook-components/StoryLabel.tsx
@@ -6,16 +6,11 @@ import type { ReactNode } from "react";
 
 export interface StoryLabelProps {
     title: ReactNode;
-    capitalize?: boolean;
 }
 
 /**
  * Small, muted label used in Storybook stories to annotate variants, states, etc.
  */
-export function StoryLabel({ title, capitalize }: StoryLabelProps) {
-    return (
-        <span style={{ fontSize: 12, opacity: 0.6, marginBottom: 4, textTransform: capitalize ? "capitalize" : undefined }}>
-            {title}
-        </span>
-    );
+export function StoryLabel({ title }: StoryLabelProps) {
+    return <span style={{ fontSize: 12, opacity: 0.6, marginBottom: 4, textTransform: "capitalize" }}>{title}</span>;
 }

--- a/packages/core/src/components/tag/CompoundTag.stories.tsx
+++ b/packages/core/src/components/tag/CompoundTag.stories.tsx
@@ -3,11 +3,11 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
 import { Button } from "../button/buttons";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { CompoundTag } from "./compoundTag";
 

--- a/packages/core/src/components/tag/CompoundTag.stories.tsx
+++ b/packages/core/src/components/tag/CompoundTag.stories.tsx
@@ -9,6 +9,7 @@ import { Intent } from "../../common";
 import { Button } from "../button/buttons";
 
 import { CompoundTag } from "./compoundTag";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 // These props are deprecated on CompoundTag — hide them from the Storybook controls panel.
 const disabledArgs = ["large", "rightIcon", "children"] as const satisfies ReadonlyArray<
@@ -133,13 +134,13 @@ export const VariantExample: Story = {
     render: args => (
         <div style={{ display: "flex", gap: 16 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <StoryLabel title="Default" />
                 <CompoundTag {...args} leftContent="Key" minimal={false}>
                     Value
                 </CompoundTag>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <StoryLabel title="Minimal" />
                 <CompoundTag {...args} leftContent="Key" minimal={true}>
                     Value
                 </CompoundTag>
@@ -263,7 +264,7 @@ export const AllIntentsAllVariants: Story = {
             <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
                 {[false, true].map(minimal => (
                     <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                        <div style={{ fontSize: 12, opacity: 0.6 }}>{minimal ? "Minimal" : "Default"}</div>
+                        <StoryLabel title={minimal ? "Minimal" : "Default"} />
                         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
                             {Object.values(Intent).map(intent => (
                                 <CompoundTag key={intent} {...args} leftContent="Key" minimal={minimal} intent={intent}>

--- a/packages/core/src/components/tag/CompoundTag.stories.tsx
+++ b/packages/core/src/components/tag/CompoundTag.stories.tsx
@@ -7,9 +7,9 @@ import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
 import { Button } from "../button/buttons";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { CompoundTag } from "./compoundTag";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 // These props are deprecated on CompoundTag — hide them from the Storybook controls panel.
 const disabledArgs = ["large", "rightIcon", "children"] as const satisfies ReadonlyArray<

--- a/packages/core/src/components/tag/Tag.stories.tsx
+++ b/packages/core/src/components/tag/Tag.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Tag } from "./tag";
 

--- a/packages/core/src/components/tag/Tag.stories.tsx
+++ b/packages/core/src/components/tag/Tag.stories.tsx
@@ -6,9 +6,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Tag } from "./tag";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 // These props are deprecated on Tag — hide them from the Storybook controls panel.
 const disabledArgs = ["large", "rightIcon", "children"] as const satisfies ReadonlyArray<

--- a/packages/core/src/components/tag/Tag.stories.tsx
+++ b/packages/core/src/components/tag/Tag.stories.tsx
@@ -8,6 +8,7 @@ import { useCallback, useState } from "react";
 import { Intent } from "../../common";
 
 import { Tag } from "./tag";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 // These props are deprecated on Tag — hide them from the Storybook controls panel.
 const disabledArgs = ["large", "rightIcon", "children"] as const satisfies ReadonlyArray<
@@ -133,13 +134,13 @@ export const VariantExample: Story = {
     render: args => (
         <div style={{ display: "flex", gap: 16 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Default</span>
+                <StoryLabel title="Default" />
                 <Tag {...args} minimal={false}>
                     Tag
                 </Tag>
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
-                <span style={{ fontSize: 12, opacity: 0.6 }}>Minimal</span>
+                <StoryLabel title="Minimal" />
                 <Tag {...args} minimal={true}>
                     Tag
                 </Tag>
@@ -261,7 +262,7 @@ export const AllIntentsAllVariants: Story = {
             <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
                 {[false, true].map(minimal => (
                     <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                        <div style={{ fontSize: 12, opacity: 0.6 }}>{minimal ? "Minimal" : "Default"}</div>
+                        <StoryLabel title={minimal ? "Minimal" : "Default"} />
                         <div style={{ display: "flex", gap: 8 }}>
                             {Object.values(Intent).map(intent => (
                                 <Tag key={intent} {...args} minimal={minimal} intent={intent}>

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -7,7 +7,6 @@ import { StoryLabel } from "@storybook-common";
 import { type MouseEvent, useCallback, useReducer } from "react";
 import { expect, waitFor } from "storybook/test";
 
-
 import { Tree } from "./tree";
 import type { TreeNodeInfo } from "./treeTypes";
 

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -6,9 +6,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type MouseEvent, useCallback, useReducer } from "react";
 import { expect, waitFor } from "storybook/test";
 
+import { StoryLabel } from "../storybook-components/StoryLabel";
+
 import { Tree } from "./tree";
 import type { TreeNodeInfo } from "./treeTypes";
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 type NodePath = number[];
 

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -3,10 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { StoryLabel } from "@storybook-common";
 import { type MouseEvent, useCallback, useReducer } from "react";
 import { expect, waitFor } from "storybook/test";
 
-import { StoryLabel } from "../storybook-components/StoryLabel";
 
 import { Tree } from "./tree";
 import type { TreeNodeInfo } from "./treeTypes";

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -8,6 +8,7 @@ import { expect, waitFor } from "storybook/test";
 
 import { Tree } from "./tree";
 import type { TreeNodeInfo } from "./treeTypes";
+import { StoryLabel } from "../storybook-components/StoryLabel";
 
 type NodePath = number[];
 
@@ -177,13 +178,13 @@ export const StateExample: Story = {
     render: args => (
         <div style={{ display: "flex", gap: 32 }}>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Selected</div>
+                <StoryLabel title="Selected" />
                 <div style={{ minWidth: "300px" }}>
                     <Tree {...args} contents={SELECTED_CONTENTS} />
                 </div>
             </div>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Disabled</div>
+                <StoryLabel title="Disabled" />
                 <div style={{ minWidth: "300px" }}>
                     <Tree {...args} contents={DISABLED_CONTENTS} />
                 </div>
@@ -200,25 +201,25 @@ export const AllStates: Story = {
     render: args => (
         <div style={{ display: "flex", gap: 32, flexWrap: "wrap" }}>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Default</div>
+                <StoryLabel title="Default" />
                 <div style={{ minWidth: "300px" }}>
                     <Tree {...args} contents={SAMPLE_CONTENTS} />
                 </div>
             </div>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Selected</div>
+                <StoryLabel title="Selected" />
                 <div style={{ minWidth: "300px" }}>
                     <Tree {...args} contents={SELECTED_CONTENTS} />
                 </div>
             </div>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Disabled</div>
+                <StoryLabel title="Disabled" />
                 <div style={{ minWidth: "300px" }}>
                     <Tree {...args} contents={DISABLED_CONTENTS} />
                 </div>
             </div>
             <div>
-                <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Compact</div>
+                <StoryLabel title="Compact" />
                 <div style={{ minWidth: "300px" }}>
                     <Tree {...args} contents={SAMPLE_CONTENTS} compact={true} />
                 </div>

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -1,4 +1,8 @@
 {
     "files": [],
-    "references": [{ "path": "./tsconfig.build.json" }, { "path": "./tsconfig.test.json" }]
+    "references": [
+        { "path": "./tsconfig.build.json" },
+        { "path": "./tsconfig.test.json" },
+        { "path": "./tsconfig.stories.json" }
+    ]
 }

--- a/packages/core/src/tsconfig.stories.json
+++ b/packages/core/src/tsconfig.stories.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../../.storybook/tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "noEmit": true,
+        "rootDir": "../../.."
+    },
+    "include": ["**/*.stories.tsx", "**/*.stories.ts", "../../../.storybook/common.tsx"]
+}


### PR DESCRIPTION
#### Fixes comment @ggdouglas left [here](https://github.com/palantir/blueprint/pull/7942#discussion_r3064974735)

### Changes proposed in this pull request:
Pull out a common component to properly title storybook stories

### What to be aware of
There were some design inconsistencies present:
- some used `div` and some used `span`
- some used margin bottom 4, or 6, or 8. 
- many of these had `textTransform: "capitalize"` and others didn't

This new component introduces a **forced standard design**.  This means that technically chromatic will catch many pages "looking different". 

```
<span
  style={{
    fontSize: 12,
    opacity: 0.6,
    marginBottom: 4,
    textTransform: "capitalize"
  }}>
{title}
</span>
```