### PR TITLE
fix(PopoverTarget): memoize mergeRefs call to prevent infinite re-render loop

### DIFF
--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -3,7 +3,7 @@
  */
 
 import classNames from "classnames";
-import { Children, cloneElement, createElement, forwardRef, useCallback } from "react";
+import { Children, cloneElement, createElement, forwardRef, useCallback, useMemo } from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Utils } from "../../common";
 import { PopoverInteractionKind } from "../popover/popoverProps";
@@ -37,7 +37,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     const tagName = fill ? "div" : targetTagName;
     const { isOpen } = floatingData;
 
-    const ref = mergeRefs(floatingData.refs.setReference, targetRef);
+    const ref = useMemo(() => mergeRefs(floatingData.refs.setReference, targetRef), [floatingData.refs.setReference, targetRef]);
 
     // Custom keyboard click handler for the reference element. Floating UI's useClick hook
     // has its keyboardHandlers disabled because it calls `preventDefault()` on Space keydown,


### PR DESCRIPTION
## Description

In `PopoverTarget`, `mergeRefs` was called unconditionally in the render body, creating a new ref callback on every render. When React sees a changed ref callback, it invokes the previous one with `null` and the new one with the DOM node. For floating-ui's `setReference`, the `null` call triggers a state update → re-render → new `mergeRefs` → infinite loop, crashing with "Maximum update depth exceeded."

This fix wraps the `mergeRefs` call in `useMemo` so the ref identity is preserved across renders, matching the recommendation already documented in Blueprint's own `mergeRefs` JSDoc.

Fixes #7857

## Test plan

This is a runtime behavior fix — existing unit tests should continue to pass. The infinite loop is timing-dependent (requires parent re-renders that resolve synchronously, e.g. React Query / Redux cache hits on mount), so it's not easily covered by unit tests. Manual verification with a `PopoverNext` inside a component that re-renders synchronously on mount should confirm the fix.
