### PR TITLE
fix(Section): flatten CardList top radius inside SectionCard

### DIFF
--- a/packages/core/changelog/@unreleased/pr-7841-section-cardlist.yml
+++ b/packages/core/changelog/@unreleased/pr-7841-section-cardlist.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Remove rounded top corners on bordered CardList when nested in SectionCard (#7841).
+  links:
+  - https://github.com/palantir/blueprint/issues/7841

--- a/packages/core/src/components/section/_section.scss
+++ b/packages/core/src/components/section/_section.scss
@@ -98,6 +98,13 @@ $section-card-padding-compact: $pt-spacing * 4 !default;
         border-color: $pt-dark-divider-white;
       }
     }
+
+    // CardList uses a bordered outer Card that keeps the default Card border-radius; flush the top edge with the
+    // section header divider so we do not get rounded corners or a stray top border line on the first row (#7841).
+    > .#{$ns}-card.#{$ns}-card-list.#{$ns}-card-list-bordered {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
   }
 
   &.#{$ns}-section-collapsed {


### PR DESCRIPTION
﻿#### Fixes #7841

#### Checklist

- [x] Includes tests (N/A: SCSS-only visual fix; verify via **Reviewers should focus** steps)
- [x] Update documentation (N/A: internal styling change only)

#### Changelog

Unreleased entry: `packages/core/changelog/@unreleased/pr-7841-section-cardlist.yml` (`type: fix`).

#### Changes proposed in this pull request

When a bordered `CardList` is nested in a `SectionCard`, its outer wrapper is still a `Card` with the default `border-radius`, which looked wrong under the section header (rounded top corners and divider clash). This change sets `border-top-left-radius` and `border-top-right-radius` to `0` for a bordered `CardList` that is a direct child of `SectionCard`.

#### Reviewers should focus on

**Visual check:** Docs → **CardList** → **Interactive Playground**, enable **Use Section container** (bordered is forced on). Confirm the list lines up cleanly with the section header in light and dark theme.
