### PR TITLE
[chore] Enable Storybook code panel via addon-docs

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -50,7 +50,11 @@ const storybookConfig: StorybookConfig = {
         });
     },
 
-    addons: [getAbsolutePath("@storybook/addon-a11y"), getAbsolutePath("@storybook/addon-themes")],
+    addons: [
+        getAbsolutePath("@storybook/addon-a11y"),
+        getAbsolutePath("@storybook/addon-docs"),
+        getAbsolutePath("@storybook/addon-themes"),
+    ],
 };
 
 // eslint-disable-next-line import/no-default-export

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -43,6 +43,7 @@ const preview: Preview = {
         docs: {
             codePanel: true,
         },
+        layout: "centered",
     },
 
     decorators: [

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -40,6 +40,9 @@ const preview: Preview = {
                 date: /Date$/i,
             },
         },
+        docs: {
+            codePanel: true,
+        },
     },
 
     decorators: [

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "license": "Apache-2.0",
     "devDependencies": {
         "@storybook/addon-a11y": "^10.2.14",
+        "@storybook/addon-docs": "^10.2.14",
         "@storybook/addon-themes": "^10.2.14",
         "@storybook/icons": "^2.0.1",
         "@storybook/react-dom-shim": "^10.2.14",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
         "@storybook/addon-a11y": "^10.2.14",
         "@storybook/addon-docs": "^10.2.14",
         "@storybook/addon-themes": "^10.2.14",
-        "@storybook/icons": "^2.0.1",
         "@storybook/react-dom-shim": "^10.2.14",
         "@storybook/react-vite": "^10.2.14",
         "chromatic": "^16.0.0",

--- a/packages/core/src/components/alert/Alert.stories.tsx
+++ b/packages/core/src/components/alert/Alert.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof Alert> = {
     parameters: {
         layout: "centered",
     },
-    tags: ["autodocs"],
     args: {
         intent: Intent.NONE,
         isOpen: true,

--- a/packages/core/src/components/alert/Alert.stories.tsx
+++ b/packages/core/src/components/alert/Alert.stories.tsx
@@ -15,9 +15,6 @@ const meta: Meta<typeof Alert> = {
     title: "Core/Alert",
     component: Alert,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     args: {
         intent: Intent.NONE,
         isOpen: true,

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -26,9 +26,6 @@ const meta: Meta<StoryArgs> = {
     title: "Core/Breadcrumbs",
     component: Breadcrumbs,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         items: SAMPLE_ITEMS,

--- a/packages/core/src/components/button/AnchorButton.stories.tsx
+++ b/packages/core/src/components/button/AnchorButton.stories.tsx
@@ -23,9 +23,6 @@ const meta: Meta<typeof AnchorButton> = {
     title: "Core/Button/AnchorButton",
     component: AnchorButton,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         text: "Link",

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -24,9 +24,6 @@ const meta: Meta<typeof Button> = {
     title: "Core/Button/Button",
     component: Button,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         text: "Button",

--- a/packages/core/src/components/button/ButtonGroup.stories.tsx
+++ b/packages/core/src/components/button/ButtonGroup.stories.tsx
@@ -21,9 +21,6 @@ const ALIGNMENT = [Alignment.START, Alignment.CENTER, Alignment.END];
 const meta: Meta<typeof ButtonGroup> = {
     title: "Core/Button/ButtonGroup",
     component: ButtonGroup,
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         variant: "solid",

--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -13,9 +13,6 @@ const meta: Meta<typeof Callout> = {
     title: "Core/Callout",
     component: Callout,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         children: "This is a callout with some informational content.",

--- a/packages/core/src/components/card-list/CardList.stories.tsx
+++ b/packages/core/src/components/card-list/CardList.stories.tsx
@@ -16,9 +16,6 @@ const meta: Meta<CardListStoryArgs> = {
     title: "Core/CardList",
     component: CardList,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         bordered: true,

--- a/packages/core/src/components/card/Card.stories.tsx
+++ b/packages/core/src/components/card/Card.stories.tsx
@@ -14,9 +14,6 @@ const meta: Meta<typeof Card> = {
     title: "Core/Card",
     component: Card,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         children: "Card content",

--- a/packages/core/src/components/collapse/Collapse.stories.tsx
+++ b/packages/core/src/components/collapse/Collapse.stories.tsx
@@ -30,9 +30,6 @@ const meta: Meta<typeof Collapse> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         isOpen: false,

--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -14,9 +14,6 @@ const meta: Meta<typeof CheckboxCard> = {
     title: "Core/Control Card/CheckboxCard",
     component: CheckboxCard,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Checkbox option",

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -14,9 +14,6 @@ const meta: Meta<typeof RadioCard> = {
     title: "Core/Control Card/RadioCard",
     component: RadioCard,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Radio option",

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -14,9 +14,6 @@ const meta: Meta<typeof SwitchCard> = {
     title: "Core/Control Card/SwitchCard",
     component: SwitchCard,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Switch option",

--- a/packages/core/src/components/dialog/Dialog.stories.tsx
+++ b/packages/core/src/components/dialog/Dialog.stories.tsx
@@ -25,7 +25,6 @@ const meta: Meta<typeof Dialog> = {
             </div>
         ),
     ],
-    tags: ["autodocs"],
     args: {
         title: "Dialog Title",
         isOpen: true,

--- a/packages/core/src/components/dialog/Dialog.stories.tsx
+++ b/packages/core/src/components/dialog/Dialog.stories.tsx
@@ -25,9 +25,6 @@ const meta: Meta<typeof Dialog> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         title: "Dialog Title",

--- a/packages/core/src/components/dialog/MultistepDialog.stories.tsx
+++ b/packages/core/src/components/dialog/MultistepDialog.stories.tsx
@@ -62,9 +62,6 @@ const meta: Meta<typeof MultistepDialog> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         title: "Multistep Dialog",

--- a/packages/core/src/components/dialog/MultistepDialog.stories.tsx
+++ b/packages/core/src/components/dialog/MultistepDialog.stories.tsx
@@ -62,7 +62,6 @@ const meta: Meta<typeof MultistepDialog> = {
             </div>
         ),
     ],
-    tags: ["autodocs"],
     args: {
         title: "Multistep Dialog",
         isOpen: true,

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -17,9 +17,6 @@ const meta: Meta<typeof Divider> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         compact: false,

--- a/packages/core/src/components/drawer/Drawer.stories.tsx
+++ b/packages/core/src/components/drawer/Drawer.stories.tsx
@@ -20,9 +20,6 @@ const meta: Meta<typeof Drawer> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         isOpen: true,

--- a/packages/core/src/components/drawer/Drawer.stories.tsx
+++ b/packages/core/src/components/drawer/Drawer.stories.tsx
@@ -20,7 +20,6 @@ const meta: Meta<typeof Drawer> = {
             </div>
         ),
     ],
-    tags: ["autodocs"],
     args: {
         isOpen: true,
         title: "Drawer Title",

--- a/packages/core/src/components/entity-title/EntityTitle.stories.tsx
+++ b/packages/core/src/components/entity-title/EntityTitle.stories.tsx
@@ -25,9 +25,6 @@ const meta: Meta<typeof EntityTitle> = {
     title: "Core/EntityTitle",
     component: EntityTitle,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         title: "Entity Title",

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -17,9 +17,6 @@ const meta: Meta<typeof Checkbox> = {
     title: "Core/Form/Controls/Checkbox",
     component: Checkbox,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Checkbox",

--- a/packages/core/src/components/forms/ControlGroup.stories.tsx
+++ b/packages/core/src/components/forms/ControlGroup.stories.tsx
@@ -14,9 +14,6 @@ const meta: Meta<typeof ControlGroup> = {
     title: "Core/Form/ControlGroup",
     component: ControlGroup,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         fill: false,

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -28,9 +28,6 @@ const meta: Meta<typeof FileInput> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         text: "Choose file...",

--- a/packages/core/src/components/forms/FormGroup.stories.tsx
+++ b/packages/core/src/components/forms/FormGroup.stories.tsx
@@ -37,9 +37,6 @@ const meta: Meta<typeof FormGroup> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Label",

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -29,9 +29,6 @@ const meta: Meta<typeof InputGroup> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         intent: "none",

--- a/packages/core/src/components/forms/Label.stories.tsx
+++ b/packages/core/src/components/forms/Label.stories.tsx
@@ -26,9 +26,6 @@ const meta: Meta<typeof Label> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
 } satisfies Meta<typeof Label>;
 

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -28,9 +28,6 @@ const meta: Meta<typeof NumericInput> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         intent: "none",

--- a/packages/core/src/components/forms/RadioGroup.stories.tsx
+++ b/packages/core/src/components/forms/RadioGroup.stories.tsx
@@ -19,9 +19,6 @@ const meta: Meta<typeof RadioGroup> = {
     title: "Core/Form/Controls/RadioGroup",
     component: RadioGroup,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Choose an option",

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -16,9 +16,6 @@ const meta: Meta<typeof Switch> = {
     title: "Core/Form/Controls/Switch",
     component: Switch,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         label: "Switch",

--- a/packages/core/src/components/link/Link.stories.tsx
+++ b/packages/core/src/components/link/Link.stories.tsx
@@ -19,9 +19,6 @@ const meta: Meta<typeof Link> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         children: "Blueprint Link",

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -31,9 +31,6 @@ const meta: Meta<typeof SegmentedControl> = {
     title: "Core/Form/Controls/SegmentedControl",
     component: SegmentedControl,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         options: DEFAULT_OPTIONS,

--- a/packages/core/src/components/skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/components/skeleton/Skeleton.stories.tsx
@@ -44,9 +44,6 @@ const meta: Meta<typeof SkeletonDemo> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         skeleton: true,

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -15,9 +15,6 @@ const meta: Meta<typeof Slider> = {
     title: "Core/Slider",
     component: Slider,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         min: 0,

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -13,9 +13,6 @@ const meta: Meta<typeof Spinner> = {
     title: "Core/Spinner",
     component: Spinner,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         intent: Intent.NONE,

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -22,9 +22,6 @@ const meta: Meta<typeof TagInput> = {
     title: "Core/Form/Inputs/TagInput",
     component: TagInput,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         values: INITIAL_VALUES,

--- a/packages/core/src/components/tag/CompoundTag.stories.tsx
+++ b/packages/core/src/components/tag/CompoundTag.stories.tsx
@@ -20,9 +20,6 @@ const meta: Meta<typeof CompoundTag> = {
     title: "Core/Tag/CompoundTag",
     component: CompoundTag,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         leftContent: "Key",

--- a/packages/core/src/components/tag/Tag.stories.tsx
+++ b/packages/core/src/components/tag/Tag.stories.tsx
@@ -19,9 +19,6 @@ const meta: Meta<typeof Tag> = {
     title: "Core/Tag/Tag",
     component: Tag,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         children: "Tag",

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -15,9 +15,6 @@ const meta: Meta<typeof Tooltip> = {
     title: "Core/Overlays/Tooltip",
     component: Tooltip,
     decorators: [storybookLayoutDecorator],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         content: "This is a tooltip",

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -132,9 +132,6 @@ const meta: Meta<typeof Tree> = {
             </div>
         ),
     ],
-    parameters: {
-        layout: "centered",
-    },
     tags: ["autodocs"],
     args: {
         contents: SAMPLE_CONTENTS,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^10.2.14
         version: 10.3.0(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/addon-docs':
+        specifier: ^10.2.14
+        version: 10.3.5(@types/react@18.3.12)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.7))
       '@storybook/addon-themes':
         specifier: ^10.2.14
         version: 10.3.4(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -2181,6 +2184,12 @@ packages:
     resolution: {integrity: sha512-VxP+PLlw62B14hP5g19RA6svqZHNN4J1P2eIzDpwQb2RNeBMuZMUveJMgiZVKF5nNjCh2mm4mKk11wcTr+v+vw==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': 18.3.12
+      react: '>=16'
+
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
@@ -2895,6 +2904,11 @@ packages:
     peerDependencies:
       storybook: ^10.3.0
 
+  '@storybook/addon-docs@10.3.5':
+    resolution: {integrity: sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==}
+    peerDependencies:
+      storybook: ^10.3.5
+
   '@storybook/addon-themes@10.3.4':
     resolution: {integrity: sha512-5734o52qtW8svu2vhKPncISWLr1FZrXZoN+u1q0BjTrbL6qTNE1AzIMCBEwn0TNdn16vC3ZsDJOj1dW4dD13cw==}
     peerDependencies:
@@ -2924,6 +2938,24 @@ packages:
       webpack:
         optional: true
 
+  '@storybook/csf-plugin@10.3.5':
+    resolution: {integrity: sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.5
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
@@ -2939,6 +2971,13 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.2.14
+
+  '@storybook/react-dom-shim@10.3.5':
+    resolution: {integrity: sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
 
   '@storybook/react-vite@10.2.14':
     resolution: {integrity: sha512-qfHkDjv0ElJFqhXN/uD+fuuMBVOI7xzJbMqLi9I4TKt4645B0P6X7s83oyLgU9y9xQEi4Dr2zSJq0VtNBe+VBg==}
@@ -3211,6 +3250,9 @@ packages:
 
   '@types/kss@3.0.4':
     resolution: {integrity: sha512-mwAQG3IFgl4s6PT1FyD4Ml6GyMl9E+uEwU2uasl+8VdgSbCweZHh1pKzyXnK01fyo0xMpPc0njLkxq5DfI5tcg==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -9658,6 +9700,12 @@ snapshots:
       - supports-color
       - typescript
 
+  '@mdx-js/react@3.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 18.3.12
+      react: 18.3.1
+
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
       '@emnapi/core': 1.6.0
@@ -10277,6 +10325,23 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  '@storybook/addon-docs@10.3.5(@types/react@18.3.12)(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.7))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.7))
+      '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/react-dom-shim': 10.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/addon-themes@10.3.4(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10303,6 +10368,16 @@ snapshots:
       vite: 7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.7)
 
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(rollup@4.60.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.7))':
+    dependencies:
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      rollup: 4.60.1
+      vite: 7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      webpack: 5.102.1(@swc/core@1.13.20)(esbuild@0.27.7)
+
   '@storybook/global@5.0.0': {}
 
   '@storybook/icons@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -10311,6 +10386,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/react-dom-shim@10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  '@storybook/react-dom-shim@10.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -10638,6 +10719,8 @@ snapshots:
       '@types/node': 24.12.2
 
   '@types/kss@3.0.4': {}
+
+  '@types/mdx@2.0.13': {}
 
   '@types/mime@1.3.5': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,9 +145,6 @@ importers:
       '@storybook/addon-themes':
         specifier: ^10.2.14
         version: 10.3.4(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@storybook/icons':
-        specifier: ^2.0.1
-        version: 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim':
         specifier: ^10.2.14
         version: 10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         version: 10.3.4(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-dom-shim':
         specifier: ^10.2.14
-        version: 10.2.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-vite':
         specifier: ^10.2.14
         version: 10.2.14(esbuild@0.27.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.2.14(@testing-library/dom@10.4.1)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)(vite@7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(webpack@5.102.1(@swc/core@1.13.20)(esbuild@0.27.7))


### PR DESCRIPTION
## Summary

- Add `@storybook/addon-docs` to the Storybook addons list so the Code panel and autodocs render
- Hoist `layout: "centered"` into the global preview config and drop per-story duplicates
- Drop unused `@storybook/icons` devDependency

**See:**
- https://storybook.js.org/docs/writing-docs
- https://storybook.js.org/addons/@storybook/addon-docs
- https://storybook.js.org/docs/writing-docs/code-panel

<img width="3456" alt="Screenshot 2026-04-17 at 12 20 06@2x" src="https://github.com/user-attachments/assets/6554e195-3244-4caf-895d-3176633943bb" />

<img width="3456" alt="Screenshot 2026-04-17 at 12 20 18@2x" src="https://github.com/user-attachments/assets/ee1bbaf1-7394-40d7-b9c1-87eaf23b07c5" />
