### PR TITLE
[datetime] Add accessible name to TimePicker AM/PM selector

### DIFF
--- a/packages/datetime/changelog/@unreleased/pr-8156.v2.yml
+++ b/packages/datetime/changelog/@unreleased/pr-8156.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[TimePicker] Add an accessible name to the AM/PM selector"
+  links:
+  - https://github.com/palantir/blueprint/pull/8156

--- a/packages/datetime/src/components/time-picker/timePicker.test.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.test.tsx
@@ -34,6 +34,12 @@ describe("<TimePicker>", () => {
         expect(screen.getByLabelText("minutes")).toBeInTheDocument();
     });
 
+    it("gives the AM/PM selector an accessible name", () => {
+        render(<TimePicker useAmPm={true} />);
+
+        expect(screen.getByLabelText("AM/PM")).toBeInTheDocument();
+    });
+
     it("should propagate class names correctly", () => {
         const { container } = render(<TimePicker className="foo" />);
         const timePicker = container.querySelector(`.${Classes.TIMEPICKER}`);

--- a/packages/datetime/src/components/time-picker/timePicker.tsx
+++ b/packages/datetime/src/components/time-picker/timePicker.tsx
@@ -213,6 +213,7 @@ export class TimePicker extends Component<TimePickerProps, TimePickerState> {
         }
         return (
             <HTMLSelect
+                aria-label="AM/PM"
                 className={Classes.TIMEPICKER_AMPM_SELECT}
                 disabled={this.props.disabled}
                 onChange={this.handleAmPmChange}


### PR DESCRIPTION
#### Fixes #7483

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

When `useAmPm` is enabled, `TimePicker` renders an `HTMLSelect` for AM/PM with no accessible name. The hour, minute, second, and millisecond inputs already set an `aria-label` (via `getTimeUnitPrintStr`), so the AM/PM select was the lone unlabeled control. This is the axe "Select element must have an accessible name" violation reported in the issue.

This adds `aria-label="AM/PM"` to the select. `HTMLSelect` spreads its extra props onto the underlying `<select>`, so the label is applied directly. The wording matches the package's existing hardcoded-English aria-label convention (e.g. `aria-label="date picker"`, `aria-label="Date picker shortcuts"`).

#### Reviewers should focus on:

`packages/datetime/src/components/time-picker/timePicker.tsx` (`maybeRenderAmPm`). A new test asserts `screen.getByLabelText("AM/PM")` resolves when `useAmPm` is set. All 46 existing TimePicker tests pass.