### PR TITLE
fix(tree): wrap static icon elements with tree-node-icon spacing class

### DIFF
--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -87,7 +87,11 @@ export class TreeNode<T = {}> extends Component<TreeNodeProps<T>> {
             <li className={classes}>
                 <div className={contentClasses} ref={this.handleContentRef} {...eventHandlers}>
                     {this.maybeRenderCaret()}
-                    <Icon className={Classes.TREE_NODE_ICON} icon={icon} aria-hidden={true} tabIndex={-1} />
+                    {typeof icon === "string" ? (
+                        <Icon className={Classes.TREE_NODE_ICON} icon={icon} aria-hidden={true} tabIndex={-1} />
+                    ) : icon != null ? (
+                        <span className={Classes.TREE_NODE_ICON}>{icon}</span>
+                    ) : null}
                     <span className={Classes.TREE_NODE_LABEL}>{label}</span>
                     {this.maybeRenderSecondaryLabel()}
                 </div>


### PR DESCRIPTION
## Summary

Tree nodes lost the `bp6-tree-node-icon` spacing class when `icon` was a JSX element, because `<Icon>` returns elements as-is. Wrap element icons in a `<span class="bp6-tree-node-icon">` so their spacing matches string icons.

This was discovered during research on #8065

## Code
```tsx
import { Tree } from "@blueprintjs/core";

// dynamic
<Tree contents={[{ id: 0, icon: "folder-close", label: "Documents" }]} />
```

```tsx
import { Tree } from "@blueprintjs/core";
import { FolderClose } from "@blueprintjs/icons";

// static
<Tree contents={[{ id: 0, icon: <FolderClose />, label: "Documents" }]} />
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="840" height="570" alt="tree-before" src="https://github.com/user-attachments/assets/2fba12b3-7a49-46d6-87b9-918f9f5db745" /> | <img width="840" height="570" alt="tree-after" src="https://github.com/user-attachments/assets/2f4d7bbe-42fc-442b-8b78-793c153ab380" /> |

**Diff**

<img width="420" alt="tree-diff" src="https://github.com/user-attachments/assets/376d7d0a-0db8-4420-b282-06737fb583cd" />