### PR TITLE
[select] fix: restore role="combobox" on the Select popover target

### DIFF
--- a/packages/select/changelog/@unreleased/pr-8225.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8225.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: "[select] `Select` popover target is once again `role=\"combobox\"` when `filterable` is true"
+  links:
+    - href: https://github.com/palantir/blueprint/pull/8225
+      text: 8225

--- a/packages/select/src/components/select/select.test.tsx
+++ b/packages/select/src/components/select/select.test.tsx
@@ -94,6 +94,34 @@ describe("<Select>", () => {
         expect(wrapper.find(PopoverNext)).toHaveLength(1);
     });
 
+    it("renders role='combobox' on the popover target while filterable and closed", () => {
+        // The query InputGroup is only mounted while the popover is open, so the target is the only
+        // element which can carry the combobox role in the default closed state.
+        const wrapper = select({ popoverProps: { usePortal: false } });
+        expect(findTargetElement(wrapper).getAttribute("role")).toBe("combobox");
+    });
+
+    it("renders role='combobox' on the popover target when filterable=false", () => {
+        const wrapper = select({ filterable: false, popoverProps: { usePortal: false } });
+        expect(findTargetElement(wrapper).getAttribute("role")).toBe("combobox");
+    });
+
+    it("keeps the combobox ARIA state attributes on the element which carries the role", () => {
+        // aria-expanded and aria-controls are not global attributes, so they are ignored by assistive
+        // technology unless the element they sit on has a role which supports them.
+        const wrapper = select({ popoverProps: { usePortal: false } });
+        expect(findTargetElement(wrapper).getAttribute("aria-expanded")).toBe("false");
+
+        findTargetButton(wrapper).simulate("click");
+        wrapper.update();
+
+        const target = findTargetElement(wrapper);
+        const listboxId = wrapper.find("[role='listbox']").hostNodes().getDOMNode().getAttribute("id");
+        expect(target.getAttribute("role")).toBe("combobox");
+        expect(target.getAttribute("aria-expanded")).toBe("true");
+        expect(target.getAttribute("aria-controls")).toBe(listboxId);
+    });
+
     it("disabled=true disables Popover", () => {
         const wrapper = select({ disabled: true });
         expect(wrapper.find(PopoverNext).prop("disabled")).toBe(true);
@@ -267,6 +295,11 @@ describe("<Select>", () => {
 
     function findTargetButton(wrapper: ReactWrapper): ReactWrapper<HTMLAttributes> {
         return wrapper.find("[data-testid='target-button']").hostNodes();
+    }
+
+    // The wrapper element which Select renders around `children` via the Popover renderTarget API.
+    function findTargetElement(wrapper: ReactWrapper): Element {
+        return wrapper.find(`.${Classes.POPOVER_TARGET}`).hostNodes().getDOMNode();
     }
 
     // Mount a closed, non-filterable Select with an arbitrary target child (optionally wrapped in an

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -242,8 +242,6 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                     ...targetProps,
                     "aria-disabled": disabled,
                     "aria-expanded": isOpen,
-                    // When filterable, the InputGroup inside is the combobox; this trigger is just a button
-                    // When not filterable, this trigger is the combobox
                     ...(filterable ? { "aria-haspopup": "listbox" } : {}),
                     // Note that we must set FILL here in addition to children to get the wrapper element to full width
                     className: classNames(targetProps.className, popoverTargetProps?.className, {
@@ -258,7 +256,10 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                     ),
                     onKeyUp: this.withPopoverTargetPropsHandler("keyup", isOpen ? handleKeyUp : undefined),
                     ref,
-                    role: filterable ? undefined : "combobox",
+                    // This trigger is always the combobox, matching MultiSelect. When filterable, the query
+                    // InputGroup only exists while the popover is open, so leaving the role off here would
+                    // strand "aria-expanded", "aria-controls" and "aria-disabled" on a roleless element.
+                    role: "combobox",
                 },
                 this.props.children,
             );


### PR DESCRIPTION
Fixes #8212 and #8142.

The Select popover target lost its combobox role in #7543, which changed it to `filterable ? undefined : "combobox"` on the theory that the query InputGroup inside the popover is the real combobox. That InputGroup is only mounted while the popover is open, so with the default `filterable={true}` a closed Select renders no combobox at all, and `aria-expanded`, `aria-controls` and `aria-disabled` are left on an element with no role, where assistive technology ignores them and axe reports a violation.

This restores the unconditional `role="combobox"` on the target, matching what MultiSelect already does, and adds three regression tests covering the filterable branch, the non-filterable branch, and the closed to open transition. Note that bvandrc raised exactly this axe regression in review on #7543.

I deliberately left the adjacent `aria-haspopup` line alone. Popover already supplies `aria-haspopup` from `popupKind`, so that line is a no-op except under `HOVER_TARGET_ONLY`, and changing it would be an unrequested behavior change.

Verified by restoring `select.tsx` to `develop` and rerunning: 2 of the new tests fail with `expected null to be 'combobox'`, and the `filterable={false}` case passes either way since that branch was already correct. With the fix the select package is 177 passed, and datetime is 481 passed since TimezoneSelect wraps Select. Type check and lint are clean.
