### PR TITLE
fix(core): skip redundant Text overflow setState

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8234.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8234.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: "Text only updates the overflow title when it changes, avoiding React 19 maximum-update-depth crashes in dense ellipsized menus and tables"
+  links:
+  - https://github.com/palantir/blueprint/pull/8234

--- a/packages/core/src/components/text/text.test.tsx
+++ b/packages/core/src/components/text/text.test.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen } from "@testing-library/react";
 
-import { describe, expect, it } from "@blueprintjs/test-commons/vitest";
+import { afterEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Classes } from "../../common";
 
@@ -56,29 +56,83 @@ describe("<Text>", () => {
         });
 
         describe("title behavior", () => {
-            // Skip: jsdom doesn't compute real overflow measurements
-            it.skip("adds the title attribute when text overflows", () => {
-                const textContent = new Array(100).join("this will overflow ");
-                const { container } = render(<Text ellipsize={true}>{textContent}</Text>);
-                const element = container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
-                expect(element).not.toBeNull();
-                expect(element!).toHaveAttribute("title", textContent);
+            let scrollWidth = 50;
+
+            afterEach(() => {
+                vi.restoreAllMocks();
+                scrollWidth = 50;
+            });
+
+            const mockOverflow = (isOverflowing: boolean) => {
+                scrollWidth = isOverflowing ? 200 : 50;
+                vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockImplementation(() => scrollWidth);
+                vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(50);
+            };
+
+            it("adds the title attribute when text overflows", () => {
+                mockOverflow(true);
+                render(<Text ellipsize={true}>Foo</Text>);
+                expect(screen.getByText("Foo")).toHaveAttribute("title", "Foo");
             });
 
             it("does not add the title attribute when text does not overflow", () => {
+                mockOverflow(false);
                 render(<Text ellipsize={true}>Foo</Text>);
                 expect(screen.getByText("Foo")).not.toHaveAttribute("title");
             });
 
             it("uses given title even if text overflows", () => {
-                const textContent = new Array(100).join("this will overflow ");
+                mockOverflow(true);
                 render(
                     <Text ellipsize={true} title="Test title">
-                        {textContent}
+                        Foo
                     </Text>,
                 );
-
                 expect(screen.getByTitle("Test title")).toBeInTheDocument();
+            });
+
+            it("clears the auto title when content no longer overflows", () => {
+                mockOverflow(true);
+                const { container, rerender } = render(
+                    <Text ellipsize={true}>
+                        <span>Foo</span>
+                    </Text>,
+                );
+                let element = container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
+                expect(element).not.toBeNull();
+                expect(element!).toHaveAttribute("title", "Foo");
+
+                mockOverflow(false);
+                rerender(
+                    <Text ellipsize={true}>
+                        <span>Foo</span>
+                    </Text>,
+                );
+                element = container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
+                expect(element).not.toBeNull();
+                expect(element!).not.toHaveAttribute("title");
+            });
+
+            it("does not nest updates when children identity changes", () => {
+                mockOverflow(true);
+                const { container, rerender } = render(
+                    <Text ellipsize={true}>
+                        <span>Foo</span>
+                    </Text>,
+                );
+                const element = container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`);
+                expect(element).not.toBeNull();
+                expect(element!).toHaveAttribute("title", "Foo");
+
+                for (let i = 0; i < 50; i++) {
+                    rerender(
+                        <Text ellipsize={true}>
+                            <span>Foo</span>
+                        </Text>,
+                    );
+                }
+
+                expect(container.querySelector(`.${Classes.TEXT_OVERFLOW_ELLIPSIS}`)).toHaveAttribute("title", "Foo");
             });
         });
     });

--- a/packages/core/src/components/text/text.tsx
+++ b/packages/core/src/components/text/text.tsx
@@ -57,19 +57,36 @@ export const Text: React.FC<TextProps> = forwardRef<HTMLElement, TextProps>(
     ({ children, tagName = "div", title, className, ellipsize = false, ...htmlProps }, forwardedRef) => {
         const contentMeasuringRef = useRef<HTMLElement>();
         const textRef = useMemo(() => mergeRefs(contentMeasuringRef, forwardedRef), [forwardedRef]);
-        const [textContent, setTextContent] = useState<string>("");
-        const [isContentOverflowing, setIsContentOverflowing] = useState<boolean>();
+        // Auto title when ellipsized content overflows. `undefined` means no auto title.
+        const [overflowTitle, setOverflowTitle] = useState<string | undefined>(undefined);
+        const overflowTitleRef = useRef(overflowTitle);
+        overflowTitleRef.current = overflowTitle;
 
         // try to be conservative about running this effect, since querying scrollWidth causes the browser to reflow / recalculate styles,
         // which can be very expensive for long lists (for example, in long Menus)
         useIsomorphicLayoutEffect(() => {
-            if (contentMeasuringRef.current?.textContent != null) {
-                setIsContentOverflowing(
-                    ellipsize! && contentMeasuringRef.current.scrollWidth > contentMeasuringRef.current.clientWidth,
-                );
-                setTextContent(contentMeasuringRef.current.textContent);
+            const element = contentMeasuringRef.current;
+            if (element == null) {
+                return;
             }
-        }, [contentMeasuringRef, children, ellipsize]);
+            // Explicit title prop wins; drop any auto title so we don't fight the caller.
+            if (title !== undefined) {
+                if (overflowTitleRef.current !== undefined) {
+                    overflowTitleRef.current = undefined;
+                    setOverflowTitle(undefined);
+                }
+                return;
+            }
+            const isOverflowing = Boolean(ellipsize && element.scrollWidth > element.clientWidth);
+            const next = isOverflowing ? element.textContent || undefined : undefined;
+            // Only setState when the derived title actually changes. Always updating from this
+            // layout effect can nest past React 19's update-depth limit when many Text nodes
+            // measure in one commit, or when children identity changes re-run the effect.
+            if (next !== overflowTitleRef.current) {
+                overflowTitleRef.current = next;
+                setOverflowTitle(next);
+            }
+        }, [children, ellipsize, title]);
 
         return createElement(
             tagName,
@@ -82,7 +99,7 @@ export const Text: React.FC<TextProps> = forwardRef<HTMLElement, TextProps>(
                     className,
                 ),
                 ref: textRef,
-                title: title ?? (isContentOverflowing ? textContent : undefined),
+                title: title ?? overflowTitle,
             },
             children,
         );


### PR DESCRIPTION
#### Fixes #8233

#### Checklist

- [x] Includes tests
- [ ] Update documentation

#### Changes proposed in this pull request:

`Text` always called `setState` from its overflow-measuring layout effect, even when the derived title had not changed. `children` is in that effect's dependency array, so any parent that passes a new element identity (menus with `HighlightText` / `EntityTitle`, table cells) re-runs the effect. Under React 19 that nested update path can exceed the update-depth limit (minified error #185) when many `Text` nodes measure in one commit.

This stores a single derived overflow title and only `setState`s when that string actually changes. If the caller passed `title`, measuring is skipped so we do not fight the explicit prop or pay a `scrollWidth` reflow.

Overflow title tests now mock `scrollWidth` / `clientWidth` so jsdom can exercise the auto-title path (the previous overflow test was skipped).

#### Reviewers should focus on:

- The layout effect now no-ops when the derived title is unchanged, including across children-identity rerenders.
- Explicit `title` still wins over the auto title.
- Auto title is added when content overflows and cleared when it no longer does.


Made with [Cursor](https://cursor.com)