### PR TITLE
fix(alert): support static icon elements with correct intent and spacing

### DIFF
--- a/packages/core/src/components/alert/_alert.scss
+++ b/packages/core/src/components/alert/_alert.scss
@@ -11,7 +11,8 @@
 .#{$ns}-alert-body {
   display: flex;
 
-  .#{$ns}-icon {
+  > .#{$ns}-icon {
+    display: flex;
     font-size: $pt-icon-size-large * 2;
     margin-right: $pt-spacing * 5;
     margin-top: 0;

--- a/packages/core/src/components/alert/alert.tsx
+++ b/packages/core/src/components/alert/alert.tsx
@@ -199,7 +199,11 @@ export const Alert: React.FC<AlertProps> = props => {
             onClose={handleCancel}
         >
             <div className={Classes.ALERT_BODY}>
-                <Icon icon={icon} size={40} intent={intent} />
+                {typeof icon === "string" ? (
+                    <Icon icon={icon} size={40} intent={intent} />
+                ) : icon != null ? (
+                    <span className={classNames(Classes.ICON, Classes.intentClass(intent))}>{icon}</span>
+                ) : null}
                 <div className={Classes.ALERT_CONTENTS}>{children}</div>
             </div>
             <div className={Classes.ALERT_FOOTER}>


### PR DESCRIPTION
## Summary

Element icons passed to `<Alert icon={...}>` were losing their intent color and alert-body spacing. Wrap element icons in a `<span class="bp6-icon bp6-intent-*">` to preserve intent. Changes the `.bp6-alert-body .bp6-icon` selector to a direct-child selector to avoid double-applying margins when element icons render nested `bp6-icon` spans, and adds `display: flex` to the wrapper.

This was discovered during research on #8065

## Code
```tsx
import { Alert, Intent } from "@blueprintjs/core";

// dynamic
<Alert icon="trash" intent={Intent.DANGER} isOpen={true}>
    Are you sure you want to delete this item?
</Alert>
```

```tsx
import { Alert, Intent } from "@blueprintjs/core";
import { Trash } from "@blueprintjs/icons";

// static
<Alert icon={<Trash />} intent={Intent.DANGER} isOpen={true}>
    Are you sure you want to delete this item?
</Alert>
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="964" height="378" alt="alert-before" src="https://github.com/user-attachments/assets/1c51f885-78f9-4ad9-93b5-aa7bddba2586" /> | <img width="964" height="378" alt="alert-after" src="https://github.com/user-attachments/assets/baeea99d-c7a9-43c5-8a10-c13088fd85e7" /> |

**Diff**

<img width="482" alt="alert-diff" src="https://github.com/user-attachments/assets/3af5327d-0e45-404c-a488-5f3fe3bb2691" />