### PR TITLE
fix(select): honour shouldDismissPopover={false} when item selected via Enter key

### DIFF
--- a/packages/select/changelog/@unreleased/pr-8192.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8192.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "fix(select): respect shouldDismissPopover={false} when selecting items via keyboard Enter"
+  links:
+    - href: https://github.com/palantir/blueprint/pull/8192
+      text: "8192"

--- a/packages/select/changelog/@unreleased/pr-8192.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8192.v2.yml
@@ -3,4 +3,4 @@ fix:
   description: "fix(select): respect shouldDismissPopover={false} when selecting items via keyboard Enter"
   links:
     - href: https://github.com/palantir/blueprint/pull/8192
-      text: "8192"
+      text: 8192

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -450,14 +450,6 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
         return null;
     };
 
-    /**
-     * Returns the DOM element corresponding to the currently active (keyboard-focused) list item,
-     * or `undefined` if there is no active item or the items parent is not yet mounted.
-     *
-     * This is intentionally public so that host components (e.g. `Select`) can inspect the active
-     * element's class list — for example to check `Classes.POPOVER_DISMISS` — when keyboard
-     * events don't originate from the menu item element itself.
-     */
     public getActiveElement(): HTMLElement | undefined {
         const { activeItem } = this.state;
         if (this.itemsParentRef != null) {

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -450,7 +450,15 @@ export class QueryList<T> extends AbstractComponent<QueryListProps<T>, QueryList
         return null;
     };
 
-    private getActiveElement() {
+    /**
+     * Returns the DOM element corresponding to the currently active (keyboard-focused) list item,
+     * or `undefined` if there is no active item or the items parent is not yet mounted.
+     *
+     * This is intentionally public so that host components (e.g. `Select`) can inspect the active
+     * element's class list — for example to check `Classes.POPOVER_DISMISS` — when keyboard
+     * events don't originate from the menu item element itself.
+     */
+    public getActiveElement(): HTMLElement | undefined {
         const { activeItem } = this.state;
         if (this.itemsParentRef != null) {
             if (isCreateNewItem(activeItem)) {

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -308,11 +308,13 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         const target = event?.target as HTMLElement;
-        // For click events the target is (or is inside) the menu item anchor, so we can walk up
-        // the DOM to find it. For keyboard Enter events the target is the popover content wrapper,
-        // not the menu item, so we fall back to querying the active element via QueryList.
+        // For click events the target is (or is inside) the menu-item anchor, so closest() finds
+        // it. For keyboard Enter events the target is the popover content wrapper; fall back to the
+        // active element from QueryList and find the inner anchor (POPOVER_DISMISS lives there).
         const menuItem =
-            target?.closest(`.${CoreClasses.MENU_ITEM}`) ?? this.queryList?.getActiveElement() ?? null;
+            target?.closest(`.${CoreClasses.MENU_ITEM}`) ??
+            this.queryList?.getActiveElement()?.querySelector(`.${CoreClasses.MENU_ITEM}`) ??
+            null;
         const menuItemDismiss = menuItem?.matches(`.${CoreClasses.POPOVER_DISMISS}`);
         const shouldDismiss = menuItemDismiss ?? true;
 

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -308,7 +308,11 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
 
     private handleItemSelect = (item: T, event?: React.SyntheticEvent<HTMLElement>) => {
         const target = event?.target as HTMLElement;
-        const menuItem = target?.closest(`.${CoreClasses.MENU_ITEM}`);
+        // For click events the target is (or is inside) the menu item anchor, so we can walk up
+        // the DOM to find it. For keyboard Enter events the target is the popover content wrapper,
+        // not the menu item, so we fall back to querying the active element via QueryList.
+        const menuItem =
+            target?.closest(`.${CoreClasses.MENU_ITEM}`) ?? this.queryList?.getActiveElement() ?? null;
         const menuItemDismiss = menuItem?.matches(`.${CoreClasses.POPOVER_DISMISS}`);
         const shouldDismiss = menuItemDismiss ?? true;
 


### PR DESCRIPTION
## Summary

Fixes #8079.

When a user presses Enter to select an item in `Select`, `QueryList.handleKeyUp` calls `handleItemSelect(activeItem, event)` where `event.target` is the popover content wrapper `<div>` — not the menu item anchor. `Select.handleItemSelect` uses:

```ts
const menuItem = target?.closest('.bp5-menu-item');
```

For keyboard events, this traversal finds nothing (the target is outside the menu item tree), so `menuItemDismiss` is `undefined` and `shouldDismiss` falls back to `true`. The popover always closes on Enter, **regardless of `shouldDismissPopover={false}` set on the `MenuItem`**.

The click path works correctly because the click target is the anchor element inside the menu item, so `.closest('.bp5-menu-item')` succeeds and `POPOVER_DISMISS` class check is evaluated.

## Fix

Two-part change:

1. **`queryList.tsx`**: Promote `getActiveElement()` from `private` to `public`. This method returns the DOM node of the currently keyboard-focused item using the `itemRefs` map or the items parent's children array.

2. **`select.tsx`**: Fall back to `this.queryList?.getActiveElement()` when `event.target.closest('.bp5-menu-item')` returns null. The `POPOVER_DISMISS` class check then works for both click and keyboard paths.

```ts
const menuItem =
    target?.closest(`.${CoreClasses.MENU_ITEM}`) ?? this.queryList?.getActiveElement() ?? null;
```

## Test plan

- [ ] Render a `Select` with a `MenuItem` that has `shouldDismissPopover={false}`
- [ ] Click the item — verify popover stays open
- [ ] Use arrow keys to navigate to that item, press Enter — verify popover stays open (previously it would close)
- [ ] Render a `Select` with normal items (no `shouldDismissPopover` override), press Enter — verify popover closes as before
- [ ] Run existing `select` package tests