### PR TITLE
fix(non-ideal-state): apply muted icon style to static icon elements

### DIFF
--- a/packages/core/src/components/non-ideal-state/nonIdealState.tsx
+++ b/packages/core/src/components/non-ideal-state/nonIdealState.tsx
@@ -98,13 +98,17 @@ export const NonIdealState: React.FC<NonIdealStateProps> = props => {
                     className={Classes.NON_IDEAL_STATE_VISUAL}
                     style={{ fontSize: `${iconSize}px`, lineHeight: `${iconSize}px` }}
                 >
-                    <Icon
-                        className={classNames({ [Classes.ICON_MUTED]: iconMuted })}
-                        icon={icon}
-                        size={iconSize}
-                        aria-hidden={true}
-                        tabIndex={-1}
-                    />
+                    {typeof icon === "string" ? (
+                        <Icon
+                            className={classNames({ [Classes.ICON_MUTED]: iconMuted })}
+                            icon={icon}
+                            size={iconSize}
+                            aria-hidden={true}
+                            tabIndex={-1}
+                        />
+                    ) : (
+                        <span className={classNames(Classes.ICON, { [Classes.ICON_MUTED]: iconMuted })}>{icon}</span>
+                    )}
                 </div>
             )}
             {title == null && description == null ? undefined : (


### PR DESCRIPTION
## Summary

When `icon` is a JSX element (not a string), `<Icon>` passes it through unchanged, so the `iconMuted` prop is silently dropped when using a pre-rendered icon element. Wrap element icons in a `<span class="bp6-icon bp6-icon-muted">` so muting works for both string and element icons.

This was discovered during research on #8065

## Code
```tsx
import { NonIdealState } from "@blueprintjs/core";

// dynamic
<NonIdealState
    icon="search"
    title="No results"
    description="Try a different query."
    action={<Button icon="plus" intent={Intent.PRIMARY} text="New item" variant="outlined" />}
/>
```

```tsx
import { NonIdealState } from "@blueprintjs/core";
import { Search } from "@blueprintjs/icons";

// static
<NonIdealState
    icon={<Search size={NonIdealStateIconSize.STANDARD} />}
    title="No results"
    description="Try a different query."
    action={<Button icon="plus" intent={Intent.PRIMARY} text="New item" variant="outlined" />}
/>
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="1352" height="498" alt="non-ideal-state-before" src="https://github.com/user-attachments/assets/3ebf1b3e-2534-4f82-8895-9f1fe853fa5e" /> | <img width="1352" height="498" alt="non-ideal-state-after" src="https://github.com/user-attachments/assets/48b40316-84d2-41ac-94c6-647dd383ef2c" /> |

**Diff**
<img width="676" alt="non-ideal-state-diff" src="https://github.com/user-attachments/assets/1a988d3a-35f8-4ea8-ab97-c93073710607" />