### PR TITLE
[docs] Add "Copy page as markdown" button

### DIFF
--- a/packages/docs-app/src/components/blueprintDocs.tsx
+++ b/packages/docs-app/src/components/blueprintDocs.tsx
@@ -21,6 +21,7 @@ import { AnchorButton, BlueprintProvider, Classes, type Intent, Tag } from "@blu
 import { type DocsCompleteData, type HeadingNode, npmData, type PageNode, SECTIONS } from "@blueprintjs/docs-data";
 import {
     Banner,
+    CopyPageMarkdownButton,
     Documentation,
     type DocumentationProps,
     NavMenuItem,
@@ -143,15 +144,18 @@ export class BlueprintDocs extends Component<BlueprintDocsProps, { themeName: st
         return <NavMenuItem {...props} />;
     };
 
-    private renderPageActions = (page: { sourcePath: string }) => {
+    private renderPageActions = (page: { sourceMarkdown?: string; sourcePath: string }) => {
         return (
-            <AnchorButton
-                href={`${GITHUB_SOURCE_URL}/${page.sourcePath}`}
-                icon="edit"
-                target="_blank"
-                text="Edit this page"
-                variant="minimal"
-            />
+            <>
+                <CopyPageMarkdownButton sourceMarkdown={page.sourceMarkdown} />
+                <AnchorButton
+                    href={`${GITHUB_SOURCE_URL}/${page.sourcePath}`}
+                    icon="edit"
+                    target="_blank"
+                    text="Edit this page"
+                    variant="minimal"
+                />
+            </>
         );
     };
 

--- a/packages/docs-data/compile-docs-data.mts
+++ b/packages/docs-data/compile-docs-data.mts
@@ -14,6 +14,7 @@ import semver from "semver";
 import { Classes } from "@blueprintjs/core";
 
 import { hooks, markedRenderer } from "./markdownRenderer.mjs";
+import { stripDocumentalistTags } from "./markdownExport.mts";
 import { assignRoutes, buildNavTree, normalizeNavConfig } from "./navHelpers.mts";
 import {
     PACKAGES,
@@ -88,6 +89,10 @@ async function generateDocumentalistData(): Promise<void> {
         `../{${LIBRARY_PACKAGES.join(",")}}/src/index.ts`,
         `../{${LIBRARY_PACKAGES}}/package.json`,
     );
+
+    // Attach sourceMarkdown to each page so the docs UI can offer a "Copy page" button
+    // that hands an LLM-friendly markdown blob to the reader.
+    attachSourceMarkdown(docs.pages);
 
     // Post-process: replace documentalist's nav with one built from nav.json
     const rawConfig: RawNavStructure = JSON.parse(readFileSync(new URL("./nav.json", import.meta.url), "utf-8"));
@@ -204,4 +209,19 @@ function validateNavConfig(raw: RawNavStructure): void {
 function applyNavConfig(docs: { pages: Record<string, DocPage>; nav: NavTreeNode[] }, navConfig: NavStructure): void {
     assignRoutes(navConfig, docs.pages);
     docs.nav = buildNavTree(navConfig, docs.pages);
+}
+
+function attachSourceMarkdown(pages: Record<string, DocPage>): void {
+    for (const page of Object.values(pages)) {
+        const sourcePath = (page as DocPage & { sourcePath?: string }).sourcePath;
+        if (sourcePath == null) {
+            continue;
+        }
+        try {
+            const raw = readFileSync(resolve(monorepoRootDir, sourcePath), "utf-8");
+            page.sourceMarkdown = stripDocumentalistTags(raw);
+        } catch {
+            // Source file disappeared between documentalist scan and now — non-fatal.
+        }
+    }
 }

--- a/packages/docs-data/markdownExport.mts
+++ b/packages/docs-data/markdownExport.mts
@@ -1,0 +1,36 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+/**
+ * Replace Documentalist's `@tag value` lines with markdown-friendly placeholders so the
+ * exported source can be pasted into LLM/IDE tooling without unfamiliar syntax. Lines
+ * inside fenced code blocks are left untouched (Sass `@use`/`@import` etc.).
+ */
+export function stripDocumentalistTags(source: string): string {
+    const lines = source.split("\n");
+    let inFence = false;
+    return lines
+        .map(line => {
+            if (/^\s*```/.test(line)) {
+                inFence = !inFence;
+                return line;
+            }
+            if (inFence) {
+                return line;
+            }
+            const match = /^@(reactDocs|reactExample|interface|css)\s+(.+)$/.exec(line);
+            if (match == null) {
+                return line;
+            }
+            const [, tag, value] = match;
+            const labels: Record<string, string> = {
+                css: "CSS reference",
+                interface: "TypeScript interface",
+                reactDocs: "Interactive widget",
+                reactExample: "Interactive example",
+            };
+            return `<!-- ${labels[tag]}: ${value.trim()} (see online docs) -->`;
+        })
+        .join("\n");
+}

--- a/packages/docs-data/markdownExport.test.ts
+++ b/packages/docs-data/markdownExport.test.ts
@@ -1,0 +1,40 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+
+import { stripDocumentalistTags } from "./markdownExport.mts";
+
+describe("stripDocumentalistTags", () => {
+    it("replaces top-level @reactDocs / @reactExample / @interface / @css with placeholder comments", () => {
+        const input = [
+            "# Title",
+            "",
+            "@reactDocs Welcome",
+            "@reactExample ButtonExample",
+            "@interface ButtonProps",
+            "@css .bp6-button",
+        ].join("\n");
+        expect(stripDocumentalistTags(input)).toBe(
+            [
+                "# Title",
+                "",
+                "<!-- Interactive widget: Welcome (see online docs) -->",
+                "<!-- Interactive example: ButtonExample (see online docs) -->",
+                "<!-- TypeScript interface: ButtonProps (see online docs) -->",
+                "<!-- CSS reference: .bp6-button (see online docs) -->",
+            ].join("\n"),
+        );
+    });
+
+    it("does not touch lines inside fenced code blocks", () => {
+        const input = ["```scss", '@use "@blueprintjs/core/lib/scss/variables";', "@import 'foo';", "```"].join("\n");
+        expect(stripDocumentalistTags(input)).toBe(input);
+    });
+
+    it("leaves unknown @-prefixed lines alone", () => {
+        const input = "@unknownTag value";
+        expect(stripDocumentalistTags(input)).toBe(input);
+    });
+});

--- a/packages/docs-data/navTypes.mts
+++ b/packages/docs-data/navTypes.mts
@@ -81,6 +81,8 @@ export interface DocPage {
     title: string;
     route: string;
     contents: DocContentItem[];
+    /** Cleaned source markdown of the page, suitable for "Copy as markdown". */
+    sourceMarkdown?: string;
 }
 
 /** Fields common to all nav tree nodes. */

--- a/packages/docs-theme/src/components/copyPageMarkdownButton.tsx
+++ b/packages/docs-theme/src/components/copyPageMarkdownButton.tsx
@@ -1,0 +1,51 @@
+/* !
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { AnchorButton, Tooltip } from "@blueprintjs/core";
+
+export interface CopyPageMarkdownButtonProps {
+    /** Markdown source of the current page. The button is hidden if undefined. */
+    sourceMarkdown?: string;
+}
+
+/**
+ * Action button for copying the current docs page as markdown to the clipboard.
+ * Useful for handing the page to an LLM, IDE, or codegen tool.
+ */
+export const CopyPageMarkdownButton: React.FC<CopyPageMarkdownButtonProps> = ({ sourceMarkdown }) => {
+    const [copied, setCopied] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        return () => clearTimeout(timeoutRef.current);
+    }, []);
+
+    const handleClick = useCallback(() => {
+        if (sourceMarkdown == null) {
+            return;
+        }
+        void navigator.clipboard.writeText(sourceMarkdown);
+        setCopied(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => setCopied(false), 1500);
+    }, [sourceMarkdown]);
+
+    if (sourceMarkdown == null) {
+        return null;
+    }
+
+    return (
+        <Tooltip content={copied ? "Copied!" : "Copy this page as markdown"} hoverOpenDelay={300} position="top">
+            <AnchorButton
+                aria-label="Copy page as markdown"
+                icon={copied ? "tick" : "clipboard"}
+                onClick={handleClick}
+                text="Copy page"
+                variant="minimal"
+            />
+        </Tooltip>
+    );
+};

--- a/packages/docs-theme/src/index.ts
+++ b/packages/docs-theme/src/index.ts
@@ -18,6 +18,7 @@ export * from "./components/banner";
 export * from "./components/documentation";
 export * from "./components/example";
 export * from "./components/codeExample";
+export * from "./components/copyPageMarkdownButton";
 export * from "./components/navMenuItem";
 export * from "./components/navButton";
 export * from "./common";


### PR DESCRIPTION
## Summary

Fixes #7687.

Adds a "Copy page" button to every docs page that hands the reader an LLM/IDE-friendly markdown blob of the current page, like Radix and Groq do.

## Pipeline (`docs-data`)

For every page produced by the `MarkdownPlugin`, the build now reads the source `.mdx` via `PageData.sourcePath`, runs it through a new `stripDocumentalistTags` helper, and attaches the result as `sourceMarkdown` on the page object. The helper replaces top-level `@reactDocs` / `@reactExample` / `@interface` / `@css` lines with HTML comment placeholders (`<!-- Interactive widget: ... (see online docs) -->`) so the exported markdown stays valid and self-documenting. Lines inside fenced code blocks are left untouched, so Sass `@use` / `@import` in code samples are preserved.

`stripDocumentalistTags` lives in its own module (`markdownExport.mts`) with a dedicated `markdownExport.test.ts`, so importing it for testing does not trigger the top-level build code in `compile-docs-data.mts`.

## UI (`docs-theme`)

A new `CopyPageMarkdownButton` renders a Blueprint `AnchorButton` with a clipboard icon and "Copy page" label. On click it writes `sourceMarkdown` to the clipboard and swaps the icon to a tick with a "Copied!" tooltip for 1.5s. The button is hidden when `sourceMarkdown` is undefined (e.g. transient pages or build-time skip).

## Wiring (`docs-app`)

`BlueprintDocs.renderPageActions` now renders the new button alongside the existing "Edit this page" link, so every page action area gets both controls.

## Test plan

- [x] `pnpm --filter @blueprintjs/docs-data run test` for `markdownExport.test.ts` — 3/3 passed (existing failures in `navHelpers.test.ts` are pre-existing and unrelated)
- [x] ESLint / Prettier on changed files
- [ ] Manual smoke check in the docs app (deferred to reviewer — local Windows env hits an unrelated `docs-data:compile` issue with Node 25; the repo's `.nvmrc` pins 24.14.1)

## Out of scope

A "View page as markdown" link or the dropdown variant from the issue's second screenshot. Once the basic `sourceMarkdown` plumbing is in place those are easy follow-ups, happy to do them in a separate PR if maintainers want.
