### PR TITLE
feat(multistepdialog): controlled variant for multistep dialog

### DIFF
--- a/packages/core/src/components/dialog/MultistepDialog.stories.tsx
+++ b/packages/core/src/components/dialog/MultistepDialog.stories.tsx
@@ -11,7 +11,7 @@ import { Flex } from "@blueprintjs/labs";
 import { Button } from "../button/buttons";
 
 import { DialogBody } from "./dialogBody";
-import { DialogStep } from "./dialogStep";
+import { DialogStep, type DialogStepId } from "./dialogStep";
 import { MultistepDialog } from "./multistepDialog";
 
 const disabledArgs = [
@@ -118,6 +118,43 @@ const disableNavigationPosition = {
 
 export const Default: Story = {
     render: renderMultistepDialog(),
+};
+
+/**
+ * Provide `selectedStepId` to control the active step externally. The built-in footer remains visible, and its button
+ * click handlers can be overridden to update the controlled selection.
+ */
+export const Controlled: Story = {
+    render: function Render(args) {
+        const [selectedStepId, setSelectedStepId] = React.useState<DialogStepId>("select");
+        const handleSelect = useCallback(() => setSelectedStepId("select"), []);
+        const handleConfirm = useCallback(() => setSelectedStepId("confirm"), []);
+        const handleComplete = useCallback(() => setSelectedStepId("complete"), []);
+
+        return (
+            <MultistepDialog {...args} onChange={setSelectedStepId} selectedStepId={selectedStepId}>
+                <DialogStep
+                    id="select"
+                    nextButtonProps={{ onClick: handleConfirm }}
+                    title="Select items"
+                    panel={<StepPanel stepNumber={1} />}
+                />
+                <DialogStep
+                    backButtonProps={{ onClick: handleSelect }}
+                    id="confirm"
+                    nextButtonProps={{ onClick: handleComplete }}
+                    title="Confirm selection"
+                    panel={<StepPanel stepNumber={2} />}
+                />
+                <DialogStep
+                    backButtonProps={{ onClick: handleConfirm }}
+                    id="complete"
+                    title="Complete"
+                    panel={<StepPanel stepNumber={3} />}
+                />
+            </MultistepDialog>
+        );
+    },
 };
 
 /**

--- a/packages/core/src/components/dialog/dialog.mdx
+++ b/packages/core/src/components/dialog/dialog.mdx
@@ -94,6 +94,35 @@ corresponding panel.
 This component expects `<DialogStep>` child elements: each "step" is rendered in order and its panel is shown as the
 dialog body content when the corresponding step is selected in the navigation panel.
 
+By default, **MultistepDialog** manages the selected step. To control the selected step externally, provide
+`selectedStepId`.
+
+```tsx
+import * as React from "react";
+import { DialogBody, DialogStep, type DialogStepId, MultistepDialog } from "@blueprintjs/core";
+
+function ControlledMultistepDialog() {
+    const [selectedStepId, setSelectedStepId] = React.useState<DialogStepId>("details");
+
+    return (
+        <MultistepDialog isOpen={true} onChange={setSelectedStepId} selectedStepId={selectedStepId} title="Create item">
+            <DialogStep
+                id="details"
+                title="Details"
+                nextButtonProps={{ onClick: () => setSelectedStepId("confirm") }}
+                panel={<DialogBody>Enter the item details.</DialogBody>}
+            />
+            <DialogStep
+                backButtonProps={{ onClick: () => setSelectedStepId("details") }}
+                id="confirm"
+                title="Confirm"
+                panel={<DialogBody>Confirm the item details.</DialogBody>}
+            />
+        </MultistepDialog>
+    );
+}
+```
+
 @interface MultistepDialogProps
 
 ### DialogStep

--- a/packages/core/src/components/dialog/multistepDialog.test.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.test.tsx
@@ -41,8 +41,8 @@ describe("<MultistepDialog>", () => {
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.lengthOf(steps.at(0).find(`.${Classes.ACTIVE}`), 0);
         assert.lengthOf(steps.at(1).find(`.${Classes.ACTIVE}`), 1);
-        assert.lengthOf(dialog.find(`.${Classes.DIALOG_FOOTER}`), 0);
-        assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "second panel");
+        assert.lengthOf(dialog.find(`.${Classes.DIALOG_FOOTER}`), 1);
+        assert.strictEqual(dialog.find("strong").text(), "second panel");
         dialog.unmount();
     });
 
@@ -62,10 +62,32 @@ describe("<MultistepDialog>", () => {
 
         dialog.find(`.${Classes.DIALOG_STEP}`).at(0).simulate("click");
         assert.deepEqual(change, ["one", "two"]);
-        assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "second panel");
+        assert.strictEqual(dialog.find("strong").text(), "second panel");
 
         dialog.setProps({ selectedStepId: "one" });
-        assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "first panel");
+        assert.strictEqual(dialog.find("strong").text(), "first panel");
+        dialog.unmount();
+    });
+
+    it("allows controlled mode to override the next button click handler", () => {
+        let selectedStepId = "one";
+        const handleNext = () => (selectedStepId = "two");
+        const dialog = mount(
+            <MultistepDialog
+                isOpen={true}
+                nextButtonProps={{ onClick: handleNext }}
+                selectedStepId={selectedStepId}
+                usePortal={false}
+            >
+                <DialogStep id="one" title="Step 1" panel={<strong>first panel</strong>} />
+                <DialogStep id="two" title="Step 2" panel={<strong>second panel</strong>} />
+            </MultistepDialog>,
+        );
+
+        findButtonWithText(dialog, "Next").simulate("click");
+        dialog.setProps({ selectedStepId });
+
+        assert.strictEqual(dialog.find("strong").text(), "second panel");
         dialog.unmount();
     });
 

--- a/packages/core/src/components/dialog/multistepDialog.test.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.test.tsx
@@ -30,6 +30,21 @@ import { MultistepDialog } from "./multistepDialog";
 const findButtonWithText = (wrapper: ReactWrapper, text: string) => wrapper.find(AnchorButton).find(`[text='${text}']`);
 
 describe("<MultistepDialog>", () => {
+    it("renders the selected step in controlled mode", () => {
+        const dialog = mount(
+            <MultistepDialog isOpen={true} selectedStepId="two" usePortal={false}>
+                <DialogStep id="one" title="Step 1" panel={<strong>first panel</strong>} />
+                <DialogStep id="two" title="Step 2" panel={<strong>second panel</strong>} />
+            </MultistepDialog>,
+        );
+
+        const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
+        assert.lengthOf(steps.at(0).find(`.${Classes.ACTIVE}`), 0);
+        assert.lengthOf(steps.at(1).find(`.${Classes.ACTIVE}`), 1);
+        assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "second panel");
+        dialog.unmount();
+    });
+
     it("renders its content correctly", () => {
         const dialog = mount(
             <MultistepDialog isOpen={true} usePortal={false}>

--- a/packages/core/src/components/dialog/multistepDialog.test.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.test.tsx
@@ -41,7 +41,50 @@ describe("<MultistepDialog>", () => {
         const steps = dialog.find(`.${Classes.DIALOG_STEP_CONTAINER}`);
         assert.lengthOf(steps.at(0).find(`.${Classes.ACTIVE}`), 0);
         assert.lengthOf(steps.at(1).find(`.${Classes.ACTIVE}`), 1);
+        assert.lengthOf(dialog.find(`.${Classes.DIALOG_FOOTER}`), 0);
         assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "second panel");
+        dialog.unmount();
+    });
+
+    it("changes a controlled selection only when the selectedStepId prop changes", () => {
+        let change: [newStepId: string | number, prevStepId: string | number | undefined] | undefined;
+        const dialog = mount(
+            <MultistepDialog
+                isOpen={true}
+                onChange={(newStepId, prevStepId) => (change = [newStepId, prevStepId])}
+                selectedStepId="two"
+                usePortal={false}
+            >
+                <DialogStep id="one" title="Step 1" panel={<strong>first panel</strong>} />
+                <DialogStep id="two" title="Step 2" panel={<strong>second panel</strong>} />
+            </MultistepDialog>,
+        );
+
+        dialog.find(`.${Classes.DIALOG_STEP}`).at(0).simulate("click");
+        assert.deepEqual(change, ["one", "two"]);
+        assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "second panel");
+
+        dialog.setProps({ selectedStepId: "one" });
+        assert.strictEqual(dialog.find(`.${Classes.MULTISTEP_DIALOG_RIGHT_PANEL}`).text(), "first panel");
+        dialog.unmount();
+    });
+
+    it("reports an undefined previous step when the controlled step ID is unknown", () => {
+        let change: [newStepId: string | number, prevStepId: string | number | undefined] | undefined;
+        const dialog = mount(
+            <MultistepDialog
+                isOpen={true}
+                onChange={(newStepId, prevStepId) => (change = [newStepId, prevStepId])}
+                selectedStepId="unknown"
+                usePortal={false}
+            >
+                <DialogStep id="one" title="Step 1" panel={<Panel />} />
+            </MultistepDialog>,
+        );
+
+        dialog.find(`.${Classes.DIALOG_STEP}`).simulate("click");
+
+        assert.deepEqual(change, ["one", undefined]);
         dialog.unmount();
     });
 

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -125,11 +125,30 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
         showCloseButtonInFooter: false,
     };
 
+    public static getDerivedStateFromProps(props: MultistepDialogProps, state: MultistepDialogState) {
+        if (props.selectedStepId !== undefined) {
+            const selectedIndex = getDialogStepChildren(props).findIndex(
+                step => step.props.id === props.selectedStepId,
+            );
+            return {
+                lastViewedIndex: Math.max(state.lastViewedIndex, selectedIndex),
+                selectedIndex,
+            };
+        }
+        return null;
+    }
+
     public state: MultistepDialogState = this.getInitialIndexFromProps(this.props);
 
     public render() {
-        const { className, navigationPosition, showCloseButtonInFooter, isCloseButtonShown, ...otherProps } =
-            this.props;
+        const {
+            className,
+            navigationPosition,
+            selectedStepId: _selectedStepId,
+            showCloseButtonInFooter,
+            isCloseButtonShown,
+            ...otherProps
+        } = this.props;
 
         return (
             <Dialog
@@ -208,7 +227,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
 
     private maybeRenderRightPanel() {
         const steps = this.getDialogStepChildren();
-        if (steps.length <= this.state.selectedIndex) {
+        if (this.state.selectedIndex < 0 || steps.length <= this.state.selectedIndex) {
             return null;
         }
 
@@ -221,14 +240,13 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
         );
     }
 
-    private maybeRenderFooter() {
-        const { closeButtonProps, showCloseButtonInFooter, onClose, activeStepIndex } = this.props;
+    private renderFooter() {
+        const { closeButtonProps, showCloseButtonInFooter, onClose } = this.props;
         const maybeCloseButton = !showCloseButtonInFooter ? undefined : (
             <DialogStepButton text="Close" onClick={onClose} {...closeButtonProps} />
         );
-        if (activeStepIndex !== undefined) {
-            return null;
-        }
+
+        return <DialogFooter actions={this.renderButtons()}>{maybeCloseButton}</DialogFooter>;
     }
 
     private renderButtons() {
@@ -272,20 +290,22 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
         return (event: React.MouseEvent<HTMLElement>) => {
             if (this.props.onChange !== undefined) {
                 const steps = this.getDialogStepChildren();
-                const prevStepId = steps[this.state.selectedIndex].props.id;
+                const prevStepId = steps[this.state.selectedIndex]?.props.id;
                 const newStepId = steps[index].props.id;
                 this.props.onChange(newStepId, prevStepId, event);
             }
-            this.setState({
-                lastViewedIndex: Math.max(this.state.lastViewedIndex, index),
-                selectedIndex: index,
-            });
+            if (this.props.selectedStepId === undefined) {
+                this.setState({
+                    lastViewedIndex: Math.max(this.state.lastViewedIndex, index),
+                    selectedIndex: index,
+                });
+            }
         };
     }
 
     /** Filters children to only `<DialogStep>`s */
     private getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode } = this.props) {
-        return Children.toArray(props.children).filter(isDialogStepElement);
+        return getDialogStepChildren(props);
     }
 
     private getInitialIndexFromProps(props: MultistepDialogProps) {
@@ -305,6 +325,10 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
             };
         }
     }
