### PR TITLE
fix(Select, MultiSelect): Respect target keyboard activation

### DIFF
--- a/packages/select/src/common/keyboardInteractions.ts
+++ b/packages/select/src/common/keyboardInteractions.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License atx
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Classes } from "@blueprintjs/core";
+
+/**
+ * Returns whether the focused target of an Enter/Space key event will fire its own click on keyup.
+ *
+ * Such targets activate the popover themselves, so a Select/MultiSelect wrapper must NOT also open on
+ * keydown — doing so opens the popover early and then the target's synthesized keyup click toggles it
+ * back closed. Targets that do not self-activate (a plain `role="button"` element, a bare anchor) get no
+ * such click, so the wrapper is responsible for opening the popover itself.
+ *
+ * Self-activating targets:
+ * - native `<button>` (fires click on Enter and on Space keyup)
+ * - Blueprint `<Button>`/`<AnchorButton>`, detected via {@link Classes.BUTTON}, which synthesize a click
+ *   on keyup for both keys regardless of tag or `href`
+ * - native `<a href>` (fires click on Enter only)
+ *
+ * The search is scoped to the handler's own element (`currentTarget`) so a clickable ancestor rendered
+ * outside the target cannot suppress activation, and a disabled activator is treated as non-activating
+ * because it never fires its own click.
+ */
+export function targetSelfActivatesOnKeyUp(event: React.KeyboardEvent<HTMLElement>): boolean {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+        return false;
+    }
+
+    const selector = event.key === " " ? `button, .${Classes.BUTTON}` : `button, a[href], .${Classes.BUTTON}`;
+    const match = target.closest(selector);
+    if (match == null || !event.currentTarget.contains(match)) {
+        return false;
+    }
+
+    return !match.matches(`:disabled, .${Classes.DISABLED}`);
+}

--- a/packages/select/src/common/keyboardInteractions.ts
+++ b/packages/select/src/common/keyboardInteractions.ts
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License atx
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,6 +15,9 @@
  */
 
 import { Classes } from "@blueprintjs/core";
