### PR TITLE
[core]: Remove redundant Sass interpolation from relative-color expressions

### DIFF
--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -1,6 +1,8 @@
 // Copyright 2015 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+/* stylelint-disable alpha-value-notation */
+
 @import "./card-variables";
 
 .#{$ns}-card {
@@ -41,7 +43,6 @@
   .#{$ns}-dark & {
     box-shadow:
       var(--bp-surface-shadow-1),
-      // stylelint-disable-next-line alpha-value-notation
       inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
       inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
@@ -58,7 +59,6 @@
   .#{$ns}-dark & {
     box-shadow:
       var(--bp-surface-shadow-2),
-      // stylelint-disable-next-line alpha-value-notation
       inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
       inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
@@ -75,7 +75,6 @@
   .#{$ns}-dark & {
     box-shadow:
       var(--bp-surface-shadow-3),
-      // stylelint-disable-next-line alpha-value-notation
       inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
       inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
@@ -92,7 +91,6 @@
   .#{$ns}-dark & {
     box-shadow:
       var(--bp-surface-shadow-4),
-      // stylelint-disable-next-line alpha-value-notation
       inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
       inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
@@ -115,7 +113,6 @@
     .#{$ns}-dark & {
       box-shadow:
         var(--bp-surface-shadow-3),
-        // stylelint-disable-next-line alpha-value-notation
         inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
         inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
     }
@@ -123,14 +120,12 @@
 
   &.#{$ns}-selected {
     box-shadow:
-      // stylelint-disable-next-line alpha-value-notation
       0 0 0 3px oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h / 0.2),
       0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h);
 
     &.#{$ns}-dark,
     .#{$ns}-dark & {
       box-shadow:
-        // stylelint-disable-next-line alpha-value-notation
         0 0 0 3px oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.4),
         0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h);
     }
@@ -144,7 +139,6 @@
     .#{$ns}-dark & {
       box-shadow:
         var(--bp-surface-shadow-1),
-        // stylelint-disable-next-line alpha-value-notation
         inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
         inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
     }

--- a/packages/core/src/components/card/_card.scss
+++ b/packages/core/src/components/card/_card.scss
@@ -15,7 +15,7 @@
   &.#{$ns}-dark,
   .#{$ns}-dark & {
     // stylelint-disable-next-line function-no-unknown
-    background-color: #{oklch(from var(--bp-intent-default-rest) calc(l * 0.54) calc(c * 0.481) h)};
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l * 0.54) calc(c * 0.481) h);
     box-shadow: var(--bp-surface-shadow-0);
   }
 
@@ -42,8 +42,8 @@
     box-shadow:
       var(--bp-surface-shadow-1),
       // stylelint-disable-next-line alpha-value-notation
-      inset 0 0 0.5px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)},
-      inset 0 0.5px 0 0 #{oklch(from var(--bp-palette-white) l c h / 0.08)};
+      inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
+      inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -59,8 +59,8 @@
     box-shadow:
       var(--bp-surface-shadow-2),
       // stylelint-disable-next-line alpha-value-notation
-      inset 0 0 0.5px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)},
-      inset 0 0.5px 0 0 #{oklch(from var(--bp-palette-white) l c h / 0.08)};
+      inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
+      inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -76,8 +76,8 @@
     box-shadow:
       var(--bp-surface-shadow-3),
       // stylelint-disable-next-line alpha-value-notation
-      inset 0 0 0.5px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)},
-      inset 0 0.5px 0 0 #{oklch(from var(--bp-palette-white) l c h / 0.08)};
+      inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
+      inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -93,8 +93,8 @@
     box-shadow:
       var(--bp-surface-shadow-4),
       // stylelint-disable-next-line alpha-value-notation
-      inset 0 0 0.5px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)},
-      inset 0 0.5px 0 0 #{oklch(from var(--bp-palette-white) l c h / 0.08)};
+      inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
+      inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
@@ -116,24 +116,23 @@
       box-shadow:
         var(--bp-surface-shadow-3),
         // stylelint-disable-next-line alpha-value-notation
-        inset 0 0 0.5px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)},
-        inset 0 0.5px 0 0 #{oklch(from var(--bp-palette-white) l c h / 0.08)};
+        inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
+        inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
     }
   }
 
   &.#{$ns}-selected {
     box-shadow:
       // stylelint-disable-next-line alpha-value-notation
-      0 0 0 3px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h / 0.2)},
-      0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)};
+      0 0 0 3px oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h / 0.2),
+      0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h);
 
     &.#{$ns}-dark,
     .#{$ns}-dark & {
       box-shadow:
         // stylelint-disable-next-line alpha-value-notation
