### PR TITLE
fix(section): apply text-muted color to static icon elements in header

### DIFF
--- a/packages/core/src/components/section/section.tsx
+++ b/packages/core/src/components/section/section.tsx
@@ -185,7 +185,12 @@ export const Section: React.FC<SectionProps> = forwardRef((props, ref) => {
                     onClick={collapsible ? toggleIsCollapsed : undefined}
                 >
                     <div className={Classes.SECTION_HEADER_LEFT}>
-                        {icon && <Icon icon={icon} aria-hidden={true} tabIndex={-1} className={Classes.TEXT_MUTED} />}
+                        {icon != null &&
+                            (typeof icon === "string" ? (
+                                <Icon icon={icon} aria-hidden={true} tabIndex={-1} className={Classes.TEXT_MUTED} />
+                            ) : (
+                                <span className={Classes.TEXT_MUTED}>{icon}</span>
+                            ))}
                         <div>
                             {createElement(
                                 titleRenderer,


### PR DESCRIPTION
## Summary

Section headers lose their `bp6-text-muted` color when `icon` is a JSX element because `<Icon>` passes elements through unchanged. Wrap element icons in a `<span class="bp6-text-muted">` so the header icon color is consistent regardless of icon type.

This was discovered during research on #8065

## Code
```tsx
import { Section } from "@blueprintjs/core";

// dynamic
<Section icon="cog" title="Settings" />
```

```tsx
import { Section } from "@blueprintjs/core";
import { Cog } from "@blueprintjs/icons";

// static
<Section icon={<Cog />} title="Settings" />
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="964" height="358" alt="section-before" src="https://github.com/user-attachments/assets/7c39b4f0-2a3c-429f-878e-8185b14f5194" /> | <img width="964" height="358" alt="section-after" src="https://github.com/user-attachments/assets/61963f1a-ea1a-4081-bb32-9ce75e2bbc28" /> |

**Diff**

<img width="482" alt="section-diff" src="https://github.com/user-attachments/assets/675c3c55-f7a6-48d4-85e4-ffc9244379c7" />