### PR TITLE
[core] Fix Tooltip renderTarget click handler regression

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -8,7 +8,7 @@ import { createRef } from "react";
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
-import { Classes } from "../../common";
+import { Classes, mergeRefs } from "../../common";
 import * as Errors from "../../common/errors";
 import { Button, Dialog, DialogBody, InputGroup, PopupKind, Tooltip } from "../../components";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
@@ -1245,6 +1245,34 @@ describe("<PopoverNext>", () => {
             expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
         });
 
+        it("opens popover when Tooltip renderTarget props are spread after PopoverNext renderTarget props", async () => {
+            const user = userEvent.setup();
+            render(
+                <PopoverNext
+                    content="popover content"
+                    renderTarget={({ isOpen: isPopoverOpen, ref: popoverRef, ...popoverProps }) => (
+                        <Tooltip
+                            content="tooltip content"
+                            disabled={isPopoverOpen}
+                            renderTarget={({ isOpen: _isTooltipOpen, ref: tooltipRef, ...tooltipProps }) => (
+                                <Button
+                                    {...popoverProps}
+                                    {...tooltipProps}
+                                    active={isPopoverOpen}
+                                    ref={mergeRefs(popoverRef, tooltipRef)}
+                                    text="target"
+                                />
+                            )}
+                        />
+                    )}
+                />,
+            );
+
+            await user.click(screen.getByRole("button", { name: "target" }));
+
+            await waitFor(() => expect(screen.getByText("popover content")).toBeInTheDocument());
+        });
+
         it("the target is focusable", () => {
             render(
                 <PopoverNext content="popover content">
@@ -1669,6 +1697,32 @@ describe("<PopoverNext>", () => {
                     )}
                 />,
             );
+        });
+    });
+
+    describe("renderTarget interaction props", () => {
+        it.each(["click", "click-target"] as const)("injects onClick into renderTarget props for %s", kind => {
+            const renderTarget = vi.fn(({ isOpen: _isOpen, ref, ...props }) => (
+                <Button ref={ref} text="target" {...props} />
+            ));
+            render(<PopoverNext content="content" interactionKind={kind} renderTarget={renderTarget} />);
+
+            expect(renderTarget).toHaveBeenCalled();
+            expect(typeof renderTarget.mock.calls[0][0].onClick).toBe("function");
+        });
+
+        // Hover popovers (and Tooltip, which is always hover) open via mouseenter/focus, never click, so
+        // their target must not receive an onClick. Injecting one shadows a consumer's own onClick when a
+        // hover target is shared with an enclosing Popover via renderTarget. See usePopover's useClick and
+        // PopoverTarget's floatingReferenceProps.
+        it.each(["hover", "hover-target"] as const)("does not inject onClick into renderTarget props for %s", kind => {
+            const renderTarget = vi.fn(({ isOpen: _isOpen, ref, ...props }) => (
+                <Button ref={ref} text="target" {...props} />
+            ));
+            render(<PopoverNext content="content" interactionKind={kind} renderTarget={renderTarget} />);
+
+            expect(renderTarget).toHaveBeenCalled();
+            expect(renderTarget.mock.calls[0][0].onClick).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -105,6 +105,10 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
 
     const computedIsOpen = disabled ? false : (isOpen ?? defaultIsOpen);
 
+    const isHoverInteractionKind =
+        interactionKind === PopoverInteractionKind.HOVER ||
+        interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
+
     const middleware = useMemo(() => {
         const defaultMiddleware: MiddlewareConfig = {
             ...(placement === undefined
@@ -135,6 +139,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
         autoUpdateOptions,
         disabled,
         isControlled,
+        isHoverInteractionKind,
         isOpen: computedIsOpen,
         middleware,
         onOpenChange: (nextOpen, event) => {
@@ -156,10 +161,6 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
     );
 
     const popoverElement = floatingData.refs.floating.current;
-
-    const isHoverInteractionKind =
-        interactionKind === PopoverInteractionKind.HOVER ||
-        interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
 
     const getPopoverElement = useCallback(() => {
         return popoverElement?.querySelector<HTMLElement>(`.${Classes.POPOVER}`);

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -88,6 +88,17 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     // Ensure target is focusable if relevant prop enabled
     const targetTabIndex = !isContentEmpty && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
 
+    // Hover targets (including Tooltip) open via the mouse/focus handlers in `targetEventHandlers`, so
+    // they must not receive Floating UI's reference props; those carry the `onClick`/keyboard click
+    // handlers used for click interactions. Applying them to a hover target injects an `onClick` that
+    // can shadow a consumer's own handler when the target is shared with an enclosing Popover via
+    // `renderTarget`. This mirrors legacy `Popover`, which only attached click handlers for click kinds.
+    const floatingProps = isHoverInteractionKind
+        ? {}
+        : floatingData.getReferenceProps({
+              onKeyDown: handleReferenceKeyDown,
+          });
+
     const ownTargetProps = {
         // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
         // If, instead, renderTarget is undefined and the target is provided as a child, props.className is
@@ -118,10 +129,6 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     let target: React.JSX.Element | undefined;
 
     if (renderTarget !== undefined) {
-        const floatingProps = floatingData.getReferenceProps({
-            onKeyDown: handleReferenceKeyDown,
-        });
-
         // When using renderTarget, if the consumer renders a tooltip target, it's their responsibility
         // to disable that tooltip when this popover is open
         target = renderTarget({
@@ -152,9 +159,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
                 ...ownTargetProps,
                 ...targetProps,
                 // Apply Floating UI's interaction props to the wrapper element (same element that has the ref)
-                ...floatingData.getReferenceProps({
-                    onKeyDown: handleReferenceKeyDown,
-                }),
+                ...floatingProps,
             },
             clonedTarget,
         );

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -22,6 +22,7 @@ interface PopoverOptions {
     autoUpdateOptions?: PopoverNextAutoUpdateOptions;
     disabled?: boolean;
     isControlled?: boolean;
+    isHoverInteractionKind?: boolean;
     isOpen?: boolean;
     middleware?: Middleware[];
     placement?: Placement;
@@ -38,6 +39,7 @@ export function usePopover({
     autoUpdateOptions,
     disabled = false,
     isControlled = false,
+    isHoverInteractionKind = false,
     isOpen = false,
     middleware,
     placement,
@@ -94,7 +96,7 @@ export function usePopover({
     const { context } = data;
 
     const click = useClick(context, {
-        enabled: !disabled,
+        enabled: !disabled && !isHoverInteractionKind,
         // Disable Floating UI's built-in Space/Enter keyboard handlers because they
         // call `preventDefault()` on the Space keydown event to prevent page scrolling.
         // This also prevents space characters from being typed in <input>/<textarea>

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -20,7 +20,8 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Button } from "..";
-import { Classes } from "../../common";
+import { Classes, mergeRefs } from "../../common";
+import { PopoverNext } from "../popover-next/popoverNext";
 
 import { Tooltip } from "./tooltip";
 
@@ -75,6 +76,23 @@ describe("<Tooltip>", () => {
             expect(
                 container.querySelector(`.${Classes.TOOLTIP}.${Classes.POPOVER_MINIMAL_ANIMATION}`),
             ).not.toBeInTheDocument();
+        });
+
+        it("does not inject click handlers into renderTarget props", () => {
+            let targetProps: Partial<React.HTMLProps<HTMLElement>> | undefined;
+
+            render(
+                <Tooltip
+                    content="content"
+                    renderTarget={({ isOpen: _isOpen, ref, ...props }) => {
+                        targetProps = props;
+                        return <Button {...props} ref={ref} text="target" />;
+                    }}
+                />,
+            );
+
+            expect(targetProps?.onClick).toBeUndefined();
+            expect(targetProps?.onKeyDown).toBeUndefined();
         });
     });
 
@@ -299,5 +317,37 @@ describe("<Tooltip>", () => {
         await user.keyboard("{Escape}");
 
         await waitFor(() => expect(screen.queryByText("first tooltip")).not.toBeInTheDocument());
+    });
+
+    // Regression test: a Tooltip nested inside a click Popover, both rendering a single shared target via
+    // `renderTarget`. Because Tooltip is hover-only, it must not inject an `onClick` into its target props;
+    // otherwise it would shadow the enclosing Popover's `onClick` and the target click would not open the
+    // Popover. The popover's props are spread first and the tooltip's second, the order that broke before.
+    it("does not inject an onClick that shadows an enclosing Popover's target onClick", async () => {
+        const user = userEvent.setup();
+        render(
+            <PopoverNext
+                content={<div>popover content</div>}
+                hoverOpenDelay={0}
+                renderTarget={({ isOpen: _isPopoverOpen, ref: popoverRef, ...popoverProps }) => (
+                    <Tooltip
+                        content="tooltip content"
+                        hoverOpenDelay={0}
+                        renderTarget={({ isOpen: _isTooltipOpen, ref: tooltipRef, ...tooltipProps }) => (
+                            <Button
+                                {...popoverProps}
+                                {...tooltipProps}
+                                ref={mergeRefs(popoverRef, tooltipRef)}
+                                text="target"
+                            />
+                        )}
+                    />
+                )}
+            />,
+        );
+
+        await user.click(screen.getByText("target"));
+
+        await waitFor(() => expect(screen.getByText("popover content")).toBeInTheDocument());
     });
 });


### PR DESCRIPTION
## Summary

Fixes a regression caused by #8091 where `Tooltip` started injecting `onClick` into `renderTarget` props after its internal migration to `PopoverNext`.

`Tooltip` is hover-only, but `PopoverNext` was always enabling Floating UI's `useClick` and spreading click reference props into targets. When consumers nested a `Tooltip` inside a `PopoverNext` and spread both render-prop bags onto one button, Tooltip's `onClick` could overwrite the popover/button click handler and prevent the target action from firing.

This change:
- disables Floating UI click handling for hover / hover-target interactions
- avoids applying Floating UI reference props to hover targets
- preserves click handlers for click / click-target popovers
- adds regression coverage for Tooltip + PopoverNext shared render targets

## Example

This pattern is common when a target needs both a click popover and a hover tooltip. The target button receives render props from both `PopoverNext` and `Tooltip`, then spreads both prop bags onto the same element.

Before this fix, `Tooltip` incorrectly included an `onClick` handler in `tooltipProps`. Because `tooltipProps` is spread after `popoverProps` here, Tooltip's handler overwrote PopoverNext's click handler, so clicking the button did not open the popover.

After this fix, hover-only Tooltip targets no longer receive click handlers, so the spread order no longer breaks the popover target. Tooltip still opens on hover/focus, and PopoverNext still owns the click interaction.

```tsx
const menu = (
    <Menu>
        <MenuItem icon="edit" text="Rename" />
        <MenuItem icon="duplicate" text="Duplicate" />
        <MenuItem icon="trash" intent="danger" text="Delete" />
    </Menu>
);

export function TooltipPopoverDemo() {
    return (
        <Flex alignItems="center" justifyContent="center" style={{ height: "100vh" }}>
            <PopoverNext
                content={menu}
                placement="bottom"
                // eslint-disable-next-line react/jsx-no-bind
                renderTarget={({ isOpen: isPopoverOpen, ref: popoverRef, ...popoverProps }) => (
                    <Tooltip
                        content="Tooltip: more actions"
                        disabled={isPopoverOpen}
                        placement="top"
                        // eslint-disable-next-line react/jsx-no-bind
                        renderTarget={({ isOpen: _isTooltipOpen, ref: tooltipRef, ...tooltipProps }) => (
                            <Button
                                {...popoverProps}
                                {...tooltipProps}
                                active={isPopoverOpen}
                                icon="more"
                                ref={mergeRefs(popoverRef, tooltipRef)}
                                text="Actions"
                            />
                        )}
                    />
                )}
            />
        </Flex>
    );
}
```