### PR TITLE
fix(Overlay2): hide background content from assistive technology when modal overlay is open

### DIFF
--- a/packages/core/src/components/overlay2/overlay2.test.tsx
+++ b/packages/core/src/components/overlay2/overlay2.test.tsx
@@ -130,6 +130,107 @@ describe("<Overlay2>", () => {
         expect(container.querySelector(BACKDROP_SELECTOR)).not.toBeInTheDocument();
     });
 
+    describe("Background content accessibility", () => {
+        function createSibling() {
+            const sibling = document.createElement("div");
+            sibling.textContent = "sibling content";
+            document.body.appendChild(sibling);
+            return sibling;
+        }
+
+        it("hides sibling content from assistive technology while a modal overlay is open", async () => {
+            const sibling = createSibling();
+
+            const { rerender } = renderWithOverlaysProvider(
+                <Overlay2 transitionDuration={0} isOpen={true} hasBackdrop={true} usePortal={true}>
+                    <span>test content</span>
+                </Overlay2>,
+            );
+
+            await waitFor(() => {
+                expect(sibling.getAttribute("aria-hidden")).to.equal("true");
+            });
+
+            rerender(
+                <Overlay2 transitionDuration={0} isOpen={false} hasBackdrop={true} usePortal={true}>
+                    <span>test content</span>
+                </Overlay2>,
+            );
+
+            await waitFor(() => {
+                expect(sibling.hasAttribute("aria-hidden")).to.be.false;
+            });
+
+            document.body.removeChild(sibling);
+        });
+
+        it("does not hide sibling content for non-modal overlays (hasBackdrop=false)", () => {
+            const sibling = createSibling();
+
+            renderWithOverlaysProvider(
+                <Overlay2 transitionDuration={0} isOpen={true} hasBackdrop={false} usePortal={true}>
+                    <span>test content</span>
+                </Overlay2>,
+            );
+
+            expect(sibling.hasAttribute("aria-hidden")).to.be.false;
+
+            document.body.removeChild(sibling);
+        });
+
+        it("does not hide sibling content when usePortal is false", () => {
+            const sibling = createSibling();
+
+            renderWithOverlaysProvider(
+                <Overlay2 transitionDuration={0} isOpen={true} hasBackdrop={true} usePortal={false}>
+                    <span>test content</span>
+                </Overlay2>,
+            );
+
+            expect(sibling.hasAttribute("aria-hidden")).to.be.false;
+
+            document.body.removeChild(sibling);
+        });
+
+        it("keeps sibling content hidden while any stacked modal overlay remains open", async () => {
+            const sibling = createSibling();
+
+            function TwoOverlays() {
+                const [firstOpen, setFirstOpen] = useState(true);
+                const [secondOpen, setSecondOpen] = useState(true);
+                return (
+                    <>
+                        <Overlay2 transitionDuration={0} isOpen={firstOpen} hasBackdrop={true} usePortal={true}>
+                            <button onClick={() => setFirstOpen(false)}>close first</button>
+                        </Overlay2>
+                        <Overlay2 transitionDuration={0} isOpen={secondOpen} hasBackdrop={true} usePortal={true}>
+                            <button onClick={() => setSecondOpen(false)}>close second</button>
+                        </Overlay2>
+                    </>
+                );
+            }
+
+            renderWithOverlaysProvider(<TwoOverlays />);
+
+            await waitFor(() => {
+                expect(sibling.getAttribute("aria-hidden")).to.equal("true");
+            });
+
+            await userEvent.click(screen.getByText("close first"));
+
+            // one overlay is still open, so sibling should remain hidden
+            expect(sibling.getAttribute("aria-hidden")).to.equal("true");
+
+            await userEvent.click(screen.getByText("close second"));
+
+            await waitFor(() => {
+                expect(sibling.hasAttribute("aria-hidden")).to.be.false;
+            });
+
+            document.body.removeChild(sibling);
+        });
+    });
+
     describe("onClose", () => {
         it("should invoke on backdrop mousedown when canOutsideClickClose=true", async () => {
             const user = userEvent.setup();

--- a/packages/core/src/components/overlay2/overlay2.tsx
+++ b/packages/core/src/components/overlay2/overlay2.tsx
@@ -51,6 +51,7 @@ import type { OverlayProps } from "../overlay/overlayProps";
 import { getKeyboardFocusableElements } from "../overlay/overlayUtils";
 import { Portal } from "../portal/portal";
 
+import { hideSiblingNodes, unhideSiblingNodes } from "./overlayA11y";
 import type { OverlayInstance } from "./overlayInstance";
 
 export interface Overlay2Props extends OverlayProps, React.RefAttributes<OverlayInstance> {
@@ -113,6 +114,8 @@ export const Overlay2 = forwardRef<OverlayInstance, Overlay2Props>((props, forwa
     const [hasEverOpened, setHasEverOpened] = useState(false);
     const [shouldFocusOnContainerMount, setShouldFocusOnContainerMount] = useState(false);
     const lastActiveElementBeforeOpened = useRef<Element>(null);
+    /** Whether this overlay instance is the one that hid its siblings (for correct cleanup) */
+    const didHideSiblingNodes = useRef(false);
 
     /** Ref for container element, containing all children and the backdrop */
     const containerElement = useRef<HTMLDivElement>(null);
@@ -165,8 +168,19 @@ export const Overlay2 = forwardRef<OverlayInstance, Overlay2Props>((props, forwa
                 setIsAutoFocusing(true);
                 bringFocusInsideOverlay(node);
             }
+
+            // Hide background content from assistive technology per the WAI-ARIA APG dialog pattern,
+            // once the Portal's container has actually mounted to the DOM. (Note: `containerElement.current`
+            // is not yet set when `overlayWillOpen` runs, due to Portal's two-phase mount — see Portal.tsx.)
+            if (node != null && usePortal && hasBackdrop && !didHideSiblingNodes.current) {
+                const portalElement = node.parentElement;
+                if (portalElement != null) {
+                    hideSiblingNodes(portalElement);
+                    didHideSiblingNodes.current = true;
+                }
+            }
         },
-        [bringFocusInsideOverlay, shouldFocusOnContainerMount],
+        [bringFocusInsideOverlay, shouldFocusOnContainerMount, usePortal, hasBackdrop],
     );
 
     /**
@@ -327,6 +341,11 @@ export const Overlay2 = forwardRef<OverlayInstance, Overlay2Props>((props, forwa
                     document.addEventListener("focus", lastOpenedOverlay.handleDocumentFocus, /* useCapture */ true);
                 }
             }
+        }
+
+        if (didHideSiblingNodes.current) {
+            unhideSiblingNodes();
+            didHideSiblingNodes.current = false;
         }
     }, [closeOverlay, getLastOpened, handleDocumentFocus, handleDocumentMousedown, id]);
 

