### PR TITLE
[core] Fix CardList rounded corners getting overshadowed in dark theme

### DIFF
--- a/packages/core/src/components/card-list/card-list.scss
+++ b/packages/core/src/components/card-list/card-list.scss
@@ -68,4 +68,16 @@
       width: calc(100% - ($pt-spacing * 0.5));
     }
   }
+
+  &.#{$ns}-card-list-bordered {
+    > .#{$ns}-card:first-child {
+      border-top-left-radius: var(--bp-surface-border-radius);
+      border-top-right-radius: var(--bp-surface-border-radius);
+    }
+
+    > .#{$ns}-card:last-child {
+      border-bottom-left-radius: var(--bp-surface-border-radius);
+      border-bottom-right-radius: var(--bp-surface-border-radius);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

In dark theme, the bordered `CardList`'s rounded outline is an inset 1px shadow, and CSS paints inset shadows below descendant content. The inner Cards' opaque square corners were covering that outline at the four corners of the list. Rounding the first and last Cards' outer corners to match `--bp-surface-border-radius` clips their fills to the parent's shape, so the outline stays visible.

This bug is currently visible on the [CardList docs page](http://localhost:9001/#core/components/card-list) in dark mode.

<img width="957"  alt="Screenshot 2026-05-11 at 22 46 49@2x" src="https://github.com/user-attachments/assets/852513c5-c7dd-4551-87c8-0aef0c8cffea" />

| Before | After | Diff
|--------|--------|--------|
| <img width="256" alt="before" src="https://github.com/user-attachments/assets/3c1be59b-cdf2-4a60-a6ee-6eb897381193" /> | <img width="256" alt="after" src="https://github.com/user-attachments/assets/afc98e84-a3ed-4640-926b-ff5046d74868" /> | <img width="256" alt="diff" src="https://github.com/user-attachments/assets/8a8e186c-c95f-44e2-89be-2a0575fc0200" /> |