-        0 0 0 3px
-          #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.4)},
-        0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h)};
+        0 0 0 3px oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.4),
+        0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h);
     }
   }
 
@@ -146,8 +145,8 @@
       box-shadow:
         var(--bp-surface-shadow-1),
         // stylelint-disable-next-line alpha-value-notation
-        inset 0 0 0.5px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)},
-        inset 0 0.5px 0 0 #{oklch(from var(--bp-palette-white) l c h / 0.08)};
+        inset 0 0 0.5px 0 oklch(from var(--bp-palette-white) l c h / 0.3),
+        inset 0 0.5px 0 0 oklch(from var(--bp-palette-white) l c h / 0.08);
     }
   }
 }

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -63,10 +63,10 @@ $control-group-stack: (
   $outer-shadow-focus-width: 1px
 ) {
   @if $focus {
-    @return inset 0 0 0 1px #{oklch(from #{$color} l c h / 0.752)},
-      0 0 0 #{$outer-shadow-focus-width} #{oklch(from #{$color} l c h / 0.752)};
+    @return inset 0 0 0 1px oklch(from $color l c h / 0.752),
+      0 0 0 #{$outer-shadow-focus-width} oklch(from $color l c h / 0.752);
   } @else {
-    @return 0 0 0 0 #{oklch(from #{$color} l c h / 0)}, 0 0 0 0 #{oklch(from #{$color} l c h / 0)};
+    @return 0 0 0 0 oklch(from $color l c h / 0), 0 0 0 0 oklch(from $color l c h / 0);
   }
 }
 
@@ -76,10 +76,10 @@ $control-group-stack: (
   $outer-shadow-focus-width: 1px
 ) {
   @if $focus {
-    @return inset 0 0 0 1px #{oklch(from #{$color} l c h / 0.752)},
-      0 0 0 #{$outer-shadow-focus-width} #{oklch(from #{$color} l c h / 0.752)};
+    @return inset 0 0 0 1px oklch(from $color l c h / 0.752),
+      0 0 0 #{$outer-shadow-focus-width} oklch(from $color l c h / 0.752);
   } @else {
-    @return 0 0 0 0 #{oklch(from #{$color} l c h / 0)}, 0 0 0 0 #{oklch(from #{$color} l c h / 0)};
+    @return 0 0 0 0 oklch(from $color l c h / 0), 0 0 0 0 oklch(from $color l c h / 0);
   }
 }
 
@@ -90,11 +90,10 @@ $control-group-stack: (
   border: none;
   border-radius: var(--bp-surface-border-radius);
   box-shadow:
-    inset 0 0 0 0
-      #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
-    0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0)"},
-    inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
-    inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
+    inset 0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0),
+    0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0),
+    inset 0 0 0 1px oklch(from var(--bp-palette-black) l c h / 0.2),
+    inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.3);
   color: var(--bp-typography-color-default-rest);
   font-size: var(--bp-typography-size-body-medium);
   font-weight: var(--bp-typography-weight-default);
@@ -110,10 +109,9 @@ $control-group-stack: (
   &.#{$ns}-active {
     box-shadow:
       inset 0 0 0 1px
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
-      0 0 0 1px
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
-      inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
+        oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752),
+      0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752),
+      inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.2);
   }
 
   &[type="search"],
@@ -130,11 +128,11 @@ $control-group-stack: (
     &:focus {
       box-shadow:
         inset 0 0 0 1px
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
+          oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752),
         0 0 0 1px
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
-        inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
-        inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
+          oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752),
+        inset 0 0 0 1px oklch(from var(--bp-palette-black) l c h / 0.2),
+        inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.3);
     }
   }
 
