### PR TITLE
[core] Replace control-group stack list with named z-index variables

### DIFF
--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -1,24 +1,9 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@use "sass:map";
 @import "../../common/variables";
 @import "../forms/common";
 @import "./common";
-
-// z-index values for button stacking order (derived from $control-group-stack in forms/_common.scss)
-$button-group-z-index: (
-  "button-disabled": 3,
-  "button-default": 4,
-  "button-focus": 5,
-  "button-hover": 6,
-  "button-active": 7,
-  "intent-button-disabled": 8,
-  "intent-button-default": 9,
-  "intent-button-focus": 10,
-  "intent-button-hover": 11,
-  "intent-button-active": 12,
-);
 
 .#{$ns}-button-group {
   display: inline-flex;
@@ -27,7 +12,7 @@ $button-group-z-index: (
     // ensure button can never be smaller than its default size
     flex: 0 0 auto;
     position: relative;
-    z-index: map.get($button-group-z-index, "button-default");
+    z-index: $control-group-z-button-default;
 
     // the ordering of these z-index CSS rules is particular because of CSS
     // selector specificity. specifically, disabled styles should have
@@ -35,42 +20,42 @@ $button-group-z-index: (
     // disabled buttons from reordering elements in the stack.
 
     &:focus {
-      z-index: map.get($button-group-z-index, "button-focus");
+      z-index: $control-group-z-button-focus;
     }
 
     &:hover {
-      z-index: map.get($button-group-z-index, "button-hover");
+      z-index: $control-group-z-button-hover;
     }
 
     &:active,
     &.#{$ns}-active {
-      z-index: map.get($button-group-z-index, "button-active");
+      z-index: $control-group-z-button-active;
     }
 
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: map.get($button-group-z-index, "button-disabled");
+      z-index: $control-group-z-button-disabled;
     }
 
     &[class*="#{$ns}-intent-"] {
-      z-index: map.get($button-group-z-index, "intent-button-default");
+      z-index: $control-group-z-intent-button-default;
 
       &:focus {
-        z-index: map.get($button-group-z-index, "intent-button-focus");
+        z-index: $control-group-z-intent-button-focus;
       }
 
       &:hover {
-        z-index: map.get($button-group-z-index, "intent-button-hover");
+        z-index: $control-group-z-intent-button-hover;
       }
 
       &:active,
       &.#{$ns}-active {
-        z-index: map.get($button-group-z-index, "intent-button-active");
+        z-index: $control-group-z-intent-button-active;
       }
 
       &:disabled,
       &.#{$ns}-disabled {
-        z-index: map.get($button-group-z-index, "intent-button-disabled");
+        z-index: $control-group-z-intent-button-disabled;
       }
     }
   }

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -31,29 +31,27 @@ $control-indicator-size-large: $pt-icon-size-large !default;
 // second box-shadow of $pt-input-box-shadow
 $input-box-shadow-focus: inset 0 1px 1px rgba($black, $pt-drop-shadow-opacity) !default;
 
-// for best visual results, button group and control group elements should be
-// stacked in the following order to ensure sharp edges in all cases and states:
-
-$control-group-stack: (
-  // lowest z-index
-  "input-disabled",
-  "input-default",
-  "button-disabled",
-  "button-default",
-  "button-focus",
-  "button-hover",
-  "button-active",
-  "intent-button-disabled",
-  "intent-button-default",
-  "intent-button-focus",
-  "intent-button-hover",
-  "intent-button-active",
-  "intent-input-default",
-  "input-focus",
-  "intent-input-focus",
-  "input-group-children",
-  "select-caret"
-);
+// Z-index stacking order for ControlGroup and ButtonGroup children. Disabled
+// values sit above their corresponding interactive states so a disabled
+// element's border is not overdrawn by an adjacent hover/active sibling
+// (which collapses borders via negative margin).
+$control-group-z-input-disabled: 1;
+$control-group-z-input-default: 2;
+$control-group-z-button-disabled: 3;
+$control-group-z-button-default: 4;
+$control-group-z-button-focus: 5;
+$control-group-z-button-hover: 6;
+$control-group-z-button-active: 7;
+$control-group-z-intent-button-disabled: 8;
+$control-group-z-intent-button-default: 9;
+$control-group-z-intent-button-focus: 10;
+$control-group-z-intent-button-hover: 11;
+$control-group-z-intent-button-active: 12;
+$control-group-z-intent-input-default: 13;
+$control-group-z-input-focus: 14;
+$control-group-z-intent-input-focus: 15;
+$control-group-z-input-group-children: 16;
+$control-group-z-select-caret: 17;
 
 // animating shadows requires the same number of shadows in different states
 @function input-transition-shadow(

--- a/packages/core/src/components/forms/_control-group.scss
+++ b/packages/core/src/components/forms/_control-group.scss
@@ -1,7 +1,6 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
-@use "sass:list";
 @import "../../common/variables";
 @import "../button/common";
 @import "./common";
@@ -29,32 +28,32 @@
   }
 
   .#{$ns}-input {
-    z-index: list.index($control-group-stack, "input-default");
+    z-index: $control-group-z-input-default;
 
     &:focus {
-      z-index: list.index($control-group-stack, "input-focus");
+      z-index: $control-group-z-input-focus;
     }
 
     &[class*="#{$ns}-intent"] {
-      z-index: list.index($control-group-stack, "intent-input-default");
+      z-index: $control-group-z-intent-input-default;
 
       &:focus {
-        z-index: list.index($control-group-stack, "intent-input-focus");
+        z-index: $control-group-z-intent-input-focus;
       }
     }
 
     &[readonly],
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: list.index($control-group-stack, "input-disabled");
+      z-index: $control-group-z-input-disabled;
     }
   }
 
   .#{$ns}-input-group[class*="#{$ns}-intent"] .#{$ns}-input {
