### PR TITLE
[core] Adding popoverRef to PopoverNext

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -4,6 +4,7 @@
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createRef } from "react";
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
@@ -234,6 +235,32 @@ describe("<PopoverNext>", () => {
 
             expect(popoverElement).toBeInTheDocument();
             expect(popoverElement).toHaveClass(Classes.DARK);
+        });
+
+        it("attaches popoverRef to the popover element", async () => {
+            const popoverRef = createRef<HTMLDivElement>();
+            const { container } = render(
+                <PopoverNext content="content" isOpen={true} popoverRef={popoverRef} usePortal={false}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+
+            await waitFor(() => expect(screen.getByText("content")).toBeInTheDocument());
+
+            const popoverElement = container.querySelector(`.${Classes.POPOVER}`);
+            expect(popoverElement).toBeInTheDocument();
+            expect(popoverRef.current).toBe(popoverElement);
+        });
+
+        it("popoverRef returns null when closed", () => {
+            const ref = createRef<HTMLDivElement>();
+            render(
+                <PopoverNext popoverRef={ref} content="content" isOpen={false}>
+                    <Button text="target" />
+                </PopoverNext>,
+            );
+
+            expect(ref.current).toBeNull();
         });
 
         it("renders with aria-haspopup attr", () => {

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -41,6 +41,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
         onClose,
         onInteraction,
         openOnTargetFocus = true,
+        popoverRef,
         placement,
         positioningStrategy = "absolute",
         renderTarget,
@@ -399,6 +400,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
                     hasDarkParent={hasDarkParent}
                     isClosingViaEscapeKeypress={isClosingViaEscapeKeypress}
                     isHoverInteractionKind={isHoverInteractionKind}
+                    popoverRef={popoverRef}
                     shouldReturnFocusOnClose={shouldReturnFocusOnClose}
                     {...props}
                 />

--- a/packages/core/src/components/popover-next/popoverNextProps.ts
+++ b/packages/core/src/components/popover-next/popoverNextProps.ts
@@ -284,6 +284,11 @@ export interface PopoverNextProps<T extends DefaultPopoverTargetHTMLProps = Defa
     openOnTargetFocus?: boolean;
 
     /**
+     * DOM ref attached to the `Classes.POPOVER` element.
+     */
+    popoverRef?: React.Ref<HTMLDivElement>;
+
+    /**
      * The placement (relative to the target) at which the popover should appear.
      * Mutually exclusive with `position` prop. Prefer using this over `position`,
      * as it more closely aligns with Floating UI semantics.
@@ -476,6 +481,7 @@ export interface PopoverPopupProps
         | "onOpened"
         | "onOpening"
         | "popoverClassName"
+        | "popoverRef"
         | "portalClassName"
         | "portalContainer"
         | "shouldReturnFocusOnClose"

--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -42,6 +42,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
         onOpened,
         onOpening,
         popoverClassName,
+        popoverRef,
         portalClassName,
         portalContainer,
         transitionDuration = 300,
@@ -139,7 +140,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
                 ref={mergeRefs(floatingData.refs.setFloating, transitionContainerElement)}
                 {...popoverHandlers}
             >
-                <div className={popoverClasses} style={{ transformOrigin }}>
+                <div className={popoverClasses} ref={popoverRef} style={{ transformOrigin }}>
                     {arrow && (
                         <PopoverArrow
                             arrowProps={{ ref: arrowRef, style: arrowStyle }}


### PR DESCRIPTION
#### Changes proposed in this pull request:

- [ ] Add `popoverRef` to `PopoverNext` to support uses of ref on the `PopoverPopup`

`Popover` included a ref to the popup element, and there are some use cases of that element. This suggests adding that prop back in for consumers who need access to it.

https://github.com/palantir/blueprint/blob/d52ab82a33b1dae58d251a6beec5915e58cd7a8d/packages/core/src/components/popover/popover.tsx#L465

https://github.com/palantir/blueprint/blob/d52ab82a33b1dae58d251a6beec5915e58cd7a8d/packages/core/src/components/popover/popoverSharedProps.ts#L227-L230

#### Reviewers should focus on:

Does this allow shim shown below to work?
* #8090