@@ -157,7 +155,7 @@ $control-group-stack: (
 }
 
 @mixin pt-input-disabled() {
-  background: #{"oklch(from var(--bp-intent-default-disabled) calc(l + 0.2) calc(c - 0.015) h / 0.5)"};
+  background: oklch(from var(--bp-intent-default-disabled) calc(l + 0.2) calc(c - 0.015) h / 0.5);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
   cursor: not-allowed;
@@ -193,46 +191,44 @@ $control-group-stack: (
 }
 
 @mixin pt-dark-input-disabled() {
-  background: #{oklch(from var(--bp-intent-default-hover) l c h / 0.5)};
+  background: oklch(from var(--bp-intent-default-hover) l c h / 0.5);
   box-shadow: none;
   color: var(--bp-typography-color-default-disabled);
 }
 
 @mixin pt-dark-input-placeholder() {
   &::placeholder {
-    color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
+    color: oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h);
   }
 }
 
 @mixin pt-dark-input() {
   @include pt-dark-input-placeholder;
-  background: #{oklch(from var(--bp-palette-black) l c h / 0.3)};
+  background: oklch(from var(--bp-palette-black) l c h / 0.3);
 
   box-shadow:
-    inset 0 0 0 0
-      #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
-    0 0 0 0 #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0)"},
-    inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
-    inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
-  color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.239) calc(c - 0.011) h)"};
+    inset 0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0),
+    0 0 0 0 oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0),
+    inset 0 0 0 1px oklch(from var(--bp-palette-white) l c h / 0.2),
+    inset 0 -1px 1px 0 oklch(from var(--bp-palette-white) l c h / 0.3);
+  color: oklch(from var(--bp-typography-color-default-rest) calc(l + 0.239) calc(c - 0.011) h);
 
   &:focus {
     box-shadow:
       inset 0 0 0 1px
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
-      0 0 0 1px
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"};
+        oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752),
+      0 0 0 1px oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752);
   }
 
   &[readonly] {
-    box-shadow: inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.4)};
+    box-shadow: inset 0 0 0 1px oklch(from var(--bp-palette-black) l c h / 0.4);
 
     &:focus {
       box-shadow:
         inset 0 0 0 1px
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
+          oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752),
         0 0 0 1px
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"};
+          oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752);
     }
   }
 
@@ -244,16 +240,16 @@ $control-group-stack: (
 
 @mixin pt-input-intent($color) {
   box-shadow:
-    inset 0 0 0 0 #{oklch(from $color l c h / 0)},
-    0 0 0 0 #{oklch(from $color l c h / 0)},
+    inset 0 0 0 0 oklch(from $color l c h / 0),
+    0 0 0 0 oklch(from $color l c h / 0),
     inset 0 0 0 1px $color,
-    inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.3)};
+    inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.3);
 
   &:focus {
     box-shadow:
-      inset 0 0 0 1px #{oklch(from $color l c h / 0.752)},
-      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color l c h / 0.752)},
-      inset 0 1px 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)};
+      inset 0 0 0 1px oklch(from $color l c h / 0.752),
+      0 0 0 calc(var(--bp-surface-spacing) * 0.5) oklch(from $color l c h / 0.752),
+      inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.2);
   }
 
   &[readonly] {
@@ -268,18 +264,18 @@ $control-group-stack: (
 
 @mixin pt-dark-input-intent($color) {
   box-shadow:
-    inset 0 0 0 0 #{oklch(from $color l c h / 0)},
-    0 0 0 0 #{oklch(from $color l c h / 0)},
+    inset 0 0 0 0 oklch(from $color l c h / 0),
+    0 0 0 0 oklch(from $color l c h / 0),
     inset 0 0 0 1px $color,
-    inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
-    inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
+    inset 0 0 0 1px oklch(from var(--bp-palette-white) l c h / 0.2),
+    inset 0 -1px 1px 0 oklch(from var(--bp-palette-white) l c h / 0.3);
 
   &:focus {
     box-shadow:
-      inset 0 0 0 1px #{oklch(from $color l c h / 0.752)},
-      0 0 0 calc(var(--bp-surface-spacing) * 0.5) #{oklch(from $color l c h / 0.752)},
-      inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
-      inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
+      inset 0 0 0 1px oklch(from $color l c h / 0.752),
+      0 0 0 calc(var(--bp-surface-spacing) * 0.5) oklch(from $color l c h / 0.752),
+      inset 0 0 0 1px oklch(from var(--bp-palette-white) l c h / 0.2),
+      inset 0 -1px 1px 0 oklch(from var(--bp-palette-white) l c h / 0.3);
   }
 
   &[readonly] {

--- a/packages/core/src/components/forms/_common.scss
+++ b/packages/core/src/components/forms/_common.scss
@@ -64,7 +64,7 @@ $control-group-stack: (
 ) {
   @if $focus {
     @return inset 0 0 0 1px oklch(from $color l c h / 0.752),
-      0 0 0 #{$outer-shadow-focus-width} oklch(from $color l c h / 0.752);
+      0 0 0 $outer-shadow-focus-width oklch(from $color l c h / 0.752);
   } @else {
     @return 0 0 0 0 oklch(from $color l c h / 0), 0 0 0 0 oklch(from $color l c h / 0);
   }
@@ -77,7 +77,7 @@ $control-group-stack: (
 ) {
   @if $focus {
     @return inset 0 0 0 1px oklch(from $color l c h / 0.752),
-      0 0 0 #{$outer-shadow-focus-width} oklch(from $color l c h / 0.752);
+      0 0 0 $outer-shadow-focus-width oklch(from $color l c h / 0.752);
   } @else {
     @return 0 0 0 0 oklch(from $color l c h / 0), 0 0 0 0 oklch(from $color l c h / 0);
   }

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -49,19 +49,19 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     &:focus + .#{$ns}-file-upload-input {
       box-shadow:
         inset 0 0 0 1px
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
+          oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752),
         0 0 0 1px
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752)"},
-        inset 0 1px 1px #{"oklch(from var(--bp-palette-black) l c h / 0.2)"};
+          oklch(from var(--bp-intent-primary-rest) calc(l - 0.074) calc(c - 0.018) h / 0.752),
+        inset 0 1px 1px oklch(from var(--bp-palette-black) l c h / 0.2);
 
       .#{$ns}-dark & {
         box-shadow:
           inset 0 0 0 1px
-            #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
+            oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752),
           0 0 0 1px
-            #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752)"},
-          inset 0 0 0 1px #{oklch(from var(--bp-palette-white) l c h / 0.2)},
-          inset 0 -1px 1px 0 #{oklch(from var(--bp-palette-white) l c h / 0.3)};
+            oklch(from var(--bp-intent-primary-rest) calc(l + 0.224) calc(c - 0.053) h / 0.752),
+          inset 0 0 0 1px oklch(from var(--bp-palette-white) l c h / 0.2),
+          inset 0 -1px 1px 0 oklch(from var(--bp-palette-white) l c h / 0.3);
       }
     }
   }
