### PR TITLE
[core] Warn on legacy Popover usage under React 19

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -84,7 +84,8 @@ export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onIntera
 export const POPOVER_WARN_TARGET_PROPS_WITH_RENDER_TARGET =
     ns + ` <Popover> targetProps value is ignored when renderTarget API is used.`;
 export const POPOVER_WARN_REACT19 =
-    ns + ` <Popover> mis-positions content under React 19 (especially in StrictMode); migrate to <PopoverNext>.`;
+    ns +
+    ` <Popover> positions content incorrectly under React 19 (especially in StrictMode); migrate to <PopoverNext>.`;
 
 export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
     ns + ` <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;

--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -83,6 +83,8 @@ export const POPOVER_WARN_PLACEMENT_AND_POSITION_MUTEX =
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 export const POPOVER_WARN_TARGET_PROPS_WITH_RENDER_TARGET =
     ns + ` <Popover> targetProps value is ignored when renderTarget API is used.`;
+export const POPOVER_WARN_REACT19 =
+    ns + ` <Popover> mis-positions content under React 19 (especially in StrictMode); migrate to <PopoverNext>.`;
 
 export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
     ns + ` <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;

--- a/packages/core/src/common/utils/jsUtils.ts
+++ b/packages/core/src/common/utils/jsUtils.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { version } from "react";
+
 import { CLAMP_MIN_MAX } from "../errors";
 
 // injected by webpack.DefinePlugin
@@ -23,6 +25,14 @@ declare let NODE_ENV: string;
 /** Returns whether bundler-injected variable `NODE_ENV` equals `env`. */
 export function isNodeEnv(env: string) {
     return typeof NODE_ENV !== "undefined" && NODE_ENV === env;
+}
+
+/**
+ * Returns the major version of the running React runtime as an integer
+ * (e.g. "19.1.0" -> 19, "18.3.1" -> 18).
+ */
+export function getReactMajorVersion(): number {
+    return parseInt(version, 10);
 }
 
 /**

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -21,6 +21,7 @@ import userEvent from "@testing-library/user-event";
 
 import {
     afterAll,
+    afterEach,
     beforeAll,
     beforeEach,
     describe,
@@ -33,6 +34,7 @@ import {
 import { Button, PopupKind, Tooltip } from "..";
 import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
+import * as Utils from "../../common/utils";
 
 import { Popover } from "./popover";
 import { type PopoverInteractionKind } from "./popoverProps";
@@ -137,6 +139,32 @@ describe("<Popover>", () => {
                     expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_HAS_BACKDROP_INTERACTION);
                 });
             }
+        });
+    });
+
+    describe("React 19 deprecation warning", () => {
+        afterEach(() => vi.restoreAllMocks());
+
+        it("does not warn on React < 19", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            vi.spyOn(Utils, "getReactMajorVersion").mockReturnValue(18);
+            render(
+                <Popover content="hello">
+                    <button>target</button>
+                </Popover>,
+            );
+            expect(warnSpy).not.toHaveBeenCalledWith(Errors.POPOVER_WARN_REACT19);
+        });
+
+        it("warns once on React 19", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            vi.spyOn(Utils, "getReactMajorVersion").mockReturnValue(19);
+            render(
+                <Popover content="hello">
+                    <button>target</button>
+                </Popover>,
+            );
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_REACT19);
         });
     });
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -143,6 +143,9 @@ export class Popover<
     // element on the same page.
     private lostFocusOnSamePage = true;
 
+    // Ensures the React 19 incompatibility warning fires at most once per instance.
+    private didWarnReact19 = false;
+
     // Reference to the Poppper.scheduleUpdate() function, this changes every time the popper is mounted
     private popperScheduleUpdate?: () => Promise<Partial<PopperState> | null>;
 
@@ -206,6 +209,19 @@ export class Popover<
 
     public componentDidMount() {
         this.updateDarkParent();
+        this.warnIfReact19();
+    }
+
+    /**
+     * Dev-only: warn that this deprecated component's react-popper dependency silently mis-positions
+     * content under React 19 (worst under StrictMode). Steers consumers to PopoverNext.
+     */
+    private warnIfReact19() {
+        if (this.didWarnReact19 || Utils.isNodeEnv("production") || Utils.getReactMajorVersion() < 19) {
+            return;
+        }
+        this.didWarnReact19 = true;
+        console.warn(Errors.POPOVER_WARN_REACT19);
     }
 
     public componentDidUpdate(props: PopoverProps<T>, state: PopoverState) {


### PR DESCRIPTION
## Summary

Add a dev-only warning when the deprecated `Popover` component is mounted under React 19.

This change:
- Adds a reusable `getReactMajorVersion()` utility
- Introduces a dedicated `POPOVER_WARN_REACT19` warning message
- Adds tests covering React 18 and React 19 behavior

## Why

Legacy `Popover` depends on `react-popper`, which can silently mis-position content under React 19, especially in `<StrictMode>`. This warning helps steer consumers toward `PopoverNext`, which is not affected.

See https://github.com/palantir/blueprint/wiki/React-19-Support#migrating-popover--popovernext