### PR TITLE
[docs] Add CodeToggle widget; use it for install snippets

### DIFF
--- a/packages/docs-app/src/blueprint.mdx
+++ b/packages/docs-app/src/blueprint.mdx
@@ -25,9 +25,7 @@ Check out the [migration guides to upgrade from v5.x &rarr;](https://github.com/
 home to over 40 UI components.
 Install it with your Node.js package manager of choice:
 
-```sh copy
-pnpm add @blueprintjs/core react react-dom
-```
+@reactDocs InstallSnippet
 
 Additional UI components and APIs are available in:
 

--- a/packages/docs-app/src/components/installSnippet.tsx
+++ b/packages/docs-app/src/components/installSnippet.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CodeToggle, type CodeToggleTab } from "@blueprintjs/docs-theme";
+
+const PACKAGE_MANAGER_PREFERENCE_KEY = "bp-docs-pm-preference";
+
+const INSTALL_TARGET = "@blueprintjs/core react react-dom";
+
+// Append a new entry here to add another package manager (e.g. bun).
+const TABS: readonly CodeToggleTab[] = [
+    { code: `npm install ${INSTALL_TARGET}`, id: "npm", label: "npm" },
+    { code: `yarn add ${INSTALL_TARGET}`, id: "yarn", label: "yarn" },
+    { code: `pnpm add ${INSTALL_TARGET}`, id: "pnpm", label: "pnpm" },
+];
+
+/**
+ * Tabbed install snippet showing the same package across the supported
+ * package managers. The user's choice is persisted across pages so the docs
+ * remember which client the reader uses.
+ */
+export const InstallSnippet: React.FC = () => (
+    <CodeToggle id="install-snippet" tabs={TABS} storageKey={PACKAGE_MANAGER_PREFERENCE_KEY} />
+);

--- a/packages/docs-app/src/getting-started.mdx
+++ b/packages/docs-app/src/getting-started.mdx
@@ -16,9 +16,7 @@ The JavaScript components are stable and their APIs adhere to [semantic versioni
 1.  Install the core package and its peer dependencies with an NPM client like `npm` or `pnpm`,
     pulling in all relevant dependencies:
 
-    ```sh copy
-    pnpm add @blueprintjs/core react react-dom
-    ```
+    @reactDocs InstallSnippet
 
 2.  After installation, you'll be able to import the React components in your application:
 

--- a/packages/docs-app/src/tags/reactDocs.ts
+++ b/packages/docs-app/src/tags/reactDocs.ts
@@ -19,4 +19,5 @@
 export * from "../components/colorPalettes";
 export * from "../components/colorSchemes";
 export * from "../components/icons";
+export * from "../components/installSnippet";
 export * from "../components/welcome";

--- a/packages/docs-theme/src/components/codeToggle.tsx
+++ b/packages/docs-theme/src/components/codeToggle.tsx
@@ -1,0 +1,95 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Code, Pre, Tab, type TabId, Tabs } from "@blueprintjs/core";
+
+export interface CodeToggleTab {
+    /** Stable identifier used for the tab and the persisted preference. */
+    id: string;
+    /** Visible tab label. */
+    label: string;
+    /** Code snippet rendered inside `<pre><code>`. */
+    code: string;
+}
+
+export interface CodeToggleProps {
+    /**
+     * Tabs to render, in display order. The first tab is selected by default
+     * when no persisted preference is found.
+     */
+    tabs: readonly CodeToggleTab[];
+
+    /**
+     * Required `id` for the underlying `<Tabs>` element. Must be unique within
+     * the rendered page.
+     */
+    id: string;
+
+    /**
+     * If provided, the user's selection is persisted in `localStorage` under
+     * this key and shared across all `CodeToggle` instances using the same key.
+     * Useful for global preferences like the package manager choice.
+     */
+    storageKey?: string;
+}
+
+function readStoredPreference(storageKey: string | undefined, validIds: readonly string[]): string | undefined {
+    if (storageKey === undefined || typeof window === "undefined") {
+        return undefined;
+    }
+    const stored = window.localStorage.getItem(storageKey);
+    return stored != null && validIds.includes(stored) ? stored : undefined;
+}
+
+/**
+ * Generic tabbed code-snippet toggle. Each tab renders a `<pre><code>` with
+ * its corresponding snippet. When `storageKey` is provided, the selection is
+ * persisted in `localStorage` so the same choice carries across pages.
+ */
+export const CodeToggle: React.FC<CodeToggleProps> = ({ tabs, id, storageKey }) => {
+    const validIds = useMemo(() => tabs.map(t => t.id), [tabs]);
+    const defaultId = tabs[0]?.id ?? "";
+    const [selected, setSelected] = useState<string>(defaultId);
+
+    // Hydrate from localStorage after mount to avoid SSR / first-render mismatches.
+    useEffect(() => {
+        const stored = readStoredPreference(storageKey, validIds);
+        if (stored !== undefined) {
+            setSelected(stored);
+        }
+    }, [storageKey, validIds]);
+
+    const handleChange = useCallback(
+        (newTabId: TabId) => {
+            const next = String(newTabId);
+            if (!validIds.includes(next)) {
+                return;
+            }
+            setSelected(next);
+            if (storageKey !== undefined && typeof window !== "undefined") {
+                window.localStorage.setItem(storageKey, next);
+            }
+        },
+        [storageKey, validIds],
+    );
+
+    return (
+        <Tabs id={id} selectedTabId={selected} onChange={handleChange}>
+            {tabs.map(tab => (
+                <Tab
+                    key={tab.id}
+                    id={tab.id}
+                    title={tab.label}
+                    panel={
+                        <Pre>
+                            <Code>{tab.code}</Code>
+                        </Pre>
+                    }
+                />
+            ))}
+        </Tabs>
+    );
+};

