### PR TITLE
[Draft] PopoverNext element ref

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -4,6 +4,7 @@
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
@@ -12,7 +13,7 @@ import * as Errors from "../../common/errors";
 import { Button, Dialog, DialogBody, InputGroup, PopupKind, Tooltip } from "../../components";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
 
-import { PopoverNext } from "./popoverNext";
+import { PopoverNext, type PopoverNextRef } from "./popoverNext";
 
 describe("<PopoverNext>", () => {
     describe("validation", () => {
@@ -1594,6 +1595,43 @@ describe("<PopoverNext>", () => {
 
                 expect(targetButton).toBe(document.activeElement);
             });
+        });
+    });
+
+    describe("imperative ref API", () => {
+        it("getPopoverElement returns the Classes.POPOVER element when open", () => {
+            const ref = createRef<PopoverNextRef>();
+            const { baseElement } = render(
+                <PopoverNext ref={ref} content="content" isOpen={true}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+
+            const popoverElement = baseElement.querySelector(`.${Classes.POPOVER}`);
+            expect(popoverElement).toBeInTheDocument();
+            expect(ref.current?.getPopoverElement()).toBe(popoverElement);
+        });
+
+        it("getPopoverElement returns null when closed", () => {
+            const ref = createRef<PopoverNextRef>();
+            render(
+                <PopoverNext ref={ref} content="content" isOpen={false}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+
+            expect(ref.current?.getPopoverElement()).toBeNull();
+        });
+
+        it("reposition triggers a position update without throwing", () => {
+            const ref = createRef<PopoverNextRef>();
+            render(
+                <PopoverNext ref={ref} content="content" isOpen={true}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+
+            expect(() => ref.current?.reposition()).not.toThrow();
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -17,7 +17,20 @@ import { PopoverTarget } from "./popoverTarget";
 import { usePopover } from "./usePopover";
 
 export interface PopoverNextRef {
+    /**
+     * Imperatively recompute the popover's position. Most consumers should not need to call this:
+     * `PopoverNext` uses Floating UI's `autoUpdate` to reposition automatically on scroll, ancestor
+     * resize, element resize, and layout shift. Use `autoUpdateOptions` to tune that behavior.
+     */
     reposition(): void;
+
+    /**
+     * Returns the `Classes.POPOVER` DOM element if the popover is currently mounted, or `null`
+     * otherwise. Useful for click-outside detection, z-index coordination, and rendering portals
+     * into the popover. Replaces the legacy `Popover` `popoverRef` prop, which exposed the same
+     * DOM element via a `React.Ref<HTMLElement>`.
+     */
+    getPopoverElement(): HTMLElement | null;
 }
 
 export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, ref) => {
@@ -148,16 +161,6 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
         positioningStrategy,
     });
 
-    useImperativeHandle(
-        ref,
-        () => ({
-            reposition: () => {
-                floatingData.update();
-            },
-        }),
-        [floatingData],
-    );
-
     const popoverElement = floatingData.refs.floating.current;
 
     const isHoverInteractionKind =
@@ -165,8 +168,19 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
         interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
 
     const getPopoverElement = useCallback(() => {
-        return popoverElement?.querySelector<HTMLElement>(`.${Classes.POPOVER}`);
+        return popoverElement?.querySelector<HTMLElement>(`.${Classes.POPOVER}`) ?? null;
     }, [popoverElement]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            getPopoverElement,
+            reposition: () => {
+                floatingData.update();
+            },
+        }),
+        [floatingData, getPopoverElement],
+    );
 
     const isElementInPopover = useCallback(
         (element: Element) => {


### PR DESCRIPTION
#### Changes proposed in this pull request:

- [ ] `getPopoverElement` onto `PopoverNextRef` so that the actual element is returned for consumers.

`PopoverNext` does not include a ref to the popover element. The current interface exposes `reposition`. What this suggests is also exposing `getPopoverElement` to cover conditions for the ref existing for consumers who need access.
https://github.com/palantir/blueprint/blob/5e6503727783fd0ce34d8c2b61de1b05c9f79949/packages/core/src/components/popover-next/popoverNext.tsx#L19-L21

#### Reviewers should focus on:

- [ ] Does this sufficiently cover cases of needing a ref on popovers for each of the components below, and their use cases?
  - [ ] ContextMenu
  - [ ] Select
  - [ ] MultiSelect
  - [ ] Suggest
  - [ ] DateInput