@@ -72,7 +72,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
     }
 
     .#{$ns}-dark & .#{$ns}-file-upload-input {
-      color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h)"};
+      color: oklch(from var(--bp-typography-color-default-rest) calc(l + 0.731) calc(c - 0.011) h);
     }
   }
 
@@ -98,7 +98,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 .#{$ns}-file-upload-input {
   @include pt-input;
   @include overflow-ellipsis;
-  color: #{oklch(from var(--bp-typography-color-muted) l c h / 0.6)};
+  color: oklch(from var(--bp-typography-color-muted) l c h / 0.6);
   left: 0;
   padding-right: calc($file-input-button-width + calc(var(--bp-surface-spacing) * 2));
   position: absolute;
@@ -157,7 +157,7 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 
   .#{$ns}-dark & {
     @include pt-dark-input;
-    color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h / 0.6)"};
+    color: oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h / 0.6);
 
     &::after {
       @include pt-dark-button-default-colors;
@@ -178,6 +178,6 @@ $file-input-button-padding-small: ($pt-input-height-small - $pt-button-height-sm
 /* stylelint-disable-next-line no-duplicate-selectors */
 .#{$ns}-file-upload-input::after {
   box-shadow:
-    inset 0 0 0 1px #{oklch(from var(--bp-palette-black) l c h / 0.2)},
-    0 1px 2px #{oklch(from var(--bp-palette-black) l c h / 0.1)};
+    inset 0 0 0 1px oklch(from var(--bp-palette-black) l c h / 0.2),
+    0 1px 2px oklch(from var(--bp-palette-black) l c h / 0.1);
 }

--- a/packages/core/src/components/forms/_file-input.scss
+++ b/packages/core/src/components/forms/_file-input.scss
@@ -1,6 +1,8 @@
 // Copyright 2016 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+/* stylelint-disable alpha-value-notation */
+
 @import "../../common/variables";
 @import "../button/common";
 @import "../../common/mixins";

--- a/packages/core/src/components/forms/_form-group.scss
+++ b/packages/core/src/components/forms/_form-group.scss
@@ -90,31 +90,31 @@
   .#{$ns}-dark & {
     &.#{$ns}-intent-primary {
       .#{$ns}-form-helper-text {
-        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
       }
     }
 
     &.#{$ns}-intent-success {
       .#{$ns}-form-helper-text {
-        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
+        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
       }
     }
 
     &.#{$ns}-intent-warning {
       .#{$ns}-form-helper-text {
-        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
+        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
       }
     }
 
     &.#{$ns}-intent-danger {
       .#{$ns}-form-helper-text {
-        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
+        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
       }
     }
 
     .#{$ns}-form-group-sub-label,
     .#{$ns}-form-helper-text {
-      color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
+      color: oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h);
     }
 
     &.#{$ns}-disabled {

--- a/packages/core/src/components/forms/_input-group.scss
+++ b/packages/core/src/components/forms/_input-group.scss
@@ -97,7 +97,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       // same goes for dark
       /* stylelint-disable-next-line selector-max-compound-selectors */
       .#{$ns}-dark & {
-        color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
+        color: oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h);
       }
 
       #{$icon-classes} {
@@ -196,7 +196,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
   .#{$ns}-dark & {
     .#{$ns}-icon {
