### PR TITLE
(chore) migrate Storybook to <Flex> usage

### DIFF
--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 import React from "react";
 
@@ -70,7 +71,7 @@ export const CollapseFromExample: Story = {
         collapseFrom: { table: { disable: true } },
     },
     render: ({ width, ...args }) => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={4} alignItems="start">
             <div style={{ width }}>
                 <StoryLabel title="Collapse from start (default)" />
                 <Breadcrumbs {...args} collapseFrom={Boundary.START} />
@@ -79,7 +80,7 @@ export const CollapseFromExample: Story = {
                 <StoryLabel title="Collapse from end" />
                 <Breadcrumbs {...args} collapseFrom={Boundary.END} />
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -89,7 +90,7 @@ export const CollapseFromExample: Story = {
 export const OverflowExample: Story = {
     name: "Overflow",
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <div>
                 <StoryLabel title="Constrained width (300px)" />
                 <div style={{ width: 300 }}>
@@ -102,7 +103,7 @@ export const OverflowExample: Story = {
                     <Breadcrumbs {...args} />
                 </div>
             </div>
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/core/src/components/breadcrumbs/Breadcrumbs.stories.tsx
@@ -3,9 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 import React from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Boundary } from "../../common/boundary";
 

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -3,8 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
 

--- a/packages/core/src/components/button/Button.stories.tsx
+++ b/packages/core/src/components/button/Button.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
@@ -119,7 +120,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8 }}>
+        <Flex gap={2}>
             {Object.values(Intent)
                 .filter(i => i !== "none")
                 .map(intent => (
@@ -130,7 +131,7 @@ export const IntentExample: Story = {
                         text={intent.charAt(0).toUpperCase() + intent.slice(1)}
                     />
                 ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -144,7 +145,7 @@ export const VariantExample: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8 }}>
+        <Flex gap={2}>
             {Object.values(ButtonVariant).map(variant => (
                 <Button
                     key={variant}
@@ -153,7 +154,7 @@ export const VariantExample: Story = {
                     text={variant.charAt(0).toUpperCase() + variant.slice(1)}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -166,11 +167,11 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Flex gap={2} alignItems="center">
             {Object.values(Size).map(size => (
                 <Button key={size} {...args} size={size} text={size.charAt(0).toUpperCase() + size.slice(1)} />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -185,12 +186,12 @@ export const StateExample: Story = {
         loading: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8 }}>
+        <Flex gap={2}>
             <Button {...args} text="Default" />
             <Button {...args} active={true} text="Active" />
             <Button {...args} disabled={true} text="Disabled" />
             <Button {...args} loading={true} text="Loading" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -204,12 +205,12 @@ export const IconExample: Story = {
         endIcon: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8 }}>
+        <Flex gap={2}>
             <Button {...args} icon="refresh" text="Reset" />
             <Button {...args} icon="user" endIcon="caret-down" text="Profile" />
             <Button {...args} endIcon="arrow-right" text="Next" />
             <Button {...args} icon="edit" text={undefined} aria-label="edit" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -222,7 +223,7 @@ export const AlignmentExample: Story = {
         alignText: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+        <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
             {Object.values(Alignment).map(alignment => (
                 <Button
                     key={alignment}
@@ -233,7 +234,7 @@ export const AlignmentExample: Story = {
                     text={alignment.charAt(0).toUpperCase() + alignment.slice(1)}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -253,10 +254,10 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <Flex flexDirection="column" gap={2}>
             <Button {...args} fill={true} text="Full Width" />
             <Button {...args} fill={false} text="Auto Width" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -272,16 +273,16 @@ export const AllIntentsAllVariants: Story = {
         loading: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             {Object.values(ButtonVariant).map(variant => (
-                <div key={variant} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Flex key={variant} flexDirection="column" gap={2}>
                     <StoryLabel title={variant} />
-                    <div style={{ display: "flex", gap: 8 }}>
+                    <Flex gap={2}>
                         {Object.values(Intent).map(intent => (
                             <Button key={intent} {...args} variant={variant} intent={intent} text={intent} />
                         ))}
-                    </div>
-                    <div style={{ display: "flex", gap: 8 }}>
+                    </Flex>
+                    <Flex gap={2}>
                         {Object.values(Intent).map(intent => (
                             <Button
                                 key={intent}
@@ -292,8 +293,8 @@ export const AllIntentsAllVariants: Story = {
                                 text={intent}
                             />
                         ))}
-                    </div>
-                    <div style={{ display: "flex", gap: 8 }}>
+                    </Flex>
+                    <Flex gap={2}>
                         {Object.values(Intent).map(intent => (
                             <Button
                                 key={intent}
@@ -304,8 +305,8 @@ export const AllIntentsAllVariants: Story = {
                                 text={intent}
                             />
                         ))}
-                    </div>
-                    <div style={{ display: "flex", gap: 8 }}>
+                    </Flex>
+                    <Flex gap={2}>
                         {Object.values(Intent).map(intent => (
                             <Button
                                 key={intent}
@@ -316,10 +317,10 @@ export const AllIntentsAllVariants: Story = {
                                 text={intent}
                             />
                         ))}
-                    </div>
-                </div>
+                    </Flex>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/button/ButtonGroup.stories.tsx
+++ b/packages/core/src/components/button/ButtonGroup.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
 import { Popover } from "../popover/popover";
@@ -90,18 +91,18 @@ export const VariantExample: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 50, alignItems: "center" }}>
+        <Flex gap={10} alignItems="center">
             {Object.values(ButtonVariant).map(variant => (
-                <div key={variant} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Flex key={variant} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={variant} />
                     <ButtonGroup {...args} variant={variant}>
                         <Button text="First" />
                         <Button text="Second" />
                         <Button text="Third" />
                     </ButtonGroup>
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -114,18 +115,18 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 50, alignItems: "center" }}>
+        <Flex gap={10} alignItems="center">
             {Object.values(Size).map(size => (
-                <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Flex key={size} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={size} />
                     <ButtonGroup {...args} size={size}>
                         <Button text="First" />
                         <Button text="Second" />
                         <Button text="Third" />
                     </ButtonGroup>
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -145,24 +146,24 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={5}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="fill={true}" />
                 <ButtonGroup {...args} fill={true}>
                     <Button text="First" />
                     <Button text="Second" />
                     <Button text="Third" />
                 </ButtonGroup>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="fill={false}" />
                 <ButtonGroup {...args} fill={false}>
                     <Button text="First" />
                     <Button text="Second" />
                     <Button text="Third" />
                 </ButtonGroup>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -175,24 +176,24 @@ export const VerticalExample: Story = {
         vertical: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 24, alignItems: "start" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex gap={6} alignItems="start">
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="horizontal" />
                 <ButtonGroup {...args} vertical={false}>
                     <Button text="First" />
                     <Button text="Second" />
                     <Button text="Third" />
                 </ButtonGroup>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="vertical" />
                 <ButtonGroup {...args} vertical={true}>
                     <Button text="First" />
                     <Button text="Second" />
                     <Button text="Third" />
                 </ButtonGroup>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -213,18 +214,18 @@ export const AlignmentExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 25 }}>
+        <Flex flexDirection="column" gap={6}>
             {Object.values(ALIGNMENT).map(alignment => (
-                <div key={alignment} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                <Flex key={alignment} flexDirection="column" gap={1}>
                     <StoryLabel title={alignment} />
                     <ButtonGroup {...args} alignText={alignment} fill={true}>
                         <Button text="First" />
                         <Button text="Second" />
                         <Button text="Third" />
                     </ButtonGroup>
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -236,9 +237,9 @@ export const AllIntentsAllVariants: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "row", gap: 50 }}>
+        <Flex flexDirection="row" gap={10}>
             {Object.values(ButtonVariant).map(variant => (
-                <div key={variant} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Flex key={variant} flexDirection="column" gap={2}>
                     <StoryLabel title={variant} />
                     {Object.values(Intent).map(intent => (
                         <ButtonGroup key={intent} {...args} variant={variant}>
@@ -247,9 +248,9 @@ export const AllIntentsAllVariants: Story = {
                             <Button intent={intent} text={intent} />
                         </ButtonGroup>
                     ))}
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -268,12 +269,9 @@ export const WithPopover: Story = {
         ] as const;
 
         return (
-            <div style={{ display: "flex", gap: 50, alignItems: "center" }}>
+            <Flex gap={10} alignItems="center">
                 {Object.values(ButtonVariant).map(variant => (
-                    <div
-                        key={variant}
-                        style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}
-                    >
+                    <Flex key={variant} flexDirection="column" gap={1} alignItems="center">
                         <StoryLabel title={variant} />
                         <ButtonGroup {...args} variant={variant}>
                             {BUTTONS.map(({ icon, label }) => (
@@ -286,9 +284,9 @@ export const WithPopover: Story = {
                                 </Popover>
                             ))}
                         </ButtonGroup>
-                    </div>
+                    </Flex>
                 ))}
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/button/ButtonGroup.stories.tsx
+++ b/packages/core/src/components/button/ButtonGroup.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
+
 import { Flex } from "@blueprintjs/labs";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";

--- a/packages/core/src/components/button/ButtonGroup.stories.tsx
+++ b/packages/core/src/components/button/ButtonGroup.stories.tsx
@@ -92,7 +92,7 @@ export const VariantExample: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <Flex gap={10} alignItems="center">
+        <Flex gap={10} alignItems="center" style={{ gap: 50 }}>
             {Object.values(ButtonVariant).map(variant => (
                 <Flex key={variant} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={variant} />
@@ -116,7 +116,7 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <Flex gap={10} alignItems="center">
+        <Flex gap={10} alignItems="center" style={{ gap: 50 }}>
             {Object.values(Size).map(size => (
                 <Flex key={size} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={size} />
@@ -238,7 +238,7 @@ export const AllIntentsAllVariants: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="row" gap={10}>
+        <Flex flexDirection="row" gap={10} style={{ gap: 50 }}>
             {Object.values(ButtonVariant).map(variant => (
                 <Flex key={variant} flexDirection="column" gap={2}>
                     <StoryLabel title={variant} />
@@ -270,7 +270,7 @@ export const WithPopover: Story = {
         ] as const;
 
         return (
-            <Flex gap={10} alignItems="center">
+            <Flex gap={10} alignItems="center" style={{ gap: 50 }}>
                 {Object.values(ButtonVariant).map(variant => (
                     <Flex key={variant} flexDirection="column" gap={1} alignItems="center">
                         <StoryLabel title={variant} />

--- a/packages/core/src/components/button/ButtonGroup.stories.tsx
+++ b/packages/core/src/components/button/ButtonGroup.stories.tsx
@@ -89,7 +89,7 @@ export const VariantExample: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <Flex gap={10} alignItems="center" style={{ gap: 50 }}>
+        <Flex gap={10} alignItems="center">
             {Object.values(ButtonVariant).map(variant => (
                 <Flex key={variant} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={variant} />
@@ -113,7 +113,7 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <Flex gap={10} alignItems="center" style={{ gap: 50 }}>
+        <Flex gap={10} alignItems="center">
             {Object.values(Size).map(size => (
                 <Flex key={size} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={size} />
@@ -235,7 +235,7 @@ export const AllIntentsAllVariants: Story = {
         variant: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="row" gap={10} style={{ gap: 50 }}>
+        <Flex flexDirection="row" gap={10}>
             {Object.values(ButtonVariant).map(variant => (
                 <Flex key={variant} flexDirection="column" gap={2}>
                     <StoryLabel title={variant} />
@@ -267,7 +267,7 @@ export const WithPopover: Story = {
         ] as const;
 
         return (
-            <Flex gap={10} alignItems="center" style={{ gap: 50 }}>
+            <Flex gap={10} alignItems="center">
                 {Object.values(ButtonVariant).map(variant => (
                     <Flex key={variant} flexDirection="column" gap={1} alignItems="center">
                         <StoryLabel title={variant} />

--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+
 import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";

--- a/packages/core/src/components/callout/Callout.stories.tsx
+++ b/packages/core/src/components/callout/Callout.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 
@@ -67,13 +68,13 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <Flex flexDirection="column" gap={2}>
             {Object.values(Intent).map(intent => (
                 <Callout key={intent} {...args} intent={intent}>
                     {intent.charAt(0).toUpperCase() + intent.slice(1)} intent callout.
                 </Callout>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -86,20 +87,20 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={4}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Default" />
                 <Callout {...args} minimal={false}>
                     Default callout with background fill.
                 </Callout>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Minimal" />
                 <Callout {...args} minimal={true}>
                     Minimal callout without background fill.
                 </Callout>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -112,20 +113,20 @@ export const CompactExample: Story = {
         compact: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={4}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Default" />
                 <Callout {...args} compact={false}>
                     Default padding callout.
                 </Callout>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Compact" />
                 <Callout {...args} compact={true}>
                     Compact padding callout.
                 </Callout>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -139,7 +140,7 @@ export const IconExample: Story = {
         icon: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <Flex flexDirection="column" gap={2}>
             <Callout {...args} icon="home">
                 Custom icon callout.
             </Callout>
@@ -149,7 +150,7 @@ export const IconExample: Story = {
             <Callout {...args} intent="primary" icon={null}>
                 Intent with icon explicitly hidden.
             </Callout>
-        </div>
+        </Flex>
     ),
 };
 
@@ -162,9 +163,9 @@ export const AllIntentsAllVariants: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             {[false, true].map(minimal => (
-                <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Flex key={String(minimal)} flexDirection="column" gap={2}>
                     <StoryLabel title={minimal ? "Minimal" : "Default"} />
                     <Callout {...args} minimal={minimal}>
                         No intent callout.
@@ -174,9 +175,9 @@ export const AllIntentsAllVariants: Story = {
                             {intent.charAt(0).toUpperCase() + intent.slice(1)} intent callout content.
                         </Callout>
                     ))}
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/card-list/CardList.stories.tsx
+++ b/packages/core/src/components/card-list/CardList.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 import { useArgs, useCallback } from "storybook/preview-api";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Card } from "../card/card";
 
 import { CardList } from "./cardList";
@@ -58,32 +60,32 @@ export const StateExample: Story = {
         compact: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 24 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+        <Flex gap={6}>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Bordered" />
                 <CardList {...args} bordered={true} compact={false}>
                     <Card>Plain</Card>
                     <Card interactive={true}>Interactive</Card>
                     <Card selected={true}>Selected</Card>
                 </CardList>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Compact" />
                 <CardList {...args} bordered={true} compact={true}>
                     <Card>Plain</Card>
                     <Card interactive={true}>Interactive</Card>
                     <Card selected={true}>Selected</Card>
                 </CardList>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Not bordered" />
                 <CardList {...args} bordered={false} compact={false}>
                     <Card>Plain</Card>
                     <Card interactive={true}>Interactive</Card>
                     <Card selected={true}>Selected</Card>
                 </CardList>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -96,11 +98,11 @@ export const AllConfigurations: Story = {
         compact: { table: { disable: true } },
     },
     render: () => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+        <Flex flexDirection="column" gap={6}>
             {[false, true].map(compact => (
-                <div key={String(compact)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Flex key={String(compact)} flexDirection="column" gap={2}>
                     <StoryLabel title={compact ? "Compact" : "Default"} />
-                    <div style={{ display: "flex", gap: 16 }}>
+                    <Flex gap={4}>
                         {[true, false].map(bordered => (
                             <CardList key={String(bordered)} bordered={bordered} compact={compact}>
                                 <Card>Plain</Card>
@@ -108,10 +110,10 @@ export const AllConfigurations: Story = {
                                 <Card selected={true}>Selected</Card>
                             </CardList>
                         ))}
-                    </div>
-                </div>
+                    </Flex>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/card/Card.stories.tsx
+++ b/packages/core/src/components/card/Card.stories.tsx
@@ -3,8 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Elevation } from "../../common";
 import { H3 } from "../html/html";

--- a/packages/core/src/components/card/Card.stories.tsx
+++ b/packages/core/src/components/card/Card.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 
 import { Elevation } from "../../common";
@@ -64,14 +65,14 @@ export const ElevationExample: Story = {
         elevation: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16 }}>
+        <Flex gap={4}>
             {Object.values(Elevation).map(elevation => (
                 <Card key={elevation} {...args} elevation={elevation} style={{ width: 140, padding: 16 }}>
                     <StoryLabel title="Elevation" />
                     {elevation}
                 </Card>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -86,7 +87,7 @@ export const StateExample: Story = {
         compact: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+        <Flex gap={4} alignItems="start">
             <Card {...args} style={{ width: 140, padding: 16 }}>
                 Default
             </Card>
@@ -99,7 +100,7 @@ export const StateExample: Story = {
             <Card {...args} compact={true} style={{ width: 140 }}>
                 Compact
             </Card>
-        </div>
+        </Flex>
     ),
 };
 
@@ -141,11 +142,11 @@ export const Compact: Story = {
  */
 export const AllElevationsAllStates: Story = {
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             {(["Default", "Interactive", "Selected", "Compact"] as const).map(state => (
                 <div key={state}>
                     <StoryLabel title={state} />
-                    <div style={{ display: "flex", gap: 16 }}>
+                    <Flex gap={4}>
                         {Object.values(Elevation).map(elevation => (
                             <Card
                                 key={elevation}
@@ -159,10 +160,10 @@ export const AllElevationsAllStates: Story = {
                                 Elev {elevation}
                             </Card>
                         ))}
-                    </div>
+                    </Flex>
                 </div>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/collapse/Collapse.stories.tsx
+++ b/packages/core/src/components/collapse/Collapse.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useCallback } from "react";
 import { useArgs } from "storybook/preview-api";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Button } from "../button/buttons";
 import { Code, H4 } from "../html/html";
 
@@ -25,9 +27,9 @@ const meta: Meta<typeof Collapse> = {
     component: Collapse,
     decorators: [
         Story => (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: "400px", maxWidth: "500px" }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: "400px", maxWidth: "500px" }}>
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -74,10 +76,10 @@ export const Default: Story = {
         const handleToggle = useCallback(() => updateArgs({ isOpen: !args.isOpen }), [args.isOpen, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <Flex flexDirection="column" gap={2}>
                 <Button text={args.isOpen ? "Hide content" : "Show content"} onClick={handleToggle} />
                 <Collapse {...args}>{sampleContent}</Collapse>
-            </div>
+            </Flex>
         );
     },
 };
@@ -97,7 +99,7 @@ export const Playground: Story = {
         const handleToggle = useCallback(() => updateArgs({ isOpen: !args.isOpen }), [args.isOpen, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 400 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 400 }}>
                 <Button text={args.isOpen ? "Collapse" : "Expand"} onClick={handleToggle} icon="exchange" />
                 <Collapse {...args}>
                     <div
@@ -119,7 +121,7 @@ export const Playground: Story = {
                         </p>
                     </div>
                 </Collapse>
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/control-card/CheckboxCard.stories.tsx
+++ b/packages/core/src/components/control-card/CheckboxCard.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
 import { useArgs, useCallback } from "storybook/preview-api";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Alignment, Elevation } from "../../common";
 
 import { CheckboxCard } from "./checkboxCard";
@@ -85,10 +87,10 @@ export const CompactExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <CheckboxCard {...args} label="Default" defaultChecked={true} onChange={handleChange} />
                 <CheckboxCard {...args} compact={true} label="Compact" defaultChecked={true} onChange={handleChange} />
-            </div>
+            </Flex>
         );
     },
 };
@@ -107,7 +109,7 @@ export const StateExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <CheckboxCard {...args} label="Default" onChange={handleChange} />
                 <CheckboxCard {...args} label="Checked" checked={true} onChange={handleChange} />
                 <CheckboxCard {...args} label="Disabled" disabled={true} />
@@ -119,7 +121,7 @@ export const StateExample: Story = {
                     showAsSelectedWhenChecked={false}
                     onChange={handleChange}
                 />
-            </div>
+            </Flex>
         );
     },
 };
@@ -137,7 +139,7 @@ export const AlignIndicatorExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <CheckboxCard
                     {...args}
                     alignIndicator={Alignment.START}
@@ -152,7 +154,7 @@ export const AlignIndicatorExample: Story = {
                     defaultChecked={true}
                     onChange={handleChange}
                 />
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/control-card/RadioCard.stories.tsx
+++ b/packages/core/src/components/control-card/RadioCard.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
 import { useArgs, useCallback } from "storybook/preview-api";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Alignment, Elevation } from "../../common";
 
 import { RadioCard } from "./radioCard";
@@ -84,10 +86,10 @@ export const CompactExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <RadioCard {...args} label="Default" defaultChecked={true} onChange={handleChange} />
                 <RadioCard {...args} compact={true} label="Compact" defaultChecked={true} onChange={handleChange} />
-            </div>
+            </Flex>
         );
     },
 };
@@ -103,13 +105,13 @@ export const StateExample: Story = {
     },
     render: function RenderState(args) {
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <RadioCard {...args} label="Default" />
                 <RadioCard {...args} label="Checked" checked={true} />
                 <RadioCard {...args} label="Disabled" disabled={true} />
                 <RadioCard {...args} label="Disabled Checked" disabled={true} checked={true} />
                 <RadioCard {...args} label="No selected styling" checked={true} showAsSelectedWhenChecked={false} />
-            </div>
+            </Flex>
         );
     },
 };
@@ -127,7 +129,7 @@ export const AlignIndicatorExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <RadioCard
                     {...args}
                     alignIndicator={Alignment.START}
@@ -142,7 +144,7 @@ export const AlignIndicatorExample: Story = {
                     defaultChecked={true}
                     onChange={handleChange}
                 />
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { useArgs, useCallback } from "storybook/preview-api";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Alignment, Elevation } from "../../common";
 

--- a/packages/core/src/components/control-card/SwitchCard.stories.tsx
+++ b/packages/core/src/components/control-card/SwitchCard.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { useArgs, useCallback } from "storybook/preview-api";
 
 import { Alignment, Elevation } from "../../common";
@@ -84,10 +85,10 @@ export const CompactExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <SwitchCard {...args} label="Default" defaultChecked={true} onChange={handleChange} />
                 <SwitchCard {...args} compact={true} label="Compact" defaultChecked={true} onChange={handleChange} />
-            </div>
+            </Flex>
         );
     },
 };
@@ -106,7 +107,7 @@ export const StateExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <SwitchCard {...args} label="Default" onChange={handleChange} />
                 <SwitchCard {...args} label="Checked" checked={true} onChange={handleChange} />
                 <SwitchCard {...args} label="Disabled" disabled={true} />
@@ -118,7 +119,7 @@ export const StateExample: Story = {
                     showAsSelectedWhenChecked={false}
                     onChange={handleChange}
                 />
-            </div>
+            </Flex>
         );
     },
 };
@@ -136,7 +137,7 @@ export const AlignIndicatorExample: Story = {
         const handleChange = useCallback(() => updateArgs({ checked: !args.checked }), [args.checked, updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, minWidth: 300 }}>
+            <Flex flexDirection="column" gap={2} style={{ minWidth: 300 }}>
                 <SwitchCard
                     {...args}
                     alignIndicator={Alignment.START}
@@ -151,7 +152,7 @@ export const AlignIndicatorExample: Story = {
                     defaultChecked={true}
                     onChange={handleChange}
                 />
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/dialog/Dialog.stories.tsx
+++ b/packages/core/src/components/dialog/Dialog.stories.tsx
@@ -5,6 +5,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useArgs, useCallback } from "storybook/preview-api";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Button } from "../button/buttons";
 
 import { Dialog } from "./dialog";
@@ -20,9 +22,9 @@ const meta: Meta<typeof Dialog> = {
     component: Dialog,
     decorators: [
         Story => (
-            <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+            <Flex justifyContent="center" alignItems="center">
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {

--- a/packages/core/src/components/dialog/MultistepDialog.stories.tsx
+++ b/packages/core/src/components/dialog/MultistepDialog.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import React from "react";
 import { useArgs, useCallback } from "storybook/preview-api";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Button } from "../button/buttons";
 
 import { DialogBody } from "./dialogBody";
@@ -57,9 +59,9 @@ const meta: Meta<typeof MultistepDialog> = {
     component: MultistepDialog,
     decorators: [
         Story => (
-            <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minWidth: "300px" }}>
+            <Flex justifyContent="center" alignItems="center" style={{ minWidth: "300px" }}>
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
 
 import { Divider } from "./divider";
@@ -44,7 +45,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     name: "Default",
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: "3em" }}>
+        <Flex flexDirection="column" gap={10}>
             <div>
                 Content above
                 <Divider {...args} />
@@ -56,7 +57,7 @@ export const Default: Story = {
                 <Divider {...args} />
                 Content below, text center-aligned
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -65,19 +66,19 @@ export const Default: Story = {
  */
 export const Vertical: Story = {
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: "3em" }}>
-            <div style={{ display: "flex" }}>
+        <Flex flexDirection="column" gap={10}>
+            <Flex>
                 Content to the left that wraps around a bit more than you'd expect
                 <Divider {...args} />
                 Content to the right that also wraps around a bit more than you'd expect
-            </div>
+            </Flex>
 
-            <div style={{ display: "flex", textAlign: "center" }}>
+            <Flex style={{ textAlign: "center" }}>
                 Content above, text center-aligned
                 <Divider {...args} />
                 Content below, text center-aligned
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -91,20 +92,20 @@ export const CompactExample: Story = {
         compact: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: "3em" }}>
-            <div style={{ display: "flex", flexDirection: "column", textAlign: "center" }}>
+        <Flex flexDirection="column" gap={10}>
+            <Flex flexDirection="column" style={{ textAlign: "center" }}>
                 <StoryLabel title="Default" />
                 Above
                 <Divider {...args} compact={false} />
                 Below
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", textAlign: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" style={{ textAlign: "center" }}>
                 <StoryLabel title="Compact" />
                 Above
                 <Divider {...args} compact={true} />
                 Below
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -114,11 +115,11 @@ export const CompactExample: Story = {
 export const Playground: Story = {
     decorators: [
         Story => (
-            <div style={{ display: "flex", flexDirection: "column" }}>
+            <Flex flexDirection="column">
                 Content above
                 <Story />
                 Content below
-            </div>
+            </Flex>
         ),
     ],
     args: {

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -43,7 +43,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     name: "Default",
     render: args => (
-        <Flex flexDirection="column" gap={10} style={{ gap: "3em" }}>
+        <Flex flexDirection="column" gap={10}>
             <div>
                 Content above
                 <Divider {...args} />
@@ -64,7 +64,7 @@ export const Default: Story = {
  */
 export const Vertical: Story = {
     render: args => (
-        <Flex flexDirection="column" gap={10} style={{ gap: "3em" }}>
+        <Flex flexDirection="column" gap={10}>
             <Flex>
                 Content to the left that wraps around a bit more than you'd expect
                 <Divider {...args} />
@@ -90,7 +90,7 @@ export const CompactExample: Story = {
         compact: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="column" gap={10} style={{ gap: "3em" }}>
+        <Flex flexDirection="column" gap={10}>
             <Flex flexDirection="column" style={{ textAlign: "center" }}>
                 <StoryLabel title="Default" />
                 Above

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -3,8 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Divider } from "./divider";
 

--- a/packages/core/src/components/divider/Divider.stories.tsx
+++ b/packages/core/src/components/divider/Divider.stories.tsx
@@ -46,7 +46,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
     name: "Default",
     render: args => (
-        <Flex flexDirection="column" gap={10}>
+        <Flex flexDirection="column" gap={10} style={{ gap: "3em" }}>
             <div>
                 Content above
                 <Divider {...args} />
@@ -67,7 +67,7 @@ export const Default: Story = {
  */
 export const Vertical: Story = {
     render: args => (
-        <Flex flexDirection="column" gap={10}>
+        <Flex flexDirection="column" gap={10} style={{ gap: "3em" }}>
             <Flex>
                 Content to the left that wraps around a bit more than you'd expect
                 <Divider {...args} />
@@ -93,7 +93,7 @@ export const CompactExample: Story = {
         compact: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="column" gap={10}>
+        <Flex flexDirection="column" gap={10} style={{ gap: "3em" }}>
             <Flex flexDirection="column" style={{ textAlign: "center" }}>
                 <StoryLabel title="Default" />
                 Above

--- a/packages/core/src/components/drawer/Drawer.stories.tsx
+++ b/packages/core/src/components/drawer/Drawer.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { useArgs, useCallback, useState } from "storybook/preview-api";
 
 import { Position } from "../../common";
@@ -15,9 +16,9 @@ const meta: Meta<typeof Drawer> = {
     component: Drawer,
     decorators: [
         Story => (
-            <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+            <Flex justifyContent="center" alignItems="center">
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -226,9 +227,9 @@ export const Playground: Story = {
                         </div>
                     </div>
                     <div className="bp6-drawer-footer">
-                        <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                        <Flex gap={2} justifyContent="end">
                             <Button onClick={handleClose}>Close</Button>
-                        </div>
+                        </Flex>
                     </div>
                 </Drawer>
             </>

--- a/packages/core/src/components/drawer/Drawer.stories.tsx
+++ b/packages/core/src/components/drawer/Drawer.stories.tsx
@@ -3,8 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { useArgs, useCallback, useState } from "storybook/preview-api";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Position } from "../../common";
 import { Button } from "../button/buttons";

--- a/packages/core/src/components/entity-title/EntityTitle.stories.tsx
+++ b/packages/core/src/components/entity-title/EntityTitle.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DashedPaddedContainer, storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 
 import { Colors } from "@blueprintjs/colors";
+import { Flex } from "@blueprintjs/labs";
 
 import { H1, H2, H3, H4, H5, H6 } from "../html/html";
 import { Tag } from "../tag/tag";
@@ -90,12 +91,12 @@ export const HeadingsExample: Story = {
         title: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+        <Flex flexDirection="column" gap={5}>
             {HEADINGS.map(({ heading, label }) => (
                 <EntityTitle key={label} {...args} icon="document" title={`Heading ${label}`} heading={heading} />
             ))}
             <EntityTitle {...args} icon="document" title="Default (no heading)" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -108,12 +109,12 @@ export const IconExample: Story = {
         title: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <Flex flexDirection="column" gap={3}>
             <EntityTitle {...args} icon="document" title="Document" />
             <EntityTitle {...args} icon="folder-close" title="Folder" />
             <EntityTitle {...args} icon="user" title="User" />
             <EntityTitle {...args} icon={undefined} title="No icon" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -127,7 +128,7 @@ export const FillExample: Story = {
         title: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <div>
                 <StoryLabel title="Fill enabled" />
                 <DashedPaddedContainer>
@@ -144,7 +145,7 @@ export const FillExample: Story = {
                     </div>
                 </DashedPaddedContainer>
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -159,13 +160,13 @@ export const EllipsizeExample: Story = {
     },
     decorators: [
         Story => (
-            <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+            <Flex justifyContent="center" alignItems="center">
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <div>
                 <StoryLabel title="Ellipsize enabled" />
                 <DashedPaddedContainer width={250}>
@@ -188,7 +189,7 @@ export const EllipsizeExample: Story = {
                     />
                 </DashedPaddedContainer>
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -202,7 +203,7 @@ export const LoadingExample: Story = {
         title: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <div>
                 <StoryLabel title="Loading" />
                 <DashedPaddedContainer width={250}>
@@ -215,7 +216,7 @@ export const LoadingExample: Story = {
                     <EntityTitle {...args} loading={false} icon="document" title="Loaded Entity" />
                 </DashedPaddedContainer>
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -228,7 +229,7 @@ export const TagsExample: Story = {
         title: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <div>
                 <StoryLabel title="With tag" />
                 <DashedPaddedContainer>
@@ -241,7 +242,7 @@ export const TagsExample: Story = {
                     <EntityTitle {...args} icon="document" title="Document" />
                 </DashedPaddedContainer>
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -254,10 +255,10 @@ export const SubtitleExample: Story = {
         title: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <Flex flexDirection="column" gap={3}>
             <EntityTitle {...args} icon="document" title="Annual Report" subtitle="Last edited 2 hours ago" />
             <EntityTitle {...args} icon="folder-close" title="Project Files" subtitle="12 items" />
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 
 import { Intent } from "../../common";
@@ -76,10 +77,10 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+        <Flex gap={4} alignItems="center">
             <Checkbox {...args} size="medium" label="Medium" defaultChecked={true} />
             <Checkbox {...args} size="large" label="Large" defaultChecked={true} />
-        </div>
+        </Flex>
     ),
 };
 
@@ -94,29 +95,29 @@ export const StateExample: Story = {
         inline: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+        <Flex gap={4} flexDirection="column">
             <StoryLabel title="Unchecked" />
-            <div style={{ display: "flex", gap: 16 }}>
+            <Flex gap={4}>
                 <Checkbox {...args} label="Default" />
                 <Checkbox {...args} label="Disabled" disabled={true} />
-            </div>
+            </Flex>
             <StoryLabel title="Checked" />
-            <div style={{ display: "flex", gap: 16 }}>
+            <Flex gap={4}>
                 <Checkbox {...args} label="Checked" defaultChecked={true} />
                 <Checkbox {...args} label="Checked Disabled" defaultChecked={true} disabled={true} />
-            </div>
+            </Flex>
             <StoryLabel title="Indeterminate" />
-            <div style={{ display: "flex", gap: 16 }}>
+            <Flex gap={4}>
                 <Checkbox {...args} label="Indeterminate" indeterminate={true} />
                 <Checkbox {...args} label="Indeterminate Disabled" indeterminate={true} disabled={true} />
-            </div>
+            </Flex>
             <StoryLabel title="Inline" />
             <div>
                 <Checkbox {...args} inline={true} label="Option A" />
                 <Checkbox {...args} inline={true} label="Option B" />
                 <Checkbox {...args} inline={true} label="Option C" />
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -126,11 +127,11 @@ export const StateExample: Story = {
 export const AllStatesAllSizes: Story = {
     name: "All States All Sizes",
     render: args => (
-        <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
+        <Flex gap={6} flexDirection="column">
             {(["medium", "large"] as const).map(size => (
                 <div key={size}>
                     <StoryLabel title={size} />
-                    <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+                    <Flex gap={4} flexDirection="column">
                         <Checkbox {...args} size={size} label="Unchecked" />
                         <Checkbox {...args} size={size} label="Checked" defaultChecked={true} />
                         <Checkbox {...args} size={size} label="Indeterminate" indeterminate={true} />
@@ -149,10 +150,10 @@ export const AllStatesAllSizes: Story = {
                             indeterminate={true}
                             disabled={true}
                         />
-                    </div>
+                    </Flex>
                 </div>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/Checkbox.stories.tsx
+++ b/packages/core/src/components/forms/Checkbox.stories.tsx
@@ -3,8 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 

--- a/packages/core/src/components/forms/ControlGroup.stories.tsx
+++ b/packages/core/src/components/forms/ControlGroup.stories.tsx
@@ -5,6 +5,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Button } from "../button/buttons";
 
 import { ControlGroup } from "./controlGroup";
@@ -76,7 +78,7 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <Flex flexDirection="column" gap={2}>
             <ControlGroup {...args} fill={true}>
                 <InputGroup placeholder="Full width input" />
                 <Button text="Submit" />
@@ -85,7 +87,7 @@ export const FillExample: Story = {
                 <InputGroup placeholder="Auto width input" />
                 <Button text="Submit" />
             </ControlGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -110,7 +112,7 @@ export const VerticalExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+        <Flex flexDirection="column" gap={8}>
             <ControlGroup {...args} vertical={true}>
                 <InputGroup placeholder="Vertical input" />
                 <Button text="Submit" />
@@ -119,7 +121,7 @@ export const VerticalExample: Story = {
                 <InputGroup placeholder="Horizontal input" />
                 <Button text="Submit" />
             </ControlGroup>
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { type ChangeEvent, useCallback, useState } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Size } from "../../common";
 

--- a/packages/core/src/components/forms/FileInput.stories.tsx
+++ b/packages/core/src/components/forms/FileInput.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { type ChangeEvent, useCallback, useState } from "react";
 
 import { Size } from "../../common";
@@ -15,17 +16,16 @@ const meta: Meta<typeof FileInput> = {
     component: FileInput,
     decorators: [
         Story => (
-            <div
+            <Flex
+                flexDirection="column"
+                gap={3}
                 style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 12,
                     width: "100%",
                     minWidth: "400px",
                 }}
             >
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -84,7 +84,7 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             {Object.values(Size).map(size => (
                 <FileInput
                     key={size}
@@ -93,7 +93,7 @@ export const SizeExample: Story = {
                     text={`${size.charAt(0).toUpperCase() + size.slice(1)} size`}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -107,11 +107,11 @@ export const StateExample: Story = {
         hasSelection: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <FileInput {...args} text="Choose file..." />
             <FileInput {...args} hasSelection={true} text="document.pdf" />
             <FileInput {...args} disabled={true} text="Disabled..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -131,10 +131,10 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={2} alignItems="start">
             <FileInput {...args} fill={true} text="Full Width" />
             <FileInput {...args} fill={false} text="Auto Width" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -147,11 +147,11 @@ export const ButtonTextExample: Story = {
         buttonText: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <FileInput {...args} buttonText="Browse" text="Default button text..." />
             <FileInput {...args} buttonText="Upload" text="Custom button text..." />
             <FileInput {...args} buttonText="Select" text="Another button text..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -172,7 +172,7 @@ export const Playground: Story = {
         );
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+            <Flex flexDirection="column" gap={3} style={{ minWidth: "400px" }}>
                 <FileInput
                     buttonText={args.buttonText}
                     disabled={args.disabled}
@@ -183,7 +183,7 @@ export const Playground: Story = {
                     text={fileName ?? "Choose file..."}
                 />
                 {fileName != null && <StoryLabel title={`Selected: ${fileName}`} />}
-            </div>
+            </Flex>
         );
     },
     args: {

--- a/packages/core/src/components/forms/FormGroup.stories.tsx
+++ b/packages/core/src/components/forms/FormGroup.stories.tsx
@@ -4,6 +4,8 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Intent } from "../../common";
 import { HTMLSelect } from "../html-select/htmlSelect";
 import { SegmentedControl } from "../segmented-control/segmentedControl";
@@ -24,17 +26,9 @@ const meta: Meta<typeof FormGroup> = {
     component: FormGroup,
     decorators: [
         Story => (
-            <div
-                style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 12,
-                    width: "100%",
-                    minWidth: "400px",
-                }}
-            >
+            <Flex flexDirection="column" gap={3} style={{ width: "100%", minWidth: "400px" }}>
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -310,7 +304,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <FormGroup {...args} intent="primary" labelInfo="(text input)" labelFor="intent-primary-input">
                 <InputGroup
                     id="intent-primary-input"
@@ -363,7 +357,7 @@ export const IntentExample: Story = {
                     ]}
                 />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -381,7 +375,7 @@ export const StateExample: Story = {
         disabled: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <FormGroup {...args} labelInfo="(text input, enabled)" labelFor="state-enabled-input">
                 <InputGroup
                     id="state-enabled-input"
@@ -422,7 +416,7 @@ export const StateExample: Story = {
                     options={["Option A", "Option B"]}
                 />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -438,7 +432,7 @@ export const LabelsExample: Story = {
         subLabel: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <FormGroup {...args} label="Text input" labelFor="labels-basic-input">
                 <InputGroup
                     id="labels-basic-input"
@@ -508,7 +502,7 @@ export const LabelsExample: Story = {
                     ]}
                 />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -522,7 +516,7 @@ export const InlineExample: Story = {
         inline: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <FormGroup {...args} inline={true} labelInfo="(text input)" labelFor="inline-name-input">
                 <InputGroup
                     id="inline-name-input"
@@ -558,7 +552,7 @@ export const InlineExample: Story = {
             <FormGroup {...args} inline={true} labelInfo="(checkbox)">
                 <Checkbox label="I accept the terms" disabled={args.disabled} />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -579,7 +573,7 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={4} alignItems="start">
             <FormGroup {...args} fill={true} labelInfo="(text input, fill)" labelFor="fill-full-input">
                 <InputGroup
                     id="fill-full-input"
@@ -635,7 +629,7 @@ export const FillExample: Story = {
                     ]}
                 />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -655,7 +649,7 @@ export const AllStates: Story = {
         disabled: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <FormGroup {...args} labelInfo="(text input, enabled)" labelFor="allstates-input">
                 <InputGroup id="allstates-input" intent={args.intent} fill={args.fill} placeholder="Enter value..." />
             </FormGroup>
@@ -766,7 +760,7 @@ export const AllStates: Story = {
                     ]}
                 />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -775,7 +769,7 @@ export const AllStates: Story = {
  */
 export const AllControlsDisabled: Story = {
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <FormGroup {...args} disabled={true} labelInfo="(text input)" labelFor="disabled-text">
                 <InputGroup id="disabled-text" disabled={true} intent={args.intent} placeholder="Disabled input..." />
             </FormGroup>
@@ -818,7 +812,7 @@ export const AllControlsDisabled: Story = {
                     ]}
                 />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -827,7 +821,7 @@ export const AllControlsDisabled: Story = {
  */
 export const InlineControls: Story = {
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <FormGroup {...args} inline={true} labelInfo="(text input)" labelFor="inline-name">
                 <InputGroup
                     id="inline-name"
@@ -854,7 +848,7 @@ export const InlineControls: Story = {
             <FormGroup {...args} inline={true} labelInfo="(checkbox)">
                 <Checkbox label="I accept the terms" disabled={args.disabled} />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 
@@ -874,7 +868,7 @@ export const MixedForm: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             <FormGroup {...args} label="Full name" labelFor="mixed-name" labelInfo="(required)">
                 <InputGroup
                     id="mixed-name"
@@ -973,7 +967,7 @@ export const MixedForm: Story = {
                 <Switch label="Subscribe to newsletter" disabled={args.disabled} />
                 <Switch label="Allow data collection" disabled={args.disabled} />
             </FormGroup>
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/InputGroup.stories.tsx
+++ b/packages/core/src/components/forms/InputGroup.stories.tsx
@@ -5,6 +5,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { type ChangeEvent, useCallback, useState } from "react";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Intent, Size } from "../../common";
 import { Button } from "../button/buttons";
 import { Tag } from "../tag/tag";
@@ -16,17 +18,9 @@ const meta: Meta<typeof InputGroup> = {
     component: InputGroup,
     decorators: [
         Story => (
-            <div
-                style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 12,
-                    width: "100%",
-                    minWidth: "400px",
-                }}
-            >
+            <Flex flexDirection="column" gap={3} style={{ width: "100%", minWidth: "400px" }}>
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -93,7 +87,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             {Object.values(Intent).map(intent => (
                 <InputGroup
                     key={intent}
@@ -102,7 +96,7 @@ export const IntentExample: Story = {
                     placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -115,7 +109,7 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             {Object.values(Size).map(size => (
                 <InputGroup
                     key={size}
@@ -124,7 +118,7 @@ export const SizeExample: Story = {
                     placeholder={`${size.charAt(0).toUpperCase() + size.slice(1)} size...`}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -138,11 +132,11 @@ export const StateExample: Story = {
         readOnly: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <InputGroup {...args} placeholder="Enabled..." />
             <InputGroup {...args} disabled={true} placeholder="Disabled..." />
             <InputGroup {...args} readOnly={true} defaultValue="Read only" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -155,7 +149,7 @@ export const IconExample: Story = {
         leftIcon: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <InputGroup {...args} leftIcon="search" placeholder="Search..." />
             <InputGroup {...args} leftIcon="user" placeholder="Username..." />
             <InputGroup
@@ -165,7 +159,7 @@ export const IconExample: Story = {
                 placeholder="Password..."
                 type="password"
             />
-        </div>
+        </Flex>
     ),
 };
 
@@ -179,7 +173,7 @@ export const LeftRightElementsExample: Story = {
         rightElement: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <InputGroup {...args} leftElement={<Tag interactive={true}>Left</Tag>} placeholder="Search..." />
             <InputGroup
                 {...args}
@@ -192,7 +186,7 @@ export const LeftRightElementsExample: Story = {
                 rightElement={<Tag interactive={true}>Right</Tag>}
                 placeholder="With right element..."
             />
-        </div>
+        </Flex>
     ),
 };
 
@@ -205,11 +199,11 @@ export const RoundExample: Story = {
         round: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <InputGroup {...args} round={false} placeholder="Default shape..." />
             <InputGroup {...args} round={true} placeholder="Round shape..." />
             <InputGroup {...args} round={true} leftIcon="search" placeholder="Round with icon..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -229,10 +223,10 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={2} alignItems="start">
             <InputGroup {...args} fill={true} placeholder="Full Width" />
             <InputGroup {...args} fill={false} placeholder="Auto Width" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -254,7 +248,7 @@ export const Playground: Story = {
         const handleClear = useCallback(() => setValue(""), []);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+            <Flex flexDirection="column" gap={3} style={{ minWidth: "400px" }}>
                 <InputGroup
                     disabled={args.disabled}
                     fill={args.fill}
@@ -272,7 +266,7 @@ export const Playground: Story = {
                     size={args.size}
                     value={value}
                 />
-            </div>
+            </Flex>
         );
     },
     args: {

--- a/packages/core/src/components/forms/Label.stories.tsx
+++ b/packages/core/src/components/forms/Label.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 
 import { Label } from "../html/html";
 
@@ -13,17 +14,9 @@ const meta: Meta<typeof Label> = {
     component: Label,
     decorators: [
         Story => (
-            <div
-                style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 12,
-                    width: "100%",
-                    minWidth: "400px",
-                }}
-            >
+            <Flex flexDirection="column" gap={3} style={{ width: "100%", minWidth: "400px" }}>
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -53,12 +46,12 @@ export const WithInput: Story = {
         children: "Label text",
     },
     render: ({ children, ...args }) => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <Label {...args}>
                 {children}
                 <InputGroup placeholder="Placeholder..." />
             </Label>
-        </div>
+        </Flex>
     ),
 };
 
@@ -68,7 +61,7 @@ export const WithInput: Story = {
 export const StateExample: Story = {
     name: "State",
     render: () => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16, width: "100%" }}>
+        <Flex flexDirection="column" gap={4} style={{ width: "100%" }}>
             <Label>
                 Enabled label
                 <InputGroup placeholder="Enabled..." />
@@ -77,7 +70,7 @@ export const StateExample: Story = {
                 Disabled label
                 <InputGroup disabled={true} placeholder="Disabled..." />
             </Label>
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/Label.stories.tsx
+++ b/packages/core/src/components/forms/Label.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+
 import { Flex } from "@blueprintjs/labs";
 
 import { Label } from "../html/html";

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -3,9 +3,10 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
 import { useCallback, useState } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent, Position, Size } from "../../common";
 

--- a/packages/core/src/components/forms/NumericInput.stories.tsx
+++ b/packages/core/src/components/forms/NumericInput.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
 import { useCallback, useState } from "react";
 
@@ -15,17 +16,16 @@ const meta: Meta<typeof NumericInput> = {
     component: NumericInput,
     decorators: [
         Story => (
-            <div
+            <Flex
+                flexDirection="column"
+                gap={3}
                 style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: 12,
                     width: "100%",
                     minWidth: "400px",
                 }}
             >
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -104,7 +104,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             {Object.values(Intent).map(intent => (
                 <NumericInput
                     key={intent}
@@ -113,7 +113,7 @@ export const IntentExample: Story = {
                     placeholder={`${intent.charAt(0).toUpperCase() + intent.slice(1)} intent...`}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -126,7 +126,7 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             {Object.values(Size).map(size => (
                 <NumericInput
                     key={size}
@@ -135,7 +135,7 @@ export const SizeExample: Story = {
                     placeholder={`${size.charAt(0).toUpperCase() + size.slice(1)} size...`}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -149,11 +149,11 @@ export const StateExample: Story = {
         readOnly: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <NumericInput {...args} placeholder="Enabled..." />
             <NumericInput {...args} disabled={true} placeholder="Disabled..." />
             <NumericInput {...args} readOnly={true} value={42} />
-        </div>
+        </Flex>
     ),
 };
 
@@ -166,14 +166,14 @@ export const ButtonPositionExample: Story = {
         buttonPosition: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <StoryLabel title="Right (default)" />
             <NumericInput {...args} buttonPosition={Position.RIGHT} placeholder="Buttons right..." />
             <StoryLabel title="Left" />
             <NumericInput {...args} buttonPosition={Position.LEFT} placeholder="Buttons left..." />
             <StoryLabel title="None" />
             <NumericInput {...args} buttonPosition="none" placeholder="No buttons..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -186,10 +186,10 @@ export const IconExample: Story = {
         leftIcon: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <NumericInput {...args} leftIcon="dollar" placeholder="Price..." />
             <NumericInput {...args} leftIcon="percentage" placeholder="Percentage..." min={0} max={100} />
-        </div>
+        </Flex>
     ),
 };
 
@@ -209,10 +209,10 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={2} alignItems="start">
             <NumericInput {...args} fill={true} placeholder="Full Width" />
             <NumericInput {...args} fill={false} placeholder="Auto Width" />
-        </div>
+        </Flex>
     ),
 };
 
@@ -232,7 +232,7 @@ export const Playground: Story = {
         );
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+            <Flex flexDirection="column" gap={3} style={{ minWidth: "400px" }}>
                 <NumericInput
                     buttonPosition={args.buttonPosition}
                     disabled={args.disabled}
@@ -249,7 +249,7 @@ export const Playground: Story = {
                     value={value}
                 />
                 <StoryLabel title={`Current value: ${value}`} />
-            </div>
+            </Flex>
         );
     },
     args: {

--- a/packages/core/src/components/forms/RadioGroup.stories.tsx
+++ b/packages/core/src/components/forms/RadioGroup.stories.tsx
@@ -4,9 +4,10 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { type ChangeEvent, useCallback, useState } from "react";
 import { useArgs } from "storybook/preview-api";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { RadioGroup } from "./radioGroup";
 

--- a/packages/core/src/components/forms/RadioGroup.stories.tsx
+++ b/packages/core/src/components/forms/RadioGroup.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { type ChangeEvent, useCallback, useState } from "react";
 import { useArgs } from "storybook/preview-api";
 
@@ -81,11 +82,11 @@ export const StateExample: Story = {
             [updateArgs],
         );
         return (
-            <div style={{ display: "flex", gap: 32 }}>
+            <Flex gap={8}>
                 <RadioGroup {...args} label="Enabled" onChange={handleChange} />
                 <RadioGroup {...args} label="Disabled" disabled={true} onChange={handleChange} />
                 <RadioGroup {...args} label="Inline" inline={true} onChange={handleChange} />
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { type ComponentProps } from "react";
 
 import { Switch } from "./controls";
@@ -78,10 +79,10 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+        <Flex gap={4} alignItems="center">
             <Switch {...args} size="medium" label="Medium" defaultChecked={true} />
             <Switch {...args} size="large" label="Large" defaultChecked={true} />
-        </div>
+        </Flex>
     ),
 };
 
@@ -96,24 +97,24 @@ export const StateExample: Story = {
         defaultChecked: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+        <Flex gap={4} flexDirection="column">
             <StoryLabel title="Unchecked" />
-            <div style={{ display: "flex", gap: 16 }}>
+            <Flex gap={4}>
                 <Switch {...args} label="Default" />
                 <Switch {...args} label="Disabled" disabled={true} />
-            </div>
+            </Flex>
             <StoryLabel title="Checked" />
-            <div style={{ display: "flex", gap: 16 }}>
+            <Flex gap={4}>
                 <Switch {...args} label="Checked" defaultChecked={true} />
                 <Switch {...args} label="Checked Disabled" defaultChecked={true} disabled={true} />
-            </div>
+            </Flex>
             <StoryLabel title="Inline" />
             <div>
                 <Switch {...args} inline={true} label="Wi-Fi" defaultChecked={true} />
                 <Switch {...args} inline={true} label="Bluetooth" />
                 <Switch {...args} inline={true} label="Airplane Mode" />
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -123,11 +124,11 @@ export const StateExample: Story = {
 export const AllStates: Story = {
     name: "All States",
     render: args => (
-        <div style={{ display: "flex", gap: 24, flexDirection: "column" }}>
+        <Flex gap={6} flexDirection="column">
             {(["medium", "large"] as const).map(size => (
                 <div key={size}>
                     <StoryLabel title={size} />
-                    <div style={{ display: "flex", gap: 16, flexDirection: "column" }}>
+                    <Flex gap={4} flexDirection="column">
                         <Switch {...args} size={size} label="Unchecked" />
                         <Switch {...args} size={size} label="Checked" defaultChecked={true} />
                         <Switch {...args} size={size} label="Disabled" disabled={true} />
@@ -140,10 +141,10 @@ export const AllStates: Story = {
                             innerLabelChecked="On"
                             defaultChecked={true}
                         />
-                    </div>
+                    </Flex>
                 </div>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/forms/Switch.stories.tsx
+++ b/packages/core/src/components/forms/Switch.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { type ComponentProps } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Switch } from "./controls";
 

--- a/packages/core/src/components/icon/IconGallery.stories.tsx
+++ b/packages/core/src/components/icon/IconGallery.stories.tsx
@@ -8,6 +8,7 @@ import { pascalCase } from "change-case";
 import classNames from "classnames";
 import React, { type ComponentType, type ReactElement } from "react";
 
+import { Flex } from "@blueprintjs/labs";
 import type { IconName } from "@blueprintjs/icons";
 import * as BlueprintIcons from "@blueprintjs/icons";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
@@ -94,7 +95,7 @@ type GalleryRenderIcon = (iconName: IconName, pixelSize: number) => ReactElement
 
 function IconGallery({ renderIcon }: { renderIcon: GalleryRenderIcon }) {
     return (
-        <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+        <Flex flexDirection="column" gap={8}>
             <section>
                 <H4>Small (16px)</H4>
                 <IconGrid pixelSize={DISPLAY_ICON_SIZE_SMALL} renderIcon={renderIcon} />
@@ -103,19 +104,19 @@ function IconGallery({ renderIcon }: { renderIcon: GalleryRenderIcon }) {
                 <H4>Large (20px)</H4>
                 <IconGrid pixelSize={DISPLAY_ICON_SIZE_LARGE} renderIcon={renderIcon} />
             </section>
-        </div>
+        </Flex>
     );
 }
 
 function IconGrid({ pixelSize, renderIcon }: { pixelSize: number; renderIcon: GalleryRenderIcon }) {
     return (
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        <Flex flexWrap="wrap" gap={2}>
             {ICON_NAMES.map(iconName => (
                 <Card key={iconName} title={`${iconName} (${pixelSize}px)`} style={ICON_GRID_CARD_STYLE}>
                     {renderIcon(iconName, pixelSize)}
                 </Card>
             ))}
-        </div>
+        </Flex>
     );
 }
 

--- a/packages/core/src/components/icon/IconGallery.stories.tsx
+++ b/packages/core/src/components/icon/IconGallery.stories.tsx
@@ -8,9 +8,9 @@ import { pascalCase } from "change-case";
 import classNames from "classnames";
 import React, { type ComponentType, type ReactElement } from "react";
 
-import { Flex } from "@blueprintjs/labs";
 import type { IconName } from "@blueprintjs/icons";
 import * as BlueprintIcons from "@blueprintjs/icons";
+import { Flex } from "@blueprintjs/labs";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 
 import { Classes } from "../../common";

--- a/packages/core/src/components/link/Link.stories.tsx
+++ b/packages/core/src/components/link/Link.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
+
 import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";

--- a/packages/core/src/components/link/Link.stories.tsx
+++ b/packages/core/src/components/link/Link.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 
@@ -14,9 +15,9 @@ const meta: Meta<typeof Link> = {
     component: Link,
     decorators: [
         Story => (
-            <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+            <Flex justifyContent="center" alignItems="center">
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -66,13 +67,13 @@ export const IntentExample: Story = {
         color: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16 }}>
+        <Flex gap={4}>
             {Object.values(Intent).map(intent => (
                 <Link key={intent} {...args} color={intent}>
                     {intent.charAt(0).toUpperCase() + intent.slice(1)}
                 </Link>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -85,16 +86,16 @@ export const UnderlineExample: Story = {
         underline: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16 }}>
+        <Flex gap={4}>
             {(["always", "hover", "none"] as const).map(underline => (
-                <div key={underline} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Flex key={underline} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={underline} />
                     <Link {...args} underline={underline}>
                         Link
                     </Link>
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -108,11 +109,11 @@ export const AllIntentsAllUnderlines: Story = {
         underline: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             {(["always", "hover", "none"] as const).map(underline => (
-                <div key={underline} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Flex key={underline} flexDirection="column" gap={2}>
                     <StoryLabel title={underline} />
-                    <div style={{ display: "flex", gap: 16 }}>
+                    <Flex gap={4}>
                         {Object.values(Intent).map(intent => (
                             <Link key={intent} {...args} color={intent} underline={underline}>
                                 {intent.charAt(0).toUpperCase() + intent.slice(1)}
@@ -121,10 +122,10 @@ export const AllIntentsAllUnderlines: Story = {
                         <Link {...args} color="inherit" underline={underline}>
                             Inherit
                         </Link>
-                    </div>
-                </div>
+                    </Flex>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
 
 import { Intent, Size } from "../../common";
@@ -95,16 +96,16 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={3}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="None" />
                 <SegmentedControl {...args} intent={Intent.NONE} />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Primary" />
                 <SegmentedControl {...args} intent={Intent.PRIMARY} />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -117,14 +118,14 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+        <Flex flexDirection="column" gap={3} alignItems="center">
             {Object.values(Size).map(size => (
-                <div key={size} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Flex key={size} flexDirection="column" gap={1} alignItems="center">
                     <StoryLabel title={size} />
                     <SegmentedControl {...args} size={size} />
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -137,16 +138,16 @@ export const StateExample: Story = {
         disabled: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={3}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Default" />
                 <SegmentedControl {...args} />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Disabled" />
                 <SegmentedControl {...args} disabled={true} />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -166,16 +167,16 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={3}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Fill" />
                 <SegmentedControl {...args} fill={true} />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title="Auto Width" />
                 <SegmentedControl {...args} fill={false} />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -196,20 +197,20 @@ export const WithIcons: Story = {
 export const AriaLabels: Story = {
     name: "Aria Labels",
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <Flex flexDirection="column" gap={3}>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title={'role="radiogroup" (default) + aria-label'} />
                 <SegmentedControl {...args} aria-label="View mode" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title={'role="toolbar" + aria-label'} />
                 <SegmentedControl {...args} role="toolbar" aria-label="View mode toolbar" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
                 <StoryLabel title={'role="group" + aria-label'} />
                 <SegmentedControl {...args} role="group" aria-label="View mode group" />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent, Size } from "../../common";
 

--- a/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
+++ b/packages/core/src/components/segmented-control/SegmentedControl.stories.tsx
@@ -225,17 +225,17 @@ export const AllIntentsAllSizes: Story = {
         disabled: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Flex flexDirection="column" gap={4}>
             {[Intent.NONE, Intent.PRIMARY].map(intent => (
-                <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <Flex key={intent} flexDirection="column" gap={2}>
                     <StoryLabel title={`Intent: ${intent}`} />
                     {Object.values(Size).map(size => (
                         <SegmentedControl key={size} {...args} intent={intent} size={size} />
                     ))}
                     <SegmentedControl {...args} intent={intent} disabled={true} />
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -251,10 +251,10 @@ export const Playground: Story = {
         }, []);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "center" }}>
+            <Flex flexDirection="column" gap={3} alignItems="center">
                 <SegmentedControl {...args} options={ICON_OPTIONS} value={value} onValueChange={handleValueChange} />
                 <StoryLabel title={`Selected: ${value}`} />
-            </div>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/components/skeleton/Skeleton.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
 
 import { Classes } from "../../common";
@@ -39,9 +40,9 @@ const meta: Meta<typeof SkeletonDemo> = {
     component: SkeletonDemo,
     decorators: [
         Story => (
-            <div style={{ display: "flex", width: "600px" }}>
+            <Flex style={{ width: "600px" }}>
                 <Story />
-            </div>
+            </Flex>
         ),
     ],
     parameters: {
@@ -76,16 +77,16 @@ export const Default: Story = {
 export const ComparisonExample: Story = {
     name: "Comparison",
     render: () => (
-        <div style={{ display: "flex", gap: 24 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+        <Flex gap={6}>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Loading" />
                 <SkeletonDemo skeleton={true} />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Loaded" />
                 <SkeletonDemo skeleton={false} />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/skeleton/Skeleton.stories.tsx
+++ b/packages/core/src/components/skeleton/Skeleton.stories.tsx
@@ -3,8 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Classes } from "../../common";
 import { Button } from "../button/buttons";

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 import { useCallback } from "react";
 import { useArgs } from "storybook/preview-api";
@@ -105,9 +106,9 @@ export const IntentExample: Story = {
         const handleChange = useCallback((newValue: number) => updateArgs({ value: newValue }), [updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
+            <Flex flexDirection="column" gap={6} style={{ width: "100%" }}>
                 {Object.values(Intent).map(intent => (
-                    <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                    <Flex key={intent} flexDirection="column" gap={1}>
                         <StoryLabel title={intent} />
                         <Slider
                             {...args}
@@ -116,9 +117,9 @@ export const IntentExample: Story = {
                             onRelease={handleChange}
                             handleHtmlProps={{ "aria-label": `${intent} intent slider` }}
                         />
-                    </div>
+                    </Flex>
                 ))}
-            </div>
+            </Flex>
         );
     },
 };
@@ -137,8 +138,8 @@ export const StateExample: Story = {
         const handleChange = useCallback((newValue: number) => updateArgs({ value: newValue }), [updateArgs]);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 24, width: "100%" }}>
-                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <Flex flexDirection="column" gap={6} style={{ width: "100%" }}>
+                <Flex flexDirection="column" gap={1}>
                     <StoryLabel title="Default" />
                     <Slider
                         {...args}
@@ -147,8 +148,8 @@ export const StateExample: Story = {
                         onRelease={handleChange}
                         handleHtmlProps={{ "aria-label": "Default state slider" }}
                     />
-                </div>
-                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                </Flex>
+                <Flex flexDirection="column" gap={1}>
                     <StoryLabel title="Disabled" />
                     <Slider
                         {...args}
@@ -157,8 +158,8 @@ export const StateExample: Story = {
                         onRelease={handleChange}
                         handleHtmlProps={{ "aria-label": "Disabled slider" }}
                     />
-                </div>
-                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                </Flex>
+                <Flex flexDirection="column" gap={1}>
                     <StoryLabel title="Vertical" />
                     <Slider
                         {...args}
@@ -167,8 +168,8 @@ export const StateExample: Story = {
                         onRelease={handleChange}
                         handleHtmlProps={{ "aria-label": "Vertical slider" }}
                     />
-                </div>
-            </div>
+                </Flex>
+            </Flex>
         );
     },
 };

--- a/packages/core/src/components/slider/Slider.stories.tsx
+++ b/packages/core/src/components/slider/Slider.stories.tsx
@@ -3,10 +3,11 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 import { useCallback } from "react";
 import { useArgs } from "storybook/preview-api";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+
 import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";

--- a/packages/core/src/components/spinner/Spinner.stories.tsx
+++ b/packages/core/src/components/spinner/Spinner.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 
@@ -55,14 +56,14 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16, alignItems: "center" }}>
+        <Flex gap={4} alignItems="center">
             {Object.values(Intent).map(intent => (
-                <div key={intent} style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+                <Flex key={intent} flexDirection="column" gap={1} alignItems="center">
                     <Spinner {...args} intent={intent} size={SpinnerSize.STANDARD} />
                     <StoryLabel title={intent} />
-                </div>
+                </Flex>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -75,20 +76,20 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+        <Flex gap={6} alignItems="center">
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} size={SpinnerSize.SMALL} />
                 <StoryLabel title="Small (20px)" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} size={SpinnerSize.STANDARD} />
                 <StoryLabel title="Standard (50px)" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} size={SpinnerSize.LARGE} />
                 <StoryLabel title="Large (100px)" />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -101,24 +102,24 @@ export const StateExample: Story = {
         value: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+        <Flex gap={6} alignItems="center">
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} value={undefined} />
                 <StoryLabel title="Indeterminate" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} value={0} />
                 <StoryLabel title="0%" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} value={0.5} />
                 <StoryLabel title="50%" />
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <Spinner {...args} value={1} />
                 <StoryLabel title="100%" />
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
@@ -102,7 +103,7 @@ export const IntentExample: Story = {
         separator: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             {Object.values(Intent).map(intent => (
                 <TagInput
                     key={intent}
@@ -112,7 +113,7 @@ export const IntentExample: Story = {
                     placeholder={`${intent} intent...`}
                 />
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -128,10 +129,10 @@ export const SizeExample: Story = {
         separator: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <TagInput {...args} size="medium" values={["Medium"]} placeholder="Medium size..." />
             <TagInput {...args} size="large" values={["Large"]} placeholder="Large size..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -147,10 +148,10 @@ export const StateExample: Story = {
         separator: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <TagInput {...args} values={["Enabled"]} placeholder="Enabled..." />
             <TagInput {...args} disabled={true} values={["Disabled"]} placeholder="Disabled..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -166,10 +167,10 @@ export const IconExample: Story = {
         separator: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12, width: "100%" }}>
+        <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <TagInput {...args} leftIcon="search" values={["Search"]} placeholder="With left icon..." />
             <TagInput {...args} leftIcon="tag" values={["Tags"]} placeholder="With tag icon..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -192,10 +193,10 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <Flex flexDirection="column" gap={3}>
             <TagInput {...args} fill={true} values={["Full Width"]} placeholder="Fill..." />
             <TagInput {...args} fill={false} values={["Auto Width"]} placeholder="Auto..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -212,10 +213,10 @@ export const AutoResizeExample: Story = {
         separator: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <Flex flexDirection="column" gap={3}>
             <TagInput {...args} autoResize={true} values={["Auto Resize"]} placeholder="Type to resize..." />
             <TagInput {...args} autoResize={false} values={["Fixed Width"]} placeholder="Fixed input width..." />
-        </div>
+        </Flex>
     ),
 };
 
@@ -252,7 +253,7 @@ export const Playground: Story = {
         const handleReset = useCallback(() => setValues([...INITIAL_VALUES]), []);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 12, minWidth: "400px" }}>
+            <Flex flexDirection="column" gap={3} style={{ minWidth: "400px" }}>
                 <TagInput
                     addOnBlur={args.addOnBlur}
                     addOnPaste={args.addOnPaste}
@@ -275,7 +276,7 @@ export const Playground: Story = {
                 {values.length === 0 && (
                     <Button icon="refresh" variant="outlined" size="small" text="Reset tags" onClick={handleReset} />
                 )}
-            </div>
+            </Flex>
         );
     },
     args: {

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 import { Button } from "../button/buttons";

--- a/packages/core/src/components/tag/CompoundTag.stories.tsx
+++ b/packages/core/src/components/tag/CompoundTag.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 import { Button } from "../button/buttons";

--- a/packages/core/src/components/tag/CompoundTag.stories.tsx
+++ b/packages/core/src/components/tag/CompoundTag.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
@@ -105,7 +106,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <Flex gap={2} flexWrap="wrap">
             {Object.values(Intent)
                 .filter(i => i !== "none")
                 .map(intent => (
@@ -113,7 +114,7 @@ export const IntentExample: Story = {
                         {intent.charAt(0).toUpperCase() + intent.slice(1)}
                     </CompoundTag>
                 ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -126,20 +127,20 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+        <Flex gap={4}>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Default" />
                 <CompoundTag {...args} leftContent="Key" minimal={false}>
                     Value
                 </CompoundTag>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Minimal" />
                 <CompoundTag {...args} leftContent="Key" minimal={true}>
                     Value
                 </CompoundTag>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -152,14 +153,14 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Flex gap={2} alignItems="center">
             <CompoundTag {...args} leftContent="Size" size="medium">
                 Medium
             </CompoundTag>
             <CompoundTag {...args} leftContent="Size" size="large">
                 Large
             </CompoundTag>
-        </div>
+        </Flex>
     ),
 };
 
@@ -174,7 +175,7 @@ export const StateExample: Story = {
     },
     render: function Render(args) {
         return (
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Flex gap={2} flexWrap="wrap">
                 <CompoundTag {...args} leftContent="Key">
                     Default
                 </CompoundTag>
@@ -187,7 +188,7 @@ export const StateExample: Story = {
                 <CompoundTag {...args} leftContent="Key" onRemove={args.onRemove}>
                     Removable
                 </CompoundTag>
-            </div>
+            </Flex>
         );
     },
 };
@@ -202,7 +203,7 @@ export const IconExample: Story = {
         endIcon: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <Flex gap={2} flexWrap="wrap">
             <CompoundTag {...args} leftContent="City" icon="globe">
                 London
             </CompoundTag>
@@ -212,7 +213,7 @@ export const IconExample: Story = {
             <CompoundTag {...args} leftContent="City" icon="globe" endIcon="map-marker">
                 New York
             </CompoundTag>
-        </div>
+        </Flex>
     ),
 };
 
@@ -232,14 +233,14 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={2} alignItems="start">
             <CompoundTag {...args} leftContent="Region" fill={true}>
                 Full Width
             </CompoundTag>
             <CompoundTag {...args} leftContent="Region" fill={false}>
                 Auto Width
             </CompoundTag>
-        </div>
+        </Flex>
     ),
 };
 
@@ -255,18 +256,18 @@ export const AllIntentsAllVariants: Story = {
     },
     render: function Render(args) {
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <Flex flexDirection="column" gap={4}>
                 {[false, true].map(minimal => (
-                    <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <Flex key={String(minimal)} flexDirection="column" gap={2}>
                         <StoryLabel title={minimal ? "Minimal" : "Default"} />
-                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        <Flex gap={2} flexWrap="wrap">
                             {Object.values(Intent).map(intent => (
                                 <CompoundTag key={intent} {...args} leftContent="Key" minimal={minimal} intent={intent}>
                                     {intent === Intent.NONE ? "none" : intent}
                                 </CompoundTag>
                             ))}
-                        </div>
-                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                        </Flex>
+                        <Flex gap={2} flexWrap="wrap">
                             {Object.values(Intent).map(intent => (
                                 <CompoundTag
                                     key={intent}
@@ -280,10 +281,10 @@ export const AllIntentsAllVariants: Story = {
                                     {intent === Intent.NONE ? "none" : intent}
                                 </CompoundTag>
                             ))}
-                        </div>
-                    </div>
+                        </Flex>
+                    </Flex>
                 ))}
-            </div>
+            </Flex>
         );
     },
 };
@@ -302,8 +303,8 @@ export const Playground: Story = {
         const handleReset = useCallback(() => setTags(PLAYGROUND_INITIAL_TAGS), []);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "center" }}>
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Flex flexDirection="column" gap={2} alignItems="center">
+                <Flex gap={2} flexWrap="wrap">
                     {tags.map(tag => (
                         <CompoundTag
                             key={tag}
@@ -322,11 +323,11 @@ export const Playground: Story = {
                             {tag}
                         </CompoundTag>
                     ))}
-                </div>
+                </Flex>
                 {tags.length === 0 && (
                     <Button icon="refresh" variant="outlined" size="small" text="Reset tags" onClick={handleReset} />
                 )}
-            </div>
+            </Flex>
         );
     },
     args: {

--- a/packages/core/src/components/tag/Tag.stories.tsx
+++ b/packages/core/src/components/tag/Tag.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
 
 import { Intent } from "../../common";
@@ -105,7 +106,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8 }}>
+        <Flex gap={2}>
             {Object.values(Intent)
                 .filter(i => i !== "none")
                 .map(intent => (
@@ -113,7 +114,7 @@ export const IntentExample: Story = {
                         {intent.charAt(0).toUpperCase() + intent.slice(1)}
                     </Tag>
                 ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -126,20 +127,20 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 16 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+        <Flex gap={4}>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Default" />
                 <Tag {...args} minimal={false}>
                     Tag
                 </Tag>
-            </div>
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, alignItems: "center" }}>
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
                 <StoryLabel title="Minimal" />
                 <Tag {...args} minimal={true}>
                     Tag
                 </Tag>
-            </div>
-        </div>
+            </Flex>
+        </Flex>
     ),
 };
 
@@ -152,14 +153,14 @@ export const SizeExample: Story = {
         size: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <Flex gap={2} alignItems="center">
             <Tag {...args} size="medium">
                 Medium
             </Tag>
             <Tag {...args} size="large">
                 Large
             </Tag>
-        </div>
+        </Flex>
     ),
 };
 
@@ -174,7 +175,7 @@ export const StateExample: Story = {
     },
     render: function Render(args) {
         return (
-            <div style={{ display: "flex", gap: 8 }}>
+            <Flex gap={2}>
                 <Tag {...args}>Default</Tag>
                 <Tag {...args} active={true}>
                     Active
@@ -185,7 +186,7 @@ export const StateExample: Story = {
                 <Tag {...args} onRemove={args.onRemove}>
                     Removable
                 </Tag>
-            </div>
+            </Flex>
         );
     },
 };
@@ -200,7 +201,7 @@ export const IconExample: Story = {
         endIcon: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", gap: 8 }}>
+        <Flex gap={2}>
             <Tag {...args} icon="home">
                 Start icon
             </Tag>
@@ -210,7 +211,7 @@ export const IconExample: Story = {
             <Tag {...args} icon="home" endIcon="map">
                 Both
             </Tag>
-        </div>
+        </Flex>
     ),
 };
 
@@ -230,14 +231,14 @@ export const FillExample: Story = {
         ),
     ],
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "flex-start" }}>
+        <Flex flexDirection="column" gap={2} alignItems="start">
             <Tag {...args} fill={true}>
                 Full Width
             </Tag>
             <Tag {...args} fill={false}>
                 Auto Width
             </Tag>
-        </div>
+        </Flex>
     ),
 };
 
@@ -253,18 +254,18 @@ export const AllIntentsAllVariants: Story = {
     },
     render: function Render(args) {
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <Flex flexDirection="column" gap={4}>
                 {[false, true].map(minimal => (
-                    <div key={String(minimal)} style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <Flex key={String(minimal)} flexDirection="column" gap={2}>
                         <StoryLabel title={minimal ? "Minimal" : "Default"} />
-                        <div style={{ display: "flex", gap: 8 }}>
+                        <Flex gap={2}>
                             {Object.values(Intent).map(intent => (
                                 <Tag key={intent} {...args} minimal={minimal} intent={intent}>
                                     {intent === Intent.NONE ? "none" : intent}
                                 </Tag>
                             ))}
-                        </div>
-                        <div style={{ display: "flex", gap: 8 }}>
+                        </Flex>
+                        <Flex gap={2}>
                             {Object.values(Intent).map(intent => (
                                 <Tag
                                     key={intent}
@@ -277,10 +278,10 @@ export const AllIntentsAllVariants: Story = {
                                     {intent === Intent.NONE ? "none" : intent}
                                 </Tag>
                             ))}
-                        </div>
-                    </div>
+                        </Flex>
+                    </Flex>
                 ))}
-            </div>
+            </Flex>
         );
     },
 };
@@ -299,8 +300,8 @@ export const Playground: Story = {
         const handleReset = useCallback(() => setTags(PLAYGROUND_INITIAL_TAGS), []);
 
         return (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, alignItems: "center" }}>
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+            <Flex flexDirection="column" gap={2} alignItems="center">
+                <Flex gap={2} flexWrap="wrap">
                     {tags.map(tag => (
                         <Tag
                             key={tag}
@@ -318,13 +319,13 @@ export const Playground: Story = {
                             {tag}
                         </Tag>
                     ))}
-                </div>
+                </Flex>
                 {tags.length === 0 && (
                     <button type="button" onClick={handleReset}>
                         Reset tags
                     </button>
                 )}
-            </div>
+            </Flex>
         );
     },
     args: {

--- a/packages/core/src/components/tag/Tag.stories.tsx
+++ b/packages/core/src/components/tag/Tag.stories.tsx
@@ -4,8 +4,9 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
-import { Flex } from "@blueprintjs/labs";
 import { useCallback, useState } from "react";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
 

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -71,7 +71,7 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="column" gap={10}>
+        <Flex flexDirection="column" gap={10} style={{ gap: 108 }}>
             {Object.values(Intent).map(intent => (
                 <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
                     <Button>{intent.charAt(0).toUpperCase() + intent.slice(1)}</Button>
@@ -91,7 +91,7 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="column" gap={10}>
+        <Flex flexDirection="column" gap={10} style={{ gap: 108 }}>
             <Tooltip {...args} compact={false} minimal={false} isOpen={true}>
                 <Button>Default</Button>
             </Tooltip>

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
 import { expect, screen, waitFor } from "storybook/test";
 
+import { Flex } from "@blueprintjs/labs";
+
 import { Intent } from "../../common";
 import { Button } from "../button/buttons";
 
@@ -69,13 +71,13 @@ export const IntentExample: Story = {
         intent: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 108 }}>
+        <Flex flexDirection="column" gap={10}>
             {Object.values(Intent).map(intent => (
                 <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
                     <Button>{intent.charAt(0).toUpperCase() + intent.slice(1)}</Button>
                 </Tooltip>
             ))}
-        </div>
+        </Flex>
     ),
 };
 
@@ -89,7 +91,7 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <div style={{ display: "flex", flexDirection: "column", gap: 108 }}>
+        <Flex flexDirection="column" gap={10}>
             <Tooltip {...args} compact={false} minimal={false} isOpen={true}>
                 <Button>Default</Button>
             </Tooltip>
@@ -102,7 +104,7 @@ export const VariantExample: Story = {
             <Tooltip {...args} compact={true} minimal={true} isOpen={true}>
                 <Button>Compact + Minimal</Button>
             </Tooltip>
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/core/src/components/tooltip/Tooltip.stories.tsx
@@ -3,7 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { storybookLayoutDecorator } from "@storybook-common";
+import { DashedPaddedContainer, storybookLayoutDecorator } from "@storybook-common";
 import { expect, screen, waitFor } from "storybook/test";
 
 import { Flex } from "@blueprintjs/labs";
@@ -67,15 +67,26 @@ export const IntentExample: Story = {
     argTypes: {
         intent: { table: { disable: true } },
     },
-    render: args => (
-        <Flex flexDirection="column" gap={10} style={{ gap: 108 }}>
-            {Object.values(Intent).map(intent => (
-                <Tooltip key={intent} {...args} intent={intent} isOpen={true}>
-                    <Button>{intent.charAt(0).toUpperCase() + intent.slice(1)}</Button>
-                </Tooltip>
-            ))}
-        </Flex>
-    ),
+    render: args => {
+        const intents = Object.values(Intent);
+        const mid = Math.ceil(intents.length / 2);
+        const columns = [intents.slice(0, mid), intents.slice(mid)];
+        return (
+            <Flex flexDirection="row" gap={10}>
+                {columns.map((col, i) => (
+                    <Flex key={i} flexDirection="column" gap={10} alignItems="center">
+                        {col.map(intent => (
+                            <div key={intent} style={{ padding: 80 }}>
+                                <Tooltip {...args} intent={intent} placement="bottom" isOpen={true}>
+                                    <Button>{intent.charAt(0).toUpperCase() + intent.slice(1)}</Button>
+                                </Tooltip>
+                            </div>
+                        ))}
+                    </Flex>
+                ))}
+            </Flex>
+        );
+    },
 };
 
 /**
@@ -88,19 +99,31 @@ export const VariantExample: Story = {
         minimal: { table: { disable: true } },
     },
     render: args => (
-        <Flex flexDirection="column" gap={10} style={{ gap: 108 }}>
-            <Tooltip {...args} compact={false} minimal={false} isOpen={true}>
-                <Button>Default</Button>
-            </Tooltip>
-            <Tooltip {...args} compact={true} minimal={false} isOpen={true}>
-                <Button>Compact</Button>
-            </Tooltip>
-            <Tooltip {...args} compact={false} minimal={true} isOpen={true}>
-                <Button>Minimal</Button>
-            </Tooltip>
-            <Tooltip {...args} compact={true} minimal={true} isOpen={true}>
-                <Button>Compact + Minimal</Button>
-            </Tooltip>
+        <Flex flexDirection="row" gap={10}>
+            <Flex flexDirection="column" gap={10} alignItems="center">
+                <div style={{ padding: 80 }}>
+                    <Tooltip {...args} compact={false} placement="bottom" minimal={false} isOpen={true}>
+                        <Button>Default</Button>
+                    </Tooltip>
+                </div>
+                <div style={{ padding: 80 }}>
+                    <Tooltip {...args} compact={true} placement="bottom" minimal={false} isOpen={true}>
+                        <Button>Compact</Button>
+                    </Tooltip>
+                </div>
+            </Flex>
+            <Flex flexDirection="column" gap={10} alignItems="center">
+                <div style={{ padding: 80 }}>
+                    <Tooltip {...args} compact={false} placement="bottom" minimal={true} isOpen={true}>
+                        <Button>Minimal</Button>
+                    </Tooltip>
+                </div>
+                <div style={{ padding: 80 }}>
+                    <Tooltip {...args} compact={true} placement="bottom" minimal={true} isOpen={true}>
+                        <Button>Compact + Minimal</Button>
+                    </Tooltip>
+                </div>
+            </Flex>
         </Flex>
     ),
 };

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -3,6 +3,7 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
 import { type MouseEvent, useCallback, useReducer } from "react";
 import { expect, waitFor } from "storybook/test";
@@ -176,7 +177,7 @@ export const CompactExample: Story = {
 export const StateExample: Story = {
     name: "State",
     render: args => (
-        <div style={{ display: "flex", gap: 32 }}>
+        <Flex gap={8}>
             <div>
                 <StoryLabel title="Selected" />
                 <div style={{ minWidth: "300px" }}>
@@ -189,7 +190,7 @@ export const StateExample: Story = {
                     <Tree {...args} contents={DISABLED_CONTENTS} />
                 </div>
             </div>
-        </div>
+        </Flex>
     ),
 };
 
@@ -199,7 +200,7 @@ export const StateExample: Story = {
 export const AllStates: Story = {
     name: "All States",
     render: args => (
-        <div style={{ display: "flex", gap: 32, flexWrap: "wrap" }}>
+        <Flex gap={8} flexWrap="wrap">
             <div>
                 <StoryLabel title="Default" />
                 <div style={{ minWidth: "300px" }}>
@@ -224,7 +225,7 @@ export const AllStates: Story = {
                     <Tree {...args} contents={SAMPLE_CONTENTS} compact={true} />
                 </div>
             </div>
-        </div>
+        </Flex>
     ),
 };
 

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -3,10 +3,11 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex } from "@blueprintjs/labs";
 import { StoryLabel } from "@storybook-common";
 import { type MouseEvent, useCallback, useReducer } from "react";
 import { expect, waitFor } from "storybook/test";
+
+import { Flex } from "@blueprintjs/labs";
 
 import { Tree } from "./tree";
 import type { TreeNodeInfo } from "./treeTypes";


### PR DESCRIPTION
#### FLUP to [this comment](https://github.com/palantir/blueprint/pull/7948#discussion_r3111461546) I left on [[core] Add Storybook stories for Editable Text](https://github.com/palantir/blueprint/pull/7948#top)

### Changes proposed in this pull request:
Simply moving from the many uses of `<div className="flex">` to `<Flex>` from `@BlueprintJS/Labs`. See [public docs](https://blueprintjs.com/docs/#labs/flex) for more

### Reviewers should focus on:
- [ ] Are these stories reasonably similar to their prior version 
