### PR TITLE
[core] Fix arrow-disable being dropped when migrating Popover modifiers to PopoverNext

### DIFF
--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -216,7 +216,7 @@ describe("popperModifiersToNextMiddleware", () => {
     });
 
     describe("arrow", () => {
-        it("should omit arrow middleware when enabled is false", () => {
+        it("should omit arrow middleware when enabled is false (no middleware equivalent)", () => {
             const element = document.createElement("div");
             const value: PopperModifierOverrides = { arrow: { enabled: false, options: { element } } };
             const expected: MiddlewareConfig = {};
@@ -408,6 +408,25 @@ describe("popoverPropsToNextProps", () => {
         it("should leave middleware undefined when modifiers is not supplied", () => {
             const result = popoverPropsToNextProps({});
             expect(result.middleware).to.be.undefined;
+        });
+    });
+
+    describe("arrow disabling via modifiers", () => {
+        it("should map modifiers.arrow.enabled: false to arrow: false", () => {
+            const result = popoverPropsToNextProps({ modifiers: { arrow: { enabled: false } } });
+            expect(result.arrow).to.equal(false);
+            // The disable cannot ride along in middleware, so the converted middleware is empty.
+            expect(result.middleware).to.deep.equal({});
+        });
+
+        it("should not set arrow when the arrow modifier is enabled", () => {
+            const result = popoverPropsToNextProps({ modifiers: { arrow: { enabled: true } } });
+            expect(result.arrow).to.be.undefined;
+        });
+
+        it("should not set arrow when the arrow modifier is absent", () => {
+            const result = popoverPropsToNextProps({ modifiers: { flip: {} } });
+            expect(result.arrow).to.be.undefined;
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -24,13 +24,19 @@ import type { PopoverNextProps } from "./popoverNextProps";
  * - `flip` → `flip`
  * - `preventOverflow` → `shift` (Floating UI's equivalent "keep within boundary" concept)
  * - `offset` → `offset` (tuple `[skidding, distance]` is converted to `{ crossAxis, mainAxis }`)
- * - `arrow` → `arrow`
+ * - `arrow` → `arrow` (only the `element` / `padding` positioning options; see the note on disabling below)
  * - `hide` → `hide`
  * - `computeStyles`, `eventListeners`, `popperOffsets` are not mapped (handled internally by Floating UI)
  *
  * **Note on offset:** If the Popper.js `offset` option is a function, it cannot be automatically
  * converted and will be omitted with a console warning. Migrate it manually to a
  * `{ mainAxis, crossAxis }` object in the `middleware` prop.
+ *
+ * **Note on disabling the arrow:** `{ arrow: { enabled: false } }` has no middleware equivalent —
+ * Floating UI's `arrow` middleware only positions the arrow, it does not control whether the arrow
+ * renders. `PopoverNext` gates arrow visibility on the `arrow` prop, so this function ignores the
+ * `enabled` flag; pass `arrow={false}` to `PopoverNext` to hide the arrow. {@link popoverPropsToNextProps}
+ * maps the disable onto `arrow` automatically.
  *
  * @example
  * // Before (Popover)
@@ -122,6 +128,8 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
  * - `placement` ?? `position` → `placement`, mirroring legacy `Popover`'s resolution
  *   (`placement ?? positionToPlacement(position)`). When `placement` is defined it always wins.
  * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}).
+ * - `modifiers.arrow.enabled: false` → `arrow: false` (PopoverNext hides the arrow via the `arrow`
+ *   prop, which has no middleware equivalent, so the disable cannot ride along in `middleware`).
  * - `minimal: true` → `animation: "minimal"` and `arrow: false` (legacy `minimal` disables the arrow).
  * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
  *
@@ -190,6 +198,12 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
 
     if (modifiers !== undefined) {
         nextProps.middleware = popperModifiersToNextMiddleware(modifiers);
+
+        // `{ arrow: { enabled: false } }` is the Popover way to hide the arrow, but PopoverNext controls
+        // arrow visibility through the `arrow` prop rather than middleware, so translate it here.
+        if (modifiers.arrow?.enabled === false) {
+            nextProps.arrow ??= false;
+        }
     }
 
     if (minimal === true) {


### PR DESCRIPTION
## Summary

Legacy `Popover` hides the arrow when given `modifiers={{ arrow: { enabled: false } }}`. `PopoverNext` controls arrow visibility through the `arrow` prop rather than middleware, so that intent was silently lost when migrating through `popoverPropsToNextProps`. This maps the disable onto `arrow: false` so the migration preserves the original behavior.

## Changes

`popoverPropsToNextProps` now sets `arrow: false` when `modifiers.arrow.enabled === false`. This mirrors the existing `minimal: true` handling and the legacy `isArrowEnabled` rule.