+}
+
+function getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode }) {
+    return Children.toArray(props.children).filter(isDialogStepElement);
 }
 
 function isDialogStepElement(child: any): child is DialogStepElement {

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -324,5 +324,9 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
 
 /** Filters children to only `<DialogStep>`s */
 function getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode }) {
-    return Children.toArray(props.children).filter(child => Utils.isElementOfType(child, DialogStep));
+    return Children.toArray(props.children).filter(isDialogStepElement);
+}
+
+function isDialogStepElement(child: any): child is DialogStepElement {
+    return Utils.isElementOfType(child, DialogStep);
 }

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -324,9 +324,5 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
 
 /** Filters children to only `<DialogStep>`s */
 function getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode }) {
-    return Children.toArray(props.children).filter(isDialogStepElement);
-}
-
-function isDialogStepElement(child: any): child is DialogStepElement {
-    return Utils.isElementOfType(child, DialogStep);
+    return Children.toArray(props.children).filter(child => Utils.isElementOfType(child, DialogStep));
 }

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -188,7 +188,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
     private renderLeftPanel() {
         return (
             <div className={Classes.MULTISTEP_DIALOG_LEFT_PANEL} role="tablist" aria-label="steps">
-                {getDialogStepChildren(this.props).filter(isDialogStepElement).map(this.renderDialogStep)}
+                {getDialogStepChildren(this.props).map(this.renderDialogStep)}
             </div>
         );
     }

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -322,6 +322,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
     }
 }
 
