### PR TITLE
[table] Clear EditableCell when value becomes undefined

### DIFF
--- a/packages/table/changelog/@unreleased/pr-8232.v2.yml
+++ b/packages/table/changelog/@unreleased/pr-8232.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Clear EditableCell content when its value becomes undefined
+  links:
+    - https://github.com/palantir/blueprint/pull/8232

--- a/packages/table/src/cell/editableCell.rtl.test.tsx
+++ b/packages/table/src/cell/editableCell.rtl.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from "@testing-library/react";
+
+import { HotkeysProvider } from "@blueprintjs/core";
+import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+
+import * as TableClasses from "../common/classes";
+
+import { EditableCell } from "./editableCell";
+
+describe("<EditableCell> prop updates", () => {
+    it("clears the displayed value when value changes to undefined", () => {
+        const { container, rerender } = renderEditableCell("populated");
+        const contents = container.querySelector(`.${TableClasses.TABLE_TRUNCATED_TEXT}`);
+        expect(contents).toHaveTextContent("populated");
+
+        rerender(editableCell(undefined));
+
+        expect(contents).toBeEmptyDOMElement();
+    });
+});
+
+function renderEditableCell(value: string | undefined) {
+    return render(editableCell(value));
+}
+
+function editableCell(value: string | undefined) {
+    return (
+        <HotkeysProvider>
+            <EditableCell value={value} />
+        </HotkeysProvider>
+    );
+}

--- a/packages/table/src/cell/editableCell.tsx
+++ b/packages/table/src/cell/editableCell.tsx
@@ -112,7 +112,7 @@ export class EditableCell extends Component<EditableCellProps, EditableCellState
             !CoreUtils.deepCompareKeys(this.props, prevProps, ["style"]);
 
         const { value } = this.props;
-        if (didPropsChange && value != null) {
+        if (didPropsChange) {
             this.setState({ dirtyValue: value, savedValue: value });
         }
 


### PR DESCRIPTION
#### Fixes #6602

#### Checklist

- [x] Includes tests
- [ ] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

`EditableCell` updates its internal value when the `value` prop changes, but the existing null check skips that update when the new value is `undefined`. As a result, sorting or replacing table data can leave the previous cell text rendered.

- Synchronize the internal value for every `value` prop change, including changes to `undefined`.
- Add a React Testing Library regression test which rerenders a populated cell with an undefined value and verifies that its content clears.

#### Reviewers should focus on:

Whether synchronizing `undefined` through the existing prop-change path preserves the intended controlled and uncontrolled editing behavior.

#### Screenshot

Not applicable — the regression is covered by the rerender test.

#### Testing

- `@blueprintjs/table` Vitest suite: 569 tests passed, 56 skipped
- Table type checking and package lint
- Root ESLint and Prettier checks for the changed files
