### PR TITLE
[core] Move MultistepDialog inline styles to CSS

### DIFF
--- a/packages/core/src/components/dialog/_multistep-dialog.scss
+++ b/packages/core/src/components/dialog/_multistep-dialog.scss
@@ -7,7 +7,15 @@
 @import "../../common/variables";
 
 $dialog-border-radius: $pt-border-radius !default;
+$multistep-dialog-min-width: 800px !default;
 $step-radius: $pt-border-radius !default;
+
+// Defaults previously applied via inline styles. Moved to CSS so consumers can override
+// without `!important`. Specificity is a single class, matching Dialog's own rules.
+.#{$ns}-multistep-dialog {
+  min-width: $multistep-dialog-min-width;
+  padding-bottom: 0;
+}
 
 .#{$ns}-multistep-dialog-panels {
   display: flex;

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -99,10 +99,6 @@ interface MultistepDialogState {
     selectedIndex: number;
 }
 
-const PADDING_BOTTOM = 0;
-
-const MIN_WIDTH = 800;
-
 /**
  * Multi-step dialog component.
  *
@@ -130,13 +126,13 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
                 isCloseButtonShown={isCloseButtonShown}
                 {...otherProps}
                 className={classNames(
+                    Classes.MULTISTEP_DIALOG,
                     {
                         [Classes.MULTISTEP_DIALOG_NAV_RIGHT]: navigationPosition === "right",
                         [Classes.MULTISTEP_DIALOG_NAV_TOP]: navigationPosition === "top",
                     },
                     className,
                 )}
-                style={this.getDialogStyle()}
             >
                 <div className={Classes.MULTISTEP_DIALOG_PANELS}>
                     {this.renderLeftPanel()}
@@ -154,10 +150,6 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
         ) {
             this.setState(this.getInitialIndexFromProps(this.props));
         }
-    }
-
-    private getDialogStyle() {
-        return { minWidth: MIN_WIDTH, paddingBottom: PADDING_BOTTOM, ...this.props.style };
     }
 
     private renderLeftPanel() {


### PR DESCRIPTION
## Summary

Fixes #7710.

`MultistepDialog` applied `min-width: 800px` and `padding-bottom: 0` via the underlying Dialog's inline `style` attribute, forcing consumers to use `!important` to override (as shown in the issue's screenshot).

This moves both defaults into `_multistep-dialog.scss` under a single `.bp6-multistep-dialog` class so they can be overridden with normal CSS specificity:

```scss
// before (consumer)
.my-dialog {
  /* stylelint-disable-next-line declaration-no-important */
  min-width: 400px !important;
  width: 400px;
}

// after
.my-dialog {
  min-width: 400px;
  width: 400px;
}
```

The `Classes.MULTISTEP_DIALOG` (`bp6-multistep-dialog`) class constant already existed but was never applied to the rendered element; it is now added to the Dialog className.

The user-provided `style` prop continues to pass through via `{...otherProps}`, so `<MultistepDialog style={{ minWidth: 600 }} />` still works (inline beats class).

## Test plan

- [x] `pnpm --filter @blueprintjs/core run compile`
- [x] `pnpm --filter @blueprintjs/core run test:typeCheck`
- [x] `pnpm --filter @blueprintjs/core run test:vitest:run` — 1250 passed
- [x] `npx prettier --check` on changed files
- [ ] Manual smoke check in docs app (deferred to reviewer)
