### PR TITLE
[core] Icon: gate size/color forwarding to Blueprint icon elements

### DIFF
--- a/packages/core/src/common/utils.test.tsx
+++ b/packages/core/src/common/utils.test.tsx
@@ -16,6 +16,7 @@
 
 import { Fragment } from "react/jsx-runtime";
 
+import { GraphIcon } from "@blueprintjs/icons";
 import { beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import * as Utils from "./utils";
@@ -38,6 +39,22 @@ describe("Utils", () => {
         expect(Utils.isReactNodeEmpty("text"), "text").toBe(false);
         expect(Utils.isReactNodeEmpty(<div />), "<div />").toBe(false);
         expect(Utils.isReactNodeEmpty([null, <div key="div" />]), "array").toBe(false);
+    });
+
+    it("isBlueprintIconElement", () => {
+        function NotAnIcon() {
+            return <svg />;
+        }
+        NotAnIcon.displayName = "NotAnIcon";
+
+        // a real @blueprintjs/icons element is recognized
+        expect(Utils.isBlueprintIconElement(<GraphIcon />), "<GraphIcon />").toBe(true);
+        // other elements are not, even Blueprint components with a different displayName namespace
+        expect(Utils.isBlueprintIconElement(<NotAnIcon />), "<NotAnIcon />").toBe(false);
+        expect(Utils.isBlueprintIconElement(<div />), "<div />").toBe(false);
+        // non-elements are not
+        expect(Utils.isBlueprintIconElement("graph"), '"graph"').toBe(false);
+        expect(Utils.isBlueprintIconElement(undefined), "undefined").toBe(false);
     });
 
     it("elementIsOrContains", () => {

--- a/packages/core/src/common/utils/reactUtils.ts
+++ b/packages/core/src/common/utils/reactUtils.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { cloneElement, createElement } from "react";
+import { cloneElement, createElement, isValidElement } from "react";
+
+import type { SVGIconProps } from "@blueprintjs/icons";
+
+import { DISPLAYNAME_PREFIX } from "../props";
 
 import { isEmptyString } from "./jsUtils";
 
@@ -122,4 +126,26 @@ export function isElementOfType<P = {}>(
         element.type.displayName != null &&
         element.type.displayName === ComponentType.displayName
     );
+}
+
+/** `displayName` prefix shared by every generated `@blueprintjs/icons` component (legacy and next). */
+const BLUEPRINT_ICON_DISPLAYNAME_PREFIX = `${DISPLAYNAME_PREFIX}.Icon.`;
+
+/**
+ * Returns true if the given value is a Blueprint icon element (from `@blueprintjs/icons`, legacy or
+ * next). Such elements accept the full `SVGIconProps` interface, so `size`/`color` may be safely
+ * forwarded onto them. Recognition is by `displayName` prefix, consistent with `isElementOfType`,
+ * which tolerates multiple minor versions of `@blueprintjs/icons` coexisting in one bundle. The
+ * trailing dot excludes the `<Icon>` component itself (`Blueprint6.Icon`) and the SVG containers.
+ */
+export function isBlueprintIconElement(value: unknown): value is React.ReactElement<SVGIconProps> {
+    if (!isValidElement(value)) {
+        return false;
+    }
+    const { type } = value;
+    if (typeof type === "string") {
+        return false;
+    }
+    const { displayName } = type as { displayName?: unknown };
+    return typeof displayName === "string" && displayName.startsWith(BLUEPRINT_ICON_DISPLAYNAME_PREFIX);
 }

--- a/packages/core/src/components/icon/Icon.stories.tsx
+++ b/packages/core/src/components/icon/Icon.stories.tsx
@@ -116,8 +116,9 @@ export const ColorExample: Story = {
 /**
  * The `icon` prop accepts either a string icon name or a React element (typically an icon
  * component from `@blueprintjs/icons`). When an element is provided, `<Icon>` clones it and
- * merges the parent-provided `className` and intent class onto its root. It also forwards the
- * `color` and `size` props onto it (the element's own props take precedence).
+ * merges the parent-provided `className` and intent class onto its root. For recognized
+ * `@blueprintjs/icons` elements, it also forwards the `color` and `size` props (the element's
+ * own props take precedence).
  */
 export const ElementIcon: Story = {
     name: "Element icon",

--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -20,7 +20,7 @@ import { GraphIcon, type IconName, Icons, IconSize } from "@blueprintjs/icons";
 import { Add, Airplane, Calendar, Graph } from "@blueprintjs/icons/lib/cjs/generated/16px/paths";
 import { afterEach, beforeAll, describe, expect, it, type MockInstance, vi } from "@blueprintjs/test-commons/vitest";
 
-import { Classes, Intent } from "../../common";
+import { Classes, DISPLAYNAME_PREFIX, Intent } from "../../common";
 
 import { Icon, type IconProps } from "./icon";
 
@@ -99,6 +99,54 @@ describe("<Icon>", () => {
     it("element icon's own color takes precedence over the <Icon> color", async () =>
         // non-regression: the element's explicit color wins over the forwarded one
         assertIconColor(<Icon icon={<GraphIcon color="blue" />} color="red" />, "blue"));
+
+    // A non-Blueprint element used as an icon: it renders its own <svg> reflecting only the props it
+    // receives, so the assertions below can prove that size/color were NOT forwarded onto it.
+    function CustomIcon(elementProps: { className?: string; color?: string; size?: number }) {
+        return (
+            <svg
+                className={elementProps.className}
+                fill={elementProps.color}
+                height={elementProps.size}
+                width={elementProps.size}
+            />
+        );
+    }
+    CustomIcon.displayName = "CustomIcon";
+
+    it("does not forward size/color onto a non-Blueprint element icon, but merges className and intent", () => {
+        const wrapper = mount(
+            <Icon icon={<CustomIcon />} size={IconSize.LARGE} color="red" className="custom" intent={Intent.DANGER} />,
+        );
+        wrapper.update();
+        const svg = wrapper.find("svg");
+        // gated: size/color are not forwarded onto a non-Blueprint element
+        expect(svg.prop("width")).toBeUndefined();
+        expect(svg.prop("height")).toBeUndefined();
+        expect(svg.prop("fill")).toBeUndefined();
+        // className + intent class are still merged onto element icons of any type (issue #8080)
+        expect(svg.hasClass("custom")).toBe(true);
+        expect(svg.hasClass(Classes.INTENT_DANGER)).toBe(true);
+    });
+
+    it("does not forward size/color onto a host-element icon, but merges className and intent", () => {
+        const wrapper = mount(
+            <Icon icon={<article />} size={IconSize.LARGE} color="red" className="custom" intent={Intent.DANGER} />,
+        );
+        wrapper.update();
+        const article = wrapper.find("article");
+        expect(article.prop("size")).toBeUndefined();
+        expect(article.prop("color")).toBeUndefined();
+        expect(article.hasClass("custom")).toBe(true);
+        expect(article.hasClass(Classes.INTENT_DANGER)).toBe(true);
+    });
+
+    it("generated icon components carry the displayName prefix that size/color gating relies on", () => {
+        // Guards against core's DISPLAYNAME_PREFIX and the @blueprintjs/icons generators drifting apart,
+        // which would silently disable size/color forwarding onto element icons.
+        expect(GraphIcon.displayName).toBeDefined();
+        expect(GraphIcon.displayName!.startsWith(`${DISPLAYNAME_PREFIX}.Icon.`)).toBe(true);
+    });
 
     it("unknown icon name renders blank icon", async () => {
         const wrapper = mount(<Icon icon={"unknown" as any} />);

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -56,10 +56,12 @@ export interface IconOwnProps {
      * - If given an `IconName` (a string literal union of all icon names), that
      *   icon will be rendered as an `<svg>` with `<path>` tags. Unknown strings
      *   will render a blank icon to occupy space.
-     * - If given a `React.JSX.Element`, that element will be rendered with the
-     *   parent-provided `className`, intent class merged onto its root, and
-     *   `color` and `size` props forwarded onto it (the element's own props take
-     *   precedence). Other props on this component are ignored. This type is
+     * - If given a `React.JSX.Element`, that element is cloned with the
+     *   parent-provided `className` and intent class merged onto its root. If the
+     *   element is a Blueprint icon component (from `@blueprintjs/icons`), the
+     *   `color` and `size` props are also forwarded onto it, with the element's
+     *   own `color`/`size` taking precedence; for any other element type they are
+     *   not forwarded. Other props on this component are ignored. This type is
      *   supported to simplify icon support in other Blueprint components. As a
      *   consumer, you should avoid using `<Icon icon={<Element />}` directly;
      *   simply render `<Element />` instead.
@@ -96,6 +98,25 @@ export interface DefaultIconProps extends IntentProps, Props, DefaultSVGIconProp
  */
 export interface IconComponent extends React.FC<IconProps<Element>> {
     <T extends Element = Element>(props: IconProps<T>): React.ReactNode;
+}
+
+/** `displayName` prefix shared by every generated `@blueprintjs/icons` component (legacy and next). */
+const BLUEPRINT_ICON_DISPLAYNAME_PREFIX = `${DISPLAYNAME_PREFIX}.Icon.`;
+
+/**
+ * Type guard for elements that are Blueprint icon components (from `@blueprintjs/icons`, legacy or
+ * next). Such components accept the full `SVGIconProps` interface, so it is safe to forward `size`/
+ * `color` onto them. Recognition is by `displayName` prefix, consistent with `isElementOfType`, which
+ * tolerates multiple minor versions of `@blueprintjs/icons` coexisting in one bundle. The trailing dot
+ * excludes `<Icon>` itself (`Blueprint6.Icon`) and the SVG containers.
+ */
+function isBlueprintIconElement(icon: React.ReactElement): icon is React.ReactElement<SVGIconProps> {
+    const { type } = icon;
+    if (typeof type === "string") {
+        return false;
+    }
+    const { displayName } = type as { displayName?: unknown };
+    return typeof displayName === "string" && displayName.startsWith(BLUEPRINT_ICON_DISPLAYNAME_PREFIX);
 }
 
 /**
@@ -159,14 +180,30 @@ export const Icon: IconComponent = forwardRef(<T extends Element>(props: IconPro
     if (icon == null || typeof icon === "boolean") {
         return null;
     } else if (typeof icon !== "string") {
-        if (isValidElement<Pick<SVGIconProps, "className" | "color" | "size">>(icon)) {
-            return cloneElement(icon, {
-                className: classNames(icon.props.className, className, Classes.intentClass(intent)),
-                // Forward `color`, letting the element's own `color` take precedence.
-                color: icon.props.color ?? color,
-                // Forward `size`, letting the element's own `size` take precedence.
-                size: icon.props.size ?? props.size,
-            });
+        if (isValidElement<Pick<SVGIconProps, "className">>(icon)) {
+            // `className` + intent class are merged onto every element icon
+            const mergedClassName = classNames(icon.props.className, className, Classes.intentClass(intent));
+
+            // `size`/`color` are forwarded only onto recognized Blueprint icon components, which accept
+            // them; forwarding onto an arbitrary element could inject props it does not understand. The
+            // element's own `size`/`color` win, and a key is omitted entirely when its resolved value is
+            // nullish, so we never write `size`/`color` as `undefined`.
+            if (isBlueprintIconElement(icon)) {
+                const iconElementProps: Pick<SVGIconProps, "className" | "color" | "size"> = {
+                    className: mergedClassName,
+                };
+                const resolvedSize = icon.props.size ?? props.size;
+                if (resolvedSize != null) {
+                    iconElementProps.size = resolvedSize;
+                }
+                const resolvedColor = icon.props.color ?? color;
+                if (resolvedColor != null) {
+                    iconElementProps.color = resolvedColor;
+                }
+                return cloneElement(icon, iconElementProps);
+            }
+
+            return cloneElement(icon, { className: mergedClassName });
         }
         return icon;
     }

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -35,6 +35,7 @@ import {
     type Props,
     removeNonHTMLProps,
 } from "../../common";
+import { isBlueprintIconElement } from "../../common/utils";
 
 // re-export for convenience, since some users won't be importing from or have a direct dependency on the icons package
 export { type IconName, IconSize };
@@ -98,25 +99,6 @@ export interface DefaultIconProps extends IntentProps, Props, DefaultSVGIconProp
  */
 export interface IconComponent extends React.FC<IconProps<Element>> {
     <T extends Element = Element>(props: IconProps<T>): React.ReactNode;
-}
-
-/** `displayName` prefix shared by every generated `@blueprintjs/icons` component (legacy and next). */
-const BLUEPRINT_ICON_DISPLAYNAME_PREFIX = `${DISPLAYNAME_PREFIX}.Icon.`;
-
-/**
- * Type guard for elements that are Blueprint icon components (from `@blueprintjs/icons`, legacy or
- * next). Such components accept the full `SVGIconProps` interface, so it is safe to forward `size`/
- * `color` onto them. Recognition is by `displayName` prefix, consistent with `isElementOfType`, which
- * tolerates multiple minor versions of `@blueprintjs/icons` coexisting in one bundle. The trailing dot
- * excludes `<Icon>` itself (`Blueprint6.Icon`) and the SVG containers.
- */
-function isBlueprintIconElement(icon: React.ReactElement): icon is React.ReactElement<SVGIconProps> {
-    const { type } = icon;
-    if (typeof type === "string") {
-        return false;
-    }
-    const { displayName } = type as { displayName?: unknown };
-    return typeof displayName === "string" && displayName.startsWith(BLUEPRINT_ICON_DISPLAYNAME_PREFIX);
 }
 
 /**


### PR DESCRIPTION
## Summary

`<Icon>` now forwards `size`/`color` onto an element `icon` only when that element is a Blueprint icon component. It previously forwarded them onto any element, which could inject props (including `size={undefined}`) onto elements that don't accept them and crash at runtime.

**Related to:**
- https://github.com/palantir/blueprint/pull/8080
- https://github.com/palantir/blueprint/pull/8178
- https://github.com/palantir/blueprint/pull/8183

## Changes

When `icon` is a React element, `<Icon>` still clones it and merges the parent `className` and intent class onto its root (issue #8080). It now forwards `size`/`color` only when the element is recognized as a Blueprint icon component, detected by its `displayName` prefix (`${DISPLAYNAME_PREFIX}.Icon.`, which covers both `@blueprintjs/icons` and `@blueprintjs/icons/next` and excludes `<Icon>` itself and the SVG containers), following the existing `isElementOfType` convention. The element's own `size`/`color` still take precedence, and each key is omitted from the clone when its resolved value is nullish, so neither is ever written as `undefined`.

Components that pass a size alongside a caller-provided icon (such as Alert, Drawer, and Dialog) keep sizing element icons correctly, with no changes needed.

Note one intended behavior change: #8178 (released in [@blueprintjs/core@6.17.0](https://github.com/palantir/blueprint/releases/tag/%40blueprintjs%2Fcore%406.17.0)) also let `<NonIdealState>` size a `<Spinner>` icon via the forwarded `size`. Because `<Spinner>` is not a `@blueprintjs/icons` component, gating no longer forwards `size` to it, so a spinner passed as an `icon` again renders at its own default size, restoring the behavior from before 6.17.0.

## Testing

Added tests covering a non-Blueprint function component and a plain host element as the `icon`, asserting neither receives `size`/`color` while both still get the merged `className` and intent class. Added a guard test asserting a generated icon's `displayName` carries the prefix the gating relies on, so a future version-prefix change fails loudly instead of silently disabling forwarding.