### PR TITLE
[core] Fix PopoverNext closing on focus for hover interactions

### DIFF
--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -18,7 +18,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
         animation = PopoverAnimation.SCALE,
         arrow = true,
         arrowRef,
-        autoFocus = true,
+        autoFocus,
         backdropProps,
         canEscapeKeyClose,
         captureDismiss = false,


### PR DESCRIPTION
## Summary

`PopoverNext` with `interactionKind="hover"` (or `hover-target`) closes the moment its trigger receives focus via Tab. The legacy `Popover` keeps the popover open and leaves focus on the trigger, so this is a regression from the original component.

## Root cause

`popoverPopup.tsx` destructures `autoFocus = true` with a default of `true`. That default short-circuits the fallback on the next line, `autoFocus ?? defaultAutoFocus`, where `defaultAutoFocus` is `false` for hover and `undefined` otherwise. The hover branch is unreachable. The legacy `Popover` doesn't set a destructure default, which is why the same fallback works there.

The JSDoc on `autoFocus` already documents the intended behavior: `@default true for click interactions, false for hover interactions`. The implementation just wasn't matching it.

https://github.com/palantir/blueprint/blob/54ceffd78d48274f98ba062dab13b9b2d493508a/packages/core/src/components/popover/popoverProps.ts#L28-L33

## How the bug manifests

When you Tab onto a hover-triggered `PopoverNext`:

1. `handleTargetFocus` schedules the popover to open after `hoverOpenDelay`.
2. `Overlay2` mounts with `autoFocus={true}` and calls `bringFocusInsideOverlay()`, which moves focus to the `OVERLAY_START_FOCUS_TRAP` dummy element.
3. The trigger fires `blur`. Its `relatedTarget` is that dummy, which sits outside both `floatingData.refs.floating.current` and `.bp6-popover`, so `handleTargetBlur` treats it as focus leaving the popover and calls `handleMouseLeave`. The popover closes.

## Fix

Drop the `= true` destructure default on `autoFocus`. The hover-aware fallback then takes effect as documented. Click interactions are unaffected: when `autoFocus` is left undefined, `Overlay2` applies its own `autoFocus = true` default in `overlay2.tsx`.

## Before / After

https://github.com/user-attachments/assets/8d49e907-4e04-4639-ab3f-76c9d9aad75c

https://github.com/user-attachments/assets/90660c7f-0ae8-4817-baf0-37cf1e1c7a59

```tsx
<div className="example-row">
    <ExampleCard label="Popover (legacy)" subLabel="Tab to focus: should stay open" width={256}>
        <input type="text" placeholder="Tab from here…" />
        <Popover
            content={popoverContent}
            interactionKind={PopoverInteractionKind.HOVER}
            matchTargetWidth={true}
            placement="bottom"
        >
            <Button fill={true} intent="primary" text="Button" />
        </Popover>
    </ExampleCard>
    <ExampleCard label="PopoverNext" subLabel="Tab to focus: closes immediately" width={256}>
        <input type="text" placeholder="Tab from here…" />
        <PopoverNext
            content={popoverContent}
            interactionKind={PopoverInteractionKind.HOVER}
            matchTargetWidth={true}
            placement="bottom"
        >
            <Button fill={true} intent="primary" text="Button" />
        </PopoverNext>
    </ExampleCard>
    <ExampleCard label="PopoverNext + autoFocus={false}" subLabel="Tab to focus: workaround test" width={256}>
        <input type="text" placeholder="Tab from here…" />
        <PopoverNext
            autoFocus={false}
            content={popoverContent}
            interactionKind={PopoverInteractionKind.HOVER}
            matchTargetWidth={true}
            placement="bottom"
        >
            <Button fill={true} intent="primary" text="Button" />
        </PopoverNext>
    </ExampleCard>
</div>
```