### PR TITLE
[table] Allow text inputs to handle Enter

### DIFF
--- a/packages/table/src/table.test.tsx
+++ b/packages/table/src/table.test.tsx
@@ -20,7 +20,7 @@ import { act } from "react";
 import * as TestUtils from "react-dom/test-utils";
 import sinon from "sinon";
 
-import { Utils as CoreUtils } from "@blueprintjs/core";
+import { Utils as CoreUtils, HotkeysProvider } from "@blueprintjs/core";
 import { dispatchMouseEvent, expectPropValidationError } from "@blueprintjs/test-commons";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
@@ -1328,6 +1328,43 @@ describe("<Table>", () => {
                 { col: 0, focusSelectionIndex: 0, row: 0 },
                 { col: 2, focusSelectionIndex: 1, row: 2 },
             );
+
+            it.each([
+                { name: "enter", shiftKey: false },
+                { name: "shift+enter", shiftKey: true },
+            ])("does not handle $name from a textarea", ({ shiftKey }) => {
+                const selectedRegions: Region[] = [{ cols: [0, 0], rows: [0, 1] }];
+                const { getAllByRole } = render(
+                    <HotkeysProvider>
+                        <Table
+                            numRows={2}
+                            enableFocusedCell={true}
+                            focusedCell={{ col: 0, focusSelectionIndex: 0, row: 0 }}
+                            onFocusedCell={onFocusedCell}
+                            selectedRegions={selectedRegions}
+                        >
+                            <Column
+                                cellRenderer={() => (
+                                    <Cell>
+                                        <textarea aria-label="Cell editor" />
+                                    </Cell>
+                                )}
+                            />
+                        </Table>
+                    </HotkeysProvider>,
+                );
+                const event = new KeyboardEvent("keydown", {
+                    bubbles: true,
+                    cancelable: true,
+                    key: "Enter",
+                    shiftKey,
+                });
+
+                getAllByRole("textbox")[0].dispatchEvent(event);
+
+                expect(event.defaultPrevented).to.be.false;
+                expect(onFocusedCell.called).to.be.false;
+            });
         });
 
         describe("scrolls viewport to fit focused cell after moving it", () => {

--- a/packages/table/src/tableUtils.ts
+++ b/packages/table/src/tableUtils.ts
@@ -175,14 +175,12 @@ function getFocusHotkeys(focusMode: FocusMode | undefined, hotkeysImpl: TableHot
                     onKeyDown: hotkeysImpl.handleFocusMoveLeftInternal,
                 },
                 {
-                    allowInInput: true,
                     combo: "enter",
                     group: "Table",
                     label: "Move focus cell enter",
                     onKeyDown: hotkeysImpl.handleFocusMoveDownInternal,
                 },
                 {
-                    allowInInput: true,
                     combo: "shift+enter",
                     group: "Table",
                     label: "Move focus cell shift enter",


### PR DESCRIPTION
#### Fixes #6425

#### Checklist

- [x] Includes tests
- [ ] Update documentation (not applicable; this does not change the public API or documented behavior)

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Let Enter and Shift+Enter events from text inputs fall back to the existing default input filtering in `useHotkeys`.
- Add regression coverage proving textarea key events are not prevented and do not move the focused table cell.
- Preserve Tab navigation inside inputs and Enter navigation from non-input table cells.

#### Reviewers should focus on:

Whether relying on the default `allowInInput: false` behavior for Enter and Shift+Enter matches the intended focused-cell keyboard interaction.

#### Screenshot

Not applicable — this is a keyboard interaction fix covered by the regression test.