### PR TITLE
feat(datetime): support custom timezone options

### DIFF
--- a/packages/datetime/changelog/@unreleased/pr-8217.v2.yml
+++ b/packages/datetime/changelog/@unreleased/pr-8217.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Support custom timezone options in TimezoneSelect
+  links:
+  - https://github.com/palantir/blueprint/pull/8217

--- a/packages/datetime/src/common/index.ts
+++ b/packages/datetime/src/common/index.ts
@@ -18,10 +18,18 @@ import * as Classes from "./classes";
 import * as DateUtils from "./dateUtils";
 import * as Errors from "./errors";
 import * as TimezoneNameUtils from "./timezoneNameUtils";
-import type { TimezoneWithNames } from "./timezoneTypes";
+import type { TimezoneWithNames, TimezoneWithoutOffset } from "./timezoneTypes";
 import * as TimezoneUtils from "./timezoneUtils";
 
-export { Classes, DateUtils, Errors, TimezoneNameUtils, TimezoneUtils, type TimezoneWithNames };
+export {
+    Classes,
+    DateUtils,
+    Errors,
+    TimezoneNameUtils,
+    TimezoneUtils,
+    type TimezoneWithNames,
+    type TimezoneWithoutOffset,
+};
 
 export type { DatePickerBaseProps, DatePickerModifiers } from "./datePickerBaseProps";
 export type { DateFormatProps } from "./dateFormatProps";

