### PR TITLE
[core] Deprecate Popover in favor of PopoverNext

### DIFF
--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -80,6 +80,7 @@ export { Text, type TextProps } from "./text/text";
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export { PanelStack, type PanelStackProps, PanelStack2, type PanelStack2Props } from "./panel-stack/panelStack";
 export type { Panel, PanelProps } from "./panel-stack/panelTypes";
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { Popover } from "./popover/popover";
 export { PopoverAnimation, PopoverInteractionKind, type PopoverProps } from "./popover/popoverProps";
 export { PopoverPosition } from "./popover/popoverPosition";

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-deprecated */
+
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * @fileoverview This component is DEPRECATED, and the code is frozen.
+ * All changes & bugfixes should be made to PopoverNext instead.
+ */
+
 import type { State as PopperState } from "@popperjs/core";
 import classNames from "classnames";
 import { Children, cloneElement, createElement, createRef } from "react";
@@ -60,6 +65,7 @@ export interface PopoverState {
 /**
  * Popover component, used to display a floating UI next to and tethered to a target element.
  *
+ * @deprecated use `PopoverNext` instead
  * @template T target element props interface. Consumers wishing to stay in sync with Blueprint's default target HTML
  * props interface should use the `DefaultPopoverTargetHTMLProps` type (although this is already the default type for
  * this type param).

--- a/packages/demo-app/src/examples/PopoverExample.tsx
+++ b/packages/demo-app/src/examples/PopoverExample.tsx
@@ -44,6 +44,7 @@ export const PopoverExample = memo(() => {
     return (
         <div className="example-row">
             <ExampleCard label="Popover" subLabel="Text content" width={200}>
+                {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
                 <Popover
                     content={
                         <div style={{ minWidth: 100 }}>
@@ -59,6 +60,7 @@ export const PopoverExample = memo(() => {
                 </Popover>
             </ExampleCard>
             <ExampleCard label="Popover" subLabel="Dropdown menu" width={200}>
+                {/* eslint-disable-next-line @typescript-eslint/no-deprecated */}
                 <Popover content={textEditorMenu} fill={true} placement="bottom-start" minimal={true}>
                     <Button fill={true} text="Click to open" endIcon="caret-down" />
                 </Popover>


### PR DESCRIPTION
## Summary

Marks the legacy `Popover` class component as deprecated, following the same pattern used for `Overlay` -> `Overlay2`. `PopoverNext` is the recommended replacement (see #7573).

## Changes

Adds a `@deprecated` JSDoc tag and a `@fileoverview` frozen-code notice to `popover.tsx`. The re-export in `components/index.ts` gets the corresponding `eslint-disable-next-line` comment.

Shared types like `PopoverProps`, `PopoverInteractionKind`, and `PopoverAnimation` are not deprecated since `PopoverNext` also uses them.
