### PR TITLE
[core] Fix: Setting input large line height using px instead of ratio

### DIFF
--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -171,7 +171,7 @@ $control-group-stack: (
 @mixin pt-input-large() {
   font-size: var(--bp-typography-size-body-large);
   height: calc(var(--bp-surface-spacing) * 10);
-  line-height: calc(var(--bp-typography-line-height-default) * 10);
+  line-height: calc(var(--bp-surface-spacing) * 10);
 
   &[type="search"],
   &.#{$ns}-round {


### PR DESCRIPTION
#### Fixes

There was a bug where `.bp6-input.bp6-large` shows as `calc(var(--bp-typography-line-height-default) * 10)` instead of `calc(var(--bp-surface-spacing) * 10)`. This defaulted to a very large height.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

* `pt-input-large` mixin will now use `var(--bp-surface-spacing)` variable (defined in px) to define the height of input.

#### Reviewers should focus on:

Large inputs should render correctly.

#### Screenshot

| Before | After |
| ----- | ----- |
| <img width="678" height="218" alt="Screenshot 2026-06-30 at 12 50 12" src="https://github.com/user-attachments/assets/9a629675-4421-41ff-9e38-a51a43582a25" /> | <img width="682" height="58" alt="Screenshot 2026-06-30 at 12 51 24" src="https://github.com/user-attachments/assets/da6d8142-44f6-4394-b4e3-cefc26d13bb5" /> |