--- a/packages/core/src/components/overlay2/overlayA11y.ts
+++ b/packages/core/src/components/overlay2/overlayA11y.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Whether the native `inert` attribute is supported in the current environment.
+ */
+function supportsInert(): boolean {
+    return typeof HTMLElement !== "undefined" && "inert" in HTMLElement.prototype;
+}
+
+interface HiddenSiblingRecord {
+    element: Element;
+    hadAriaHidden: string | null;
+    hadInert: boolean;
+}
+
+let hiddenSiblings: HiddenSiblingRecord[] = [];
+let hideCount = 0;
+
+/**
+ * Hides all siblings of `container` (within its parent) from assistive technology by
+ * applying `aria-hidden` and, where supported, the `inert` attribute.
+ *
+ * Safe to call from multiple concurrently-open modal overlays: only the first (outermost)
+ * call actually mutates the DOM. Each call must be paired with exactly one
+ * `unhideSiblingNodes()` call.
+ */
+export function hideSiblingNodes(container: HTMLElement) {
+    hideCount++;
+    if (hideCount > 1) {
+        // a modal overlay is already open; siblings are already hidden
+        return;
+    }
+
+    const root = container.parentElement;
+    if (root == null) {
+        return;
+    }
+
+    const useInert = supportsInert();
+    for (const sibling of Array.from(root.children)) {
+        if (sibling === container) {
+            continue;
+        }
+        // don't clobber elements that are already hidden for some other reason
+        if (sibling.hasAttribute("aria-hidden") || (useInert && (sibling as HTMLElement).inert)) {
+            continue;
+        }
+        hiddenSiblings.push({
+            element: sibling,
+            hadAriaHidden: sibling.getAttribute("aria-hidden"),
+            hadInert: useInert ? (sibling as HTMLElement).inert : false,
+        });
+        sibling.setAttribute("aria-hidden", "true");
+        if (useInert) {
+            (sibling as HTMLElement).inert = true;
+        }
+    }
+}
+
+/**
+ * Reverses the effect of `hideSiblingNodes()`. Only restores the DOM once the matching
+ * number of calls have been made (i.e. once the last modal overlay has closed).
+ */
+export function unhideSiblingNodes() {
+    hideCount = Math.max(0, hideCount - 1);
+    if (hideCount > 0) {
+        return;
+    }
+
+    for (const { element, hadAriaHidden, hadInert } of hiddenSiblings) {
+        if (hadAriaHidden == null) {
+            element.removeAttribute("aria-hidden");
+        } else {
+            element.setAttribute("aria-hidden", hadAriaHidden);
+        }
+        if (supportsInert()) {
+            (element as HTMLElement).inert = hadInert;
+        }
+    }
+    hiddenSiblings = [];
+}


### PR DESCRIPTION
#### Fixes #6756

#### Checklist
- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Adds aria-hidden/inert support to background content behind modal Overlay2-based components (Dialog, Drawer), per the WAI-ARIA APG dialog pattern: https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/

Previously, screen reader users could navigate into content behind an open modal overlay (e.g. via heading navigation), which is unexpected and inaccessible.

- New overlayA11y.ts utility with hideSiblingNodes/unhideSiblingNodes, using a reference count so stacked modal overlays (e.g. a Dialog opening an Alert) are handled correctly.
- Wired into Overlay2's handleContainerMount callback (not overlayWillOpen, due to Portal's two-phase mount, see code comment) and overlayWillClose.
- Only applies to modal overlays: usePortal=true and hasBackdrop=true (the defaults for Dialog; opt-in via backdrop for Drawer). Non-modal overlays (e.g. Popover) and nested/inline overlays are unaffected.

Note: 2 pre-existing test failures in contextMenu.test.tsx and popover.test.tsx exist on a clean develop checkout, unrelated to this change.

#### Reviewers should focus on:

Whether hooking into handleContainerMount (rather than overlayWillOpen) is the right place for this, given Portal's two-phase mount timing, and the reference-counting approach in overlayA11y.ts for correctly handling stacked modal overlays.

#### Screenshot

N/A, this change affects the accessibility tree (aria-hidden/inert attributes), not visual rendering.