### PR TITLE
Center align dialog icons and adjust line height

### DIFF
--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -87,7 +87,8 @@ $dialog-header-padding: $pt-spacing;
     flex: 0 0 auto;
     margin-left: -$pt-spacing;
     margin-right: $dialog-padding * 0.5;
-
+align-self: center;
+line-height: 0;
     // only apply light color to icons that are not intent-specific
     &:not([class*="#{$ns}-intent"]) {
       color: $pt-icon-color;


### PR DESCRIPTION
Fixes #8214

The icon in the Dialog header wasn't vertically centered with the title text. Added align-self: center and line-height: 0 to the icon styles in _dialog.scss to fix the alignment.

#### Changes proposed in this pull request:

Added align-self: center and line-height: 0 to the dialog header icon styling in _dialog.scss.

#### Checklist

- [ ] Includes tests
- [ ] Update documentation

