### PR TITLE
fix(core): Memoize refs in PopoverNext to prevent infinite re-render loop

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -4,7 +4,7 @@
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createRef } from "react";
+import { createRef, useState } from "react";
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
@@ -1723,6 +1723,36 @@ describe("<PopoverNext>", () => {
 
             expect(renderTarget).toHaveBeenCalled();
             expect(renderTarget.mock.calls[0][0].onClick).toBeUndefined();
+        });
+    });
+
+    // Regression test for https://github.com/palantir/blueprint/issues/7857
+    describe("ref stability", () => {
+        it("passes an identity-stable ref to the target across parent re-renders", async () => {
+            const seenRefs = new Set<unknown>();
+
+            function Wrapper() {
+                const [count, setCount] = useState(0);
+                return (
+                    <>
+                        <button data-testid="rerender" onClick={() => setCount(c => c + 1)}>
+                            {count}
+                        </button>
+                        <PopoverNext
+                            content="content"
+                            renderTarget={({ isOpen: _isOpen, ref, ...targetProps }) => {
+                                seenRefs.add(ref);
+                                return <button ref={ref} {...targetProps} />;
+                            }}
+                        />
+                    </>
+                );
+            }
+
+            render(<Wrapper />);
+            await userEvent.click(screen.getByTestId("rerender"));
+
+            expect(seenRefs.size).toBe(1);
         });
     });
 });

--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -2,10 +2,11 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import { useMergeRefs } from "@floating-ui/react";
 import classNames from "classnames";
 import { useRef } from "react";
 
-import { Classes, type HTMLDivProps, mergeRefs, Utils } from "../../common";
+import { Classes, type HTMLDivProps, Utils } from "../../common";
 import { Overlay2 } from "../overlay2/overlay2";
 import { PopoverArrow } from "../popover/popoverArrow";
 import { PopoverAnimation, PopoverInteractionKind } from "../popover/popoverProps";
@@ -109,6 +110,8 @@ export function PopoverPopup(props: PopoverPopupProps) {
         ? false
         : isClosingViaEscapeKeypress || props.shouldReturnFocusOnClose;
 
+    const ref = useMergeRefs([floatingData.refs.setFloating, transitionContainerElement]);
+
     return (
         <Overlay2
             // eslint-disable-next-line jsx-a11y/no-autofocus
@@ -137,7 +140,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
             <div
                 className={Classes.POPOVER_TRANSITION_CONTAINER}
                 style={floatingData.floatingStyles}
-                ref={mergeRefs(floatingData.refs.setFloating, transitionContainerElement)}
+                ref={ref}
                 {...popoverHandlers}
             >
                 <div className={popoverClasses} ref={popoverRef} style={{ transformOrigin }}>

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -2,10 +2,11 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
+import { useMergeRefs } from "@floating-ui/react";
 import classNames from "classnames";
 import { Children, cloneElement, createElement, forwardRef, useCallback } from "react";
 
-import { Classes, DISPLAYNAME_PREFIX, mergeRefs, Utils } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
 import { PopoverInteractionKind } from "../popover/popoverProps";
 import type { PopoverClickTargetHandlers, PopoverHoverTargetHandlers } from "../popover/popoverSharedProps";
 
@@ -37,7 +38,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     const tagName = fill ? "div" : targetTagName;
     const { isOpen } = floatingData;
 
-    const ref = mergeRefs(floatingData.refs.setReference, targetRef);
+    const ref = useMergeRefs([floatingData.refs.setReference, targetRef]);
 
     // Custom keyboard click handler for the reference element. Floating UI's useClick hook
     // has its keyboardHandlers disabled because it calls `preventDefault()` on Space keydown,


### PR DESCRIPTION
Fixes #7857

## Changes

`PopoverTarget` and `PopoverPopup` built their DOM callback ref by calling Blueprint's `mergeRefs(...)` directly in the render body. That helper returns a new function on every call, so each render gave React a different ref. React responds to a changed callback ref by calling the old one with `null` and the new one with the node, and that `null` call reaches Floating UI's `setReference`/`setFloating`, which updates state and triggers another render, which produces yet another ref. That loops until React throws "Maximum update depth exceeded".

The fix points the call sites at Floating UI's `useMergeRefs` hook, which memoizes the merged callback so its identity stays stable across renders.

Only `PopoverTarget` was reported in #7857. `PopoverPopup` had the same bug via `setFloating`, so it gets the same fix.

## Checklist

- [x] Includes tests
- [ ] Update documentation
