### PR TITLE
[node-build-scripts] Align package lint with root ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,6 +89,41 @@ module.exports = tseslint.config([
         },
     },
     {
+        // Stylelint rules are consumed as default-exported plugin modules.
+        files: ["**/packages/stylelint-plugin/src/rules/*.ts"],
+        rules: {
+            "import/no-default-export": "off",
+        },
+    },
+    {
+        // These mapped type utilities are copied from type-fest and retain their upstream style.
+        files: ["**/packages/icons/src/type-utils/*.ts"],
+        rules: {
+            "@typescript-eslint/no-shadow": "off",
+            "header/header": "off",
+            "import/order": "off",
+            "jsdoc/check-alignment": "off",
+        },
+    },
+    {
+        // Documentation examples include legacy APIs and favor concise, copyable component snippets.
+        files: ["**/packages/docs-app/src/examples/**/*.{ts,tsx}"],
+        rules: {
+            "@typescript-eslint/no-deprecated": "off",
+            "header/header": "off",
+            "import/no-default-export": "off",
+            "no-console": "off",
+            "react/display-name": "off",
+            "react/jsx-no-bind": "off",
+        },
+    },
+    {
+        files: ["**/packages/docs-app/src/components/colorPalettes.tsx"],
+        rules: {
+            "react/display-name": "off",
+        },
+    },
+    {
         ignores: [
             "**/node_modules",
             "**/dist",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,6 +93,7 @@ module.exports = tseslint.config([
         files: ["**/packages/stylelint-plugin/src/rules/*.ts"],
         rules: {
             "import/no-default-export": "off",
+            "no-duplicate-imports": "off",
         },
     },
     {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,7 +39,7 @@ module.exports = tseslint.config([
             "**/test/**/*.{ts,tsx,js,mjs}",
             "**/test/isotest.mjs",
             "**/vitest.setup.{ts,js,mts,mjs}",
-            "**/*.test.{ts,tsx}",
+            "**/*.test.{ts,tsx,js,mjs}",
             "**/*TestUtils*.{ts,tsx}",
         ],
         languageOptions: {
@@ -79,8 +79,8 @@ module.exports = tseslint.config([
         files: ["**/*.stories.{ts,tsx}"],
         languageOptions: {
             parserOptions: {
-                projectService: false,
                 project: `${__dirname}/.storybook/tsconfig.json`,
+                projectService: false,
             },
         },
         rules: {

--- a/packages/node-build-scripts/changelog/@unreleased/pr-8231.v2.yml
+++ b/packages/node-build-scripts/changelog/@unreleased/pr-8231.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Resolve package ESLint configuration from the workspace root
+  links:
+    - https://github.com/palantir/blueprint/pull/8231

--- a/packages/node-build-scripts/es-lint.mjs
+++ b/packages/node-build-scripts/es-lint.mjs
@@ -15,7 +15,7 @@ import { globSync } from "glob";
 import { resolve } from "node:path";
 import { argv, cwd, exit } from "node:process";
 
-import { junitReportPath } from "./src/utils.mjs";
+import { getRootDir, junitReportPath } from "./src/utils.mjs";
 
 await main();
 
@@ -26,7 +26,7 @@ async function main() {
     // ESLint may fail if provided with no files, so we expand the glob before running it
     const anyFilesToLint = globSync(absoluteFileGlob);
     if (anyFilesToLint.length === 0) {
-        console.log(`[node-build-scripts/es-lint] Not running ESLint because no files match the glob "${FILES_GLOB}"`);
+        console.info(`[node-build-scripts/es-lint] Not running ESLint because no files match the glob "${FILES_GLOB}"`);
         return;
     }
 
@@ -38,7 +38,9 @@ async function main() {
     }
 
     const fix = argv.includes("--fix");
-    const eslint = new ESLint({ fix });
+    // Resolve config file patterns from the workspace root so package-level linting
+    // applies the same rules as invoking ESLint from the repository root.
+    const eslint = new ESLint({ cwd: getRootDir() ?? cwd(), fix });
     let exitCode = 0;
 
     try {
@@ -61,7 +63,7 @@ async function main() {
         if (outputReportPath !== undefined) {
             fs.outputFileSync(outputReportPath, resultText);
         } else {
-            console.log(resultText);
+            console.info(resultText);
         }
         console.info(
             `[node-build-scripts/es-lint] Done running ESLint, with ${exitCode === 0 ? "no" : "some"} errors.`,

--- a/packages/node-build-scripts/src/__tests__/utils.test.mjs
+++ b/packages/node-build-scripts/src/__tests__/utils.test.mjs
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { getRootDir } from "../utils.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) {
+        rmSync(directory, { force: true, recursive: true });
+    }
+});
+
+describe("getRootDir", () => {
+    test("finds the workspace root from a package source directory", () => {
+        const workspaceDir = createTemporaryDirectory();
+        const sourceDir = join(workspaceDir, "packages", "select", "src");
+        mkdirSync(sourceDir, { recursive: true });
+        writeFileSync(join(workspaceDir, "package.json"), JSON.stringify({ workspaces: ["packages/*"] }));
+        writeFileSync(join(workspaceDir, "packages", "select", "package.json"), JSON.stringify({ name: "select" }));
+
+        expect(getRootDir(sourceDir)).toBe(workspaceDir);
+    });
+
+    test("falls back to the closest package root outside a workspace", () => {
+        const packageDir = createTemporaryDirectory();
+        const sourceDir = join(packageDir, "src", "components");
+        mkdirSync(sourceDir, { recursive: true });
+        writeFileSync(join(packageDir, "package.json"), JSON.stringify({ name: "standalone-package" }));
+
+        expect(getRootDir(sourceDir)).toBe(packageDir);
+    });
+});
+
+function createTemporaryDirectory() {
+    const directory = mkdtempSync(join(tmpdir(), "blueprint-node-build-scripts-"));
+    temporaryDirectories.push(directory);
+    return directory;
+}

--- a/packages/node-build-scripts/src/utils.mjs
+++ b/packages/node-build-scripts/src/utils.mjs
@@ -16,9 +16,9 @@
 
 // @ts-check
 
+import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { cwd, env } from "node:process";
-import { packageUpSync } from "package-up";
 
 /**
  * @param {string} dirName name of directory containing XML file.
@@ -39,19 +39,39 @@ export function junitReportPath(dirName, fileName = basename(cwd())) {
 }
 
 /**
- * WARNING: this function only works inside the palantir/blueprint monorepo. It is currently broken for
- * consumers who use @blueprintjs/node-build-scripts as an NPM dependency.
+ * Finds the workspace root containing the current package. For standalone packages,
+ * falls back to the closest directory containing a package.json file.
  *
- * @see https://github.com/palantir/blueprint/issues/5295
- * @see https://github.com/palantir/blueprint/issues/4942
- *
- * @returns the root directory of this Blueprint monorepo
+ * @param {string} startDir directory to start searching from
+ * @returns the root directory of the current workspace or package
  */
-export function getRootDir() {
-    const manifestFilePath = packageUpSync({ cwd: import.meta.dirname });
-    if (manifestFilePath === undefined) {
-        return undefined;
+export function getRootDir(startDir = cwd()) {
+    let currentDir = resolve(startDir);
+    let closestPackageDir;
+
+    while (true) {
+        const manifestFilePath = join(currentDir, "package.json");
+        if (existsSync(manifestFilePath)) {
+            closestPackageDir ??= currentDir;
+
+            try {
+                const manifest = JSON.parse(readFileSync(manifestFilePath, "utf8"));
+                if (manifest.workspaces !== undefined) {
+                    return currentDir;
+                }
+            } catch {
+                // Ignore malformed manifests here; the package manager will report them separately.
+            }
+        }
+
+        if (existsSync(join(currentDir, "pnpm-workspace.yaml"))) {
+            return currentDir;
+        }
+
+        const parentDir = dirname(currentDir);
+        if (parentDir === currentDir) {
+            return closestPackageDir;
+        }
+        currentDir = parentDir;
     }
-    const nodeModuleScriptsDir = dirname(manifestFilePath);
-    return resolve(nodeModuleScriptsDir, "..", "..");
 }

--- a/packages/node-build-scripts/vitest.config.mts
+++ b/packages/node-build-scripts/vitest.config.mts
@@ -6,8 +6,8 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
     test: {
-        name: "node-build-scripts",
         environment: "node",
-        include: ["src/**/*.test.ts"],
+        include: ["src/**/*.test.{mjs,ts}"],
+        name: "node-build-scripts",
     },
 });

--- a/packages/select/changelog/@unreleased/pr-8231.v2.yml
+++ b/packages/select/changelog/@unreleased/pr-8231.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Apply the repository ESLint rules during Select package lint
+  links:
+    - https://github.com/palantir/blueprint/pull/8231

--- a/packages/select/src/components/multi-select/multiSelect.tsx
+++ b/packages/select/src/components/multi-select/multiSelect.tsx
@@ -221,6 +221,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
             <PopoverNext
+                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
                 canEscapeKeyClose={true}
                 disabled={disabled}
@@ -230,6 +231,7 @@ export class MultiSelect<T> extends AbstractPureComponent<MultiSelectProps<T>, M
                 {...popoverPropsToNextProps(popoverProps)}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
+                    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                     <div
                         // In the case where customTarget is supplied and the TagInput is rendered within the Popover,
                         // without matchTargetWidth there is no width defined in any of TagInput's

--- a/packages/select/src/components/omnibar/omnibar.tsx
+++ b/packages/select/src/components/omnibar/omnibar.tsx
@@ -98,6 +98,7 @@ export class Omnibar<T> extends PureComponent<OmnibarProps<T>> {
             >
                 <div className={classNames(Classes.OMNIBAR, listProps.className)} {...handlers}>
                     <InputGroup
+                        // eslint-disable-next-line jsx-a11y/no-autofocus
                         autoFocus={true}
                         leftIcon={<SearchIcon />}
                         placeholder="Search..."

--- a/packages/select/src/components/select/select.tsx
+++ b/packages/select/src/components/select/select.tsx
@@ -197,6 +197,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
         // N.B. no need to set `fill` since that is unused with the `renderTarget` API
         return (
             <PopoverNext
+                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={this.state.isOpen}
@@ -205,6 +206,7 @@ export class Select<T> extends AbstractPureComponent<SelectProps<T>, SelectState
                 {...popoverPropsToNextProps(popoverProps)}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
+                    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                     <div {...popoverContentProps} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                         {filterable ? input : undefined}
                         {listProps.itemList}

--- a/packages/select/src/components/suggest/suggest.tsx
+++ b/packages/select/src/components/suggest/suggest.tsx
@@ -201,6 +201,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
         // N.B. no need to set `popoverProps.fill` since that is unused with the `renderTarget` API
         return (
             <PopoverNext
+                // eslint-disable-next-line jsx-a11y/no-autofocus
                 autoFocus={false}
                 enforceFocus={false}
                 isOpen={isOpen}
@@ -208,6 +209,7 @@ export class Suggest<T> extends AbstractPureComponent<SuggestProps<T>, SuggestSt
                 {...popoverPropsToNextProps(popoverProps)}
                 className={classNames(listProps.className, popoverProps.className)}
                 content={
+                    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
                     <div {...popoverContentProps} onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
                         {listProps.itemList}
                     </div>

--- a/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
@@ -15,8 +15,7 @@
 
 import type { Root } from "postcss";
 import selectorParser from "postcss-selector-parser";
-import stylelint from "stylelint";
-import type { PostcssResult, RuleContext } from "stylelint";
+import stylelint, { type PostcssResult, type RuleContext } from "stylelint";
 
 import { checkImportExists } from "../utils/checkImportExists";
 import {

--- a/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
+++ b/packages/stylelint-plugin/src/rules/no-prefix-literal.ts
@@ -15,7 +15,8 @@
 
 import type { Root } from "postcss";
 import selectorParser from "postcss-selector-parser";
-import stylelint, { type PostcssResult, type RuleContext } from "stylelint";
+import stylelint from "stylelint";
+import type { PostcssResult, RuleContext } from "stylelint";
 
 import { checkImportExists } from "../utils/checkImportExists";
 import {


### PR DESCRIPTION
#### Fixes #8211

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Package lint constructs `ESLint` from the package directory, so root config patterns such as `**/packages/select/**` are evaluated against `src/**` and do not match. This makes package lint apply fewer rules than root ESLint and `lint-staged`.

- Run the shared ESLint wrapper with the workspace root as its `cwd` while keeping package-relative file selection unchanged.
- Update `getRootDir()` to find either a workspace manifest or `pnpm-workspace.yaml`, with the closest package root as a fallback for standalone consumers of `@blueprintjs/node-build-scripts`.
- Add unit coverage for workspace and standalone-package root discovery.
- Apply narrow suppressions to the existing intentional autofocus and delegated keyboard-handler patterns exposed in `@blueprintjs/select` when package lint begins using the root accessibility rules.
- Add targeted overrides for existing patterns newly exposed in Stylelint rule modules, copied icon type utilities, and documentation examples.
- Include JavaScript and MJS test files in the test-specific ESLint configuration.
- Add changelog entries for `@blueprintjs/node-build-scripts` and `@blueprintjs/select`.

#### Reviewers should focus on:

- Whether resolving ESLint configuration from the workspace root preserves the intended package-level lint behavior.
- The standalone-package fallback in `getRootDir()` and the scope of the package-specific rule overrides.

#### Screenshot

Not applicable — this changes lint configuration resolution.

#### Testing

- `@blueprintjs/node-build-scripts` Vitest suite: 4 tests passed
- ESLint for `@blueprintjs/stylelint-plugin`, `@blueprintjs/icons`, `@blueprintjs/docs-app`, and `@blueprintjs/select`
- Root ESLint and Prettier checks for the changed files
