### PR TITLE
[core] NumericInput: fix invalid calc() shrinking spinner buttons

### DIFF
--- a/packages/core/src/components/forms/_numeric-input.scss
+++ b/packages/core/src/components/forms/_numeric-input.scss
@@ -5,7 +5,7 @@
   // we need a very-specific selector here to override specificicty of selectors defined elsewhere.
   .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
     // let the buttons shrink to equal heights
-    flex: 1 1 calc(var(--bp-surface-spacing) * 3 - 1);
+    flex: 1 1 calc(var(--bp-surface-spacing) * 2.75);
     min-height: 0;
     padding: 0;
     width: calc(var(--bp-surface-spacing) * 6);


### PR DESCRIPTION
## Problem

The vertical spinner (increment/decrement) buttons on `NumericInput` render a few pixels taller than the adjacent text input, so the button group no longer lines up with the field. This appeared after #7865 migrated the form SCSS to design tokens.

## Root Cause

#7865 translated the button `flex-basis` from the Sass expression `$pt-button-height-small * 0.5 - 1` (which evaluates to 11px) directly into `calc(var(--bp-surface-spacing) * 3 - 1)`. That `calc()` is invalid CSS: you can multiply a length by a unitless number, but you cannot subtract a unitless `1` from a length. The type mismatch makes the whole expression invalid, so the browser discards the entire `flex` shorthand declaration.

With `flex` dropped, the two stacked buttons fall back to the button-group default `flex: 0 0 auto` and stop shrinking to split the input's height between them, so each sizes to its own content and the pair ends up taller than the input. The old Sass math worked because Sass treats `12px - 1` as `11px`; CSS `calc()` does not.

## Solution

Replace the invalid expression with `calc(var(--bp-surface-spacing) * 2.75)`, which evaluates to the same intended 11px basis and parses as valid CSS. This restores the `flex: 1 1 11px` behavior so both buttons shrink equally to fill the input height.

## Result

The spinner button group matches the input height again across all size variants. No API or markup changes, CSS-only.

| Before | After |
|--------|--------|
| <img width="450" alt="before" src="https://github.com/user-attachments/assets/7ab67572-cc56-46d8-9886-6fd431a18f1b" /> | <img width="450" alt="after" src="https://github.com/user-attachments/assets/2ff12b41-f9f0-4814-85f1-86434182d5c4" /> | 

<img width="450" alt="diff" src="https://github.com/user-attachments/assets/32fbe883-62f1-4c64-a04d-f722ccf5fe52" />


