### PR TITLE
Preserve legacy 15px default offset in popoverPropsToNextProps shim

### DIFF
--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -208,10 +208,10 @@ describe("popperModifiersToNextMiddleware", () => {
             warnSpy.mockRestore();
         });
 
-        it("should omit offset from result when no offset options provided", () => {
-            const value: PopperModifierOverrides = { offset: {} };
-            const expected: MiddlewareConfig = {};
-            expect(popperModifiersToNextMiddleware(value)).to.deep.equal(expected);
+        it("should fall back to Blueprint's legacy default offset (15px main-axis) when modifier is enabled with no explicit options", () => {
+            const expected: MiddlewareConfig = { offset: { mainAxis: 15 } };
+            expect(popperModifiersToNextMiddleware({ offset: {} })).to.deep.equal(expected);
+            expect(popperModifiersToNextMiddleware({ offset: { enabled: true } })).to.deep.equal(expected);
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -6,6 +6,7 @@ import type { Placement, Boundary as PopperBoundary } from "@popperjs/core";
 
 import * as Errors from "../../common/errors";
 import { isNodeEnv } from "../../common/utils";
+import { POPOVER_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
 import type { PopoverProps } from "../popover/popoverProps";
@@ -83,6 +84,12 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
                     ...(distance != null ? { mainAxis: distance } : {}),
                 };
             }
+        } else {
+            // Legacy `Popover` always populated `options.offset` with a default of
+            // `[0, POPOVER_ARROW_SVG_SIZE / 2]`, so `{ offset: { enabled: true } }` (a common pattern
+            // for forcing the offset on when the arrow is disabled) implicitly produced a 15px main-axis
+            // gap. Preserve that behavior here so the visual gap is not silently dropped.
+            middleware.offset = { mainAxis: POPOVER_ARROW_SVG_SIZE / 2 };
         }
     }
 


### PR DESCRIPTION
## Summary
- `popperModifiersToNextMiddleware` now falls back to `{ mainAxis: POPOVER_ARROW_SVG_SIZE / 2 }` when the `offset` modifier is enabled with no explicit `options.offset`, matching legacy `Popover`'s implicit default
- Fixes a silent regression where `{ offset: { enabled: true } }` (a common pattern to force the offset on with arrow disabled) produced a 0px gap under PopoverNext