+
+/** `KeyboardEvent.key` value for the spacebar. */
+export const SPACE_KEY = " ";
 
 /**
  * Returns whether the focused target of an Enter/Space key event will fire its own click on keyup.
@@ -40,7 +43,7 @@ export function targetSelfActivatesOnKeyUp(event: React.KeyboardEvent<HTMLElemen
         return false;
     }
 
-    const selector = event.key === " " ? `button, .${Classes.BUTTON}` : `button, a[href], .${Classes.BUTTON}`;
+    const selector = event.key === SPACE_KEY ? `button, .${Classes.BUTTON}` : `button, a[href], .${Classes.BUTTON}`;
     const match = target.closest(selector);
     if (match == null || !event.currentTarget.contains(match)) {
         return false;

--- a/packages/select/src/components/multi-select/multiSelect.test.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.test.tsx
@@ -121,6 +121,25 @@ describe("<MultiSelect>", () => {
         expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
+    it.each(["Enter", " "] as const)(
+        "opens popover from a button custom target's %s keyup click, not on keydown",
+        key => {
+            const customTarget = () => <Button data-testid="custom-target-button" text="Target" />;
+            const wrapper = multiselect({ customTarget, popoverProps: { usePortal: false } });
+
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+            const targetButton = findTargetButton(wrapper);
+
+            targetButton.simulate("keydown", { key });
+            // The button activates itself on keyup, so MultiSelect should not open early on keydown.
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+
+            targetButton.simulate("keyup", { key });
+            // ...and should open once after the button synthesizes its keyup click.
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
+        },
+    );
+
     it("allows searching within popover content when custom target provided", async () => {
         // Mount to document for this test to check from input focus
         const containerElement = document.createElement("div");

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -39,6 +39,7 @@ import {
 import { CrossIcon } from "@blueprintjs/icons";
 
 import { Classes, type ListItemsProps, type SelectPopoverProps } from "../../common";
+import { targetSelfActivatesOnKeyUp } from "../../common/keyboardInteractions";
 import { QueryList, type QueryListRendererProps } from "../query-list/queryList";
 
 export interface MultiSelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
@@ -432,11 +433,15 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
             } else if (!(e.key === "Backspace" || e.key === "ArrowLeft" || e.key === "ArrowRight")) {
                 // Custom target might not be an input, so certain keystrokes might have other effects (space pushing the scrollview down)
                 if (this.props.customTarget != null) {
-                    if (e.key === " ") {
-                        e.preventDefault();
-                        this.setState({ isOpen: true });
-                    } else if (e.key === "Enter") {
-                        this.setState({ isOpen: true });
+                    // Skip opening on keydown when the custom target activates itself on keyup, otherwise
+                    // its synthesized click would toggle the popover back closed. See targetSelfActivatesOnKeyUp.
+                    if (!targetSelfActivatesOnKeyUp(e)) {
+                        if (e.key === " ") {
+                            e.preventDefault();
+                            this.setState({ isOpen: true });
+                        } else if (e.key === "Enter") {
+                            this.setState({ isOpen: true });
+                        }
                     }
                 } else {
                     this.setState({ isOpen: true });

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -39,7 +39,7 @@ import {
 import { CrossIcon } from "@blueprintjs/icons";
 
 import { Classes, type ListItemsProps, type SelectPopoverProps } from "../../common";
-import { targetSelfActivatesOnKeyUp } from "../../common/keyboardInteractions";
+import { SPACE_KEY, targetSelfActivatesOnKeyUp } from "../../common/keyboardInteractions";
 import { QueryList, type QueryListRendererProps } from "../query-list/queryList";
 
 export interface MultiSelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
@@ -436,7 +436,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                     // Skip opening on keydown when the custom target activates itself on keyup, otherwise
                     // its synthesized click would toggle the popover back closed. See targetSelfActivatesOnKeyUp.
                     if (!targetSelfActivatesOnKeyUp(e)) {
-                        if (e.key === " ") {
+                        if (e.key === SPACE_KEY) {
                             e.preventDefault();
                             this.setState({ isOpen: true });
                         } else if (e.key === "Enter") {

--- a/packages/select/src/components/select/select.test.tsx
+++ b/packages/select/src/components/select/select.test.tsx
@@ -152,6 +152,46 @@ describe("<Select>", () => {
         expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
+    it.each(["Enter", " "] as const)(
+        "opens Popover on %s keydown for a non-native role='button' target (no keyup click to defer to)",
+        key => {
+            const wrapper = selectWithTarget(
+                <div data-testid="target" role="button" tabIndex={0}>
+                    Target
+                </div>,
+            );
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+            // A plain role="button" element does not synthesize its own click, so Select must open itself.
+            wrapper.find("[data-testid='target']").hostNodes().simulate("keydown", { key });
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
+        },
+    );
+
+    it.each(["Enter", " "] as const)("opens Popover on %s keydown for a disabled Button target", key => {
+        const wrapper = selectWithTarget(<Button data-testid="target-button" disabled={true} text="Target" />);
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+        // A disabled button never fires its own click, so Select must open itself rather than defer.
+        findTargetButton(wrapper).simulate("keydown", { key });
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
+    });
+
+    it.each(["Enter", " "] as const)(
+        "opens Popover on %s keydown when the target is nested inside a clickable ancestor",
+        key => {
+            const wrapper = selectWithTarget(<span data-testid="target">Target</span>, {
+                wrap: children => (
+                    <span data-testid="ancestor" role="button" tabIndex={0}>
+                        {children}
+                    </span>
+                ),
+            });
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+            // The outer role="button" ancestor must not suppress Select's own keyboard-open.
+            wrapper.find("[data-testid='target']").hostNodes().simulate("keydown", { key });
+            expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
+        },
+    );
+
     it("invokes onItemSelect when clicking first MenuItem", () => {
         const wrapper = select();
         // N.B. need to trigger interaction on nested <a> element, where item onClick is actually attached to the DOM
@@ -227,6 +267,22 @@ describe("<Select>", () => {
 
     function findTargetButton(wrapper: ReactWrapper): ReactWrapper<HTMLAttributes> {
         return wrapper.find("[data-testid='target-button']").hostNodes();
+    }
+
+    // Mount a closed, non-filterable Select with an arbitrary target child (optionally wrapped in an
+    // ancestor element), for exercising keyboard-open behavior across different target shapes.
+    function selectWithTarget(
+        target: React.ReactNode,
+        { wrap }: { wrap?: (children: React.ReactNode) => React.ReactNode } = {},
+    ) {
+        const wrapper = mount(
+            <Select<Film> {...defaultProps} {...handlers} filterable={false} popoverProps={{ usePortal: false }}>
+                {wrap ? wrap(target) : target}
+            </Select>,
+            { attachTo: containerElement },
+        );
+        mountedWrappers.push(wrapper);
+        return wrapper;
     }
 });
 

--- a/packages/select/src/components/select/select.test.tsx
+++ b/packages/select/src/components/select/select.test.tsx
@@ -136,6 +136,22 @@ describe("<Select>", () => {
         expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
     });
 
+    it.each(["Enter", " "] as const)("opens Popover from the focused button target's %s keyup click", key => {
+        // override isOpen in defaultProps
+        const wrapper = select({ filterable: false, popoverProps: { usePortal: false } });
+        // should be closed to start
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+        const targetButton = findTargetButton(wrapper);
+
+        targetButton.simulate("keydown", { key });
+        // Native clickable targets handle keyboard activation themselves, so Select should not open on keydown.
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(false);
+
+        targetButton.simulate("keyup", { key });
+        // ...and should open after Button synthesizes its keyup click
+        expect(wrapper.find(PopoverNext).prop("isOpen")).toBe(true);
+    });
+
     it("invokes onItemSelect when clicking first MenuItem", () => {
         const wrapper = select();
         // N.B. need to trigger interaction on nested <a> element, where item onClick is actually attached to the DOM

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -301,7 +301,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         if (event.key === "ArrowUp" || event.key === "ArrowDown") {
             event.preventDefault();
             this.setState({ isOpen: true });
-        } else if (Utils.isKeyboardClick(event)) {
+        } else if (Utils.isKeyboardClick(event) && !isKeyboardClickHandledByTarget(event)) {
             this.setState({ isOpen: true });
         }
     };
@@ -364,4 +364,14 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
     };
 
     private resetQuery = () => this.queryList && this.queryList.setQuery("", true);
+}
+
+function isKeyboardClickHandledByTarget(event: React.KeyboardEvent<HTMLElement>) {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+        return false;
+    }
+
+    const selector = event.key === " " ? "button, [role='button']" : "button, a, [role='button']";
+    return target.closest(selector) != null;
 }

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -36,6 +36,7 @@ import {
 import { CrossIcon, SearchIcon } from "@blueprintjs/icons";
 
 import { Classes, type ListItemsProps, type SelectPopoverProps } from "../../common";
+import { targetSelfActivatesOnKeyUp } from "../../common/keyboardInteractions";
 import { QueryList, type QueryListRendererProps } from "../query-list/queryList";
 
 export interface SelectProps<T> extends ListItemsProps<T>, SelectPopoverProps {
@@ -301,7 +302,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         if (event.key === "ArrowUp" || event.key === "ArrowDown") {
             event.preventDefault();
             this.setState({ isOpen: true });
-        } else if (Utils.isKeyboardClick(event) && !isKeyboardClickHandledByTarget(event)) {
+        } else if (Utils.isKeyboardClick(event) && !targetSelfActivatesOnKeyUp(event)) {
             this.setState({ isOpen: true });
         }
     };
@@ -364,14 +365,4 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
     };
 
     private resetQuery = () => this.queryList && this.queryList.setQuery("", true);
-}
-
-function isKeyboardClickHandledByTarget(event: React.KeyboardEvent<HTMLElement>) {
-    const target = event.target;
-    if (!(target instanceof Element)) {
-        return false;
-    }
-
-    const selector = event.key === " " ? "button, [role='button']" : "button, a, [role='button']";
-    return target.closest(selector) != null;
 }


### PR DESCRIPTION
## Summary

This fixes a `Select` regression where a focused `Button` target opened the popover on `keydown`, then immediately closed when the button synthesized its keyboard click on `keyup`.

The fix distinguishes targets by whether they fire their own click on `keyup`. When the target self-activates (a native `<button>`, a Blueprint `Button`/`AnchorButton`, or a native `<a href>` on Enter only), `Select` lets that target's own click open the popover once instead of opening on `keydown`. For every other target, including a non-native `role="button"` element such as a plain `<div>`/`<span>`, `Select` opens the popover itself on `keydown` (those targets have no `keyup` click to defer to).

| Before | After |
|--------|--------|
| <img width="554" alt="before" src="https://github.com/user-attachments/assets/7d7531bc-56f7-4b36-8e6c-0ccb487d99a2" /> | <img width="554" alt="after" src="https://github.com/user-attachments/assets/bb7c420e-87c5-4fca-8b8f-b7adb9559611" /> | 

## Changes
- Added a shared `targetSelfActivatesOnKeyUp` helper that matches only genuinely self-activating targets: native `<button>` and Blueprint `Button`/`AnchorButton` (detected via `Classes.BUTTON`) for both keys, and native `<a href>` for Enter. It scopes the search to the handler's own element so a clickable ancestor cannot suppress activation, and treats a disabled activator as non-activating (it never fires its own click).
- `Select.handleTargetKeyDown` uses this helper to decide whether to open on `keydown`.
- `MultiSelect` applies the same guard to its custom-target `keydown` path.
- Regression coverage for `Select` targets that are `div`/`span` with `role="button"`, a disabled `Button`, and a target nested inside a clickable ancestor; plus a button custom target for `MultiSelect`, and the existing `Button` Enter/Space cases.

## Behavior by target shape
| Target | keydown-open | Opens via |
|---|---|---|
| Blueprint `Button` / `AnchorButton`, native `<button>` | deferred | the target's own keyup click |
| native `<a href>` | deferred (Enter), self-opens (Space) | Enter: native activation; Space: `Select` |
| `div` / `span` with `role="button"` | self-opens | `Select` |
| disabled `Button` | self-opens | `Select` |
