### PR TITLE
[eslint-plugin] Don't flag class names in dynamic imports or re-exports (classes-constants)

### DIFF
--- a/packages/eslint-plugin/changelog/@unreleased/pr-8158.v2.yml
+++ b/packages/eslint-plugin/changelog/@unreleased/pr-8158.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[eslint-plugin] Do not flag Blueprint class names inside dynamic imports or `export *` re-exports in the `classes-constants` rule"
+  links:
+  - https://github.com/palantir/blueprint/pull/8158

--- a/packages/eslint-plugin/src/rules/classes-constants.ts
+++ b/packages/eslint-plugin/src/rules/classes-constants.ts
@@ -53,10 +53,13 @@ function create(
     context: TSESLint.RuleContext<MessageIds, []>,
     node: TSESTree.Literal | TSESTree.TemplateElement,
 ): void {
-    // We shouldn't lint on strings from imports/exports
+    // We shouldn't lint on strings from imports/exports, including dynamic imports
+    // (`import("...")`) and re-exports (`export * from "..."`).
     if (
         node.parent?.type === AST_NODE_TYPES.ImportDeclaration ||
-        node.parent?.type === AST_NODE_TYPES.ExportNamedDeclaration
+        node.parent?.type === AST_NODE_TYPES.ImportExpression ||
+        node.parent?.type === AST_NODE_TYPES.ExportNamedDeclaration ||
+        node.parent?.type === AST_NODE_TYPES.ExportAllDeclaration
     ) {
         return;
     }

--- a/packages/eslint-plugin/test/classes-constants.test.ts
+++ b/packages/eslint-plugin/test/classes-constants.test.ts
@@ -198,6 +198,10 @@ ruleTester.run("classes-constants", classesConstantsRule, {
         'import { test } from "packagewithpt-thatshouldnterror";',
         'export { test } from "packagewithpt-thatshouldnterror";',
 
+        // don't flag strings in dynamic imports or re-exports
+        'const promise = import("packagewithpt-thatshouldnterror");',
+        'export * from "packagewithpt-thatshouldnterror";',
+
         // don't flag non applicable strings in function calls
         `myFunction("stringwithpt-thatshouldnt-error");`,
         "myFunction(`stringwithpt-thatshouldnt-error`);",


### PR DESCRIPTION
#### Fixes #6209

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

The `classes-constants` rule skips string literals that are part of static imports (`ImportDeclaration`) and named re-exports (`ExportNamedDeclaration`), so module specifiers are never treated as class-name strings. It did not skip:

- dynamic imports: `import("...")` (`ImportExpression`)
- re-exports: `export * from "..."` (`ExportAllDeclaration`)

So a module specifier that happens to contain a Blueprint-like substring (for example a package whose name contains `pt-`) was wrongly reported, and `--fix` would rewrite the import path into a `Classes.*` constant, breaking the import.

This extends the early-return guard to also skip `ImportExpression` and `ExportAllDeclaration` parents.

#### Reviewers should focus on:

`packages/eslint-plugin/src/rules/classes-constants.ts` (the guard at the top of `create`). Two new `valid` test cases cover a dynamic import and an `export * from` whose specifiers contain `pt-`.