### PR TITLE
fix(core): remove context menu container DOM element in hideContextMenu

### DIFF
--- a/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.test.tsx
@@ -126,6 +126,10 @@ describe("showContextMenu() + hideContextMenu()", () => {
                         requestAnimationFrame(() => {
                             hideContextMenu();
                             assertMenuState(false);
+                            assert.isNull(
+                                document.querySelector(`.${Classes.CONTEXT_MENU}`),
+                                "Expected context menu container element to be removed from the DOM",
+                            );
                             done();
                         }),
                 });

--- a/packages/core/src/components/context-menu/contextMenuSingleton.tsx
+++ b/packages/core/src/components/context-menu/contextMenuSingleton.tsx
@@ -114,6 +114,7 @@ const defaultDomRenderer: ShowContextMenuDOMRenderer = (element, container) => {
 
 export function hideContextMenu() {
     contextMenuState?.unmount();
+    contextMenuState?.element.remove();
     contextMenuState = undefined;
 }
 


### PR DESCRIPTION
#### Checklist

- [x] Includes tests
- [ ] Update documentation (N/A)

#### Changes proposed in this pull request:

Remove the context menu container element when using the imperative `hideContextMenu` API, preventing a leak of DOM nodes.

#### Screenshot

Issue can be reproduced on the live demo site:

<img width="2048" height="990" alt="image" src="https://github.com/user-attachments/assets/5dd8c9ee-393a-4f94-b9db-edaebfdc24df" />