-      color: #{"oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h)"};
+      color: oklch(from var(--bp-typography-color-muted) calc(l + 0.24) calc(c - 0.011) h);
     }
 
     &.#{$ns}-disabled .#{$ns}-icon {
@@ -210,7 +210,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)"}
+          oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)
         );
       }
     }
@@ -219,7 +219,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-primary-hover);
 
       .#{$ns}-dark & {
-        color: #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"};
+        color: oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h);
       }
     }
   }
@@ -230,7 +230,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"}
+          oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)
         );
       }
     }
@@ -239,7 +239,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-success-hover);
 
       .#{$ns}-dark & {
-        color: #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"};
+        color: oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h);
       }
     }
   }
@@ -250,7 +250,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)"}
+          oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)
         );
       }
     }
@@ -259,7 +259,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-warning-hover);
 
       .#{$ns}-dark & {
-        color: #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"};
+        color: oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h);
       }
     }
   }
@@ -270,7 +270,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
 
       .#{$ns}-dark & {
         @include pt-dark-input-intent(
-          #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)"}
+          oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)
         );
       }
     }
@@ -279,7 +279,7 @@ $input-button-height-small: $pt-button-height-smaller !default;
       color: var(--bp-intent-danger-hover);
 
       .#{$ns}-dark & {
-        color: #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"};
+        color: oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h);
       }
     }
   }

--- a/packages/core/src/components/forms/_input.scss
+++ b/packages/core/src/components/forms/_input.scss
@@ -28,7 +28,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)"}
+        oklch(from var(--bp-intent-primary-rest) calc(l + 0.095) calc(c - 0.004) h)
       );
     }
   }
@@ -38,7 +38,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)"}
+        oklch(from var(--bp-intent-success-rest) calc(l + 0.092) calc(c + 0.016) h)
       );
     }
   }
@@ -48,7 +48,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)"}
+        oklch(from var(--bp-intent-warning-rest) calc(l + 0.111) calc(c + 0.004) h)
       );
     }
   }
@@ -58,7 +58,7 @@
 
     .#{$ns}-dark & {
       @include pt-dark-input-intent(
-        #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)"}
+        oklch(from var(--bp-intent-danger-rest) calc(l + 0.098) calc(c - 0.02) h)
       );
     }
   }

--- a/packages/core/src/components/forms/_label.scss
+++ b/packages/core/src/components/forms/_label.scss
@@ -93,7 +93,7 @@ label.#{$ns}-label {
   }
 
   .#{$ns}-dark & {
-    color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.452) calc(c + -0.028) calc(h + 6.2))"};
+    color: oklch(from var(--bp-intent-default-rest) calc(l + 0.452) calc(c + -0.028) calc(h + 6.2));
 
     &.#{$ns}-disabled {
       &,

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -1,6 +1,8 @@
 // Copyright 2017 Palantir Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0.
 
+/* stylelint-disable alpha-value-notation */
+
 @import "../../common/variables";
 @import "../forms/common";
 @import "../tag/common";
@@ -122,7 +124,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     box-shadow: input-transition-shadow($input-shadow-color-focus, true), $input-box-shadow-focus;
 
     &.#{$ns}-intent-primary {
-      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
         0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
@@ -130,7 +131,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     &.#{$ns}-intent-success {
-      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
         0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
@@ -138,7 +138,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     &.#{$ns}-intent-warning {
-      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
         0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
@@ -146,7 +145,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     }
 
     &.#{$ns}-intent-danger {
-      /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
         inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
         0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
@@ -173,7 +171,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
         $pt-dark-input-box-shadow;
 
       &.#{$ns}-intent-primary {
-        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
           0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
@@ -181,7 +178,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       }
 
       &.#{$ns}-intent-success {
-        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
           0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
@@ -189,7 +185,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       }
 
       &.#{$ns}-intent-warning {
-        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
           0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
@@ -197,7 +192,6 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       }
 
       &.#{$ns}-intent-danger {
-        /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
           inset 0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
           0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),

--- a/packages/core/src/components/tag-input/_tag-input.scss
+++ b/packages/core/src/components/tag-input/_tag-input.scss
@@ -124,32 +124,32 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
     &.#{$ns}-intent-primary {
       /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
-        inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) l c h / 0.752)},
-        0 0 0 1px #{oklch(from var(--bp-intent-primary-rest) l c h / 0.752)},
+        inset 0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-primary-rest) l c h / 0.752),
         $input-box-shadow-focus;
     }
 
     &.#{$ns}-intent-success {
       /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
-        inset 0 0 0 1px #{oklch(from var(--bp-intent-success-rest) l c h / 0.752)},
-        0 0 0 1px #{oklch(from var(--bp-intent-success-rest) l c h / 0.752)},
+        inset 0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-success-rest) l c h / 0.752),
         $input-box-shadow-focus;
     }
 
     &.#{$ns}-intent-warning {
       /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
