### PR TITLE
Use next icons internally in components

### DIFF
--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -22,7 +22,7 @@
 
     &::after {
       background: svg-icon(
-        "16px/chevron-right.svg",
+        "next/outlined/chevron-right.svg",
         (
           path: (
             fill: $pt-icon-color,
@@ -92,7 +92,7 @@
 
   &::before {
     background: svg-icon(
-        "16px/more.svg",
+        "next/outlined/dots-three.svg",
         (
           path: (
             fill: $pt-icon-color,
@@ -121,7 +121,7 @@
 
   .#{$ns}-breadcrumbs > li::after {
     background: svg-icon(
-      "16px/chevron-right.svg",
+      "next/outlined/chevron-right.svg",
       (
         path: (
           fill: $pt-dark-icon-color,
@@ -144,7 +144,7 @@
 
     &::before {
       background: svg-icon(
-          "16px/more.svg",
+          "next/outlined/dots-three.svg",
           (
             path: (
               fill: $pt-dark-icon-color,

--- a/packages/core/src/components/callout/callout.test.tsx
+++ b/packages/core/src/components/callout/callout.test.tsx
@@ -16,7 +16,6 @@
 
 import { render, screen } from "@testing-library/react";
 
-import { IconNames } from "@blueprintjs/icons";
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
 import { Classes, Intent } from "../../common";
@@ -53,7 +52,7 @@ describe("<Callout>", () => {
     it(`should render the associated default icon when intent="primary"`, () => {
         const { container } = render(<Callout intent={Intent.PRIMARY} />);
 
-        expect(container.querySelector(`[data-icon="${IconNames.INFO_SIGN}"]`)).to.exist;
+        expect(container.querySelector(`[data-icon="circle-info"]`)).to.exist;
     });
 
     it("should remove intent icon when icon=null", () => {

--- a/packages/core/src/components/callout/callout.tsx
+++ b/packages/core/src/components/callout/callout.tsx
@@ -16,7 +16,8 @@
 
 import classNames from "classnames";
 
-import { Error, type IconName, InfoSign, type SVGIconProps, Tick, WarningSign } from "@blueprintjs/icons";
+import type { IconName, SVGIconProps } from "@blueprintjs/icons";
+import { CheckIcon, CircleExclamationIcon, CircleInfoIcon, TriangleExclamationIcon } from "@blueprintjs/icons/next";
 
 import {
     Classes,
@@ -118,13 +119,13 @@ const renderIcon = (icon?: CalloutProps["icon"], intent?: Intent): IconName | Ma
     // 3. icon specified by intent prop
     switch (intent) {
         case Intent.DANGER:
-            return <Error {...iconProps} />;
+            return <CircleExclamationIcon {...iconProps} />;
         case Intent.PRIMARY:
-            return <InfoSign {...iconProps} />;
+            return <CircleInfoIcon {...iconProps} />;
         case Intent.WARNING:
-            return <WarningSign {...iconProps} />;
+            return <TriangleExclamationIcon {...iconProps} />;
         case Intent.SUCCESS:
-            return <Tick {...iconProps} />;
+            return <CheckIcon {...iconProps} />;
         default:
             return undefined;
     }

--- a/packages/core/src/components/dialog/dialog.tsx
+++ b/packages/core/src/components/dialog/dialog.tsx
@@ -17,7 +17,8 @@
 import classNames from "classnames";
 import { useMemo, useRef } from "react";
 
-import { type IconName, IconSize, SmallCross } from "@blueprintjs/icons";
+import { type IconName, IconSize } from "@blueprintjs/icons";
+import { XIcon } from "@blueprintjs/icons/next";
 
 import { Classes, DISPLAYNAME_PREFIX, type MaybeElement, mergeRefs, type Props } from "../../common";
 import * as Errors from "../../common/errors";
@@ -175,7 +176,7 @@ export const Dialog: React.FC<DialogProps> & { displayName?: string } = props =>
                                 <Button
                                     aria-label="Close"
                                     className={Classes.DIALOG_CLOSE_BUTTON}
-                                    icon={<SmallCross size={IconSize.STANDARD} />}
+                                    icon={<XIcon />}
                                     onClick={onClose}
                                     variant="minimal"
                                 />

--- a/packages/core/src/components/drawer/drawer.tsx
+++ b/packages/core/src/components/drawer/drawer.tsx
@@ -16,7 +16,8 @@
 
 import classNames from "classnames";
 
-import { type IconName, IconSize, SmallCross } from "@blueprintjs/icons";
+import { type IconName, IconSize } from "@blueprintjs/icons";
+import { XIcon } from "@blueprintjs/icons/next";
 
 import { AbstractPureComponent, Classes, type Props } from "../../common";
 import * as Errors from "../../common/errors";
@@ -167,7 +168,7 @@ export class Drawer extends AbstractPureComponent<DrawerProps> {
                 <Button
                     aria-label="Close"
                     className={Classes.DIALOG_CLOSE_BUTTON}
-                    icon={<SmallCross size={IconSize.LARGE} />}
+                    icon={<XIcon size={IconSize.LARGE} />}
                     onClick={this.props.onClose}
                     variant="minimal"
                 />

--- a/packages/core/src/components/entity-title/entityTitle.tsx
+++ b/packages/core/src/components/entity-title/entityTitle.tsx
@@ -17,7 +17,8 @@
 import classNames from "classnames";
 import { createElement, forwardRef, useMemo } from "react";
 
-import { type IconName, IconNames } from "@blueprintjs/icons";
+import { type IconName } from "@blueprintjs/icons";
+import { SquareIcon } from "@blueprintjs/icons/next";
 
 import { Classes, DISPLAYNAME_PREFIX, type MaybeElement, type Props } from "../../common";
 import { H1, H2, H3, H4, H5, H6 } from "../html/html";
@@ -151,7 +152,7 @@ export const EntityTitle: React.FC<EntityTitleProps> = forwardRef<HTMLDivElement
                     <Icon
                         aria-hidden={true}
                         className={classNames(Classes.TEXT_MUTED, { [Classes.SKELETON]: loading })}
-                        icon={loading ? IconNames.SQUARE : icon}
+                        icon={loading ? <SquareIcon /> : icon}
                         tabIndex={-1}
                     />
                 </div>

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -248,7 +248,7 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
         // embed SVG icon image as backgroud-image above gradient.
         // the SVG image content is inlined into the CSS, so use this sparingly.
         background-image: svg-icon(
-          "16px/#{$icon}.svg",
+          "next/outlined/#{$icon}.svg",
           (
             path: (
               fill: $fill-color,
@@ -266,11 +266,11 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
     }
 
     input:checked ~ .#{$ns}-control-indicator {
-      @include indicator-inline-icon("small-tick");
+      @include indicator-inline-icon("check-small");
     }
 
     input:indeterminate ~ .#{$ns}-control-indicator {
-      @include indicator-inline-icon("small-minus");
+      @include indicator-inline-icon("minus-small");
     }
 
     input:disabled ~ .#{$ns}-control-indicator::before {
@@ -279,11 +279,11 @@ $control-indicator-spacing: $pt-spacing * 2 !default;
 
     @media (forced-colors: active) and (prefers-color-scheme: dark) {
       input:checked:not(:disabled) ~ .#{$ns}-control-indicator {
-        @include indicator-inline-icon("small-tick", $black);
+        @include indicator-inline-icon("check-small", $black);
       }
 
       input:indeterminate:not(:disabled) ~ .#{$ns}-control-indicator {
-        @include indicator-inline-icon("small-minus", $black);
+        @include indicator-inline-icon("minus-small", $black);
       }
 
       input:disabled ~ .#{$ns}-control-indicator {

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -16,7 +16,7 @@
 
 import classNames from "classnames";
 
-import { ChevronDown, ChevronUp } from "@blueprintjs/icons";
+import { ChevronDownIcon, ChevronUpIcon } from "@blueprintjs/icons/next";
 
 import {
     AbstractPureComponent,
@@ -439,7 +439,7 @@ export class NumericInput extends AbstractPureComponent<
                     aria-label="increment"
                     aria-controls={this.numericInputId}
                     disabled={disabled || isIncrementDisabled}
-                    icon={<ChevronUp />}
+                    icon={<ChevronUpIcon />}
                     intent={intent}
                     {...this.incrementButtonHandlers}
                 />
@@ -447,7 +447,7 @@ export class NumericInput extends AbstractPureComponent<
                     aria-label="decrement"
                     aria-controls={this.numericInputId}
                     disabled={disabled || isDecrementDisabled}
-                    icon={<ChevronDown />}
+                    icon={<ChevronDownIcon />}
                     intent={intent}
                     {...this.decrementButtonHandlers}
                 />

--- a/packages/core/src/components/hotkeys/keyComboTag.tsx
+++ b/packages/core/src/components/hotkeys/keyComboTag.tsx
@@ -18,17 +18,17 @@ import classNames from "classnames";
 import { Fragment, memo, useCallback } from "react";
 
 import {
-    ArrowDown,
-    ArrowLeft,
-    ArrowRight,
-    ArrowUp,
-    KeyCommand,
-    KeyControl,
-    KeyDelete,
-    KeyEnter,
-    KeyOption,
-    KeyShift,
-} from "@blueprintjs/icons";
+    ArrowDownIcon,
+    ArrowLeftIcon,
+    ArrowRightIcon,
+    ArrowTurnBottomLeftIcon,
+    ArrowUpIcon,
+    KeyCommandIcon,
+    KeyControlIcon,
+    KeyDeleteIcon,
+    KeyOptionIcon,
+    KeyShiftIcon,
+} from "@blueprintjs/icons/next";
 
 import { Classes, DISPLAYNAME_PREFIX, type Props } from "../../common";
 import { Icon } from "../icon/icon";
@@ -36,17 +36,17 @@ import { Icon } from "../icon/icon";
 import { isMac, normalizeKeyCombo } from "./hotkeyParser";
 
 const KEY_ICONS: Record<string, { icon: React.JSX.Element; iconTitle: string; isMacOnly?: boolean }> = {
-    alt: { icon: <KeyOption />, iconTitle: "Alt/Option key", isMacOnly: true },
-    arrowdown: { icon: <ArrowDown />, iconTitle: "Down key" },
-    arrowleft: { icon: <ArrowLeft />, iconTitle: "Left key" },
-    arrowright: { icon: <ArrowRight />, iconTitle: "Right key" },
-    arrowup: { icon: <ArrowUp />, iconTitle: "Up key" },
-    cmd: { icon: <KeyCommand />, iconTitle: "Command key", isMacOnly: true },
-    ctrl: { icon: <KeyControl />, iconTitle: "Control key", isMacOnly: true },
-    delete: { icon: <KeyDelete />, iconTitle: "Delete key" },
-    enter: { icon: <KeyEnter />, iconTitle: "Enter key" },
-    meta: { icon: <KeyCommand />, iconTitle: "Command key", isMacOnly: true },
-    shift: { icon: <KeyShift />, iconTitle: "Shift key", isMacOnly: true },
+    alt: { icon: <KeyOptionIcon />, iconTitle: "Alt/Option key", isMacOnly: true },
+    arrowdown: { icon: <ArrowDownIcon />, iconTitle: "Down key" },
+    arrowleft: { icon: <ArrowLeftIcon />, iconTitle: "Left key" },
+    arrowright: { icon: <ArrowRightIcon />, iconTitle: "Right key" },
+    arrowup: { icon: <ArrowUpIcon />, iconTitle: "Up key" },
+    cmd: { icon: <KeyCommandIcon />, iconTitle: "Command key", isMacOnly: true },
+    ctrl: { icon: <KeyControlIcon />, iconTitle: "Control key", isMacOnly: true },
+    delete: { icon: <KeyDeleteIcon />, iconTitle: "Delete key" },
+    enter: { icon: <ArrowTurnBottomLeftIcon />, iconTitle: "Enter key" },
+    meta: { icon: <KeyCommandIcon />, iconTitle: "Command key", isMacOnly: true },
+    shift: { icon: <KeyShiftIcon />, iconTitle: "Shift key", isMacOnly: true },
 };
 
 /** Reverse table of some CONFIG_ALIASES fields, for display by KeyComboTag */

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -17,7 +17,8 @@
 import classNames from "classnames";
 import { forwardRef } from "react";
 
-import { CaretDown, DoubleCaretVertical, type IconName, type SVGIconProps } from "@blueprintjs/icons";
+import type { IconName, SVGIconProps } from "@blueprintjs/icons";
+import { CaretDownIcon, CaretsVerticalIcon } from "@blueprintjs/icons/next";
 
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
 import { DISPLAYNAME_PREFIX, type OptionProps } from "../../common/props";
@@ -109,9 +110,9 @@ export const HTMLSelect: React.FC<HTMLSelectProps> = forwardRef((props, ref) => 
     const iconTitle = "Open dropdown";
     const endIcon =
         iconName === "double-caret-vertical" ? (
-            <DoubleCaretVertical title={iconTitle} {...iconProps} />
+            <CaretsVerticalIcon title={iconTitle} {...iconProps} />
         ) : (
-            <CaretDown title={iconTitle} {...iconProps} />
+            <CaretDownIcon title={iconTitle} {...iconProps} />
         );
 
     const optionChildren = options.map(option => {

--- a/packages/core/src/components/menu/menuItem.tsx
+++ b/packages/core/src/components/menu/menuItem.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import { createElement, forwardRef } from "react";
 
-import { CaretRight, SmallTick } from "@blueprintjs/icons";
+import { CaretRightIcon, CheckSmallIcon } from "@blueprintjs/icons/next";
 
 import { Classes } from "../../common";
 import { type ActionProps, DISPLAYNAME_PREFIX, removeNonHTMLProps } from "../../common/props";
@@ -264,7 +264,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             ...(disabled ? DISABLED_PROPS : {}),
             className: anchorClasses,
         },
-        isSelected ? <SmallTick className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
+        isSelected ? <CheckSmallIcon className={Classes.MENU_ITEM_SELECTED_ICON} /> : undefined,
         hasIcon ? (
             // wrap icon in a <span> in case `icon` is a custom element rather than a built-in icon identifier,
             // so that we always render this class and hide it from a screen reader
@@ -276,7 +276,7 @@ export const MenuItem: React.FC<MenuItemProps> = forwardRef<HTMLLIElement, MenuI
             {text}
         </Text>,
         maybeLabel,
-        hasSubmenu ? <CaretRight className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" /> : undefined,
+        hasSubmenu ? <CaretRightIcon className={Classes.MENU_SUBMENU_ICON} title="Open sub menu" /> : undefined,
     );
 
     const liClasses = classNames({ [Classes.MENU_SUBMENU]: hasSubmenu });

--- a/packages/core/src/components/tag/tagRemoveButton.tsx
+++ b/packages/core/src/components/tag/tagRemoveButton.tsx
@@ -16,7 +16,8 @@
 
 import { useCallback } from "react";
 
-import { IconSize, SmallCross } from "@blueprintjs/icons";
+import { IconSize } from "@blueprintjs/icons";
+import { XSmallIcon } from "@blueprintjs/icons/next";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 
@@ -43,7 +44,7 @@ export const TagRemoveButton = (props: TagRemoveButtonProps) => {
             onClick={handleRemoveClick}
             tabIndex={tabIndex}
         >
-            <SmallCross size={isLarge ? IconSize.LARGE : IconSize.STANDARD} />
+            <XSmallIcon size={isLarge ? IconSize.LARGE : IconSize.STANDARD} />
         </button>
     );
 };

--- a/packages/core/src/components/toast/toast.tsx
+++ b/packages/core/src/components/toast/toast.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import { forwardRef, useCallback, useEffect, useState } from "react";
 
-import { Cross } from "@blueprintjs/icons";
+import { XIcon } from "@blueprintjs/icons/next";
 
 import { Classes } from "../../common";
 import { DISPLAYNAME_PREFIX } from "../../common/props";
@@ -99,7 +99,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProps>((props, ref) => {
             </span>
             <ButtonGroup variant="minimal">
                 {action && <AnchorButton {...action} intent={undefined} onClick={handleActionClick} />}
-                {isCloseButtonShown && <Button aria-label="Close" icon={<Cross />} onClick={handleCloseClick} />}
+                {isCloseButtonShown && <Button aria-label="Close" icon={<XIcon />} onClick={handleCloseClick} />}
             </ButtonGroup>
         </div>
     );

--- a/packages/core/src/components/tree/treeNode.tsx
+++ b/packages/core/src/components/tree/treeNode.tsx
@@ -17,7 +17,7 @@
 import classNames from "classnames";
 import { Children, Component } from "react";
 
-import { ChevronRight } from "@blueprintjs/icons";
+import { ChevronRightIcon } from "@blueprintjs/icons/next";
 
 import { Classes, DISPLAYNAME_PREFIX } from "../../common";
 import { Collapse } from "../collapse/collapse";
@@ -104,7 +104,7 @@ export class TreeNode<T = {}> extends Component<TreeNodeProps<T>> {
                 isExpanded ? Classes.TREE_NODE_CARET_OPEN : Classes.TREE_NODE_CARET_CLOSED,
             );
             return (
-                <ChevronRight
+                <ChevronRightIcon
                     title={isExpanded ? "Collapse group" : "Expand group"}
                     className={caretClasses}
                     onClick={disabled === true ? undefined : this.handleCaretClick}

--- a/packages/datetime/src/components/react-day-picker/datePickerCaption.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerCaption.tsx
@@ -20,7 +20,7 @@ import { CaptionLabel, type CaptionProps, useDayPicker, useNavigation } from "re
 import innerText from "react-innertext";
 
 import { Button, DISPLAYNAME_PREFIX, HTMLSelect, type OptionProps } from "@blueprintjs/core";
-import { ChevronLeft, ChevronRight } from "@blueprintjs/icons";
+import { ChevronLeftIcon, ChevronRightIcon } from "@blueprintjs/icons/next";
 
 import { DateUtils, Months } from "../../common";
 import { DatePickerCaptionClasses as CaptionClasses, ReactDayPickerClasses } from "../../common/classes";
@@ -64,7 +64,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
                 CaptionClasses.DATEPICKER3_NAV_BUTTON_PREVIOUS,
             )}
             disabled={!previousMonth}
-            icon={<ChevronLeft />}
+            icon={<ChevronLeftIcon />}
             onClick={handlePreviousClick}
             variant="minimal"
         />
@@ -74,7 +74,7 @@ export const DatePickerCaption = (props: CaptionProps) => {
             aria-label={labels.labelNext(nextMonth, { locale })}
             className={classNames(CaptionClasses.DATEPICKER3_NAV_BUTTON, CaptionClasses.DATEPICKER3_NAV_BUTTON_NEXT)}
             disabled={!nextMonth}
-            icon={<ChevronRight />}
+            icon={<ChevronRightIcon />}
             onClick={handleNextClick}
             variant="minimal"
         />

--- a/packages/datetime/src/components/react-day-picker/datePickerNavIcons.tsx
+++ b/packages/datetime/src/components/react-day-picker/datePickerNavIcons.tsx
@@ -16,12 +16,12 @@
 
 import type { StyledComponent } from "react-day-picker";
 
-import { ChevronLeft, ChevronRight } from "@blueprintjs/icons";
+import { ChevronLeftIcon, ChevronRightIcon } from "@blueprintjs/icons/next";
 
 export function IconLeft({ children, ...props }: StyledComponent) {
-    return <ChevronLeft {...props} />;
+    return <ChevronLeftIcon {...props} />;
 }
 
 export function IconRight({ children, ...props }: StyledComponent) {
-    return <ChevronRight {...props} />;
+    return <ChevronRightIcon {...props} />;
 }

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -36,7 +36,7 @@ import {
     type TagInputProps,
     Utils,
 } from "@blueprintjs/core";
-import { Cross } from "@blueprintjs/icons";
+import { XIcon } from "@blueprintjs/icons/next";
 
 import { Classes, type ListItemsProps, type SelectPopoverProps } from "../../common";
 import { QueryList, type QueryListRendererProps } from "../query-list/queryList";
@@ -316,7 +316,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                 <Button
                     aria-label="Clear selected items"
                     disabled={disabled}
-                    icon={<Cross />}
+                    icon={<XIcon />}
                     onClick={this.handleClearButtonClick}
                     title="Clear selected items"
                     variant="minimal"

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import { PureComponent } from "react";
 
 import { DISPLAYNAME_PREFIX, InputGroup, type InputGroupProps, Overlay2, type OverlayProps } from "@blueprintjs/core";
-import { Search } from "@blueprintjs/icons";
+import { MagnifyingGlassIcon } from "@blueprintjs/icons/next";
 
 import { Classes, type ListItemsProps } from "../../common";
 import { QueryList, type QueryListRendererProps } from "../query-list/queryList";
@@ -99,7 +99,7 @@ export class Omnibar<T> extends PureComponent<OmnibarProps<T>> {
                 <div className={classNames(Classes.OMNIBAR, listProps.className)} {...handlers}>
                     <InputGroup
                         autoFocus={true}
-                        leftIcon={<Search />}
+                        leftIcon={<MagnifyingGlassIcon />}
                         placeholder="Search..."
                         size="large"
                         {...inputProps}

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -33,7 +33,7 @@ import {
     setRef,
     Utils,
 } from "@blueprintjs/core";
-import { Cross, Search } from "@blueprintjs/icons";
+import { MagnifyingGlassIcon, XIcon } from "@blueprintjs/icons/next";
 
 import { Classes, type ListItemsProps, type SelectPopoverProps } from "../../common";
 import { QueryList, type QueryListRendererProps } from "../query-list/queryList";
@@ -180,7 +180,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                 aria-activedescendant={listProps.activeItemId}
                 aria-autocomplete="list"
                 aria-expanded={this.state.isOpen}
-                leftIcon={<Search />}
+                leftIcon={<MagnifyingGlassIcon />}
                 placeholder={placeholder}
                 rightElement={this.maybeRenderClearButton(listProps.query)}
                 role="combobox"
@@ -267,7 +267,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         return query.length > 0 ? (
             <Button
                 aria-label="Clear filter query"
-                icon={<Cross />}
+                icon={<XIcon />}
                 onClick={this.resetQuery}
                 title="Clear filter query"
                 variant="minimal"

--- a/packages/table/src/cell/formats/truncatedFormat.tsx
+++ b/packages/table/src/cell/formats/truncatedFormat.tsx
@@ -18,7 +18,7 @@ import classNames from "classnames";
 import { PureComponent } from "react";
 
 import { DISPLAYNAME_PREFIX, PopoverNext, type Props } from "@blueprintjs/core";
-import { More } from "@blueprintjs/icons";
+import { DotsThreeIcon } from "@blueprintjs/icons/next";
 
 import * as Classes from "../../common/classes";
 import { Utils } from "../../common/utils";
@@ -241,7 +241,7 @@ export class TruncatedFormat extends PureComponent<TruncatedFormatProps, Truncat
                     rootBoundary="document"
                     shouldReturnFocusOnClose={false}
                 >
-                    <More />
+                    <DotsThreeIcon />
                 </PopoverNext>
             );
         } else {
@@ -249,7 +249,7 @@ export class TruncatedFormat extends PureComponent<TruncatedFormatProps, Truncat
             return (
                 // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
                 <span className={Classes.TABLE_TRUNCATED_POPOVER_TARGET} onClick={this.handlePopoverOpen}>
-                    <More />
+                    <DotsThreeIcon />
                 </span>
             );
         }


### PR DESCRIPTION
## Summary

Switches Blueprint's built-in components to render icons from `@blueprintjs/icons/next` instead of the legacy `@blueprintjs/icons` set. This is internal-only: no public API changes, and component props that accept icons continue to work as before. It moves the default visual language of the library onto the next-generation icon set introduced in #8174 / #8175.

## Changes

Component icon imports are repointed from `@blueprintjs/icons` to `@blueprintjs/icons/next`, which also adopts the new `*Icon` export naming. Most swaps are one-to-one, but the next set renames several glyphs, so the mapping is not always nominal.

### Non-mechanical changes

Two swaps go beyond a rename and are worth a closer look during review. In Dialog the close button drops its explicit `IconSize.STANDARD` and relies on the icon's default size. In EntityTitle the loading placeholder switches from the `IconNames.SQUARE` string identifier to a rendered `<SquareIcon />` element.

## Screenshots

### Breadcrumbs

| Before | After |
|--------|--------|
| <img width="350" alt="breadcrumbs-before" src="https://github.com/user-attachments/assets/5b5c1d7f-7e6e-4a29-ba36-d1192559db97" /> | <img width="350" alt="breadcrumbs-after" src="https://github.com/user-attachments/assets/4239d1cb-6c0c-4eac-abb1-710f956f6fc1" /> |

<img width="350" alt="breadcrumbs-diff" src="https://github.com/user-attachments/assets/bb0eef87-5803-4bf5-86c9-48b7f1b4d65d" />

### Callout

| Before | After |
|--------|--------|
| <img width="754" alt="callout-before" src="https://github.com/user-attachments/assets/dbe022ca-040d-41f8-bf03-bc7a54bd0230" /> | <img width="754" alt="callout-after" src="https://github.com/user-attachments/assets/b388e962-7123-4985-818e-b63dd1154abe" /> | 

<img width="754" alt="callout-diff" src="https://github.com/user-attachments/assets/179eaa2d-18a6-42ea-89ff-d342916a4873" />

### Checkbox

| Before | After |
|--------|--------|
| <img width="147" alt="checkbox-before" src="https://github.com/user-attachments/assets/8ef5d0a0-da19-46ab-8351-45f606015538" /> | <img width="147" alt="checkbox-after" src="https://github.com/user-attachments/assets/65759015-1441-4fe1-907b-beb839ffe154" /> |

<img width="147" alt="checkbox-diff" src="https://github.com/user-attachments/assets/fb768fb5-dc6d-46d5-8ff2-6c1a0683d571" />

### DatePicker

| Before | After |
|--------|--------|
| <img width="245" alt="dp-before" src="https://github.com/user-attachments/assets/e8549d8f-880a-4462-9f3c-94776e857a04" /> | <img width="245" alt="dp-after" src="https://github.com/user-attachments/assets/903a8518-373c-4c23-9272-6ec1b74bf416" /> |

<img width="245" alt="dp-diff" src="https://github.com/user-attachments/assets/f052b1a0-01ee-4edc-aa74-e6927b957300" />

### Dialog

| Before | After |
|--------|--------|
| <img width="537" alt="dialog-before" src="https://github.com/user-attachments/assets/a1fba94e-1e92-4c60-b8b3-9f5b329d7076" /> | <img width="537" alt="dialog-after" src="https://github.com/user-attachments/assets/c8d1546e-5f87-426e-a8b9-74e01bbfd301" /> |

<img width="537" alt="dialog-diff" src="https://github.com/user-attachments/assets/e82b7b8d-af94-4174-9514-cf2261d57c89" />

### Drawer

| Before | After |
|--------|--------|
| <img width="428" alt="drawer-before" src="https://github.com/user-attachments/assets/26541dba-30d0-4d42-998c-bd718378b512" /> | <img width="428" alt="drawer-after" src="https://github.com/user-attachments/assets/2686fbfd-29bf-45ee-b687-99b5f14d794f" /> |

<img width="428" alt="drawer-diff" src="https://github.com/user-attachments/assets/bf1f9408-7f12-4bfa-ad2e-fdfb03d3c6a6" />

### NumericInput

| Before | After |
|--------|--------|
| <img width="226" alt="ni-before" src="https://github.com/user-attachments/assets/4df7ce51-d2ae-45c4-9341-c36e9536aad1" /> | <img width="226" alt="ni-after" src="https://github.com/user-attachments/assets/ea008816-be7d-452b-b214-cd69ab2af8ea" /> |

<img width="226" alt="ni-diff" src="https://github.com/user-attachments/assets/5f61c431-2265-4eda-8247-837cba6b32cc" />

### HTMLSelect

| Before | After |
|--------|--------|
| <img width="88" alt="html-select-before" src="https://github.com/user-attachments/assets/f12c438f-361f-4ab2-b337-2012e71b350c" /> | <img width="88" alt="html-select-after" src="https://github.com/user-attachments/assets/9350ffb0-fce6-4e7c-a8eb-733934390395" /> |

<img width="88" alt="html-select-diff" src="https://github.com/user-attachments/assets/cf051be9-c696-4994-bf07-838ebefc6fe8" />

### KeyComboTag

| Before | After |
|--------|--------|
| <img width="262" alt="key-combo-before" src="https://github.com/user-attachments/assets/aa500dcc-3599-46ed-9e76-0f4fcc17bfe5" /> | <img width="262" alt="key-combo-after" src="https://github.com/user-attachments/assets/c34ceb8d-a2ba-4a6d-a7f8-a0875e1faef5" /> |

<img width="262" alt="key-combo-diff" src="https://github.com/user-attachments/assets/30e5812c-00a3-487c-9a76-ac62b3c467a8" />

### MenuItem

| Before | After |
|--------|--------|
| <img width="195" alt="menu-item-before" src="https://github.com/user-attachments/assets/c0c1b93e-255a-4d56-bb14-0f7fa27e633e" /> | <img width="195" alt="menu-item-after" src="https://github.com/user-attachments/assets/e21f4772-a964-4a8d-ade5-608397ee61cf" /> |

<img width="195" alt="menu-item-diff" src="https://github.com/user-attachments/assets/42c4a3cb-d8c3-4ba7-94df-caceb575a1d9" />

### Omnibar

| Before | After |
|--------|--------|
| <img width="533" alt="omnibar-before" src="https://github.com/user-attachments/assets/7b729bda-1eeb-41df-b432-4c575c2f050f" /> | <img width="533" alt="omnibar-after" src="https://github.com/user-attachments/assets/f0261053-3c88-4d76-82e2-5a796b11b2d9" /> |

<img width="533" alt="omnibar-diff" src="https://github.com/user-attachments/assets/61fd54ea-e995-4acf-b9c4-c9b42489f13b" />

### Select

| Before | After |
|--------|--------|
| <img width="440" alt="select-before" src="https://github.com/user-attachments/assets/b88a563f-c432-437c-851c-bc337e240490" /> | <img width="440" alt="select-after" src="https://github.com/user-attachments/assets/d938b895-b6b9-4e64-906c-816c3cfe9bcc" /> |

<img width="440" alt="select-diff" src="https://github.com/user-attachments/assets/2bd2b3ba-008e-4725-9826-bd2d01cbe17c" />

### Tag / CompundTag

| Before | After |
|--------|--------|
| <img width="153" alt="tag-before" src="https://github.com/user-attachments/assets/f50423c5-2c42-419c-953c-8f87e81c634d" /> | <img width="153" alt="tag-after" src="https://github.com/user-attachments/assets/d73bca6b-b769-4a26-a864-ee6200148aee" /> |

<img width="153" alt="tag-diff" src="https://github.com/user-attachments/assets/d3f6e097-528b-4d8e-adff-4db07b20f2dc" />

### Toast

| Before | After |
|--------|--------|
| <img width="317" alt="toast-before" src="https://github.com/user-attachments/assets/164415cc-f69c-4d68-9a33-f7c3da76e1af" /> | <img width="317" alt="toast-after" src="https://github.com/user-attachments/assets/587b5a05-c438-4d04-9dff-991b89fad463" /> |

<img width="317" alt="toast-diff" src="https://github.com/user-attachments/assets/46963e19-b836-4f9d-9b6a-a687973168ab" />

### Tree

| Before | After |
|--------|--------|
| <img width="398" alt="tree-before" src="https://github.com/user-attachments/assets/94a569f8-3c65-4b59-bf61-a77ccd047f00" /> | <img width="398" alt="tree-after" src="https://github.com/user-attachments/assets/9c75a5e4-f644-4f30-ba23-e3f8792f6ad2" /> |

<img width="398" alt="tree-diff" src="https://github.com/user-attachments/assets/e522612d-44fc-486e-b74b-8a44525b99d7" />

### TruncatedFormat

| Before | After |
|--------|--------|
| <img width="731" alt="truncated-before" src="https://github.com/user-attachments/assets/16d68f50-fd84-4d49-bded-e0574ba3e722" /> | <img width="731" alt="truncated-after" src="https://github.com/user-attachments/assets/b85e588c-c01d-4a4d-8404-408c77acaa1f" /> |

<img width="731" alt="truncated-diff" src="https://github.com/user-attachments/assets/b807b990-719b-4084-85f4-18bc354847f4" />