### PR TITLE
[table] Fix infinite loop in eachUniqueFullRow/Column for unbounded intervals

### DIFF
--- a/packages/table/changelog/@unreleased/pr-8134.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-8134.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: "`Regions.eachUniqueFullRow` and `Regions.eachUniqueFullColumn` no longer hang on regions with an unbounded interval"
-  links:
-  - https://github.com/palantir/blueprint/pull/8134

--- a/packages/table/changelog/@unreleased/pr-8134.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-8134.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "`Regions.eachUniqueFullRow` and `Regions.eachUniqueFullColumn` no longer hang on regions with an unbounded interval"
+  links:
+  - https://github.com/palantir/blueprint/pull/8134

--- a/packages/table/src/regions.test.ts
+++ b/packages/table/src/regions.test.ts
@@ -257,6 +257,26 @@ describe("Regions", () => {
         expect(hits).to.have.lengthOf(4);
     });
 
+    it("does not hang on unbounded intervals", () => {
+        // regression test for https://github.com/palantir/blueprint/issues/6383:
+        // an unbounded interval such as [1, Infinity] (which can result from shift-clicking a
+        // row or column header) must not cause an infinite loop.
+        const hits: number[] = [];
+        const append = (index: number) => {
+            hits.push(index);
+        };
+
+        Regions.eachUniqueFullRow([Regions.row(1, Infinity)], append);
+        expect(hits).to.have.lengthOf(0);
+
+        Regions.eachUniqueFullColumn([Regions.column(1, Infinity)], append);
+        expect(hits).to.have.lengthOf(0);
+
+        // bounded regions in the same array are still enumerated normally
+        Regions.eachUniqueFullRow([Regions.row(1, Infinity), Regions.row(0, 2)], append);
+        expect(hits).to.deep.equal([0, 1, 2]);
+    });
+
     it("enumerates cells", () => {
         const invalid = Regions.enumerateUniqueCells(null, 3, 2);
         expect(invalid).to.have.lengthOf(0);

--- a/packages/table/src/regions.ts
+++ b/packages/table/src/regions.ts
@@ -439,6 +439,11 @@ export class Regions {
         regions.forEach((region: Region) => {
             if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_COLUMNS) {
                 const [start, end] = region.cols!;
+                if (!isFinite(end)) {
+                    // An unbounded interval (e.g. [0, Infinity], which can result from shift-clicking a
+                    // column header) would loop forever, so skip it rather than hang. See issue #6383.
+                    return;
+                }
                 for (let col = start; col <= end; col++) {
                     if (!seen[col]) {
                         seen[col] = true;
@@ -458,6 +463,11 @@ export class Regions {
         regions.forEach((region: Region) => {
             if (Regions.getRegionCardinality(region) === RegionCardinality.FULL_ROWS) {
                 const [start, end] = region.rows!;
+                if (!isFinite(end)) {
+                    // An unbounded interval (e.g. [1, Infinity], which can result from shift-clicking a
+                    // row header) would loop forever, so skip it rather than hang. See issue #6383.
+                    return;
+                }
                 for (let row = start; row <= end; row++) {
                     if (!seen[row]) {
                         seen[row] = true;


### PR DESCRIPTION
#### Fixes #6383

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

`Regions.eachUniqueFullRow` and `Regions.eachUniqueFullColumn` iterate from the interval start to its end with a counting `for` loop. When a full-row or full-column region has an unbounded end (for example `rows: [1, Infinity]`), the loop never terminates. As noted in #6383, such a region can be produced by shift-clicking a row header and then passed to the public API inside an `onSelection` handler, at which point the page hangs (or eventually throws `RangeError: Invalid array length` once an accumulating array overflows).

This change skips any full-row or full-column region whose interval end is not finite, so the iteration cannot run unbounded. Bounded regions in the same array continue to be enumerated as before. The maintainer's comment on the issue pointed at these exact loops and suggested the function should short circuit, which is what this does.

#### Reviewers should focus on:

Whether silently skipping an unbounded region is the preferred behavior versus clamping it to the table bounds. These iteration helpers do not receive `numRows`/`numCols`, so skipping is the least surprising option without changing the signatures. The internal callers in `table.tsx` (`handleRowHeightChanged` / `handleColumnWidthChanged`) write into bounded arrays, so they are unaffected in practice; the user-facing impact is in the public `Regions` API.

Verification: `nx run @blueprintjs/table:compile`, `vitest run regions.test.ts` (38 passing), and `eslint` on the changed files all pass. The added test "does not hang on unbounded intervals" fails without the fix and passes with it.