### PR TITLE
Migrate all internal Popover usages to PopoverNext

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,8 +21,9 @@ import { Boundary, Classes, DISPLAYNAME_PREFIX, type Props, removeNonHTMLProps }
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
-import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 
 import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
 
@@ -150,11 +151,11 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
 
             return (
                 <li>
-                    <Popover
+                    <PopoverNext
                         content={<Menu>{orderedItems.map(renderOverflowBreadcrumb)}</Menu>}
                         disabled={orderedItems.length === 0}
                         placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
-                        {...popoverProps}
+                        {...popoverPropsToNextProps(popoverProps)}
                     >
                         <span
                             aria-label="collapsed breadcrumbs"
@@ -163,7 +164,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
                             {...overflowButtonProps}
                             className={classNames(Classes.BREADCRUMBS_COLLAPSED, overflowButtonProps?.className)}
                         />
-                    </Popover>
+                    </PopoverNext>
                 </li>
             );
         },

--- a/packages/core/src/components/button/ButtonGroup.stories.tsx
+++ b/packages/core/src/components/button/ButtonGroup.stories.tsx
@@ -8,7 +8,7 @@ import { StoryLabel } from "@storybook-common";
 import { Flex } from "@blueprintjs/labs";
 
 import { Alignment, ButtonVariant, Intent, Size } from "../../common";
-import { Popover } from "../popover/popover";
+import { PopoverNext } from "../popover-next/popoverNext";
 
 import { ButtonGroup } from "./buttonGroup";
 import { Button } from "./buttons";
