### PR TITLE
feature/date-reverse-ordered-range

### DIFF
--- a/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
@@ -267,6 +267,16 @@ export class DateRangePicker extends DateFnsLocalizedComponent<DateRangePickerPr
         const newTimeRange: DateRange = [time[0], time[1]];
         newTimeRange[dateIndex] = newTime;
 
+        if (newDateRange[0] != null && newDateRange[1] != null && newDateRange[0] > newDateRange[1]) {
+        const temp = newDateRange[0];
+        newDateRange[0] = newDateRange[1];
+        newDateRange[1] = temp;
+
+        const tempTime = newTimeRange[0];
+        newTimeRange[0] = newTimeRange[1];
+        newTimeRange[1] = tempTime;
+    }
+
         this.props.onChange?.(newDateRange);
         this.setState({ time: newTimeRange, value: newDateRange });
     };

--- a/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
@@ -268,14 +268,9 @@ export class DateRangePicker extends DateFnsLocalizedComponent<DateRangePickerPr
         newTimeRange[dateIndex] = newTime;
 
         if (newDateRange[0] != null && newDateRange[1] != null && newDateRange[0] > newDateRange[1]) {
-        const temp = newDateRange[0];
-        newDateRange[0] = newDateRange[1];
-        newDateRange[1] = temp;
-
-        const tempTime = newTimeRange[0];
-        newTimeRange[0] = newTimeRange[1];
-        newTimeRange[1] = tempTime;
-    }
+            [newDateRange[0], newDateRange[1]] = [newDateRange[1], newDateRange[0]];
+            [newTimeRange[0], newTimeRange[1]] = [newTimeRange[1], newTimeRange[0]];
+        }
 
         this.props.onChange?.(newDateRange);
         this.setState({ time: newTimeRange, value: newDateRange });


### PR DESCRIPTION
#### Fixes #8122

#### Checklist

- [ ] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

<!-- Fill this out. -->

Here I have changed in dateRangePicker.tsx there is a function called handleTimeChange I have modified the code on that

#### Reviewers should focus on:


<!-- Fill this out. -->

private handleTimeChange = (newTime: Date, dateIndex: number) => {
        this.props.timePickerProps?.onChange?.(newTime);

        const { value, time } = this.state;
        const newValue = DateUtils.getDateTime(
            value[dateIndex] != null ? DateUtils.clone(value[dateIndex]!) : this.getDefaultDate(dateIndex),
            newTime,
        );
        const newDateRange: DateRange = [value[0], value[1]];
        newDateRange[dateIndex] = newValue;
        const newTimeRange: DateRange = [time[0], time[1]];
        newTimeRange[dateIndex] = newTime;

        if (newDateRange[0] != null && newDateRange[1] != null && newDateRange[0] > newDateRange[1]) {
        const temp = newDateRange[0];
        newDateRange[0] = newDateRange[1];
        newDateRange[1] = temp;

        const tempTime = newTimeRange[0];
        newTimeRange[0] = newTimeRange[1];
        newTimeRange[1] = tempTime;
    }

        this.props.onChange?.(newDateRange);
        this.setState({ time: newTimeRange, value: newDateRange });
    };

#### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->

closes #8122
