### PR TITLE
chore(stylelint-plugin): use HTTPS repository metadata

### DIFF
--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -29,7 +29,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git@github.com:palantir/blueprint.git",
+        "url": "git+https://github.com/palantir/blueprint.git",
         "directory": "packages/stylelint-plugin"
     },
     "author": "Palantir Technologies",


### PR DESCRIPTION
## Summary

- update `@blueprintjs/stylelint-plugin` package metadata to use the HTTPS GitHub repository URL
- keep the existing `packages/stylelint-plugin` repository directory metadata unchanged

## Validation

- Parsed `packages/stylelint-plugin/package.json` and asserted `repository.url` is `git+https://github.com/palantir/blueprint.git`
- `git diff --check`
- `git ls-remote https://github.com/palantir/blueprint.git HEAD`

## Notes

I did not run a workspace install/build locally because this environment has Node `24.14.0` and pnpm `11.5.3`, while the repository currently requires Node `>=24.14.1` and pnpm `11.3.0`. The change is limited to package metadata.
