### PR TITLE
[eslint-plugin] Detect deprecated components imported with aliases

### DIFF
--- a/packages/eslint-plugin/changelog/@unreleased/pr-8165.v2.yml
+++ b/packages/eslint-plugin/changelog/@unreleased/pr-8165.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: Detect deprecated components imported with aliases.
-  links:
-    - https://github.com/palantir/blueprint/pull/8165

--- a/packages/eslint-plugin/changelog/@unreleased/pr-8165.v2.yml
+++ b/packages/eslint-plugin/changelog/@unreleased/pr-8165.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Detect deprecated components imported with aliases.
+  links:
+    - https://github.com/palantir/blueprint/pull/8165

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts
@@ -29,6 +29,12 @@ type MessageIds =
  */
 export type DeprecatedComponentsConfig = Record<string, string | [string, string]>;
 
+type DeprecatedImport =
+    | { namespace: string; type: "namespace" }
+    | { type: "function"; functionName: string; localFunctionName: string };
+
+type DeprecatedFunctionImport = Extract<DeprecatedImport, { type: "function" }>;
+
 /**
  * Higher-order function to create an ESLint rule which checks for usage of deprecated React components in JSX syntax.
  *
@@ -73,10 +79,7 @@ export function createNoDeprecatedComponentsRule(
         },
         defaultOptions: [],
         create: context => {
-            const deprecatedImports: Array<
-                | { namespace: string; type: "namespace" }
-                | { type: "function"; functionName: string; localFunctionName: string }
-            > = [];
+            const deprecatedImports: DeprecatedImport[] = [];
 
             // parses out additional deprecated components from entries like { "MenuItem.popoverProps": "MenuItem2" }
             const additionalDeprecatedComponents = Object.keys(deprecatedComponentConfig).reduce<string[]>(
@@ -90,13 +93,21 @@ export function createNoDeprecatedComponentsRule(
                 [],
             );
 
-            function isDeprecatedComponent(name: string) {
+            function getDeprecatedComponentImport(name: string): DeprecatedFunctionImport | undefined {
+                return deprecatedImports.find(
+                    (deprecatedImport): deprecatedImport is DeprecatedFunctionImport =>
+                        deprecatedImport.type === "function" &&
+                        deprecatedImport.localFunctionName === name &&
+                        deprecatedComponentConfig[deprecatedImport.functionName] != null,
+                );
+            }
+
+            function getImportedComponentName(localName: string) {
                 return (
-                    deprecatedComponentConfig[name] != null &&
-                    deprecatedImports.some(
-                        deprecatedImport =>
-                            deprecatedImport.type === "function" && deprecatedImport.localFunctionName === name,
-                    )
+                    deprecatedImports.find(
+                        (deprecatedImport): deprecatedImport is DeprecatedFunctionImport =>
+                            deprecatedImport.type === "function" && deprecatedImport.localFunctionName === localName,
+                    )?.functionName ?? localName
                 );
             }
 
@@ -133,7 +144,7 @@ export function createNoDeprecatedComponentsRule(
                     getReportDescriptor(
                         jsxOpeningElementChildNode,
                         deprecatedComponentConfig,
-                        elementName,
+                        getImportedComponentName(elementName),
                         deprecatedPropName,
                     ),
                 );
@@ -173,8 +184,15 @@ export function createNoDeprecatedComponentsRule(
 
                 // check <DeprecatedComponent> syntax (includes self-closing tags)
                 "JSXElement > JSXOpeningElement > JSXIdentifier": (node: TSESTree.JSXIdentifier) => {
-                    if (isDeprecatedComponent(node.name)) {
-                        context.report(getReportDescriptor(node, deprecatedComponentConfig, node.name));
+                    const deprecatedComponentImport = getDeprecatedComponentImport(node.name);
+                    if (deprecatedComponentImport !== undefined) {
+                        context.report(
+                            getReportDescriptor(
+                                node,
+                                deprecatedComponentConfig,
+                                deprecatedComponentImport.functionName,
+                            ),
+                        );
                     } else if (isOpeningElement(node.parent)) {
                         // check <DeprecatedComponent withDeprecatedProp={...}> syntax
                         checkDeprecatedComponentAndProp(node, node.name, node.parent);
@@ -207,8 +225,15 @@ export function createNoDeprecatedComponentsRule(
                 // check `class Foo extends DeprecatedComponent` syntax
                 "ClassDeclaration[superClass.type='Identifier']": (node: TSESTree.ClassDeclaration) => {
                     const superClass = node.superClass as TSESTree.Identifier;
-                    if (isDeprecatedComponent(superClass.name)) {
-                        context.report(getReportDescriptor(node, deprecatedComponentConfig, superClass.name));
+                    const deprecatedComponentImport = getDeprecatedComponentImport(superClass.name);
+                    if (deprecatedComponentImport !== undefined) {
+                        context.report(
+                            getReportDescriptor(
+                                node,
+                                deprecatedComponentConfig,
+                                deprecatedComponentImport.functionName,
+                            ),
+                        );
                     }
                 },
 
@@ -241,8 +266,15 @@ export function createNoDeprecatedComponentsRule(
                         return;
                     }
 
-                    if (isDeprecatedComponent(node.object.name)) {
-                        context.report(getReportDescriptor(node.object, deprecatedComponentConfig, node.object.name));
+                    const deprecatedComponentImport = getDeprecatedComponentImport(node.object.name);
+                    if (deprecatedComponentImport !== undefined) {
+                        context.report(
+                            getReportDescriptor(
+                                node.object,
+                                deprecatedComponentConfig,
+                                deprecatedComponentImport.functionName,
+                            ),
+                        );
                     }
                 },
             };

--- a/packages/eslint-plugin/test/no-deprecated-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-components.test.ts
@@ -49,6 +49,22 @@ ruleTester.run("no-deprecated-components", noDeprecatedComponentsRule, {
         },
         {
             code: dedent`
+                import { Popover as BlueprintPopover } from "@blueprintjs/core";
+
+                return <BlueprintPopover />;
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Popover",
+                        newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+        {
+            code: dedent`
                 import * as Blueprint from "@blueprintjs/core";
 
                 return <Blueprint.Popover />;
@@ -58,6 +74,38 @@ ruleTester.run("no-deprecated-components", noDeprecatedComponentsRule, {
                     data: {
                         deprecatedComponentName: "Popover",
                         newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+        {
+            code: dedent`
+                import { Popover as BlueprintPopover } from "@blueprintjs/core";
+
+                export class MyPopover extends BlueprintPopover {}
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Popover",
+                        newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+            ],
+        },
+        {
+            code: dedent`
+                import { Select2 as BlueprintSelect } from "@blueprintjs/select";
+
+                BlueprintSelect.ofType<string>();
+            `,
+            errors: [
+                {
+                    data: {
+                        deprecatedComponentName: "Select2",
+                        newComponentName: "Select",
                     },
                     messageId: "migration",
                 },


### PR DESCRIPTION
#### Fixes #6408

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

This updates the deprecated component ESLint rule to resolve the original imported component name when a deprecated Blueprint component is imported under a local alias.

Previously, imports such as:

```ts
import { Popover as BlueprintPopover } from "@blueprintjs/core";
```

were tracked with both the imported name and local name, but the rule reported/checks against the local name. That meant aliases could bypass the deprecated component detector. The rule now resolves the original imported component name before reporting JSX usage, class extension usage, member expression usage, and prop-specific checks.

Added regression coverage for:

- aliased JSX usage
- aliased class extension usage
- aliased static/member expression usage

Local verification:

- `pnpm --dir packages/eslint-plugin test` -> 73 passed
- `pnpm --dir packages/eslint-plugin compile` -> passed
- `pnpm --dir packages/eslint-plugin lint` -> passed
- `prettier --check packages/eslint-plugin/src/rules/no-deprecated-components/createNoDeprecatedComponentsRule.ts packages/eslint-plugin/test/no-deprecated-components.test.ts` -> passed

#### Reviewers should focus on:

Whether resolving reports to the original imported component name is the preferred behavior for aliased imports, especially for the existing prop-specific deprecated component path.

#### Screenshot

N/A; eslint-plugin rule change only.