### PR TITLE
[docs] Add next-icons documentation page

### DIFF
--- a/packages/docs-app/src/components/iconsNext.tsx
+++ b/packages/docs-app/src/components/iconsNext.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { memo, useCallback, useMemo, useState } from "react";
+
+import { Classes, Code, Dialog, DialogBody, H5, InputGroup, NonIdealState, Radio, RadioGroup } from "@blueprintjs/core";
+import { CopyToClipboardButton, smartSearch, useTheme } from "@blueprintjs/docs-theme";
+import { type SVGIconProps } from "@blueprintjs/icons";
+import * as NextIcons from "@blueprintjs/icons/next";
+import { nextIconManifest, type NextIconManifestEntry } from "@blueprintjs/icons/next";
+
+type IconVariant = "outlined" | "filled";
+
+const icons: readonly NextIconManifestEntry[] = nextIconManifest;
+
+const HERO_SIZE = 64;
+const SAMPLE_SIZES = [16, 24, 32, 48, 64];
+const HERO_BACKGROUNDS = ["default", "primary", "dark"] as const;
+
+export function IconsNext() {
+    const [filter, setFilter] = useState("");
+    const [variant, setVariant] = useState<IconVariant>("outlined");
+    const [selectedIcon, setSelectedIcon] = useState<NextIconManifestEntry | undefined>(undefined);
+
+    const filteredIcons = useMemo(
+        () => icons.filter(icon => matchesVariant(variant, icon) && matchesFilter(filter, icon)),
+        [filter, variant],
+    );
+
+    const iconCards = useMemo(
+        () =>
+            filteredIcons.map(icon => (
+                <IconCard icon={icon} key={icon.name} onClick={setSelectedIcon} variant={variant} />
+            )),
+        [filteredIcons, variant],
+    );
+
+    const handleVariantChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+        setVariant(event.currentTarget.value as IconVariant);
+    }, []);
+
+    const handleDialogClose = useCallback(() => setSelectedIcon(undefined), []);
+
+    return (
+        <div className="docs-icons-next">
+            <InputGroup
+                autoFocus={true}
+                className="docs-icons-next-search"
+                fill={true}
+                leftIcon="search"
+                onValueChange={setFilter}
+                placeholder="Search icons..."
+                size="large"
+                type="search"
+                value={filter}
+            />
+            <div className="docs-icons-next-body">
+                <div className="docs-icons-next-filter">
+                    <H5>Filter by style</H5>
+                    <RadioGroup onChange={handleVariantChange} selectedValue={variant}>
+                        <Radio label="Outlined" value="outlined" />
+                        <Radio label="Filled" value="filled" />
+                    </RadioGroup>
+                </div>
+                <div className="docs-icons-next-results">
+                    <div className={`docs-icons-next-count ${Classes.TEXT_MUTED}`}>
+                        {filteredIcons.length} matching results
+                    </div>
+                    {filteredIcons.length === 0 ? (
+                        <NonIdealState className={Classes.TEXT_MUTED} icon="zoom-out" description="No icons found" />
+                    ) : (
+                        <div className="docs-icon-next-grid">{iconCards}</div>
+                    )}
+                </div>
+            </div>
+            <IconDialog icon={selectedIcon} onClose={handleDialogClose} variant={variant} />
+        </div>
+    );
+}
+
+interface IconCardProps {
+    icon: NextIconManifestEntry;
+    variant: IconVariant;
+    onClick: (icon: NextIconManifestEntry) => void;
+}
+
+const IconCard = memo(function IconCard({ icon, onClick, variant }: IconCardProps) {
+    const { name } = icon;
+    const displayName = kebabToPascal(name);
+    const IconComponent = getIconComponent(name, variant);
+    const handleClick = useCallback(() => onClick(icon), [icon, onClick]);
+
+    return (
+        <button className="docs-icon-next-card" onClick={handleClick} type="button">
+            <span className="docs-icon-next-glyph">
+                {IconComponent != null ? <IconComponent size={24} /> : <span className={Classes.TEXT_MUTED}>N/A</span>}
+            </span>
+            <span className="docs-icon-next-name" title={displayName}>
+                {displayName}
+            </span>
+        </button>
+    );
+});
+
+interface IconDialogProps {
+    icon: NextIconManifestEntry | undefined;
+    variant: IconVariant;
+    onClose: () => void;
+}
+
+function IconDialog({ icon, onClose, variant }: IconDialogProps) {
+    const { isDarkTheme } = useTheme();
+
+    if (icon == null) {
+        return null;
+    }
+
+    const { name } = icon;
+    const displayName = kebabToPascal(name);
+    const exportName = getExportName(name, variant);
+    const importStatement = `import { ${exportName} } from "@blueprintjs/icons/next";`;
+    const usage = `<${exportName} />`;
+    const IconComponent = getIconComponent(name, variant);
+
+    return (
+        <Dialog
+            className="docs-icons-next-dialog"
+            isOpen={true}
+            onClose={onClose}
+            portalClassName={isDarkTheme ? Classes.DARK : undefined}
+            title={displayName}
+        >
+            <DialogBody>
+                <div className="docs-icons-next-dialog-heroes">
+                    {HERO_BACKGROUNDS.map(background => (
+                        <div
+                            className={`docs-icons-next-dialog-hero docs-icons-next-dialog-hero-${background}`}
+                            key={background}
+                        >
+                            {IconComponent != null ? <IconComponent size={HERO_SIZE} /> : null}
+                        </div>
+                    ))}
+                </div>
+                <div className="docs-icons-next-dialog-section-label">Sizes</div>
+                <div className="docs-icons-next-dialog-sizes">
+                    {SAMPLE_SIZES.map(size => (
+                        <div className="docs-icons-next-dialog-size" key={size}>
+                            {IconComponent != null ? <IconComponent size={size} /> : null}
+                            <span className={`docs-icons-next-dialog-size-label ${Classes.TEXT_MUTED}`}>{size}</span>
+                        </div>
+                    ))}
+                </div>
+                <CopyableCode label="Import" value={importStatement} />
+                <CopyableCode label="Usage" value={usage} />
+            </DialogBody>
+        </Dialog>
+    );
+}
+
+const CopyableCode = memo(function CopyableCode({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="docs-icons-next-code">
+            <div className="docs-icons-next-code-header">
+                <div className={`docs-icons-next-code-label ${Classes.TEXT_MUTED}`}>{label}</div>
+                <CopyToClipboardButton text={value} variant="minimal" />
+            </div>
+            <Code className="docs-icons-next-code-block">{value}</Code>
+        </div>
+    );
+});
+
+function getIconComponent(name: string, variant: IconVariant) {
+    const exportName = getExportName(name, variant);
+    return NextIcons[exportName as keyof typeof NextIcons] as React.FC<SVGIconProps> | undefined;
+}
+
+function getExportName(name: string, variant: IconVariant) {
+    return `${kebabToPascal(name)}${variant === "filled" ? "FilledIcon" : "Icon"}`;
+}
+
+function matchesVariant(variant: IconVariant, icon: NextIconManifestEntry) {
+    return variant === "outlined" || icon.hasFilled;
+}
+
+function matchesFilter(filter: string, icon: NextIconManifestEntry) {
+    if (filter === "") {
+        return true;
+    }
+    return smartSearch(filter, icon.name, ...icon.tags);
+}
+
+function kebabToPascal(value: string) {
+    return value
+        .split("-")
+        .map(word => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+        .join("");
+}

--- a/packages/docs-app/src/components/iconsNext.tsx
+++ b/packages/docs-app/src/components/iconsNext.tsx
@@ -34,25 +34,31 @@ export function IconsNext() {
     const [filter, setFilter] = useState("");
     const [variant, setVariant] = useState<IconVariant>("outlined");
     const [selectedIcon, setSelectedIcon] = useState<NextIconManifestEntry | undefined>(undefined);
+    const [isDialogOpen, setIsDialogOpen] = useState(false);
 
     const filteredIcons = useMemo(
         () => icons.filter(icon => matchesVariant(variant, icon) && matchesFilter(filter, icon)),
         [filter, variant],
     );
 
+    const handleCardClick = useCallback((icon: NextIconManifestEntry) => {
+        setSelectedIcon(icon);
+        setIsDialogOpen(true);
+    }, []);
+
     const iconCards = useMemo(
         () =>
             filteredIcons.map(icon => (
-                <IconCard icon={icon} key={icon.name} onClick={setSelectedIcon} variant={variant} />
+                <IconCard icon={icon} key={icon.name} onClick={handleCardClick} variant={variant} />
             )),
-        [filteredIcons, variant],
+        [filteredIcons, handleCardClick, variant],
     );
 
     const handleVariantChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
         setVariant(event.currentTarget.value as IconVariant);
     }, []);
 
