### PR TITLE
Restore flat `core/components/<page>` doc URLs via section routeAlias

### DIFF
--- a/packages/docs-data/nav.json
+++ b/packages/docs-data/nav.json
@@ -45,6 +45,7 @@
             },
             {
                 "section": "form-controls",
+                "routeAlias": "components",
                 "pages": [
                     "form-group",
                     "control-group",
@@ -59,10 +60,12 @@
             },
             {
                 "section": "form-inputs",
+                "routeAlias": "components",
                 "pages": ["input-group", "text-area", "file-input", "numeric-input", "tag-input"]
             },
             {
                 "section": "overlays",
+                "routeAlias": "components",
                 "pages": [
                     "overlay",
                     "overlay2",

--- a/packages/docs-data/navHelpers.mts
+++ b/packages/docs-data/navHelpers.mts
@@ -26,6 +26,7 @@ export function normalizeNavConfig(raw: RawNavStructure): NavStructure {
         pages: entry.pages.map(pageRef),
         sections: entry.sections?.map(section => ({
             section: section.section,
+            routeAlias: section.routeAlias,
             pages: section.pages.map(pageRef),
         })),
     }));
@@ -72,8 +73,9 @@ export function assignRoutes(navConfig: NavStructure, pages: Record<string, DocP
             const sectionRoute = `${packageRoute}/${section.section}`;
             applyRoute(section.section, sectionRoute);
 
+            const childRoutePrefix = section.routeAlias ? `${packageRoute}/${section.routeAlias}` : sectionRoute;
             for (const child of section.pages) {
-                applyRoute(child.ref, `${sectionRoute}/${child.ref}`);
+                applyRoute(child.ref, `${childRoutePrefix}/${child.ref}`);
             }
         }
     }
@@ -139,7 +141,8 @@ export function buildNavTree(navConfig: NavStructure, pages: Record<string, DocP
             ...entry.pages.map(pageRef => buildNavLeafPage(pageRef.ref, 2, `${packageRoute}/${pageRef.ref}`, pages)),
             ...(entry.sections ?? []).map(section => {
                 const sectionRoute = `${packageRoute}/${section.section}`;
-                return buildNavSection(section, 2, sectionRoute, pages);
+                const childRoutePrefix = section.routeAlias ? `${packageRoute}/${section.routeAlias}` : sectionRoute;
+                return buildNavSection(section, 2, sectionRoute, childRoutePrefix, pages);
             }),
         ];
         return buildNavPage(entry.package, 1, packageRoute, pages, packageChildren);
