### PR TITLE
[Blueprint] Adding scaffolding for feature flagging next styles

### DIFF
--- a/packages/core/src/blueprint.scss
+++ b/packages/core/src/blueprint.scss
@@ -18,3 +18,9 @@ Licensed under the Apache License, Version 2.0.
 @import "accessibility/focus-states";
 @import "dark-theme";
 @import "components/index";
+
+.bp-next {
+  // TODO: Remove stylelint disable once -next is fully incorporated
+  /* stylelint-disable-next-line no-invalid-position-at-import-rule */
+  @import "components/index-next";
+}

--- a/packages/core/src/common/_variables.scss
+++ b/packages/core/src/common/_variables.scss
@@ -72,6 +72,9 @@ $pt-line-height: 1.28581 !default;
 // equivalent to: $pt-spacing
 $pt-border-radius: 4px !default;
 
+// Intents
+$pt-intents: ("primary", "success", "warning", "danger");
+
 // Buttons
 $pt-button-height: $pt-spacing * 7.5 !default;
 $pt-button-height-small: $pt-spacing * 6 !default;

--- a/packages/core/src/components/_index-next.scss
+++ b/packages/core/src/components/_index-next.scss
@@ -1,0 +1,5 @@
+// Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0.
+
+@import "button/button-next";
+@import "button/button-group-next";

--- a/packages/core/src/components/button/_button-group-next.scss
+++ b/packages/core/src/components/button/_button-group-next.scss
@@ -1,0 +1,159 @@
+@use "sass:map";
+@import "../../common/variables";
+@import "./common-next";
+
+// z-index values for button stacking order (derived from $control-group-stack in forms/_common.scss)
+$button-group-z-index: (
+  "button-disabled": 3,
+  "button-default": 4,
+  "button-focus": 5,
+  "button-hover": 6,
+  "button-active": 7,
+  "intent-button-disabled": 8,
+  "intent-button-default": 9,
+  "intent-button-focus": 10,
+  "intent-button-hover": 11,
+  "intent-button-active": 12,
+);
+
+.#{$ns}-button-group {
+  display: inline-flex;
+
+  .#{$ns}-button {
+    // ensure button can never be smaller than its default size
+    flex: 0 0 auto;
+    position: relative;
+  }
+
+  // support wrapping buttons in a tooltip, which adds a wrapper element
+  &:not(.#{$ns}-minimal),
+  &.#{$ns}-outlined {
+    > .#{$ns}-popover-wrapper:not(:first-child) .#{$ns}-button,
+    > .#{$ns}-popover-target:not(:first-child) > .#{$ns}-button,
+    > .#{$ns}-button:not(:first-child) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+
+    > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
+    > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button,
+    > .#{$ns}-button:not(:last-child) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
+  }
+
+  &:not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
+    > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
+    > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button,
+    > .#{$ns}-button:not(:last-child) {
+      margin-right: calc(-1 * var(--bp-surface-border-width));
+    }
+  }
+
+  &.#{$ns}-minimal,
+  &.#{$ns}-outlined {
+    .#{$ns}-button {
+      @include pt-button-minimal-next;
+    }
+
+    @media (forced-colors: active) and (prefers-color-scheme: dark) {
+      // Because we give even minimal buttons a border in high contrast mode, we need to handle border styles
+      // similar to how we handle non-minimal buttons
+
+      &:not(:first-child) {
+        border-bottom-left-radius: 0;
+        border-left: none;
+        border-top-left-radius: 0;
+      }
+
+      &:not(:last-child) {
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+        margin-right: calc(-1 * var(--bp-surface-border-width));
+      }
+    }
+  }
+
+  &.#{$ns}-outlined {
+    > .#{$ns}-button,
+    > .#{$ns}-popover-target > .#{$ns}-button {
+      @include pt-button-outlined-next;
+    }
+
+    &:not(.#{$ns}-vertical) {
+      > .#{$ns}-button:not(:last-child),
+      > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button {
+        border-right: none;
+      }
+    }
+  }
+
+  .#{$ns}-popover-wrapper,
+  .#{$ns}-popover-target {
+    display: flex;
+    flex: 1 1 auto;
+  }
+
+  &.#{$ns}-fill {
+    display: flex;
+    width: 100%;
+  }
+
+  .#{$ns}-button.#{$ns}-fill,
+  &.#{$ns}-fill .#{$ns}-button:not(.#{$ns}-fixed) {
+    flex: 1 1 auto;
+  }
+
+  &.#{$ns}-vertical {
+    align-items: stretch;
+    flex-direction: column;
+    vertical-align: top;
+
+    &.#{$ns}-fill {
+      height: 100%;
+      width: unset;
+    }
+
+    .#{$ns}-button {
+      // we never want that margin-right when vertical
+      margin-right: 0 !important; /* stylelint-disable-line declaration-no-important */
+      // needed to ensure buttons take up the full width when wrapped in a Popover:
+      width: 100%;
+    }
+
+    &:not(.#{$ns}-minimal),
+    &.#{$ns}-outlined {
+      > .#{$ns}-popover-wrapper:first-child .#{$ns}-button,
+      > .#{$ns}-popover-target:first-child > .#{$ns}-button,
+      > .#{$ns}-button:first-child {
+        border-radius: var(--bp-surface-border-radius) var(--bp-surface-border-radius) 0 0;
+      }
+
+      > .#{$ns}-popover-wrapper:last-child .#{$ns}-button,
+      > .#{$ns}-popover-target:last-child > .#{$ns}-button,
+      > .#{$ns}-button:last-child {
+        border-radius: 0 0 var(--bp-surface-border-radius) var(--bp-surface-border-radius);
+      }
+    }
+
+    &:not(.#{$ns}-minimal):not(.#{$ns}-outlined) {
+      > .#{$ns}-popover-wrapper:not(:last-child) .#{$ns}-button,
+      > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button,
+      > .#{$ns}-button:not(:last-child) {
+        margin-bottom: calc(-1 * var(--bp-surface-border-width));
+      }
+    }
+
+    &.#{$ns}-outlined {
+      > .#{$ns}-button:not(:last-child),
+      > .#{$ns}-popover-target:not(:last-child) > .#{$ns}-button {
+        border-bottom: none;
+      }
+    }
+  }
+
+  &.#{$ns}-align-left .#{$ns}-button {
+    text-align: left;
+  }
+}

