### PR TITLE
[draft] shim adoption for MenuItem

### DIFF
--- a/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/packages/core/src/components/breadcrumbs/breadcrumbs.tsx
@@ -21,8 +21,9 @@ import { Boundary, Classes, DISPLAYNAME_PREFIX, type Props, removeNonHTMLProps }
 import { Menu } from "../menu/menu";
 import { MenuItem } from "../menu/menuItem";
 import { OverflowList, type OverflowListProps } from "../overflow-list/overflowList";
-import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 
 import { Breadcrumb, type BreadcrumbProps } from "./breadcrumb";
 
@@ -150,11 +151,11 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
 
             return (
                 <li>
-                    <Popover
+                    <PopoverNext
                         content={<Menu>{orderedItems.map(renderOverflowBreadcrumb)}</Menu>}
                         disabled={orderedItems.length === 0}
                         placement={collapseFrom === Boundary.END ? "bottom-end" : "bottom-start"}
-                        {...popoverProps}
+                        {...popoverPropsToNextProps(popoverProps ?? {})}
                     >
                         <span
                             aria-label="collapsed breadcrumbs"
@@ -163,7 +164,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = memo(props => {
                             {...overflowButtonProps}
                             className={classNames(Classes.BREADCRUMBS_COLLAPSED, overflowButtonProps?.className)}
                         />
-                    </Popover>
+                    </PopoverNext>
                 </li>
             );
         },

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -95,6 +95,7 @@ export type {
 export { PopoverNext, type PopoverNextRef } from "./popover-next/popoverNext";
 export {
     popoverPositionToNextPlacement,
+    popoverPropsToNextProps,
     popperModifiersToNextMiddleware,
 } from "./popover-next/popoverNextMigrationUtils";
 export type {

--- a/packages/core/src/components/menu/menuItem.test.tsx
+++ b/packages/core/src/components/menu/menuItem.test.tsx
@@ -25,6 +25,7 @@ import { Button } from "../button/buttons";
 import { Icon } from "../icon/icon";
 import { Popover } from "../popover/popover";
 import { PopoverInteractionKind } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
 import { Text } from "../text/text";
 
 import { type MenuProps } from "./menu";
@@ -134,9 +135,9 @@ describe("MenuItem", () => {
         const handleClose = vi.fn();
         const menu = <MenuItem text="Graph" shouldDismissPopover={false} />;
         const wrapper = mount(
-            <Popover content={menu} isOpen={true} onInteraction={handleClose} usePortal={false}>
+            <PopoverNext content={menu} isOpen={true} onInteraction={handleClose} usePortal={false}>
                 <Button />
-            </Popover>,
+            </PopoverNext>,
         );
         wrapper.find(MenuItem).find("a").simulate("click");
         expect(handleClose).not.toHaveBeenCalled();

--- a/packages/core/src/components/menu/menuItem.test.tsx
+++ b/packages/core/src/components/menu/menuItem.test.tsx
@@ -23,7 +23,6 @@ import { assert, describe, expect, it, vi } from "@blueprintjs/test-commons/vite
 import { Classes } from "../../common";
 import { Button } from "../button/buttons";
 import { Icon } from "../icon/icon";
-import { Popover } from "../popover/popover";
 import { PopoverInteractionKind } from "../popover/popoverProps";
 import { PopoverNext } from "../popover-next/popoverNext";
 import { Text } from "../text/text";
@@ -93,7 +92,7 @@ describe("MenuItem", () => {
                 <MenuItem icon="underline" text="Underline" />
             </MenuItem>,
         );
-        assert.isTrue(wrapper.find(Popover).prop("disabled"));
+        assert.isTrue(wrapper.find(PopoverNext).prop("disabled"));
     });
 
     it("disabled MenuItem blocks mouse listeners", () => {
@@ -168,12 +167,12 @@ describe("MenuItem", () => {
                 <MenuItem text="two" />
             </MenuItem>,
         );
-        assert.strictEqual(wrapper.find(Popover).prop("interactionKind"), popoverProps.interactionKind);
+        assert.strictEqual(wrapper.find(PopoverNext).prop("interactionKind"), popoverProps.interactionKind);
         assert.notStrictEqual(
-            wrapper.find(Popover).prop("popoverClassName")!.indexOf(popoverProps.popoverClassName),
+            wrapper.find(PopoverNext).prop("popoverClassName")!.indexOf(popoverProps.popoverClassName),
             0,
         );
-        assert.notStrictEqual(wrapper.find(Popover).prop("content"), popoverProps.content);
+        assert.notStrictEqual(wrapper.find(PopoverNext).prop("content"), popoverProps.content);
     });
 
     it("multiline prop determines if long content is ellipsized", () => {
@@ -272,7 +271,7 @@ describe("MenuItem", () => {
 });
 
 function findSubmenu(wrapper: ShallowWrapper<any, any>) {
-    return wrapper.find(Popover).prop("content") as React.ReactElement<
+    return wrapper.find(PopoverNext).prop("content") as React.ReactElement<
         MenuProps & { children: Array<React.ReactElement<MenuItemProps>> }
     >;
 }

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -24,6 +24,7 @@ import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
 import type { PopoverProps } from "../popover/popoverProps";
+import type { MiddlewareConfig } from "../popover-next/middlewareTypes";
 import { PopoverNext } from "../popover-next/popoverNext";
 import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 import { Text } from "../text/text";
@@ -292,13 +293,12 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
                     enforceFocus={false}
                     hoverCloseDelay={0}
                     interactionKind="hover"
-                    modifiers={SUBMENU_POPOVER_MODIFIERS}
+                    middleware={SUBMENU_POPOVER_MIDDLEWARE}
                     targetProps={{ role: targetRole, tabIndex: 0 }}
                     placement="right-start"
                     usePortal={false}
                     {...popoverPropsToNextProps(popoverProps)}
                     content={<Menu {...submenuProps}>{children}</Menu>}
-                    minimal={true}
                     popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
                 >
                     {target}
@@ -309,12 +309,11 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
 });
 MenuItem.displayName = `${DISPLAYNAME_PREFIX}.MenuItem`;
 
-const SUBMENU_POPOVER_MODIFIERS: PopoverProps["modifiers"] = {
-    // 20px padding - scrollbar width + a bit
-    flip: { enabled: true, options: { padding: 20, rootBoundary: "viewport" } },
+const SUBMENU_POPOVER_MIDDLEWARE: MiddlewareConfig = {
+    flip: { padding: 20, rootBoundary: "viewport" },
     // shift popover up 5px so MenuItems align
-    offset: { enabled: true, options: { offset: [-5, 0] } },
-    preventOverflow: { enabled: true, options: { padding: 20, rootBoundary: "viewport" } },
+    offset: { crossAxis: -5, mainAxis: 0 },
+    shift: { padding: 20, rootBoundary: "viewport" },
 };
 
 // props to ignore when disabled

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -23,8 +23,9 @@ import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
 import { clickElementOnKeyPress } from "../../common/utils";
 import { Icon } from "../icon/icon";
-import { Popover } from "../popover/popover";
 import type { PopoverProps } from "../popover/popoverProps";
+import { PopoverNext } from "../popover-next/popoverNext";
+import { popoverPropsToNextProps } from "../popover-next/popoverNextMigrationUtils";
 import { Text } from "../text/text";
 
 import { Menu, type MenuProps } from "./menu";
@@ -283,7 +284,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             {children == null ? (
                 target
             ) : (
-                <Popover
+                <PopoverNext
                     // eslint-disable-next-line jsx-a11y/no-autofocus -- intentionally disabled
                     autoFocus={false}
                     captureDismiss={false}
@@ -295,13 +296,13 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
                     targetProps={{ role: targetRole, tabIndex: 0 }}
                     placement="right-start"
                     usePortal={false}
-                    {...popoverProps}
+                    {...popoverPropsToNextProps(popoverProps)}
                     content={<Menu {...submenuProps}>{children}</Menu>}
                     minimal={true}
                     popoverClassName={classNames(Classes.MENU_SUBMENU, popoverProps?.popoverClassName)}
                 >
                     {target}
-                </Popover>
+                </PopoverNext>
             )}
         </li>
     );

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -6,9 +6,14 @@ import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import type { MiddlewareConfig } from "../..";
 import { PopoverPosition } from "../popover/popoverPosition";
+import type { PopoverProps } from "../popover/popoverProps";
 import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
 
-import { popoverPositionToNextPlacement, popperModifiersToNextMiddleware } from "./popoverNextMigrationUtils";
+import {
+    popoverPositionToNextPlacement,
+    popoverPropsToNextProps,
+    popperModifiersToNextMiddleware,
+} from "./popoverNextMigrationUtils";
 
 describe("popoverPositionToNextPlacement", () => {
     it("should convert top-left to top-start", () => {
@@ -264,5 +269,129 @@ describe("popperModifiersToNextMiddleware", () => {
             shift: { padding: 4 },
         };
         expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+    });
+});
+
+describe("popoverPropsToNextProps", () => {
+    it("should pin shouldReturnFocusOnClose to false when not supplied (legacy default)", () => {
+        expect(popoverPropsToNextProps({})).to.deep.equal({ shouldReturnFocusOnClose: false });
+    });
+
+    it("should pass through shouldReturnFocusOnClose when supplied", () => {
+        const result = popoverPropsToNextProps({ shouldReturnFocusOnClose: true });
+        expect(result.shouldReturnFocusOnClose).to.equal(true);
+    });
+
+    it("should pass through 1:1 props as-is", () => {
+        const onClose = vi.fn();
+        const result = popoverPropsToNextProps({
+            content: "hello",
+            hasBackdrop: true,
+            isOpen: true,
+            matchTargetWidth: true,
+            onClose,
+            usePortal: false,
+        });
+        expect(result.content).to.equal("hello");
+        expect(result.hasBackdrop).to.equal(true);
+        expect(result.isOpen).to.equal(true);
+        expect(result.matchTargetWidth).to.equal(true);
+        expect(result.onClose).to.equal(onClose);
+        expect(result.usePortal).to.equal(false);
+    });
+
+    describe("position → placement", () => {
+        it("should convert position to placement", () => {
+            const result = popoverPropsToNextProps({ position: PopoverPosition.TOP_LEFT });
+            expect(result.placement).to.equal("top-start");
+        });
+
+        it("should leave placement undefined when position is auto", () => {
+            const result = popoverPropsToNextProps({ position: "auto" });
+            expect(result.placement).to.be.undefined;
+        });
+
+        it("should prefer placement over position when both are supplied", () => {
+            const result = popoverPropsToNextProps({
+                placement: "right",
+                position: PopoverPosition.TOP_LEFT,
+            });
+            expect(result.placement).to.equal("right");
+        });
+    });
+
+    describe("modifiers → middleware", () => {
+        it("should convert modifiers to middleware", () => {
+            const result = popoverPropsToNextProps({
+                modifiers: { flip: { options: { padding: 8 } } },
+            });
+            expect(result.middleware).to.deep.equal({ flip: { padding: 8 } });
+        });
+
+        it("should leave middleware undefined when modifiers is not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.middleware).to.be.undefined;
+        });
+    });
+
+    describe("minimal", () => {
+        it("should map minimal: true to animation: 'minimal' and arrow: false", () => {
+            const result = popoverPropsToNextProps({ minimal: true });
+            expect(result.animation).to.equal("minimal");
+            expect(result.arrow).to.equal(false);
+        });
+
+        it("should not set animation or arrow when minimal is false", () => {
+            const result = popoverPropsToNextProps({ minimal: false });
+            expect(result.animation).to.be.undefined;
+            expect(result.arrow).to.be.undefined;
+        });
+    });
+
+    describe("boundary", () => {
+        it("should remap 'clippingParents' to 'clippingAncestors'", () => {
+            const result = popoverPropsToNextProps({ boundary: "clippingParents" });
+            expect(result.boundary).to.equal("clippingAncestors");
+        });
+
+        it("should pass through Element boundary", () => {
+            const element = document.createElement("div");
+            const result = popoverPropsToNextProps({ boundary: element });
+            expect(result.boundary).to.equal(element);
+        });
+
+        it("should leave boundary undefined when not supplied (PopoverNext default = clippingAncestors)", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.boundary).to.be.undefined;
+        });
+    });
+
+    describe("dropped props", () => {
+        it("should drop modifiersCustom with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const props: Partial<PopoverProps> = { modifiersCustom: [{ name: "custom" }] };
+            const result = popoverPropsToNextProps(props);
+            expect(result).not.to.have.property("modifiersCustom");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
+
+        it("should drop popoverRef with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const ref = { current: null };
+            const result = popoverPropsToNextProps({ popoverRef: ref });
+            expect(result).not.to.have.property("popoverRef");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
+
+        it("should drop portalStopPropagationEvents with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+            const result = popoverPropsToNextProps({ portalStopPropagationEvents: ["click"] });
+            expect(result).not.to.have.property("portalStopPropagationEvents");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
     });
 });

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -2,11 +2,14 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import { isNodeEnv } from "../../common/utils";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
-import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
+import type { PopoverProps } from "../popover/popoverProps";
+import type { DefaultPopoverTargetHTMLProps, PopperModifierOverrides } from "../popover/popoverSharedProps";
 
 import type { MiddlewareConfig, PopoverNextPlacement } from "./middlewareTypes";
+import type { PopoverNextProps } from "./popoverNextProps";
 
 /**
  * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
@@ -126,4 +129,94 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     }
 
     return middleware;
+}
+
+/**
+ * Converts a partial legacy `PopoverProps` bag into a partial `PopoverNextProps` bag suitable
+ * for spreading onto `PopoverNext`. Preserves legacy default behavior where it differs from
+ * `PopoverNext`'s defaults (`shouldReturnFocusOnClose`).
+ *
+ * Transformations:
+ * - `position` → `placement` (via {@link popoverPositionToNextPlacement}). If both are supplied,
+ *   `placement` wins, mirroring legacy `Popover`'s mutex behavior.
+ * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}). A consumer-supplied
+ *   `middleware` bag takes precedence over the converted modifiers.
+ * - `minimal: true` → `animation: "minimal"` and `arrow: false` (legacy `minimal` disables the arrow).
+ * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
+ *
+ * Dropped (with dev-only `console.warn`):
+ * - `modifiersCustom` — no Floating UI equivalent; migrate manually to `middleware`.
+ * - `popoverRef` — `PopoverNext`'s `forwardRef` exposes `{ reposition }`, not the popover DOM node.
+ * - `portalStopPropagationEvents` — already deprecated and non-functional in React 17+.
+ *
+ * Intended for use inside Blueprint components that wrap `Popover` internally and pass
+ * through a `popoverProps` prop, so they can swap to `PopoverNext` without changing their public API.
+ */
+export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>(
+    props: Partial<PopoverProps<T>>,
+): Partial<PopoverNextProps<T>> {
+    const {
+        boundary,
+        minimal,
+        modifiers,
+        modifiersCustom,
+        popoverRef,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        portalStopPropagationEvents,
+        position,
+        shouldReturnFocusOnClose,
+        ...rest
+    } = props;
+
+    if (!isNodeEnv("production")) {
+        if (modifiersCustom !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `modifiersCustom` has no equivalent in PopoverNext and will be dropped. " +
+                    "Migrate to the `middleware` prop manually.",
+            );
+        }
+        if (popoverRef !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `popoverRef` has no equivalent in PopoverNext and will be dropped. " +
+                    "PopoverNext's forwarded ref exposes `{ reposition }`, not the popover DOM element.",
+            );
+        }
+        if (portalStopPropagationEvents !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `portalStopPropagationEvents` has no equivalent in PopoverNext and will be dropped.",
+            );
+        }
+    }
+
+    // `rest` is the 1:1 pass-through. Cast through `unknown` because the legacy `boundary` type
+    // (Popper.js's `Boundary`, which permits the string `"clippingParents"`) is structurally
+    // incompatible with `PopoverNextBoundary`, even though we strip `boundary` out above.
+    const nextProps: Partial<PopoverNextProps<T>> = { ...rest } as unknown as Partial<PopoverNextProps<T>>;
+
+    if (boundary !== undefined) {
+        // "clippingParents" (Popper.js) ≡ "clippingAncestors" (Floating UI).
+        nextProps.boundary = boundary === "clippingParents" ? "clippingAncestors" : (boundary as Element | Element[]);
+    }
+
+    // position → placement. Legacy `placement` wins over `position` when both are supplied.
+    if (position !== undefined && rest.placement === undefined) {
+        const converted = popoverPositionToNextPlacement(position);
+        if (converted !== undefined) {
+            nextProps.placement = converted;
+        }
+    }
+
+    if (modifiers !== undefined) {
+        nextProps.middleware = popperModifiersToNextMiddleware(modifiers);
+    }
+
+    if (minimal === true) {
+        nextProps.animation ??= "minimal";
+        nextProps.arrow ??= false;
+    }
+
+    // Legacy default for `shouldReturnFocusOnClose` is `false`; PopoverNext's is `true`.
+    nextProps.shouldReturnFocusOnClose = shouldReturnFocusOnClose ?? false;
+
+    return nextProps;
 }


### PR DESCRIPTION
#### Base branch: [Migrate Breadcrumbs internals to PopoverNext via compat shim](https://github.com/palantir/blueprint/pull/8090#top)

### What this does
Uses `PopoverNext` instead of `Popover` with the help of `popoverPropsToNextProps`