### PR TITLE
[core] Introduce BP7 palette (preview)

### DIFF
--- a/packages/core/src/design-tokens/tokens/next/palette.bp7.dark.tokens.json
+++ b/packages/core/src/design-tokens/tokens/next/palette.bp7.dark.tokens.json
@@ -1,0 +1,1086 @@
+{
+    "palette": {
+        "$type": "color",
+        "$description": "BP7 palette PREVIEW dark-mode override, CIECAM02 contrast-compensated (#ffffff to #000000, Yb=15). white/black are mode-independent and intentionally omitted (they fall back to the light/base values).",
+        "orange": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8886, 0.0492, 47.64],
+                    "hex": "#f7d1bf"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7812, 0.0987, 47.58],
+                    "hex": "#eca480"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6748, 0.1304, 46.68],
+                    "hex": "#d77b4c"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5731, 0.1453, 46.11],
+                    "hex": "#bb571e"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4738, 0.143, 41.97],
+                    "hex": "#9a3700"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3781, 0.1298, 35.91],
+                    "hex": "#771c00"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2853, 0.1028, 33.93],
+                    "hex": "#520c00"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1988, 0.0759, 31.74],
+                    "hex": "#300200"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1188, 0.0487, 29.23],
+                    "hex": "#140000"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0483, 0.0197, 29.35],
+                    "hex": "#010000"
+                }
+            }
+        },
+        "blue": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8888, 0.0495, 254.58],
+                    "hex": "#c5ddfb"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7805, 0.0995, 255.92],
+                    "hex": "#8dbaf7"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6768, 0.1379, 257.22],
+                    "hex": "#5d98eb"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5725, 0.1574, 257.36],
+                    "hex": "#3476d3"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4733, 0.1619, 257.08],
+                    "hex": "#0a58b4"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3785, 0.1501, 259.46],
+                    "hex": "#003b8f"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2883, 0.1282, 261.44],
+                    "hex": "#002369"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2029, 0.0963, 262.34],
+                    "hex": "#001041"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1212, 0.0592, 262.67],
+                    "hex": "#00031c"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0488, 0.022, 261.66],
+                    "hex": "#000002"
+                }
+            }
+        },
+        "green": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8992, 0.0482, 153.68],
+                    "hex": "#c6e8cf"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7902, 0.0952, 153.31],
+                    "hex": "#8acd9e"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6849, 0.1291, 153.06],
+                    "hex": "#51b173"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5808, 0.1449, 153.28],
+                    "hex": "#0f924f"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4862, 0.1352, 149.59],
+                    "hex": "#007331"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3936, 0.1187, 146.47],
+                    "hex": "#005619"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3006, 0.0947, 144.94],
+                    "hex": "#003909"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2098, 0.0688, 143.66],
+                    "hex": "#002001"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1276, 0.0434, 142.5],
+                    "hex": "#000b00"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0493, 0.0157, 144.72],
+                    "hex": "#000100"
+                }
+            }
+        },
+        "red": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8868, 0.0493, 23.28],
+                    "hex": "#f9ceca"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7792, 0.0998, 22.62],
+                    "hex": "#f09e9a"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.674, 0.1306, 22.99],
+                    "hex": "#db7370"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5711, 0.1472, 22.98],
+                    "hex": "#bf4d4d"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4718, 0.1499, 23.06],
+                    "hex": "#9e2c31"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3758, 0.1404, 23.08],
+                    "hex": "#7b0f1a"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2856, 0.1155, 23.97],
+                    "hex": "#560009"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2029, 0.0825, 26.34],
+                    "hex": "#330002"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1226, 0.0499, 26.58],
+                    "hex": "#150000"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0487, 0.0196, 24],
+                    "hex": "#020000"
+                }
+            }
+        },
+        "vermilion": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8912, 0.0503, 35.65],
+                    "hex": "#fad0c5"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7828, 0.0995, 34.43],
+                    "hex": "#f1a18e"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6761, 0.1309, 34.18],
+                    "hex": "#db775f"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.574, 0.1466, 34.16],
+                    "hex": "#bf5239"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4738, 0.1492, 33.75],
+                    "hex": "#9e3119"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3771, 0.1393, 32.96],
+                    "hex": "#7b1400"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2845, 0.1163, 29.36],
+                    "hex": "#560000"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2022, 0.083, 29.23],
+                    "hex": "#330000"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1222, 0.0502, 29.23],
+                    "hex": "#150000"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0483, 0.0197, 29.35],
+                    "hex": "#010000"
+                }
+            }
+        },
+        "rose": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8906, 0.0503, 3.51],
+                    "hex": "#f9ced7"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7811, 0.1009, 3.4],
+                    "hex": "#ef9cb1"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6754, 0.1339, 3.85],
+                    "hex": "#da718d"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5719, 0.1502, 3.76],
+                    "hex": "#bd4a6e"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4726, 0.1533, 4.07],
+                    "hex": "#9c2951"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3763, 0.1438, 3.98],
+                    "hex": "#790a39"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2889, 0.116, 5.7],
+                    "hex": "#550022"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2042, 0.0818, 7.47],
+                    "hex": "#320010"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1236, 0.0495, 8.93],
+                    "hex": "#140004"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0498, 0.02, 4.05],
+                    "hex": "#020000"
+                }
+            }
+        },
+        "violet": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8873, 0.051, 326.52],
+                    "hex": "#edcfec"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7799, 0.1012, 327.21],
+                    "hex": "#daa0d9"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6758, 0.134, 326.82],
+                    "hex": "#c278c2"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5714, 0.1536, 327.09],
+                    "hex": "#a552a6"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.472, 0.1573, 326.92],
+                    "hex": "#873288"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3751, 0.1475, 327.13],
+                    "hex": "#671768"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2832, 0.1269, 327.31],
+                    "hex": "#470349"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1997, 0.0927, 326.47],
+                    "hex": "#29002b"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1199, 0.0555, 326.99],
+                    "hex": "#0f0010"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0487, 0.0226, 326.61],
+                    "hex": "#010001"
+                }
+            }
+        },
+        "indigo": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8887, 0.0514, 287.82],
+                    "hex": "#d8d6fb"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.782, 0.1031, 287.61],
+                    "hex": "#b4aef7"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6767, 0.1391, 288.07],
+                    "hex": "#9488e7"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5732, 0.1576, 288.43],
+                    "hex": "#7764ce"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4734, 0.1623, 288.08],
+                    "hex": "#5b45b0"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3766, 0.1524, 288.03],
+                    "hex": "#422a8b"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2849, 0.1308, 288.11],
+                    "hex": "#2b1465"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1971, 0.1002, 287.87],
+                    "hex": "#17053f"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1188, 0.0628, 288.04],
+                    "hex": "#06011b"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0483, 0.0234, 285.48],
+                    "hex": "#000002"
+                }
+            }
+        },
+        "cerulean": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9053, 0.0456, 241.73],
+                    "hex": "#c6e4fc"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7962, 0.0933, 242.95],
+                    "hex": "#87c4f4"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6904, 0.1242, 242.35],
+                    "hex": "#4ca4e2"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5847, 0.1409, 242.82],
+                    "hex": "#0083c8"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4905, 0.1325, 248.15],
+                    "hex": "#0064a7"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3971, 0.1219, 252.85],
+                    "hex": "#004786"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3025, 0.0997, 255.03],
+                    "hex": "#002d5f"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2114, 0.0756, 257.19],
+                    "hex": "#00173a"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1259, 0.0474, 258.38],
+                    "hex": "#000619"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0521, 0.0179, 256.2],
+                    "hex": "#000002"
+                }
+            }
+        },
+        "turquoise": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9056, 0.0349, 183.7],
+                    "hex": "#c7e8e2"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7956, 0.0671, 183.88],
+                    "hex": "#8bcbc1"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6872, 0.0896, 184.38],
+                    "hex": "#51ada1"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5835, 0.1026, 184.44],
+                    "hex": "#038f83"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4895, 0.0873, 182.82],
+                    "hex": "#007065"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3955, 0.0711, 181.4],
+                    "hex": "#005349"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3031, 0.0547, 180.69],
+                    "hex": "#003730"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2122, 0.0387, 179.41],
+                    "hex": "#001e19"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1271, 0.023, 180.15],
+                    "hex": "#000907"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0512, 0.0093, 179.59],
+                    "hex": "#000100"
+                }
+            }
+        },
+        "forest": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8885, 0.0513, 144.75],
+                    "hex": "#c6e4c6"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7812, 0.1006, 144.66],
+                    "hex": "#8fc98f"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6747, 0.1332, 144.67],
+                    "hex": "#5eac60"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5744, 0.1516, 144.46],
+                    "hex": "#318f38"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4734, 0.1515, 144.41],
+                    "hex": "#007017"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3809, 0.1296, 142.5],
+                    "hex": "#005200"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2924, 0.0995, 142.5],
+                    "hex": "#003700"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2058, 0.07, 142.5],
+                    "hex": "#001f00"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1244, 0.0423, 142.5],
+                    "hex": "#000a00"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0489, 0.0166, 142.5],
+                    "hex": "#000100"
+                }
+            }
+        },
+        "lime": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8893, 0.0455, 125.33],
+                    "hex": "#d3e0c0"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.782, 0.0902, 124.65],
+                    "hex": "#abc282"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6786, 0.1197, 124.83],
+                    "hex": "#87a44d"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5752, 0.1328, 124.84],
+                    "hex": "#67861b"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4751, 0.1208, 125.94],
+                    "hex": "#4b6700"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3797, 0.0992, 127.95],
+                    "hex": "#334b00"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2853, 0.0752, 128.55],
+                    "hex": "#1f3100"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1994, 0.053, 129.21],
+                    "hex": "#0e1a00"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1189, 0.0322, 130.36],
+                    "hex": "#030700"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0465, 0.0126, 130.51],
+                    "hex": "#000000"
+                }
+            }
+        },
+        "gold": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8917, 0.0381, 75.24],
+                    "hex": "#ead8c0"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7854, 0.0754, 76.26],
+                    "hex": "#d5b382"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6784, 0.0994, 76.87],
+                    "hex": "#ba8f4d"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5762, 0.1102, 75.66],
+                    "hex": "#9e6f1d"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4758, 0.1022, 71.5],
+                    "hex": "#7f5100"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.381, 0.0854, 65.07],
+                    "hex": "#613700"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2872, 0.0652, 63.55],
+                    "hex": "#412200"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1999, 0.0467, 60.27],
+                    "hex": "#251000"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.118, 0.0296, 53.96],
+                    "hex": "#0d0300"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0503, 0.0114, 63.96],
+                    "hex": "#010000"
+                }
+            }
+        },
+        "sepia": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8943, 0.0434, 59.82],
+                    "hex": "#f3d6c0"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7877, 0.0862, 58.08],
+                    "hex": "#e4ac82"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6809, 0.1137, 58.16],
+                    "hex": "#cd864d"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5762, 0.1272, 56.81],
+                    "hex": "#b0631d"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4769, 0.1222, 52.24],
+                    "hex": "#904400"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3803, 0.1081, 45.33],
+                    "hex": "#6f2a00"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2882, 0.0841, 43.84],
+                    "hex": "#4b1900"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1994, 0.0616, 40.76],
+                    "hex": "#2c0900"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1193, 0.0406, 36.24],
+                    "hex": "#110100"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0493, 0.015, 41.67],
+                    "hex": "#010000"
+                }
+            }
+        },
+        "grey": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9373, 0.0174, 253.37],
+                    "hex": "#e2ebf6"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8199, 0.0172, 253.52],
+                    "hex": "#bdc5cf"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.707, 0.0157, 250.61],
+                    "hex": "#9aa2aa"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5965, 0.0148, 254.59],
+                    "hex": "#798088"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4901, 0.0147, 254.75],
+                    "hex": "#5b6169"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3887, 0.0145, 254.91],
+                    "hex": "#40454d"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2925, 0.0144, 255.06],
+                    "hex": "#272c33"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1954, 0.0137, 259.34],
+                    "hex": "#11151b"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1457, 0.0137, 259.36],
+                    "hex": "#070a10"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1035, 0.0124, 256.43],
+                    "hex": "#020407"
+                }
+            }
+        }
+    }
+}

