### PR TITLE
[core] Display the alt key as "option" on macOS in KeyComboTag

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8157.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8157.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[KeyComboTag] Display the `alt` key as 'option' on macOS"
+  links:
+  - https://github.com/palantir/blueprint/pull/8157

--- a/packages/core/src/components/hotkeys/keyComboTag.test.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.test.tsx
@@ -50,4 +50,18 @@ describe("KeyCombo", () => {
         expect(icon).to.exist;
         expect(screen.getByText("left")).to.exist;
     });
+
+    it("should label the alt key as 'option' on Mac", () => {
+        render(<KeyComboTagInternal combo="alt+S" platformOverride="Mac" />);
+
+        expect(screen.getByText("option")).to.exist;
+        expect(screen.queryByText("alt")).not.toBeInTheDocument();
+    });
+
+    it("should label the alt key as 'alt' on non-Macs", () => {
+        render(<KeyComboTagInternal combo="alt+S" platformOverride="Win32" />);
+
+        expect(screen.getByText("alt")).to.exist;
+        expect(screen.queryByText("option")).not.toBeInTheDocument();
+    });
 });

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -57,6 +57,14 @@ export const DISPLAY_ALIASES: Record<string, string> = {
     arrowup: "up",
 };
 
+/**
+ * Display aliases which only apply on macOS, where some modifier keys are named differently than on
+ * other platforms (for example, the `alt` key is labeled "option").
+ */
+const MAC_DISPLAY_ALIASES: Record<string, string> = {
+    alt: "option",
+};
+
 export interface KeyComboTagProps extends Props {
     /** The key combo to display, such as `"cmd + s"`. */
     combo: string;
@@ -92,7 +100,11 @@ export const KeyComboTagInternal: React.FC<KeyComboTagInternalProps> = memo(prop
 
     const renderKey = useCallback(
         (key: string, index: number) => {
-            const keyString = DISPLAY_ALIASES[key.toLowerCase()] ?? key;
+            const lowerKey = key.toLowerCase();
+            const keyString =
+                (isMac(platformOverride) ? MAC_DISPLAY_ALIASES[lowerKey] : undefined) ??
+                DISPLAY_ALIASES[lowerKey] ??
+                key;
             const icon = getKeyIcon(key);
             const reactKey = `key-${index}`;
             return (
@@ -102,7 +114,7 @@ export const KeyComboTagInternal: React.FC<KeyComboTagInternalProps> = memo(prop
                 </kbd>
             );
         },
-        [getKeyIcon],
+        [getKeyIcon, platformOverride],
     );
 
     const renderMinimalKey = useCallback(


### PR DESCRIPTION
#### Fixes #4959

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

On macOS, `KeyComboTag` rendered the option-key icon next to the literal text `alt`. macOS labels this key "option", so the text and the platform did not match (Windows/Linux correctly show `alt`).

This adds a Mac-only display alias (`MAC_DISPLAY_ALIASES`) so the `alt` modifier reads `option` on macOS, while non-Mac platforms continue to read `alt`. The resolution order in `renderKey` is: Mac-specific alias (only when `isMac`), then the existing `DISPLAY_ALIASES` (arrow keys), then the raw key. Minimal mode is unaffected because `alt` renders as the icon there.

#### Reviewers should focus on:

`packages/core/src/components/hotkeys/keyComboTag.tsx`. `renderKey` now reads `platformOverride` directly, so it was added to the `useCallback` dependency list. New tests assert `alt+S` renders "option" (not "alt") with `platformOverride="Mac"`, and "alt" (not "option") with `platformOverride="Win32"`.