-    z-index: list.index($control-group-stack, "intent-input-default");
+    z-index: $control-group-z-intent-input-default;
 
     &:focus {
-      z-index: list.index($control-group-stack, "intent-input-focus");
+      z-index: $control-group-z-intent-input-focus;
     }
   }
 
@@ -62,45 +61,45 @@
   .#{$ns}-html-select select,
   .#{$ns}-select select {
     @include new-render-layer;
-    z-index: list.index($control-group-stack, "button-default");
+    z-index: $control-group-z-button-default;
 
     &:focus {
-      z-index: list.index($control-group-stack, "button-focus");
+      z-index: $control-group-z-button-focus;
     }
 
     &:hover {
-      z-index: list.index($control-group-stack, "button-hover");
+      z-index: $control-group-z-button-hover;
     }
 
     &:active {
-      z-index: list.index($control-group-stack, "button-active");
+      z-index: $control-group-z-button-active;
     }
 
     &[readonly],
     &:disabled,
     &.#{$ns}-disabled {
-      z-index: list.index($control-group-stack, "button-disabled");
+      z-index: $control-group-z-button-disabled;
     }
 
     &[class*="#{$ns}-intent"] {
-      z-index: list.index($control-group-stack, "intent-button-default");
+      z-index: $control-group-z-intent-button-default;
 
       &:focus {
-        z-index: list.index($control-group-stack, "intent-button-focus");
+        z-index: $control-group-z-intent-button-focus;
       }
 
       &:hover {
-        z-index: list.index($control-group-stack, "intent-button-hover");
+        z-index: $control-group-z-intent-button-hover;
       }
 
       &:active {
-        z-index: list.index($control-group-stack, "intent-button-active");
+        z-index: $control-group-z-intent-button-active;
       }
 
       &[readonly],
       &:disabled,
       &.#{$ns}-disabled {
-        z-index: list.index($control-group-stack, "intent-button-disabled");
+        z-index: $control-group-z-intent-button-disabled;
       }
     }
   }
@@ -110,7 +109,7 @@
   .#{$ns}-input-group > .#{$ns}-button,
   .#{$ns}-input-group > .#{$ns}-input-left-container,
   .#{$ns}-input-group > .#{$ns}-input-action {
-    z-index: list.index($control-group-stack, "input-group-children");
+    z-index: $control-group-z-input-group-children;
   }
 
   // keep the select-menu carets on top of everything always (particularly when
@@ -119,14 +118,14 @@
   .#{$ns}-html-select::after,
   .#{$ns}-select > .#{$ns}-icon,
   .#{$ns}-html-select > .#{$ns}-icon {
-    z-index: list.index($control-group-stack, "select-caret");
+    z-index: $control-group-z-select-caret;
   }
 
   // select container does not get focus directly (its <select> does), and it
   // sometimes needs to compete with adjacent container elements
   .#{$ns}-html-select:focus-within,
   .#{$ns}-select:focus-within {
-    z-index: list.index($control-group-stack, "button-focus");
+    z-index: $control-group-z-button-focus;
   }
 
   &:not(.#{$ns}-vertical) {


### PR DESCRIPTION
## Summary

Addresses #7732 (cc @mm-wang).

`forms/_common.scss` exposed a 17-item Sass list (`$control-group-stack`) whose elements' *positions* encoded z-index values. `_control-group.scss` consumed it via `list.index($control-group-stack, "name")`, and `_button-group.scss` separately maintained a `sass:map` with hand-copied numeric values derived from the same list — keeping the two files implicitly coupled and depending on `sass:list` / `sass:map`.

This refactor replaces the list with 17 explicit named scalar variables (`$control-group-z-input-default`, `$control-group-z-button-focus`, …) defined once in `forms/_common.scss`. Both `_control-group.scss` and `_button-group.scss` now reference the shared variables by name, so the two files are consistent by construction rather than by convention.

Numeric z-index values, selector ordering, and the resulting cascade are unchanged, so adjacent button border resolution is preserved (the stack exists so disabled siblings are not visually overdrawn by hover/active on neighbors due to the `margin-right: -1px` border collapse).

Addresses these points raised in #7732:

- *"Relies on `sass:list` module"* — removed; `@use "sass:list"` and `@use "sass:map"` are gone from the affected files.
- *"Duplicated/referenced across multiple files"* — single source of truth in `forms/_common.scss`.
- *"Harder to migrate to pure CSS"* — values are now plain scalars, trivially inlinable in a future pure-CSS migration.

The fourth point in the issue (`:not(:disabled)` guards in place of z-index) is intentionally **not** applied here. That substitution would address hover/active styling *on a disabled element*, which is already a non-issue in the current SCSS, but it does **not** address the actual reason the stack exists: *adjacency* under negative margin. Removing the z-indices in favor of those guards would regress the visual border resolution for disabled buttons next to hovered siblings. I'll leave a follow-up comment on #7732 with this rationale.

## Test plan

- [x] `pnpm --filter @blueprintjs/core run compile` (tokens, esm, cjs, esnext, css)
- [x] `pnpm --filter @blueprintjs/core run test:typeCheck`
- [x] `pnpm --filter @blueprintjs/core run lint:es`
- [x] `npx prettier --write` on the three changed files
- [ ] Manual smoke check in the docs app for ButtonGroup / ControlGroup across permutations (default, intent, disabled adjacencies, focus, hover, active; light + dark themes; minimal + outlined) — deferred to reviewer (local Windows env can't run the docs app reliably)