@@ -157,11 +160,12 @@ export function buildNavSection(
     section: NavSection,
     level: number,
     route: string,
+    childRoutePrefix: string,
     pages: Record<string, DocPage>,
 ): NavTreePage {
     const childLevel = level + 1;
     const children: NavTreeNode[] = section.pages.map(child =>
-        buildNavLeafPage(child.ref, childLevel, `${route}/${child.ref}`, pages),
+        buildNavLeafPage(child.ref, childLevel, `${childRoutePrefix}/${child.ref}`, pages),
     );
 
     const page = pages[section.section];

--- a/packages/docs-data/navHelpers.test.ts
+++ b/packages/docs-data/navHelpers.test.ts
@@ -205,6 +205,35 @@ describe("assignRoutes", () => {
         expect((pages.buttons.contents[1] as DocHeadingItem).route).toBe("core/components/buttons.usage");
     });
 
+    it("should route section children through routeAlias when set", () => {
+        const pages: Record<string, DocPage> = {
+            core: makePage("Core"),
+            overlays: makePage("Overlays"),
+            popover: makePage("Popover", [makeHeading("Popover", 1), makeHeading("Concepts", 2)]),
+        };
+        const navConfig: NavStructure = [
+            {
+                package: "core",
+                pages: [],
+                sections: [
+                    {
+                        section: "overlays",
+                        routeAlias: "components",
+                        pages: [{ type: "page", ref: "popover" }],
+                    },
+                ],
+            },
+        ];
+
+        assignRoutes(navConfig, pages);
+
+        // section landing route is unchanged
+        expect(pages.overlays.route).toBe("core/overlays");
+        // child page and its sub-headings are routed under the alias
+        expect(pages.popover.route).toBe("core/components/popover");
+        expect((pages.popover.contents[1] as DocHeadingItem).route).toBe("core/components/popover.concepts");
+    });
+
     it("should not modify pages that are not referenced in the nav config", () => {
         const pages: Record<string, DocPage> = {
             core: makePage("Core"),
@@ -262,6 +291,33 @@ describe("buildNavTree", () => {
         expect((tree[0].children[0] as NavTreePage).route).toBe("core/overview");
     });
 
+    it("should apply routeAlias to section children but keep section route unchanged", () => {
+        const pages: Record<string, DocPage> = {
+            core: makePage("Core"),
+            popover: makePage("Popover"),
+        };
+        const navConfig: NavStructure = [
+            {
+                package: "core",
+                pages: [],
+                sections: [
+                    {
+                        section: "overlays",
+                        routeAlias: "components",
+                        pages: [{ type: "page", ref: "popover" }],
+                    },
+                ],
+            },
+        ];
+
+        const tree = buildNavTree(navConfig, pages);
+
+        const sectionNode = tree[0].children[0] as NavTreePage;
+        expect(sectionNode.reference).toBe("overlays");
+        expect(sectionNode.route).toBe("core/overlays");
+        expect((sectionNode.children[0] as NavTreePage).route).toBe("core/components/popover");
+    });
+
     it("should include section children and leaf pages at correct levels", () => {
         const pages: Record<string, DocPage> = {
             core: makePage("Core"),
@@ -308,7 +364,7 @@ describe("buildNavSection", () => {
             ],
         };
 
-        const node = buildNavSection(section, 2, "core/components", pages);
+        const node = buildNavSection(section, 2, "core/components", "core/components", pages);
 
         expect(node.reference).toBe("components");
         expect(node.route).toBe("core/components");
@@ -333,7 +389,7 @@ describe("buildNavSection", () => {
             ],
         };
 
-        const node = buildNavSection(section, 2, "core/overlays", pages);
+        const node = buildNavSection(section, 2, "core/overlays", "core/overlays", pages);
 
         expect(node.reference).toBe("overlays");
         expect(node.title).toBe("Overlays");
@@ -343,6 +399,27 @@ describe("buildNavSection", () => {
         expect((node.children[0] as NavTreePage).route).toBe("core/overlays/dialog");
         expect((node.children[1] as NavTreePage).reference).toBe("popover");
         expect((node.children[1] as NavTreePage).route).toBe("core/overlays/popover");
+    });
+
+    it("should route children through childRoutePrefix when it differs from the section route", () => {
+        const pages: Record<string, DocPage> = {
+            dialog: makePage("Dialog"),
+            popover: makePage("Popover"),
+        };
+        const section: NavSection = {
+            section: "overlays",
+            routeAlias: "components",
+            pages: [
+                { type: "page", ref: "dialog" },
+                { type: "page", ref: "popover" },
+            ],
+        };
+
+        const node = buildNavSection(section, 2, "core/overlays", "core/components", pages);
+
+        expect(node.route).toBe("core/overlays");
+        expect((node.children[0] as NavTreePage).route).toBe("core/components/dialog");
+        expect((node.children[1] as NavTreePage).route).toBe("core/components/popover");
     });
 });
 

--- a/packages/docs-data/navTypes.mts
+++ b/packages/docs-data/navTypes.mts
@@ -35,6 +35,14 @@ export type RawNavSectionItem = string;
 
 export interface RawNavSection {
     section: Section;
+    /**
+     * Optional override for the URL prefix applied to child page routes.
+     * When set, children are routed as `${package}/${routeAlias}/${page}`
+     * instead of `${package}/${section}/${page}`. Used to preserve URL
+     * stability when a section is split out of an existing parent (e.g.
+     * `overlays` aliasing back to `components`).
+     */
+    routeAlias?: Section;
     pages: RawNavSectionItem[];
 }
 
@@ -55,6 +63,7 @@ export interface NavPageRef {
 
 export interface NavSection {
     section: Section;
+    routeAlias?: Section;
     pages: NavPageRef[];
 }
 


### PR DESCRIPTION
## Summary

Inline doc cross-references like `#core/components/popover` and `#core/components/checkbox`, plus the matching `@see` JSDoc URLs, broke during the documentalist migration in [#7773](https://github.com/palantir/blueprint/pull/7773). That PR split `form-controls`, `form-inputs`, and `overlays` out of the `@# Components` page and gave each its own route prefix, so the URL for those pages became `core/overlays/popover`, `core/form-controls/checkbox`, etc. The inline references throughout MDX and JSDoc were never updated to match.

Rather than sweep every cross-reference by hand, this adds an optional `routeAlias` field to nav sections (`navTypes.mts` / `navHelpers.mts`). When set, child routes use `${package}/${routeAlias}/${page}` instead of `${package}/${section}/${page}`.

The three affected sections in `nav.json` now set `"routeAlias": "components"`, routing their children and sub-headings back under `core/components/<page>` while leaving section landing pages and sidebar grouping alone.

## Testing
- [ ] Load the docs site, click a popover/checkbox/input-group cross-reference link, confirm it navigates to the right page
- [ ] Confirm sidebar still groups pages under Overlays / Form Controls / Form Inputs
