### PR TITLE
fix(entity-title): apply text-muted color to static icon elements

### DIFF
--- a/packages/core/src/components/entity-title/entityTitle.tsx
+++ b/packages/core/src/components/entity-title/entityTitle.tsx
@@ -148,12 +148,16 @@ export const EntityTitle: React.FC<EntityTitleProps> = forwardRef<HTMLDivElement
                         [Classes.ENTITY_TITLE_HAS_SUBTITLE]: maybeSubtitle != null,
                     })}
                 >
-                    <Icon
-                        aria-hidden={true}
-                        className={classNames(Classes.TEXT_MUTED, { [Classes.SKELETON]: loading })}
-                        icon={loading ? IconNames.SQUARE : icon}
-                        tabIndex={-1}
-                    />
+                    {loading || typeof icon === "string" ? (
+                        <Icon
+                            aria-hidden={true}
+                            className={classNames(Classes.TEXT_MUTED, { [Classes.SKELETON]: loading })}
+                            icon={loading ? IconNames.SQUARE : icon}
+                            tabIndex={-1}
+                        />
+                    ) : (
+                        <span className={Classes.TEXT_MUTED}>{icon}</span>
+                    )}
                 </div>
             )}
             <div className={Classes.ENTITY_TITLE_TEXT}>


### PR DESCRIPTION
## Summary

When `icon` is a JSX element, `<Icon>` drops the `bp6-text-muted` class. Wrap element icons in a `<span class="bp6-text-muted">` so they render with the same muted color as string icons. Preserves the existing `<Icon>` path for the loading skeleton state.

This was discovered during research on #8065

## Code
```tsx
import { EntityTitle } from "@blueprintjs/core";

// dynamic
<EntityTitle icon="bookmark" title="Saved Search" subtitle="Modified 2 hours ago" />
```

```tsx
import { EntityTitle } from "@blueprintjs/core";
import { Bookmark } from "@blueprintjs/icons";

// static
<EntityTitle icon={<Bookmark />} title="Saved Search" subtitle="Modified 2 hours ago" />
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="964" height="378" alt="entity-title-before" src="https://github.com/user-attachments/assets/cc46e3c3-9061-4465-8783-dd4cf6b537c4" /> | <img width="964" height="378" alt="entity-title-after" src="https://github.com/user-attachments/assets/07b5efc3-3649-41d0-b75a-c77f5d984999" /> |

**Diff**

<img width="482" alt="entity-title-diff" src="https://github.com/user-attachments/assets/1ce0f236-38d1-4544-b9ea-e4ef36b6bd4f" />