### PR TITLE
Fix numpad plus hotkey matching

### DIFF
--- a/packages/core/changelog/@unreleased/pr-3738-hotkey-numpad-plus.yml
+++ b/packages/core/changelog/@unreleased/pr-3738-hotkey-numpad-plus.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Add `numadd` hotkey support for matching the physical numpad plus key (#3738).
+  links:
+  - https://github.com/palantir/blueprint/issues/3738

--- a/packages/core/src/components/hotkeys/hotkeyParser.ts
+++ b/packages/core/src/components/hotkeys/hotkeyParser.ts
@@ -171,6 +171,12 @@ export const getKeyComboString = (e: KeyboardEvent): string => {
 const KEY_CODE_PREFIX = "Key";
 const DIGIT_CODE_PREFIX = "Digit";
 
+const SPECIAL_CODE_KEYS: KeyMap = {
+    Delete: "delete",
+    NumpadAdd: "numadd",
+    Space: "space",
+};
+
 function maybeGetKeyFromEventCode(e: KeyboardEvent) {
     if (e.code == null) {
         return undefined;
@@ -182,8 +188,8 @@ function maybeGetKeyFromEventCode(e: KeyboardEvent) {
     } else if (e.code.startsWith(DIGIT_CODE_PREFIX)) {
         // Code looks like "Digit1", etc.
         return e.code.substring(DIGIT_CODE_PREFIX.length).toLowerCase();
-    } else if (e.code === "Space" || e.code === "Delete") {
-        return e.code.toLowerCase();
+    } else if (SPECIAL_CODE_KEYS[e.code] !== undefined) {
+        return SPECIAL_CODE_KEYS[e.code];
     }
 
     return undefined;
@@ -202,16 +208,19 @@ function maybeGetKeyFromEventCode(e: KeyboardEvent) {
  */
 export const getKeyCombo = (e: KeyboardEvent): KeyCombo => {
     let key: string | undefined;
+    let shouldApplyShiftKeyMapping = true;
     if (MODIFIER_KEYS.has(e.key)) {
         // Leave local variable `key` undefined
     } else {
         const codeKey = maybeGetKeyFromEventCode(e);
 
         // Special cases where we must use code instead of key
-        if (e.code === "Space" || e.code === "Delete") {
+        if (e.code != null && SPECIAL_CODE_KEYS[e.code] !== undefined) {
             // Space: event.key is " " but we need "space" to match parseKeyCombo
             // Delete: need lowercase code name
+            // NumpadAdd: event.key is "+" but the key is physically distinct from top-row plus
             key = codeKey;
+            shouldApplyShiftKeyMapping = false;
         } else if (e.altKey && isAltModifiedCharacter(e.key) && codeKey !== undefined) {
             // Alt on macOS produces special characters (e.g., Alt+c → ç), use code for those cases
             key = codeKey;
@@ -236,7 +245,7 @@ export const getKeyCombo = (e: KeyboardEvent): KeyCombo => {
     }
     if (e.shiftKey) {
         modifiers += MODIFIER_BIT_MASKS.shift;
-        if (SHIFT_KEYS[e.key] !== undefined) {
+        if (shouldApplyShiftKeyMapping && SHIFT_KEYS[e.key] !== undefined) {
             key = SHIFT_KEYS[e.key];
         }
     }

--- a/packages/core/src/components/hotkeys/hotkeysParser.test.ts
+++ b/packages/core/src/components/hotkeys/hotkeysParser.test.ts
@@ -132,6 +132,15 @@ describe("HotkeysParser", () => {
             verifyCombos(tests);
         });
 
+        it("handles numpad plus key", () => {
+            const tests = [] as ComboTest[];
+            tests.push(
+                makeComboTest("numadd", { code: "NumpadAdd", key: "+" }),
+                makeComboTest("ctrl + numadd", { code: "NumpadAdd", ctrlKey: true, key: "+" }),
+            );
+            verifyCombos(tests);
+        });
+
         it("handles alt modifier key", () => {
             const tests = [] as ComboTest[];
             tests.push(makeComboTest("alt + a", { altKey: true, code: "KeyA", key: "a" }));
@@ -223,6 +232,7 @@ describe("HotkeysParser", () => {
         it("handles 'plus' key identifier", () => {
             expect(() => parseKeyCombo("ctrl + +")).to.throw(/failed to parse/i);
             expect(comboMatches(parseKeyCombo("cmd + plus"), parseKeyCombo("meta + plus"))).to.be.true;
+            expect(comboMatches(parseKeyCombo("plus"), parseKeyCombo("numadd"))).to.be.false;
         });
 
         it("applies aliases", () => {

--- a/packages/core/src/hooks/hotkeys/use-hotkeys.mdx
+++ b/packages/core/src/hooks/hotkeys/use-hotkeys.mdx
@@ -101,6 +101,7 @@ characters are case-insensitive, so `X` is equivalent to `x`.
 Examples of valid key combos:
 
 - `cmd+plus`
+- `ctrl+numadd` (numpad plus)
 - `shift+1` (note: `!` is not supported)
 - `return` or, equivalently `enter`
 - `alt + shift + x`
@@ -111,6 +112,7 @@ Note that spaces are ignored.
 ### Named keys
 
 - `plus`
+- `numadd` (numpad plus)
 - `minus`
 - `backspace`
 - `tab`


### PR DESCRIPTION
#### Fixes #3738

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changelog

Added `packages/core/changelog/@unreleased/pr-3738-hotkey-numpad-plus.yml`.

#### Changes proposed in this pull request:

- Add a `numadd` key combo identifier for the physical numpad plus key (`KeyboardEvent.code === "NumpadAdd"`).
- Keep numpad plus distinct from top-row `plus`, which normalizes to `shift+=`.
- Add parser tests, docs, and an unreleased core changelog entry.

#### Reviewers should focus on:

- Hotkey parser handling for `NumpadAdd`, especially keeping shifted-symbol normalization from rewriting numpad plus as top-row plus.

#### Screenshot

N/A; behavior-only hotkey parser change.