### PR TITLE
fix(core): Preserve `minimal=false` in Popover migration props

### DIFF
--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -11,7 +11,12 @@ import { POPOVER_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import { PopoverInteractionKind } from "../popover/popoverProps";
 
 import { convertMiddlewareConfigToArray } from "./floatingUtils";
-import type { MiddlewareConfig, PopoverNextProps } from "./popoverNextProps";
+import {
+    type MiddlewareConfig,
+    POPOVER_NEXT_DEFAULT_ANIMATION,
+    POPOVER_NEXT_DEFAULT_ARROW,
+    type PopoverNextProps,
+} from "./popoverNextProps";
 import { PopoverPopup } from "./popoverPopup";
 import { PopoverTarget } from "./popoverTarget";
 import { usePopover } from "./usePopover";
@@ -22,9 +27,9 @@ export interface PopoverNextRef {
 
 export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, ref) => {
     const {
-        animation = "scale",
+        animation = POPOVER_NEXT_DEFAULT_ANIMATION,
         autoUpdateOptions,
-        arrow = true,
+        arrow = POPOVER_NEXT_DEFAULT_ARROW,
         boundary = "clippingAncestors",
         children,
         content,

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -418,10 +418,18 @@ describe("popoverPropsToNextProps", () => {
             expect(result.arrow).to.equal(false);
         });
 
-        it("should not set animation or arrow when minimal is false", () => {
+        it("should map minimal: false to animation: 'scale' and arrow: true", () => {
             const result = popoverPropsToNextProps({ minimal: false });
-            expect(result.animation).to.be.undefined;
-            expect(result.arrow).to.be.undefined;
+            expect(result.animation).to.equal("scale");
+            expect(result.arrow).to.equal(true);
+        });
+
+        it("should preserve minimal: false as an override of wrapper defaults", () => {
+            const wrapperDefaults = { animation: "minimal" as const, arrow: false };
+            const result = { ...wrapperDefaults, ...popoverPropsToNextProps({ minimal: false }) };
+
+            expect(result.animation).to.equal("scale");
+            expect(result.arrow).to.equal(true);
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import type { MiddlewareConfig } from "../..";
 import { PopoverPosition } from "../popover/popoverPosition";
-import type { PopoverProps } from "../popover/popoverProps";
+import { PopoverAnimation, type PopoverProps } from "../popover/popoverProps";
 import type { PopperModifierOverrides } from "../popover/popoverSharedProps";
 
 import {
@@ -15,6 +15,7 @@ import {
     popoverPropsToNextProps,
     popperModifiersToNextMiddleware,
 } from "./popoverNextMigrationUtils";
+import { POPOVER_NEXT_DEFAULT_ANIMATION, POPOVER_NEXT_DEFAULT_ARROW } from "./popoverNextProps";
 
 describe("popoverPositionToNextPlacement", () => {
     it("should convert top-left to top-start", () => {
@@ -412,24 +413,16 @@ describe("popoverPropsToNextProps", () => {
     });
 
     describe("minimal", () => {
-        it("should map minimal: true to animation: 'minimal' and arrow: false", () => {
+        it("should map minimal: true to the minimal animation and no arrow", () => {
             const result = popoverPropsToNextProps({ minimal: true });
-            expect(result.animation).to.equal("minimal");
+            expect(result.animation).to.equal(PopoverAnimation.MINIMAL);
             expect(result.arrow).to.equal(false);
         });
 
-        it("should map minimal: false to animation: 'scale' and arrow: true", () => {
+        it("should map minimal: false to PopoverNext's animation and arrow defaults", () => {
             const result = popoverPropsToNextProps({ minimal: false });
-            expect(result.animation).to.equal("scale");
-            expect(result.arrow).to.equal(true);
-        });
-
-        it("should preserve minimal: false as an override of wrapper defaults", () => {
-            const wrapperDefaults = { animation: "minimal" as const, arrow: false };
-            const result = { ...wrapperDefaults, ...popoverPropsToNextProps({ minimal: false }) };
-
-            expect(result.animation).to.equal("scale");
-            expect(result.arrow).to.equal(true);
+            expect(result.animation).to.equal(POPOVER_NEXT_DEFAULT_ANIMATION);
+            expect(result.arrow).to.equal(POPOVER_NEXT_DEFAULT_ARROW);
         });
     });
 

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -122,7 +122,7 @@ export function popperModifiersToNextMiddleware(modifiers: PopperModifierOverrid
  * - `placement` ?? `position` → `placement`, mirroring legacy `Popover`'s resolution
  *   (`placement ?? positionToPlacement(position)`). When `placement` is defined it always wins.
  * - `modifiers` → `middleware` (via {@link popperModifiersToNextMiddleware}).
- * - `minimal: true` → `animation: "minimal"` and `arrow: false` (legacy `minimal` disables the arrow).
+ * - `minimal` → the equivalent explicit `animation` and `arrow` values.
  * - `boundary: "clippingParents"` → `"clippingAncestors"` (the Floating UI equivalent).
  *
  * Dropped (with dev-only `console.warn`):
@@ -192,9 +192,9 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         nextProps.middleware = popperModifiersToNextMiddleware(modifiers);
     }
 
-    if (minimal === true) {
-        nextProps.animation ??= "minimal";
-        nextProps.arrow ??= false;
+    if (minimal !== undefined) {
+        nextProps.animation ??= minimal ? "minimal" : "scale";
+        nextProps.arrow ??= !minimal;
     }
 
     if (onClose !== undefined) {

--- a/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
+++ b/packages/core/src/components/popover-next/popoverNextMigrationUtils.ts
@@ -9,11 +9,11 @@ import { isNodeEnv } from "../../common/utils";
 import { POPOVER_ARROW_SVG_SIZE } from "../popover/popoverArrow";
 import { positionToPlacement } from "../popover/popoverPlacementUtils";
 import { type PopoverPosition } from "../popover/popoverPosition";
-import type { PopoverProps } from "../popover/popoverProps";
+import { PopoverAnimation, type PopoverProps } from "../popover/popoverProps";
 import type { DefaultPopoverTargetHTMLProps, PopperModifierOverrides } from "../popover/popoverSharedProps";
 
 import type { MiddlewareConfig, PopoverNextBoundary, PopoverNextPlacement } from "./middlewareTypes";
-import type { PopoverNextProps } from "./popoverNextProps";
+import { POPOVER_NEXT_DEFAULT_ANIMATION, POPOVER_NEXT_DEFAULT_ARROW, type PopoverNextProps } from "./popoverNextProps";
 
 /**
  * Converts Popper.js v2 `modifiers` (used by `Popover`) to a Floating UI `MiddlewareConfig` (used by `PopoverNext`).
@@ -192,9 +192,9 @@ export function popoverPropsToNextProps<T extends DefaultPopoverTargetHTMLProps>
         nextProps.middleware = popperModifiersToNextMiddleware(modifiers);
     }
 
-    if (minimal !== undefined) {
-        nextProps.animation ??= minimal ? "minimal" : "scale";
-        nextProps.arrow ??= !minimal;
+    if (minimal != null) {
+        nextProps.animation ??= minimal ? PopoverAnimation.MINIMAL : POPOVER_NEXT_DEFAULT_ANIMATION;
+        nextProps.arrow ??= minimal ? false : POPOVER_NEXT_DEFAULT_ARROW;
     }
 
     if (onClose !== undefined) {

--- a/packages/core/src/components/popover-next/popoverNextProps.ts
+++ b/packages/core/src/components/popover-next/popoverNextProps.ts
@@ -2,7 +2,7 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
-import type { PopoverAnimation, PopoverInteractionKind } from "../popover/popoverProps";
+import { PopoverAnimation, type PopoverInteractionKind } from "../popover/popoverProps";
 import type {
     DefaultPopoverTargetHTMLProps,
     PopoverClickTargetHandlers,
@@ -76,6 +76,10 @@ export interface PopoverNextAutoUpdateOptions {
      */
     animationFrame?: boolean;
 }
+
+export const POPOVER_NEXT_DEFAULT_ANIMATION: PopoverAnimation = PopoverAnimation.SCALE;
+
+export const POPOVER_NEXT_DEFAULT_ARROW = true;
 
 /**
  * Props interface for PopoverNext component.

--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -12,12 +12,12 @@ import { PopoverArrow } from "../popover/popoverArrow";
 import { PopoverAnimation, PopoverInteractionKind } from "../popover/popoverProps";
 import { getBasePlacement, getTransformOrigin } from "../popover/popperUtils";
 
-import type { PopoverPopupProps } from "./popoverNextProps";
+import { POPOVER_NEXT_DEFAULT_ANIMATION, POPOVER_NEXT_DEFAULT_ARROW, type PopoverPopupProps } from "./popoverNextProps";
 
 export function PopoverPopup(props: PopoverPopupProps) {
     const {
-        animation = PopoverAnimation.SCALE,
-        arrow = true,
+        animation = POPOVER_NEXT_DEFAULT_ANIMATION,
+        arrow = POPOVER_NEXT_DEFAULT_ARROW,
         arrowRef,
         autoFocus,
         backdropProps,


### PR DESCRIPTION
## Summary

`popoverPropsToNextProps` currently translates `minimal: true` but drops an explicit `minimal: false`. This prevents converted props from restoring the standard arrow and scale animation when spread over a wrapper component’s defaults.

## Changes

- Map `minimal: false` to `arrow: true` and `animation: "scale"`.
- Add regression coverage for direct conversion and wrapper prop overrides.