### PR TITLE
[core] Prevent native context menu on context menu backdrop

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuPopover.tsx
+++ b/packages/core/src/components/context-menu/contextMenuPopover.tsx
@@ -88,7 +88,7 @@ export const ContextMenuPopover = memo(function ContextMenuPopover(props: Contex
             // when offset changes, to force recomputing position.
             key={getPopoverKey(targetOffset)}
             hasBackdrop={true}
-            backdropProps={{ className: Classes.CONTEXT_MENU_BACKDROP }}
+            backdropProps={{ className: Classes.CONTEXT_MENU_BACKDROP, onContextMenu: cancelContextMenu }}
             animation="minimal"
             arrow={false}
             onInteraction={handleInteraction}

--- a/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
@@ -17,7 +17,7 @@
 import { waitFor } from "@testing-library/dom";
 
 import { afterAll, assert, beforeAll, beforeEach, describe, it } from "@blueprintjs/test-commons/vitest";
-import { dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
+import { createMouseEvent, dispatchMouseEvent } from "@blueprintjs/test-commons/vitest-utils";
 
 import { Classes, Utils } from "../../common";
 import { Menu } from "../menu/menu";
@@ -92,6 +92,25 @@ describe("showContextMenu() + hideContextMenu()", () => {
                     requestAnimationFrame(() => {
                         assertMenuState(true);
                         // important: close menu for the next test
+                        dismissContextMenu();
+                        done();
+                    }),
+            });
+        }));
+
+    it("prevents the native context menu on the backdrop", () =>
+        new Promise<void>(done => {
+            showContextMenu({
+                ...DEFAULT_CONTEXT_MENU_POPOVER_PROPS,
+                onOpened: () =>
+                    requestAnimationFrame(() => {
+                        const backdrop = document.querySelector<HTMLElement>(`.${Classes.CONTEXT_MENU_BACKDROP}`);
+                        assert.isNotNull(backdrop, "Expected context menu backdrop to be rendered");
+
+                        const contextMenuEvent = createMouseEvent("contextmenu");
+                        backdrop!.dispatchEvent(contextMenuEvent);
+
+                        assert.isTrue(contextMenuEvent.defaultPrevented);
                         dismissContextMenu();
                         done();
                     }),


### PR DESCRIPTION
#### Fixes #6469

#### Checklist

- [x] Includes tests covering the new behavior

#### Changes proposed in this pull request:

This prevents the browser's native context menu from opening when a `ContextMenuPopover` backdrop receives a `contextmenu` event. The menu content already called `preventDefault()` for right-clicks; this applies the same handling to the backdrop, which matches the race described in #6469 where the newly mounted backdrop can receive the original right-click event.

#### Test plan

- `npm exec -- pnpm --dir packages/core test:vitest:run src/components/context-menu/contextMenuSingleton.test.tsx`
- `npm exec -- pnpm --dir packages/core test:typeCheck`
- `npm exec -- prettier --check packages/core/src/components/context-menu/contextMenuPopover.tsx packages/core/src/components/context-menu/contextMenuSingleton.test.tsx`
- `git diff --check`
