### PR TITLE
Add popoverPropsToNextProps migration shim

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -94,7 +94,10 @@ export type {
 } from "./popover-next/popoverNextProps";
 export { PopoverNext, type PopoverNextRef } from "./popover-next/popoverNext";
 export {
+    popoverPlacementToNextPlacement,
     popoverPositionToNextPlacement,
+    popoverPropsToNextProps,
+    popperBoundaryToNextBoundary,
     popperModifiersToNextMiddleware,
 } from "./popover-next/popoverNextMigrationUtils";
 export type {

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -310,12 +310,16 @@ describe("popoverPropsToNextProps", () => {
             hasBackdrop: true,
             isOpen: true,
             matchTargetWidth: true,
+            positioningStrategy: "fixed",
+            rootBoundary: "viewport",
             usePortal: false,
         });
         expect(result.content).to.equal("hello");
         expect(result.hasBackdrop).to.equal(true);
         expect(result.isOpen).to.equal(true);
         expect(result.matchTargetWidth).to.equal(true);
+        expect(result.positioningStrategy).to.equal("fixed");
+        expect(result.rootBoundary).to.equal("viewport");
         expect(result.usePortal).to.equal(false);
     });
 
@@ -323,15 +327,17 @@ describe("popoverPropsToNextProps", () => {
         it("should wrap onClose so legacy callbacks are only invoked with a defined event", () => {
             const onClose = vi.fn();
             const result = popoverPropsToNextProps({ onClose });
-            // Wrapper, not the original.
+            // Wrapper exists, and it's not the original.
+            expect(result.onClose).to.be.a("function");
             expect(result.onClose).to.not.equal(onClose);
+            const wrapped = result.onClose!;
             // Forwards real events.
             const event = { type: "click" } as React.SyntheticEvent<HTMLElement>;
-            result.onClose!(event);
+            wrapped(event);
             expect(onClose).toHaveBeenCalledOnce();
             expect(onClose).toHaveBeenCalledWith(event);
             // Drops undefined events to honor legacy `(event: SyntheticEvent) => void` signature.
-            result.onClose!(undefined);
+            wrapped(undefined);
             expect(onClose).toHaveBeenCalledOnce();
         });
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -341,7 +341,7 @@ describe("popoverPropsToNextProps", () => {
         });
     });
 
