### PR TITLE
Support React 19 in v6 peer dependency ranges

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,9 +60,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -48,9 +48,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -43,9 +43,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -49,9 +49,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -33,9 +33,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -44,9 +44,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -44,9 +44,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {


### PR DESCRIPTION
## Summary

This change widens the React peer-dependency range from `18` to `18 || 19` in the following packages:

- `@blueprintjs/core`
- `@blueprintjs/datetime`
- `@blueprintjs/docs-theme`
- `@blueprintjs/icons`
- `@blueprintjs/labs`
- `@blueprintjs/select`
- `@blueprintjs/table`

> The `@blueprintjs/datetime2` package was left alone since it's going away in v7, and `test-commons` already allows `>=16.8`. This is a peer-metadata change only. The dev and test toolchain stays on React 18 because the Enzyme adapter can't run the suite under 19.

## Context 
With this place, React 19 apps can install Blueprint without tripping npm's `ERESOLVE` and without reaching for `--legacy-peer-deps` or manual overrides. See the [React 19 Support](https://github.com/palantir/blueprint/wiki/React-19-Support) wiki for more details.