@@ -273,13 +273,13 @@ export const WithPopover: Story = {
                         <StoryLabel title={variant} />
                         <ButtonGroup {...args} variant={variant}>
                             {BUTTONS.map(({ icon, label }) => (
-                                <Popover
+                                <PopoverNext
                                     key={icon}
                                     content={<span style={{ padding: 10 }}>{label}</span>}
                                     placement="bottom"
                                 >
                                     <Button icon={icon} aria-label={label} />
-                                </Popover>
+                                </PopoverNext>
                             ))}
                         </ButtonGroup>
                     </Flex>

--- a/packages/core/src/components/button/button-group.mdx
+++ b/packages/core/src/components/button/button-group.mdx
@@ -109,7 +109,7 @@ Set it at the group level for uniform alignment or on individual buttons for spe
 ### Usage with popovers
 
 **Button** elements inside a **ButtonGroup** can be wrapped with a
-[**Popover**](#core/components/popover) to create complex toolbars.
+[**PopoverNext**](#core/components/popover-next) to create complex toolbars.
 
 @reactExample ButtonGroupPopoverExample
 

--- a/packages/core/src/components/context-menu/context-menu-popover.mdx
+++ b/packages/core/src/components/context-menu/context-menu-popover.mdx
@@ -18,7 +18,7 @@ The APIs described on this page are lower-level and have some limitations compar
 
 **Context Menu Popover** is a lower-level API for [**Context Menu**](#core/components/context-menu) which does
 not hook up any interaction handlers for you and simply renders an opinionated
-[**Popover**](#core/components/popover) at a particular target offset on the page through a
+[**PopoverNext**](#core/components/popover-next) at a particular target offset on the page through a
 [**Portal**](#core/components/portal).
 
 @reactExample ContextMenuPopoverExample

--- a/packages/core/src/components/context-menu/context-menu.mdx
+++ b/packages/core/src/components/context-menu/context-menu.mdx
@@ -5,7 +5,7 @@ title: Context Menu
 # Context Menu
 
 **Context menus** present the user with a list of actions when right-clicking on a target element.
-They essentially generate an opinionated [**Popover**](#core/components/popover) instance configured
+They essentially generate an opinionated [**PopoverNext**](#core/components/popover-next) instance configured
 with the appropriate interaction handlers.
 
 ## Import

--- a/packages/core/src/components/context-menu/contextMenu.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom";
 import classNames from "classnames";
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef, useCallback } from "react";
@@ -24,7 +25,6 @@ import { Classes, Utils } from "../../common";
 import { Drawer } from "../drawer/drawer";
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
-import { PopoverInteractionKind } from "../popover/popoverProps";
 import { PopoverNext } from "../popover-next/popoverNext";
 import { Tooltip, type TooltipProps } from "../tooltip/tooltip";
 
@@ -44,6 +44,7 @@ const TOOLTIP_SELECTOR = `.${Classes.TOOLTIP}`;
 const COMMON_TOOLTIP_PROPS: Partial<TooltipProps> = {
     hoverCloseDelay: 0,
     hoverOpenDelay: 0,
+    transitionDuration: 0,
     usePortal: false,
 };
 
@@ -339,9 +340,7 @@ describe("ContextMenu", () => {
 
     describe("interacting with other components", () => {
         describe("with one level of nesting", () => {
-            // TODO(popover-next-migration): re-enable after migrating these assertions off PopoverNext class state.
-            // PopoverNext is a function component; .state("isOpen") no longer applies.
-            it.skip("closes parent Tooltip", () => {
+            it("closes parent Tooltip", async () => {
                 const wrapper = mount(
                     <Tooltip content="hello" {...COMMON_TOOLTIP_PROPS}>
                         <ContextMenu content={MENU} popoverProps={{ transitionDuration: 0 }}>
@@ -357,7 +356,7 @@ describe("ContextMenu", () => {
                     wrapper.find(ContextMenu).find(PopoverNext).prop("isOpen"),
                     "ContextMenu popover should be open",
                 ).toBe(true);
-                assertTooltipClosed(wrapper);
+                await assertTooltipClosed();
                 closeCtxMenu(wrapper);
             });
 
@@ -383,14 +382,15 @@ describe("ContextMenu", () => {
                 closeCtxMenu(wrapper);
             });
 
-            function assertTooltipClosed(wrapper: ReactWrapper) {
-                expect(
-                    wrapper
-                        .find(PopoverNext)
-                        .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
-                        .state("isOpen"),
-                    "Tooltip should be closed",
-                ).toBe(false);
+            async function assertTooltipClosed() {
+                // Tooltip close is driven by a `useEffect` inside PopoverNext that syncs internal
+                // state when `disabled` flips true, so the DOM unmount lands in a later tick.
+                // Query the document directly because the Enzyme wrapper can hold stale references.
+                await waitFor(() => {
+                    expect(document.querySelectorAll(`.${Classes.TOOLTIP}`), "Tooltip should be closed").toHaveLength(
+                        0,
+                    );
+                });
             }
         });
 
@@ -398,13 +398,12 @@ describe("ContextMenu", () => {
             const OUTER_TARGET_CLASSNAME = "outer-target";
 
             describe("ContextMenu > Tooltip > ContextMenu", () => {
-                // TODO(popover-next-migration): re-enable after migrating these assertions off PopoverNext class state.
-                it.skip("closes tooltip when inner menu opens", () => {
+                it("closes tooltip when inner menu opens", async () => {
                     const wrapper = mountTestCase();
                     openTooltip(wrapper);
                     expect(wrapper.find(TOOLTIP_SELECTOR), "tooltip should be open").toHaveLength(1);
                     openCtxMenu(wrapper);
-                    assertTooltipClosed(wrapper);
+                    await assertTooltipClosed();
                     const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
                     expect(ctxMenuPopover.exists(), "ContextMenu popover should be open").toBe(true);
                     expect(ctxMenuPopover.text().includes("first"), "inner ContextMenu should be open").toBe(true);
@@ -473,14 +472,16 @@ describe("ContextMenu", () => {
                     return wrapper;
                 }
 
-                function assertTooltipClosed(wrapper: ReactWrapper) {
-                    expect(
-                        wrapper
-                            .find(PopoverNext)
-                            .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
-                            .state("isOpen"),
-                        "Tooltip should be closed",
-                    ).toBe(false);
+                async function assertTooltipClosed() {
+                    // Tooltip close is driven by a `useEffect` inside PopoverNext that syncs internal
+                    // state when `disabled` flips true, so the DOM unmount lands in a later tick.
+                    // Query the document directly because the Enzyme wrapper can hold stale references.
+                    await waitFor(() => {
+                        expect(
+                            document.querySelectorAll(`.${Classes.TOOLTIP}`),
+                            "Tooltip should be closed",
+                        ).toHaveLength(0);
+                    });
                 }
             });
 
@@ -489,22 +490,21 @@ describe("ContextMenu", () => {
                 const INNER_TOOLTIP_CONTENT = "goodbye";
                 const CTX_MENU_CLASSNAME = "test-ctx-menu";
 
-                // TODO(popover-next-migration): re-enable after migrating these assertions off PopoverNext class state.
-                it.skip("closes inner tooltip when menu opens (after hovering inner target)", () => {
+                it("closes inner tooltip when menu opens (after hovering inner target)", async () => {
                     const wrapper = mountTestCase();
                     wrapper.find(`.${OUTER_TARGET_CLASSNAME}`).simulate("mouseenter");
                     openTooltip(wrapper);
-                    expect(wrapper.find(`.${Classes.TOOLTIP}`), "tooltip should be open").toHaveLength(1);
+                    expect(wrapper.find(TOOLTIP_SELECTOR), "tooltip should be open").toHaveLength(1);
                     openCtxMenu(wrapper);
-                    // this assertion is difficult to test, but we know that the tooltip eventually does close in manual testing
-                    expect(
-                        wrapper
-                            .find(PopoverNext)
-                            .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
-                            .first()
-                            .state("isOpen"),
-                        "Tooltip should be closed",
-                    ).toBe(false);
+                    // Tooltip close is driven by a `useEffect` inside PopoverNext that syncs internal
+                    // state when `disabled` flips true, so the DOM unmount lands in a later tick.
+                    // Query the document directly because the Enzyme wrapper can hold stale references.
+                    await waitFor(() => {
+                        expect(
+                            document.querySelectorAll(`.${Classes.TOOLTIP}`),
+                            "Tooltip should be closed",
+                        ).toHaveLength(0);
+                    });
                     const ctxMenuPopover = wrapper.find(`.${Classes.CONTEXT_MENU_POPOVER}`).hostNodes();
                     expect(ctxMenuPopover.exists(), "ContextMenu popover should be open").toBe(true);
                     closeCtxMenu(wrapper);

--- a/packages/core/src/components/context-menu/contextMenu.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.test.tsx
@@ -24,8 +24,8 @@ import { Classes, Utils } from "../../common";
 import { Drawer } from "../drawer/drawer";
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
-import { Popover } from "../popover/popover";
 import { PopoverInteractionKind } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
 import { Tooltip, type TooltipProps } from "../tooltip/tooltip";
 
 import { ContextMenu, type ContextMenuContentProps, type ContextMenuProps } from "./contextMenu";
@@ -88,13 +88,13 @@ describe("ContextMenu", () => {
         it("renders children and Popover", () => {
             const ctxMenu = mountTestMenu();
             expect(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists()).toBe(true);
-            expect(ctxMenu.find(Popover).exists()).toBe(true);
+            expect(ctxMenu.find(PopoverNext).exists()).toBe(true);
         });
 
         it("opens popover on right click", () => {
             const ctxMenu = mountTestMenu();
             openCtxMenu(ctxMenu);
-            expect(ctxMenu.find(Popover).prop("isOpen")).toBe(true);
+            expect(ctxMenu.find(PopoverNext).prop("isOpen")).toBe(true);
         });
 
         it("renders custom HTML tag if specified", () => {
@@ -119,7 +119,7 @@ describe("ContextMenu", () => {
                     key: "Escape",
                     nativeEvent: new KeyboardEvent("keydown"),
                 });
-            expect(ctxMenu.find(Popover).prop("isOpen")).toBe(false);
+            expect(ctxMenu.find(PopoverNext).prop("isOpen")).toBe(false);
         });
 
         it("clicks inside popover don't propagate to context menu wrapper", () => {
@@ -166,13 +166,13 @@ describe("ContextMenu", () => {
         it("renders children and Popover", () => {
             const ctxMenu = mountTestMenu();
             expect(ctxMenu.find(`.${TARGET_CLASSNAME}`).exists()).toBe(true);
-            expect(ctxMenu.find(Popover).exists()).toBe(true);
+            expect(ctxMenu.find(PopoverNext).exists()).toBe(true);
         });
 
         it("opens popover on right click", () => {
             const ctxMenu = mountTestMenu();
             openCtxMenu(ctxMenu);
-            expect(ctxMenu.find(Popover).prop("isOpen")).toBe(true);
+            expect(ctxMenu.find(PopoverNext).prop("isOpen")).toBe(true);
         });
 
         it("handles context menu event, even if content is undefined", () => {
@@ -339,7 +339,9 @@ describe("ContextMenu", () => {
 
     describe("interacting with other components", () => {
         describe("with one level of nesting", () => {
-            it("closes parent Tooltip", () => {
+            // TODO(popover-next-migration): re-enable after migrating these assertions off PopoverNext class state.
+            // PopoverNext is a function component; .state("isOpen") no longer applies.
+            it.skip("closes parent Tooltip", () => {
                 const wrapper = mount(
                     <Tooltip content="hello" {...COMMON_TOOLTIP_PROPS}>
                         <ContextMenu content={MENU} popoverProps={{ transitionDuration: 0 }}>
@@ -352,7 +354,7 @@ describe("ContextMenu", () => {
                 openTooltip(wrapper);
                 openCtxMenu(wrapper);
                 expect(
-                    wrapper.find(ContextMenu).find(Popover).prop("isOpen"),
+                    wrapper.find(ContextMenu).find(PopoverNext).prop("isOpen"),
                     "ContextMenu popover should be open",
                 ).toBe(true);
                 assertTooltipClosed(wrapper);
@@ -372,7 +374,7 @@ describe("ContextMenu", () => {
                 openTooltip(wrapper);
                 openCtxMenu(wrapper);
                 expect(
-                    wrapper.find(ContextMenu).find(Popover).first().prop("isOpen"),
+                    wrapper.find(ContextMenu).find(PopoverNext).first().prop("isOpen"),
                     "ContextMenu popover should be open",
                 ).toBe(true);
                 // this assertion is difficult to unit test, but we know that the tooltip closes in manual testing,
@@ -384,7 +386,7 @@ describe("ContextMenu", () => {
             function assertTooltipClosed(wrapper: ReactWrapper) {
                 expect(
                     wrapper
-                        .find(Popover)
+                        .find(PopoverNext)
                         .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                         .state("isOpen"),
                     "Tooltip should be closed",
@@ -396,7 +398,8 @@ describe("ContextMenu", () => {
             const OUTER_TARGET_CLASSNAME = "outer-target";
 
             describe("ContextMenu > Tooltip > ContextMenu", () => {
-                it("closes tooltip when inner menu opens", () => {
+                // TODO(popover-next-migration): re-enable after migrating these assertions off PopoverNext class state.
+                it.skip("closes tooltip when inner menu opens", () => {
                     const wrapper = mountTestCase();
                     openTooltip(wrapper);
                     expect(wrapper.find(TOOLTIP_SELECTOR), "tooltip should be open").toHaveLength(1);
@@ -473,7 +476,7 @@ describe("ContextMenu", () => {
                 function assertTooltipClosed(wrapper: ReactWrapper) {
                     expect(
                         wrapper
-                            .find(Popover)
+                            .find(PopoverNext)
                             .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                             .state("isOpen"),
                         "Tooltip should be closed",
@@ -486,7 +489,8 @@ describe("ContextMenu", () => {
                 const INNER_TOOLTIP_CONTENT = "goodbye";
                 const CTX_MENU_CLASSNAME = "test-ctx-menu";
 
-                it("closes inner tooltip when menu opens (after hovering inner target)", () => {
+                // TODO(popover-next-migration): re-enable after migrating these assertions off PopoverNext class state.
+                it.skip("closes inner tooltip when menu opens (after hovering inner target)", () => {
                     const wrapper = mountTestCase();
                     wrapper.find(`.${OUTER_TARGET_CLASSNAME}`).simulate("mouseenter");
                     openTooltip(wrapper);
@@ -495,7 +499,7 @@ describe("ContextMenu", () => {
                     // this assertion is difficult to test, but we know that the tooltip eventually does close in manual testing
                     expect(
                         wrapper
-                            .find(Popover)
+                            .find(PopoverNext)
                             .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                             .first()
                             .state("isOpen"),
@@ -515,7 +519,7 @@ describe("ContextMenu", () => {
                     // this assertion is difficult to test, but we know that the tooltip eventually does close in manual testing
                     // assert.isFalse(
                     //     wrapper
-                    //         .find(Popover)
+                    //         .find(PopoverNext)
                     //         .find({ interactionKind: PopoverInteractionKind.HOVER_TARGET_ONLY })
                     //         .last()
                     //         .state("isOpen"),

--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -18,8 +18,9 @@ import classNames from "classnames";
 import { memo, useCallback } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
-import { Popover } from "../popover/popover";
 import type { PopoverTargetProps } from "../popover/popoverSharedProps";
+import { PopoverNext } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 import { Portal } from "../portal/portal";
 
 import type { ContextMenuPopoverOptions, Offset } from "./contextMenuShared";
@@ -73,11 +74,11 @@ export const ContextMenuPopover = memo(function ContextMenuPopover(props: Contex
     );
 
     return (
-        <Popover
+        <PopoverNext
             placement="right-start"
             rootBoundary={rootBoundary}
             transitionDuration={transitionDuration}
-            {...popoverProps}
+            {...popoverPropsToNextProps(popoverProps)}
             content={
                 // this prevents right-clicking inside our context menu
                 <div onContextMenu={cancelContextMenu}>{content}</div>
@@ -88,7 +89,8 @@ export const ContextMenuPopover = memo(function ContextMenuPopover(props: Contex
             key={getPopoverKey(targetOffset)}
             hasBackdrop={true}
             backdropProps={{ className: Classes.CONTEXT_MENU_BACKDROP }}
-            minimal={true}
+            animation="minimal"
+            arrow={false}
             onInteraction={handleInteraction}
             popoverClassName={classNames(Classes.CONTEXT_MENU_POPOVER, popoverClassName, {
                 [Classes.DARK]: isDarkTheme,

--- a/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { waitFor } from "@testing-library/dom";
+
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
 import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
@@ -70,8 +72,10 @@ describe("showContextMenu() + hideContextMenu()", () => {
         document.body.appendChild(containerElement);
     });
 
-    beforeEach(() => {
-        assertMenuState(false);
+    beforeEach(async () => {
+        // The prior test's dismissal may still be flushing through React when the next test starts;
+        // poll briefly so we don't fail on leftover overlay state.
+        await waitFor(() => assertMenuState(false));
     });
 
     afterAll(() => {
@@ -95,10 +99,7 @@ describe("showContextMenu() + hideContextMenu()", () => {
         }));
 
     describe("hides a menu", () => {
-        // TODO(popover-next-migration): the OVERLAY_OPEN class lingers on the portal after dismissal.
-        // Likely a transition-timing diff between PopoverNext and the legacy Popover. Skipped pending
-        // a closer look at ContextMenuPopover + PopoverNext close behavior.
-        it.skip("by clicking on the backdrop (when onClose prop is defined)", () =>
+        it("by clicking on the backdrop (when onClose prop is defined)", () =>
             new Promise<void>(done => {
                 const handleClose = () =>
                     requestAnimationFrame(() => {
@@ -116,8 +117,7 @@ describe("showContextMenu() + hideContextMenu()", () => {
                 });
             }));
 
-        // TODO(popover-next-migration): same story as the backdrop dismissal test above.
-        it.skip("via hideContextMenu()", () =>
+        it("via hideContextMenu()", () =>
             new Promise<void>(done => {
                 showContextMenu({
                     ...DEFAULT_CONTEXT_MENU_POPOVER_PROPS,

--- a/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
@@ -95,7 +95,10 @@ describe("showContextMenu() + hideContextMenu()", () => {
         }));
 
     describe("hides a menu", () => {
-        it("by clicking on the backdrop (when onClose prop is defined)", () =>
+        // TODO(popover-next-migration): the OVERLAY_OPEN class lingers on the portal after dismissal.
+        // Likely a transition-timing diff between PopoverNext and the legacy Popover. Skipped pending
+        // a closer look at ContextMenuPopover + PopoverNext close behavior.
+        it.skip("by clicking on the backdrop (when onClose prop is defined)", () =>
             new Promise<void>(done => {
                 const handleClose = () =>
                     requestAnimationFrame(() => {
@@ -113,7 +116,8 @@ describe("showContextMenu() + hideContextMenu()", () => {
                 });
             }));
 
-        it("via hideContextMenu()", () =>
+        // TODO(popover-next-migration): same story as the backdrop dismissal test above.
+        it.skip("via hideContextMenu()", () =>
             new Promise<void>(done => {
                 showContextMenu({
                     ...DEFAULT_CONTEXT_MENU_POPOVER_PROPS,

--- a/packages/core/src/components/menu/menu.mdx
+++ b/packages/core/src/components/menu/menu.mdx
@@ -62,12 +62,12 @@ prop to define **MenuItem** content.
 ## Dropdowns
 
 **Menu** only renders a static list container element. To make an interactive dropdown menu, you may leverage
-[**Popover**](#core/components/popover) and specify a **Menu** as the `content` property:
+[**PopoverNext**](#core/components/popover-next) and specify a **Menu** as the `content` property:
 
 ```tsx
-<Popover content={<Menu>...</Menu>} placement="bottom">
+<PopoverNext content={<Menu>...</Menu>} placement="bottom">
     <Button alignText="start" icon="applications" endIcon="caret-down" text="Open with..." />
-</Popover>
+</PopoverNext>
 ```
 
 Some tips for designing dropdown menus:

--- a/packages/core/src/components/menu/menuItem.test.tsx
+++ b/packages/core/src/components/menu/menuItem.test.tsx
@@ -23,8 +23,8 @@ import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vite
 import { Classes } from "../../common";
 import { Button } from "../button/buttons";
 import { Icon } from "../icon/icon";
-import { Popover } from "../popover/popover";
 import { PopoverInteractionKind } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
 import { Text } from "../text/text";
 
 import { type MenuProps } from "./menu";
@@ -92,7 +92,7 @@ describe("MenuItem", () => {
                 <MenuItem icon="underline" text="Underline" />
             </MenuItem>,
         );
-        assert.isTrue(wrapper.find(Popover).prop("disabled"));
+        assert.isTrue(wrapper.find(PopoverNext).prop("disabled"));
     });
 
     it("disabled MenuItem blocks mouse listeners", () => {
@@ -134,9 +134,9 @@ describe("MenuItem", () => {
         const handleClose = vi.fn();
         const menu = <MenuItem text="Graph" shouldDismissPopover={false} />;
         const wrapper = mount(
-            <Popover content={menu} isOpen={true} onInteraction={handleClose} usePortal={false}>
+            <PopoverNext content={menu} isOpen={true} onInteraction={handleClose} usePortal={false}>
                 <Button />
-            </Popover>,
+            </PopoverNext>,
         );
         wrapper.find(MenuItem).find("a").simulate("click");
         expect(handleClose).not.toHaveBeenCalled();
@@ -167,12 +167,12 @@ describe("MenuItem", () => {
                 <MenuItem text="two" />
             </MenuItem>,
         );
-        assert.strictEqual(wrapper.find(Popover).prop("interactionKind"), popoverProps.interactionKind);
+        assert.strictEqual(wrapper.find(PopoverNext).prop("interactionKind"), popoverProps.interactionKind);
         assert.notStrictEqual(
-            wrapper.find(Popover).prop("popoverClassName")!.indexOf(popoverProps.popoverClassName),
+            wrapper.find(PopoverNext).prop("popoverClassName")!.indexOf(popoverProps.popoverClassName),
             0,
         );
-        assert.notStrictEqual(wrapper.find(Popover).prop("content"), popoverProps.content);
+        assert.notStrictEqual(wrapper.find(PopoverNext).prop("content"), popoverProps.content);
     });
 
     it("multiline prop determines if long content is ellipsized", () => {
@@ -271,7 +271,7 @@ describe("MenuItem", () => {
 });
 
 function findSubmenu(wrapper: ShallowWrapper<any, any>) {
-    return wrapper.find(Popover).prop("content") as React.ReactElement<
+    return wrapper.find(PopoverNext).prop("content") as React.ReactElement<
         MenuProps & { children: Array<React.ReactElement<MenuItemProps>> }
     >;
 }

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -280,6 +280,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
     );
 
     const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });
+    const nextPopoverProps = popoverPropsToNextProps(popoverProps);
     return (
         <li className={liClasses} ref={ref} role={liRole} aria-selected={ariaSelected}>
             {children == null ? (
@@ -293,11 +294,16 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
                     enforceFocus={false}
                     hoverCloseDelay={0}
                     interactionKind="hover"
-                    middleware={SUBMENU_POPOVER_MIDDLEWARE}
                     targetProps={{ role: targetRole, tabIndex: 0 }}
                     placement="right-start"
                     usePortal={false}
-                    {...popoverPropsToNextProps(popoverProps)}
+                    {...nextPopoverProps}
+                    // Merge per-key so a consumer that customizes one middleware (e.g. `flip`) doesn't
+                    // wipe out the submenu's positioning baseline; consumer-supplied keys still win.
+                    middleware={{
+                        ...SUBMENU_POPOVER_MIDDLEWARE,
+                        ...nextPopoverProps.middleware,
+                    }}
                     content={<Menu {...submenuProps}>{children}</Menu>}
                     animation="minimal"
                     arrow={false}

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -23,8 +23,10 @@ import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
-import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
+import type { MiddlewareConfig } from "../popover-next/middlewareTypes";
+import { PopoverNext } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 import { Text } from "../text/text";
 
 import { Menu, type MenuProps } from "./menu";
@@ -283,7 +285,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             {children == null ? (
                 target
             ) : (
-                <Popover
+                <PopoverNext
                     // eslint-disable-next-line jsx-a11y/no-autofocus -- intentionally disabled
                     autoFocus={false}
                     captureDismiss={false}
@@ -291,29 +293,30 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
                     enforceFocus={false}
                     hoverCloseDelay={0}
                     interactionKind="hover"
-                    modifiers={SUBMENU_POPOVER_MODIFIERS}
+                    middleware={SUBMENU_POPOVER_MIDDLEWARE}
                     targetProps={{ role: targetRole, tabIndex: 0 }}
                     placement="right-start"
                     usePortal={false}
-                    {...popoverProps}
+                    {...popoverPropsToNextProps(popoverProps)}
                     content={<Menu {...submenuProps}>{children}</Menu>}
-                    minimal={true}
+                    animation="minimal"
+                    arrow={false}
                     popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
                 >
                     {target}
-                </Popover>
+                </PopoverNext>
             )}
         </li>
     );
 });
 MenuItem.displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;
 
-const SUBMENU_POPOVER_MODIFIERS: PopoverProps["modifiers"] = {
+const SUBMENU_POPOVER_MIDDLEWARE: MiddlewareConfig = {
     // 20px padding - scrollbar width + a bit
-    flip: { enabled: true, options: { padding: 20, rootBoundary: "viewport" } },
+    flip: { padding: 20, rootBoundary: "viewport" },
     // shift popover up 5px so MenuItems align
-    offset: { enabled: true, options: { offset: [-5, 0] } },
-    preventOverflow: { enabled: true, options: { padding: 20, rootBoundary: "viewport" } },
+    offset: { crossAxis: -5 },
+    shift: { padding: 20, rootBoundary: "viewport" },
 };
 
 // props to ignore when disabled

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -299,6 +299,11 @@ describe("popoverPropsToNextProps", () => {
         expect(popoverPropsToNextProps({})).to.deep.equal({ shouldReturnFocusOnClose: false });
     });
 
+    it("should treat undefined input the same as an empty object", () => {
+        expect(popoverPropsToNextProps()).to.deep.equal({ shouldReturnFocusOnClose: false });
+        expect(popoverPropsToNextProps(undefined)).to.deep.equal({ shouldReturnFocusOnClose: false });
+    });
+
     it("should pass through shouldReturnFocusOnClose when supplied", () => {
         const result = popoverPropsToNextProps({ shouldReturnFocusOnClose: true });
         expect(result.shouldReturnFocusOnClose).to.equal(true);

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -131,9 +131,12 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
  *
  * Intended for use inside Blueprint components that wrap `Popover` internally and pass
  * through a `popoverProps` prop, so they can swap to `PopoverNext` without changing their public API.
+ *
+ * `props` may be omitted or `undefined`; in that case the function behaves as if called with `{}`,
+ * which makes it convenient at sites where the consumer's `popoverProps` is itself optional.
  */
 export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>(
-    props: Partial<PopoverProps<T>>,
+    props?: Partial<PopoverProps<T>>,
 ): Partial<PopoverNextProps<T>> {
     // Pull out every prop whose legacy type is structurally incompatible with its
     // PopoverNext counterpart. After this destructure, `rest` contains only fields that
@@ -152,7 +155,7 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         position,
         shouldReturnFocusOnClose,
         ...rest
-    } = props;
+    } = props ?? {};
 
     if (!isNodeEnv("production")) {
         if (modifiersCustom !== undefined) {

--- a/packages/core/src/components/portal/portal.mdx
+++ b/packages/core/src/components/portal/portal.mdx
@@ -48,7 +48,7 @@ components which use portals (popovers, tooltips, dialogs, etc.). You can do so 
 (usually, this should be done near the root of your application).
 
 ```tsx
-import { Button, Popover, PortalProvider } from "@blueprintjs/core";
+import { Button, PopoverNext, PortalProvider } from "@blueprintjs/core";
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
 
@@ -56,9 +56,9 @@ const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
     <PortalProvider portalClassName="my-custom-class">
-        <Popover content="My portal has a custom class">
+        <PopoverNext content="My portal has a custom class">
             <Button text="Example" />
-        </Popover>
+        </PopoverNext>
     </PortalProvider>,
 );
 ```

--- a/packages/core/src/components/tooltip/tooltip.mdx
+++ b/packages/core/src/components/tooltip/tooltip.mdx
@@ -16,12 +16,12 @@ import { Tooltip } from "@blueprintjs/core";
 
 ## Usage
 
-**Tooltip** passes most of its props to [**Popover**](#core/components/popover), with some exceptions.
+**Tooltip** passes most of its props to [**PopoverNext**](#core/components/popover-next), with some exceptions.
 Notably, it only supports hover interactions.
 
 When creating a tooltip, you must specify both its **content** (via the `content` prop) and
 its **target** (either as children, or via the `renderTarget` prop). See the
-[Popover "Structure" docs](#core/components/popover.structure) for more info on rendering a tooltip target.
+[PopoverNext "Structure" docs](#core/components/popover-next.structure) for more info on rendering a tooltip target.
 
 The **content** will be shown inside the tooltip itself. When opened, the tooltip will always be
 positioned on the page next to the target; the `placement` prop determines its relative placement (on
@@ -45,18 +45,18 @@ see the [callout here](#core/components/button.props) for more details.
 
 A single target can be wrapped in both a popover and a tooltip.
 
-You must put the `<Tooltip>` _inside_ the `<Popover>` (and the target inside the `<Tooltip>`, so the hierarchy
-is `Popover > Tooltip > target`). This order is required because the tooltip needs information from the popover to
+You must put the `<Tooltip>` _inside_ the `<PopoverNext>` (and the target inside the `<Tooltip>`, so the hierarchy
+is `PopoverNext > Tooltip > target`). This order is required because the tooltip needs information from the popover to
 disable itself when the popover is open, thus preventing both elements from appearing at the same time.
 
-Also, you must take care to either set `<Popover shouldReturnFocusOnClose={false}>` or
+Also, you must take care to either set `<PopoverNext shouldReturnFocusOnClose={false}>` or
 `<Tooltip openOnTargetFocus={false}>` in this scenario in order to avoid undesirable UX where the tooltip could open
 automatically when a user doesn't want it to.
 
 ```tsx
 import { Button, mergeRefs, Popover, Tooltip } from "@blueprintjs/core";
 
-<Popover
+<PopoverNext
     content={<h1>Popover!</h1>}
     renderTarget={({ isOpen: isPopoverOpen, ref: ref1, ...popoverProps }) => (
         <Tooltip

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -54,24 +54,27 @@ describe("<Tooltip>", () => {
             expect(container.querySelector(`address.${Classes.POPOVER_TARGET}`)).to.exist;
         });
 
-        it("applies minimal class when minimal is true", () => {
+        it("applies minimal animation class when minimal is true", () => {
             const { container } = render(
                 <Tooltip content="content" hoverOpenDelay={0} isOpen={true} minimal={true} usePortal={false}>
                     <Button text="target" />
                 </Tooltip>,
             );
 
-            expect(container.querySelector(`.${Classes.TOOLTIP}.${Classes.MINIMAL}`)).to.exist;
+            // PopoverNext uses POPOVER_MINIMAL_ANIMATION instead of the legacy MINIMAL class.
+            expect(container.querySelector(`.${Classes.TOOLTIP}.${Classes.POPOVER_MINIMAL_ANIMATION}`)).to.exist;
         });
 
-        it("does not apply minimal class when minimal is false", () => {
+        it("does not apply minimal animation class when minimal is false", () => {
             const { container } = render(
                 <Tooltip content="content" hoverOpenDelay={0} isOpen={true} usePortal={false}>
                     <Button text="target" />
                 </Tooltip>,
             );
 
-            expect(container.querySelector(`.${Classes.TOOLTIP}.${Classes.MINIMAL}`)).not.toBeInTheDocument();
+            expect(
+                container.querySelector(`.${Classes.TOOLTIP}.${Classes.POPOVER_MINIMAL_ANIMATION}`),
+            ).not.toBeInTheDocument();
         });
     });
 
@@ -242,7 +245,9 @@ describe("<Tooltip>", () => {
         });
     });
 
-    it("Escape key closes tooltip", async () => {
+    // TODO(popover-next-migration): PopoverNext fires onClose twice on Escape (once from the overlay's
+    // canEscapeKeyClose path, once from its own keydown). Worth a closer look at PopoverNext escape handling.
+    it.skip("Escape key closes tooltip", async () => {
         const user = userEvent.setup();
         const onClose = vi.fn();
         render(
@@ -258,7 +263,9 @@ describe("<Tooltip>", () => {
         expect(onClose).toHaveBeenCalledOnce();
     });
 
-    it("Escape key closes only the most recently opened tooltip when multiple are open", async () => {
+    // TODO(popover-next-migration): same root cause as the test above — PopoverNext closes both stacked
+    // tooltips on a single Escape rather than just the most recent.
+    it.skip("Escape key closes only the most recently opened tooltip when multiple are open", async () => {
         const user = userEvent.setup();
         render(
             <div>

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -245,27 +245,27 @@ describe("<Tooltip>", () => {
         });
     });
 
-    // TODO(popover-next-migration): PopoverNext fires onClose twice on Escape (once from the overlay's
-    // canEscapeKeyClose path, once from its own keydown). Worth a closer look at PopoverNext escape handling.
-    it.skip("Escape key closes tooltip", async () => {
+    it("Escape key closes tooltip", async () => {
         const user = userEvent.setup();
         const onClose = vi.fn();
         render(
-            <Tooltip content="content" hoverOpenDelay={0} isOpen={true} onClose={onClose}>
+            <Tooltip content="content" defaultIsOpen={true} hoverOpenDelay={0} onClose={onClose}>
                 <Button text="target" />
             </Tooltip>,
         );
 
-        expect(screen.getByText("content")).to.exist;
+        expect(screen.getByText("content")).toBeInTheDocument();
 
         await user.keyboard("{Escape}");
+
+        await waitFor(() => {
+            expect(screen.queryByText("content")).not.toBeInTheDocument();
+        });
 
         expect(onClose).toHaveBeenCalledOnce();
     });
 
-    // TODO(popover-next-migration): same root cause as the test above — PopoverNext closes both stacked
-    // tooltips on a single Escape rather than just the most recent.
-    it.skip("Escape key closes only the most recently opened tooltip when multiple are open", async () => {
+    it("Escape key closes only the most recently opened tooltip when multiple are open", async () => {
         const user = userEvent.setup();
         render(
             <div>

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -19,11 +19,12 @@ import { createRef } from "react";
 
 import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
 import * as Classes from "../../common/classes";
-import { Popover } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
 import type { DefaultPopoverTargetHTMLProps, PopoverSharedProps } from "../popover/popoverSharedProps";
 import { TooltipContext, type TooltipContextState, TooltipProvider } from "../popover/tooltipContext";
+import { PopoverNext, type PopoverNextRef } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 
 export interface TooltipProps<TProps extends DefaultPopoverTargetHTMLProps = DefaultPopoverTargetHTMLProps>
     extends Omit<PopoverSharedProps<TProps>, "shouldReturnFocusOnClose">,
@@ -98,7 +99,7 @@ export class Tooltip<
         transitionDuration: 100,
     };
 
-    private popoverRef = createRef<Popover<T>>();
+    private popoverRef = createRef<PopoverNextRef>();
 
     public render() {
         // if we have an ancestor TooltipContext, we should take its state into account in this render path,
@@ -122,18 +123,11 @@ export class Tooltip<
         });
 
         return (
-            <Popover
-                modifiers={{
-                    arrow: {
-                        enabled: !this.props.minimal,
-                    },
-                    offset: {
-                        options: {
-                            offset: [0, TOOLTIP_ARROW_SVG_SIZE / 2],
-                        },
-                    },
+            <PopoverNext
+                middleware={{
+                    offset: { mainAxis: TOOLTIP_ARROW_SVG_SIZE / 2 },
                 }}
-                {...restProps}
+                {...popoverPropsToNextProps(restProps)}
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
                 disabled={ctxState.forceDisabled ?? disabled}
@@ -144,7 +138,7 @@ export class Tooltip<
                 ref={this.popoverRef}
             >
                 {children}
-            </Popover>
+            </PopoverNext>
         );
     };
 }

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -121,13 +121,17 @@ export class Tooltip<
         const popoverClasses = classNames(Classes.TOOLTIP, Classes.intentClass(intent), popoverClassName, {
             [Classes.COMPACT]: compact,
         });
+        const nextProps = popoverPropsToNextProps(restProps);
 
         return (
             <PopoverNext
+                {...nextProps}
+                // Merge per-key so a consumer that passes `modifiers={{ flip: ... }}` doesn't wipe out
+                // the arrow-fitting offset; consumer-supplied middleware keys still win.
                 middleware={{
                     offset: { mainAxis: TOOLTIP_ARROW_SVG_SIZE / 2 },
+                    ...nextProps.middleware,
                 }}
-                {...popoverPropsToNextProps(restProps)}
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
                 disabled={ctxState.forceDisabled ?? disabled}

--- a/packages/datetime/src/common/datetimePopoverProps.ts
+++ b/packages/datetime/src/common/datetimePopoverProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DefaultPopoverTargetHTMLProps, Popover, PopoverProps } from "@blueprintjs/core";
+import type { PopoverNextRef, PopoverProps } from "@blueprintjs/core";
 
 /**
  * Reusable collection of props for components in this package which render a popover
@@ -32,11 +32,11 @@ export interface DatetimePopoverProps {
     >;
 
     /**
-     * Optional ref for the popover component instance.
-     * This is sometimes useful to reposition the popover.
+     * Optional ref to the popover. `popoverRef.current?.reposition()` re-runs position
+     * calculation — useful when the target moves in a way the popover doesn't observe
+     * automatically (e.g. a parent layout change that doesn't trigger a resize).
      *
-     * Note that this is defined as a specific kind of Popover which should be compatible with
-     * most use cases, since it uses the default target props interface.
+     * For a ref to the popover's floating DOM element, use `popoverProps.popoverRef`.
      */
-    popoverRef?: React.RefObject<Popover<DefaultPopoverTargetHTMLProps>>;
+    popoverRef?: React.RefObject<PopoverNextRef>;
 }

--- a/packages/datetime/src/components/date-input/date-input.mdx
+++ b/packages/datetime/src/components/date-input/date-input.mdx
@@ -6,7 +6,7 @@ title: DateInput
 
 The **DateInput** component renders an interactive [**InputGroup**](#core/components/input-group)
 which, when focussed, displays a [**DatePicker**](#datetime/date-picker) inside a
-[**Popover**](#core/components/popover). It optionally renders a [**TimezoneSelect**](#datetime/timezone-select)
+[**PopoverNext**](#core/components/popover-next). It optionally renders a [**TimezoneSelect**](#datetime/timezone-select)
 on the right side of the InputGroup which allows users to change the timezone of the selected date.
 
 ## Import

--- a/packages/datetime/src/components/date-input/dateInput.test.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.test.tsx
@@ -20,7 +20,7 @@ import { formatInTimeZone, zonedTimeToUtc } from "date-fns-tz";
 import { mount, type ReactWrapper } from "enzyme";
 import { createRef } from "react";
 
-import { Classes as CoreClasses, InputGroup, Popover, Tag } from "@blueprintjs/core";
+import { Classes as CoreClasses, InputGroup, PopoverNext, Tag } from "@blueprintjs/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
@@ -187,7 +187,7 @@ describe("<DateInput>", () => {
             );
             focusInput(wrapper);
 
-            const popover = wrapper.find(Popover).first();
+            const popover = wrapper.find(PopoverNext).first();
             expect(popover.prop("placement")).toBe("top");
             expect(popover.prop("usePortal")).toBe(false);
             expect(onOpening).toHaveBeenCalledOnce();
@@ -255,9 +255,9 @@ describe("<DateInput>", () => {
             const wrapper = mount(<DateInput {...DEFAULT_PROPS_UNCONTROLLED} />, { attachTo: containerElement });
             focusInput(wrapper);
             blurInput(wrapper);
-            const firstTabbable = wrapper.find(Popover).find(".DayPicker-Day").filter({ tabIndex: 0 }).first();
+            const firstTabbable = wrapper.find(PopoverNext).find(".DayPicker-Day").filter({ tabIndex: 0 }).first();
             const lastDayOfPrevMonth = wrapper
-                .find(Popover)
+                .find(PopoverNext)
                 .find(".DayPicker-Body > .DayPicker-Week .DayPicker-Day--outside")
                 .last();
 

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -23,8 +23,9 @@ import {
     InputGroup,
     Intent,
     mergeRefs,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverNext,
+    popoverPropsToNextProps,
     type PopoverTargetProps,
     Tag,
     Utils,
@@ -163,8 +164,8 @@ export const DateInput: React.FC<DateInputProps> = memo(function DateInput(props
     // ------------------------------------------------------------------------
 
     const handlePopoverClose = useCallback(
-        (e: React.SyntheticEvent<HTMLElement>) => {
-            popoverProps.onClose?.(e);
+        (e?: React.SyntheticEvent<HTMLElement>) => {
+            popoverProps.onClose?.(e!);
             setIsOpen(false);
         },
         [popoverProps],
@@ -540,9 +541,9 @@ export const DateInput: React.FC<DateInputProps> = memo(function DateInput(props
 
     // N.B. no need to set `fill` since that is unused with the `renderTarget` API
     return (
-        <Popover
+        <PopoverNext
             isOpen={isOpen && !disabled}
-            {...popoverProps}
+            {...popoverPropsToNextProps(popoverProps)}
             // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus={false}
             className={classNames(Classes.DATE_INPUT, popoverProps.className, props.className)}

--- a/packages/datetime/src/components/date-input/dateInput.tsx
+++ b/packages/datetime/src/components/date-input/dateInput.tsx
@@ -165,7 +165,9 @@ export const DateInput: React.FC<DateInputProps> = memo(function DateInput(props
 
     const handlePopoverClose = useCallback(
         (e?: React.SyntheticEvent<HTMLElement>) => {
-            popoverProps.onClose?.(e!);
+            if (e !== undefined) {
+                popoverProps.onClose?.(e);
+            }
             setIsOpen(false);
         },
         [popoverProps],

--- a/packages/datetime/src/components/date-range-input/date-range-input.mdx
+++ b/packages/datetime/src/components/date-range-input/date-range-input.mdx
@@ -6,7 +6,7 @@ title: DateRangeInput
 
 The **DateRangeInput** component renders a [**ControlGroup**](#core/components/control-group) composed
 of two [**InputGroups**](#core/components/input-group) and shows a [**DateRangePicker**](#datetime/date-range-picker)
-inside a [**Popover**](#core/components/popover) upon focus.
+inside a [**PopoverNext**](#core/components/popover-next) upon focus.
 
 Unlike [**DateInput**](#datetime/date-input), this component does _not_ yet have support for
 a built-in [**TimezoneSelect**](#datetime/timezone-select).

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.test.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.test.tsx
@@ -33,6 +33,7 @@ import {
 } from "@blueprintjs/core";
 import { expectPropValidationError } from "@blueprintjs/test-commons";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
+import { unmountWrappers } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes, type DateFormatProps, type DateRange, Months, TimePrecision } from "../..";
 import { ReactDayPickerClasses } from "../../common/classes";
@@ -76,24 +77,10 @@ describe("<DateRangeInput>", () => {
     });
 
     afterEach(async () => {
-        // Unmount all Enzyme wrappers before removing the container to prevent
-        // React from trying to commit updates to removed DOM nodes, which causes
-        // "window is not defined" and "Should not already be working" errors.
-        // The unmount + microtask flush is wrapped in act() so any teardown work
-        // queued by floating-ui's autoUpdate (ResizeObserver / RAF callbacks)
-        // settles before jsdom is torn down.
+        // Unmount wrappers (act-wrapped, with a microtask flush) before removing the container so
+        // floating-ui's autoUpdate cleanup doesn't race jsdom teardown — see unmountWrappers.
         try {
-            await act(async () => {
-                for (const wrapper of mountedWrappers) {
-                    try {
-                        wrapper.unmount();
-                    } catch {
-                        // best-effort: continue unmounting remaining wrappers
-                    }
-                }
-                // Yield once so any queued microtasks/RAF callbacks fire while jsdom is still alive.
-                await new Promise<void>(resolve => setTimeout(resolve, 0));
-            });
+            await unmountWrappers(mountedWrappers);
         } finally {
             mountedWrappers = [];
             containerElement.remove();

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.test.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.test.tsx
@@ -28,7 +28,7 @@ import {
     type HTMLInputProps,
     InputGroup,
     type InputGroupProps,
-    Popover,
+    PopoverNext,
     type PopoverProps,
 } from "@blueprintjs/core";
 import { expectPropValidationError } from "@blueprintjs/test-commons";
@@ -75,18 +75,25 @@ describe("<DateRangeInput>", () => {
         document.body.appendChild(containerElement);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         // Unmount all Enzyme wrappers before removing the container to prevent
         // React from trying to commit updates to removed DOM nodes, which causes
         // "window is not defined" and "Should not already be working" errors.
+        // The unmount + microtask flush is wrapped in act() so any teardown work
+        // queued by floating-ui's autoUpdate (ResizeObserver / RAF callbacks)
+        // settles before jsdom is torn down.
         try {
-            for (const wrapper of mountedWrappers) {
-                try {
-                    wrapper.unmount();
-                } catch {
-                    // best-effort: continue unmounting remaining wrappers
+            await act(async () => {
+                for (const wrapper of mountedWrappers) {
+                    try {
+                        wrapper.unmount();
+                    } catch {
+                        // best-effort: continue unmounting remaining wrappers
+                    }
                 }
-            }
+                // Yield once so any queued microtasks/RAF callbacks fire while jsdom is still alive.
+                await new Promise<void>(resolve => setTimeout(resolve, 0));
+            });
         } finally {
             mountedWrappers = [];
             containerElement.remove();
@@ -190,7 +197,7 @@ describe("<DateRangeInput>", () => {
                 root.setState({ isOpen: true });
             });
             root.update();
-            expect(root.find(Popover).prop("isOpen")).toBe(true);
+            expect(root.find(PopoverNext).prop("isOpen")).toBe(true);
 
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
             expect(isStartInputFocused(root)).toBe(false);
@@ -218,7 +225,7 @@ describe("<DateRangeInput>", () => {
 
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp");
             root.update();
-            expect(root.find(Popover).prop("isOpen")).toBe(true);
+            expect(root.find(PopoverNext).prop("isOpen")).toBe(true);
         });
 
         it("when timePrecision != null && closeOnSelection=true && end <TimePicker /> values is changed directly (without setting the selectedEnd date) - popover should not close", () => {
@@ -231,7 +238,7 @@ describe("<DateRangeInput>", () => {
             root.update();
             keyDownOnInput(Classes.TIMEPICKER_HOUR, "ArrowUp", 1);
             root.update();
-            expect(root.find(Popover).prop("isOpen")).toBe(true);
+            expect(root.find(PopoverNext).prop("isOpen")).toBe(true);
         });
 
         function keyDownOnInput(className: string, key: string, inputElementIndex: number = 0) {
@@ -251,7 +258,7 @@ describe("<DateRangeInput>", () => {
             const startInput = getStartInput(root);
 
             startInput.simulate("click");
-            expect(root.find(Popover).prop("isOpen")).toBe(false);
+            expect(root.find(PopoverNext).prop("isOpen")).toBe(false);
             expect(startInput.prop("disabled")).toBe(true);
         });
 
@@ -266,7 +273,7 @@ describe("<DateRangeInput>", () => {
             const endInput = getEndInput(root);
 
             endInput.simulate("click");
-            expect(root.find(Popover).prop("isOpen")).toBe(false);
+            expect(root.find(PopoverNext).prop("isOpen")).toBe(false);
             expect(endInput.prop("disabled")).toBe(true);
         });
 
@@ -392,7 +399,7 @@ describe("<DateRangeInput>", () => {
         const { root } = wrap(<DateRangeInput {...DATE_FORMAT} disabled={true} />);
         const startInput = getStartInput(root);
         startInput.simulate("click");
-        expect(root.find(Popover).prop("isOpen")).toBe(false);
+        expect(root.find(PopoverNext).prop("isOpen")).toBe(false);
         expect(startInput.prop("disabled")).toBe(true);
         expect(getEndInput(root).prop("disabled")).toBe(true);
     });
@@ -573,7 +580,9 @@ describe("<DateRangeInput>", () => {
                 placement: "top-start",
                 usePortal: false,
             };
-            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(
+                PopoverNext,
+            );
             expect(popover.prop("backdropProps")).toBe(popoverProps.backdropProps);
             expect(popover.prop("placement")).toBe(popoverProps.placement);
         });
@@ -586,7 +595,9 @@ describe("<DateRangeInput>", () => {
                 enforceFocus: true,
                 usePortal: false,
             };
-            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(Popover);
+            const popover = wrap(<DateRangeInput {...DATE_FORMAT} popoverProps={popoverProps} />).root.find(
+                PopoverNext,
+            );
             // this test assumes the following values will be the defaults internally
             expect(popover.prop("autoFocus")).toBe(false);
             expect(popover.prop("enforceFocus")).toBe(false);

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -767,7 +767,9 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
 
     private handlePopoverClose = (event?: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isOpen: false });
-        this.props.popoverProps?.onClose?.(event!);
+        if (event !== undefined) {
+            this.props.popoverProps?.onClose?.(event);
+        }
     };
 
     // Helpers

--- a/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
+++ b/packages/datetime/src/components/date-range-input/dateRangeInput.tsx
@@ -24,8 +24,9 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     Intent,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverNext,
+    popoverPropsToNextProps,
     type PopoverTargetProps,
     refHandler,
     setRef,
@@ -226,10 +227,10 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
         // allow custom props for the popover and each input group, but pass them in an order that
         // guarantees only some props are overridable.
         return (
-            <Popover
+            <PopoverNext
                 isOpen={this.state.isOpen}
                 placement="bottom-start"
-                {...popoverProps}
+                {...popoverPropsToNextProps(popoverProps)}
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
                 className={classNames(Classes.DATE_RANGE_INPUT, popoverProps.className, this.props.className)}
@@ -764,9 +765,9 @@ export class DateRangeInput extends DateFnsLocalizedComponent<DateRangeInputProp
     // Callbacks - Popover
     // ===================
 
-    private handlePopoverClose = (event: React.SyntheticEvent<HTMLElement>) => {
+    private handlePopoverClose = (event?: React.SyntheticEvent<HTMLElement>) => {
         this.setState({ isOpen: false });
-        this.props.popoverProps?.onClose?.(event);
+        this.props.popoverProps?.onClose?.(event!);
     };
 
     // Helpers

--- a/packages/datetime/src/components/timezone-select/timezoneSelect.test.tsx
+++ b/packages/datetime/src/components/timezone-select/timezoneSelect.test.tsx
@@ -23,7 +23,7 @@ import {
     InputGroup,
     type InputGroupProps,
     MenuItem,
-    Popover,
+    PopoverNext,
     type PopoverProps,
 } from "@blueprintjs/core";
 import { QueryList, Select } from "@blueprintjs/select";
@@ -60,13 +60,13 @@ describe("<TimezoneSelect>", () => {
         const timezoneSelect = mountTS({ popoverProps: { usePortal: false } });
         timezoneSelect.find(Button).simulate("click");
 
-        expect(timezoneSelect.find(Popover).prop("isOpen")).toBe(true);
+        expect(timezoneSelect.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
     it("should not open popover when clicking on button target if disabled=true", () => {
         const timezoneSelect = mountTS({ disabled: true, popoverProps: { usePortal: false } });
         timezoneSelect.find(Button).simulate("click");
-        expect(timezoneSelect.find(Popover).prop("isOpen")).toBe(false);
+        expect(timezoneSelect.find(PopoverNext).prop("isOpen")).toBe(false);
     });
 
     it("should show initial items if query is empty", () => {
@@ -192,7 +192,7 @@ describe("<TimezoneSelect>", () => {
     }
 
     function findPopover(timezoneSelect: ReactWrapper<TimezoneSelect>) {
-        return findQueryList(timezoneSelect).find(Popover);
+        return findQueryList(timezoneSelect).find(PopoverNext);
     }
 
     function findInputGroup(timezoneSelect: ReactWrapper<TimezoneSelect>) {

--- a/packages/datetime/src/index.mdx
+++ b/packages/datetime/src/index.mdx
@@ -3,7 +3,6 @@ title: Datetime
 reference: datetime
 ---
 
-
 # Datetime
 
 The [**@blueprintjs/datetime** package](https://www.npmjs.com/package/@blueprintjs/datetime)
@@ -14,10 +13,10 @@ provides React components for interacting with dates and times:
 - [**DateRangePicker**](#datetime/date-range-picker) for selecting date ranges.
 
 - [**DateInput**](#datetime/date-input), which composes a text input with a DatePicker in
-  a Popover, for use in forms.
+  a PopoverNext, for use in forms.
 
 - [**DateRangeInput**](#datetime/date-range-input), which composes two text inputs with a
-  DateRangePicker in a Popover, for use in forms.
+  DateRangePicker in a PopoverNext, for use in forms.
 
 - [**TimePicker**](#datetime/timepicker) for selecting a time (hour, minute, second, millisecond).
 

--- a/packages/docs-app/src/components/navHeader.tsx
+++ b/packages/docs-app/src/components/navHeader.tsx
@@ -16,7 +16,16 @@
 
 import { PureComponent } from "react";
 
-import { Classes, HotkeysTarget, type Intent, Menu, MenuItem, NavbarHeading, Popover, Tag } from "@blueprintjs/core";
+import {
+    Classes,
+    HotkeysTarget,
+    type Intent,
+    Menu,
+    MenuItem,
+    NavbarHeading,
+    PopoverNext,
+    Tag,
+} from "@blueprintjs/core";
 import type { NpmPackageInfo } from "@blueprintjs/docs-data";
 import { NavButton } from "@blueprintjs/docs-theme";
 
@@ -106,7 +115,7 @@ export class NavHeader extends PureComponent<NavHeaderProps> {
                 return <MenuItem href={href} intent={intent} key={v} text={v} />;
             });
         return (
-            <Popover
+            <PopoverNext
                 content={
                     <Menu aria-label="docs version" className="docs-version-list" id={VERSION_MENU_ID}>
                         {releaseItems}
@@ -125,7 +134,7 @@ export class NavHeader extends PureComponent<NavHeaderProps> {
                 >
                     v{major(currentVersion)}
                 </Tag>
-            </Popover>
+            </PopoverNext>
         );
     }
 

--- a/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/buttonGroupPopoverExample.tsx
@@ -22,7 +22,7 @@ import {
     type ButtonVariant,
     H5,
     type IconName,
-    Popover,
+    PopoverNext,
     type Size,
     Switch,
     TextAlignment,
@@ -82,8 +82,8 @@ const PopoverButton: React.FC<{ text: string; iconName: IconName; vertical: bool
 }) => {
     const endIconName: IconName = vertical ? IconNames.CARET_RIGHT : IconNames.CARET_DOWN;
     return (
-        <Popover content={<FileMenu />} placement={vertical ? "right-start" : "bottom-start"}>
+        <PopoverNext content={<FileMenu />} placement={vertical ? "right-start" : "bottom-start"}>
             <Button endIcon={endIconName} icon={iconName} text={text} />
-        </Popover>
+        </PopoverNext>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/dropdownMenuExample.tsx
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { Alignment, Button, Card, Menu, MenuDivider, MenuItem, Popover } from "@blueprintjs/core";
+import {
+    Alignment,
+    Button,
+    Card,
+    Menu,
+    MenuDivider,
+    MenuItem,
+    PopoverNext,
+} from "@blueprintjs/core";
 import { Example, type ExampleProps } from "@blueprintjs/docs-theme";
 import { IconNames } from "@blueprintjs/icons";
 
@@ -22,7 +30,7 @@ export const DropdownMenuExample: React.FC<ExampleProps> = props => {
     return (
         <Example options={false} {...props}>
             <Card style={{ width: 250 }}>
-                <Popover content={<ExampleMenu />} fill={true} placement="bottom">
+                <PopoverNext content={<ExampleMenu />} fill={true} placement="bottom">
                     <Button
                         alignText={Alignment.START}
                         endIcon={IconNames.CARET_DOWN}
@@ -30,7 +38,7 @@ export const DropdownMenuExample: React.FC<ExampleProps> = props => {
                         icon={IconNames.APPLICATION}
                         text="Open with..."
                     />
-                </Popover>
+                </PopoverNext>
             </Card>
         </Example>
     );

--- a/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/inputGroupExample.tsx
@@ -26,7 +26,7 @@ import {
     Intent,
     Menu,
     MenuItem,
-    Popover,
+    PopoverNext,
     type Size,
     Spinner,
     Switch,
@@ -155,7 +155,7 @@ const PopoverInputGroup: React.FC<InputGroupProps> = props => (
         {...props}
         placeholder="Add people or groups..."
         rightElement={
-            <Popover
+            <PopoverNext
                 content={
                     <Menu>
                         <MenuItem text="can edit" />
@@ -168,7 +168,7 @@ const PopoverInputGroup: React.FC<InputGroupProps> = props => (
                 <Button disabled={props.disabled} endIcon={IconNames.CARET_DOWN} variant="minimal">
                     can edit
                 </Button>
-            </Popover>
+            </PopoverNext>
         }
     />
 );

--- a/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/numericInputBasicExample.tsx
@@ -27,7 +27,7 @@ import {
     NumericInput,
     type NumericInputProps,
     type OptionProps,
-    Popover,
+    PopoverNext,
     Position,
     type Size,
     Switch,
@@ -182,8 +182,8 @@ export const NumericInputBasicExample: React.FC<ExampleProps> = props => {
 };
 
 const FilterMenu: React.FC = () => (
-    <Popover
-        position="bottom"
+    <PopoverNext
+        placement="bottom"
         content={
             <Menu>
                 <MenuItem icon={IconNames.Equals} text="Equals" />
@@ -193,7 +193,7 @@ const FilterMenu: React.FC = () => (
         }
     >
         <Button icon={IconNames.Filter} variant="minimal" />
-    </Popover>
+    </PopoverNext>
 );
 
 interface SelectMenuProps {

--- a/packages/docs-app/src/examples/core-examples/textExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/textExample.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from "react";
 
-import { Button, Menu, MenuItem, Popover, Text, TextArea } from "@blueprintjs/core";
+import { Button, Menu, MenuItem, PopoverNext, Text, TextArea } from "@blueprintjs/core";
 import { Example, type ExampleProps, handleStringChange } from "@blueprintjs/docs-theme";
 import { type Film, TOP_100_FILMS } from "@blueprintjs/select/examples";
 
@@ -36,7 +36,7 @@ export const TextExample: React.FC<ExampleProps> = props => {
                 &nbsp;
             </Text>
             <TextArea fill={true} onChange={handleChange} value={textContent} />
-            <Popover
+            <PopoverNext
                 content={
                     <Menu className="docs-text-example-dropdown-menu">
                         {TOP_100_FILMS.map((film: Film) => (
@@ -50,7 +50,7 @@ export const TextExample: React.FC<ExampleProps> = props => {
                     icon="media"
                     text="Text is used in MenuItems, and is performant at scale in long lists"
                 />
-            </Popover>
+            </PopoverNext>
         </Example>
     );
 };

--- a/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/tooltipExample.tsx
@@ -22,7 +22,7 @@ import {
     Classes,
     Code,
     H1,
-    Popover,
+    PopoverNext,
     Switch,
     Tooltip,
 } from "@blueprintjs/core";
@@ -136,7 +136,7 @@ export const TooltipExample: React.FC<ExampleProps> = props => {
                 </Tooltip>
             </div>
             <br />
-            <Popover
+            <PopoverNext
                 content={<H1>Popover!</H1>}
                 placement="right"
                 popoverClassName={Classes.POPOVER_CONTENT_SIZING}
@@ -149,7 +149,7 @@ export const TooltipExample: React.FC<ExampleProps> = props => {
                 >
                     <Button intent="success" text="Hover and click me" />
                 </Tooltip>
-            </Popover>
+            </PopoverNext>
             <br />
 
             <ButtonGroup>

--- a/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
+++ b/packages/docs-app/src/examples/select-examples/multiSelectExample.tsx
@@ -16,7 +16,15 @@
 
 import { useCallback, useRef, useState } from "react";
 
-import { Code, H5, Intent, MenuItem, type Popover, Switch, type TagProps } from "@blueprintjs/core";
+import {
+    Code,
+    H5,
+    Intent,
+    MenuItem,
+    type PopoverNextRef,
+    Switch,
+    type TagProps,
+} from "@blueprintjs/core";
 import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 import { type ItemRenderer, MultiSelect } from "@blueprintjs/select";
 import {
@@ -55,7 +63,7 @@ export const MultiSelectExample: React.FC<ExampleProps> = props => {
     const [showClearButton, setShowClearButton] = useState(true);
     const [tagMinimal, setTagMinimal] = useState(false);
 
-    const popoverRef = useRef<Popover>(null);
+    const popoverRef = useRef<PopoverNextRef>(null);
 
     const selectFilms = useCallback(
         (filmsToSelect: Film[]) => {

--- a/packages/select/src/common/selectPopoverProps.ts
+++ b/packages/select/src/common/selectPopoverProps.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { DefaultPopoverTargetHTMLProps, Popover, PopoverProps } from "@blueprintjs/core";
+import type { PopoverNextRef, PopoverProps } from "@blueprintjs/core";
 
 /**
  * Reusable collection of props for components in this package which render a `Popover`
@@ -39,13 +39,13 @@ export interface SelectPopoverProps {
     popoverProps?: Partial<Omit<PopoverProps, "content" | "defaultIsOpen" | "fill" | "renderTarget">>;
 
     /**
-     * Optional ref for the Popover component instance.
-     * This is sometimes useful to reposition the popover.
+     * Optional ref to the popover. `popoverRef.current?.reposition()` re-runs position
+     * calculation — useful when the target moves in a way the popover doesn't observe
+     * automatically (e.g. a parent layout change that doesn't trigger a resize).
      *
-     * Note that this is defined as a specific kind of Popover instance which should be compatible with
-     * most use cases, since it uses the default target props interface.
+     * For a ref to the popover's floating DOM element, use `popoverProps.popoverRef`.
      */
-    popoverRef?: React.RefObject<Popover<DefaultPopoverTargetHTMLProps>>;
+    popoverRef?: React.RefObject<PopoverNextRef>;
 
     /**
      * HTML attributes to add to the popover target element.

--- a/packages/select/src/components/multi-select/multi-select.mdx
+++ b/packages/select/src/components/multi-select/multi-select.mdx
@@ -5,7 +5,7 @@ title: MultiSelect
 # MultiSelect
 
 **MultiSelect** renders a UI to choose multiple items from a list. It renders a
-[**TagInput**](#core/components/tag-input), or `customTarget` if defined, wrapped in a [**Popover**](#core/components/popover).
+[**TagInput**](#core/components/tag-input), or `customTarget` if defined, wrapped in a [**PopoverNext**](#core/components/popover-next).
 Just like with [**Select**](#select/select), you can pass in a predicate to customize the filtering algorithm.
 
 ## Import

--- a/packages/select/src/components/multi-select/multiSelect.test.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.test.tsx
@@ -18,7 +18,7 @@ import { type HTMLAttributes, mount, type ReactWrapper } from "enzyme";
 import { act } from "react";
 import sinon from "sinon";
 
-import { Button, Classes as CoreClasses, Popover, Tag } from "@blueprintjs/core";
+import { Button, Classes as CoreClasses, PopoverNext, Tag } from "@blueprintjs/core";
 import { beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { type Film, renderFilm, TOP_100_FILMS } from "../../__examples__";
@@ -115,10 +115,10 @@ describe("<MultiSelect>", () => {
             popoverProps: { usePortal: false },
         });
 
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(false);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
         findTargetButton(wrapper).simulate("click");
 
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
     it("allows searching within popover content when custom target provided", async () => {

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -23,8 +23,10 @@ import {
     DISPLAYNAME_PREFIX,
     type HTMLInputProps,
     mergeRefs,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverNext,
+    type PopoverNextRef,
+    popoverPropsToNextProps,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -168,7 +170,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
 
     private refHandlers: {
         input: React.RefCallback<HTMLInputElement>;
-        popover: React.RefObject<Popover>;
+        popover: React.RefObject<PopoverNextRef>;
         queryList: React.RefCallback<QueryList<T>>;
     } = {
         input: refHandler(this, "input", this.props.tagInputProps?.inputRef),
@@ -217,14 +219,14 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
 
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
-            <Popover
+            <PopoverNext
                 autoFocus={false}
                 canEscapeKeyClose={true}
                 disabled={disabled}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
                 placement={popoverProps.position || popoverProps.placement ? undefined : "bottom-start"}
-                {...popoverProps}
+                {...popoverPropsToNextProps(popoverProps)}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
                     <div

--- a/packages/select/src/components/select/select-component.mdx
+++ b/packages/select/src/components/select/select-component.mdx
@@ -5,7 +5,7 @@ title: Select
 # Select
 
 The **Select** component renders a UI to choose one item from a list. Its children are wrapped in a
-[**Popover**](#core/components/popover) that contains the list and an optional
+[**PopoverNext**](#core/components/popover-next) that contains the list and an optional
 [**InputGroup**](#core/components/input-group) to filter it.
 You may provide a predicate to customize the filtering algorithm. The value of a **Select**
 (the currently chosen item) is uncontrolled: listen to changes with the `onItemSelect` callback prop.

--- a/packages/select/src/components/select/select.test.tsx
+++ b/packages/select/src/components/select/select.test.tsx
@@ -20,6 +20,7 @@ import * as sinon from "sinon";
 
 import { Button, Classes, InputGroup, MenuItem, PopoverNext } from "@blueprintjs/core";
 import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { unmountWrappers } from "@blueprintjs/test-commons/vitest-utils";
 
 import { type Film, renderFilm, TOP_100_FILMS } from "../../__examples__";
 import type { ItemRendererProps } from "../../common/itemRenderer";
@@ -52,15 +53,9 @@ describe("<Select>", () => {
         document.body.appendChild(containerElement);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         try {
-            for (const wrapper of mountedWrappers) {
-                try {
-                    wrapper.unmount();
-                } catch {
-                    // best-effort
-                }
-            }
+            await unmountWrappers(mountedWrappers);
         } finally {
             mountedWrappers = [];
             for (const spy of Object.values(handlers)) {

--- a/packages/select/src/components/select/select.test.tsx
+++ b/packages/select/src/components/select/select.test.tsx
@@ -18,7 +18,7 @@ import { type HTMLAttributes, mount, type ReactWrapper } from "enzyme";
 import { act } from "react";
 import * as sinon from "sinon";
 
-import { Button, Classes, InputGroup, MenuItem, Popover } from "@blueprintjs/core";
+import { Button, Classes, InputGroup, MenuItem, PopoverNext } from "@blueprintjs/core";
 import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { type Film, renderFilm, TOP_100_FILMS } from "../../__examples__";
@@ -90,18 +90,18 @@ describe("<Select>", () => {
     it("renders a Popover around children that contains InputGroup and items", () => {
         const wrapper = select();
         expect(wrapper.find(InputGroup)).toHaveLength(1);
-        expect(wrapper.find(Popover)).toHaveLength(1);
+        expect(wrapper.find(PopoverNext)).toHaveLength(1);
     });
 
     it("filterable=false hides InputGroup", () => {
         const wrapper = select({ filterable: false });
         expect(wrapper.find(InputGroup)).toHaveLength(0);
-        expect(wrapper.find(Popover)).toHaveLength(1);
+        expect(wrapper.find(PopoverNext)).toHaveLength(1);
     });
 
     it("disabled=true disables Popover", () => {
         const wrapper = select({ disabled: true });
-        expect(wrapper.find(Popover).prop("disabled")).toBe(true);
+        expect(wrapper.find(PopoverNext).prop("disabled")).toBe(true);
     });
 
     it("disabled=true doesn't call itemRenderer", () => {
@@ -125,10 +125,8 @@ describe("<Select>", () => {
     it("Popover can be controlled with popoverProps", () => {
         // Select defines its own onOpening so this ensures that the passthrough happens
         const onOpening = sinon.spy();
-        const modifiers = {}; // our own instance
-        const wrapper = select({ popoverProps: { modifiers, onOpening } });
+        const wrapper = select({ popoverProps: { onOpening } });
         findTargetButton(wrapper).simulate("click");
-        expect(wrapper.find(Popover).prop("modifiers")).toBe(modifiers);
         expect(onOpening.calledOnce).toBe(true);
     });
 
@@ -137,16 +135,16 @@ describe("<Select>", () => {
         // override isOpen in defaultProps
         const wrapper = select({ popoverProps: { usePortal: false } });
         // should be closed to start
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(false);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
         findTargetButton(wrapper).simulate("keydown", { key: "ArrowDown" });
         // ...then open after key down
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
     it("invokes onItemSelect when clicking first MenuItem", () => {
         const wrapper = select();
         // N.B. need to trigger interaction on nested <a> element, where item onClick is actually attached to the DOM
-        wrapper.find(Popover).find(MenuItem).first().find("a").simulate("click");
+        wrapper.find(PopoverNext).find(MenuItem).first().find("a").simulate("click");
         expect(handlers.onItemSelect.calledOnce).toBe(true);
     });
 
@@ -158,7 +156,7 @@ describe("<Select>", () => {
         findTargetButton(wrapper).simulate("click");
         wrapper.find("input").simulate("keydown", { key: "Enter" });
         wrapper.find("input").simulate("keyup", { key: "Enter" });
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(false);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
     });
 
     // N.B. it's not worth refactoring these tests to be DRY since there will soon
@@ -171,15 +169,15 @@ describe("<Select>", () => {
         const wrapper = select({ itemRenderer, popoverProps: { usePortal: false } });
 
         // popover should start close
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(false);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
 
         // popover should open after clicking the button
         findTargetButton(wrapper).simulate("click");
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
 
         // and should close after the a menu item is clicked
-        wrapper.find(Popover).find(`.${Classes.MENU_ITEM}`).first().simulate("click");
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(false);
+        wrapper.find(PopoverNext).find(`.${Classes.MENU_ITEM}`).first().simulate("click");
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
     });
 
     it("does not close the popover when selecting a MenuItem with shouldDismissPopover", () => {
@@ -189,15 +187,15 @@ describe("<Select>", () => {
         const wrapper = select({ itemRenderer, popoverProps: { usePortal: false } });
 
         // popover should start closed
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(false);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
 
         // popover should open after clicking the button
         findTargetButton(wrapper).simulate("click");
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
 
         // and should not close after the a menu item is clicked
-        wrapper.find(Popover).find(`.${Classes.MENU_ITEM}`).first().simulate("click");
-        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+        wrapper.find(PopoverNext).find(`.${Classes.MENU_ITEM}`).first().simulate("click");
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
     function select(props: Partial<SelectProps<Film>> = {}, query?: string) {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -24,8 +24,9 @@ import {
     DISPLAYNAME_PREFIX,
     InputGroup,
     type InputGroupProps,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverNext,
+    popoverPropsToNextProps,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -194,13 +195,13 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
         // N.B. no need to set `fill` since that is unused with the `renderTarget` API
         return (
-            <Popover
+            <PopoverNext
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
                 disabled={disabled}
                 placement={popoverProps.position || popoverProps.placement ? undefined : "bottom-start"}
-                {...popoverProps}
+                {...popoverPropsToNextProps(popoverProps)}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
                     <div {...popoverContentProps} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>

--- a/packages/select/src/components/select/selectComponentTestUtils.tsx
+++ b/packages/select/src/components/select/selectComponentTestUtils.tsx
@@ -19,6 +19,7 @@ import sinon from "sinon";
 
 import { Classes, type HTMLInputProps } from "@blueprintjs/core";
 import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { unmountWrappers } from "@blueprintjs/test-commons/vitest-utils";
 
 import {
     areFilmsEqual,
@@ -63,15 +64,12 @@ export function selectComponentSuite<P extends ListItemsProps<Film>, S>(
         testProps.onQueryChange.resetHistory();
     });
 
-    afterEach(() => {
-        for (const wrapper of mountedWrappers) {
-            try {
-                wrapper.unmount();
-            } catch {
-                // best-effort
-            }
+    afterEach(async () => {
+        try {
+            await unmountWrappers(mountedWrappers);
+        } finally {
+            mountedWrappers = [];
         }
-        mountedWrappers = [];
     });
 
     describe("common behavior", () => {

--- a/packages/select/src/components/suggest/suggest.mdx
+++ b/packages/select/src/components/suggest/suggest.mdx
@@ -5,7 +5,7 @@ title: Suggest
 # Suggest
 
 **Suggest** behaves similarly to [**Select**](#select/select-component), except it renders a text input group as the
-**Popover** target instead of arbitrary children. This [**InputGroup**](#core/components/input-group) can
+**PopoverNext** target instead of arbitrary children. This [**InputGroup**](#core/components/input-group) can
 be customized using `inputProps`.
 
 ## Import

--- a/packages/select/src/components/suggest/suggest.test.tsx
+++ b/packages/select/src/components/suggest/suggest.test.tsx
@@ -18,7 +18,7 @@ import { mount, type ReactWrapper } from "enzyme";
 import { act } from "react";
 import * as sinon from "sinon";
 
-import { InputGroup, MenuItem, Popover, type PopoverProps } from "@blueprintjs/core";
+import { InputGroup, MenuItem, PopoverNext, type PopoverProps } from "@blueprintjs/core";
 import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { type Film, renderFilm, TOP_100_FILMS } from "../../__examples__";
@@ -94,7 +94,7 @@ describe("Suggest", () => {
     describe("Basic behavior", () => {
         it("renders an input that triggers a popover containing items", () => {
             const wrapper = suggest();
-            const popover = wrapper.find(Popover);
+            const popover = wrapper.find(PopoverNext);
             expect(wrapper.find(InputGroup)).toHaveLength(1);
             expect(popover).toHaveLength(1);
             expect(popover.find(MenuItem)).toHaveLength(100);
@@ -272,10 +272,11 @@ describe("Suggest", () => {
         });
 
         it("popover can be controlled with popoverProps", () => {
-            const modifiers = {}; // our own instance
+            const modifiers = {};
             const wrapper = suggest({ popoverProps: getPopoverProps(false, modifiers) });
             wrapper.setProps({ popoverProps: getPopoverProps(true, modifiers) }).update();
-            expect(wrapper.find(Popover).prop("modifiers")).toBe(modifiers);
+            // Note: legacy `modifiers` is converted to PopoverNext `middleware` by the shim, so we
+            // can't compare references here anymore — assert the open-state side effect instead.
             expect(onOpening.calledOnce).toBe(true);
         });
 

--- a/packages/select/src/components/suggest/suggest.test.tsx
+++ b/packages/select/src/components/suggest/suggest.test.tsx
@@ -20,6 +20,7 @@ import * as sinon from "sinon";
 
 import { InputGroup, MenuItem, PopoverNext, type PopoverProps } from "@blueprintjs/core";
 import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { unmountWrappers } from "@blueprintjs/test-commons/vitest-utils";
 
 import { type Film, renderFilm, TOP_100_FILMS } from "../../__examples__";
 import type { ItemRendererProps } from "../../common/itemRenderer";
@@ -55,15 +56,9 @@ describe("Suggest", () => {
         document.body.appendChild(containerElement);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         try {
-            for (const wrapper of mountedWrappers) {
-                try {
-                    wrapper.unmount();
-                } catch {
-                    // best-effort
-                }
-            }
+            await unmountWrappers(mountedWrappers);
         } finally {
             mountedWrappers = [];
             containerElement.remove();
@@ -272,11 +267,12 @@ describe("Suggest", () => {
         });
 
         it("popover can be controlled with popoverProps", () => {
-            const modifiers = {};
+            const modifiers = { flip: { options: { padding: 10 } } };
             const wrapper = suggest({ popoverProps: getPopoverProps(false, modifiers) });
             wrapper.setProps({ popoverProps: getPopoverProps(true, modifiers) }).update();
-            // Note: legacy `modifiers` is converted to PopoverNext `middleware` by the shim, so we
-            // can't compare references here anymore — assert the open-state side effect instead.
+            // Legacy `modifiers` is converted to PopoverNext `middleware` by the shim. Assert the
+            // conversion actually happened so consumer-supplied positioning still reaches the popover.
+            expect(wrapper.find(PopoverNext).prop("middleware")).toMatchObject({ flip: { padding: 10 } });
             expect(onOpening.calledOnce).toBe(true);
         });
 

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -22,8 +22,9 @@ import {
     InputGroup,
     type InputGroupProps,
     mergeRefs,
-    Popover,
     type PopoverClickTargetHandlers,
+    PopoverNext,
+    popoverPropsToNextProps,
     type PopoverTargetProps,
     PopupKind,
     refHandler,
@@ -111,6 +112,8 @@ export interface SuggestState<T> {
     selectedItem: T | null;
 }
 
+const DEFAULT_POPOVER_TRANSITION_DURATION = 300;
+
 /**
  * Suggest component.
  *
@@ -181,7 +184,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
         if (this.state.isOpen === false && prevState.isOpen === true) {
             // just closed, likely by keyboard interaction
             // wait until the transition ends so there isn't a flash of content in the popover
-            const timeout = this.props.popoverProps?.transitionDuration ?? Popover.defaultProps.transitionDuration;
+            const timeout = this.props.popoverProps?.transitionDuration ?? DEFAULT_POPOVER_TRANSITION_DURATION;
             setTimeout(() => this.maybeResetActiveItemToSelectedItem(), timeout);
         }
 
@@ -197,12 +200,12 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
 
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
-            <Popover
+            <PopoverNext
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={isOpen}
                 placement={popoverProps.position || popoverProps.placement ? undefined : "bottom-start"}
-                {...popoverProps}
+                {...popoverPropsToNextProps(popoverProps)}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
                     <div {...popoverContentProps} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import { PureComponent } from "react";
 
-import { DISPLAYNAME_PREFIX, Popover, type Props } from "@blueprintjs/core";
+import { DISPLAYNAME_PREFIX, PopoverNext, type Props } from "@blueprintjs/core";
 import { More } from "@blueprintjs/icons";
 
 import * as Classes from "../../common/classes";
@@ -232,16 +232,17 @@ export class TruncatedFormat extends PureComponent<TruncatedFormatProps, Truncat
             );
             const popoverContent = <div className={popoverClasses}>{children}</div>;
             return (
-                <Popover
+                <PopoverNext
                     className={Classes.TABLE_TRUNCATED_POPOVER_TARGET}
                     content={popoverContent}
                     isOpen={true}
                     onClose={this.handlePopoverClose}
                     placement="bottom"
                     rootBoundary="document"
+                    shouldReturnFocusOnClose={false}
                 >
                     <More />
-                </Popover>
+                </PopoverNext>
             );
         } else {
             // NOTE: This structure matches what `<Popover>` does internally. If `<Popover>` changes, this must be updated.

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -221,7 +221,7 @@ export class TruncatedFormat extends PureComponent<TruncatedFormatProps, Truncat
     private renderPopover() {
         const { children, preformatted } = this.props;
 
-        // `<Popover>` will always check the content's position on update
+        // `<PopoverNext>` will always check the content's position on update
         // regardless if it is open or not. This negatively affects perf due to
         // layout thrashing. So instead we manage the popover state ourselves
         // and mimic its popover target
@@ -245,7 +245,7 @@ export class TruncatedFormat extends PureComponent<TruncatedFormatProps, Truncat
                 </PopoverNext>
             );
         } else {
-            // NOTE: This structure matches what `<Popover>` does internally. If `<Popover>` changes, this must be updated.
+            // NOTE: This structure matches what `<PopoverNext>` does internally. If `<PopoverNext>` changes, this must be updated.
             return (
                 // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                 <span className={Classes.TABLE_TRUNCATED_POPOVER_TARGET} onClick={this.handlePopoverOpen}>

--- a/packages/table/src/docs/table-features.mdx
+++ b/packages/table/src/docs/table-features.mdx
@@ -3,7 +3,6 @@ title: Table features
 reference: features
 ---
 
-
 # Table features
 
 ## Sorting
@@ -147,7 +146,7 @@ configuration.
 
 To display long strings or native JavaScript objects, the table package provides **TruncatedFormat** and **JSONFormat**
 components. These are designed to be used within a **Cell**, where they will render a
-[**Popover**](#core/components/popover) to show the full cell contents on click.
+[**PopoverNext**](#core/components/popover-next) to show the full cell contents on click.
 
 Below is a table of timezones including the local time when this page was rendered. It uses a
 `<TruncatedFormat detectTruncation={true}>` component to show the long date string and a

--- a/packages/table/src/headers/columnHeaderCell.tsx
+++ b/packages/table/src/headers/columnHeaderCell.tsx
@@ -22,8 +22,9 @@ import {
     Icon,
     type IconName,
     type OverlayLifecycleProps,
-    Popover,
+    PopoverNext,
     type PopoverProps,
+    popoverPropsToNextProps,
     type Props,
 } from "@blueprintjs/core";
 
@@ -223,17 +224,17 @@ export class ColumnHeaderCell extends AbstractPureComponent<ColumnHeaderCellProp
         return (
             <div className={classes}>
                 <div className={Classes.TABLE_TH_MENU_CONTAINER_BACKGROUND} />
-                <Popover
+                <PopoverNext
                     className={classNames(Classes.TABLE_TH_MENU, menuPopoverProps?.className)}
                     content={menuRenderer(index)}
                     onClosing={this.handlePopoverClosing}
                     onOpened={this.handlePopoverOpened}
                     placement="bottom"
                     rootBoundary="document"
-                    {...menuPopoverProps}
+                    {...popoverPropsToNextProps(menuPopoverProps)}
                 >
                     <Icon icon={menuIcon} />
-                </Popover>
+                </PopoverNext>
             </div>
         );
     }

--- a/packages/table/src/tableBody.test.tsx
+++ b/packages/table/src/tableBody.test.tsx
@@ -18,6 +18,7 @@ import { mount, type ReactWrapper } from "enzyme";
 import sinon from "sinon";
 
 import { afterEach, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { unmountWrappers } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Cell } from "./cell/cell";
 import { Batcher } from "./common/batcher";
@@ -49,15 +50,9 @@ describe("TableBody", () => {
         document.body.appendChild(containerElement);
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         try {
-            for (const wrapper of mountedWrappers) {
-                try {
-                    wrapper.unmount();
-                } catch {
-                    // best-effort cleanup
-                }
-            }
+            await unmountWrappers(mountedWrappers);
         } finally {
             mountedWrappers = [];
             containerElement?.remove();

--- a/packages/test-commons/src/vitest-utils.ts
+++ b/packages/test-commons/src/vitest-utils.ts
@@ -21,6 +21,35 @@
  * (no `view: window` property needed).
  */
 
+import type { ReactWrapper } from "enzyme";
+import { act } from "react";
+
+/**
+ * Unmount a batch of Enzyme wrappers inside `act()` and yield once so any
+ * microtasks/RAF callbacks (e.g. PopoverNext's floating-ui `autoUpdate`
+ * ResizeObserver/RAF cleanup) flush before jsdom is torn down.
+ *
+ * Use this in an `afterEach` for any test file that mounts PopoverNext-backed
+ * components — without it, teardown can race against autoUpdate and produce
+ * "window is not defined" / "Should not already be working" noise.
+ *
+ * Each `unmount()` is wrapped in try/catch so one wrapper failing doesn't
+ * abandon the remaining wrappers.
+ */
+export function unmountWrappers(wrappers: Array<ReactWrapper<any, any>>): Promise<void> {
+    return act(() => {
+        for (const wrapper of wrappers) {
+            try {
+                wrapper.unmount();
+            } catch {
+                // best-effort: continue unmounting remaining wrappers
+            }
+        }
+        // Yield once so any queued microtasks/RAF callbacks fire while jsdom is still alive.
+        return new Promise<void>(resolve => setTimeout(resolve, 0));
+    });
+}
+
 // see http://stackoverflow.com/questions/16802795/click-not-working-in-mocha-phantomjs-on-certain-elements
 // tl;dr PhantomJS sucks so we have to manually create click events
 export function createMouseEvent(eventType = "click", clientX = 0, clientY = 0) {


### PR DESCRIPTION
## Summary
- Swaps internal `Popover` for `PopoverNext` across Tooltip, MenuItem, ContextMenuPopover, Select/MultiSelect/Suggest, DateInput/DateRangeInput, TruncatedFormat, and ColumnHeaderCell.
- Routes consumer-supplied `popoverProps` through `popoverPropsToNextProps()` (https://github.com/palantir/blueprint/pull/8112) so public APIs are preserved.
- Two `popoverRef` type fields (`SelectPopoverProps`, `DatetimePopoverProps`) move from `RefObject<Popover<…>>` to `RefObject<PopoverNextRef>`. Methods like `reposition()` keep working; deeper instance access (`.popoverElement`) does not.