### PR TITLE
[core] Icon: forward `size` prop to element icons

### DIFF
--- a/packages/core/src/components/icon/Icon.stories.tsx
+++ b/packages/core/src/components/icon/Icon.stories.tsx
@@ -116,7 +116,8 @@ export const ColorExample: Story = {
 /**
  * The `icon` prop accepts either a string icon name or a React element (typically an icon
  * component from `@blueprintjs/icons`). When an element is provided, `<Icon>` clones it and
- * merges the parent-provided `className` and intent class onto its root.
+ * merges the parent-provided `className` and intent class onto its root. It also forwards the
+ * `size` prop onto it (the element's own `size` takes precedence).
  */
 export const ElementIcon: Story = {
     name: "Element icon",
@@ -127,7 +128,7 @@ export const ElementIcon: Story = {
                 <StoryLabel title='icon="buggy"' />
             </Flex>
             <Flex flexDirection="column" gap={1} alignItems="center">
-                <Icon {...args} icon={<Buggy size={args.size} />} />
+                <Icon {...args} icon={<Buggy />} />
                 <StoryLabel title="icon={<Buggy />}" />
             </Flex>
         </Flex>

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -16,7 +16,7 @@
 
 import { mount } from "enzyme";
 
-import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
+import { Graph as GraphIcon, type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 import { afterEach, beforeAll, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
@@ -62,6 +62,19 @@ describe("<Icon>", () => {
     it("size=20 renders large size", async () =>
         assertIconSize(<Icon icon="graph" size={IconSize.LARGE} />, IconSize.LARGE));
 
+    it("forwards size onto an element icon", async () =>
+        assertIconSize(<Icon icon={<GraphIcon />} size={IconSize.LARGE} />, IconSize.LARGE));
+
+    it("forwards a custom size onto an element icon", async () =>
+        assertIconSize(<Icon icon={<GraphIcon />} size={128} />, 128));
+
+    it("element icon's own size takes precedence over the <Icon> size", async () =>
+        // non-regression: the element's explicit size wins over the forwarded one
+        assertIconSize(<Icon icon={<GraphIcon size={IconSize.STANDARD} />} size={128} />, IconSize.STANDARD));
+
+    it("element icon without a size falls back to the default size", async () =>
+        assertIconSize(<Icon icon={<GraphIcon />} />, IconSize.STANDARD));
+
     it("renders intent class", async () => {
         const wrapper = mount(<Icon icon="add" intent={Intent.DANGER} />);
         expect(wrapper.find(`.${Classes.INTENT_DANGER}`).exists()).toBe(true);
@@ -99,6 +112,8 @@ describe("<Icon>", () => {
         wrapper.update();
         expect(wrapper.childAt(0).is("article")).toBe(true);
         expect(wrapper.find("article").prop("onClick")).toBe(onClick);
+        // a forwarded `size` should not leak onto a non-icon element when none is provided
+        expect(wrapper.find("article").prop("size")).toBeUndefined();
     });
 
     it("icon=undefined renders nothing", async () => {

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -57,11 +57,12 @@ export interface IconOwnProps {
      *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
      *   will render a blank icon to occupy space.
      * - If given a `React.JSX.Element`, that element will be rendered with the
-     *   parent-provided `className` and intent class merged onto its root. All
-     *   other props on this component are ignored. This type is supported to
-     *   simplify icon support in other Blueprint components. As a consumer, you
-     *   should avoid using `<Icon icon={<Element />}` directly; simply render
-     *   `<Element />` instead.
+     *   parent-provided `className`, intent class merged onto its root, and
+     *   `size` prop forwarded onto it (the element's own `size` takes
+     *   precedence). Other props on this component are ignored. This type is
+     *   supported to simplify icon support in other Blueprint components. As a
+     *   consumer, you should avoid using `<Icon icon={<Element />}` directly;
+     *   simply render `<Element />` instead.
      */
     icon: IconName | MaybeElement;
 
@@ -158,9 +159,11 @@ export const Icon: IconComponent = forwardRef(<T extends Element>(props: IconPro
     if (icon == null || typeof icon === "boolean") {
         return null;
     } else if (typeof icon !== "string") {
-        if (isValidElement<{ className?: string }>(icon)) {
+        if (isValidElement<Pick<SVGIconProps, "className" | "size">>(icon)) {
             return cloneElement(icon, {
                 className: classNames(icon.props.className, className, Classes.intentClass(intent)),
+                // Forward `size`, letting the element's own `size` take precedence.
+                size: icon.props.size ?? props.size,
             });
         }
         return icon;


### PR DESCRIPTION
## Summary

`<Icon>` respects the `size` prop for dynamic icons (`icon="home"`) but silently dropped it for static element icons (e.g. `icon={<Home />}`), which always rendered at the default 16px. This forwards `size` onto the cloned element so both forms render at the same size.

## Context

`<Icon>` doesn't render an element icon itself. Since #8080 it `cloneElement`s the element and merges only the parent-provided `className` and intent class onto its root, so `size` is dropped and the element falls back to its own 16px default. The only workaround was to set the size on the element directly (`icon={<Home size={128} />}`).

That workaround is difficult to apply via codemod when migrating string icons to static element references in bulk, especially through wrapper components that extend `IconProps` and still accept `icon`. Forwarding `size` lets a migration swap `icon="home"` for `icon={<Home />}` and leave the `size` prop in place on the Icon component.

## Changes

- forward `size` onto cloned element icons via `size: icon.props.size ?? props.size`. The element's own `size` takes precedence, so the change is non-regressive.
- scope is `size` only. `intent` and `className` are still applied as classes (unchanged), and `color`/`title` are intentionally out of scope.

**Reviewer note:** a few components pass an explicit `size` to `<Icon>` (`Alert` 40px, `Drawer` 20px, `NonIdealState` 48px, `TagInput` 16/20px). Element icons passed to those now render at that size instead of being pinned to 16px. `Dialog` (16px) is unchanged.

## Example

```tsx
<>
    <Icon icon="home" size={128} />                // dynamic — always worked
    <Icon icon={<Home />} size={128} />            // static — was 16px, now 128px  ← fix
    <Icon icon={<Home size={128} />} />            // size on element — always worked
    <Icon icon={<Home size={20} />} size={128} />  // both set — element wins (20px)
<>
```

| Before | After |
|--------|--------|
| <img width="515" alt="before" src="https://github.com/user-attachments/assets/b29d397f-fe3e-429a-afcb-2701d7787f86" /> | <img width="515" alt="after" src="https://github.com/user-attachments/assets/9c8ecea2-6ef5-4240-af0e-c40fadf2707e" /> |



