### PR TITLE
[core] Icon: forward DOM props to Blueprint icon elements

### DIFF
--- a/packages/core/src/components/icon/icon.test.tsx
+++ b/packages/core/src/components/icon/icon.test.tsx
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 
 import { GraphIcon, type IconName, Icons, IconSize } from "@blueprintjs/icons";
@@ -100,6 +102,17 @@ describe("<Icon>", () => {
         // non-regression: the element's explicit color wins over the forwarded one
         assertIconColor(<Icon icon={<GraphIcon color="blue" />} color="red" />, "blue"));
 
+    it("forwards DOM attributes onto a Blueprint element icon", async () => {
+        const user = userEvent.setup();
+        const onClick = vi.fn();
+        render(<Icon aria-label="graph" icon={<GraphIcon />} onClick={onClick} tabIndex={0} />);
+
+        const icon = screen.getByLabelText("graph");
+        expect(icon.getAttribute("tabindex")).toBe("0");
+        await user.click(icon);
+        expect(onClick).toHaveBeenCalledOnce();
+    });
+
     // A non-Blueprint element used as an icon: it renders its own <svg> reflecting only the props it
     // receives, so the assertions below can prove that size/color were NOT forwarded onto it.
     function CustomIcon(elementProps: { className?: string; color?: string; size?: number }) {
@@ -113,6 +126,15 @@ describe("<Icon>", () => {
         );
     }
     CustomIcon.displayName = "CustomIcon";
+
+    it("does not forward DOM attributes onto a non-Blueprint element icon", async () => {
+        const user = userEvent.setup();
+        const onClick = vi.fn();
+        const { container } = render(<Icon icon={<CustomIcon />} onClick={onClick} />);
+
+        await user.click(container.querySelector("svg")!);
+        expect(onClick).not.toHaveBeenCalled();
+    });
 
     it("does not forward size/color onto a non-Blueprint element icon, but merges className and intent", () => {
         const wrapper = mount(

--- a/packages/core/src/components/icon/icon.tsx
+++ b/packages/core/src/components/icon/icon.tsx
@@ -59,13 +59,13 @@ export interface IconOwnProps {
      *   will render a blank icon to occupy space.
      * - If given a `React.JSX.Element`, that element is cloned with the
      *   parent-provided `className` and intent class merged onto its root. If the
-     *   element is a Blueprint icon component (from `@blueprintjs/icons`), the
-     *   `color` and `size` props are also forwarded onto it, with the element's
-     *   own `color`/`size` taking precedence; for any other element type they are
-     *   not forwarded. Other props on this component are ignored. This type is
-     *   supported to simplify icon support in other Blueprint components. As a
-     *   consumer, you should avoid using `<Icon icon={<Element />}` directly;
-     *   simply render `<Element />` instead.
+     *   element is a Blueprint icon component (from `@blueprintjs/icons`), DOM
+     *   attributes and the `color` and `size` props are also forwarded onto it,
+     *   with the element's own `color`/`size` taking precedence; for any other
+     *   element type they are not forwarded. Other props on this component are
+     *   ignored. This type is supported to simplify icon support in other
+     *   Blueprint components. As a consumer, you should avoid using
+     *   `<Icon icon={<Element />}` directly; simply render `<Element />` instead.
      */
     icon: IconName | MaybeElement;
 
@@ -166,12 +166,13 @@ export const Icon: IconComponent = forwardRef(<T extends Element>(props: IconPro
             // `className` + intent class are merged onto every element icon
             const mergedClassName = classNames(icon.props.className, className, Classes.intentClass(intent));
 
-            // `size`/`color` are forwarded only onto recognized Blueprint icon components, which accept
-            // them; forwarding onto an arbitrary element could inject props it does not understand. The
-            // element's own `size`/`color` win, and a key is omitted entirely when its resolved value is
+            // DOM attributes and `size`/`color` are forwarded only onto recognized Blueprint icon components,
+            // which accept them; forwarding onto an arbitrary element could inject props it does not understand.
+            // The element's own `size`/`color` win, and a key is omitted entirely when its resolved value is
             // nullish, so we never write `size`/`color` as `undefined`.
             if (isBlueprintIconElement(icon)) {
-                const iconElementProps: Pick<SVGIconProps, "className" | "color" | "size"> = {
+                const iconElementProps: SVGIconProps = {
+                    ...removeNonHTMLProps(htmlProps),
                     className: mergedClassName,
                 };
                 const resolvedSize = icon.props.size ?? props.size;


### PR DESCRIPTION
## Summary

`<Icon>` forwards DOM props such as `onClick`, `aria-label`, and `tabIndex` for dynamic icons, but silently dropped them for static Blueprint element icons such as `icon={<HomeIcon />}`. This forwards those props onto the cloned Blueprint icon element so both forms behave consistently.

## Context

Previous changes added support for forwarding `size` and `color` to static element icons, then restricted that forwarding to recognized Blueprint icon components:

- https://github.com/palantir/blueprint/pull/8178
- https://github.com/palantir/blueprint/pull/8183
- https://github.com/palantir/blueprint/pull/8209

The same element-cloning path still omitted other valid SVG DOM props. As a result, event handlers and accessibility attributes accepted by `<Icon>` never reached a static Blueprint icon.

## Changes

- forward valid DOM props onto recognized Blueprint icon elements
- preserve the existing `className`, `size`, and `color` behavior
- continue withholding these props from arbitrary non-Blueprint elements

## Example

```tsx
<Icon icon={<HomeIcon />} onClick={handleClick} aria-label="Home" tabIndex={0} />