### PR TITLE
[select] Preserve QueryList active item when items change but query does not

### DIFF
--- a/packages/select/changelog/@unreleased/pr-8154.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8154.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[QueryList] Preserve the active item when the items list changes while the query stays the same"
+  links:
+  - https://github.com/palantir/blueprint/pull/8154

--- a/packages/select/src/components/query-list/queryList.test.tsx
+++ b/packages/select/src/components/query-list/queryList.test.tsx
@@ -162,6 +162,26 @@ describe("<QueryList>", () => {
             });
             expect(filmQueryList.state().activeItem).toEqual(TOP_100_FILMS[1]);
         });
+
+        it("preserves activeItem when the items list changes but the active item is still present", () => {
+            // see https://github.com/palantir/blueprint/issues/4562 and
+            // https://github.com/palantir/blueprint/issues/4192
+            const props: QueryListProps<Film> = {
+                ...testProps,
+                items: [TOP_100_FILMS[0], TOP_100_FILMS[1]],
+                query: "abc",
+            };
+            const filmQueryList: FilmQueryListWrapper = mount(<QueryList<Film> {...props} />);
+            act(() => {
+                filmQueryList.setState({ activeItem: TOP_100_FILMS[1] });
+            });
+            testProps.onActiveItemChange.resetHistory();
+            // the items array changes by reference (e.g. a re-filtered list) while the query
+            // stays the same; the still-present active item must not be reset to the first item
+            filmQueryList.setProps({ items: [TOP_100_FILMS[2], TOP_100_FILMS[1]] });
+            expect(filmQueryList.state().activeItem).toEqual(TOP_100_FILMS[1]);
+            expect(testProps.onActiveItemChange.callCount).toBe(0);
+        });
     });
 
     describe("activeItem state initialization", () => {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -281,7 +281,10 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
                 include: ["items", "itemListPredicate", "itemPredicate"],
             })
         ) {
-            this.setQuery(this.state.query);
+            // the query did not change, so preserve the current active item instead of resetting
+            // it to the first item. setQuery still resets when the active item is no longer present
+            // in (or is disabled within) the new filtered list.
+            this.setQuery(this.state.query, false);
         }
 
         if (this.shouldCheckActiveItemInViewport) {


### PR DESCRIPTION
#### Fixes #4562
#### Fixes #4192

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

When the `items`, `itemPredicate`, or `itemListPredicate` props change while the query stays the same, `QueryList.componentDidUpdate` called `setQuery(this.state.query)`. That uses the default `resetActiveItem = resetOnQuery` (which is `true`), so the active item was reset to the first filtered item on every re-filter or list update.

Two user-visible symptoms result:

- `Suggest`/`Select` lose the currently selected/active item after a re-render when an `itemPredicate` is supplied (#4562).
- `onActiveItemChange` fires a second, spurious time with the first item instead of the intended one (#4192).

This branch now passes `resetActiveItem=false`, so the active item is preserved across an items-list change. `setQuery` still resets it when the active item is no longer present in (`activeIndex < 0`) or is disabled within the new filtered list, so the existing "reset when no longer in new items" behavior is unchanged.

#### Reviewers should focus on:

`packages/select/src/components/query-list/queryList.tsx` line ~284. The only behavioral change is preserving a still-present, still-enabled active item when the list changes without a query change. A new test in `queryList.test.tsx` mounts a list, sets an active item, then swaps the items array (active item still present, but no longer first) and asserts the active item is preserved and `onActiveItemChange` does not fire. The pre-existing "ensure activeItem changes on when no longer in new items" test still passes via the `activeIndex < 0` path.