### PR TITLE
[chore] Fix clean scripts to fully remove build output directories

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -11,7 +11,7 @@
         "src"
     ],
     "scripts": {
-        "clean": "rm -rf lib",
+        "clean": "rm -rf coverage lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -11,7 +11,7 @@
         "src"
     ],
     "scripts": {
-        "clean": "rm -rf lib/* || true",
+        "clean": "rm -rf lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "scripts": {
         "build:tokens": "tsx src/design-tokens/build.ts",
         "build:sass": "sass-compile ./src",
-        "clean": "rm -rf dist/* || rm -rf lib/* || true",
+        "clean": "rm -rf dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "scripts": {
         "build:tokens": "tsx src/design-tokens/build.ts",
         "build:sass": "sass-compile ./src",
-        "clean": "rm -rf dist lib",
+        "clean": "rm -rf coverage dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "scripts": {
         "build:tokens": "tsx src/design-tokens/build.ts",
         "build:sass": "sass-compile ./src",
-        "clean": "rm -rf coverage dist lib src/design-tokens/build",
+        "clean": "rm -rf coverage lib src/design-tokens/build",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "scripts": {
         "build:tokens": "tsx src/design-tokens/build.ts",
         "build:sass": "sass-compile ./src",
-        "clean": "rm -rf coverage dist lib",
+        "clean": "rm -rf coverage dist lib src/design-tokens/build",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf coverage dist lib",
+        "clean": "rm -rf coverage lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist lib",
+        "clean": "rm -rf coverage dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* || rm -rf lib/* || true",
+        "clean": "rm -rf dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -15,7 +15,7 @@
         "src"
     ],
     "scripts": {
-        "clean": "rm -rf coverage dist lib",
+        "clean": "rm -rf coverage lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -15,7 +15,7 @@
         "src"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* || rm -rf lib/* || true",
+        "clean": "rm -rf dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -15,7 +15,7 @@
         "src"
     ],
     "scripts": {
-        "clean": "rm -rf dist lib",
+        "clean": "rm -rf coverage dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "bundle": "webpack",
         "bundle:analyze": "webpack --profile --json > dist/stats.json && webpack-bundle-analyzer dist/stats.json",
-        "clean": "rm -rf dist/* || true",
+        "clean": "rm -rf dist",
         "dev": "PORT=9002 webpack-dev-server",
         "dist": "NODE_ENV=production pnpm bundle",
         "lint": "run-p lint:scss lint:es",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "bundle": "webpack",
         "bundle:analyze": "webpack --profile --json > dist/stats.json && webpack-bundle-analyzer dist/stats.json",
-        "clean": "rm -rf dist/* || true",
+        "clean": "rm -rf dist",
         "dev": "webpack-dev-server",
         "dist": "NODE_ENV=production pnpm bundle",
         "lint": "run-p lint:scss lint:es",

--- a/packages/docs-data/package.json
+++ b/packages/docs-data/package.json
@@ -5,7 +5,7 @@
     "types": "src/index.d.ts",
     "private": true,
     "scripts": {
-        "clean": "rm -rf src/generated/* || true",
+        "clean": "rm -rf src/generated",
         "compile": "tsx ./compile-docs-data.mts",
         "test": "vitest run",
         "test:vitest": "vitest",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist lib",
+        "clean": "rm -rf coverage dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf coverage dist lib",
+        "clean": "rm -rf coverage lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* || rm -rf lib/* || true",
+        "clean": "rm -rf dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -4,7 +4,7 @@
     "description": "ESLint rules for use with @blueprintjs packages",
     "main": "lib/index.js",
     "scripts": {
-        "clean": "rm -rf lib/* || true",
+        "clean": "rm -rf lib",
         "compile": "tsc -p src/",
         "lint": "es-lint",
         "lint-fix": "es-lint --fix",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -16,7 +16,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist lib src/generated",
+        "clean": "rm -rf coverage dist lib src/generated",
         "compile": "npm-run-all -s \"icons:verify\" \"generate-icon-src\" -p \"compile:*\" -p \"copy:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -16,7 +16,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* || rm -rf lib/**/* || rm -rf src/generated/* || true",
+        "clean": "rm -rf dist lib src/generated",
         "compile": "npm-run-all -s \"icons:verify\" \"generate-icon-src\" -p \"compile:*\" -p \"copy:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -16,7 +16,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf coverage dist lib src/generated",
+        "clean": "rm -rf coverage lib src/generated",
         "compile": "npm-run-all -s \"icons:verify\" \"generate-icon-src\" -p \"compile:*\" -p \"copy:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -8,7 +8,7 @@
     "typings": "lib/esm/index.d.ts",
     "style": "lib/css/blueprint-labs.css",
     "scripts": {
-        "clean": "rm -rf lib/* || true",
+        "clean": "rm -rf lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src",
         "compile:cjs": "tsc -p ./src -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/landing-app/package.json
+++ b/packages/landing-app/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "scripts": {
         "bundle": "webpack",
-        "clean": "rm -rf dist/* || true",
+        "clean": "rm -rf dist",
         "dev": "webpack-dev-server",
         "dist": "NODE_ENV=production pnpm bundle",
         "lint": "run-p lint:scss lint:es",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf coverage dist lib",
+        "clean": "rm -rf coverage lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist lib",
+        "clean": "rm -rf coverage dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* || rm -rf lib/* || true",
+        "clean": "rm -rf dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -4,7 +4,7 @@
     "description": "Stylelint rules for use with @blueprintjs packages",
     "main": "lib/index.js",
     "scripts": {
-        "clean": "rm -rf lib/* || true",
+        "clean": "rm -rf lib",
         "compile": "tsc -p src/",
         "lint": "es-lint",
         "lint-fix": "es-lint --fix",

--- a/packages/table-dev-app/package.json
+++ b/packages/table-dev-app/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "scripts": {
         "bundle": "webpack",
-        "clean": "rm -rf dist/* || true",
+        "clean": "rm -rf dist",
         "dev": "webpack-dev-server",
         "dist": "NODE_ENV=production pnpm bundle",
         "lint": "npm-run-all -p lint:scss lint:es",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf coverage dist lib",
+        "clean": "rm -rf coverage lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist lib",
+        "clean": "rm -rf coverage dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -15,7 +15,7 @@
         "**/*.css"
     ],
     "scripts": {
-        "clean": "rm -rf dist/* || rm -rf lib/* || true",
+        "clean": "rm -rf dist lib",
         "compile": "run-p \"compile:*\"",
         "compile:esm": "tsc -p ./src/tsconfig.build.json",
         "compile:cjs": "tsc -p ./src/tsconfig.build.json -m commonjs --verbatimModuleSyntax false --outDir lib/cjs",

--- a/packages/test-commons/package.json
+++ b/packages/test-commons/package.json
@@ -34,7 +34,7 @@
     },
     "scripts": {
         "compile": "tsc -p ./src",
-        "clean": "rm -rf lib/* || true",
+        "clean": "rm -rf lib",
         "dev": "pnpm compile --watch",
         "lint": "run-p lint:es",
         "lint:es": "es-lint",

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "description": "TSLint configuration for @blueprintjs packages",
     "scripts": {
+        "clean": "rm -rf lib",
         "compile": "tsc -p ./src",
         "test": "tslint --rules-dir ./lib/rules --test test/rules/**/tslint.json"
     },


### PR DESCRIPTION
## Summary
The `||` chaining in these scripts short-circuited after the first `rm` succeeded, so later targets never ran and `lib/` folders piled up across the monorepo. Rewrote them as single `rm -rf` calls, and made them remove the directories themselves rather than just their contents so no empty folders stick around. Added `coverage/` cleanup to packages that already list it in `.npmignore`, and gave `tslint-config` a `clean` script (it didn't have one).

## Testing
- [x] `pnpm clean` from root: all `dist/`, `lib/`, `coverage/`, `src/generated/` dirs are removed across all packages
- [x] `pnpm compile` and `pnpm dist` still succeed after clean