--- a/packages/docs-theme/src/index.ts
+++ b/packages/docs-theme/src/index.ts
@@ -18,6 +18,7 @@ export * from "./components/banner";
 export * from "./components/documentation";
 export * from "./components/example";
 export * from "./components/codeExample";
+export * from "./components/codeToggle";
 export * from "./components/navMenuItem";
 export * from "./components/navButton";
 export * from "./common";


### PR DESCRIPTION
## Summary

Fixes #7684.

Adds a tabbed code-snippet toggle to the docs and uses it for the install commands on the Blueprint and Getting Started pages, so a reader can pick their package manager (`npm` / `yarn` / `pnpm`) instead of the docs hard-coding one.

## Architecture

The widget is split in two:

- **`@blueprintjs/docs-theme` → `<CodeToggle>`** — generic, reusable. Takes `tabs: { id, label, code }[]`, an `id` for the underlying `<Tabs>`, and an optional `storageKey` for cross-page persistence in `localStorage`. Uses Blueprint `<Tabs>`, `<Pre>`, `<Code>`. Sits next to the existing `CodeExample` widget so any consumer of the docs theme can reuse it.
- **`docs-app` → `<InstallSnippet>`** — thin wrapper that supplies the npm/yarn/pnpm install commands for `@blueprintjs/core react react-dom`, registered as a `@reactDocs InstallSnippet` Documentalist tag.

Why the split: Documentalist's `@reactDocs` tag does not accept arguments, so each specific use case needs its own thin wrapper component registered in `tags/reactDocs.ts`. The generic `CodeToggle` lives in `docs-theme` where it's reusable.

## Extensibility

- **New package manager** (e.g. bun): one entry in the `TABS` array in `installSnippet.tsx`. Tab order is the array order.
- **New snippet toggle elsewhere** (e.g. Vite vs Webpack vs Parcel): a new thin wrapper that calls `<CodeToggle tabs={...} id="..." />`, re-exported via `tags/reactDocs.ts`, then `@reactDocs MyNewWidget` in the relevant MDX page.

## Persistence

`InstallSnippet` passes `storageKey="bp-docs-pm-preference"`, so the reader's PM choice is remembered across pages and across visits. Default is `pnpm` (the docs current default after #7685). The state hydrates from `localStorage` after mount to avoid first-render mismatches and stays SSR-safe.

## Test plan

- [x] `eslint` clean on changed files
- [x] `prettier` applied
- [x] `pnpm --filter @blueprintjs/docs-theme run compile:esm` clean
- [ ] Bundle docs-app and inspect the rendered widget in the browser (deferred — local Windows env hits an unrelated `docs-data:compile` issue with Node 25; the repo's `.nvmrc` pins 24.14.1)

No new tests: neither `docs-theme` nor `docs-app` has a test setup today, and adding the infrastructure for a single widget felt like scope creep for this issue. Happy to follow up in a separate PR if maintainers want test coverage for `docs-theme` widgets.
