### PR TITLE
fix(popover-next): memoize mergeRefs in PopoverTarget to prevent infinite re-render loop

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8190.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8190.v2.yml
@@ -3,4 +3,4 @@ fix:
   description: "fix(popover-next): memoize mergeRefs in PopoverTarget to prevent infinite re-render loop"
   links:
     - href: https://github.com/palantir/blueprint/pull/8190
-      text: "8190"
+      text: 8190

--- a/packages/core/changelog/@unreleased/pr-8190.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8190.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "fix(popover-next): memoize mergeRefs in PopoverTarget to prevent infinite re-render loop"
+  links:
+    - href: https://github.com/palantir/blueprint/pull/8190
+      text: "8190"

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -3,7 +3,7 @@
  */
 
 import classNames from "classnames";
-import { Children, cloneElement, createElement, forwardRef, useCallback } from "react";
+import { Children, cloneElement, createElement, forwardRef, useCallback, useMemo } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Utils } from "../../common";
 import { PopoverInteractionKind } from "../popover/popoverProps";
@@ -37,7 +37,17 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     const tagName = fill ? "div" : targetTagName;
     const { isOpen } = floatingData;
 
-    const ref = mergeRefs(floatingData.refs.setReference, targetRef);
+    // Memoize the merged ref callback so its identity is stable across re-renders.
+    // Without memoization, a new callback is created on every render, causing React to
+    // call the old ref with null and the new ref with the DOM node on each cycle. This
+    // triggers a floating-ui state update → re-render → new ref → infinite loop.
+    // Blueprint's mergeRefs JSDoc warns: "If using in a functional component, would
+    // recommend using useMemo to preserve function identity."
+    const ref = useMemo(
+        () => mergeRefs(floatingData.refs.setReference, targetRef),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [floatingData.refs.setReference, targetRef],
+    );
 
     // Custom keyboard click handler for the reference element. Floating UI's useClick hook
     // has its keyboardHandlers disabled because it calls `preventDefault()` on Space keydown,


### PR DESCRIPTION
## Summary

Fixes #7857.

`PopoverTarget` calls `mergeRefs(floatingData.refs.setReference, targetRef)` unconditionally in the render body, creating a **new ref callback on every render**. React detects the identity change, tears down the old ref (calls it with `null`) and sets up the new one (calls it with the DOM node). This triggers a floating-ui internal state update, which causes another re-render, which produces yet another new ref callback — an infinite loop.

Blueprint's own `mergeRefs` JSDoc already warns:

> If using in a functional component, would recommend using `useMemo` to preserve function identity.

## Fix

Wrap the `mergeRefs(...)` call in `useMemo` with `[floatingData.refs.setReference, targetRef]` as dependencies. The merged ref is now only recreated when either underlying ref actually changes, keeping React's ref diffing stable between renders.

```tsx
const ref = useMemo(
    () => mergeRefs(floatingData.refs.setReference, targetRef),
    [floatingData.refs.setReference, targetRef],
);
```

## Test plan

- [ ] Open a page with a `PopoverNext` or `Tooltip` component
- [ ] Verify the popover opens/closes without triggering an infinite re-render loop (no React "Maximum update depth exceeded" error)
- [ ] Verify existing popover-next tests pass