### PR TITLE
(chore) fix .policy.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,19 @@ aliases:
     key: v1-pnpm-store-{{ checksum "pnpm-lock.yaml" }}
 
 jobs:
+  circle-all:
+    resource_class: small
+    docker: *docker-node-image
+    steps:
+      - checkout
+      - run:
+          name: Validate policy file
+          command: |
+            rcode=$(curl "https://policy.bots.palantir.build/api/validate" -XPUT -T "policy.yml" -s -w "%{http_code}" -o /tmp/response)
+            if [[ "${rcode}" -gt 299 ]]; then
+              jq -r .message < /tmp/response && exit 1
+            fi
+
   checkout-code:
     docker: *docker-node-image
     steps:
@@ -224,6 +237,7 @@ jobs:
 workflows:
   compile_lint_test_dist_deploy:
     jobs:
+      - circle-all
       - checkout-code
       - clean-lockfile:
           requires: [checkout-code]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Validate policy file
           command: |
-            rcode=$(curl "https://policy-bot.general.dmz.palantir.tech/" -XPUT -T "policy.yml" -s -w "%{http_code}" -o /tmp/response)
+            rcode=$(curl "https://policy-bot.general.dmz.palantir.tech/" -XPUT -T ".policy.yml" -s -w "%{http_code}" -o /tmp/response)
             if [[ "${rcode}" -gt 299 ]]; then
               jq -r .message < /tmp/response && exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Validate policy file
           command: |
-            rcode=$(curl "https://policy-bot.general.dmz.palantir.tech/" -XPUT -T ".policy.yml" -s -w "%{http_code}" -o /tmp/response)
+            rcode=$(curl "https://policy-bot.general.dmz.palantir.tech/api/validate" -XPUT -T ".policy.yml" -s -w "%{http_code}" -o /tmp/response)
             if [[ "${rcode}" -gt 299 ]]; then
               jq -r .message < /tmp/response && exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Validate policy file
           command: |
-            rcode=$(curl "https://policy.bots.palantir.build/api/validate" -XPUT -T "policy.yml" -s -w "%{http_code}" -o /tmp/response)
+            rcode=$(curl "https://policy-bot.general.dmz.palantir.tech/" -XPUT -T "policy.yml" -s -w "%{http_code}" -o /tmp/response)
             if [[ "${rcode}" -gt 299 ]]; then
               jq -r .message < /tmp/response && exit 1
             fi

--- a/.policy.yml
+++ b/.policy.yml
@@ -16,7 +16,7 @@ policy:
         # Special cases
         - changelog only and contributor approval
         - fixing excavator
-        - excavator only touched baseline, circle, gradle files, godel files, generated code, go dependencies, docker-compose-rule config or versions.props
+        - excavator only touched changelog or circle files
         - excavator only touched config files
         - bots updated package.json and lock files
   disapproval:


### PR DESCRIPTION
### Fixes
`
Error
failed to create evaluator: palantir/blueprint@develop: .policy.yml: failed to parse approval policy: failed to parse subpolicies for 'and': failed to parse subpolicies for 'or': policy references undefined rule 'excavator only touched baseline, circle, gradle files, godel files, generated code, go dependencies, docker-compose-rule config or versions.props', allowed values: [fixing excavator bots updated package.json and lock files blueprint team member approved by one admin external contributor approved by one admin external contributor approved by two admins (contributor allowed) excavator only touched changelog or circle files excavator only touched config files blueprint team member approved by two admins (contributor allowed) changelog only and contributor approval]
`

### What was wrong
Each of these must be present twice: once at the top of the file and next as a `name:`
```
policy:
  approval:
    - or:
        # Blueprint team members - trusted
        - blueprint team member approved by one admin
        - blueprint team member approved by two admins (contributor allowed)
        # External contributors - stricter
        - external contributor approved by one admin
        - external contributor approved by two admins (contributor allowed)
        # Special cases
        - changelog only and contributor approval
        - fixing excavator
        - excavator only touched changelog or circle files
        - excavator only touched config files
        - bots updated package.json and lock files
```