### PR TITLE
[core] Add Storybook stories for Context Menu

### DIFF
--- a/packages/core/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenu.stories.tsx
@@ -3,11 +3,8 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
-import classNames from "classnames";
+import { storybookLayoutDecorator } from "@storybook-common";
 import { expect, screen, waitFor } from "storybook/test";
-
-import { Flex } from "@blueprintjs/labs";
 
 import { Menu } from "../menu/menu";
 import { MenuDivider } from "../menu/menuDivider";
@@ -46,8 +43,6 @@ const TARGET_STYLE: React.CSSProperties = {
     width: 240,
 };
 
-const disabledArgs = ["children"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof ContextMenu>>;
-
 const meta: Meta<typeof ContextMenu> = {
     title: "Core/Context Menu/ContextMenu",
     component: ContextMenu,
@@ -57,23 +52,13 @@ const meta: Meta<typeof ContextMenu> = {
         disabled: false,
     },
     argTypes: {
-        content: { control: false },
+        content: { control: false, table: { disable: true } },
         disabled: { control: "boolean" },
         tagName: { control: "text" },
         onContextMenu: { action: "context-menu-opened" },
-        onClose: { action: "closed" },
+        onClose: { table: { disable: true } },
         popoverProps: { table: { disable: true } },
-        onOpening: { table: { disable: true } },
-        onOpened: { table: { disable: true } },
-        onClosing: { table: { disable: true } },
-        onClosed: { table: { disable: true } },
-        ...disabledArgs.reduce(
-            (acc, argName) => {
-                acc[argName] = { table: { disable: true } };
-                return acc;
-            },
-            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
-        ),
+        children: { table: { disable: true } },
     },
 } satisfies Meta<typeof ContextMenu>;
 
@@ -127,7 +112,7 @@ export const AdvancedChildren: Story = {
     args: {
         children: (props: ContextMenuChildrenProps) => (
             <div
-                className={classNames(props.className)}
+                className={props.className}
                 onContextMenu={props.onContextMenu}
                 ref={props.ref}
                 style={{
@@ -149,7 +134,7 @@ export const CustomTagName: Story = {
     name: "Custom Tag Name",
     args: {
         tagName: "section",
-        children: <div style={TARGET_STYLE}>Wrapped in a &lt;section&gt; element</div>,
+        children: <div style={TARGET_STYLE}>{"Wrapped in a <section> element"}</div>,
     },
 };
 
@@ -174,40 +159,6 @@ export const Disabled: Story = {
         disabled: true,
         children: <div style={TARGET_STYLE}>Disabled — browser context menu shows instead</div>,
     },
-};
-
-/**
- * Showcases how the same `ContextMenu` wrapper can be applied around a variety
- * of targets — text, blocks, and inline elements all support right-click.
- */
-export const MultipleTargets: Story = {
-    argTypes: {
-        children: { table: { disable: true } },
-    },
-    render: args => (
-        <Flex flexDirection="column" gap={4}>
-            <Flex flexDirection="column" gap={1}>
-                <StoryLabel title="Block target" />
-                <ContextMenu {...args}>
-                    <div style={TARGET_STYLE}>Right-click this block</div>
-                </ContextMenu>
-            </Flex>
-            <Flex flexDirection="column" gap={1}>
-                <StoryLabel title="Inline target" />
-                <ContextMenu {...args} tagName="span">
-                    <span
-                        style={{
-                            background: "rgba(138, 155, 168, 0.15)",
-                            borderRadius: 3,
-                            padding: "2px 6px",
-                        }}
-                    >
-                        Right-click this inline span
-                    </span>
-                </ContextMenu>
-            </Flex>
-        </Flex>
-    ),
 };
 
 /**

--- a/packages/core/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenu.stories.tsx
@@ -116,7 +116,6 @@ export const AdvancedChildren: Story = {
                 onContextMenu={props.onContextMenu}
                 ref={props.ref}
                 style={{
-                    ...TARGET_STYLE,
                     background: props.contentProps.isOpen ? "rgba(45, 114, 210, 0.2)" : TARGET_STYLE.background,
                 }}
             >

--- a/packages/core/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenu.stories.tsx
@@ -1,0 +1,251 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import classNames from "classnames";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import { expect, screen, waitFor } from "storybook/test";
+
+import { Flex } from "@blueprintjs/labs";
+
+import { Menu } from "../menu/menu";
+import { MenuDivider } from "../menu/menuDivider";
+import { MenuItem } from "../menu/menuItem";
+
+import { ContextMenu, type ContextMenuChildrenProps } from "./contextMenu";
+
+const SAMPLE_MENU = (
+    <Menu>
+        <MenuItem icon="select" text="Select all" />
+        <MenuItem icon="insert" text="Insert...">
+            <MenuItem icon="new-object" text="Object" />
+            <MenuItem icon="new-text-box" text="Text box" />
+            <MenuItem icon="star" text="Astral body" />
+        </MenuItem>
+        <MenuItem icon="layout" text="Layout...">
+            <MenuItem icon="layout-auto" text="Auto" />
+            <MenuItem icon="layout-circle" text="Circle" />
+            <MenuItem icon="layout-grid" text="Grid" />
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem icon="cross-circle" intent="danger" text="Delete" />
+    </Menu>
+);
+
+const TARGET_STYLE: React.CSSProperties = {
+    alignItems: "center",
+    background: "rgba(138, 155, 168, 0.15)",
+    border: "1px dashed rgba(138, 155, 168, 0.5)",
+    borderRadius: 3,
+    display: "flex",
+    height: 120,
+    justifyContent: "center",
+    padding: 20,
+    textAlign: "center",
+    width: 240,
+};
+
+const disabledArgs = ["children"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof ContextMenu>>;
+
+const meta: Meta<typeof ContextMenu> = {
+    title: "Core/ContextMenu",
+    component: ContextMenu,
+    decorators: [storybookLayoutDecorator],
+    args: {
+        content: SAMPLE_MENU,
+        disabled: false,
+    },
+    argTypes: {
+        content: { control: false },
+        disabled: { control: "boolean" },
+        tagName: { control: "text" },
+        onContextMenu: { action: "context-menu-opened" },
+        onClose: { action: "closed" },
+        ...disabledArgs.reduce(
+            (acc, argName) => {
+                acc[argName] = { table: { disable: true } };
+                return acc;
+            },
+            {} as Record<(typeof disabledArgs)[number], { table: { disable: boolean } }>,
+        ),
+    },
+} satisfies Meta<typeof ContextMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * A basic context menu wraps its children in a `<div>` and opens on right-click.
+ */
+export const Default: Story = {
+    args: {
+        children: <div style={TARGET_STYLE}>Right-click anywhere in this box</div>,
+    },
+};
+
+/**
+ * The `content` prop accepts a render function. The function receives the current
+ * `isOpen` state, `targetOffset`, and `mouseEvent`, which can be used to render
+ * content that reacts to the click location.
+ */
+export const RenderFunctionContent: Story = {
+    name: "Content Render Function",
+    args: {
+        children: <div style={TARGET_STYLE}>Right-click to see click coordinates</div>,
+        content: ({ targetOffset }) => (
+            <Menu>
+                <MenuItem icon="select" text="Select all" />
+                <MenuItem icon="insert" text="Insert..." />
+                <MenuItem icon="layout" text="Layout..." />
+                {targetOffset === undefined ? undefined : (
+                    <>
+                        <MenuDivider />
+                        <MenuItem
+                            disabled={true}
+                            text={`Clicked at (${Math.round(targetOffset.left)}, ${Math.round(targetOffset.top)})`}
+                        />
+                    </>
+                )}
+            </Menu>
+        ),
+    },
+};
+
+/**
+ * Provide `children` as a render function to take full control of the wrapper element.
+ * This is useful when the default `<div>` wrapper breaks layout. You must wire up the
+ * `className`, `onContextMenu`, `ref`, and embed the `popover` element yourself.
+ */
+export const AdvancedChildren: Story = {
+    name: "Advanced Children Render",
+    args: {
+        children: (props: ContextMenuChildrenProps) => (
+            <div
+                className={classNames(props.className)}
+                onContextMenu={props.onContextMenu}
+                ref={props.ref}
+                style={{
+                    ...TARGET_STYLE,
+                    background: props.contentProps.isOpen ? "rgba(45, 114, 210, 0.2)" : TARGET_STYLE.background,
+                }}
+            >
+                {props.popover}
+                Render-function child — background changes when menu opens
+            </div>
+        ),
+    },
+};
+
+/**
+ * Use the `tagName` prop to customize the HTML tag of the generated wrapper element.
+ */
+export const CustomTagName: Story = {
+    name: "Custom Tag Name",
+    args: {
+        tagName: "section",
+        children: <div style={TARGET_STYLE}>Wrapped in a &lt;section&gt; element</div>,
+    },
+};
+
+/**
+ * Override the popover placement via `popoverProps.placement`. The default is
+ * `right-start`, but you may need a different placement near viewport edges.
+ */
+export const CustomPlacement: Story = {
+    name: "Custom Placement",
+    args: {
+        children: <div style={TARGET_STYLE}>Right-click — menu opens above-left</div>,
+        popoverProps: { placement: "top-end" },
+    },
+};
+
+/**
+ * When `disabled` is true, right-clicking the target falls back to the browser's
+ * native context menu instead of opening the Blueprint menu.
+ */
+export const Disabled: Story = {
+    args: {
+        disabled: true,
+        children: <div style={TARGET_STYLE}>Disabled — browser context menu shows instead</div>,
+    },
+};
+
+/**
+ * Showcases how the same `ContextMenu` wrapper can be applied around a variety
+ * of targets — text, blocks, and inline elements all support right-click.
+ */
+export const MultipleTargets: Story = {
+    argTypes: {
+        children: { table: { disable: true } },
+    },
+    render: args => (
+        <Flex flexDirection="column" gap={4}>
+            <Flex flexDirection="column" gap={1}>
+                <StoryLabel title="Block target" />
+                <ContextMenu {...args}>
+                    <div style={TARGET_STYLE}>Right-click this block</div>
+                </ContextMenu>
+            </Flex>
+            <Flex flexDirection="column" gap={1}>
+                <StoryLabel title="Inline target" />
+                <ContextMenu {...args} tagName="span">
+                    <span
+                        style={{
+                            background: "rgba(138, 155, 168, 0.15)",
+                            borderRadius: 3,
+                            padding: "2px 6px",
+                        }}
+                    >
+                        Right-click this inline span
+                    </span>
+                </ContextMenu>
+            </Flex>
+        </Flex>
+    ),
+};
+
+/**
+ * Interactive playground — toggle `disabled` and adjust other props via the controls panel.
+ */
+export const Playground: Story = {
+    args: {
+        children: <div style={TARGET_STYLE}>Right-click me!</div>,
+    },
+};
+
+/**
+ * Demonstrates the menu opening on a right-click (contextmenu) event.
+ */
+export const RightClickOpen: Story = {
+    name: "Right Click Open",
+    args: {
+        children: <div style={TARGET_STYLE}>Right-click to open menu</div>,
+        popoverProps: { transitionDuration: 0 },
+    },
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Right-click target to open menu", async () => {
+            const target = canvas.getByText("Right-click to open menu");
+            await userEvent.pointer({ keys: "[MouseRight>]", target });
+            await waitFor(() => expect(screen.getByText("Select all")).toBeVisible());
+        });
+    },
+};
+
+/**
+ * When `disabled` is true, right-clicking does not open the Blueprint context menu.
+ */
+export const DisabledNoOpen: Story = {
+    name: "Disabled No Open",
+    args: {
+        disabled: true,
+        children: <div style={TARGET_STYLE}>Disabled target</div>,
+    },
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Right-click disabled target — menu does not open", async () => {
+            const target = canvas.getByText("Disabled target");
+            await userEvent.pointer({ keys: "[MouseRight>]", target });
+            await expect(screen.queryByText("Select all")).not.toBeInTheDocument();
+        });
+    },
+};

