### PR TITLE
[select] Open MultiSelect popover on input focus to match Suggest

### DIFF
--- a/packages/select/changelog/@unreleased/pr-8160.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8160.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[MultiSelect] Open the popover when its input gains focus, matching `Suggest`"
+  links:
+  - https://github.com/palantir/blueprint/pull/8160

--- a/packages/select/src/components/multi-select/multiSelect.test.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.test.tsx
@@ -140,6 +140,38 @@ describe("<MultiSelect>", () => {
         },
     );
 
+    it("opens the popover when the input is focused", () => {
+        // see https://github.com/palantir/blueprint/issues/4152: MultiSelect should open on keyboard
+        // focus like Suggest does, not only on click
+        const wrapper = multiselect({ popoverProps: { usePortal: false } });
+
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+        wrapper.find("input").simulate("focus");
+
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
+    });
+
+    it("does not open the popover on input focus when openOnKeyDown is set", () => {
+        const wrapper = multiselect({ openOnKeyDown: true, popoverProps: { usePortal: false } });
+
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+        wrapper.find("input").simulate("focus");
+
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+    });
+
+    it("forwards tagInputProps.inputProps.onFocus when the input is focused", () => {
+        const onFocus = sinon.spy();
+        const wrapper = multiselect({
+            popoverProps: { usePortal: false },
+            tagInputProps: { inputProps: { onFocus } },
+        });
+
+        wrapper.find("input").simulate("focus");
+
+        expect(onFocus.calledOnce).toBe(true);
+    });
+
     it("allows searching within popover content when custom target provided", async () => {
         // Mount to document for this test to check from input focus
         const containerElement = document.createElement("div");

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -87,13 +87,10 @@ export interface MultiSelectProps<T> extends ListItemsProps<T>, SelectPopoverPro
      * If true, the component waits until a keydown event in the TagInput
      * before opening its popover.
      *
-     * If false, the popover opens immediately after a mouse click focuses
-     * the component's TagInput.
+     * If false, the popover opens as soon as the component's TagInput is
+     * focused, matching the Suggest component.
      *
-     * N.B. the behavior of this prop differs slightly from the same one
-     * in the Suggest component; see https://github.com/palantir/blueprint/issues/4152.
-     *
-     * Ignored is customTarget prop is supplied.
+     * Ignored if the customTarget prop is supplied.
      *
      * @default false
      */
@@ -328,6 +325,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
         const inputProps: HTMLInputProps = {
             ...tagInputProps.inputProps,
             className: classNames(tagInputProps.inputProps?.className, Classes.MULTISELECT_TAG_INPUT_INPUT),
+            onFocus: this.handleInputFocus,
         };
 
         return (
@@ -355,6 +353,15 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
         }
         this.props.onItemSelect?.(item, evt);
         this.refHandlers.popover.current?.reposition(); // reposition when size of input changes
+    };
+
+    private handleInputFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+        // open the popover when the input gains focus to match <Suggest>, unless the popover should
+        // only open on keydown or a custom target is in use (in which case the input is not the target)
+        if (!this.props.openOnKeyDown && this.props.customTarget == null) {
+            this.setState({ isOpen: true });
+        }
+        this.props.tagInputProps?.inputProps?.onFocus?.(event);
     };
 
     private handleQueryChange = (query: string, evt?: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
#### Fixes #4152

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

`MultiSelect` and `Suggest` handled the `openOnKeyDown` prop inconsistently. `Suggest` opens its popover on any input focus (when `openOnKeyDown` is false) via `handleInputFocus`. `MultiSelect` had no focus handler, opening only on query change or on a click interaction, so focusing the input with the keyboard (Tab) did not open the popover.

This adds an `onFocus` handler to the input `MultiSelect` passes to `TagInput`, mirroring `Suggest`: when `openOnKeyDown` is false and no `customTarget` is in use, it opens the popover. The handler forwards to any consumer-provided `tagInputProps.inputProps.onFocus`. `TagInput` already invokes `inputProps.onFocus` from its own focus handler, so no `core` change is needed.

#### Reviewers should focus on:

`packages/select/src/components/multi-select/multiSelect.tsx` (`getTagInput` and the new `handleInputFocus`). The `customTarget == null` and `!openOnKeyDown` gates match the existing `handleQueryChange` open logic, so escape-to-close still works (the popover only reopens on a genuine focus event). New tests cover: opens on focus, does not open on focus when `openOnKeyDown` is set, and forwards a consumer `onFocus`.