### PR TITLE
chore: use public repository URL for stylelint plugin

### DIFF
--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -29,7 +29,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git@github.com:palantir/blueprint.git",
+        "url": "git+https://github.com/palantir/blueprint.git",
         "directory": "packages/stylelint-plugin"
     },
     "author": "Palantir Technologies",


### PR DESCRIPTION
Summary

- Update `@blueprintjs/stylelint-plugin` repository metadata from the SSH form to the public HTTPS form.
- Preserve the existing `repository.directory` value for `packages/stylelint-plugin`.

Why

The package currently points at `git@github.com:palantir/blueprint.git`, which requires SSH configuration for consumers following the package source link. The `git+https://github.com/palantir/blueprint.git` URL is publicly accessible and matches common npm package metadata expectations.

Validation

- `node -e "const p=require('./packages/stylelint-plugin/package.json'); if (p.repository.url !== 'git+https://github.com/palantir/blueprint.git') throw new Error(p.repository.url); if (p.repository.directory !== 'packages/stylelint-plugin') throw new Error('bad dir'); console.log(JSON.stringify(p.repository))"`
- `git diff --check`
- `git ls-remote https://github.com/palantir/blueprint.git HEAD`
- `pnpm dlx pnpm@11.3.0 --config.engine-strict=false install --frozen-lockfile --ignore-scripts`
- `./node_modules/.bin/tsc -p packages/colors/src`
- `./node_modules/.bin/tsc -p packages/colors/src -m commonjs --verbatimModuleSyntax false --outDir packages/colors/lib/cjs`
- `./node_modules/.bin/tsc -p packages/stylelint-plugin/src`
- `pnpm dlx pnpm@11.3.0 --config.engine-strict=false --dir packages/stylelint-plugin test`
- `pnpm dlx pnpm@11.3.0 --config.engine-strict=false --dir packages/stylelint-plugin pack --dry-run`

Note: I used `--config.engine-strict=false` locally because this machine has Node 24.14.0 while the repo currently requires Node >=24.14.1 and pnpm 11.3.0.