-    const handleDialogClose = useCallback(() => setSelectedIcon(undefined), []);
+    const handleDialogClose = useCallback(() => setIsDialogOpen(false), []);
 
     return (
         <div className="docs-icons-next">
@@ -86,7 +92,7 @@ export function IconsNext() {
                     )}
                 </div>
             </div>
-            <IconDialog icon={selectedIcon} onClose={handleDialogClose} variant={variant} />
+            <IconDialog icon={selectedIcon} isOpen={isDialogOpen} onClose={handleDialogClose} variant={variant} />
         </div>
     );
 }
@@ -117,11 +123,12 @@ const IconCard = memo(function IconCard({ icon, onClick, variant }: IconCardProp
 
 interface IconDialogProps {
     icon: NextIconManifestEntry | undefined;
+    isOpen: boolean;
     variant: IconVariant;
     onClose: () => void;
 }
 
-function IconDialog({ icon, onClose, variant }: IconDialogProps) {
+function IconDialog({ icon, isOpen, onClose, variant }: IconDialogProps) {
     const { isDarkTheme } = useTheme();
 
     if (icon == null) {
@@ -138,7 +145,7 @@ function IconDialog({ icon, onClose, variant }: IconDialogProps) {
     return (
         <Dialog
             className="docs-icons-next-dialog"
-            isOpen={true}
+            isOpen={isOpen}
             onClose={onClose}
             portalClassName={isDarkTheme ? Classes.DARK : undefined}
             title={displayName}

--- a/packages/docs-app/src/components/iconsNext.tsx
+++ b/packages/docs-app/src/components/iconsNext.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useId, useMemo, useState } from "react";
 
 import { Classes, Code, Dialog, DialogBody, H5, InputGroup, NonIdealState, Radio, RadioGroup } from "@blueprintjs/core";
 import { CopyToClipboardButton, smartSearch, useTheme } from "@blueprintjs/docs-theme";
@@ -31,6 +31,7 @@ const SAMPLE_SIZES = [16, 24, 32, 48, 64];
 const HERO_BACKGROUNDS = ["default", "primary", "dark"] as const;
 
 export function IconsNext() {
+    const variantLabelId = useId();
     const [filter, setFilter] = useState("");
     const [variant, setVariant] = useState<IconVariant>("outlined");
     const [selectedIcon, setSelectedIcon] = useState<NextIconManifestEntry | undefined>(undefined);
@@ -75,8 +76,8 @@ export function IconsNext() {
             />
             <div className="docs-icons-next-body">
                 <div className="docs-icons-next-filter">
-                    <H5>Filter by style</H5>
-                    <RadioGroup onChange={handleVariantChange} selectedValue={variant}>
+                    <H5 id={variantLabelId}>Filter by style</H5>
+                    <RadioGroup aria-labelledby={variantLabelId} onChange={handleVariantChange} selectedValue={variant}>
                         <Radio label="Outlined" value="outlined" />
                         <Radio label="Filled" value="filled" />
                     </RadioGroup>

--- a/packages/docs-app/src/components/iconsNext.tsx
+++ b/packages/docs-app/src/components/iconsNext.tsx
@@ -206,7 +206,7 @@ function matchesFilter(filter: string, icon: NextIconManifestEntry) {
     if (filter === "") {
         return true;
     }
-    return smartSearch(filter, icon.name, ...icon.tags);
+    return smartSearch(filter, kebabToPascal(icon.name), icon.name, ...icon.tags);
 }
 
 function kebabToPascal(value: string) {

--- a/packages/docs-app/src/examples/core-examples/icon/NextIconUsage.tsx
+++ b/packages/docs-app/src/examples/core-examples/icon/NextIconUsage.tsx
@@ -1,0 +1,11 @@
+import { Button } from "@blueprintjs/core";
+import { AirplaneFilledIcon, AirplaneIcon } from "@blueprintjs/icons/next";
+
+export default function NextIconUsage() {
+    return (
+        <div className="group">
+            <Button icon={<AirplaneIcon />} intent="primary" text="Book flight" />
+            <Button icon={<AirplaneFilledIcon />} text="Booked" />
+        </div>
+    );
+}

--- a/packages/docs-app/src/examples/core-examples/icon/NextIconUsage.tsx.preview
+++ b/packages/docs-app/src/examples/core-examples/icon/NextIconUsage.tsx.preview
@@ -1,0 +1,5 @@
+import { Button } from "@blueprintjs/core";
+import { AirplaneFilledIcon, AirplaneIcon } from "@blueprintjs/icons/next";
+
+<Button icon={<AirplaneIcon />} intent="primary" text="Book flight" />
+<Button icon={<AirplaneFilledIcon />} text="Booked" />

--- a/packages/docs-app/src/examples/core-examples/iconExamples.tsx
+++ b/packages/docs-app/src/examples/core-examples/iconExamples.tsx
@@ -7,11 +7,22 @@ import { CodeExample, type ExampleProps } from "@blueprintjs/docs-theme";
 import IconUsage from "./icon/IconUsage";
 import iconUsagePreview from "./icon/IconUsage.tsx.preview?raw";
 import iconUsageCode from "./icon/IconUsage.tsx?raw";
+import NextIconUsage from "./icon/NextIconUsage";
+import nextIconUsagePreview from "./icon/NextIconUsage.tsx.preview?raw";
+import nextIconUsageCode from "./icon/NextIconUsage.tsx?raw";
 
 export const IconUsageExample: React.FC<ExampleProps> = props => {
     return (
         <CodeExample previewCode={iconUsagePreview} sourceCode={iconUsageCode} {...props}>
             <IconUsage />
+        </CodeExample>
+    );
+};
+
+export const NextIconUsageExample: React.FC<ExampleProps> = props => {
+    return (
+        <CodeExample previewCode={nextIconUsagePreview} sourceCode={nextIconUsageCode} {...props}>
+            <NextIconUsage />
         </CodeExample>
     );
 };

--- a/packages/docs-app/src/styles/_icons.scss
+++ b/packages/docs-app/src/styles/_icons.scss
@@ -29,6 +29,212 @@ $icons-per-row: 5;
   }
 }
 
+// Standalone styles for the next-generation icon browser.
+$docs-icon-next-rail-width: $pt-spacing * 30;
+$docs-icon-next-columns: 6;
+
+.docs-icons-next {
+  .docs-icons-next-search {
+    margin: 0 0 ($pt-spacing * 8);
+  }
+
+  .docs-icons-next-body {
+    align-items: flex-start;
+    display: flex;
+    gap: $pt-spacing * 8;
+  }
+
+  .docs-icons-next-filter {
+    flex: 0 0 $docs-icon-next-rail-width;
+    width: $docs-icon-next-rail-width;
+
+    .#{$ns}-heading {
+      margin-bottom: $pt-spacing * 4;
+    }
+  }
+
+  .docs-icons-next-results {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .docs-icons-next-count {
+    font-size: $pt-font-size-small;
+    margin-bottom: $pt-spacing * 4;
+    text-align: end;
+  }
+
+  .docs-icon-next-grid {
+    display: grid;
+    gap: $pt-spacing * 3;
+    grid-template-columns: repeat($docs-icon-next-columns, minmax(0, 1fr));
+  }
+
+  .docs-icon-next-card {
+    align-items: center;
+    appearance: none;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    font: inherit;
+    gap: $pt-spacing * 2;
+    padding: $pt-spacing * 3;
+
+    &:hover .docs-icon-next-glyph {
+      background-color: $light-gray4;
+    }
+
+    &:active .docs-icon-next-glyph {
+      background-color: $light-gray3;
+    }
+
+    &:focus-visible {
+      outline: none;
+
+      .docs-icon-next-glyph {
+        @include focus-outline;
+      }
+    }
+
+    .#{$ns}-dark & {
+      &:hover .docs-icon-next-glyph {
+        background-color: $dark-gray3;
+      }
+
+      &:active .docs-icon-next-glyph {
+        background-color: $dark-gray2;
+      }
+    }
+  }
+
+  .docs-icon-next-glyph {
+    align-items: center;
+    border-radius: $pt-border-radius * 2;
+    color: $pt-icon-color;
+    display: flex;
+    justify-content: center;
+    padding: $pt-spacing * 4;
+    transition: background-color $hover-transition;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-icon-color;
+    }
+  }
+
+  .docs-icon-next-name {
+    color: $pt-text-color-muted;
+    font-size: 10px;
+    max-width: 100%;
+    overflow: hidden;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-text-color-muted;
+    }
+  }
+}
+
+// detail dialog opened by clicking an icon card.
+.docs-icons-next-dialog {
+  width: 600px;
+
+  .docs-icons-next-dialog-heroes {
+    display: grid;
+    gap: $pt-spacing * 3;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-bottom: $pt-spacing * 6;
+  }
+
+  .docs-icons-next-dialog-hero {
+    align-items: center;
+    border-radius: $pt-border-radius * 2;
+    display: flex;
+    justify-content: center;
+    padding: $pt-spacing * 8;
+  }
+
+  .docs-icons-next-dialog-hero-default {
+    background-color: $white;
+    box-shadow: $pt-elevation-shadow-1;
+    color: $pt-icon-color;
+
+    .#{$ns}-dark & {
+      background-color: $dark-gray3;
+      box-shadow: $pt-dark-elevation-shadow-1;
+      color: $pt-dark-icon-color;
+    }
+  }
+
+  .docs-icons-next-dialog-hero-primary {
+    background-color: $pt-intent-primary;
+    color: $white;
+  }
+
+  .docs-icons-next-dialog-hero-dark {
+    background-color: $dark-gray1;
+    color: $white;
+  }
+
+  .docs-icons-next-dialog-section-label,
+  .docs-icons-next-code-label {
+    color: $pt-text-color-muted;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-text-color-muted;
+    }
+  }
+
+  .docs-icons-next-dialog-section-label {
+    margin-bottom: $pt-spacing * 3;
+  }
+
+  .docs-icons-next-dialog-sizes {
+    align-items: flex-end;
+    display: flex;
+    gap: $pt-spacing * 6;
+    margin-bottom: $pt-spacing * 6;
+  }
+
+  .docs-icons-next-dialog-size {
+    align-items: center;
+    color: $pt-icon-color;
+    display: flex;
+    flex-direction: column;
+    gap: $pt-spacing * 2;
+
+    .#{$ns}-dark & {
+      color: $pt-dark-icon-color;
+    }
+
+    .docs-icons-next-dialog-size-label {
+      font-size: $pt-font-size-small;
+    }
+  }
+
+  .docs-icons-next-code + .docs-icons-next-code {
+    margin-top: $pt-spacing * 4;
+  }
+
+  .docs-icons-next-code-header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: $pt-spacing * 1;
+  }
+
+  .docs-icons-next-code-block {
+    display: block;
+    overflow-x: auto;
+    padding: ($pt-spacing * 4) ($pt-spacing * 3);
+    white-space: nowrap;
+  }
+}
+
 .docs-icon-container,
 .docs-icon-spacer {
   height: $pt-spacing * 30;

--- a/packages/docs-app/src/tags/reactDocs.ts
+++ b/packages/docs-app/src/tags/reactDocs.ts
@@ -19,4 +19,5 @@
 export * from "../components/colorPalettes";
 export * from "../components/colorSchemes";
 export * from "../components/icons";
+export * from "../components/iconsNext";
 export * from "../components/welcome";

--- a/packages/docs-data/nav.json
+++ b/packages/docs-data/nav.json
@@ -97,7 +97,7 @@
     },
     {
         "package": "icons",
-        "pages": ["loading-icons", "icons-list"]
+        "pages": ["loading-icons", "icons-list", "next-icons"]
     },
     {
         "package": "select",

--- a/packages/icons/src/next-icons.mdx
+++ b/packages/icons/src/next-icons.mdx
@@ -1,0 +1,32 @@
+---
+title: Next icons
+tag: new
+---
+
+# Next icons
+
+<div class="@ns-callout @ns-intent-warning @ns-icon-warning-sign @ns-callout-has-body-content">
+
+**Experimental**
+
+These next-generation icons are experimental: names are stable, but the icon set and component API may change in upcoming 6.x releases.
+
+</div>
+
+`@blueprintjs/icons/next` is a full redesign of Blueprint's icon set. Every icon was redrawn in a
+single design language for a consistent look. These icons are built on a single 16px grid rather
+than separate 16px and 20px sizes. Many icons were also renamed to follow a more consistent naming scheme.
+
+Icons come in two styles, outlined and filled. Every icon has an outlined version, exported as
+`*Icon`. A subset also have a filled version, exported as `*FilledIcon`. Each is a React component
+imported by name, so bundlers include only the icons in use. Each renders an inline `<svg>` that
+inherits its color from `currentColor` and its size from a `size` prop (16px by default), so it picks
+up the surrounding text color and Blueprint intent classes automatically.
+
+@reactCodeExample NextIconUsageExample
+
+## Search next icons
+
+Browse the full set below. Filter by style, then search by name or by what an icon represents.
+
+@reactDocs IconsNext


### PR DESCRIPTION
## Summary

Stacked on #8175. Adds the static `@blueprintjs/icons/next` documentation page for the new static icon components.

The page introduces the experimental next-generation icon set, shows direct component usage, and adds a searchable browser with outlined/filled filtering, icon previews, size samples, and copyable import/usage snippets.

## Screenshots

[🔗 Preview](https://output.circle-artifacts.com/output/job/e0ba0c49-ca6b-4d3b-a6f7-5c9f2df67d48/artifacts/0/packages/docs-app/dist/index.html#icons/next-icons)

<img width="3456" height="1670" alt="Screenshot 2026-08-13 at 20 58 44@2x" src="https://github.com/user-attachments/assets/a1137e08-7d29-47be-b825-a48037fd030b" />

<img width="3456" height="1670" alt="Screenshot 2026-08-13 at 20 58 50@2x" src="https://github.com/user-attachments/assets/624c793e-a4b2-4944-8b28-5eb7d7b5195a" />

## Stack

0. Base PR (#8065)
1. assets + manifests (#8174)
2. static icon components (#8175)
3. **(this PR)** static icon docs
4. dynamic `IconNext` component (#8177)