### PR TITLE
(chore) Create docs page for KeyComboTag

### DIFF
--- a/packages/core/src/components/hotkeys/key-combo-tag.mdx
+++ b/packages/core/src/components/hotkeys/key-combo-tag.mdx
@@ -1,0 +1,47 @@
+---
+title: Key Combo Tag
+---
+
+# Key Combo Tag
+
+**KeyComboTag** renders a keyboard shortcut combination as a styled visual element. Each key in the combo is displayed inside a `<kbd>` tag. Modifier keys display platform-aware icons on macOS (command, shift, control, option) and text labels on other platforms.
+
+## Usage
+
+```ts copy
+import { KeyComboTag } from "@blueprintjs/core";
+```
+
+```tsx
+<KeyComboTag combo="cmd + s" />
+```
+
+## Examples
+
+### Basic
+
+Pass a key combo string to the `combo` prop to render the shortcut. Each key is displayed inside a `<kbd>` tag, and modifier keys are rendered with icons on macOS.
+
+@reactCodeExample KeyComboTagBasicExample
+
+### Minimal
+
+Set `minimal={true}` to render a compact version without `<kbd>` wrapper styles. Modifier keys render as just an icon, and non-modifier keys render as plain text. This is useful when displaying key combos inline within text or in space-constrained layouts.
+
+@reactCodeExample KeyComboTagMinimalExample
+
+### Modifier keys
+
+Modifier keys like `cmd`, `ctrl`, `shift`, and `alt` display platform-specific icons on macOS. On non-Mac platforms, these render as text labels instead. The special `mod` alias resolves to `cmd` on macOS or `ctrl` on other platforms.
+
+@reactCodeExample KeyComboTagModifiersExample
+
+## Key combo tester
+
+Use the interactive tester below to press any key combination and see how it renders as both a standard and minimal KeyComboTag. See the [key combos documentation](#core/hooks/use-hotkeys.key-combos) for the full list of supported named keys, aliases, and modifier key syntax.
+
+@reactExample HotkeyTesterExample
+
+## Props interface
+
+@interface KeyComboTagProps

--- a/packages/docs-app/src/examples/core-examples/index.ts
+++ b/packages/docs-app/src/examples/core-examples/index.ts
@@ -53,6 +53,7 @@ export { HotkeyModifierExample } from "./hotkeyModifierExample";
 export { HotkeyTesterExample } from "./hotkeyTesterExample";
 export { HotkeysTargetExample } from "./hotkeysTargetExample";
 export { HTMLSelectExample } from "./htmlSelectExample";
+export * from "./keyComboTagExamples";
 export { IconExample } from "./iconExample";
 export { IconGeneratedComponentExample } from "./iconGeneratedComponentExample";
 export * from "./linkExamples";

--- a/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagBasic.tsx
+++ b/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagBasic.tsx
@@ -1,0 +1,11 @@
+import { KeyComboTag } from "@blueprintjs/core";
+
+export default function KeyComboTagBasic() {
+    return (
+        <div className="group">
+            <KeyComboTag combo="cmd + s" />
+            <KeyComboTag combo="ctrl + shift + z" />
+            <KeyComboTag combo="enter" />
+        </div>
+    );
+}

--- a/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagBasic.tsx.preview
+++ b/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagBasic.tsx.preview
@@ -1,0 +1,3 @@
+<KeyComboTag combo="cmd + s" />
+<KeyComboTag combo="ctrl + shift + z" />
+<KeyComboTag combo="enter" />

--- a/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagMinimal.tsx
+++ b/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagMinimal.tsx
@@ -1,0 +1,11 @@
+import { KeyComboTag } from "@blueprintjs/core";
+
+export default function KeyComboTagMinimal() {
+    return (
+        <div className="group">
+            <KeyComboTag combo="cmd + s" minimal={true} />
+            <KeyComboTag combo="ctrl + shift + z" minimal={true} />
+            <KeyComboTag combo="enter" minimal={true} />
+        </div>
+    );
+}

--- a/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagMinimal.tsx.preview
+++ b/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagMinimal.tsx.preview
@@ -1,0 +1,3 @@
+<KeyComboTag combo="cmd + s" minimal={true} />
+<KeyComboTag combo="ctrl + shift + z" minimal={true} />
+<KeyComboTag combo="enter" minimal={true} />

--- a/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagModifiers.tsx
+++ b/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagModifiers.tsx
@@ -1,0 +1,13 @@
+import { KeyComboTag } from "@blueprintjs/core";
+
+export default function KeyComboTagModifiers() {
+    return (
+        <div className="group">
+            <KeyComboTag combo="cmd" />
+            <KeyComboTag combo="ctrl" />
+            <KeyComboTag combo="shift" />
+            <KeyComboTag combo="alt" />
+            <KeyComboTag combo="mod + s" />
+        </div>
+    );
+}

--- a/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagModifiers.tsx.preview
+++ b/packages/docs-app/src/examples/core-examples/keyComboTag/KeyComboTagModifiers.tsx.preview
@@ -1,0 +1,5 @@
+<KeyComboTag combo="cmd" />
+<KeyComboTag combo="ctrl" />
+<KeyComboTag combo="shift" />
+<KeyComboTag combo="alt" />
+<KeyComboTag combo="mod + s" />

--- a/packages/docs-app/src/examples/core-examples/keyComboTagExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/keyComboTagExamples.tsx
@@ -1,0 +1,52 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";
+
+import KeyComboTagBasic from "./keyComboTag/KeyComboTagBasic";
+import keyComboTagBasicPreview from "./keyComboTag/KeyComboTagBasic.tsx.preview?raw";
+import keyComboTagBasicCode from "./keyComboTag/KeyComboTagBasic.tsx?raw";
+import KeyComboTagMinimal from "./keyComboTag/KeyComboTagMinimal";
+import keyComboTagMinimalPreview from "./keyComboTag/KeyComboTagMinimal.tsx.preview?raw";
+import keyComboTagMinimalCode from "./keyComboTag/KeyComboTagMinimal.tsx?raw";
+import KeyComboTagModifiers from "./keyComboTag/KeyComboTagModifiers";
+import keyComboTagModifiersPreview from "./keyComboTag/KeyComboTagModifiers.tsx.preview?raw";
+import keyComboTagModifiersCode from "./keyComboTag/KeyComboTagModifiers.tsx?raw";
+
+export const KeyComboTagBasicExample: React.FC<ExampleProps> = props => {
+    return (
+        <CodeExample
+            previewCode={keyComboTagBasicPreview}
+            sourceCode={keyComboTagBasicCode}
+            {...props}
+        >
+            <KeyComboTagBasic />
+        </CodeExample>
+    );
+};
+
+export const KeyComboTagMinimalExample: React.FC<ExampleProps> = props => {
+    return (
+        <CodeExample
+            previewCode={keyComboTagMinimalPreview}
+            sourceCode={keyComboTagMinimalCode}
+            {...props}
+        >
+            <KeyComboTagMinimal />
+        </CodeExample>
+    );
+};
+
+export const KeyComboTagModifiersExample: React.FC<ExampleProps> = props => {
+    return (
+        <CodeExample
+            previewCode={keyComboTagModifiersPreview}
+            sourceCode={keyComboTagModifiersCode}
+            {...props}
+        >
+            <KeyComboTagModifiers />
+        </CodeExample>
+    );
+};

--- a/packages/docs-data/nav.json
+++ b/packages/docs-data/nav.json
@@ -25,6 +25,7 @@
                     "html-table",
                     "hotkeys-target",
                     "icon",
+                    "key-combo-tag",
                     "link",
                     "menu",
                     "navbar",


### PR DESCRIPTION
#### FLUP to [[core] Add Storybook stories for KeyComboTag](https://github.com/palantir/blueprint/pull/7951#top)

### Changes proposed in this pull request:
I realized while working on the above-linked `story` that we were missing a proper docs page, with a visual depiction of `KeyComboTag`

### Visual changes
<img width="1321" height="831" alt="Screenshot 2026-04-17 at 4 17 24 PM" src="https://github.com/user-attachments/assets/3ee1cc55-a9e0-4a50-a617-b03182cdd5ad" />
