### PR TITLE
feat(core) HTMLSelect: Add new `icon` prop

### DIFF
--- a/packages/core/src/components/html-select/HTMLSelect.stories.tsx
+++ b/packages/core/src/components/html-select/HTMLSelect.stories.tsx
@@ -6,9 +6,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { storybookLayoutDecorator, StoryLabel } from "@storybook-common";
 import { type ComponentProps } from "react";
 
+import { EndorsedIcon, type IconName } from "@blueprintjs/icons";
 import { Flex } from "@blueprintjs/labs";
 
-import { HTMLSelect, type HTMLSelectIconName } from "./htmlSelect";
+import { HTMLSelect } from "./htmlSelect";
 
 const SAMPLE_OPTIONS = [
     { label: "Option 1", value: "1" },
@@ -31,7 +32,7 @@ const meta: Meta<typeof HTMLSelect> = {
         large: false,
         minimal: false,
         disabled: false,
-        iconName: "double-caret-vertical",
+        icon: "double-caret-vertical",
     },
     argTypes: {
         fill: {
@@ -46,9 +47,9 @@ const meta: Meta<typeof HTMLSelect> = {
         disabled: {
             control: "boolean",
         },
-        iconName: {
+        icon: {
             control: "select",
-            options: ["double-caret-vertical", "caret-down"] satisfies HTMLSelectIconName[],
+            options: ["double-caret-vertical", "caret-down"] satisfies IconName[],
         },
         onChange: { action: "changed" },
         ...disabledArgs.reduce(
@@ -124,22 +125,30 @@ export const StateExample: Story = {
 };
 
 /**
- * Use the `iconName` prop to choose between the supported dropdown icons.
+ * Use the `icon` prop to render any Blueprint icon — or an icon element — on the right side of the select.
  */
 export const IconsExample: Story = {
     name: "Icons",
     argTypes: {
-        iconName: { table: { disable: true } },
+        icon: { table: { disable: true } },
     },
     render: args => (
         <Flex gap={2} alignItems="center">
             <Flex flexDirection="column" gap={1} alignItems="center">
-                <HTMLSelect {...args} iconName="double-caret-vertical" />
+                <HTMLSelect {...args} icon="double-caret-vertical" />
                 <StoryLabel title="double-caret-vertical" />
             </Flex>
             <Flex flexDirection="column" gap={1} alignItems="center">
-                <HTMLSelect {...args} iconName="caret-down" />
+                <HTMLSelect {...args} icon="caret-down" />
                 <StoryLabel title="caret-down" />
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
+                <HTMLSelect {...args} icon="filter" />
+                <StoryLabel title="filter" />
+            </Flex>
+            <Flex flexDirection="column" gap={1} alignItems="center">
+                <HTMLSelect {...args} icon={<EndorsedIcon />} />
+                <StoryLabel title="<EndorsedIcon />" />
             </Flex>
         </Flex>
     ),

--- a/packages/core/src/components/html-select/htmlSelect.test.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.test.tsx
@@ -22,6 +22,11 @@ import { type OptionProps } from "../../common";
 
 import { HTMLSelect } from "./htmlSelect";
 
+/** A stand-in for a consumer-provided icon component injected as a JSX element. */
+function CustomIcon() {
+    return <span data-testid="custom-icon" />;
+}
+
 describe("<HtmlSelect>", () => {
     it("renders options strings", () => {
         render(<HTMLSelect onChange={vi.fn()} options={["a", "b"]} />);
@@ -43,5 +48,52 @@ describe("<HtmlSelect>", () => {
         expect(screen.getByRole("option", { name: "c" })).toHaveValue("c");
         expect(screen.getByRole("option", { name: "c" })).toBeDisabled();
         expect(screen.getByRole("option", { name: "Dog" })).toHaveValue("d");
+    });
+
+    describe("icon", () => {
+        it("renders the double-caret-vertical icon by default", () => {
+            const { container } = render(<HTMLSelect onChange={vi.fn()} options={["a"]} />);
+            expect(container.querySelector('[data-icon="double-caret-vertical"]')).toBeInTheDocument();
+        });
+
+        it("renders a supported caret name passed via `icon`", () => {
+            const { container } = render(<HTMLSelect icon="caret-down" onChange={vi.fn()} options={["a"]} />);
+            expect(container.querySelector('[data-icon="caret-down"]')).toBeInTheDocument();
+            expect(container.querySelector('[data-icon="double-caret-vertical"]')).not.toBeInTheDocument();
+        });
+
+        it("accepts any icon name, not just the carets", () => {
+            const { container } = render(<HTMLSelect icon="filter" onChange={vi.fn()} options={["a"]} />);
+            expect(container.querySelector('[data-icon="filter"]')).toBeInTheDocument();
+        });
+
+        it("renders an injected icon element", () => {
+            render(<HTMLSelect icon={<CustomIcon />} onChange={vi.fn()} options={["a"]} />);
+            expect(screen.getByTestId("custom-icon")).toBeInTheDocument();
+        });
+
+        it("forwards `iconProps` to the icon", () => {
+            const { container } = render(
+                <HTMLSelect iconProps={{ className: "custom-icon-class" }} onChange={vi.fn()} options={["a"]} />,
+            );
+            expect(container.querySelector(".custom-icon-class")).toBeInTheDocument();
+        });
+
+        it("supports `iconName` prop", () => {
+            const { container } = render(
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                <HTMLSelect iconName="caret-down" onChange={vi.fn()} options={["a"]} />,
+            );
+            expect(container.querySelector('[data-icon="caret-down"]')).toBeInTheDocument();
+        });
+
+        it("prefers `icon` over deprecated `iconName`", () => {
+            const { container } = render(
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
+                <HTMLSelect icon="filter" iconName="caret-down" onChange={vi.fn()} options={["a"]} />,
+            );
+            expect(container.querySelector('[data-icon="filter"]')).toBeInTheDocument();
+            expect(container.querySelector('[data-icon="caret-down"]')).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -82,8 +82,6 @@ export interface HTMLSelectProps
     placeholder?: string;
 }
 
-// this component is simple enough that tests would be purely tautological.
-/* istanbul ignore next */
 /**
  * HTML select component
  *

--- a/packages/core/src/components/html-select/htmlSelect.tsx
+++ b/packages/core/src/components/html-select/htmlSelect.tsx
@@ -15,13 +15,14 @@
  */
 
 import classNames from "classnames";
-import { forwardRef } from "react";
+import { forwardRef, useMemo } from "react";
 
 import { CaretDownIcon, DoubleCaretVerticalIcon, type IconName, type SVGIconProps } from "@blueprintjs/icons";
 
 import { DISABLED, FILL, HTML_SELECT, LARGE, MINIMAL } from "../../common/classes";
-import { DISPLAYNAME_PREFIX, type OptionProps } from "../../common/props";
+import { DISPLAYNAME_PREFIX, type MaybeElement, type OptionProps } from "../../common/props";
 import type { Extends } from "../../common/utils";
+import { Icon } from "../icon/icon";
 
 export type HTMLSelectIconName = Extends<IconName, "double-caret-vertical" | "caret-down">;
 
@@ -37,9 +38,16 @@ export interface HTMLSelectProps
     fill?: boolean;
 
     /**
-     * Name of one of the supported icons for this component to display on the right side of the element.
+     * Name of a Blueprint icon (or an icon element) to render on the right side of the element.
      *
      * @default "double-caret-vertical"
+     */
+    icon?: IconName | MaybeElement;
+
+    /**
+     * Name of one of the supported icons for this component to display on the right side of the element.
+     *
+     * @deprecated use `icon` instead
      */
     iconName?: HTMLSelectIconName;
 
@@ -87,7 +95,9 @@ export const HTMLSelect: React.FC<HTMLSelectProps> = forwardRef((props, ref) => 
         children,
         disabled,
         fill,
-        iconName = "double-caret-vertical",
+        icon,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        iconName,
         iconProps,
         large,
         minimal,
@@ -106,18 +116,33 @@ export const HTMLSelect: React.FC<HTMLSelectProps> = forwardRef((props, ref) => 
         className,
     );
 
-    const iconTitle = "Open dropdown";
-    const endIcon =
-        iconName === "double-caret-vertical" ? (
-            <DoubleCaretVerticalIcon title={iconTitle} {...iconProps} />
-        ) : (
-            <CaretDownIcon title={iconTitle} {...iconProps} />
-        );
+    // `icon` takes precedence over the deprecated `iconName`.
+    const iconValue = icon !== undefined ? icon : iconName;
+    const endIcon = useMemo(() => {
+        const iconTitle = "Open dropdown";
+        if (iconValue === "double-caret-vertical" || iconValue === undefined) {
+            return <DoubleCaretVerticalIcon title={iconTitle} {...iconProps} />;
+        } else if (iconValue === "caret-down") {
+            return <CaretDownIcon title={iconTitle} {...iconProps} />;
+        } else {
+            return <Icon icon={iconValue} title={iconTitle} {...iconProps} />;
+        }
+    }, [iconValue, iconProps]);
 
-    const optionChildren = options.map(option => {
-        const optionProps: OptionProps = typeof option === "object" ? option : { value: option };
-        return <option {...optionProps} key={optionProps.value} children={optionProps.label || optionProps.value} />;
-    });
+    const optionChildren = useMemo(
+        () =>
+            options.map(option => {
+                const optionProps: OptionProps = typeof option === "object" ? option : { value: option };
+                return (
+                    <option
+                        {...optionProps}
+                        key={optionProps.value}
+                        children={optionProps.label || optionProps.value}
+                    />
+                );
+            }),
+        [options],
+    );
 
     return (
         <div className={classes}>

--- a/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
+++ b/packages/docs-app/src/examples/core-examples/htmlSelectExample.tsx
@@ -16,33 +16,19 @@
 
 import { useState } from "react";
 
-import {
-    Divider,
-    FormGroup,
-    H5,
-    HTMLSelect,
-    type HTMLSelectIconName,
-    Switch,
-} from "@blueprintjs/core";
-import {
-    Example,
-    type ExampleProps,
-    handleBooleanChange,
-    handleStringChange,
-} from "@blueprintjs/docs-theme";
+import { Divider, H5, HTMLSelect, type IconName, Switch } from "@blueprintjs/core";
+import { Example, type ExampleProps, handleBooleanChange } from "@blueprintjs/docs-theme";
 
-const SUPPORTED_ICON_NAMES: HTMLSelectIconName[] = ["double-caret-vertical", "caret-down"];
+import { IconSelect } from "./common/iconSelect";
 
 const SELECT_OPTIONS = ["One", "Two", "Three", "Four"];
 
 export const HTMLSelectExample: React.FC<ExampleProps> = props => {
     const [disabled, setDisabled] = useState(false);
     const [fill, setFill] = useState(false);
-    const [iconName, setIconName] = useState<HTMLSelectIconName>(undefined);
+    const [icon, setIcon] = useState<IconName>("double-caret-vertical");
     const [large, setLarge] = useState(false);
     const [minimal, setMinimal] = useState(false);
-
-    const handleIconChange = handleStringChange(value => setIconName(value as HTMLSelectIconName));
 
     const options = (
         <>
@@ -56,13 +42,7 @@ export const HTMLSelectExample: React.FC<ExampleProps> = props => {
                 onChange={handleBooleanChange(setDisabled)}
             />
             <Divider />
-            <FormGroup label="Icon">
-                <HTMLSelect
-                    onChange={handleIconChange}
-                    options={SUPPORTED_ICON_NAMES}
-                    placeholder="Choose an item..."
-                />
-            </FormGroup>
+            <IconSelect iconName={icon} onChange={setIcon} />
         </>
     );
 
@@ -71,7 +51,7 @@ export const HTMLSelectExample: React.FC<ExampleProps> = props => {
             <HTMLSelect
                 disabled={disabled}
                 fill={fill}
-                iconName={iconName}
+                icon={icon}
                 large={large}
                 minimal={minimal}
                 options={SELECT_OPTIONS}


### PR DESCRIPTION
## Summary

HTMLSelect's dropdown icon API surface was limited to `iconName`, which accepted only a very limited set of Blueprint-specific icons. This change adds a new `icon` prop that takes any `IconName` or an injected icon element in the same way other Blueprint components (e.g. Button) currently accept icons. The goal is to allow consumers use their own icons instead of being tied to Blueprint's set.

## Changes

- Adds `icon?: IconName | MaybeElement` to `HTMLSelectProps`. The `iconName` prop still remains but is now deprecated; if both are passed, `icon` wins. `HTMLSelectIconName` also remains exported.
- Updates docs and stories