### PR TITLE
[select] Fix Select not respecting shouldDismissPopover={false} on Enter

### DIFF
--- a/packages/select/changelog/@unreleased/pr-8096.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8096.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Select now respects `shouldDismissPopover={false}` when items are selected via keyboard (Enter)
+  links:
+  - https://github.com/palantir/blueprint/pull/8096

--- a/packages/select/changelog/@unreleased/pr-8096.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8096.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: Select now respects `shouldDismissPopover={false}` when items are selected via keyboard (Enter)
-  links:
-  - https://github.com/palantir/blueprint/pull/8096

--- a/packages/select/src/components/select/select.test.tsx
+++ b/packages/select/src/components/select/select.test.tsx
@@ -200,6 +200,29 @@ describe("<Select>", () => {
         expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
     });
 
+    it("does not close the popover when selecting via Enter on a MenuItem with shouldDismissPopover={false}", () => {
+        const itemRenderer = (film: Film, { handleClick, handleFocus, modifiers }: any) => {
+            return (
+                <MenuItem
+                    active={modifiers.active}
+                    onClick={handleClick}
+                    onFocus={handleFocus}
+                    text={`${film.rank}. ${film.title}`}
+                    shouldDismissPopover={false}
+                />
+            );
+        };
+        const wrapper = select({ itemRenderer, popoverProps: { usePortal: false } });
+
+        findTargetButton(wrapper).simulate("click");
+        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+
+        // simulate keyboard selection: Enter on the input element
+        wrapper.find("input").simulate("keydown", { key: "Enter" });
+        wrapper.find("input").simulate("keyup", { key: "Enter" });
+        expect(wrapper.find(Popover).prop("isOpen")).toBe(true);
+    });
+
     function select(props: Partial<SelectProps<Film>> = {}, query?: string) {
         const wrapper = mount(
             <Select<Film> {...defaultProps} {...handlers} {...props}>

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -306,8 +306,13 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
     };
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
-        const target = event?.target as HTMLElement;
-        const menuItem = target?.closest(`.${CoreClasses.MENU_ITEM}`);
+        const target = event?.target as HTMLElement | undefined;
+        // When selection is triggered via keyboard (Enter), event.target is the input element,
+        // not the menu item. Fall back to looking up the active menu item in the document so
+        // that `shouldDismissPopover={false}` is respected in both click and keyboard flows.
+        const menuItem =
+            target?.closest(`.${CoreClasses.MENU_ITEM}`) ??
+            (target?.ownerDocument ?? document).querySelector(`.${CoreClasses.MENU_ITEM}.${CoreClasses.ACTIVE}`);
         const menuItemDismiss = menuItem?.matches(`.${CoreClasses.POPOVER_DISMISS}`);
         const shouldDismiss = menuItemDismiss ?? true;
 


### PR DESCRIPTION
## Summary

Fixes #8079.

When a `MenuItem` is selected via keyboard (Enter), `event.target` is the `<input>` element rather than the menu item. The existing `target.closest('.bp6-menu-item')` therefore returned `null`, the dismiss check fell back to its default of `true`, and the popover always closed — ignoring `shouldDismissPopover={false}`.

This change adds a fallback in `Select.handleItemSelect` that looks up the active menu item (`.bp6-menu-item.bp6-active`) when the event target is not inside a menu item, so `shouldDismissPopover` is respected in both click and keyboard flows.

Reproduction from the issue: https://codesandbox.io/p/devbox/exciting-payne-swcdjy

## Test plan

- [x] Existing `select.test.tsx` suite passes (165 tests)
- [x] New regression test: simulate keydown+keyup `Enter` on the input, assert popover stays open when `shouldDismissPopover={false}`