-    describe("position → placement", () => {
+    describe("placement / position", () => {
         it("should convert position to placement", () => {
             const result = popoverPropsToNextProps({ position: PopoverPosition.TOP_LEFT });
             expect(result.placement).to.equal("top-start");
@@ -352,12 +352,37 @@ describe("popoverPropsToNextProps", () => {
             expect(result.placement).to.be.undefined;
         });
 
-        it("should prefer placement over position when both are supplied", () => {
+        it("should leave placement undefined when placement is auto", () => {
+            const result = popoverPropsToNextProps({ placement: "auto" });
+            expect(result.placement).to.be.undefined;
+        });
+
+        it("should prefer placement over position when both are supplied (placement ?? position)", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
             const result = popoverPropsToNextProps({
                 placement: "right",
                 position: PopoverPosition.TOP_LEFT,
             });
             expect(result.placement).to.equal("right");
+            warnSpy.mockRestore();
+        });
+
+        it("should prefer explicit placement: 'auto' over position (legacy placement ?? position rule)", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const result = popoverPropsToNextProps({
+                placement: "auto",
+                position: PopoverPosition.TOP_LEFT,
+            });
+            // Explicit `placement: "auto"` wins, mapping to undefined (autoPlacement default).
+            expect(result.placement).to.be.undefined;
+            warnSpy.mockRestore();
+        });
+
+        it("should warn when both placement and position are supplied (mutex)", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            popoverPropsToNextProps({ placement: "right", position: PopoverPosition.TOP_LEFT });
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -6,9 +6,15 @@ import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import type { MiddlewareConfig } from "../..";
 import { PopoverPosition } from "../popover/popoverPosition";
+import type { PopoverProps } from "../popover/popoverProps";
 import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
 
-import { popoverPositionToNextPlacement, popperModifiersToNextMiddleware } from "./popoverNextMigrationUtils";
+import {
+    popoverPlacementToNextPlacement,
+    popoverPositionToNextPlacement,
+    popoverPropsToNextProps,
+    popperModifiersToNextMiddleware,
+} from "./popoverNextMigrationUtils";
 
 describe("popoverPositionToNextPlacement", () => {
     it("should convert top-left to top-start", () => {
@@ -69,6 +75,27 @@ describe("popoverPositionToNextPlacement", () => {
 
     it("should return undefined for auto-end", () => {
         expect(popoverPositionToNextPlacement("auto-end")).to.be.undefined;
+    });
+});
+
+describe("popoverPlacementToNextPlacement", () => {
+    it("should pass through non-auto placements unchanged", () => {
+        expect(popoverPlacementToNextPlacement("top")).to.equal("top");
+        expect(popoverPlacementToNextPlacement("top-start")).to.equal("top-start");
+        expect(popoverPlacementToNextPlacement("bottom-end")).to.equal("bottom-end");
+        expect(popoverPlacementToNextPlacement("left-start")).to.equal("left-start");
+    });
+
+    it("should return undefined for auto", () => {
+        expect(popoverPlacementToNextPlacement("auto")).to.be.undefined;
+    });
+
+    it("should return undefined for auto-start", () => {
+        expect(popoverPlacementToNextPlacement("auto-start")).to.be.undefined;
+    });
+
+    it("should return undefined for auto-end", () => {
+        expect(popoverPlacementToNextPlacement("auto-end")).to.be.undefined;
     });
 });
 
@@ -264,5 +291,152 @@ describe("popperModifiersToNextMiddleware", () => {
             shift: { padding: 4 },
         };
         expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+    });
+});
+
+describe("popoverPropsToNextProps", () => {
+    it("should pin shouldReturnFocusOnClose to false when not supplied (legacy default)", () => {
+        expect(popoverPropsToNextProps({})).to.deep.equal({ shouldReturnFocusOnClose: false });
+    });
+
+    it("should pass through shouldReturnFocusOnClose when supplied", () => {
+        const result = popoverPropsToNextProps({ shouldReturnFocusOnClose: true });
+        expect(result.shouldReturnFocusOnClose).to.equal(true);
+    });
+
+    it("should pass through 1:1 props as-is", () => {
+        const result = popoverPropsToNextProps({
+            content: "hello",
+            hasBackdrop: true,
+            isOpen: true,
+            matchTargetWidth: true,
+            usePortal: false,
+        });
+        expect(result.content).to.equal("hello");
+        expect(result.hasBackdrop).to.equal(true);
+        expect(result.isOpen).to.equal(true);
+        expect(result.matchTargetWidth).to.equal(true);
+        expect(result.usePortal).to.equal(false);
+    });
+
+    describe("onClose", () => {
+        it("should wrap onClose so legacy callbacks are only invoked with a defined event", () => {
+            const onClose = vi.fn();
+            const result = popoverPropsToNextProps({ onClose });
+            // Wrapper, not the original.
+            expect(result.onClose).to.not.equal(onClose);
+            // Forwards real events.
+            const event = { type: "click" } as React.SyntheticEvent<HTMLElement>;
+            result.onClose!(event);
+            expect(onClose).toHaveBeenCalledOnce();
+            expect(onClose).toHaveBeenCalledWith(event);
+            // Drops undefined events to honor legacy `(event: SyntheticEvent) => void` signature.
+            result.onClose!(undefined);
+            expect(onClose).toHaveBeenCalledOnce();
+        });
+
+        it("should leave onClose undefined when not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.onClose).to.be.undefined;
+        });
+    });
+
+    describe("position → placement", () => {
+        it("should convert position to placement", () => {
+            const result = popoverPropsToNextProps({ position: PopoverPosition.TOP_LEFT });
+            expect(result.placement).to.equal("top-start");
+        });
+
+        it("should leave placement undefined when position is auto", () => {
+            const result = popoverPropsToNextProps({ position: "auto" });
+            expect(result.placement).to.be.undefined;
+        });
+
+        it("should prefer placement over position when both are supplied", () => {
+            const result = popoverPropsToNextProps({
+                placement: "right",
+                position: PopoverPosition.TOP_LEFT,
+            });
+            expect(result.placement).to.equal("right");
+        });
+    });
+
+    describe("modifiers → middleware", () => {
+        it("should convert modifiers to middleware", () => {
+            const result = popoverPropsToNextProps({
+                modifiers: { flip: { options: { padding: 8 } } },
+            });
+            expect(result.middleware).to.deep.equal({ flip: { padding: 8 } });
+        });
+
+        it("should leave middleware undefined when modifiers is not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.middleware).to.be.undefined;
+        });
+    });
+
+    describe("minimal", () => {
+        it("should map minimal: true to animation: 'minimal' and arrow: false", () => {
+            const result = popoverPropsToNextProps({ minimal: true });
+            expect(result.animation).to.equal("minimal");
+            expect(result.arrow).to.equal(false);
+        });
+
+        it("should not set animation or arrow when minimal is false", () => {
+            const result = popoverPropsToNextProps({ minimal: false });
+            expect(result.animation).to.be.undefined;
+            expect(result.arrow).to.be.undefined;
+        });
+    });
+
+    describe("boundary", () => {
+        it("should remap 'clippingParents' to 'clippingAncestors'", () => {
+            const result = popoverPropsToNextProps({ boundary: "clippingParents" });
+            expect(result.boundary).to.equal("clippingAncestors");
+        });
+
+        it("should pass through Element boundary", () => {
+            const element = document.createElement("div");
+            const result = popoverPropsToNextProps({ boundary: element });
+            expect(result.boundary).to.equal(element);
+        });
+
+        it("should leave boundary undefined when not supplied (PopoverNext default = clippingAncestors)", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.boundary).to.be.undefined;
+        });
+    });
+
+    describe("popoverRef", () => {
+        it("should pass through popoverRef to PopoverNext", () => {
+            const ref: React.RefObject<HTMLElement> = { current: null };
+            const result = popoverPropsToNextProps({ popoverRef: ref });
+            expect(result.popoverRef).to.equal(ref);
+        });
+
+        it("should leave popoverRef undefined when not supplied", () => {
+            const result = popoverPropsToNextProps({});
+            expect(result.popoverRef).to.be.undefined;
+        });
+    });
+
+    describe("dropped props", () => {
+        it("should drop modifiersCustom with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            const props: Partial<PopoverProps> = { modifiersCustom: [{ name: "custom" }] };
+            const result = popoverPropsToNextProps(props);
+            expect(result).not.to.have.property("modifiersCustom");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
+
+        it("should drop portalStopPropagationEvents with a dev warning", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+
+            const result = popoverPropsToNextProps({ portalStopPropagationEvents: ["click"] });
+            expect(result).not.to.have.property("portalStopPropagationEvents");
+            expect(warnSpy).toHaveBeenCalledOnce();
+            warnSpy.mockRestore();
+        });
     });
 });

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -4,6 +4,7 @@
 
 import type { Placement, Boundary as PopperBoundary } from "@popperjs/core";
 
+import * as Errors from "../../common/errors";
 import { isNodeEnv } from "../../common/utils";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
@@ -111,10 +112,9 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
  * `PopoverNext`'s defaults (`shouldReturnFocusOnClose`).
  *
  * Transformations:
- * - `position` → `placement` (via {@link popoverPositionToNextPlacement}). If both are supplied,
- *   `placement` wins, mirroring legacy `Popover`'s mutex behavior.
- * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}). A consumer-supplied
- *   `middleware` bag takes precedence over the converted modifiers.
+ * - `placement` ?? `position` → `placement`, mirroring legacy `Popover`'s resolution
+ *   (`placement ?? positionToPlacement(position)`). When `placement` is defined it always wins.
+ * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}).
  * - `minimal: true` → `animation: "minimal"` and `arrow: false` (legacy `minimal` disables the arrow).
  * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
  *