--- a/packages/core/src/components/button/_button-group.scss
+++ b/packages/core/src/components/button/_button-group.scss
@@ -20,7 +20,7 @@ $button-group-z-index: (
   "intent-button-active": 12,
 );
 
-.#{$ns}-button-group {
+.#{$ns}-button-group:not(.bp-next .#{$ns}-button-group) {
   display: inline-flex;
 
   .#{$ns}-button {

--- a/packages/core/src/components/button/_button-next.scss
+++ b/packages/core/src/components/button/_button-next.scss
@@ -1,0 +1,47 @@
+@import "../../common/variables";
+@import "../../common/variables-extended";
+@import "./common-next";
+
+.#{$ns}-button {
+  @include pt-button-layout-next;
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
+
+  &:empty {
+    // override padding from other modifiers (for CSS icon support)
+    /* stylelint-disable-next-line declaration-no-important */
+    padding: 0 !important;
+  }
+
+  &:disabled,
+  &.#{$ns}-disabled {
+    cursor: not-allowed;
+  }
+
+  &.#{$ns}-fill {
+    display: flex;
+    width: 100%;
+  }
+
+  &.#{$ns}-align-right,
+  .#{$ns}-align-right & {
+    text-align: right;
+  }
+
+  &.#{$ns}-align-left,
+  .#{$ns}-align-left & {
+    text-align: left;
+  }
+
+  // default styles
+  &:not([class*="#{$ns}-intent-"]) {
+    @include pt-button-next;
+  }
+
+  // intents
+  @each $intent in $pt-intents {
+    &.#{$ns}-intent-#{$intent} {
+      @include pt-button-intent-variant-next($intent);
+    }
+  }
+}

--- a/packages/core/src/components/button/_button.scss
+++ b/packages/core/src/components/button/_button.scss
@@ -5,7 +5,7 @@
 @import "../../common/variables-extended";
 @import "./common";
 
-.#{$ns}-button {
+.#{$ns}-button:not(.bp-next .#{$ns}-button) {
   @include pt-button-layout;
   min-height: calc(var(--bp-surface-spacing) * 7.5);
   min-width: calc(var(--bp-surface-spacing) * 7.5);

--- a/packages/core/src/components/button/_common-next.scss
+++ b/packages/core/src/components/button/_common-next.scss
@@ -1,0 +1,76 @@
+@use "sass:map";
+@import "../../common/mixins";
+@import "../../common/variables";
+@import "../../common/variables-extended";
+
+// TODO: Remove once updated tokens are included
+/* stylelint-disable color-named */
+@mixin pt-button-layout-next() {
+  @include pt-flex-container(row, calc(var(--bp-surface-spacing) * 2), $inline: inline);
+  align-items: center;
+  border: none;
+  border-radius: var(--bp-surface-border-radius);
+  cursor: pointer;
+  font-size: var(--bp-typography-size-body-medium);
+  justify-content: center;
+  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
+  text-align: left;
+  vertical-align: middle;
+}
+
+@mixin pt-button-height-default-next() {
+  min-height: calc(var(--bp-surface-spacing) * 7.5);
+  min-width: calc(var(--bp-surface-spacing) * 7.5);
+  padding: var(--bp-surface-spacing) calc(var(--bp-surface-spacing) * 2);
+}
+
+@mixin pt-button-height-small-next() {
+  min-height: calc(var(--bp-surface-spacing) * 6);
+  min-width: calc(var(--bp-surface-spacing) * 6);
+  padding: 0 calc(var(--bp-surface-spacing) * 2);
+}
+
+@mixin pt-button-next() {
+  background-color: blue;
+  box-shadow: inset var(--bp-surface-shadow-0);
+  color: turquoise;
+}
+
+@mixin pt-button-intent-variant-next($intent) {
+  background-color: lightskyblue;
+  color: aliceblue;
+}
+
+@mixin pt-dark-button-next() {
+  background-color: darkblue;
+}
+
+@mixin pt-dark-button-default-colors-next() {
+  background-color: darkblue;
+}
+
+@mixin pt-dark-button-hover-next() {
+  background-color: darkblue;
+}
+
+@mixin pt-dark-button-active-next() {
+  background-color: darkblue;
+}
+
+@mixin pt-dark-button-disabled-next() {
+  background-color: darkblue;
+}
+
+@mixin pt-button-minimal-next() {
+  background: none;
+  color: blueviolet;
+}
+
+@mixin pt-button-minimal-intent-next($intent) {
+  color: indigo;
+}
+
+@mixin pt-button-outlined-next() {
+  border: var(--bp-surface-border-width) solid;
+  border-color: violet;
+}


### PR DESCRIPTION
#### Checklist

- [ ] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

Adds `.bp-next` class with updated styling for the components
Testing the capability - no changes now.

#### Reviewers should focus on:

Does this work?

#### Screenshot

N/A