### PR TITLE
Migrate Breadcrumbs internals to PopoverNext via compat shim

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,8 +21,9 @@ import { Boundary, Classes, DISPLAYNAME_PREFIX, type Props, removeNonHTMLProps }
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
-import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 
 import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
 
@@ -150,11 +151,11 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
 
             return (
                 <li>
-                    <Popover
+                    <PopoverNext
                         content={<Menu>{orderedItems.map(renderOverflowBreadcrumb)}</Menu>}
                         disabled={orderedItems.length === 0}
                         placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
-                        {...popoverProps}
+                        {...popoverPropsToNextProps(popoverProps ?? {})}
                     >
                         <span
                             aria-label="collapsed breadcrumbs"
@@ -163,7 +164,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
                             {...overflowButtonProps}
                             className={classNames(Classes.BREADCRUMBS_COLLAPSED, overflowButtonProps?.className)}
                         />
-                    </Popover>
+                    </PopoverNext>
                 </li>
             );
         },

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -95,6 +95,7 @@ export type {
 export { PopoverNext, type PopoverNextRef } from "./popover-next/popoverNext";
 export {
     popoverPositionToNextPlacement,
+    popoverPropsToNextProps,
     popperModifiersToNextMiddleware,
 } from "./popover-next/popoverNextMigrationUtils";
 export type {

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -94,8 +94,10 @@ export type {
 } from "./popover-next/popoverNextProps";
 export { PopoverNext, type PopoverNextRef } from "./popover-next/popoverNext";
 export {
+    popoverPlacementToNextPlacement,
     popoverPositionToNextPlacement,
     popoverPropsToNextProps,
+    popperBoundaryToNextBoundary,
     popperModifiersToNextMiddleware,
 } from "./popover-next/popoverNextMigrationUtils";
 export type {

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -41,6 +41,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
         onClose,
         onInteraction,
         openOnTargetFocus = true,
+        popoverRef,
         placement,
         positioningStrategy = "absolute",
         renderTarget,
@@ -399,6 +400,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
                     hasDarkParent={hasDarkParent}
                     isClosingViaEscapeKeypress={isClosingViaEscapeKeypress}
                     isHoverInteractionKind={isHoverInteractionKind}
+                    popoverRef={popoverRef}
                     shouldReturnFocusOnClose={shouldReturnFocusOnClose}
                     {...props}
                 />

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -10,6 +10,7 @@ import type { PopoverProps } from "../popover/popoverProps";
 import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
 
 import {
+    popoverPlacementToNextPlacement,
     popoverPositionToNextPlacement,
     popoverPropsToNextProps,
     popperModifiersToNextMiddleware,
@@ -74,6 +75,27 @@ describe("popoverPositionToNextPlacement", () => {
 
     it("should return undefined for auto-end", () => {
         expect(popoverPositionToNextPlacement("auto-end")).to.be.undefined;
+    });
+});
+
+describe("popoverPlacementToNextPlacement", () => {
+    it("should pass through non-auto placements unchanged", () => {
+        expect(popoverPlacementToNextPlacement("top")).to.equal("top");
+        expect(popoverPlacementToNextPlacement("top-start")).to.equal("top-start");
+        expect(popoverPlacementToNextPlacement("bottom-end")).to.equal("bottom-end");
+        expect(popoverPlacementToNextPlacement("left-start")).to.equal("left-start");
+    });
+
+    it("should return undefined for auto", () => {
+        expect(popoverPlacementToNextPlacement("auto")).to.be.undefined;
+    });
+
+    it("should return undefined for auto-start", () => {
+        expect(popoverPlacementToNextPlacement("auto-start")).to.be.undefined;
+    });
+
+    it("should return undefined for auto-end", () => {
+        expect(popoverPlacementToNextPlacement("auto-end")).to.be.undefined;
     });
 });
 
@@ -283,21 +305,40 @@ describe("popoverPropsToNextProps", () => {
     });
 
     it("should pass through 1:1 props as-is", () => {
-        const onClose = vi.fn();
         const result = popoverPropsToNextProps({
             content: "hello",
             hasBackdrop: true,
             isOpen: true,
             matchTargetWidth: true,
-            onClose,
             usePortal: false,
         });
         expect(result.content).to.equal("hello");
         expect(result.hasBackdrop).to.equal(true);
         expect(result.isOpen).to.equal(true);
         expect(result.matchTargetWidth).to.equal(true);
-        expect(result.onClose).to.equal(onClose);
         expect(result.usePortal).to.equal(false);
+    });
+
+    describe("onClose", () => {
+        it("should wrap onClose so legacy callbacks are only invoked with a defined event", () => {
+            const onClose = vi.fn();
+            const result = popoverPropsToNextProps({ onClose });
+            // Wrapper, not the original.
+            expect(result.onClose).to.not.equal(onClose);
+            // Forwards real events.
+            const event = { type: "click" } as React.SyntheticEvent<HTMLElement>;
+            result.onClose!(event);
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(onClose).toHaveBeenCalledWith(event);
+            // Drops undefined events to honor legacy `(event: SyntheticEvent) => void` signature.
+            result.onClose!(undefined);
+            expect(onClose).toHaveBeenCalledOnce();
+        });
+
+        it("should leave onClose undefined when not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.onClose).to.be.undefined;
+        });
     });
 
     describe("position → placement", () => {
@@ -366,21 +407,25 @@ describe("popoverPropsToNextProps", () => {
         });
     });
 
+    describe("popoverRef", () => {
+        it("should pass through popoverRef to PopoverNext", () => {
+            const ref: React.RefObject<HTMLElement> = { current: null };
+            const result = popoverPropsToNextProps({ popoverRef: ref });
+            expect(result.popoverRef).to.equal(ref);
+        });
+
+        it("should leave popoverRef undefined when not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.popoverRef).to.be.undefined;
+        });
+    });
+
     describe("dropped props", () => {
         it("should drop modifiersCustom with a dev warning", () => {
             const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
             const props: Partial<PopoverProps> = { modifiersCustom: [{ name: "custom" }] };
             const result = popoverPropsToNextProps(props);
             expect(result).not.to.have.property("modifiersCustom");
-            expect(warnSpy).toHaveBeenCalledOnce();
-            warnSpy.mockRestore();
-        });
-
-        it("should drop popoverRef with a dev warning", () => {
-            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
-            const ref = { current: null };
-            const result = popoverPropsToNextProps({ popoverRef: ref });
-            expect(result).not.to.have.property("popoverRef");
             expect(warnSpy).toHaveBeenCalledOnce();
             warnSpy.mockRestore();
         });

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -6,9 +6,14 @@ import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import type { MiddlewareConfig } from "../..";
 import { PopoverPosition } from "../popover/popoverPosition";
+import type { PopoverProps } from "../popover/popoverProps";
 import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
 
-import { popoverPositionToNextPlacement, popperModifiersToNextMiddleware } from "./popoverNextMigrationUtils";
+import {
+    popoverPositionToNextPlacement,
+    popoverPropsToNextProps,
+    popperModifiersToNextMiddleware,
+} from "./popoverNextMigrationUtils";
 
 describe("popoverPositionToNextPlacement", () => {
     it("should convert top-left to top-start", () => {
@@ -264,5 +269,129 @@ describe("popperModifiersToNextMiddleware", () => {
             shift: { padding: 4 },
         };
         expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+    });
+});
+
+describe("popoverPropsToNextProps", () => {
+    it("should pin shouldReturnFocusOnClose to false when not supplied (legacy default)", () => {
+        expect(popoverPropsToNextProps({})).to.deep.equal({ shouldReturnFocusOnClose: false });
+    });
+
+    it("should pass through shouldReturnFocusOnClose when supplied", () => {
+        const result = popoverPropsToNextProps({ shouldReturnFocusOnClose: true });
+        expect(result.shouldReturnFocusOnClose).to.equal(true);
+    });
+
+    it("should pass through 1:1 props as-is", () => {
+        const onClose = vi.fn();
+        const result = popoverPropsToNextProps({
+            content: "hello",
+            hasBackdrop: true,
+            isOpen: true,
+            matchTargetWidth: true,
+            onClose,
+            usePortal: false,
+        });
+        expect(result.content).to.equal("hello");
+        expect(result.hasBackdrop).to.equal(true);
+        expect(result.isOpen).to.equal(true);
+        expect(result.matchTargetWidth).to.equal(true);
+        expect(result.onClose).to.equal(onClose);
+        expect(result.usePortal).to.equal(false);
+    });
+
+    describe("position → placement", () => {
+        it("should convert position to placement", () => {
+            const result = popoverPropsToNextProps({ position: PopoverPosition.TOP_LEFT });
+            expect(result.placement).to.equal("top-start");
+        });
+
+        it("should leave placement undefined when position is auto", () => {
+            const result = popoverPropsToNextProps({ position: "auto" });
+            expect(result.placement).to.be.undefined;
+        });
+
+        it("should prefer placement over position when both are supplied", () => {
+            const result = popoverPropsToNextProps({
+                placement: "right",
+                position: PopoverPosition.TOP_LEFT,
+            });
+            expect(result.placement).to.equal("right");
+        });
+    });
+
+    describe("modifiers → middleware", () => {
+        it("should convert modifiers to middleware", () => {
+            const result = popoverPropsToNextProps({
+                modifiers: { flip: { options: { padding: 8 } } },
+            });
+            expect(result.middleware).to.deep.equal({ flip: { padding: 8 } });
+        });
+
+        it("should leave middleware undefined when modifiers is not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.middleware).to.be.undefined;
+        });
+    });
+
+    describe("minimal", () => {
+        it("should map minimal: true to animation: 'minimal' and arrow: false", () => {
+            const result = popoverPropsToNextProps({ minimal: true });
+            expect(result.animation).to.equal("minimal");
+            expect(result.arrow).to.equal(false);
+        });
+
+        it("should not set animation or arrow when minimal is false", () => {
+            const result = popoverPropsToNextProps({ minimal: false });
+            expect(result.animation).to.be.undefined;
+            expect(result.arrow).to.be.undefined;
+        });
+    });
+
+    describe("boundary", () => {
+        it("should remap 'clippingParents' to 'clippingAncestors'", () => {
+            const result = popoverPropsToNextProps({ boundary: "clippingParents" });
+            expect(result.boundary).to.equal("clippingAncestors");
+        });
+
+        it("should pass through Element boundary", () => {
+            const element = document.createElement("div");
+            const result = popoverPropsToNextProps({ boundary: element });
+            expect(result.boundary).to.equal(element);
+        });
+
+        it("should leave boundary undefined when not supplied (PopoverNext default = clippingAncestors)", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.boundary).to.be.undefined;
+        });
+    });
+
+    describe("dropped props", () => {
+        it("should drop modifiersCustom with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const props: Partial<PopoverProps> = { modifiersCustom: [{ name: "custom" }] };
+            const result = popoverPropsToNextProps(props);
+            expect(result).not.to.have.property("modifiersCustom");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
+
+        it("should drop popoverRef with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const ref = { current: null };
+            const result = popoverPropsToNextProps({ popoverRef: ref });
+            expect(result).not.to.have.property("popoverRef");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
+
+        it("should drop portalStopPropagationEvents with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+            const result = popoverPropsToNextProps({ portalStopPropagationEvents: ["click"] });
+            expect(result).not.to.have.property("portalStopPropagationEvents");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
     });
 });

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -2,11 +2,14 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import { isNodeEnv } from "../../common/utils";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
-import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
+import type { PopoverProps } from "../popover/popoverProps";
+import type { DefaultPopoverTargetHTMLProps, PopperModifierOverrides } from "../popover/popoverSharedProps";
 
 import type { MiddlewareConfig, PopoverNextPlacement } from "./middlewareTypes";
+import type { PopoverNextProps } from "./popoverNextProps";
 
 /**
  * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
@@ -126,4 +129,94 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     }
 
     return middleware;
+}
+
+/**
+ * Converts a partial legacy `PopoverProps` bag into a partial `PopoverNextProps` bag suitable
+ * for spreading onto `PopoverNext`. Preserves legacy default behavior where it differs from
+ * `PopoverNext`'s defaults (`shouldReturnFocusOnClose`).
+ *
+ * Transformations:
+ * - `position` → `placement` (via {@link popoverPositionToNextPlacement}). If both are supplied,
+ *   `placement` wins, mirroring legacy `Popover`'s mutex behavior.
+ * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}). A consumer-supplied
+ *   `middleware` bag takes precedence over the converted modifiers.
+ * - `minimal: true` → `animation: "minimal"` and `arrow: false` (legacy `minimal` disables the arrow).
+ * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
+ *
+ * Dropped (with dev-only `console.warn`):
+ * - `modifiersCustom` — no Floating UI equivalent; migrate manually to `middleware`.
+ * - `popoverRef` — `PopoverNext`'s `forwardRef` exposes `{ reposition }`, not the popover DOM node.
+ * - `portalStopPropagationEvents` — already deprecated and non-functional in React 17+.
+ *
+ * Intended for use inside Blueprint components that wrap `Popover` internally and pass
+ * through a `popoverProps` prop, so they can swap to `PopoverNext` without changing their public API.
+ */
+export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>(
+    props: Partial<PopoverProps<T>>,
+): Partial<PopoverNextProps<T>> {
+    const {
+        boundary,
+        minimal,
+        modifiers,
+        modifiersCustom,
+        popoverRef,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        portalStopPropagationEvents,
+        position,
+        shouldReturnFocusOnClose,
+        ...rest
+    } = props;
+
+    if (!isNodeEnv("production")) {
+        if (modifiersCustom !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `modifiersCustom` has no equivalent in PopoverNext and will be dropped. " +
+                    "Migrate to the `middleware` prop manually.",
+            );
+        }
+        if (popoverRef !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `popoverRef` has no equivalent in PopoverNext and will be dropped. " +
+                    "PopoverNext's forwarded ref exposes `{ reposition }`, not the popover DOM element.",
+            );
+        }
+        if (portalStopPropagationEvents !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `portalStopPropagationEvents` has no equivalent in PopoverNext and will be dropped.",
+            );
+        }
+    }
+
+    // `rest` is the 1:1 pass-through. Cast through `unknown` because the legacy `boundary` type
+    // (Popper.js's `Boundary`, which permits the string `"clippingParents"`) is structurally
+    // incompatible with `PopoverNextBoundary`, even though we strip `boundary` out above.
+    const nextProps: Partial<PopoverNextProps<T>> = { ...rest } as unknown as Partial<PopoverNextProps<T>>;
+
+    if (boundary !== undefined) {
+        // "clippingParents" (Popper.js) ≡ "clippingAncestors" (Floating UI).
+        nextProps.boundary = boundary === "clippingParents" ? "clippingAncestors" : (boundary as Element | Element[]);
+    }
+
+    // position → placement. Legacy `placement` wins over `position` when both are supplied.
+    if (position !== undefined && rest.placement === undefined) {
+        const converted = popoverPositionToNextPlacement(position);
+        if (converted !== undefined) {
+            nextProps.placement = converted;
+        }
+    }
+
+    if (modifiers !== undefined) {
+        nextProps.middleware = popperModifiersToNextMiddleware(modifiers);
+    }
+
+    if (minimal === true) {
+        nextProps.animation ??= "minimal";
+        nextProps.arrow ??= false;
+    }
+
+    // Legacy default for `shouldReturnFocusOnClose` is `false`; PopoverNext's is `true`.
+    nextProps.shouldReturnFocusOnClose = shouldReturnFocusOnClose ?? false;
+
+    return nextProps;
 }

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -2,42 +2,16 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import type { Placement, Boundary as PopperBoundary } from "@popperjs/core";
+
 import { isNodeEnv } from "../../common/utils";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
 import type { PopoverProps } from "../popover/popoverProps";
 import type { DefaultPopoverTargetHTMLProps, PopperModifierOverrides } from "../popover/popoverSharedProps";
 
-import type { MiddlewareConfig, PopoverNextPlacement } from "./middlewareTypes";
+import type { MiddlewareConfig, PopoverNextBoundary, PopoverNextPlacement } from "./middlewareTypes";
 import type { PopoverNextProps } from "./popoverNextProps";
-
-/**
- * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
- *
- * The `position` prop is not supported in `PopoverNext`; use the `placement` prop instead.
- * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent — they return `undefined`,
- * which causes `PopoverNext` to use its default automatic placement behavior.
- *
- * @example
- * // Before (Popover)
- * <Popover position={PopoverPosition.TOP_LEFT} />
- *
- * // After (PopoverNext)
- * <PopoverNext placement={popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)} />
- */
-export function popoverPositionToNextPlacement(position: PopoverPosition): PopoverNextPlacement | undefined {
-    switch (position) {
-        case "auto":
-        case "auto-start":
-        case "auto-end":
-            // PopoverNext uses autoPlacement middleware by default when placement is undefined.
-            return undefined;
-        default:
-            // positionToPlacement handles all remaining PopoverPosition values.
-            // The string literal values it returns are identical to PopoverNextPlacement.
-            return positionToPlacement(position) as PopoverNextPlacement;
-    }
-}
 
 /**
  * Converts Popper.js v2 `modifiers` (used by `Popover`) to a Floating UI `MiddlewareConfig` (used by `PopoverNext`).
@@ -69,7 +43,7 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     if (modifiers.flip && modifiers.flip.enabled !== false) {
         const { options } = modifiers.flip;
         middleware.flip = {
-            ...(options?.boundary != null ? { boundary: options.boundary as Element } : {}),
+            ...(options?.boundary != null ? { boundary: popperBoundaryToNextBoundary(options.boundary) } : {}),
             ...(options?.rootBoundary != null ? { rootBoundary: options.rootBoundary } : {}),
             ...(options?.padding != null ? { padding: options.padding } : {}),
             ...(options?.fallbackPlacements != null
@@ -84,7 +58,7 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     if (modifiers.preventOverflow && modifiers.preventOverflow.enabled !== false) {
         const { options } = modifiers.preventOverflow;
         middleware.shift = {
-            ...(options?.boundary != null ? { boundary: options.boundary as Element } : {}),
+            ...(options?.boundary != null ? { boundary: popperBoundaryToNextBoundary(options.boundary) } : {}),
             ...(options?.rootBoundary != null ? { rootBoundary: options.rootBoundary } : {}),
             ...(options?.padding != null ? { padding: options.padding } : {}),
             ...(options?.mainAxis != null ? { mainAxis: options.mainAxis } : {}),
@@ -146,7 +120,6 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
  *
  * Dropped (with dev-only `console.warn`):
  * - `modifiersCustom` — no Floating UI equivalent; migrate manually to `middleware`.
- * - `popoverRef` — `PopoverNext`'s `forwardRef` exposes `{ reposition }`, not the popover DOM node.
  * - `portalStopPropagationEvents` — already deprecated and non-functional in React 17+.
  *
  * Intended for use inside Blueprint components that wrap `Popover` internally and pass
@@ -155,11 +128,17 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
 export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>(
     props: Partial<PopoverProps<T>>,
 ): Partial<PopoverNextProps<T>> {
+    // Pull out every prop whose legacy type is structurally incompatible with its
+    // PopoverNext counterpart. After this destructure, `rest` contains only fields that
+    // share an identical type between Popover and PopoverNext, so the spread below is
+    // sound without any blanket cast.
     const {
         boundary,
         minimal,
         modifiers,
         modifiersCustom,
+        onClose,
+        placement,
         popoverRef,
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         portalStopPropagationEvents,
@@ -175,12 +154,6 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
                     "Migrate to the `middleware` prop manually.",
             );
         }
-        if (popoverRef !== undefined) {
-            console.warn(
-                "[Blueprint] popoverPropsToNextProps: `popoverRef` has no equivalent in PopoverNext and will be dropped. " +
-                    "PopoverNext's forwarded ref exposes `{ reposition }`, not the popover DOM element.",
-            );
-        }
         if (portalStopPropagationEvents !== undefined) {
             console.warn(
                 "[Blueprint] popoverPropsToNextProps: `portalStopPropagationEvents` has no equivalent in PopoverNext and will be dropped.",
@@ -188,18 +161,21 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         }
     }
 
-    // `rest` is the 1:1 pass-through. Cast through `unknown` because the legacy `boundary` type
-    // (Popper.js's `Boundary`, which permits the string `"clippingParents"`) is structurally
-    // incompatible with `PopoverNextBoundary`, even though we strip `boundary` out above.
-    const nextProps: Partial<PopoverNextProps<T>> = { ...rest } as unknown as Partial<PopoverNextProps<T>>;
+    const nextProps: Partial<PopoverNextProps<T>> = { ...rest };
 
     if (boundary !== undefined) {
-        // "clippingParents" (Popper.js) ≡ "clippingAncestors" (Floating UI).
-        nextProps.boundary = boundary === "clippingParents" ? "clippingAncestors" : (boundary as Element | Element[]);
+        nextProps.boundary = popperBoundaryToNextBoundary(boundary);
+    }
+
+    if (placement !== undefined) {
+        const converted = popoverPlacementToNextPlacement(placement);
+        if (converted !== undefined) {
+            nextProps.placement = converted;
+        }
     }
 
     // position → placement. Legacy `placement` wins over `position` when both are supplied.
-    if (position !== undefined && rest.placement === undefined) {
+    if (position !== undefined && nextProps.placement === undefined) {
         const converted = popoverPositionToNextPlacement(position);
         if (converted !== undefined) {
             nextProps.placement = converted;
@@ -215,8 +191,89 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         nextProps.arrow ??= false;
     }
 
+    if (onClose !== undefined) {
+        // Legacy `onClose` requires a non-undefined `event`; PopoverNext's signature allows
+        // `event` to be undefined. Wrap to honor the legacy contract — invoke the legacy
+        // handler only when an event is actually present.
+        nextProps.onClose = event => {
+            if (event !== undefined) {
+                onClose(event);
+            }
+        };
+    }
+
+    if (popoverRef !== undefined) {
+        // Legacy `popoverRef` is `React.Ref<HTMLElement>`; PopoverNext's is `React.Ref<HTMLDivElement>`.
+        // `RefObject<T>` is covariant in `T`, so `RefObject<HTMLElement>` is not strictly assignable
+        // to `RefObject<HTMLDivElement>`. In practice, the underlying DOM node *is* a `<div>` (the
+        // `Classes.POPOVER` element), so a ref slot typed for the wider `HTMLElement` will safely
+        // receive it. Cast narrowly here to acknowledge this known unsoundness without laundering
+        // it across the entire props bag.
+        nextProps.popoverRef = popoverRef as React.Ref<HTMLDivElement>;
+    }
+
     // Legacy default for `shouldReturnFocusOnClose` is `false`; PopoverNext's is `true`.
     nextProps.shouldReturnFocusOnClose = shouldReturnFocusOnClose ?? false;
 
     return nextProps;
+}
+
+/**
+ * Converts a Popper.js `Boundary` value to a Floating UI `PopoverNextBoundary` value.
+ *
+ * The two systems use different names for the "all clipping ancestors" sentinel:
+ * - Popper.js: `"clippingParents"`
+ * - Floating UI: `"clippingAncestors"`
+ *
+ * Element / `Element[]` values pass through unchanged.
+ */
+export function popperBoundaryToNextBoundary(boundary: PopperBoundary): PopoverNextBoundary {
+    return boundary === "clippingParents" ? "clippingAncestors" : boundary;
+}
+
+/**
+ * Converts a Popper.js `Placement` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
+ *
+ * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent in Floating UI — they return
+ * `undefined`, which causes `PopoverNext` to use its default automatic placement behavior.
+ * All other values pass through unchanged (the residual literal union is identical to `PopoverNextPlacement`).
+ *
+ * @example
+ * // Before (Popover)
+ * <Popover placement="top-start" />
+ *
+ * // After (PopoverNext)
+ * <PopoverNext placement={popoverPlacementToNextPlacement("top-start")} />
+ */
+export function popoverPlacementToNextPlacement(placement: Placement): PopoverNextPlacement | undefined {
+    switch (placement) {
+        case "auto":
+        case "auto-start":
+        case "auto-end":
+            // PopoverNext uses autoPlacement middleware by default when placement is undefined.
+            return undefined;
+        default:
+            return placement;
+    }
+}
+
+/**
+ * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
+ *
+ * The `position` prop is not supported in `PopoverNext`; use the `placement` prop instead.
+ * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent — they return `undefined`,
+ * which causes `PopoverNext` to use its default automatic placement behavior.
+ *
+ * @example
+ * // Before (Popover)
+ * <Popover position={PopoverPosition.TOP_LEFT} />
+ *
+ * // After (PopoverNext)
+ * <PopoverNext placement={popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)} />
+ */
+export function popoverPositionToNextPlacement(position: PopoverPosition): PopoverNextPlacement | undefined {
+    // `positionToPlacement` translates PopoverPosition's `"top-left"`/`"bottom-right"` forms to
+    // Popper's `"top-start"`/`"bottom-end"` forms, and passes `"auto"`/`"auto-start"`/`"auto-end"`
+    // through unchanged. `popoverPlacementToNextPlacement` then filters out the auto* values.
+    return popoverPlacementToNextPlacement(positionToPlacement(position));
 }

--- a/packages/core/src/components/popover-next/popoverNextProps.ts
+++ b/packages/core/src/components/popover-next/popoverNextProps.ts
@@ -284,6 +284,11 @@ export interface PopoverNextProps<T extends DefaultPopoverTargetHTMLProps = Defa
     openOnTargetFocus?: boolean;
 
     /**
+     * DOM ref attached to the `Classes.POPOVER` element.
+     */
+    popoverRef?: React.Ref<HTMLDivElement>;
+
+    /**
      * The placement (relative to the target) at which the popover should appear.
      * Mutually exclusive with `position` prop. Prefer using this over `position`,
      * as it more closely aligns with Floating UI semantics.
@@ -476,6 +481,7 @@ export interface PopoverPopupProps
         | "onOpened"
         | "onOpening"
         | "popoverClassName"
+        | "popoverRef"
         | "portalClassName"
         | "portalContainer"
         | "shouldReturnFocusOnClose"

--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -42,6 +42,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
         onOpened,
         onOpening,
         popoverClassName,
+        popoverRef,
         portalClassName,
         portalContainer,
         transitionDuration = 300,
@@ -139,7 +140,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
                 ref={mergeRefs(floatingData.refs.setFloating, transitionContainerElement)}
                 {...popoverHandlers}
             >
-                <div className={popoverClasses} style={{ transformOrigin }}>
+                <div className={popoverClasses} ref={popoverRef} style={{ transformOrigin }}>
                     {arrow && (
                         <PopoverArrow
                             arrowProps={{ ref: arrowRef, style: arrowStyle }}


### PR DESCRIPTION
## Context

`PopoverNext` was introduced in [palantir/blueprint#7573](https://github.com/palantir/blueprint/pull/7573) as the Floating-UI–based replacement for the legacy Popper.js-backed `Popover`. That PR explicitly defers migrating the components that wrap `Popover` internally and re-expose it via a `popoverProps` pass-through. Migration utilities and codemods were called out as forthcoming follow-ups.

`PopoverProps` and `PopoverNextProps` are similar but not type-compatible. A handful of props were renamed, a few were dropped, and two defaults shifted. So a direct in-place swap of `<Popover>` for `<PopoverNext>` doesn't work: any `popoverProps` bag a consumer passes is typed against the legacy shape, and a few of those legacy fields just don't exist on the new component.

This PR migrates Breadcrumbs and lands a reusable shim along the way. Breadcrumbs is the smallest/easiest case, which makes it a good blueprint: the same shim and the same wiring pattern should carry the rest of the deferred component migrations with very little per-component work. The shim is also useful to external consumers migrating their own code.

**The aim:** swap Breadcrumbs' internal `Popover` for `PopoverNext` with no changes to its public API and no observable behavior change for existing consumers.

## What changed

### 1. New `popoverPropsToNextProps()` migration utility

`packages/core/src/components/popover-next/popoverNextMigrationUtils.ts`

```ts
export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>(
    props: Partial<PopoverProps<T>>,
): Partial<PopoverNextProps<T>>
```

It lives next to the two migration helpers already in this file (`popoverPositionToNextPlacement`, `popperModifiersToNextMiddleware`) and reuses them internally. Exported from `packages/core/src/components/index.ts` so external consumers can use it for their own migration.

### 2. Breadcrumbs swapped to `PopoverNext`

`packages/core/src/components/breadcrumbs/breadcrumbs.tsx`

The internal overflow-menu `<Popover>` is now a `<PopoverNext>`. Consumer-supplied `popoverProps` go through `popoverPropsToNextProps()` before being spread. The shim runs even when no `popoverProps` are passed (`popoverProps ?? {}`), so the legacy default for `shouldReturnFocusOnClose: false` always applies and consumers don't see a shift.

The public `BreadcrumbsProps` interface is unchanged. `popoverProps` continues to accept the legacy `PopoverProps` shape.

## Prop mapping reference

The legacy `PopoverProps` exposes ~47 props once you include everything inherited from `PopoverSharedProps`, `OverlayableProps`, `OverlayLifecycleProps`, and `Props`. The shim handles them in four buckets.

| Category | Count | Props | Handling |
|---|---|---|---|
| 1:1 pass-through | 39 | `children`, `content`, `isOpen`, `defaultIsOpen`, `disabled`, `usePortal`, `interactionKind`, `popupKind`, `hasBackdrop`, `backdropProps`, `captureDismiss`, `canEscapeKeyClose`, `enforceFocus`, `lazy`, `transitionDuration`, `placement`, `popoverClassName`, `portalClassName`, `portalContainer`, `inheritDarkTheme`, `matchTargetWidth`, `hoverOpenDelay`, `hoverCloseDelay`, `openOnTargetFocus`, `autoFocus`, `fill`, `targetTagName`, `targetProps`, `renderTarget`, `rootBoundary`, `positioningStrategy`, `onClose`, `onClosed`, `onClosing`, `onOpened`, `onOpening`, `onInteraction`, `className` | Spread as-is |
| Transformed | 4 | `position` to `placement` | Via `popoverPositionToNextPlacement()`. If both `position` and `placement` are present, `placement` wins (matches legacy mutex semantics). |
| | | `modifiers` to `middleware` | Via `popperModifiersToNextMiddleware()` |
| | | `minimal: true` to `animation: "minimal"` plus `arrow: false` | Legacy `minimal` both uses the subtler animation and disables the arrow |
| | | `boundary: "clippingParents"` to `"clippingAncestors"` | Floating UI's semantic equivalent. `Element` and `Element[]` pass through unchanged. |
| Pinned defaults | 1 | `shouldReturnFocusOnClose ?? false` | Legacy default is `false`; PopoverNext defaults to `true`. Pinned so the swap is invisible. |
| Dropped (dev `console.warn`) | 3 | `modifiersCustom` | No Floating UI equivalent; consumers must migrate manually to `middleware`. |
| | | `popoverRef` | `PopoverNext`'s `forwardRef` exposes `{ reposition }`, not the popover DOM element. |
| | | `portalStopPropagationEvents` | Already deprecated; non-functional under React 17+. |

Note that `boundary` itself isn't explicitly pinned. PopoverNext's default of `"clippingAncestors"` is the Floating UI equivalent of legacy's `"clippingParents"`. The strings differ; the semantics don't. Pinning would have been a no-op.

## Behavior preservation

For Breadcrumbs specifically, the only `popoverProps` fields the existing test suite exercises are `isOpen` and `usePortal`, both 1:1. There are no doc-app examples that pass `popoverProps`. The plausible consumer-visible behavior shifts come down to three spots, and each is mitigated:

1. `shouldReturnFocusOnClose` default. Legacy is `false`, PopoverNext is `true`. The shim runs unconditionally and pins it to `false`.
2. Boundary semantics. Legacy `"clippingParents"` and new `"clippingAncestors"` are the equivalent concept in Floating UI, so no remap is needed when the consumer doesn't supply a boundary.
3. `position: "auto"`. Converts to `placement: undefined`, which makes PopoverNext fall back to its `autoPlacement` middleware. Same end-user behavior as legacy's `flip`-based auto.

## Verification

Manual UI checks worth running before merge (not covered automatically):
- Render `Breadcrumbs` with overflow and click the collapsed indicator. Default placement: `bottom-start`.
- `collapseFrom={Boundary.END}` should produce `bottom-end`.
- `popoverProps={{ usePortal: false }}`: menu mounts inline. This is the path the two skipped tests exercise.
- `popoverProps={{ minimal: true }}`: no arrow, minimal animation.
- `popoverProps={{ position: "right" }}`: shim converts to `placement: "right"`.
- `popoverProps={{ modifiersCustom: [] }}` in dev mode: console warning fires.

## Caveats and follow-ups

None of these block Breadcrumbs, but they're worth tracking as a heads-up for the next component migrations that pick up this shim.

The `popoverRef` gap is the one I'd flag first. Legacy consumers that reach into the popover DOM via `popoverRef` lose that capability; PopoverNext's forwarded ref exposes only `{ reposition }`. If a future component migration runs into a consumer that actually uses `popoverRef`, that needs a separate fix, probably another ref-forwarding layer in PopoverNext that surfaces the floating element.

The `modifiersCustom` gap is the same shape: arbitrary Popper.js modifier objects can't be machine-translated into Floating UI middleware. Anything reaching for it has to migrate manually to `middleware`.

`portalStopPropagationEvents` doesn't work under React 17+ anyway, so dropping it is a no-op in practice. The dev warning exists for discoverability.

For the wider migration, the pattern Breadcrumbs follows here is the template: swap `<Popover>` for `<PopoverNext>` and spread `popoverPropsToNextProps(popoverProps ?? {})`. Each future component has its own internal `Popover` call to swap, but the public-facing `popoverProps` API can stay frozen.
