### PR TITLE
[core] Fix PopoverNext closing on click inside child overlay for hover interactions

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -945,7 +945,32 @@ describe("<PopoverNext>", () => {
 
                 await waitFor(() => expect(screen.getByRole("button", { name: "dialog button" })).toBeInTheDocument());
 
-                onInteraction.mockClear();
+                await user.click(screen.getByRole("button", { name: "dialog button" }));
+
+                expect(onInteraction).not.toHaveBeenCalledWith(false, expect.anything());
+            });
+
+            it("is not invoked on HOVER popover when clicking inside a child Dialog rendered in popover content", async () => {
+                const user = userEvent.setup();
+                const onInteraction = vi.fn();
+                render(
+                    <PopoverNext
+                        content={
+                            <Dialog isOpen={true} title="Child dialog" usePortal={true}>
+                                <DialogBody>
+                                    <Button text="dialog button" />
+                                </DialogBody>
+                            </Dialog>
+                        }
+                        interactionKind="hover"
+                        isOpen={true}
+                        onInteraction={onInteraction}
+                    >
+                        <Button text="target" />
+                    </PopoverNext>,
+                );
+
+                await waitFor(() => expect(screen.getByRole("button", { name: "dialog button" })).toBeInTheDocument());
 
                 await user.click(screen.getByRole("button", { name: "dialog button" }));
 

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -134,8 +134,6 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
     const floatingData = usePopover({
         autoUpdateOptions,
         disabled,
-        hasBackdrop,
-        interactionKind,
         isControlled,
         isOpen: computedIsOpen,
         middleware,

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -15,16 +15,12 @@ import {
 } from "@floating-ui/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { PopoverInteractionKind } from "../popover/popoverProps";
-
 import type { PopoverNextPositioningStrategy } from "./middlewareTypes";
 import type { PopoverNextAutoUpdateOptions } from "./popoverNextProps";
 
 interface PopoverOptions {
     autoUpdateOptions?: PopoverNextAutoUpdateOptions;
     disabled?: boolean;
-    hasBackdrop?: boolean;
-    interactionKind?: PopoverInteractionKind;
     isControlled?: boolean;
     isOpen?: boolean;
     middleware?: Middleware[];
@@ -41,8 +37,6 @@ interface UsePopoverReturn extends UseFloatingReturn, UseInteractionsReturn {
 export function usePopover({
     autoUpdateOptions,
     disabled = false,
-    hasBackdrop = false,
-    interactionKind,
     isControlled = false,
     isOpen = false,
     middleware,
@@ -118,16 +112,12 @@ export function usePopover({
         // `useDismiss` attaches a non-stack-aware document keydown listener — enabling both
         // means every stacked popover/tooltip closes on a single Escape.
         escapeKey: false,
-        // Disable Floating UI outside-press in two cases:
-        // 1. CLICK interactions: delegate to Overlay2's stack-aware handler
-        //    (getThisOverlayAndDescendants) so clicks inside child overlays like Dialog
-        //    don't incorrectly close the popover. useDismiss is not overlay-stack-aware
-        //    and treats clicks in portaled child overlays as "outside" clicks.
-        // 2. hasBackdrop: Overlay2 handles backdrop clicks and outside-click detection.
-        outsidePress:
-            interactionKind !== PopoverInteractionKind.CLICK_TARGET_ONLY &&
-            interactionKind !== PopoverInteractionKind.CLICK &&
-            !hasBackdrop,
+        // Outside-press handling lives on Overlay2 (`canOutsideClickClose`), which is
+        // stack-aware via OverlayContext so clicks inside portaled child overlays (e.g. a
+        // Dialog rendered in popover content) don't incorrectly close the popover. Floating
+        // UI's `useDismiss` treats those clicks as "outside" the popover because the child
+        // overlay is rendered outside the popover's DOM subtree.
+        outsidePress: false,
     });
 
     const interactions = useInteractions([click, dismiss]);


### PR DESCRIPTION
## Problem

If you render a `Dialog` (or any portaled overlay) inside a HOVER `PopoverNext`'s content, clicking inside the dialog closes the popover, which unmounts the dialog.

#7920 fixed this for `CLICK` and `CLICK_TARGET_ONLY` by handing outside-click detection back to `Overlay2`'s stack-aware handler, but left Floating UI's `useDismiss` outside-press enabled for `HOVER` and `HOVER_TARGET_ONLY`. `useDismiss` isn't overlay-stack-aware, so a click inside a portaled child overlay still looks "outside" the popover and triggers a dismiss.

The original `Popover` only sets `canOutsideClickClose` for `CLICK` interactions, so hover popovers were never closed by outside clicks there either.

## Fix

`usePopover.ts`: disable `useDismiss`'s `outsidePress` unconditionally. All outside-click detection now lives on `Overlay2`, which is stack-aware via `OverlayContext` and only enabled for `CLICK` interactions in `popoverPopup.tsx` (unchanged). `HOVER` popovers continue to close on mouse leave, matching the original `Popover`.
