### PR TITLE
[core] Icon: revert size/color prop forwarding to element icons

### DIFF
--- a/packages/core/src/components/icon/Icon.stories.tsx
+++ b/packages/core/src/components/icon/Icon.stories.tsx
@@ -116,8 +116,7 @@ export const ColorExample: Story = {
 /**
  * The `icon` prop accepts either a string icon name or a React element (typically an icon
  * component from `@blueprintjs/icons`). When an element is provided, `<Icon>` clones it and
- * merges the parent-provided `className` and intent class onto its root. It also forwards the
- * `color` and `size` props onto it (the element's own props take precedence).
+ * merges the parent-provided `className` and intent class onto its root.
  */
 export const ElementIcon: Story = {
     name: "Element icon",
@@ -128,7 +127,7 @@ export const ElementIcon: Story = {
                 <StoryLabel title='icon="buggy"' />
             </Flex>
             <Flex flexDirection="column" gap={1} alignItems="center">
-                <Icon {...args} icon={<Buggy />} />
+                <Icon {...args} icon={<Buggy size={args.size} />} />
                 <StoryLabel title="icon={<Buggy />}" />
             </Flex>
         </Flex>

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -16,7 +16,7 @@
 
 import { mount } from "enzyme";
 
-import { GraphIcon, type IconName, Icons, IconSize } from "@blueprintjs/icons";
+import { type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 import { afterEach, beforeAll, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
@@ -62,19 +62,6 @@ describe("<Icon>", () => {
     it("size=20 renders large size", async () =>
         assertIconSize(<Icon icon="graph" size={IconSize.LARGE} />, IconSize.LARGE));
 
-    it("forwards size onto an element icon", async () =>
-        assertIconSize(<Icon icon={<GraphIcon />} size={IconSize.LARGE} />, IconSize.LARGE));
-
-    it("forwards a custom size onto an element icon", async () =>
-        assertIconSize(<Icon icon={<GraphIcon />} size={128} />, 128));
-
-    it("element icon's own size takes precedence over the <Icon> size", async () =>
-        // non-regression: the element's explicit size wins over the forwarded one
-        assertIconSize(<Icon icon={<GraphIcon size={IconSize.STANDARD} />} size={128} />, IconSize.STANDARD));
-
-    it("element icon without a size falls back to the default size", async () =>
-        assertIconSize(<Icon icon={<GraphIcon />} />, IconSize.STANDARD));
-
     it("renders intent class", async () => {
         const wrapper = mount(<Icon icon="add" intent={Intent.DANGER} />);
         expect(wrapper.find(`.${Classes.INTENT_DANGER}`).exists()).toBe(true);
@@ -91,14 +78,6 @@ describe("<Icon>", () => {
     it("renders icon color", async () => {
         assertIconColor(<Icon icon="add" color="red" />, "red");
     });
-
-    it("forwards color onto an element icon", async () => {
-        assertIconColor(<Icon icon={<GraphIcon />} color="red" />, "red");
-    });
-
-    it("element icon's own color takes precedence over the <Icon> color", async () =>
-        // non-regression: the element's explicit color wins over the forwarded one
-        assertIconColor(<Icon icon={<GraphIcon color="blue" />} color="red" />, "blue"));
 
     it("unknown icon name renders blank icon", async () => {
         const wrapper = mount(<Icon icon={"unknown" as any} />);
@@ -120,8 +99,6 @@ describe("<Icon>", () => {
         wrapper.update();
         expect(wrapper.childAt(0).is("article")).toBe(true);
         expect(wrapper.find("article").prop("onClick")).toBe(onClick);
-        // a forwarded `size` should not leak onto a non-icon element when none is provided
-        expect(wrapper.find("article").prop("size")).toBeUndefined();
     });
 
     it("icon=undefined renders nothing", async () => {

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -57,12 +57,11 @@ export interface IconOwnProps {
      *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
      *   will render a blank icon to occupy space.
      * - If given a `React.JSX.Element`, that element will be rendered with the
-     *   parent-provided `className`, intent class merged onto its root, and
-     *   `color` and `size` props forwarded onto it (the element's own props take
-     *   precedence). Other props on this component are ignored. This type is
-     *   supported to simplify icon support in other Blueprint components. As a
-     *   consumer, you should avoid using `<Icon icon={<Element />}` directly;
-     *   simply render `<Element />` instead.
+     *   parent-provided `className` and intent class merged onto its root. All
+     *   other props on this component are ignored. This type is supported to
+     *   simplify icon support in other Blueprint components. As a consumer, you
+     *   should avoid using `<Icon icon={<Element />}` directly; simply render
+     *   `<Element />` instead.
      */
     icon: IconName | MaybeElement;
 
@@ -159,13 +158,9 @@ export const Icon: IconComponent = forwardRef(<T extends Element>(props: IconPro
     if (icon == null || typeof icon === "boolean") {
         return null;
     } else if (typeof icon !== "string") {
-        if (isValidElement<Pick<SVGIconProps, "className" | "color" | "size">>(icon)) {
+        if (isValidElement<{ className?: string }>(icon)) {
             return cloneElement(icon, {
                 className: classNames(icon.props.className, className, Classes.intentClass(intent)),
-                // Forward `color`, letting the element's own `color` take precedence.
-                color: icon.props.color ?? color,
-                // Forward `size`, letting the element's own `size` take precedence.
-                size: icon.props.size ?? props.size,
             });
         }
         return icon;


### PR DESCRIPTION
## Summary

Reverts #8178 (forward `size`) and #8183 (forward `color`), which caused runtime crashes for some consumers. Because `<Icon>`'s `icon` prop accepts arbitrary React elements rather than only Blueprint icon components, cloning the element and injecting Blueprint-shaped `size`/`color` props onto it is an unsafe API boundary: an element used as an icon has no obligation to accept those props, and injecting them (including an injected `size={undefined}`) could break it at runtime.
