### PR TITLE
make PopoverNext scale out of correct target when arrow is hidden

### DIFF
--- a/packages/core/src/components/popover/popperUtils.test.ts
+++ b/packages/core/src/components/popover/popperUtils.test.ts
@@ -18,7 +18,7 @@ import type { BasePlacement } from "@popperjs/core";
 
 import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
 
-import { getAlignment, getOppositePlacement } from "./popperUtils";
+import { getAlignment, getOppositePlacement, getTransformOrigin } from "./popperUtils";
 
 describe("Popper utils", () => {
     it("getOppositePlacement returns opposite", () => {
@@ -35,5 +35,41 @@ describe("Popper utils", () => {
         expect(getAlignment("bottom-start")).to.equal("left");
         expect(getAlignment("top-end")).to.equal("right");
         expect(getAlignment("left")).to.equal("center");
+    });
+
+    it("getAlignment returns vertical keywords on the y axis", () => {
+        expect(getAlignment("left-start", "y")).to.equal("top");
+        expect(getAlignment("right-end", "y")).to.equal("bottom");
+        expect(getAlignment("right", "y")).to.equal("center");
+    });
+
+    describe("getTransformOrigin", () => {
+        it("points at the target's edge for unaligned placements", () => {
+            expect(getTransformOrigin("top", undefined)).to.equal("center bottom");
+            expect(getTransformOrigin("bottom", undefined)).to.equal("center top");
+            expect(getTransformOrigin("left", undefined)).to.equal("right center");
+            expect(getTransformOrigin("right", undefined)).to.equal("left center");
+        });
+
+        it("points at the target's corner for aligned top/bottom placements", () => {
+            expect(getTransformOrigin("bottom-start", undefined)).to.equal("left top");
+            expect(getTransformOrigin("bottom-end", undefined)).to.equal("right top");
+            expect(getTransformOrigin("top-start", undefined)).to.equal("left bottom");
+            expect(getTransformOrigin("top-end", undefined)).to.equal("right bottom");
+        });
+
+        // regression test: these used to produce invalid CSS like "right left", which browsers
+        // drop entirely, causing the popover to scale out of its own center
+        it("uses vertical keywords for aligned left/right placements", () => {
+            expect(getTransformOrigin("left-start", undefined)).to.equal("right top");
+            expect(getTransformOrigin("left-end", undefined)).to.equal("right bottom");
+            expect(getTransformOrigin("right-start", undefined)).to.equal("left top");
+            expect(getTransformOrigin("right-end", undefined)).to.equal("left bottom");
+        });
+
+        it("offsets by half the arrow size when an arrow is present", () => {
+            expect(getTransformOrigin("bottom-start", { left: "20px", top: "0px" })).to.equal("35px top");
+            expect(getTransformOrigin("left-start", { left: "0px", top: "12px" })).to.equal("right 27px");
+        });
     });
 });

--- a/packages/core/src/components/popover/popperUtils.ts
+++ b/packages/core/src/components/popover/popperUtils.ts
@@ -45,14 +45,18 @@ export function getOppositePlacement(side: BasePlacement) {
     }
 }
 
-/** Returns the CSS alignment keyword corresponding to given placement. */
-export function getAlignment(placement: Placement) {
+/**
+ * Returns the CSS alignment keyword corresponding to given placement, along the given axis.
+ * The `"y"` axis is needed for left/right placements, where popper aligns the popover along
+ * the vertical edge of the target and `left`/`right` would be invalid keywords.
+ */
+export function getAlignment(placement: Placement, axis: "x" | "y" = "x") {
     const align = placement.split("-")[1] as "start" | "end" | undefined;
     switch (align) {
         case "start":
-            return "left";
+            return axis === "x" ? "left" : "top";
         case "end":
-            return "right";
+            return axis === "x" ? "right" : "bottom";
         default:
             return "center";
     }
@@ -65,9 +69,11 @@ export function getAlignment(placement: Placement) {
 export function getTransformOrigin(placement: Placement, arrowStyles: { left: string; top: string } | undefined) {
     const basePlacement = getBasePlacement(placement);
     if (arrowStyles === undefined) {
+        // N.B. alignment must be read from the full `placement`, not `basePlacement`, which has
+        // already had its `-start`/`-end` suffix stripped.
         return isVerticalPlacement(basePlacement)
-            ? `${getOppositePlacement(basePlacement)} ${getAlignment(basePlacement)}`
-            : `${getAlignment(basePlacement)} ${getOppositePlacement(basePlacement)}`;
+            ? `${getOppositePlacement(basePlacement)} ${getAlignment(placement, "y")}`
+            : `${getAlignment(placement, "x")} ${getOppositePlacement(basePlacement)}`;
     } else {
         // const arrowSizeShift = state.elements.arrow.clientHeight / 2;
         const arrowSizeShift = 30 / 2;


### PR DESCRIPTION
#### Checklist

- [X] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

- fix `getTransformOrigin` so that `PopoverNext` scales out of the target when the arrow is hidden

basePlacement is only "top", "bottom", "left", or "right", the "-start"/"-end" information has already been removed, so `getAlignment()` always returns "center". the effect is that `bottom-end` produced `transform-origin: center top` instead of `right top`

additionally, side placements produced invalid CSS. `getAlignment` only returned horizontal keywords (left/right/center), but for left/right base placements that value lands in the y slot. `left-start` would have yielded `right left` and been rejected by the browser

under these changes, `getAlignment` gets an optional axis parameter defaulting to "x", so "start"/"end" map to top/bottom when asked for the y axis. the arrowless branch now passes the full placement (not basePlacement) and requests the axis matching the placement side.

before:

https://github.com/user-attachments/assets/4de79838-85e1-464e-a648-97b88f26f67b

<img width="363" height="178" alt="Screenshot 2026-08-06 at 4 43 20 PM" src="https://github.com/user-attachments/assets/c30d1eac-6340-49cd-aab0-2e856b29452d" />

after:

https://github.com/user-attachments/assets/857fb733-1d1b-48e1-8999-04524d0d8116

<img width="520" height="191" alt="Screenshot 2026-08-06 at 4 44 05 PM" src="https://github.com/user-attachments/assets/b34c86ba-0012-43eb-9a6c-f124cea71ddd" />

<img width="518" height="191" alt="Screenshot 2026-08-06 at 4 44 17 PM" src="https://github.com/user-attachments/assets/e6f3d7d3-7e4a-431d-9413-f6120c660a09" />