--- a/packages/core/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenu.stories.tsx
@@ -49,7 +49,7 @@ const TARGET_STYLE: React.CSSProperties = {
 const disabledArgs = ["children"] as const satisfies ReadonlyArray<keyof React.ComponentProps<typeof ContextMenu>>;
 
 const meta: Meta<typeof ContextMenu> = {
-    title: "Core/ContextMenu",
+    title: "Core/Context Menu/ContextMenu",
     component: ContextMenu,
     decorators: [storybookLayoutDecorator],
     args: {
@@ -226,7 +226,9 @@ export const RightClickOpen: Story = {
     play: async ({ canvas, userEvent, step }) => {
         await step("Right-click target to open menu", async () => {
             const target = canvas.getByText("Right-click to open menu");
-            await userEvent.pointer({ keys: "[MouseRight>]", target });
+            const rect = target.getBoundingClientRect();
+            const coords = { clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 };
+            await userEvent.pointer({ keys: "[MouseRight]", target, coords });
             await waitFor(() => expect(screen.getByText("Select all")).toBeVisible());
         });
     },
@@ -244,7 +246,9 @@ export const DisabledNoOpen: Story = {
     play: async ({ canvas, userEvent, step }) => {
         await step("Right-click disabled target — menu does not open", async () => {
             const target = canvas.getByText("Disabled target");
-            await userEvent.pointer({ keys: "[MouseRight>]", target });
+            const rect = target.getBoundingClientRect();
+            const coords = { clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 };
+            await userEvent.pointer({ keys: "[MouseRight]", target, coords });
             await expect(screen.queryByText("Select all")).not.toBeInTheDocument();
         });
     },

--- a/packages/core/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenu.stories.tsx
@@ -2,9 +2,9 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
-import classNames from "classnames";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
+import classNames from "classnames";
 import { expect, screen, waitFor } from "storybook/test";
 
 import { Flex } from "@blueprintjs/labs";

--- a/packages/core/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenu.stories.tsx
@@ -62,6 +62,11 @@ const meta: Meta<typeof ContextMenu> = {
         tagName: { control: "text" },
         onContextMenu: { action: "context-menu-opened" },
         onClose: { action: "closed" },
+        popoverProps: { table: { disable: true } },
+        onOpening: { table: { disable: true } },
+        onOpened: { table: { disable: true } },
+        onClosing: { table: { disable: true } },
+        onClosed: { table: { disable: true } },
         ...disabledArgs.reduce(
             (acc, argName) => {
                 acc[argName] = { table: { disable: true } };

--- a/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
@@ -24,8 +24,6 @@ const SAMPLE_MENU = (
     </Menu>
 );
 
-const DEFAULT_OFFSET = { left: 200, top: 200 };
-
 const meta: Meta<typeof ContextMenuPopover> = {
     title: "Core/Context Menu/ContextMenuPopover",
     component: ContextMenuPopover,
@@ -38,8 +36,7 @@ const meta: Meta<typeof ContextMenuPopover> = {
     ],
     args: {
         content: SAMPLE_MENU,
-        isOpen: true,
-        targetOffset: DEFAULT_OFFSET,
+        isOpen: false,
         transitionDuration: 0,
         isDarkTheme: false,
     },
@@ -47,6 +44,7 @@ const meta: Meta<typeof ContextMenuPopover> = {
         content: { control: false },
         isOpen: { control: "boolean" },
         isDarkTheme: { control: "boolean" },
+        targetOffset: { control: false },
         onClose: { action: "closed" },
     },
 } satisfies Meta<typeof ContextMenuPopover>;
@@ -56,20 +54,27 @@ type Story = StoryObj<typeof meta>;
 
 function ContextMenuPopoverStoryRender(args: ContextMenuPopoverProps) {
     const [, updateArgs] = useArgs();
-    const handleOpen = useCallback(() => updateArgs({ isOpen: true }), [updateArgs]);
+    const handleOpen = useCallback(
+        (event: React.MouseEvent<HTMLElement>) =>
+            updateArgs({
+                isOpen: true,
+                targetOffset: { left: event.clientX, top: event.clientY },
+            }),
+        [updateArgs],
+    );
     const handleClose = useCallback(() => updateArgs({ isOpen: false }), [updateArgs]);
     return (
         <>
-            <Button text="Open Context Menu" onClick={handleOpen} />
+            <Button text="Click to open menu" onClick={handleOpen} />
             <ContextMenuPopover {...args} onClose={handleClose} />
         </>
     );
 }
 
 /**
- * A basic controlled context menu popover anchored at a fixed `targetOffset`.
- * Unlike `ContextMenu`, this lower-level component does not wire up its own
- * right-click handler — you control its open state directly.
+ * A basic controlled context menu popover. Click the button to open the menu
+ * anchored at the click location. Unlike `ContextMenu`, this lower-level component
+ * does not wire up its own right-click handler — you control its open state directly.
  */
 export const Default: Story = {
     render: ContextMenuPopoverStoryRender,
@@ -108,7 +113,7 @@ export const DarkTheme: Story = {
 };
 
 /**
- * Interactive playground — toggle `isOpen` and adjust other props via the controls panel.
+ * Interactive playground — click the button to open the menu, then adjust props via the controls panel.
  */
 export const Playground: Story = {
     render: ContextMenuPopoverStoryRender,

--- a/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
@@ -1,0 +1,115 @@
+/*
+ * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useArgs, useCallback } from "storybook/preview-api";
+
+import { Flex } from "@blueprintjs/labs";
+
+import { Button } from "../button/buttons";
+import { Menu } from "../menu/menu";
+import { MenuDivider } from "../menu/menuDivider";
+import { MenuItem } from "../menu/menuItem";
+
+import { ContextMenuPopover, type ContextMenuPopoverProps } from "./contextMenuPopover";
+
+const SAMPLE_MENU = (
+    <Menu>
+        <MenuItem icon="select" text="Select all" />
+        <MenuItem icon="insert" text="Insert..." />
+        <MenuItem icon="layout" text="Layout..." />
+        <MenuDivider />
+        <MenuItem icon="cross-circle" intent="danger" text="Delete" />
+    </Menu>
+);
+
+const DEFAULT_OFFSET = { left: 200, top: 200 };
+
+const meta: Meta<typeof ContextMenuPopover> = {
+    title: "Core/Context Menu/ContextMenuPopover",
+    component: ContextMenuPopover,
+    decorators: [
+        Story => (
+            <Flex justifyContent="center" alignItems="center" style={{ minHeight: 320, minWidth: 480 }}>
+                <Story />
+            </Flex>
+        ),
+    ],
+    args: {
+        content: SAMPLE_MENU,
+        isOpen: true,
+        targetOffset: DEFAULT_OFFSET,
+        transitionDuration: 0,
+        isDarkTheme: false,
+    },
+    argTypes: {
+        content: { control: false },
+        isOpen: { control: "boolean" },
+        isDarkTheme: { control: "boolean" },
+        onClose: { action: "closed" },
+    },
+} satisfies Meta<typeof ContextMenuPopover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ContextMenuPopoverStoryRender(args: ContextMenuPopoverProps) {
+    const [, updateArgs] = useArgs();
+    const handleOpen = useCallback(() => updateArgs({ isOpen: true }), [updateArgs]);
+    const handleClose = useCallback(() => updateArgs({ isOpen: false }), [updateArgs]);
+    return (
+        <>
+            <Button text="Open Context Menu" onClick={handleOpen} />
+            <ContextMenuPopover {...args} onClose={handleClose} />
+        </>
+    );
+}
+
+/**
+ * A basic controlled context menu popover anchored at a fixed `targetOffset`.
+ * Unlike `ContextMenu`, this lower-level component does not wire up its own
+ * right-click handler — you control its open state directly.
+ */
+export const Default: Story = {
+    render: ContextMenuPopoverStoryRender,
+};
+
+/**
+ * Override `placement` via the prop to control which corner of the menu anchors
+ * to the click point. The default is `right-start` (menu opens below and to the right).
+ */
+export const CustomPlacement: Story = {
+    name: "Custom Placement",
+    args: {
+        placement: "top-end",
+    },
+    render: ContextMenuPopoverStoryRender,
+};
+
+/**
+ * Pass `isDarkTheme` to render the popover with dark-theme styling. This is
+ * needed when calling the imperative `showContextMenu()` API outside of a
+ * `.bp6-dark` ancestor, since the singleton renders in its own React root.
+ */
+export const DarkTheme: Story = {
+    name: "Dark Theme",
+    args: {
+        isDarkTheme: true,
+    },
+    decorators: [
+        Story => (
+            <div className="bp6-dark" style={{ padding: 40, background: "#1c2127" }}>
+                <Story />
+            </div>
+        ),
+    ],
+    render: ContextMenuPopoverStoryRender,
+};
+
+/**
+ * Interactive playground — toggle `isOpen` and adjust other props via the controls panel.
+ */
+export const Playground: Story = {
+    render: ContextMenuPopoverStoryRender,
+};

--- a/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
@@ -3,10 +3,9 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { storybookLayoutDecorator } from "@storybook-common";
 import { useArgs, useCallback } from "storybook/preview-api";
 import { expect, screen, waitFor } from "storybook/test";
-
-import { Flex } from "@blueprintjs/labs";
 
 import { Button } from "../button/buttons";
 import { Menu } from "../menu/menu";
@@ -28,13 +27,7 @@ const SAMPLE_MENU = (
 const meta: Meta<typeof ContextMenuPopover> = {
     title: "Core/Context Menu/ContextMenuPopover",
     component: ContextMenuPopover,
-    decorators: [
-        Story => (
-            <Flex justifyContent="center" alignItems="center" style={{ minHeight: 320, minWidth: 480 }}>
-                <Story />
-            </Flex>
-        ),
-    ],
+    decorators: [storybookLayoutDecorator],
     args: {
         content: SAMPLE_MENU,
         isOpen: false,
@@ -111,13 +104,6 @@ export const DarkTheme: Story = {
     args: {
         isDarkTheme: true,
     },
-    decorators: [
-        Story => (
-            <div className="bp6-dark" style={{ padding: 40, background: "#1c2127" }}>
-                <Story />
-            </div>
-        ),
-    ],
     render: ContextMenuPopoverStoryRender,
 };
 

--- a/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
@@ -45,8 +45,16 @@ const meta: Meta<typeof ContextMenuPopover> = {
         content: { control: false },
         isOpen: { control: "boolean" },
         isDarkTheme: { control: "boolean" },
-        targetOffset: { control: false },
+        targetOffset: { table: { disable: true } },
         onClose: { action: "closed" },
+        onOpening: { table: { disable: true } },
+        onOpened: { table: { disable: true } },
+        onClosing: { table: { disable: true } },
+        onClosed: { table: { disable: true } },
+        popoverClassName: { table: { disable: true } },
+        popoverRef: { table: { disable: true } },
+        rootBoundary: { table: { disable: true } },
+        transitionDuration: { table: { disable: true } },
     },
 } satisfies Meta<typeof ContextMenuPopover>;
 

--- a/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
+++ b/packages/core/src/components/context-menu/ContextMenuPopover.stories.tsx
@@ -4,6 +4,7 @@
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useArgs, useCallback } from "storybook/preview-api";
+import { expect, screen, waitFor } from "storybook/test";
 
 import { Flex } from "@blueprintjs/labs";
 
@@ -117,4 +118,22 @@ export const DarkTheme: Story = {
  */
 export const Playground: Story = {
     render: ContextMenuPopoverStoryRender,
+};
+
+/**
+ * Demonstrates the popover opening on click. The play function simulates a left-click
+ * at the center of the trigger button, which sets `targetOffset` to those coordinates.
+ */
+export const ClickToOpen: Story = {
+    name: "Click To Open",
+    render: ContextMenuPopoverStoryRender,
+    play: async ({ canvas, userEvent, step }) => {
+        await step("Click button to open menu at click location", async () => {
+            const target = canvas.getByRole("button", { name: "Click to open menu" });
+            const rect = target.getBoundingClientRect();
+            const coords = { clientX: rect.left + rect.width / 2, clientY: rect.top + rect.height / 2 };
+            await userEvent.pointer({ keys: "[MouseLeft]", target, coords });
+            await waitFor(() => expect(screen.getByText("Select all")).toBeVisible());
+        });
+    },
 };


### PR DESCRIPTION
## Summary
- Added Storybook stories for `ContextMenu` and `ContextMenuPopover` components
- Stories provide visual regression testing coverage

## Files
- `ContextMenu.stories.tsx`
- `ContextMenuPopover.stories.tsx`

## Test plan
- [ ] Verify stories render correctly in Storybook
- [ ] Check all story variants display properly in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)