### PR TITLE
fix(tabs): wrap static icon elements with tab-icon class for spacing

### DIFF
--- a/packages/core/src/components/tabs/tabTitle.tsx
+++ b/packages/core/src/components/tabs/tabTitle.tsx
@@ -73,7 +73,12 @@ export class TabTitle extends AbstractPureComponent<TabTitleProps> {
                 role="tab"
                 tabIndex={disabled ? undefined : selected ? 0 : -1}
             >
-                {icon != null && <Icon icon={icon} intent={intent} className={Classes.TAB_ICON} />}
+                {icon != null &&
+                    (typeof icon === "string" ? (
+                        <Icon icon={icon} intent={intent} className={Classes.TAB_ICON} />
+                    ) : (
+                        <span className={Classes.TAB_ICON}>{icon}</span>
+                    ))}
                 {title}
                 {children}
                 {tagContent != null && (


### PR DESCRIPTION
## Summary

Tabs lost the `bp6-tab-icon` spacing class when `icon` was a JSX element, because `<Icon>` returns elements as-is. Wrap element icons in a `<span class="bp6-tab-icon">` so their spacing matches string icons.

This was discovered during research on #8065

## Code
```tsx
import { Tab, Tabs } from "@blueprintjs/core";

// dynamic
<Tabs>
    <Tab id="home" icon="home" title="Home" panel={<div>Home</div>} />
</Tabs>
```

```tsx
import { Tab, Tabs } from "@blueprintjs/core";
import { Home } from "@blueprintjs/icons";

// static
<Tabs>
    <Tab id="home" icon={<Home />} title="Home" panel={<div>Home</div>} />
</Tabs>
```

## Screenshots
| Before | After |
|--------|--------|
| <img width="960" height="490" alt="tabs-before" src="https://github.com/user-attachments/assets/3f33daa6-c688-4f7e-837e-b0057b5d1d3c" /> | <img width="960" height="490" alt="tabs-after" src="https://github.com/user-attachments/assets/1eddb393-385d-4748-86fc-0138c73dfeb8" /> |

**Diff**

<img width="480" alt="tabs-diff" src="https://github.com/user-attachments/assets/21dd7384-c9d3-4dd8-963f-e040259d3e79" />