### PR TITLE
fix(select): add missing ARIA attributes to Select combobox for screen reader accessibility

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8190.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8190.v2.yml
@@ -1,6 +1,0 @@
-type: fix
-fix:
-  description: "fix(popover-next): memoize mergeRefs in PopoverTarget to prevent infinite re-render loop"
-  links:
-    - href: https://github.com/palantir/blueprint/pull/8190
-      text: "8190"

--- a/packages/core/changelog/@unreleased/pr-8190.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8190.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "fix(popover-next): memoize mergeRefs in PopoverTarget to prevent infinite re-render loop"
+  links:
+    - href: https://github.com/palantir/blueprint/pull/8190
+      text: "8190"

--- a/packages/select/changelog/@unreleased/pr-8193.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8193.v2.yml
@@ -3,4 +3,4 @@ fix:
   description: "fix(select): add missing aria-controls and aria-activedescendant ARIA attributes to Select combobox"
   links:
     - href: https://github.com/palantir/blueprint/pull/8193
-      text: "8193"
+      text: 8193

--- a/packages/select/changelog/@unreleased/pr-8193.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8193.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "fix(select): add missing aria-controls and aria-activedescendant ARIA attributes to Select combobox"
+  links:
+    - href: https://github.com/palantir/blueprint/pull/8193
+      text: "8193"

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -179,6 +179,10 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
             <InputGroup
                 aria-activedescendant={listProps.activeItemId}
                 aria-autocomplete="list"
+                // aria-controls links this combobox input to the listbox it opens, which is required
+                // by the ARIA 1.1 combobox pattern so that screen readers can announce the relationship.
+                // Suggest already sets this correctly; Select was missing it.
+                aria-controls={this.listboxId}
                 aria-expanded={this.state.isOpen}
                 leftIcon={<SearchIcon />}
                 placeholder={placeholder}
@@ -241,9 +245,12 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                     ...targetProps,
                     "aria-disabled": disabled,
                     "aria-expanded": isOpen,
-                    // When filterable, the InputGroup inside is the combobox; this trigger is just a button
-                    // When not filterable, this trigger is the combobox
-                    ...(filterable ? { "aria-haspopup": "listbox" } : {}),
+                    // When filterable, the InputGroup inside is the combobox; this trigger is just a button.
+                    // When not filterable, this trigger IS the combobox and needs aria-activedescendant
+                    // so screen readers announce the currently focused item during keyboard navigation.
+                    ...(filterable
+                        ? { "aria-haspopup": "listbox" }
+                        : { "aria-activedescendant": listProps.activeItemId }),
                     // Note that we must set FILL here in addition to children to get the wrapper element to full width
                     className: classNames(targetProps.className, popoverTargetProps?.className, {
                         [CoreClasses.FILL]: this.props.fill,


### PR DESCRIPTION
## Summary

Fixes #8142.

`Select` was missing two ARIA attributes required by the [ARIA 1.1 combobox pattern](https://www.w3.org/TR/wai-aria-1.1/#combobox), both of which `Suggest` already implements correctly:

### 1. `aria-controls` missing on the filterable `InputGroup`

The `InputGroup` rendered when `filterable={true}` has `role="combobox"` but no `aria-controls` pointing to the listbox. Without this attribute, screen readers cannot announce which listbox the input controls or programmatically associate the two elements.

`Suggest` correctly sets `aria-controls={this.listboxId}` on its input. This PR adds the same to `Select`.

```tsx
<InputGroup
    aria-controls={this.listboxId}   // ← added
    role="combobox"
    ...
/>
```

### 2. `aria-activedescendant` missing on the non-filterable combobox target

When `filterable={false}`, the popover target wrapper has `role="combobox"` but was missing `aria-activedescendant`. Without it, screen readers cannot announce which option is currently keyboard-focused during arrow-key navigation.

```tsx
...(filterable
    ? { "aria-haspopup": "listbox" }
    : { "aria-activedescendant": listProps.activeItemId }),  // ← added for non-filterable
```

## Test plan

- [ ] Render `<Select filterable={true}>` and verify the input element has `aria-controls` matching the listbox `id`
- [ ] Render `<Select filterable={false}>` and use arrow keys; verify the target element's `aria-activedescendant` updates to the focused item's ID
- [ ] Run screen reader (VoiceOver / NVDA) over a filterable Select — verify it announces the listbox when the combobox is focused
- [ ] Run existing `select` package tests