### PR TITLE
fix(Dialog): fix header icon alignment (#8214)

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8219.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8219.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix Dialog header title icon alignment
+  links:
+    - https://github.com/palantir/blueprint/issues/8214

--- a/packages/core/src/components/dialog/_dialog.scss
+++ b/packages/core/src/components/dialog/_dialog.scss
@@ -84,8 +84,9 @@ $dialog-header-padding: $pt-spacing;
 
   .#{$ns}-icon-large,
   .#{$ns}-icon {
+    align-self: center;
     flex: 0 0 auto;
-    margin-left: -$pt-spacing;
+    line-height: 0;
     margin-right: $dialog-padding * 0.5;
 
     // only apply light color to icons that are not intent-specific


### PR DESCRIPTION
Fixes #8214

### Cause
In `_dialog.scss`, header icons had `margin-left: -$pt-spacing;` (-4px), which shifted the icon 4px to the left of the header padding (`16px`), causing horizontal misalignment with `.bp-dialog-body` content below.

### Solution
- Removed `margin-left: -$pt-spacing;` so the icon aligns flush with dialog body content at 16px.
- Added `align-self: center; line-height: 0;` for vertical Y-axis icon centering within the header.
- Added unreleased changelog entry for `@blueprintjs/core`.
