### PR TITLE
fix(core): stop warning on out-of-constraint NumericInput controlled value

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -65,8 +65,6 @@ export const NUMERIC_INPUT_MAJOR_STEP_SIZE_NON_POSITIVE =
     ns + ` <NumericInput> requires majorStepSize to be strictly greater than zero.`;
 export const NUMERIC_INPUT_STEP_SIZE_NON_POSITIVE =
     ns + ` <NumericInput> requires stepSize to be strictly greater than zero.`;
-export const NUMERIC_INPUT_CONTROLLED_VALUE_INVALID =
-    ns + ` <NumericInput> controlled value prop does not adhere to stepSize, min, and/or max constraints.`;
 
 export const OVERFLOW_LIST_OBSERVE_PARENTS_CHANGED =
     ns + ` <OverflowList> does not support changing observeParents after mounting.`;

--- a/packages/core/src/components/forms/numericInput.test.tsx
+++ b/packages/core/src/components/forms/numericInput.test.tsx
@@ -476,6 +476,25 @@ describe("<NumericInput>", () => {
         afterEach(() => warnSpy.mockClear());
         afterAll(() => warnSpy.mockRestore());
 
+        // A free-text input can legitimately hold an out-of-range or off-step value while the user
+        // is typing, so these are not developer misconfigurations worth warning about.
+        // Regression test for https://github.com/palantir/blueprint/issues/7370.
+        it("does not warn when a controlled value is outside the min/max bounds", () => {
+            render(<NumericInput value={150} min={0} max={100} />);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not warn when a controlled value is not a multiple of stepSize", () => {
+            render(<NumericInput value={7} stepSize={10} />);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it("does not warn when a controlled value moves out of bounds on re-render", () => {
+            const { rerender } = render(<NumericInput value={50} min={0} max={100} />);
+            rerender(<NumericInput value={150} min={0} max={100} />);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
         describe("if no bounds are defined", () => {
             it("enforces no minimum bound", async () => {
                 const user = userEvent.setup();

--- a/packages/core/src/components/forms/numericInput.test.tsx
+++ b/packages/core/src/components/forms/numericInput.test.tsx
@@ -495,6 +495,12 @@ describe("<NumericInput>", () => {
             expect(warnSpy).not.toHaveBeenCalled();
         });
 
+        it("does not warn when a controlled value is within all constraints", () => {
+            // Control case: a valid value must remain warning-free as well.
+            render(<NumericInput value={20} min={0} max={100} stepSize={10} />);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
         describe("if no bounds are defined", () => {
             it("enforces no minimum bound", async () => {
                 const user = userEvent.setup();

--- a/packages/core/src/components/forms/numericInput.tsx
+++ b/packages/core/src/components/forms/numericInput.tsx
@@ -379,7 +379,7 @@ export class NumericInput extends AbstractPureComponent<
     }
 
     protected validateProps(nextProps: HTMLInputProps & NumericInputProps) {
-        const { majorStepSize, max, min, minorStepSize, stepSize, value } = nextProps;
+        const { majorStepSize, max, min, minorStepSize, stepSize } = nextProps;
         if (min != null && max != null && min > max) {
             console.error(Errors.NUMERIC_INPUT_MIN_MAX);
         }
@@ -399,28 +399,11 @@ export class NumericInput extends AbstractPureComponent<
             console.error(Errors.NUMERIC_INPUT_MAJOR_STEP_SIZE_BOUND);
         }
 
-        // controlled mode
-        if (value != null) {
-            const stepMaxPrecision = NumericInput.getStepMaxPrecision(nextProps);
-            const sanitizedValue = NumericInput.roundAndClampValue(
-                value.toString(),
-                stepMaxPrecision,
-                min,
-                max,
-                0,
-                this.props.locale,
-            );
-            const valueDoesNotMatch = sanitizedValue !== value.toString();
-            const localizedValue = toLocaleString(
-                Number(parseStringToStringNumber(value, this.props.locale)),
-                this.props.locale,
-            );
-            const isNotLocalized = sanitizedValue !== localizedValue;
-
-            if (valueDoesNotMatch && isNotLocalized) {
-                console.warn(Errors.NUMERIC_INPUT_CONTROLLED_VALUE_INVALID);
-            }
-        }
+        // Note: we intentionally do not warn when a controlled `value` falls outside the
+        // stepSize/min/max constraints. Unlike the checks above, that is not a developer
+        // misconfiguration — a free-text input can legitimately hold an intermediate or
+        // out-of-range value while the user is typing, and coercing it away would be worse
+        // UX than allowing it. See https://github.com/palantir/blueprint/issues/7370.
     }
 
     // Render Helpers


### PR DESCRIPTION
#### Fixes #7370

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

`NumericInput.validateProps` logs a `console.warn` on **every render** whenever a controlled `value` prop does not adhere to the `stepSize`, `min`, and/or `max` constraints:

> `[Blueprint] <NumericInput> controlled value prop does not adhere to stepSize, min, and/or max constraints.`

Unlike the other checks in `validateProps` (`min > max`, non-positive `stepSize`, etc.), an out-of-constraint controlled `value` is **not a developer misconfiguration**. `NumericInput` is a free-text field, so it can legitimately hold an intermediate or out-of-range value while the user is typing — e.g. typing `2` on the way to `20` when `min={10}`. The only way to make the warning never fire would be to silently coerce the user's input, which is worse UX than allowing it.

This PR:

- Removes the controlled-value branch from `validateProps` and replaces it with a comment explaining why the check was dropped.
- Removes the now-unused `Errors.NUMERIC_INPUT_CONTROLLED_VALUE_INVALID` message.
- Adds regression tests covering an out-of-bounds value, an off-`stepSize` value, and a value that moves out of bounds on re-render — asserting `console.warn` is not called in any case.

No behavior other than the console warning changes: clamping/rounding of the *committed* value on increment/decrement/blur is untouched.

#### Reviewers should focus on:

- Whether dropping this warning entirely is preferred over gating it (the issue and linked #4327 argue for dropping it — a free-text input legitimately passes through invalid intermediate states).
- That no remaining code path depends on `NUMERIC_INPUT_CONTROLLED_VALUE_INVALID` (grep confirms the constant and its only usage are both removed).

#### Screenshot

N/A — this removes console noise; there is no visual change.

---

<sub>Authored with assistance from Claude Code (Anthropic). All changes were reviewed and the `@blueprintjs/core` `numericInput` suite (163 tests) passes locally.</sub>
