### PR TITLE
[core] Round focus outline on submenu menu items

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8155.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8155.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[Menu] Render the focus outline on submenu items with rounded corners, matching regular menu items"
+  links:
+  - https://github.com/palantir/blueprint/pull/8155

--- a/packages/core/src/components/menu/_submenu.scss
+++ b/packages/core/src/components/menu/_submenu.scss
@@ -11,6 +11,9 @@
   }
 
   .#{$ns}-popover-target {
+    // the popover target span is the focusable element for a submenu item, so it must carry the
+    // same border-radius as a regular menu item for its focus outline to render rounded (#6890)
+    border-radius: $menu-item-border-radius;
     display: block;
 
     &.#{$ns}-popover-open > .#{$ns}-menu-item {


### PR DESCRIPTION
#### Fixes #6890

#### Checklist

- [ ] Includes tests (CSS-only change with no unit-test harness for focus outline styling, verified visually)
- [ ] Update documentation

#### Changes proposed in this pull request:

For a submenu item, the focusable element is the wrapping `.#{$ns}-popover-target` span, not the inner `.#{$ns}-menu-item` anchor. The inner anchor already has `border-radius: $menu-item-border-radius`, but the popover target span had none. CSS `outline` follows the focused element's `border-radius`, so the submenu item's focus outline rendered as a square, unlike the rounded outline on regular (non-submenu) menu items.

This applies the same `$menu-item-border-radius` to the submenu popover target span so the focus outline rounds to match. One declaration, scoped to `.#{$ns}-submenu .#{$ns}-popover-target`.

#### Reviewers should focus on:

`packages/core/src/components/menu/_submenu.scss`. The variable is already in scope via the existing `@import "./common"` and is used identically at `_common.scss:87`. To verify, open a Menu with a submenu, Tab to a submenu item, and confirm the focus outline corners are now rounded.
