### PR TITLE
(chore) Removing pnpm config set for OIDC token

### DIFF
--- a/scripts/publish-npm-semver-tagged
+++ b/scripts/publish-npm-semver-tagged
@@ -14,14 +14,6 @@ if [ -z "$publishable_paths" ]; then
     exit 0
 fi
 
-if [ -z "${NPM_ID_TOKEN}" ]; then
-    echo "No NPM OIDC token available."
-    exit 1
-fi
-
-pnpm config set //registry.npmjs.org/:_authToken "${NPM_ID_TOKEN}"
-
-
 for path in $publishable_paths; do
     pushd "$path"
     echo "Attempting to publish package at path '$path'"


### PR DESCRIPTION
#### Changes proposed in this pull request:

* Removing the setting of `NPM_ID_TOKEN` in pnpm config, since this should now work without this commit

Related:
* #8062
* #8055 
* #8018 

#### Reviewers should focus on:

On a release, the release should still pass `deploy-npm` even without this token being explicitly set.