### PR TITLE
[core] Icon: forward `color` prop to element icons

### DIFF
--- a/packages/core/src/components/icon/Icon.stories.tsx
+++ b/packages/core/src/components/icon/Icon.stories.tsx
@@ -117,7 +117,7 @@ export const ColorExample: Story = {
  * The `icon` prop accepts either a string icon name or a React element (typically an icon
  * component from `@blueprintjs/icons`). When an element is provided, `<Icon>` clones it and
  * merges the parent-provided `className` and intent class onto its root. It also forwards the
- * `size` prop onto it (the element's own `size` takes precedence).
+ * `color` and `size` props onto it (the element's own props take precedence).
  */
 export const ElementIcon: Story = {
     name: "Element icon",

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -92,6 +92,14 @@ describe("<Icon>", () => {
         assertIconColor(<Icon icon="add" color="red" />, "red");
     });
 
+    it("forwards color onto an element icon", async () => {
+        assertIconColor(<Icon icon={<GraphIcon />} color="red" />, "red");
+    });
+
+    it("element icon's own color takes precedence over the <Icon> color", async () =>
+        // non-regression: the element's explicit color wins over the forwarded one
+        assertIconColor(<Icon icon={<GraphIcon color="blue" />} color="red" />, "blue"));
+
     it("unknown icon name renders blank icon", async () => {
         const wrapper = mount(<Icon icon={"unknown" as any} />);
         wrapper.update();

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -58,7 +58,7 @@ export interface IconOwnProps {
      *   will render a blank icon to occupy space.
      * - If given a `React.JSX.Element`, that element will be rendered with the
      *   parent-provided `className`, intent class merged onto its root, and
-     *   `size` prop forwarded onto it (the element's own `size` takes
+     *   `color` and `size` props forwarded onto it (the element's own props take
      *   precedence). Other props on this component are ignored. This type is
      *   supported to simplify icon support in other Blueprint components. As a
      *   consumer, you should avoid using `<Icon icon={<Element />}` directly;
@@ -159,9 +159,11 @@ export const Icon: IconComponent = forwardRef(<T extends Element>(props: IconPro
     if (icon == null || typeof icon === "boolean") {
         return null;
     } else if (typeof icon !== "string") {
-        if (isValidElement<Pick<SVGIconProps, "className" | "size">>(icon)) {
+        if (isValidElement<Pick<SVGIconProps, "className" | "color" | "size">>(icon)) {
             return cloneElement(icon, {
                 className: classNames(icon.props.className, className, Classes.intentClass(intent)),
+                // Forward `color`, letting the element's own `color` take precedence.
+                color: icon.props.color ?? color,
                 // Forward `size`, letting the element's own `size` take precedence.
                 size: icon.props.size ?? props.size,
             });


### PR DESCRIPTION
## Summary

`<Icon>` respects the `color` prop for dynamic icons (`icon="home"`) but silently dropped it for static element icons (e.g. `icon={<Home />}`), which fell back to the inherited text color. This forwards `color` onto the cloned element so both forms render with the same fill. It's a direct follow-up to #8178, which did the same for `size`.

## Changes

- forward `color` onto cloned element icons. The element's own color takes precedence, so the change is non-regressive.
- scope is `color` only. `intent` and `className` are still applied as classes (unchanged)

## Example 

```tsx
<>
    <Icon icon="home" color="red" />                  // dynamic — always worked
    <Icon icon={<Home />} color="red" />              // static — was inherited color, now red  ← fix
    <Icon icon={<Home color="red" />} />              // color on element — always worked
    <Icon icon={<Home color="blue" />} color="red" /> // both set — element wins (blue)
</>
```

| Before | After |
|--------|--------|
| <img width="115"  alt="before" src="https://github.com/user-attachments/assets/fcec019a-8391-4318-bf72-2d44342c6efc" /> | <img width="115"  alt="after" src="https://github.com/user-attachments/assets/d8546623-0bda-4ae9-bd81-c05a61571a85" /> |


