### PR TITLE
fix(datetime): normalize date range order after time-picker change

### DIFF
--- a/packages/datetime/changelog/@unreleased/pr-8191.v2.yml
+++ b/packages/datetime/changelog/@unreleased/pr-8191.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "fix(datetime): ensure DateRangePicker time-picker changes emit chronologically ordered date ranges"
+  links:
+    - href: https://github.com/palantir/blueprint/pull/8191
+      text: "8191"

--- a/packages/datetime/changelog/@unreleased/pr-8191.v2.yml
+++ b/packages/datetime/changelog/@unreleased/pr-8191.v2.yml
@@ -3,4 +3,4 @@ fix:
   description: "fix(datetime): ensure DateRangePicker time-picker changes emit chronologically ordered date ranges"
   links:
     - href: https://github.com/palantir/blueprint/pull/8191
-      text: "8191"
+      text: 8191

--- a/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
@@ -267,12 +267,8 @@ export class DateRangePicker extends DateFnsLocalizedComponent<DateRangePickerPr
         const newTimeRange: DateRange = [time[0], time[1]];
         newTimeRange[dateIndex] = newTime;
 
-        // Ensure chronological order: the day-click path normalizes via boundary swap logic, but
-        // the time-picker path skips it. If adjusting the start time pushes it past the end (or
-        // vice versa), swap the boundaries so the range is always [earlier, later].
         const [start, end] = newDateRange;
-        const orderedDateRange: DateRange =
-            start != null && end != null && start > end ? [end, start] : newDateRange;
+        const orderedDateRange: DateRange = start != null && end != null && start > end ? [end, start] : newDateRange;
 
         this.props.onChange?.(orderedDateRange);
         this.setState({ time: newTimeRange, value: orderedDateRange });

--- a/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
+++ b/packages/datetime/src/components/date-range-picker/dateRangePicker.tsx
@@ -267,8 +267,15 @@ export class DateRangePicker extends DateFnsLocalizedComponent<DateRangePickerPr
         const newTimeRange: DateRange = [time[0], time[1]];
         newTimeRange[dateIndex] = newTime;
 
-        this.props.onChange?.(newDateRange);
-        this.setState({ time: newTimeRange, value: newDateRange });
+        // Ensure chronological order: the day-click path normalizes via boundary swap logic, but
+        // the time-picker path skips it. If adjusting the start time pushes it past the end (or
+        // vice versa), swap the boundaries so the range is always [earlier, later].
+        const [start, end] = newDateRange;
+        const orderedDateRange: DateRange =
+            start != null && end != null && start > end ? [end, start] : newDateRange;
+
+        this.props.onChange?.(orderedDateRange);
+        this.setState({ time: newTimeRange, value: orderedDateRange });
     };
 
     // When a user sets the time value before choosing a date, we need to pick a date for them


### PR DESCRIPTION
## Summary

Fixes #8122.

`DateRangePicker.handleTimeChange` builds a new `DateRange` after a time-picker interaction and passes it directly to `onChange` and `setState` without checking whether the start is still before the end. The day-click path runs through `DateRangeSelectionStrategy` which enforces chronological order via boundary-swap logic, but the time-picker path skips this entirely.

**Reproduction:** Select a range (e.g. Jan 1 – Jan 3), then use the left time-picker to move the start time past midnight so it becomes later than the end time. The emitted range is `[Jan 1 23:59, Jan 3 00:00]` when it should be `[Jan 3 00:00, Jan 1 23:59]` — i.e. the boundaries are reversed.

## Fix

After computing `newDateRange`, check whether `start > end` and swap the pair if so, exactly mirroring what the day-click path does:

```ts
const [start, end] = newDateRange;
const orderedDateRange: DateRange =
    start != null && end != null && start > end ? [end, start] : newDateRange;
```

Both `onChange` and `setState` now always receive a chronologically ordered range.

## Test plan

- [ ] Select a date range with the time-picker enabled
- [ ] Drag the start time past the end time — verify the emitted `onChange` value has `[earlier, later]` order
- [ ] Drag the end time before the start time — verify same ordering guarantee
- [ ] Verify existing `DateRangePicker` tests pass