### PR TITLE
[docs] Document OverflowList item key requirement

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8164.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8164.v2.yml
@@ -1,5 +1,0 @@
-type: improvement
-improvement:
-  description: Document OverflowList item key requirements.
-  links:
-    - https://github.com/palantir/blueprint/pull/8164

--- a/packages/core/changelog/@unreleased/pr-8164.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8164.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Document OverflowList item key requirements.
+  links:
+    - https://github.com/palantir/blueprint/pull/8164

--- a/packages/core/src/components/overflow-list/overflow-list.mdx
+++ b/packages/core/src/components/overflow-list/overflow-list.mdx
@@ -17,6 +17,19 @@ the `observeParents` prop to watch for resizing further up in the DOM tree.
 
 [resizeobserver]: https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver
 
+## Usage notes
+
+`visibleItemRenderer` is called once for each rendered item, so its returned element must include a unique `key` prop.
+This key should usually come from a stable item identifier.
+
+```tsx
+// Correct: returned elements have stable keys.
+visibleItemRenderer={item => <Tag key={item.id}>{item.name}</Tag>}
+
+// Incorrect: React will warn that each child in a list needs a unique key.
+visibleItemRenderer={item => <Tag>{item.name}</Tag>}
+```
+
 ## Import
 
 ```ts copy


### PR DESCRIPTION
## Summary

Documents the `visibleItemRenderer` key requirement on the OverflowList docs page.

Fixes #7746.

## Testing

- `pnpm exec prettier --check packages/core/src/components/overflow-list/overflow-list.mdx`
- `git diff --check`

## Notes

I also tried `pnpm docs-data`, but it failed while generating docs for `datetime2` because `@blueprintjs/datetime` could not be resolved in this local environment, before any issue with this MDX change was reported.
