### PR TITLE
[eslint-plugin] Add deprecated core component mappings to ESLint rule

### DIFF
--- a/packages/docs-app/src/examples/core-examples/overlayExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/overlayExample.tsx
@@ -97,6 +97,7 @@ export class OverlayExample extends PureComponent<
                     onClick={this.handleOpen}
                     text="Show overlay"
                 />
+                {/* eslint-disable-next-line @blueprintjs/no-deprecated-components */}
                 <Overlay
                     onClose={this.handleClose}
                     className={Classes.OVERLAY_SCROLL_CONTAINER}

--- a/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
+++ b/packages/eslint-plugin/src/rules/no-deprecated-components/no-deprecated-core-components.ts
@@ -7,9 +7,11 @@ import type { TSESLint } from "@typescript-eslint/utils";
 import { createNoDeprecatedComponentsRule, type DeprecatedComponentsConfig } from "./createNoDeprecatedComponentsRule";
 
 export const coreComponentsMigrationMapping: DeprecatedComponentsConfig = {
-    // TODO(@adidahiya): Blueprint v6
-    // PanelStack: "PanelStack2",
+    HotkeysTarget2: "HotkeysTarget",
+    Overlay: "Overlay2",
+    PanelStack2: "PanelStack",
     Popover: "PopoverNext",
+    Toast2: "Toast",
 };
 
 /**

--- a/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
+++ b/packages/eslint-plugin/test/no-deprecated-core-components.test.ts
@@ -30,20 +30,54 @@ const ruleTester = new RuleTester({
 });
 
 ruleTester.run("no-deprecated-core-components", noDeprecatedCoreComponentsRule, {
-    // N.B. most other deprecated components are tested by no-deprecated-components.test.ts, this suite just tests
-    // for more specific violations which involve certain deprecated props
     invalid: [
         {
             code: dedent`
-                import { Popover } from "@blueprintjs/core";
+                import { HotkeysTarget2, Overlay, PanelStack2, Popover, Toast2 } from "@blueprintjs/core";
 
-                return <Popover />;
+                return (
+                    <>
+                        <HotkeysTarget2 />
+                        <Overlay />
+                        <PanelStack2 />
+                        <Popover />
+                        <Toast2 />
+                    </>
+                );
             `,
             errors: [
                 {
                     data: {
+                        deprecatedComponentName: "HotkeysTarget2",
+                        newComponentName: "HotkeysTarget",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
+                        deprecatedComponentName: "Overlay",
+                        newComponentName: "Overlay2",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
+                        deprecatedComponentName: "PanelStack2",
+                        newComponentName: "PanelStack",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
                         deprecatedComponentName: "Popover",
                         newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
+                        deprecatedComponentName: "Toast2",
+                        newComponentName: "Toast",
                     },
                     messageId: "migration",
                 },
@@ -53,13 +87,49 @@ ruleTester.run("no-deprecated-core-components", noDeprecatedCoreComponentsRule, 
             code: dedent`
                 import * as Blueprint from "@blueprintjs/core";
 
-                return <Blueprint.Popover />;
+                return (
+                    <>
+                        <Blueprint.HotkeysTarget2 />
+                        <Blueprint.Overlay />
+                        <Blueprint.PanelStack2 />
+                        <Blueprint.Popover />
+                        <Blueprint.Toast2 />
+                    </>
+                );
             `,
             errors: [
                 {
                     data: {
+                        deprecatedComponentName: "HotkeysTarget2",
+                        newComponentName: "HotkeysTarget",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
+                        deprecatedComponentName: "Overlay",
+                        newComponentName: "Overlay2",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
+                        deprecatedComponentName: "PanelStack2",
+                        newComponentName: "PanelStack",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
                         deprecatedComponentName: "Popover",
                         newComponentName: "PopoverNext",
+                    },
+                    messageId: "migration",
+                },
+                {
+                    data: {
+                        deprecatedComponentName: "Toast2",
+                        newComponentName: "Toast",
                     },
                     messageId: "migration",
                 },


### PR DESCRIPTION
## Changes

Updates the `@blueprintjs/no-deprecated-core-components` rule to flag additional deprecated `@blueprintjs/core` component exports:

- `HotkeysTarget2` -> `HotkeysTarget`
- `Overlay` -> `Overlay2`
- `PanelStack2` -> `PanelStack`
- `Toast2` -> `Toast`