### PR TITLE
[core] Add aria-describedby to Tooltip target

### DIFF
--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -468,7 +468,15 @@ export class Popover<
                             {this.isArrowEnabled() && (
                                 <PopoverArrow arrowProps={popperProps.arrowProps} placement={popperProps.placement} />
                             )}
-                            <div className={Classes.POPOVER_CONTENT}>{this.props.content}</div>
+                            <div
+                                {...this.props.popoverContentProps}
+                                className={classNames(
+                                    Classes.POPOVER_CONTENT,
+                                    this.props.popoverContentProps?.className,
+                                )}
+                            >
+                                {this.props.content}
+                            </div>
                         </div>
                     </ResizeSensor>
                 </div>

--- a/packages/core/src/components/popover/popoverSharedProps.ts
+++ b/packages/core/src/components/popover/popoverSharedProps.ts
@@ -313,6 +313,13 @@ export interface PopoverSharedProps<TProps extends DefaultPopoverTargetHTMLProps
     targetProps?: TProps;
 
     /**
+     * HTML props applied to the popover content element (the inner
+     * `.bp6-popover-content` wrapper). Useful for ARIA attributes such as `id`
+     * and `role` on the floating element.
+     */
+    popoverContentProps?: React.HTMLProps<HTMLDivElement>;
+
+    /**
      * Whether the popover should be rendered inside a `Portal` attached to
      * `portalContainer` prop.
      *

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import { createRef } from "react";
 
-import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps } from "../../common";
+import { AbstractPureComponent, DISPLAYNAME_PREFIX, type IntentProps, Utils } from "../../common";
 import * as Classes from "../../common/classes";
 import { Popover } from "../popover/popover";
 import { TOOLTIP_ARROW_SVG_SIZE } from "../popover/popoverArrow";
@@ -100,6 +100,8 @@ export class Tooltip<
 
     private popoverRef = createRef<Popover<T>>();
 
+    private tooltipId = Utils.uniqueId(`${Classes.TOOLTIP}-`);
+
     public render() {
         // if we have an ancestor TooltipContext, we should take its state into account in this render path,
         // it was likely created by a parent ContextMenu
@@ -116,10 +118,24 @@ export class Tooltip<
 
     // any descendant ContextMenus may update this ctxState
     private renderPopover = (ctxState: TooltipContextState) => {
-        const { children, compact, disabled, intent, popoverClassName, ...restProps } = this.props;
+        const { children, compact, content, disabled, intent, popoverClassName, targetProps, ...restProps } =
+            this.props;
         const popoverClasses = classNames(Classes.TOOLTIP, Classes.intentClass(intent), popoverClassName, {
             [Classes.COMPACT]: compact,
         });
+        const isDisabled = ctxState.forceDisabled ?? disabled;
+        const isContentEmpty = content == null || (typeof content === "string" && content.trim() === "");
+        const resolvedContent = isContentEmpty ? (
+            content
+        ) : (
+            <div id={this.tooltipId} role="tooltip">
+                {content}
+            </div>
+        );
+        const mergedTargetProps = {
+            "aria-describedby": isDisabled || isContentEmpty ? undefined : this.tooltipId,
+            ...targetProps,
+        } as T;
 
         return (
             <Popover
@@ -136,12 +152,14 @@ export class Tooltip<
                 {...restProps}
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
-                disabled={ctxState.forceDisabled ?? disabled}
+                content={resolvedContent}
+                disabled={isDisabled}
                 enforceFocus={false}
                 lazy={true}
                 popoverClassName={popoverClasses}
                 portalContainer={this.props.portalContainer}
                 ref={this.popoverRef}
+                targetProps={mergedTargetProps}
             >
                 {children}
             </Popover>

--- a/packages/core/src/components/tooltip/tooltip.tsx
+++ b/packages/core/src/components/tooltip/tooltip.tsx
@@ -100,7 +100,7 @@ export class Tooltip<
 
     private popoverRef = createRef<Popover<T>>();
 
-    private tooltipId = Utils.uniqueId(`${Classes.TOOLTIP}-`);
+    private tooltipId = Utils.uniqueId("bp-tooltip");
 
     public render() {
         // if we have an ancestor TooltipContext, we should take its state into account in this render path,
@@ -118,24 +118,31 @@ export class Tooltip<
 
     // any descendant ContextMenus may update this ctxState
     private renderPopover = (ctxState: TooltipContextState) => {
-        const { children, compact, content, disabled, intent, popoverClassName, targetProps, ...restProps } =
-            this.props;
+        const {
+            children,
+            compact,
+            content,
+            disabled,
+            intent,
+            popoverClassName,
+            popoverContentProps,
+            targetProps,
+            ...restProps
+        } = this.props;
         const popoverClasses = classNames(Classes.TOOLTIP, Classes.intentClass(intent), popoverClassName, {
             [Classes.COMPACT]: compact,
         });
         const isDisabled = ctxState.forceDisabled ?? disabled;
         const isContentEmpty = content == null || (typeof content === "string" && content.trim() === "");
-        const resolvedContent = isContentEmpty ? (
-            content
-        ) : (
-            <div id={this.tooltipId} role="tooltip">
-                {content}
-            </div>
-        );
         const mergedTargetProps = {
             "aria-describedby": isDisabled || isContentEmpty ? undefined : this.tooltipId,
             ...targetProps,
         } as T;
+        const mergedPopoverContentProps: React.HTMLProps<HTMLDivElement> = {
+            id: this.tooltipId,
+            role: "tooltip",
+            ...popoverContentProps,
+        };
 
         return (
             <Popover
@@ -152,11 +159,12 @@ export class Tooltip<
                 {...restProps}
                 // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
-                content={resolvedContent}
+                content={content}
                 disabled={isDisabled}
                 enforceFocus={false}
                 lazy={true}
                 popoverClassName={popoverClasses}
+                popoverContentProps={mergedPopoverContentProps}
                 portalContainer={this.props.portalContainer}
                 ref={this.popoverRef}
                 targetProps={mergedTargetProps}


### PR DESCRIPTION
## Summary

Fixes #7672.

`Tooltip` targets had no `aria-describedby` referencing the tooltip content, so screen readers had no way to announce the tooltip text to users when the target was focused.

This PR implements the standard WAI-ARIA tooltip pattern by:

1. **Adding a new `Popover.popoverContentProps` API** (mirrors the existing `targetProps`): `HTMLProps<HTMLDivElement>` spread onto the `.bp6-popover-content` element. Useful for attaching ARIA attributes (or any HTML props) to the floating content without extra DOM nodes.
2. **Using it from `Tooltip`** to set `id={uniqueId}` and `role="tooltip"` directly on the existing content div, and passing `aria-describedby={tooltipId}` on the target via `targetProps`.

### Why a new API instead of a wrapper div

An earlier iteration of this PR wrapped `content` in `<div role="tooltip" id={tooltipId}>{content}</div>`. Reviewer feedback pointed out that introducing a new pattern just for Tooltip would be a regression in API consistency, since Popover already exposes `targetProps` for the symmetric concern on the target side. The new `popoverContentProps` is the natural counterpart: same shape, same behavior, no extra DOM, and immediately usable by **all** consumers that forward `popoverProps` (Select, MultiSelect, Suggest, ContextMenu, DateInput, etc.) if they ever need to attach attributes to their popover content.

### API specifics

```ts
// new in PopoverSharedProps:
popoverContentProps?: React.HTMLProps<HTMLDivElement>;
```

Spread on the existing `<div className={Classes.POPOVER_CONTENT}>` wrapper, with `className` merged so consumer-supplied classes don't clobber Blueprint's. Other consumers can opt-in via `<Popover popoverProps={{ popoverContentProps: { ... } }}>` — no proactive change is required for them; they continue to render as before.

### Edge cases handled in Tooltip

- **Empty/whitespace content**: detected before assembling props so Popover's existing `POPOVER_WARN_EMPTY_CONTENT` warn path still fires; `aria-describedby` is also omitted to avoid pointing at a missing element.
- **Disabled tooltip**: `aria-describedby` is omitted (the tooltip never opens, so the id never exists in the DOM).
- **User-supplied `targetProps`**: their props are spread *after* our default, so a consumer-supplied `aria-describedby` still wins.
- **User-supplied `popoverContentProps`**: their props are spread *after* our defaults, so a consumer can override `id`/`role` if needed (e.g. for a custom ARIA pattern). They cannot accidentally drop the `bp6-popover-content` class — that's merged in popover.tsx.
- **Lazy mount** (Tooltip's default): the tooltip element only exists in the DOM while open. Screen readers handle a missing reference gracefully when the tooltip is closed and announce content correctly when it opens. Matches MUI Tooltip and Reach UI Tooltip behavior.

### Why no other components need to change

- **ContextMenu** already sets `role="menu"` on its inner `<Menu>` element; no `popoverContentProps` needed.
- **Select / MultiSelect / Suggest** apply `role="listbox"` on the QueryList; no change needed.
- **DateInput / DateRangeInput** render calendar widgets with their own ARIA semantics inside.
- **Popover-next** has its own structure and does not extend `PopoverSharedProps` for content rendering.

The new API is a general-purpose escape hatch; no consumer is forced to use it.

## Test plan

- [x] `pnpm --filter @blueprintjs/core run compile` (esm, cjs, esnext, css)
- [x] `pnpm --filter @blueprintjs/core run test:typeCheck`
- [x] `pnpm --filter @blueprintjs/core run test:vitest:run` — 1250 passed (including existing Popover empty-content warn assertions)
- [x] `npx prettier --check` and `eslint` clean on changed files
- [ ] Manual smoke check with a screen reader (deferred to reviewer)

## Files changed

- `packages/core/src/components/popover/popoverSharedProps.ts` — new `popoverContentProps` prop with TSDoc
- `packages/core/src/components/popover/popover.tsx` — spread `popoverContentProps` on the `.bp6-popover-content` div, merging `className`
- `packages/core/src/components/tooltip/tooltip.tsx` — generate stable `tooltipId`, set `id`/`role` via `popoverContentProps`, set `aria-describedby` via `targetProps`, with the edge cases above
