### PR TITLE
fix(tag-input): apply icon spacing and color to static icon elements

### DIFF
--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -22,6 +22,7 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
 
   .#{$ns}-tag-input-icon {
     color: var(--bp-typography-color-muted);
+    display: flex;
     margin-left: calc(var(--bp-surface-spacing) * 0.75);
     margin-right: calc(var(--bp-surface-spacing) * 1.75);
     // margins to center icon in one-line input

--- a/packages/core/src/components/tag-input/tagInput.tsx
+++ b/packages/core/src/components/tag-input/tagInput.tsx
@@ -317,11 +317,15 @@ export class TagInput extends AbstractPureComponent<TagInputProps, TagInputState
         return (
             // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- container delegates interaction to input element
             <div className={classes} onBlur={this.handleContainerBlur} onClick={this.handleContainerClick}>
-                <Icon
-                    className={Classes.TAG_INPUT_ICON}
-                    icon={leftIcon}
-                    size={isLarge ? IconSize.LARGE : IconSize.STANDARD}
-                />
+                {typeof leftIcon === "string" ? (
+                    <Icon
+                        className={Classes.TAG_INPUT_ICON}
+                        icon={leftIcon}
+                        size={isLarge ? IconSize.LARGE : IconSize.STANDARD}
+                    />
+                ) : leftIcon != null ? (
+                    <span className={Classes.TAG_INPUT_ICON}>{leftIcon}</span>
+                ) : null}
                 <div className={Classes.TAG_INPUT_VALUES}>
                     {values.map(this.maybeRenderTag)}
                     {this.props.children}


### PR DESCRIPTION
## Summary

When `leftIcon` is a JSX element (not a string), `<Icon>` passes it through unchanged, so the `bp6-tag-input-icon` class never gets applied and the icon loses its margins and muted color. Wrap element icons in a `<span class="bp6-tag-input-icon">` so they get the same spacing and color as string icons. Also adds `display: flex` to the wrapper class so the inner icon aligns correctly.

This was discovered during research on #8065

## Code
```tsx
import { TagInput } from "@blueprintjs/core";

// dynamic
<TagInput leftIcon="flag" values={["Important", "Review"]} />
```

```tsx
import { TagInput } from "@blueprintjs/core";
import { Flag } from "@blueprintjs/icons";

// static
<TagInput leftIcon={<Flag />} values={["Important", "Review"]} />
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="754" height="296" alt="tag-input-before" src="https://github.com/user-attachments/assets/9cd90069-48be-4480-8a26-f049196fa648" /> | <img width="756" height="296" alt="tag-input-after" src="https://github.com/user-attachments/assets/f8e175c1-24cc-4e96-afd8-9bee1e50bd2e" /> | 

**Diff**
<img width="378" alt="tag-input-diff" src="https://github.com/user-attachments/assets/ccf01cb5-e7e8-47b1-912b-0c7c6e82cee9" />

