### PR TITLE
fix(Button): Fix Icon width collapse inside Tooltip/Popover within Button

### DIFF
--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -107,9 +107,9 @@
   }
 
   // button with SVG icon only (no text or children)
-  .#{$ns}-icon:first-child:last-child,
+  > .#{$ns}-icon:first-child:last-child,
   // if loading, then it contains exactly [spinner, icon]
-  .#{$ns}-spinner + .#{$ns}-icon:last-child {
+  > .#{$ns}-spinner + .#{$ns}-icon:last-child {
     // center icon horizontally. this works for large buttons too.
     margin: 0
       calc(


### PR DESCRIPTION
## Summary
- Icon-only buttons use a negative horizontal margin on` .bp6-icon:first-child:last-child` to keep the button compact. Because this was a descendant selector, it also matched icons that happened to be the sole child of a Popover/Tooltip target wrapper inside a button, collapsing them as well.
- Tighten the selector to `>` (direct child) so the margin only fires when the icon is an immediate child of `.bp6-button`.

## Demo

Demo of issue: https://codesandbox.io/p/sandbox/ld7prc

```tsx
<Button>
  <Flex gap={2}>
    Some text:
    <Tooltip content="Info details">
      <Icon icon="info-sign" size={16} intent="primary" />
    </Tooltip>
    <Tooltip content="Warning details">
      <Icon icon="warning-sign" size={16} intent="warning" />
    </Tooltip>
  </Flex>
</Button>
}
```

**Before:**
<img width="3456" height="1740" alt="before" src="https://github.com/user-attachments/assets/85fe1caf-7070-44a1-a307-764603f71303" />

**After:**
<img width="3456" height="1740" alt="after" src="https://github.com/user-attachments/assets/d143986b-534f-4a30-821f-795f9f07a360" />


## Testing
- [ ]  Icon inside a Tooltip or Popover passed to a Button's `text` prop renders at full size, not collapsed
- [ ]  Icon-only buttons (`<Button icon="..." />`) still render square
- [ ]  Buttons with both icon and text still lay out correctly
