### PR TITLE
[eslint-plugin] Detect aliased imports in no-deprecated-components rules

### DIFF
--- a/packages/eslint-plugin/changelog/@unreleased/pr-8159.v2.yml
+++ b/packages/eslint-plugin/changelog/@unreleased/pr-8159.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[eslint-plugin] Detect aliased imports in the `no-deprecated-components` rules"
+  links:
+  - https://github.com/palantir/blueprint/pull/8159

--- a/packages/eslint-plugin/test/no-deprecated-datetime2-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-datetime2-components.test.ts
@@ -65,6 +65,23 @@ ruleTester.run("no-deprecated-datetime2-components", noDeprecatedDatetime2Compon
                 },
             ],
         },
+        // aliased import should still be detected (#6408)
+        {
+            code: dedent`
+                import { DateInput2 as MyDateInput } from "@blueprintjs/datetime2";
+
+                return <MyDateInput />;
+            `,
+            errors: [
+                {
+                    messageId: "migration",
+                    data: {
+                        deprecatedComponentName: "DateInput2",
+                        newComponentName: "DateInput",
+                    },
+                },
+            ],
+        },
     ],
     valid: [
         {


### PR DESCRIPTION
#### Fixes #6408

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

The `no-deprecated-components` rule family records each deprecated import with both its original name (`functionName`) and its local name (`localFunctionName`), but `isDeprecatedComponent` and the report sites looked the component up in `deprecatedComponentConfig` by the **local** JSX name. The config is keyed by the original name, so an aliased import was never flagged:

```tsx
import { DateInput2 as Foo } from "@blueprintjs/datetime2";
return <Foo />; // not flagged before this change
```

This change:

- `isDeprecatedComponent` now matches a deprecated import by `localFunctionName` and verifies the original `functionName` is in the config. This keeps the existing distinction that prop-only-deprecated components (which appear only in `Component.prop` config keys) are not reported as fully-deprecated components.
- A new `resolveImportedComponentName` helper maps a local/aliased name back to the original imported name, and is used at every report site (JSX element, prop usage, `class extends`, and `Component.ofType()` member expressions) so the config resolves and the migration message names the correct replacement.

#### Reviewers should focus on:

`createNoDeprecatedComponentsRule.ts`. The squiggle still lands on the alias the user wrote, while the message references the underlying deprecated component (for example `Usage of DateInput2 is deprecated, migrate to DateInput`). A new invalid test covers `import { DateInput2 as MyDateInput }` plus `<MyDateInput />`. All existing deprecated-component rule tests (core/popover2/select/table/datetime2) still pass.
