### PR TITLE
fix alignment for box

### DIFF
--- a/packages/labs/src/components/box/_box.scss
+++ b/packages/labs/src/components/box/_box.scss
@@ -297,11 +297,11 @@ $relative-sizes: (
   }
 
   &.#{bp.$ns}-self-baseline {
-    align-self: stretch;
+    align-self: baseline;
   }
 
   &.#{bp.$ns}-self-stretch {
-    align-self: baseline;
+    align-self: stretch;
   }
 
   // display


### PR DESCRIPTION
#### Fixes alignment classes for Box

#### Changes proposed in this pull request:

- fix alignment classes for Box: `alignSelf="stretch"` and `alignSelf="baseline"` were swapped