--- a/packages/core/src/design-tokens/tokens/next/palette.bp7.tokens.json
+++ b/packages/core/src/design-tokens/tokens/next/palette.bp7.tokens.json
@@ -1,0 +1,1248 @@
+{
+    "palette": {
+        "$type": "color",
+        "$description": "BP7 palette PREVIEW (not built — current BP6 palette is active). 100=lightest, 1000=darkest. Light mode.",
+        "orange": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9147, 0.0427, 47.48],
+                    "hex": "#fcdbcb"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8297, 0.0891, 47.62],
+                    "hex": "#f8b695"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7426, 0.1236, 47.04],
+                    "hex": "#eb9265"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6562, 0.1455, 47.13],
+                    "hex": "#d77139"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5673, 0.1563, 47.24],
+                    "hex": "#bd5200"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4784, 0.1481, 40.69],
+                    "hex": "#9e3600"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3867, 0.1248, 38.65],
+                    "hex": "#782300"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2943, 0.0996, 36.52],
+                    "hex": "#531200"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1971, 0.0737, 32.5],
+                    "hex": "#2f0300"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1011, 0.0325, 38.79],
+                    "hex": "#0b0100"
+                }
+            }
+        },
+        "blue": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9152, 0.0416, 255.01],
+                    "hex": "#d1e5ff"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8298, 0.0858, 256.19],
+                    "hex": "#a3caff"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.745, 0.1224, 257.51],
+                    "hex": "#7aaef9"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6561, 0.1448, 257.73],
+                    "hex": "#5591e8"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5678, 0.1553, 257.52],
+                    "hex": "#3475d0"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.476, 0.1544, 257.66],
+                    "hex": "#1759b1"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3847, 0.1418, 257.9],
+                    "hex": "#003f8d"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2947, 0.1145, 259.06],
+                    "hex": "#002864"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1991, 0.0778, 259.16],
+                    "hex": "#001338"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0988, 0.033, 255.43],
+                    "hex": "#00030d"
+                }
+            }
+        },
+        "green": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.923, 0.0407, 153.1],
+                    "hex": "#d2eed9"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8372, 0.0835, 152.92],
+                    "hex": "#a0dab0"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7515, 0.1177, 152.65],
+                    "hex": "#70c48a"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6634, 0.1379, 152.81],
+                    "hex": "#42ab69"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5727, 0.148, 152.83],
+                    "hex": "#00904b"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4882, 0.1363, 149.44],
+                    "hex": "#007431"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3983, 0.1159, 147.78],
+                    "hex": "#00571e"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3034, 0.0915, 146.46],
+                    "hex": "#003a0e"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.208, 0.0654, 144.99],
+                    "hex": "#001f03"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1005, 0.0274, 150.49],
+                    "hex": "#000501"
+                }
+            }
+        },
+        "red": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9133, 0.0428, 23.3],
+                    "hex": "#fed8d5"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8283, 0.0897, 22.54],
+                    "hex": "#fcb0ac"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7422, 0.1225, 22.88],
+                    "hex": "#ef8b87"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6548, 0.145, 22.88],
+                    "hex": "#db6866"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5667, 0.1557, 23.02],
+                    "hex": "#c14849"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4771, 0.1549, 23.18],
+                    "hex": "#a22b30"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3839, 0.1416, 22.86],
+                    "hex": "#7e111c"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2913, 0.1164, 23.21],
+                    "hex": "#58010c"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1977, 0.0797, 22.61],
+                    "hex": "#310004"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.102, 0.0309, 24.44],
+                    "hex": "#0b0101"
+                }
+            }
+        },
+        "vermilion": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9167, 0.0437, 35.56],
+                    "hex": "#ffdad0"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8311, 0.0896, 34.37],
+                    "hex": "#fcb3a1"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7438, 0.1232, 34.21],
+                    "hex": "#ef8e77"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6571, 0.1451, 34.41],
+                    "hex": "#db6c52"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5683, 0.1562, 34.4],
+                    "hex": "#c14c31"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.478, 0.1557, 34.35],
+                    "hex": "#a22f13"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3859, 0.1407, 33.45],
+                    "hex": "#7e1700"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2923, 0.1156, 30.49],
+                    "hex": "#580400"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1984, 0.079, 30.23],
+                    "hex": "#310100"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1011, 0.0325, 38.79],
+                    "hex": "#0b0100"
+                }
+            }
+        },
+        "rose": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9163, 0.0435, 3.75],
+                    "hex": "#fed8e0"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.83, 0.0902, 3.46],
+                    "hex": "#faafc1"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7437, 0.1247, 3.85],
+                    "hex": "#ed89a3"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6559, 0.1464, 3.72],
+                    "hex": "#d86687"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5678, 0.1571, 3.99],
+                    "hex": "#be466c"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4779, 0.1563, 3.87],
+                    "hex": "#9f2953"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3858, 0.1435, 3.98],
+                    "hex": "#7c0f3b"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2918, 0.1174, 3.97],
+                    "hex": "#560025"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1989, 0.0799, 4.8],
+                    "hex": "#300011"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1039, 0.0313, 3.71],
+                    "hex": "#0b0103"
+                }
+            }
+        },
+        "violet": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.914, 0.0436, 327.11],
+                    "hex": "#f3d9f2"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8293, 0.089, 327.59],
+                    "hex": "#e7b3e5"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7443, 0.1217, 327.2],
+                    "hex": "#d590d4"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6557, 0.1452, 327.51],
+                    "hex": "#bf6ebe"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5675, 0.1555, 327.38],
+                    "hex": "#a550a5"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.477, 0.1539, 327.66],
+                    "hex": "#883588"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3857, 0.1413, 327.89],
+                    "hex": "#691e69"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2924, 0.1173, 327.35],
+                    "hex": "#480c49"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1967, 0.0808, 328.12],
+                    "hex": "#270327"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1013, 0.0343, 327.74],
+                    "hex": "#080108"
+                }
+            }
+        },
+        "indigo": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9151, 0.0434, 288.38],
+                    "hex": "#e1dfff"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.831, 0.0891, 287.87],
+                    "hex": "#c4bfff"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7449, 0.124, 288.27],
+                    "hex": "#a99ff6"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6568, 0.1457, 288.61],
+                    "hex": "#8f80e4"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.568, 0.1565, 288.26],
+                    "hex": "#7563cc"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4773, 0.1546, 288.21],
+                    "hex": "#5c48ad"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3859, 0.1412, 288.29],
+                    "hex": "#443089"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2916, 0.117, 288.04],
+                    "hex": "#2c1b61"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1984, 0.0807, 288.23],
+                    "hex": "#160b37"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1002, 0.0333, 285.73],
+                    "hex": "#03020d"
+                }
+            }
+        },
+        "cerulean": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9279, 0.038, 242.12],
+                    "hex": "#d2ebff"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8424, 0.08, 243.25],
+                    "hex": "#9ed2fc"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7564, 0.1098, 242.75],
+                    "hex": "#6eb8f0"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6664, 0.1299, 242.89],
+                    "hex": "#3f9cdd"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5762, 0.1392, 242.96],
+                    "hex": "#0080c4"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4906, 0.1308, 247.59],
+                    "hex": "#0064a6"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3992, 0.1129, 249.96],
+                    "hex": "#004981"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3042, 0.0918, 252.3],
+                    "hex": "#002f5b"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2051, 0.0637, 253.21],
+                    "hex": "#001733"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1041, 0.028, 247.9],
+                    "hex": "#00040c"
+                }
+            }
+        },
+        "turquoise": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9281, 0.0291, 183.33],
+                    "hex": "#d3eee9"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8417, 0.058, 183.74],
+                    "hex": "#a1d8cf"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7538, 0.08, 184.32],
+                    "hex": "#71c0b5"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6662, 0.095, 184.43],
+                    "hex": "#42a79b"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5753, 0.1016, 184.33],
+                    "hex": "#018c80"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4895, 0.0871, 183.14],
+                    "hex": "#007065"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4002, 0.0715, 182.57],
+                    "hex": "#00544b"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3056, 0.0549, 181.54],
+                    "hex": "#003831"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2071, 0.037, 182.42],
+                    "hex": "#001d19"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1032, 0.0184, 182.95],
+                    "hex": "#000504"
+                }
+            }
+        },
+        "forest": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9147, 0.0437, 144.16],
+                    "hex": "#d2ebd1"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8299, 0.0892, 144.25],
+                    "hex": "#a4d7a3"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7429, 0.1232, 144.21],
+                    "hex": "#79c079"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6577, 0.1471, 143.89],
+                    "hex": "#52a853"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5674, 0.1567, 144.05],
+                    "hex": "#2c8d32"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4762, 0.1546, 143.96],
+                    "hex": "#007113"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3895, 0.1325, 142.5],
+                    "hex": "#005500"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2986, 0.1016, 142.5],
+                    "hex": "#003900"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2036, 0.0693, 142.5],
+                    "hex": "#001e00"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0996, 0.0339, 142.5],
+                    "hex": "#000500"
+                }
+            }
+        },
+        "lime": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9152, 0.0391, 124.67],
+                    "hex": "#dde8cc"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8304, 0.0808, 124.3],
+                    "hex": "#bcd197"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7458, 0.1128, 124.51],
+                    "hex": "#9db967"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6581, 0.1329, 124.48],
+                    "hex": "#809f3a"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5684, 0.1419, 124.44],
+                    "hex": "#658400"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4799, 0.1225, 126.2],
+                    "hex": "#4c6900"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3867, 0.0993, 126.69],
+                    "hex": "#364d00"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.295, 0.0762, 127.16],
+                    "hex": "#223300"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1996, 0.0521, 127.85],
+                    "hex": "#0f1a00"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0982, 0.0252, 126.59],
+                    "hex": "#020400"
+                }
+            }
+        },
+        "gold": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.917, 0.033, 74.78],
+                    "hex": "#f1e1cc"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.833, 0.0679, 76.25],
+                    "hex": "#e2c397"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7456, 0.0942, 77.26],
+                    "hex": "#cea566"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6589, 0.1109, 76.66],
+                    "hex": "#b8883a"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5691, 0.1192, 76.81],
+                    "hex": "#9e6c00"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4812, 0.1037, 70.85],
+                    "hex": "#825200"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3887, 0.0844, 69.6],
+                    "hex": "#613b00"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2956, 0.0654, 66.82],
+                    "hex": "#422500"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1985, 0.0458, 61.82],
+                    "hex": "#241000"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1042, 0.0219, 75.86],
+                    "hex": "#070300"
+                }
+            }
+        },
+        "sepia": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9191, 0.0376, 59.54],
+                    "hex": "#f8dfcc"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8349, 0.0776, 58.12],
+                    "hex": "#f0bd97"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.7477, 0.1075, 58.59],
+                    "hex": "#e09c66"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6589, 0.1274, 57.94],
+                    "hex": "#cb7c39"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5701, 0.1364, 58.06],
+                    "hex": "#b15f00"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4805, 0.1254, 50.95],
+                    "hex": "#934400"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3897, 0.1037, 49.55],
+                    "hex": "#6f3000"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.295, 0.0821, 46.65],
+                    "hex": "#4c1c00"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2002, 0.0596, 42.68],
+                    "hex": "#2b0a00"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1027, 0.0258, 53.71],
+                    "hex": "#090200"
+                }
+            }
+        },
+        "grey": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.9525, 0.0142, 254.61],
+                    "hex": "#e9f0f9"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.8611, 0.0146, 254.62],
+                    "hex": "#cbd2db"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.77, 0.0138, 251.59],
+                    "hex": "#aeb5bd"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.6773, 0.0137, 255.54],
+                    "hex": "#9298a0"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.5839, 0.0142, 255.55],
+                    "hex": "#767c84"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.4902, 0.0148, 255.57],
+                    "hex": "#5b6169"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.3954, 0.0157, 255.6],
+                    "hex": "#41474f"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2916, 0.0163, 259.79],
+                    "hex": "#272c34"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.2336, 0.0172, 259.75],
+                    "hex": "#191e26"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.1804, 0.0165, 256.84],
+                    "hex": "#0d1219"
+                }
+            }
+        },
+        "white": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.06,
+                    "hex": "#ffffff0f"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.12,
+                    "hex": "#ffffff1f"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.2,
+                    "hex": "#ffffff33"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.3,
+                    "hex": "#ffffff4d"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.5,
+                    "hex": "#ffffff80"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.8,
+                    "hex": "#ffffffcc"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.85,
+                    "hex": "#ffffffd9"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.9,
+                    "hex": "#ffffffe6"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "alpha": 0.95,
+                    "hex": "#fffffff2"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [1, 0, 0],
+                    "hex": "#ffffff"
+                }
+            }
+        },
+        "black": {
+            "100": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.025,
+                    "hex": "#00010506"
+                }
+            },
+            "200": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.09,
+                    "hex": "#00010517"
+                }
+            },
+            "300": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.12,
+                    "hex": "#0001051f"
+                }
+            },
+            "400": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.3,
+                    "hex": "#0001054d"
+                }
+            },
+            "500": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.5,
+                    "hex": "#00010580"
+                }
+            },
+            "600": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.8,
+                    "hex": "#000105cc"
+                }
+            },
+            "700": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.85,
+                    "hex": "#000105d9"
+                }
+            },
+            "800": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.9,
+                    "hex": "#000105e6"
+                }
+            },
+            "900": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "alpha": 0.95,
+                    "hex": "#000105f2"
+                }
+            },
+            "1000": {
+                "$value": {
+                    "colorSpace": "oklch",
+                    "components": [0.0696, 0.0248, 257.1],
+                    "hex": "#000105"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this adds

Two preview token files under `packages/core/src/design-tokens/tokens/next/`:

- `palette.bp7.tokens.json` (light)
<img width="1728" height="784" alt="image" src="https://github.com/user-attachments/assets/03c7f27e-94ef-4153-9fbf-9027a5b803c3" />

- `palette.bp7.dark.tokens.json` (dark)
<img width="1728" height="783" alt="image" src="https://github.com/user-attachments/assets/37a98dea-5ea4-4b1f-b793-7077228d7a4b" />

Each holds 17 hues at 10 stops (`100` lightest to `1000` darkest), written as [OKLCH](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) [DTCG color values](https://tr.designtokens.org/format/) with an sRGB `hex` fallback.

## Nothing ships yet

`sd.config.ts` builds only `tokens/base/**` and `tokens/themes/dark/**`. These files live in `tokens/next/`, outside both globs, so the build skips them and the current BP6 (`1–5`) palette stays active.

## How the colors are built

One source hue, two perceptual corrections.

### OKLCH over hex and HSL

[Evil Martians walks through the move](https://evilmartians.com/chronicles/oklch-in-css-why-quit-rgb-hsl) ([MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch)). In OKLCH one lightness value reads as the same brightness across every hue, so a 10-step ramp climbs in even steps and the blue ramp lines up rung-for-rung with the red one. HSL breaks that promise: set a yellow and a blue to the same `50%` HSL lightness and the yellow still looks far brighter. So HSL ramps step unevenly, and a blue stop won't match the red stop beside it.

### Orange goes first

Orange has caused the most contrast trouble in today's Blueprint palette, so we anchor the system on it. Get orange right and the rest follow. Orange defines one lightness-and-chroma profile; every other hue keeps that profile and swaps in only its own hue angle (from its old BP `3` color). Each ramp inherits orange's vetted contrast instead of getting hand-tuned on its own.

### Grey, matched by weight

[The Helmholtz–Kohlrausch effect](https://gorkemyildiz.com/articles/the-helmholtz-kohlrausch-effect-why-saturated-colors-look-brighter): saturated colors look brighter than their measured lightness. A plain grey set to the same OKLCH lightness as a chromatic stop reads lighter than its neighbors. We match grey's perceived weight to the orange reference.

### Dark mode, matched by appearance

[CIECAM02](https://en.wikipedia.org/wiki/Color_appearance_model) models how a color looks under a given viewing context. The same swatch reads differently on white than on black ([simultaneous contrast](https://colorarchive.org/notes/may-2026-dark-mode-saturation/)). Instead of guessing dark tints, we push each light color through CIECAM02: read its appearance against a white background, then solve for the color that looks the same against black (Yb 15).

### white and black

Fixed alpha overlay ramps, shared across both modes. They use the same opacity values in light and dark, so the dark file omits them and they fall back to the base values. No model involved.
