### PR TITLE
[core] Animate Overlay2 content alongside backdrop

### DIFF
--- a/packages/core/src/components/overlay/_overlay.scss
+++ b/packages/core/src/components/overlay/_overlay.scss
@@ -71,6 +71,19 @@ body.#{$ns}-overlay-open {
   }
 }
 
+// Fade content alongside the backdrop. Dialog/Drawer get their own transitions on this element,
+// so we exclude them to avoid clobbering their duration/easing.
+.#{$ns}-overlay-content:not(.#{$ns}-dialog-container, .#{$ns}-drawer) {
+  @include react-transition(
+    "#{$ns}-overlay",
+    (
+      opacity: 0 1,
+    ),
+    $pt-transition-duration * 2,
+    $before: "&"
+  );
+}
+
 // fixed position so the backdrop forecefully covers the whole screen
 .#{$ns}-overlay-backdrop {
   @include position-all(fixed, 0);


### PR DESCRIPTION
## Summary

Fixes #7781.

`Overlay2` wraps backdrop and content in separate `CSSTransition` components, but only the backdrop had CSS transition rules in `_overlay.scss`. When closing an Overlay2 with custom content, the backdrop fades smoothly while the content stays fully opaque until the transition timeout fires and it abruptly disappears.

This adds a default opacity fade to `.bp6-overlay-content` so the content animates in/out together with the backdrop. Dialog and Drawer define their own transitions on the same element (different duration/easing for Dialog, slide-in for Drawer), so they are excluded via `:not(.bp6-dialog-container, .bp6-drawer)`.

Other internal Overlay2 consumers (Popover, Popover-next, OverlayToaster) pass a custom `transitionName` to Overlay2, so they don't share the `bp6-overlay-*` enter/exit classes and are unaffected by this change.

Reproduction from the issue: https://codesandbox.io/p/devbox/serene-visvesvaraya-k73346

## Test plan

- [x] `pnpm --filter @blueprintjs/core run compile` (tokens, esm, cjs, esnext, css)
- [x] `pnpm --filter @blueprintjs/core run test` — 1250 passed
- [x] Inspected compiled CSS to confirm `:not()` scoping
- [x] Manual smoke check in a browser with bare Overlay2, Dialog, Drawer (deferred to reviewer — local Windows env can't run the docs app reliably)
