### PR TITLE
[core] Hide focus styles immediately when FocusStyleManager starts

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8161.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8161.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "[FocusStyleManager] Hide focus styles immediately when `onlyShowFocusOnTabs` is enabled, instead of waiting for the first mouse interaction"
+  links:
+  - https://github.com/palantir/blueprint/pull/8161

--- a/packages/core/src/common/interactionMode.test.ts
+++ b/packages/core/src/common/interactionMode.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
+
+import { InteractionModeEngine } from "./interactionMode";
+
+describe("InteractionModeEngine", () => {
+    const CLASS_NAME = "test-focus-disabled";
+    let container: HTMLElement | undefined;
+    let engine: InteractionModeEngine | undefined;
+
+    afterEach(() => {
+        engine?.stop();
+        container?.remove();
+        engine = undefined;
+        container = undefined;
+    });
+
+    function createEngine() {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        engine = new InteractionModeEngine(container, CLASS_NAME);
+        return engine;
+    }
+
+    it("applies the className immediately on start so focus styles are hidden until Tab", () => {
+        createEngine().start();
+        expect(container!.classList.contains(CLASS_NAME)).toBe(true);
+        expect(engine!.isActive()).toBe(true);
+    });
+
+    it("removes the className when Tab is pressed (keyboard mode)", () => {
+        createEngine().start();
+        container!.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+        expect(container!.classList.contains(CLASS_NAME)).toBe(false);
+    });
+
+    it("re-applies the className on mousedown after Tab (back to mouse mode)", () => {
+        createEngine().start();
+        container!.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+        container!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        expect(container!.classList.contains(CLASS_NAME)).toBe(true);
+    });
+
+    it("ignores non-Tab keydown events", () => {
+        createEngine().start();
+        container!.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+        expect(container!.classList.contains(CLASS_NAME)).toBe(true);
+    });
+
+    it("removes the className and stops on stop()", () => {
+        const e = createEngine();
+        e.start();
+        e.stop();
+        expect(container!.classList.contains(CLASS_NAME)).toBe(false);
+        expect(e.isActive()).toBe(false);
+    });
+});

--- a/packages/core/src/common/interactionMode.ts
+++ b/packages/core/src/common/interactionMode.ts
@@ -36,7 +36,11 @@ export class InteractionModeEngine {
 
     /** Enable behavior which applies the given className when in mouse mode. */
     public start() {
-        this.container.addEventListener("mousedown", this.handleMouseDown);
+        // start in mouse mode so the className is applied immediately and focus styles stay hidden
+        // until the user presses Tab. This also attaches the keydown listener, so the first Tab still
+        // reveals focus styles. Without this, focus styles render on the initially focused element
+        // (for example an autofocused Overlay2) until the first mouse interaction occurs.
+        this.handleMouseDown();
         this.isRunning = true;
     }
 


### PR DESCRIPTION
#### Fixes #7195

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

`InteractionModeEngine.start()` (used by `FocusStyleManager.onlyShowFocusOnTabs()`) attached a `mousedown` listener but did not apply the `FOCUS_DISABLED` class until the first mouse interaction. So between enabling the manager and the first `mousedown`, focus styles were visible, including on the initially focused element on mount. The reported symptom is an unwanted focus outline on `Overlay2` (and anything autofocused) on initial render. This also contradicts the documented behavior that focus styles are hidden until Tab is pressed.

`start()` now enters mouse mode immediately, applying the class and attaching the `keydown` listener by delegating to the existing `handleMouseDown`, so focus styles are hidden on mount and the first Tab still reveals them. The state machine is otherwise unchanged: Tab returns to keyboard mode (class removed), a later `mousedown` returns to mouse mode.

#### Reviewers should focus on:

`packages/core/src/common/interactionMode.ts`. The only behavioral change is that `start()` begins in mouse mode rather than waiting for the first `mousedown`. This file previously had no unit tests. A new `interactionMode.test.ts` covers start (class applied immediately), Tab (class removed), mousedown-after-Tab (class re-applied), non-Tab keydown (no-op), and stop.
