### PR TITLE
(chore) Replace deprecated `typescript.tsdk` VSCode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "typescript.tsdk": "./node_modules/typescript/lib",
+    "js/ts.tsdk.path": "./node_modules/typescript/lib",
     "files.watcherExclude": {
         "**/build": true,
         "**/coverage": true,


### PR DESCRIPTION
## Summary

- Replace deprecated `typescript.tsdk` with `js/ts.tsdk.path` in `.vscode/settings.json`
- Aligns with current VSCode TypeScript extension API

See: https://code.visualstudio.com/docs/typescript/typescript-transpiling#_using-the-workspace-version-of-typescript

Fixes this:

<img width="1774" height="676" alt="Screenshot 2026-04-15 at 18 16 47@2x" src="https://github.com/user-attachments/assets/238c56c1-20e6-48f0-a86c-4f388289d28c" />

```
This setting is deprecated. Use js/ts.tsdk.path instead.(2)
Specifies the folder path to the tsserver and lib*.d.ts files under a TypeScript install to use for IntelliSense, for example: ./node_modules/typescript/lib.

When specified as a user setting, the TypeScript version from typescript.tsdk automatically replaces the built-in TypeScript version.
When specified as a workspace setting, typescript.tsdk allows you to switch to use that workspace version of TypeScript for IntelliSense with the TypeScript: Select TypeScript version command.
See the [TypeScript documentation](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for more detail about managing TypeScript versions.
```