### PR TITLE
Add element-icon story examples

### DIFF
--- a/packages/core/src/components/alert/Alert.stories.tsx
+++ b/packages/core/src/components/alert/Alert.stories.tsx
@@ -6,6 +6,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
 import { useCallback, useState } from "react";
 
+import { Home } from "@blueprintjs/icons";
+
 import { Intent } from "../../common";
 import { Button } from "../button/buttons";
 
@@ -150,6 +152,20 @@ export const Loading: Story = {
         cancelButtonText: "Cancel",
         loading: true,
         children: "Loading alert.",
+    },
+};
+
+/**
+ * The `icon` prop accepts either a string icon name or a React element.
+ * When an element is provided, `<Icon>` clones it and merges the parent-provided
+ * `className` and intent class onto its root.
+ */
+export const ElementIconExample: Story = {
+    name: "Element icon",
+    args: {
+        intent: Intent.PRIMARY,
+        icon: <Home size={40} />,
+        children: "This alert renders <Home /> as its icon.",
     },
 };
 

--- a/packages/core/src/components/entity-title/EntityTitle.stories.tsx
+++ b/packages/core/src/components/entity-title/EntityTitle.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DashedPaddedContainer, storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 
 import { Colors } from "@blueprintjs/colors";
+import { Home } from "@blueprintjs/icons";
 import { Flex } from "@blueprintjs/labs";
 
 import { H1, H2, H3, H4, H5, H6 } from "../html/html";
@@ -110,6 +111,7 @@ export const IconExample: Story = {
             <EntityTitle {...args} icon="document" title="Document" />
             <EntityTitle {...args} icon="folder-close" title="Folder" />
             <EntityTitle {...args} icon="user" title="User" />
+            <EntityTitle {...args} icon={<Home />} title="Element icon" />
             <EntityTitle {...args} icon={undefined} title="No icon" />
         </Flex>
     ),

--- a/packages/core/src/components/non-ideal-state/NonIdealState.stories.tsx
+++ b/packages/core/src/components/non-ideal-state/NonIdealState.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { DashedPaddedContainer, storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 
 import { Button } from "../button/buttons";
+import { Spinner } from "../spinner/spinner";
 
 import { NonIdealState, NonIdealStateIconSize } from "./nonIdealState";
 
@@ -127,6 +128,22 @@ export const IconMutedExample: Story = {
             ))}
         </div>
     ),
+};
+
+/**
+ * Pass a `<Spinner>` as the `icon` to communicate a loading state.
+ */
+export const LoadingExample: Story = {
+    name: "Loading",
+    args: {
+        icon: <Spinner />,
+        title: "Loading search results",
+        description: "This may take a moment.",
+    },
+    argTypes: {
+        icon: { table: { disable: true } },
+    },
+    render: args => <NonIdealState {...args} icon={<Spinner size={args.iconSize} />} />,
 };
 
 /**

--- a/packages/core/src/components/tabs/Tabs.stories.tsx
+++ b/packages/core/src/components/tabs/Tabs.stories.tsx
@@ -7,6 +7,7 @@ import { DashedPaddedContainer, storybookLayoutDecorator, StoryLabel } from "@st
 import { useCallback } from "react";
 import { useArgs } from "storybook/preview-api";
 
+import { Home } from "@blueprintjs/icons";
 import { Flex } from "@blueprintjs/labs";
 
 import { Colors } from "../../common";
@@ -222,6 +223,7 @@ export const IconExample: Story = {
             <Tab id="tab1" title="Books" icon="book" panel={<p>Books panel content</p>} />
             <Tab id="tab2" title="Documents" icon="document" panel={<p>Documents panel content</p>} />
             <Tab id="tab3" title="Applications" icon="application" panel={<p>Applications panel content</p>} />
+            <Tab id="tab4" title="Element icon" icon={<Home />} panel={<p>Element icon panel</p>} />
         </Tabs>
     ),
 };

--- a/packages/core/src/components/tag-input/TagInput.stories.tsx
+++ b/packages/core/src/components/tag-input/TagInput.stories.tsx
@@ -6,6 +6,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator } from "@storybook-common";
 import { useCallback, useState } from "react";
 
+import { Home } from "@blueprintjs/icons";
 import { Flex } from "@blueprintjs/labs";
 
 import { Intent } from "../../common";
@@ -168,6 +169,7 @@ export const IconExample: Story = {
         <Flex flexDirection="column" gap={3} style={{ width: "100%" }}>
             <TagInput {...args} leftIcon="search" values={["Search"]} placeholder="With left icon..." />
             <TagInput {...args} leftIcon="tag" values={["Tags"]} placeholder="With tag icon..." />
+            <TagInput {...args} leftIcon={<Home />} values={["Element icon"]} placeholder="leftIcon={<Home />}" />
         </Flex>
     ),
 };

--- a/packages/core/src/components/tree/Tree.stories.tsx
+++ b/packages/core/src/components/tree/Tree.stories.tsx
@@ -7,6 +7,7 @@ import { StoryLabel } from "@storybook-common";
 import { type MouseEvent, useCallback, useReducer } from "react";
 import { expect, waitFor } from "storybook/test";
 
+import { Home } from "@blueprintjs/icons";
 import { Flex } from "@blueprintjs/labs";
 
 import { Tree } from "./tree";
@@ -106,6 +107,11 @@ const SELECTED_CONTENTS: TreeNodeInfo[] = [
         ],
     },
     { id: 3, icon: "document", label: "Item 2" },
+];
+
+const ELEMENT_ICON_CONTENTS: TreeNodeInfo[] = [
+    { id: 0, icon: "home", label: "String icon" },
+    { id: 1, icon: <Home />, label: "Element icon" },
 ];
 
 const DISABLED_CONTENTS: TreeNodeInfo[] = [
@@ -225,6 +231,14 @@ export const AllStates: Story = {
             </div>
         </Flex>
     ),
+};
+
+/**
+ * `TreeNodeInfo.icon` accepts either a string icon name or a React element.
+ */
+export const ElementIconExample: Story = {
+    name: "Element icon",
+    args: { contents: ELEMENT_ICON_CONTENTS },
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds story examples that pass static icon elements (e.g. `<Home />`, `<Spinner />`) to the components affected by [#8080](https://github.com/palantir/blueprint/pull/8080): `Tab`, `Tree`, `EntityTitle`, `TagInput` (`leftIcon`), `Alert`, and `NonIdealState`, so the className and intent merging behavior is visible in Storybook.

## Screenshots:

**Entity Title**
<img width="235" alt="entity-title" src="https://github.com/user-attachments/assets/e46f384d-8042-4a39-b241-03b5420344b1" />

**Tree**
<img width="213" alt="tree" src="https://github.com/user-attachments/assets/e7bb700a-c769-421a-a29c-34ff2a2820f6" />

**Tabs**
<img width="490" alt="tabs" src="https://github.com/user-attachments/assets/20dc6c07-c0c5-4bee-920b-9121055f2313" />

**Alert**
<img width="501"  alt="alert" src="https://github.com/user-attachments/assets/216bb0c2-92b7-46a5-af77-0766662c8561" />

**TagInput**
<img width="455" alt="tag-input" src="https://github.com/user-attachments/assets/1a1ae0a3-741a-4e49-85c0-3454007f71f3" />

**NonIdealState**
<img width="282"  alt="non-ideal-state" src="https://github.com/user-attachments/assets/66aa1d4f-f495-462a-af5d-5c4dc704a8d1" />