+/** Filters children to only `<DialogStep>`s */
 function getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode }) {
     return Children.toArray(props.children).filter(isDialogStepElement);
 }

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -32,6 +32,12 @@ export type MultistepDialogNavPosition = typeof Position.TOP | typeof Position.L
 
 export interface MultistepDialogProps extends DialogProps {
     /**
+     * Selected step ID, for controlled usage.
+     * Providing this prop puts the dialog in controlled mode.
+     */
+    selectedStepId?: DialogStepId;
+
+    /**
      * Props for the back button.
      */
     backButtonProps?: DialogStepButtonProps;
@@ -215,12 +221,14 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
         );
     }
 
-    private renderFooter() {
-        const { closeButtonProps, showCloseButtonInFooter, onClose } = this.props;
+    private maybeRenderFooter() {
+        const { closeButtonProps, showCloseButtonInFooter, onClose, activeStepIndex } = this.props;
         const maybeCloseButton = !showCloseButtonInFooter ? undefined : (
             <DialogStepButton text="Close" onClick={onClose} {...closeButtonProps} />
         );
-        return <DialogFooter actions={this.renderButtons()}>{maybeCloseButton}</DialogFooter>;
+        if (activeStepIndex !== undefined) {
+            return null;
+        }
     }
 
     private renderButtons() {

--- a/packages/core/src/components/dialog/multistepDialog.tsx
+++ b/packages/core/src/components/dialog/multistepDialog.tsx
@@ -188,7 +188,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
     private renderLeftPanel() {
         return (
             <div className={Classes.MULTISTEP_DIALOG_LEFT_PANEL} role="tablist" aria-label="steps">
-                {this.getDialogStepChildren().filter(isDialogStepElement).map(this.renderDialogStep)}
+                {getDialogStepChildren(this.props).filter(isDialogStepElement).map(this.renderDialogStep)}
             </div>
         );
     }
@@ -226,7 +226,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
     };
 
     private maybeRenderRightPanel() {
-        const steps = this.getDialogStepChildren();
+        const steps = getDialogStepChildren(this.props);
         if (this.state.selectedIndex < 0 || steps.length <= this.state.selectedIndex) {
             return null;
         }
@@ -251,7 +251,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
 
     private renderButtons() {
         const { selectedIndex } = this.state;
-        const steps = this.getDialogStepChildren();
+        const steps = getDialogStepChildren(this.props);
         const buttons = [];
 
         if (this.state.selectedIndex > 0) {
@@ -266,7 +266,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
             );
         }
 
-        if (selectedIndex === this.getDialogStepChildren().length - 1) {
+        if (selectedIndex === getDialogStepChildren(this.props).length - 1) {
             buttons.push(
                 <DialogStepButton intent="primary" key="final" text="Submit" {...this.props.finalButtonProps} />,
             );
@@ -289,7 +289,7 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
     private getDialogStepChangeHandler(index: number) {
         return (event: React.MouseEvent<HTMLElement>) => {
             if (this.props.onChange !== undefined) {
-                const steps = this.getDialogStepChildren();
+                const steps = getDialogStepChildren(this.props);
                 const prevStepId = steps[this.state.selectedIndex]?.props.id;
                 const newStepId = steps[index].props.id;
                 this.props.onChange(newStepId, prevStepId, event);
@@ -303,16 +303,11 @@ export class MultistepDialog extends AbstractPureComponent<MultistepDialogProps,
         };
     }
 
-    /** Filters children to only `<DialogStep>`s */
-    private getDialogStepChildren(props: MultistepDialogProps & { children?: React.ReactNode } = this.props) {
-        return getDialogStepChildren(props);
-    }
-
     private getInitialIndexFromProps(props: MultistepDialogProps) {
         if (props.initialStepIndex !== undefined) {
             const boundedInitialIndex = Math.max(
                 0,
-                Math.min(props.initialStepIndex, this.getDialogStepChildren(props).length - 1),
+                Math.min(props.initialStepIndex, getDialogStepChildren(props).length - 1),
             );
             return {
                 lastViewedIndex: boundedInitialIndex,


### PR DESCRIPTION
#### Fixes [#7509](https://github.com/palantir/blueprint/issues/7509)

#### Checklist

- [x] Includes tests
- [x] Update documentation

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

Enabled users to specify a `selectedStepId` to use the MultiStepDialog in a controlled manner. This gives users more control in managing dialog flow (i.e. if a network request must be made based on the contents of the first dialog panel, and it's response is required to render the contents of the next step).

Users can override the dialog footer button's `onClick` to trigger such a side effect, and then change `selectedTabId` to move on to the next tab.

This uses the same pattern as the tabs component, which similarly exposes a `selectedTabId` for controlled usage.


#### Reviewers should focus on:

- Handling of the `lastViewedIndex`. I set it to `Math.max(state.lastViewedIndex, selectedIndex)` to account for if a user skips forward some steps in the dialog
 
#### Screenshot

N/A