-        inset 0 0 0 1px #{oklch(from var(--bp-intent-warning-rest) l c h / 0.752)},
-        0 0 0 1px #{oklch(from var(--bp-intent-warning-rest) l c h / 0.752)},
+        inset 0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-warning-rest) l c h / 0.752),
         $input-box-shadow-focus;
     }
 
     &.#{$ns}-intent-danger {
       /* stylelint-disable-next-line alpha-value-notation */
       box-shadow:
-        inset 0 0 0 1px #{oklch(from var(--bp-intent-danger-rest) l c h / 0.752)},
-        0 0 0 1px #{oklch(from var(--bp-intent-danger-rest) l c h / 0.752)},
+        inset 0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
+        0 0 0 1px oklch(from var(--bp-intent-danger-rest) l c h / 0.752),
         $input-box-shadow-focus;
     }
   }
@@ -175,32 +175,32 @@ $tag-input-icon-padding-large: ($pt-input-height-large - $pt-icon-size-large) * 
       &.#{$ns}-intent-primary {
         /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
-          inset 0 0 0 1px #{oklch(from var(--bp-intent-primary-hover) l c h / 0.752)},
-          0 0 0 1px #{oklch(from var(--bp-intent-primary-hover) l c h / 0.752)},
+          inset 0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-primary-hover) l c h / 0.752),
           $pt-dark-input-box-shadow;
       }
 
       &.#{$ns}-intent-success {
         /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
-          inset 0 0 0 1px #{oklch(from var(--bp-intent-success-hover) l c h / 0.752)},
-          0 0 0 1px #{oklch(from var(--bp-intent-success-hover) l c h / 0.752)},
+          inset 0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-success-hover) l c h / 0.752),
           $pt-dark-input-box-shadow;
       }
 
       &.#{$ns}-intent-warning {
         /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
-          inset 0 0 0 1px #{oklch(from var(--bp-intent-warning-hover) l c h / 0.752)},
-          0 0 0 1px #{oklch(from var(--bp-intent-warning-hover) l c h / 0.752)},
+          inset 0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-warning-hover) l c h / 0.752),
           $pt-dark-input-box-shadow;
       }
 
       &.#{$ns}-intent-danger {
         /* stylelint-disable-next-line alpha-value-notation */
         box-shadow:
-          inset 0 0 0 1px #{oklch(from var(--bp-intent-danger-hover) l c h / 0.752)},
-          0 0 0 1px #{oklch(from var(--bp-intent-danger-hover) l c h / 0.752)},
+          inset 0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
+          0 0 0 1px oklch(from var(--bp-intent-danger-hover) l c h / 0.752),
           $pt-dark-input-box-shadow;
       }
     }

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -40,10 +40,10 @@ $tag-intent-colors: (
     var(--bp-intent-success-foreground),
   ),
   "warning": (
-    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h)"},
-    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h)"},
-    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.20) calc(c + 0.05) h)"},
-    #{"oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h)"},
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.19) c h),
+    oklch(from var(--bp-intent-warning-hover) calc(l + 0.24) c h),
+    oklch(from var(--bp-intent-warning-active) calc(l + 0.2) calc(c + 0.05) h),
+    oklch(from var(--bp-intent-warning-foreground) calc(l + 0.05) c h),
   ),
   "danger": (
     var(--bp-intent-danger-rest),
@@ -79,23 +79,23 @@ $minimal-tag-intent-colors: (
 $minimal-dark-tag-intent-colors: (
   "primary": (
     var(--bp-intent-primary-rest),
-    #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h)"},
-    #{"oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h)"},
+    oklch(from var(--bp-intent-primary-rest) calc(l + 0.22) calc(c - 0.02) h),
+    oklch(from var(--bp-intent-primary-rest) calc(l + 0.3) calc(c - 0.04) h),
   ),
   "success": (
     var(--bp-intent-success-rest),
-    #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h)"},
-    #{"oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h)"},
+    oklch(from var(--bp-intent-success-rest) calc(l + 0.25) calc(c - 0.03) h),
+    oklch(from var(--bp-intent-success-rest) calc(l + 0.33) calc(c - 0.05) h),
   ),
   "warning": (
     var(--bp-intent-warning-rest),
-    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h)"},
-    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h)"},
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.18) calc(c - 0.02) h),
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.26) calc(c - 0.04) h),
   ),
   "danger": (
     var(--bp-intent-danger-rest),
-    #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h)"},
-    #{"oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h)"},
+    oklch(from var(--bp-intent-danger-rest) calc(l + 0.2) calc(c - 0.02) h),
+    oklch(from var(--bp-intent-danger-rest) calc(l + 0.28) calc(c - 0.04) h),
   ),
 ) !default;
 
