### PR TITLE
[core] Fix inaccurate modifiersCustom migration warning (#8131)

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8151.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8151.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[core] Fix inaccurate `modifiersCustom` migration warning emitted by `popoverPropsToNextProps`"
+  links:
+  - https://github.com/palantir/blueprint/pull/8151

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -126,7 +126,9 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
  * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
  *
  * Dropped (with dev-only `console.warn`):
- * - `modifiersCustom` — no Floating UI equivalent; migrate manually to `middleware`.
+ * - `modifiersCustom` — no Floating UI equivalent; reimplement as a Floating UI middleware and pass it via
+ *   `middleware` on `PopoverNext`, or via `modifiers` on a wrapping component such as `Tooltip`
+ *   (which has no public `middleware` prop but converts `modifiers` to `middleware` internally).
  * - `portalStopPropagationEvents` — already deprecated and non-functional in React 17+.
  *
  * Intended for use inside Blueprint components that wrap `Popover` internally and pass
@@ -161,7 +163,9 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         if (modifiersCustom !== undefined) {
             console.warn(
                 "[Blueprint] popoverPropsToNextProps: `modifiersCustom` has no equivalent in PopoverNext and will be dropped. " +
-                    "Migrate to the `middleware` prop manually.",
+                    "Reimplement the behavior as a Floating UI middleware: pass it via the `middleware` prop on `PopoverNext`, " +
+                    "or via the `modifiers` prop on a wrapping component such as `Tooltip` (Blueprint converts `modifiers` to `middleware`). " +
+                    "Components that wrap `Popover` do not expose a `middleware` prop directly.",
             );
         }
         if (portalStopPropagationEvents !== undefined) {


### PR DESCRIPTION
#### Addresses the incorrect warning text from #8131

This does not fully resolve the feature request in #8131 (whether to expose a public `middleware` prop on `Tooltip` is a maintainer API decision). It only corrects the dev-only warning so it points at a migration path that actually exists today.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

On 6.15.0, `Tooltip` migrated to `PopoverNext` internally. When a consumer passes `modifiersCustom`, `popoverPropsToNextProps` drops it and emits a dev-only warning telling the user to "Migrate to the `middleware` prop manually."

The problem reported in #8131 is that components which wrap `Popover` internally (`Tooltip`, and also `Select`, `Suggest`, `MultiSelect`, `Breadcrumbs`, `MenuItem`, `ContextMenuPopover`, the datetime inputs) do not expose a public `middleware` prop. They forward `middleware` to `PopoverNext` internally, but a `Tooltip` consumer reading the warning has no `middleware` prop to migrate to, so the warning points at a nonexistent target.

This changes only the warning message (and the matching JSDoc line) to describe the paths that do exist:

- on `PopoverNext`, reimplement the behavior as a Floating UI middleware and pass it via the `middleware` prop
- on a wrapping component such as `Tooltip`, pass it via the `modifiers` prop, which Blueprint already converts to `middleware` internally
- and it states plainly that wrapping components have no public `middleware` prop

No API change and no behavioral change. `modifiersCustom` is still dropped exactly as before, the warning still fires once, only the text is corrected.

The corrected message reads:

> [Blueprint] popoverPropsToNextProps: `modifiersCustom` has no equivalent in PopoverNext and will be dropped. Reimplement the behavior as a Floating UI middleware: pass it via the `middleware` prop on `PopoverNext`, or via the `modifiers` prop on a wrapping component such as `Tooltip` (Blueprint converts `modifiers` to `middleware`). Components that wrap `Popover` do not expose a `middleware` prop directly.

#### Reviewers should focus on:

Whether the suggested migration paths are the ones you want to point consumers at, in particular the `modifiers`-on-`Tooltip` path. The existing test in `popoverNextMigrationUtils.test.ts` asserts the warning fires once but not its text, so it still passes unchanged. No new test was added since this is a message-only correction.

#### Screenshot

Not applicable, dev-console message only.
