### PR TITLE
Fix stuck table reordering state after invalid column drop

### DIFF
--- a/packages/table/src/interactions/reorderable.tsx
+++ b/packages/table/src/interactions/reorderable.tsx
@@ -191,6 +191,10 @@ export class DragReorderable extends PureComponent<DragReorderableProps> {
         const oldIndex = this.selectedRegionStartIndex;
         const guideIndex = this.props.locateDrag(event, coords);
         if (oldIndex === undefined || guideIndex === undefined) {
+            // Reset reordering state when drag ends outside a valid drop target.
+            this.props.onReordered(0, 0, 0);
+            this.selectedRegionStartIndex = undefined;
+            this.selectedRegionLength = 0;
             return;
         }
         const length = this.selectedRegionLength;


### PR DESCRIPTION


<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->


Fixes #5769

Checklist
Includes tests -> No
Update documentation -> No

Changes proposed in this pull request:

Fixes an issue where the table could become stuck in reordering mode after a column drag ended outside a valid drop target.

When guideIndex is undefined during handleDragEnd, the reorder operation never completes and the table remains in a reordering state. This change ensures that the reordering state is reset when an invalid drop occurs, allowing the table to remain interactive.

Reviewers should focus on:
The handling of invalid drop targets in DragReorderable.handleDragEnd.
Whether resetting the reordering state on cancelled/invalid drops is the correct behaviour.
Any potential impact on existing column and row reordering flows.

Screenshot
N/A – behaviour change only. The issue is reproduced by dragging a column outside the table bounds and releasing the mouse.