@@ -190,7 +190,7 @@ $minimal-dark-tag-intent-colors: (
 
   .#{$ns}-tag-remove {
     /* stylelint-disable-next-line alpha-value-notation */
-    color: #{"oklch(from "}#{$text-color}#{" l c h / 0.7)"};
+    color: oklch(from $text-color l c h / 0.7);
 
     &:hover,
     &:active {
@@ -206,12 +206,12 @@ $minimal-dark-tag-intent-colors: (
 
   &:not([class*="#{$ns}-intent-"]) {
     @include pt-tag-minimal-interactive(
-      #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
+      oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
       var(--bp-palette-black)
     );
 
     /* stylelint-disable-next-line alpha-value-notation */
-    background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
+    background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
     color: var(--bp-typography-color-default-rest);
 
     .#{$ns}-tag-remove {
@@ -226,20 +226,20 @@ $minimal-dark-tag-intent-colors: (
     .#{$ns}-dark &,
     [data-bp-color-scheme="dark"] & {
       @include pt-tag-minimal-interactive(
-        #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h)"},
+        oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h),
         var(--bp-palette-white)
       );
 
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15)"};
-      color: #{"oklch(from var(--bp-typography-color-default-rest) calc(l + 0.24) c h)"};
+      background-color: oklch(from var(--bp-intent-default-rest) calc(l + 0.16) c h / 0.15);
+      color: oklch(from var(--bp-typography-color-default-rest) calc(l + 0.24) c h);
 
       .#{$ns}-tag-remove {
         color: var(--bp-typography-color-muted);
 
         &:hover,
         &:active {
-          color: #{"oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h)"};
+          color: oklch(from var(--bp-typography-color-default-hover) calc(l + 0.35) c h);
         }
       }
     }
@@ -252,14 +252,14 @@ $minimal-dark-tag-intent-colors: (
 
     &:hover {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+      background-color: oklch(from $background-color l c h / 0.3);
       color: $text-color;
     }
 
     &.#{$ns}-active,
     &:active {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
+      background-color: oklch(from $background-color l c h / 0.35);
       color: $text-color;
     }
   }
@@ -267,7 +267,7 @@ $minimal-dark-tag-intent-colors: (
 
 @mixin pt-tag-minimal-intent($background-color, $text-color, $hover-active-text-color) {
   /* stylelint-disable-next-line alpha-value-notation */
-  background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.1)"};
+  background-color: oklch(from $background-color l c h / 0.1);
   color: $text-color;
 
   > #{$icon-classes} {
@@ -277,14 +277,14 @@ $minimal-dark-tag-intent-colors: (
   &.#{$ns}-interactive {
     &:hover {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
+      background-color: oklch(from $background-color l c h / 0.2);
       color: $hover-active-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+      background-color: oklch(from $background-color l c h / 0.3);
       color: $hover-active-text-color;
     }
   }
@@ -301,20 +301,20 @@ $minimal-dark-tag-intent-colors: (
 
 @mixin pt-tag-minimal-dark-intent($background-color, $text-color, $hover-active-text-color) {
   /* stylelint-disable-next-line alpha-value-notation */
-  background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.2)"};
+  background-color: oklch(from $background-color l c h / 0.2);
   color: $text-color;
 
   &.#{$ns}-interactive {
     &:hover {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.3)"};
+      background-color: oklch(from $background-color l c h / 0.3);
       color: $hover-active-text-color;
     }
 
     &:active,
     &.#{$ns}-active {
       /* stylelint-disable-next-line alpha-value-notation */
-      background-color: #{"oklch(from "}#{$background-color}#{" l c h / 0.35)"};
+      background-color: oklch(from $background-color l c h / 0.35);
       color: $hover-active-text-color;
     }
   }
@@ -333,7 +333,7 @@ $minimal-dark-tag-intent-colors: (
   background: none;
   border: none;
   /* stylelint-disable-next-line alpha-value-notation */
-  color: #{"oklch(from var(--bp-intent-default-foreground) l c h / 0.7)"};
+  color: oklch(from var(--bp-intent-default-foreground) l c h / 0.7);
   cursor: pointer;
   display: flex;
   margin-bottom: calc(var(--bp-surface-spacing) * -0.5);
@@ -424,14 +424,14 @@ $minimal-dark-tag-intent-colors: (
 @mixin minimal-compound-tag-colors($base-color) {
   /* stylelint-disable alpha-value-notation */
   $left-colors: (
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"}
+    oklch(from $base-color l c h / 0.2),
+    oklch(from $base-color l c h / 0.3),
+    oklch(from $base-color l c h / 0.4)
   );
   $right-colors: (
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.1)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"}
+    oklch(from $base-color l c h / 0.1),
+    oklch(from $base-color l c h / 0.2),
+    oklch(from $base-color l c h / 0.3)
   );
   /* stylelint-enable alpha-value-notation */
 
@@ -441,14 +441,14 @@ $minimal-dark-tag-intent-colors: (
 @mixin dark-minimal-compound-tag-colors($base-color) {
   /* stylelint-disable alpha-value-notation */
   $left-colors: (
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.4)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.5)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.55)"}
+    oklch(from $base-color l c h / 0.4),
+    oklch(from $base-color l c h / 0.5),
+    oklch(from $base-color l c h / 0.55)
   );
   $right-colors: (
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.2)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.3)"},
-    #{"oklch(from "}#{$base-color}#{" l c h / 0.35)"}
+    oklch(from $base-color l c h / 0.2),
+    oklch(from $base-color l c h / 0.3),
+    oklch(from $base-color l c h / 0.35)
   );
   /* stylelint-enable alpha-value-notation */
 

