### PR TITLE
[fix] Downgrade change-case back to `4.1.2` (icons + core) and switch to paramCase

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
         "@tokens-studio/sd-transforms": "^2.0.3",
         "@types/culori": "^4.0.1",
         "@vitejs/plugin-react": "catalog:",
-        "change-case": "^5.4.4",
+        "change-case": "^4.1.2",
         "culori": "^4.0.2",
         "enzyme": "catalog:",
         "jsdom": "catalog:",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -44,7 +44,7 @@
         "verify": "npm-run-all compile -p dist test lint"
     },
     "dependencies": {
-        "change-case": "^5.4.4",
+        "change-case": "^4.1.2",
         "classnames": "catalog:",
         "tslib": "catalog:"
     },

--- a/packages/icons/scripts/iconNaming.mjs
+++ b/packages/icons/scripts/iconNaming.mjs
@@ -15,7 +15,7 @@
 
 // @ts-check
 
-import { kebabCase } from "change-case";
+import { paramCase } from "change-case";
 
 /** Lowercase kebab-case segments only (matches Blueprint icon filenames / IconName strings). */
 export const ICON_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -27,5 +27,5 @@ export const ICON_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
  * @param {string} name
  */
 export function canonicalIconName(name) {
-    return kebabCase(name);
+    return paramCase(name);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ importers:
         specifier: 'catalog:'
         version: 5.1.0(vite@7.1.12(@types/node@24.12.2)(jiti@2.6.1)(sass@1.93.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       change-case:
-        specifier: ^5.4.4
-        version: 5.4.4
+        specifier: ^4.1.2
+        version: 4.1.2
       culori:
         specifier: ^4.0.2
         version: 4.0.2
@@ -753,8 +753,8 @@ importers:
         specifier: 18.3.12
         version: 18.3.12
       change-case:
-        specifier: ^5.4.4
-        version: 5.4.4
+        specifier: ^4.1.2
+        version: 4.1.2
       classnames:
         specifier: 'catalog:'
         version: 2.5.1


### PR DESCRIPTION
This reverts commit e1c660c9ce9aaf5a7bc8af834b9dbf570ada2411.

#### Changes proposed in this pull request:

* Goes back to `change-case` v4 in order to have compatible CJS output. See changelog of `change-case` in v5: https://github.com/blakeembrey/change-case/releases/tag/change-case%405.0.0
* Uses `paramCase` instead of `kebabCase`

#### Reviewers should focus on:

* This allows downstream tests to function