--- a/packages/datetime/src/components/timezone-select/timezone-select.mdx
+++ b/packages/datetime/src/components/timezone-select/timezone-select.mdx
@@ -36,6 +36,20 @@ function TimezoneExample() {
 The optional `date` prop is used to determine the timezone offsets. This is useful to disambiguate timezones which have
 more than one offset from UTC due to [Daylight saving time](https://en.wikipedia.org/wiki/Daylight_saving_time).
 
+Use `timezoneItems` to replace the built-in options with a custom list. The component derives each option's current
+offset and display names from its IANA code:
+
+```tsx
+<TimezoneSelect
+    timezoneItems={[
+        { ianaCode: "America/Chicago", label: "Chicago" },
+        { ianaCode: "Europe/Oslo", label: "Oslo" },
+    ]}
+    value={timezone}
+    onChange={setTimezone}
+/>
+```
+
 By default, the component will show a clickable button target which displays the selected timezone formatted according
 to the `valueDisplayFormat` prop. The button can be customized via `disabled`, `placeholder`, and more generally via
 `buttonProps`.

--- a/packages/datetime/src/components/timezone-select/timezoneSelect.test.tsx
+++ b/packages/datetime/src/components/timezone-select/timezoneSelect.test.tsx
@@ -33,7 +33,9 @@ import { TimezoneSelect, type TimezoneSelectProps } from "../..";
 import { getCurrentTimezone } from "../../common/getTimezone";
 import { TIMEZONE_ITEMS } from "../../common/timezoneItems";
 import { getInitialTimezoneItems, mapTimezonesWithNames } from "../../common/timezoneNameUtils";
-import type { TimezoneWithNames } from "../../common/timezoneTypes";
+import type { TimezoneWithNames, TimezoneWithoutOffset } from "../../common/timezoneTypes";
+
+import type { TimezoneSelectState } from "./timezoneSelect";
 
 const LOS_ANGELES_TZ = "America/Los_Angeles";
 let CURRENT_TZ = getCurrentTimezone();
@@ -92,6 +94,48 @@ describe("<TimezoneSelect>", () => {
         expect(timezoneSelect.state("query")).toBe(query);
         const items = findSelect(timezoneSelect).prop("items");
         expect(items).toEqual(mapTimezonesWithNames(date, TIMEZONE_ITEMS));
+    });
+
+    it("should use custom timezone items for initial suggestions and search", () => {
+        const timezoneItems: TimezoneWithoutOffset[] = [
+            { ianaCode: "America/Chicago", label: "Chicago" },
+            { ianaCode: "Europe/Oslo", label: "Oslo" },
+        ];
+        const timezoneSelect = mountTS({ timezoneItems });
+
+        expect(
+            findSelect(timezoneSelect)
+                .prop("items")
+                .map(item => item.ianaCode),
+        ).toEqual(["America/Chicago", "Europe/Oslo"]);
+
+        act(() => timezoneSelect.setState({ query: "Chicago" }));
+        timezoneSelect.update();
+
+        expect(
+            findSelect(timezoneSelect)
+                .prop("items")
+                .map(item => item.ianaCode),
+        ).toEqual(["America/Chicago", "Europe/Oslo"]);
+    });
+
+    it("should update when custom timezone items change", () => {
+        const timezoneSelect = mountTS({
+            timezoneItems: [{ ianaCode: "America/Chicago", label: "Chicago" }],
+        });
+
+        act(() => {
+            timezoneSelect.setProps({
+                timezoneItems: [{ ianaCode: "Europe/Oslo", label: "Oslo" }],
+            });
+        });
+        timezoneSelect.update();
+
+        expect(
+            findSelect(timezoneSelect)
+                .prop("items")
+                .map(item => item.ianaCode),
+        ).toEqual(["Europe/Oslo"]);
     });
 
     it("should render the local timezone at the top of the item list if showLocalTimezone=true", () => {
@@ -179,27 +223,31 @@ describe("<TimezoneSelect>", () => {
         }
     });
 
-    function mountTS(props: Partial<TimezoneSelectProps> = {}): ReactWrapper<TimezoneSelect> {
+    function mountTS(
+        props: Partial<TimezoneSelectProps> = {},
+    ): ReactWrapper<TimezoneSelectProps, TimezoneSelectState, TimezoneSelect> {
         return mount(<TimezoneSelect {...DEFAULT_PROPS} {...props} />);
     }
 
-    function findSelect(timezoneSelect: ReactWrapper<TimezoneSelect>) {
+    function findSelect(timezoneSelect: ReactWrapper<TimezoneSelectProps, TimezoneSelectState, TimezoneSelect>) {
         return timezoneSelect.find<Select<TimezoneWithNames>>(Select);
     }
 
-    function findQueryList(timezoneSelect: ReactWrapper<TimezoneSelect>) {
+    function findQueryList(timezoneSelect: ReactWrapper<TimezoneSelectProps, TimezoneSelectState, TimezoneSelect>) {
         return findSelect(timezoneSelect).find<QueryList<TimezoneWithNames>>(QueryList);
     }
 
-    function findPopover(timezoneSelect: ReactWrapper<TimezoneSelect>) {
+    function findPopover(timezoneSelect: ReactWrapper<TimezoneSelectProps, TimezoneSelectState, TimezoneSelect>) {
         return findQueryList(timezoneSelect).find(PopoverNext);
     }
 
-    function findInputGroup(timezoneSelect: ReactWrapper<TimezoneSelect>) {
+    function findInputGroup(timezoneSelect: ReactWrapper<TimezoneSelectProps, TimezoneSelectState, TimezoneSelect>) {
         return findQueryList(timezoneSelect).find(InputGroup);
     }
 
-    function clickFirstMenuItem(timezoneSelect: ReactWrapper<TimezoneSelect>): void {
+    function clickFirstMenuItem(
+        timezoneSelect: ReactWrapper<TimezoneSelectProps, TimezoneSelectState, TimezoneSelect>,
+    ): void {
         findSelect(timezoneSelect).find(MenuItem).first().simulate("click");
     }
 });

--- a/packages/datetime/src/components/timezone-select/timezoneSelect.tsx
+++ b/packages/datetime/src/components/timezone-select/timezoneSelect.tsx
@@ -28,10 +28,11 @@ import {
 } from "@blueprintjs/core";
 import { type ItemListPredicate, type ItemRenderer, Select, type SelectPopoverProps } from "@blueprintjs/select";
 
-import { Classes, type TimezoneWithNames } from "../../common";
+import { Classes, type TimezoneWithNames, type TimezoneWithoutOffset } from "../../common";
 import { formatTimezone, TimezoneDisplayFormat } from "../../common/timezoneDisplayFormat";
 import { TIMEZONE_ITEMS } from "../../common/timezoneItems";
 import { getInitialTimezoneItems, mapTimezonesWithNames } from "../../common/timezoneNameUtils";
+import { lookupTimezoneOffset } from "../../common/timezoneOffsetUtils";
 
 export interface TimezoneSelectProps extends Props {
     /**
@@ -85,6 +86,14 @@ export interface TimezoneSelectProps extends Props {
      * @default false
      */
     showLocalTimezone?: boolean;
+
+    /**
+     * Custom timezone options to show instead of the built-in list. Offsets and
+     * display names are derived from each IANA code using the current `date`.
+     *
+     * @default undefined
+     */
+    timezoneItems?: readonly TimezoneWithoutOffset[];
 
     /**
      * Text to show when no timezone has been selected (`value === undefined`).
@@ -146,16 +155,26 @@ export class TimezoneSelect extends AbstractPureComponent<TimezoneSelectProps, T
 
     private initialTimezoneItems: TimezoneWithNames[];
 
+    private timezoneItemsDate: number | undefined;
+
+    private timezoneItemsProp: readonly TimezoneWithoutOffset[] | undefined;
+
+    private showLocalTimezone: boolean | undefined;
+
     constructor(props: TimezoneSelectProps) {
         super(props);
 
-        const { showLocalTimezone, inputProps = {}, date } = props;
+        const { inputProps = {} } = props;
         this.state = { query: inputProps.value || "" };
-        this.timezoneItems = mapTimezonesWithNames(date, TIMEZONE_ITEMS);
-        this.initialTimezoneItems = getInitialTimezoneItems(date, showLocalTimezone!);
+        this.timezoneItems = this.getTimezoneItems(props);
+        this.initialTimezoneItems = this.getInitialTimezoneItems(props);
+        this.timezoneItemsDate = props.date?.getTime();
+        this.timezoneItemsProp = props.timezoneItems;
+        this.showLocalTimezone = props.showLocalTimezone;
     }
 
     public render() {
+        this.refreshTimezoneItems(this.props);
         const { children, className, disabled, fill, inputProps, popoverProps } = this.props;
         const { query } = this.state;
 
@@ -187,17 +206,34 @@ export class TimezoneSelect extends AbstractPureComponent<TimezoneSelectProps, T
         );
     }
 
-    public componentDidUpdate(prevProps: TimezoneSelectProps, prevState: TimezoneSelectState) {
-        super.componentDidUpdate(prevProps, prevState);
-        const { date: nextDate } = this.props;
+    private refreshTimezoneItems(props: TimezoneSelectProps): void {
+        const date = props.date?.getTime();
+        const dateChanged = date !== this.timezoneItemsDate;
+        const customItemsChanged = props.timezoneItems !== this.timezoneItemsProp;
+        const localTimezoneChanged = props.showLocalTimezone !== this.showLocalTimezone;
 
-        if (this.props.showLocalTimezone !== prevProps.showLocalTimezone) {
-            this.initialTimezoneItems = getInitialTimezoneItems(nextDate, this.props.showLocalTimezone!);
+        if (dateChanged || customItemsChanged) {
+            this.timezoneItems = this.getTimezoneItems(props);
+            this.initialTimezoneItems = this.getInitialTimezoneItems(props);
+        } else if (localTimezoneChanged && props.timezoneItems === undefined) {
+            this.initialTimezoneItems = getInitialTimezoneItems(props.date, props.showLocalTimezone!);
         }
-        if (nextDate != null && nextDate.getTime() !== prevProps.date?.getTime()) {
-            this.initialTimezoneItems = mapTimezonesWithNames(nextDate, this.initialTimezoneItems);
-            this.timezoneItems = mapTimezonesWithNames(nextDate, this.timezoneItems);
-        }
+
+        this.timezoneItemsDate = date;
+        this.timezoneItemsProp = props.timezoneItems;
+        this.showLocalTimezone = props.showLocalTimezone;
+    }
+
+    private getTimezoneItems(props: TimezoneSelectProps): TimezoneWithNames[] {
+        const items =
+            props.timezoneItems?.map(timezone => lookupTimezoneOffset(timezone, props.date)) ?? TIMEZONE_ITEMS;
+        return mapTimezonesWithNames(props.date, items);
+    }
+
+    private getInitialTimezoneItems(props: TimezoneSelectProps): TimezoneWithNames[] {
+        return props.timezoneItems === undefined
+            ? getInitialTimezoneItems(props.date, props.showLocalTimezone!)
+            : this.getTimezoneItems(props);
     }
 
     private renderButton() {


### PR DESCRIPTION
#### Fixes #6333

#### Checklist

- [x] Includes tests
- [x] Update documentation

#### Changes proposed in this pull request:

- Add a `timezoneItems` prop to replace the built-in timezone list.
- Derive current offsets and display names from each supplied IANA code.
- Refresh derived options when the list or formatting date changes.

#### Reviewers should focus on:

Custom items replace both initial suggestions and search results while default behavior remains unchanged.

#### Screenshot

Not applicable; this is an API-only change.

#### Testing

- Datetime type-check and ISO tests
- 483 Vitest tests
- Package compile, lint, and formatting

AI-assisted; reviewed and tested by the contributor.