--- a/packages/core/src/components/tag/_compound-tag.scss
+++ b/packages/core/src/components/tag/_compound-tag.scss
@@ -13,9 +13,9 @@ Compound Tags
 
 // some of these values are copied from _common.scss, but our mixins have a different shape here
 $compound-tag-left-default-colors: (
-  #{"oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h)"},
-  #{"oklch(from var(--bp-intent-default-hover) calc(l - 0.05) c h)"},
-  #{"oklch(from var(--bp-intent-default-active) calc(l - 0.03) c h)"}
+  oklch(from var(--bp-intent-default-rest) calc(l - 0.14) c h),
+  oklch(from var(--bp-intent-default-hover) calc(l - 0.05) c h),
+  oklch(from var(--bp-intent-default-active) calc(l - 0.03) c h)
 ) !default;
 $compound-tag-right-default-colors: (
   var(--bp-intent-default-rest),
@@ -26,24 +26,24 @@ $compound-tag-right-default-colors: (
 // one shade darker than $tag-intent-colors
 $compound-tag-left-intent-colors: (
   "primary": (
-    #{"oklch(from var(--bp-intent-primary-rest) calc(l - 0.06) c h)"},
-    #{"oklch(from var(--bp-intent-primary-hover) calc(l - 0.07) c h)"},
-    #{"oklch(from var(--bp-intent-primary-active) calc(l - 0.07) c h)"},
+    oklch(from var(--bp-intent-primary-rest) calc(l - 0.06) c h),
+    oklch(from var(--bp-intent-primary-hover) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-primary-active) calc(l - 0.07) c h),
   ),
   "success": (
-    #{"oklch(from var(--bp-intent-success-rest) calc(l - 0.07) c h)"},
-    #{"oklch(from var(--bp-intent-success-hover) calc(l - 0.07) c h)"},
-    #{"oklch(from var(--bp-intent-success-active) calc(l - 0.09) c h)"},
+    oklch(from var(--bp-intent-success-rest) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-success-hover) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-success-active) calc(l - 0.09) c h),
   ),
   "warning": (
-    #{"oklch(from var(--bp-intent-warning-rest) calc(l + 0.11) c h)"},
-    #{"oklch(from var(--bp-intent-warning-hover) calc(l + 0.13) c h)"},
-    #{"oklch(from var(--bp-intent-warning-active) calc(l + 0.08) c h)"},
+    oklch(from var(--bp-intent-warning-rest) calc(l + 0.11) c h),
+    oklch(from var(--bp-intent-warning-hover) calc(l + 0.13) c h),
+    oklch(from var(--bp-intent-warning-active) calc(l + 0.08) c h),
   ),
   "danger": (
-    #{"oklch(from var(--bp-intent-danger-rest) calc(l - 0.07) c h)"},
-    #{"oklch(from var(--bp-intent-danger-hover) calc(l - 0.05) c h)"},
-    #{"oklch(from var(--bp-intent-danger-active) calc(l - 0.04) c h)"},
+    oklch(from var(--bp-intent-danger-rest) calc(l - 0.07) c h),
+    oklch(from var(--bp-intent-danger-hover) calc(l - 0.05) c h),
+    oklch(from var(--bp-intent-danger-active) calc(l - 0.04) c h),
   ),
 ) !default;
 


### PR DESCRIPTION
## Summary
- Unwrap `#{…}` / `#{"…"}` from relative-color expressions leaving bare `oklch(from var(--…) …)`.
- No behavior change: compiled CSS should be functionally identical