@@ -159,6 +159,9 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
                 "[Blueprint] popoverPropsToNextProps: `portalStopPropagationEvents` has no equivalent in PopoverNext and will be dropped.",
             );
         }
+        if (placement !== undefined && position !== undefined) {
+            console.warn(Errors.POPOVER_WARN_PLACEMENT_AND_POSITION_MUTEX);
+        }
     }
 
     const nextProps: Partial<PopoverNextProps<T>> = { ...rest };
@@ -167,19 +170,12 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         nextProps.boundary = popperBoundaryToNextBoundary(boundary);
     }
 
+    // Mirror legacy `Popover`'s `placement ?? positionToPlacement(position)` rule: an explicit
+    // `placement` always wins, even `"auto*"` (which maps to `undefined` = autoPlacement default).
     if (placement !== undefined) {
-        const converted = popoverPlacementToNextPlacement(placement);
-        if (converted !== undefined) {
-            nextProps.placement = converted;
-        }
-    }
-
-    // position → placement. Legacy `placement` wins over `position` when both are supplied.
-    if (position !== undefined && nextProps.placement === undefined) {
-        const converted = popoverPositionToNextPlacement(position);
-        if (converted !== undefined) {
-            nextProps.placement = converted;
-        }
+        nextProps.placement = popoverPlacementToNextPlacement(placement);
+    } else if (position !== undefined) {
+        nextProps.placement = popoverPositionToNextPlacement(position);
     }
 
     if (modifiers !== undefined) {

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -200,11 +200,12 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
 
     if (popoverRef !== undefined) {
         // Legacy `popoverRef` is `React.Ref<HTMLElement>`; PopoverNext's is `React.Ref<HTMLDivElement>`.
-        // `RefObject<T>` is covariant in `T`, so `RefObject<HTMLElement>` is not strictly assignable
-        // to `RefObject<HTMLDivElement>`. In practice, the underlying DOM node *is* a `<div>` (the
-        // `Classes.POPOVER` element), so a ref slot typed for the wider `HTMLElement` will safely
-        // receive it. Cast narrowly here to acknowledge this known unsoundness without laundering
-        // it across the entire props bag.
+        // `RefObject<T>` is invariant in `T` (`.current` is mutable, so `T` appears in both read
+        // and write positions), so `RefObject<HTMLElement>` is not assignable to
+        // `RefObject<HTMLDivElement>` even though `HTMLDivElement` is a subtype of `HTMLElement`.
+        // In practice the underlying DOM node is a `<div>` (the `Classes.POPOVER` element), so a
+        // ref slot typed for the wider `HTMLElement` safely receives it. Cast narrowly here so
+        // the unsoundness stays scoped to this one prop instead of the whole bag.
         nextProps.popoverRef = popoverRef as React.Ref<HTMLDivElement>;
     }
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -2,39 +2,16 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import type { Placement, Boundary as PopperBoundary } from "@popperjs/core";
+
+import { isNodeEnv } from "../../common/utils";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
-import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
+import type { PopoverProps } from "../popover/popoverProps";
+import type { DefaultPopoverTargetHTMLProps, PopperModifierOverrides } from "../popover/popoverSharedProps";
 
-import type { MiddlewareConfig, PopoverNextPlacement } from "./middlewareTypes";
-
-/**
- * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
- *
- * The `position` prop is not supported in `PopoverNext`; use the `placement` prop instead.
- * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent — they return `undefined`,
- * which causes `PopoverNext` to use its default automatic placement behavior.
- *
- * @example
- * // Before (Popover)
- * <Popover position={PopoverPosition.TOP_LEFT} />
- *
- * // After (PopoverNext)
- * <PopoverNext placement={popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)} />
- */
-export function popoverPositionToNextPlacement(position: PopoverPosition): PopoverNextPlacement | undefined {
-    switch (position) {
-        case "auto":
-        case "auto-start":
-        case "auto-end":
-            // PopoverNext uses autoPlacement middleware by default when placement is undefined.
-            return undefined;
-        default:
-            // positionToPlacement handles all remaining PopoverPosition values.
-            // The string literal values it returns are identical to PopoverNextPlacement.
-            return positionToPlacement(position) as PopoverNextPlacement;
-    }
-}
+import type { MiddlewareConfig, PopoverNextBoundary, PopoverNextPlacement } from "./middlewareTypes";
+import type { PopoverNextProps } from "./popoverNextProps";
 
 /**
  * Converts Popper.js v2 `modifiers` (used by `Popover`) to a Floating UI `MiddlewareConfig` (used by `PopoverNext`).
@@ -66,7 +43,7 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     if (modifiers.flip && modifiers.flip.enabled !== false) {
         const { options } = modifiers.flip;
         middleware.flip = {
-            ...(options?.boundary != null ? { boundary: options.boundary as Element } : {}),
+            ...(options?.boundary != null ? { boundary: popperBoundaryToNextBoundary(options.boundary) } : {}),
             ...(options?.rootBoundary != null ? { rootBoundary: options.rootBoundary } : {}),
             ...(options?.padding != null ? { padding: options.padding } : {}),
             ...(options?.fallbackPlacements != null
@@ -81,7 +58,7 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     if (modifiers.preventOverflow && modifiers.preventOverflow.enabled !== false) {
         const { options } = modifiers.preventOverflow;
         middleware.shift = {
-            ...(options?.boundary != null ? { boundary: options.boundary as Element } : {}),
+            ...(options?.boundary != null ? { boundary: popperBoundaryToNextBoundary(options.boundary) } : {}),
             ...(options?.rootBoundary != null ? { rootBoundary: options.rootBoundary } : {}),
             ...(options?.padding != null ? { padding: options.padding } : {}),
             ...(options?.mainAxis != null ? { mainAxis: options.mainAxis } : {}),
@@ -126,4 +103,177 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
     }
 
     return middleware;
+}
+
+/**
+ * Converts a partial legacy `PopoverProps` bag into a partial `PopoverNextProps` bag suitable
+ * for spreading onto `PopoverNext`. Preserves legacy default behavior where it differs from
+ * `PopoverNext`'s defaults (`shouldReturnFocusOnClose`).
+ *
+ * Transformations:
+ * - `position` → `placement` (via {@link popoverPositionToNextPlacement}). If both are supplied,
+ *   `placement` wins, mirroring legacy `Popover`'s mutex behavior.
+ * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}). A consumer-supplied
+ *   `middleware` bag takes precedence over the converted modifiers.
+ * - `minimal: true` → `animation: "minimal"` and `arrow: false` (legacy `minimal` disables the arrow).
+ * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
+ *
+ * Dropped (with dev-only `console.warn`):
+ * - `modifiersCustom` — no Floating UI equivalent; migrate manually to `middleware`.
+ * - `portalStopPropagationEvents` — already deprecated and non-functional in React 17+.
+ *
+ * Intended for use inside Blueprint components that wrap `Popover` internally and pass
+ * through a `popoverProps` prop, so they can swap to `PopoverNext` without changing their public API.
+ */
+export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>(
+    props: Partial<PopoverProps<T>>,
+): Partial<PopoverNextProps<T>> {
+    // Pull out every prop whose legacy type is structurally incompatible with its
+    // PopoverNext counterpart. After this destructure, `rest` contains only fields that
+    // share an identical type between Popover and PopoverNext, so the spread below is
+    // sound without any blanket cast.
+    const {
+        boundary,
+        minimal,
+        modifiers,
+        modifiersCustom,
+        onClose,
+        placement,
+        popoverRef,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        portalStopPropagationEvents,
+        position,
+        shouldReturnFocusOnClose,
+        ...rest
+    } = props;
+
+    if (!isNodeEnv("production")) {
+        if (modifiersCustom !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `modifiersCustom` has no equivalent in PopoverNext and will be dropped. " +
+                    "Migrate to the `middleware` prop manually.",
+            );
+        }
+        if (portalStopPropagationEvents !== undefined) {
+            console.warn(
+                "[Blueprint] popoverPropsToNextProps: `portalStopPropagationEvents` has no equivalent in PopoverNext and will be dropped.",
+            );
+        }
+    }
+
+    const nextProps: Partial<PopoverNextProps<T>> = { ...rest };
+
+    if (boundary !== undefined) {
+        nextProps.boundary = popperBoundaryToNextBoundary(boundary);
+    }
+
+    if (placement !== undefined) {
+        const converted = popoverPlacementToNextPlacement(placement);
+        if (converted !== undefined) {
+            nextProps.placement = converted;
+        }
+    }
+
+    // position → placement. Legacy `placement` wins over `position` when both are supplied.
+    if (position !== undefined && nextProps.placement === undefined) {
+        const converted = popoverPositionToNextPlacement(position);
+        if (converted !== undefined) {
+            nextProps.placement = converted;
+        }
+    }
+
+    if (modifiers !== undefined) {
+        nextProps.middleware = popperModifiersToNextMiddleware(modifiers);
+    }
+
+    if (minimal === true) {
+        nextProps.animation ??= "minimal";
+        nextProps.arrow ??= false;
+    }
+
+    if (onClose !== undefined) {
+        // Legacy `onClose` requires a non-undefined `event`; PopoverNext's signature allows
+        // `event` to be undefined. Wrap to honor the legacy contract — invoke the legacy
+        // handler only when an event is actually present.
+        nextProps.onClose = event => {
+            if (event !== undefined) {
+                onClose(event);
+            }
+        };
+    }
+
+    if (popoverRef !== undefined) {
+        // Legacy `popoverRef` is `React.Ref<HTMLElement>`; PopoverNext's is `React.Ref<HTMLDivElement>`.
+        // `RefObject<T>` is covariant in `T`, so `RefObject<HTMLElement>` is not strictly assignable
+        // to `RefObject<HTMLDivElement>`. In practice, the underlying DOM node *is* a `<div>` (the
+        // `Classes.POPOVER` element), so a ref slot typed for the wider `HTMLElement` will safely
+        // receive it. Cast narrowly here to acknowledge this known unsoundness without laundering
+        // it across the entire props bag.
+        nextProps.popoverRef = popoverRef as React.Ref<HTMLDivElement>;
+    }
+
+    // Legacy default for `shouldReturnFocusOnClose` is `false`; PopoverNext's is `true`.
+    nextProps.shouldReturnFocusOnClose = shouldReturnFocusOnClose ?? false;
+
+    return nextProps;
+}
+
+/**
+ * Converts a Popper.js `Boundary` value to a Floating UI `PopoverNextBoundary` value.
+ *
+ * The two systems use different names for the "all clipping ancestors" sentinel:
+ * - Popper.js: `"clippingParents"`
+ * - Floating UI: `"clippingAncestors"`
+ *
+ * Element / `Element[]` values pass through unchanged.
+ */
+export function popperBoundaryToNextBoundary(boundary: PopperBoundary): PopoverNextBoundary {
+    return boundary === "clippingParents" ? "clippingAncestors" : boundary;
+}
+
+/**
+ * Converts a Popper.js `Placement` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
+ *
+ * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent in Floating UI — they return
+ * `undefined`, which causes `PopoverNext` to use its default automatic placement behavior.
+ * All other values pass through unchanged (the residual literal union is identical to `PopoverNextPlacement`).
+ *
+ * @example
+ * // Before (Popover)
+ * <Popover placement="top-start" />
+ *
+ * // After (PopoverNext)
+ * <PopoverNext placement={popoverPlacementToNextPlacement("top-start")} />
+ */
+export function popoverPlacementToNextPlacement(placement: Placement): PopoverNextPlacement | undefined {
+    switch (placement) {
+        case "auto":
+        case "auto-start":
+        case "auto-end":
+            // PopoverNext uses autoPlacement middleware by default when placement is undefined.
+            return undefined;
+        default:
+            return placement;
+    }
+}
+
+/**
+ * Converts a legacy `PopoverPosition` value to a `PopoverNextPlacement` value for use with `PopoverNext`.
+ *
+ * The `position` prop is not supported in `PopoverNext`; use the `placement` prop instead.
+ * `"auto"`, `"auto-start"`, and `"auto-end"` have no direct equivalent — they return `undefined`,
+ * which causes `PopoverNext` to use its default automatic placement behavior.
+ *
+ * @example
+ * // Before (Popover)
+ * <Popover position={PopoverPosition.TOP_LEFT} />
+ *
+ * // After (PopoverNext)
+ * <PopoverNext placement={popoverPositionToNextPlacement(PopoverPosition.TOP_LEFT)} />
+ */
+export function popoverPositionToNextPlacement(position: PopoverPosition): PopoverNextPlacement | undefined {
+    // `positionToPlacement` translates PopoverPosition's `"top-left"`/`"bottom-right"` forms to
+    // Popper's `"top-start"`/`"bottom-end"` forms, and passes `"auto"`/`"auto-start"`/`"auto-end"`
+    // through unchanged. `popoverPlacementToNextPlacement` then filters out the auto* values.
+    return popoverPlacementToNextPlacement(positionToPlacement(position));
 }


### PR DESCRIPTION
## Summary

Depends on https://github.com/palantir/blueprint/pull/8109

Adds a `popoverPropsToNextProps()` shim that converts a `Partial<PopoverProps>` bag into a `Partial<PopoverNextProps>` bag, so call sites that wrap `Popover` (and consumers `passing popoverProps`) can swap to `PopoverNext` without breaking their public API. Also factors out two new building blocks (`popoverPlacementToNextPlacement`, `popperBoundaryToNextBoundary`) and refactors `popoverPositionToNextPlacement` to compose from them.
