### PR TITLE
[core] Link Tooltip targets to tooltip content

### DIFF
--- a/packages/core/changelog/@unreleased/pr-8184.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8184.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Link Tooltip targets to their tooltip content with aria-describedby
+  links:
+  - https://github.com/palantir/blueprint/pull/8184

--- a/packages/core/changelog/@unreleased/pr-8184.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8184.v2.yml
@@ -1,5 +1,0 @@
-type: fix
-fix:
-  description: Link Tooltip targets to their tooltip content with aria-describedby
-  links:
-  - https://github.com/palantir/blueprint/pull/8184

--- a/packages/core/changelog/@unreleased/pr-8247.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8247.v2.yml
@@ -3,3 +3,4 @@ fix:
   description: Link Tooltip targets to their tooltip content with aria-describedby
   links:
     - https://github.com/palantir/blueprint/issues/7672
+    - https://github.com/palantir/blueprint/pull/8247

--- a/packages/core/changelog/@unreleased/pr-8247.v2.yml
+++ b/packages/core/changelog/@unreleased/pr-8247.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Link Tooltip targets to their tooltip content with aria-describedby
+  links:
+    - https://github.com/palantir/blueprint/issues/7672

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -2,7 +2,17 @@
  * (c) Copyright 2026 Palantir Technologies Inc. All rights reserved.
  */
 
-import { Children, forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import {
+    Children,
+    forwardRef,
+    useCallback,
+    useEffect,
+    useId,
+    useImperativeHandle,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 
 import { Classes, DISPLAYNAME_PREFIX, Utils } from "../../common";
 import * as Errors from "../../common/errors";
@@ -97,6 +107,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
     const cancelOpenTimeout = useRef<(() => void) | undefined>(undefined);
     const isMouseInTargetOrPopover = useRef(false);
     const lostFocusOnSamePage = useRef(true);
+    const popoverId = useId();
     const targetRef = useRef<HTMLElement>(null);
     const timeoutIds = useRef<number[]>([]);
 
@@ -380,6 +391,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
                 isControlled={isControlled}
                 isHoverInteractionKind={isHoverInteractionKind}
                 openOnTargetFocus={openOnTargetFocus}
+                popoverId={popoverId}
                 ref={targetRef}
                 {...props}
             >
@@ -397,6 +409,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
                     hasDarkParent={hasDarkParent}
                     isClosingViaEscapeKeypress={isClosingViaEscapeKeypress}
                     isHoverInteractionKind={isHoverInteractionKind}
+                    popoverId={popoverId}
                     popoverRef={popoverRef}
                     shouldReturnFocusOnClose={shouldReturnFocusOnClose}
                     {...props}

--- a/packages/core/src/components/popover-next/popoverNextProps.ts
+++ b/packages/core/src/components/popover-next/popoverNextProps.ts
@@ -455,6 +455,7 @@ export interface PopoverTargetProps
     isContentEmpty: boolean;
     isControlled: boolean;
     isHoverInteractionKind: boolean;
+    popoverId: string;
 }
 
 /**
@@ -497,13 +498,17 @@ export interface PopoverPopupProps
     hasDarkParent: boolean;
     isClosingViaEscapeKeypress: boolean;
     isHoverInteractionKind: boolean;
+    popoverId: string;
 }
 
 /**
  * Properties injected by PopoverNext when rendering custom targets via the `renderTarget` API.
  */
 export interface PopoverRenderTargetProps
-    extends Pick<React.HTMLAttributes<HTMLElement>, "aria-haspopup" | "aria-expanded" | "className" | "tabIndex"> {
+    extends Pick<
+        React.HTMLAttributes<HTMLElement>,
+        "aria-describedby" | "aria-haspopup" | "aria-expanded" | "className" | "tabIndex"
+    > {
     /** Target ref. */
     ref: React.Ref<any>;
 

--- a/packages/core/src/components/popover-next/popoverPopup.tsx
+++ b/packages/core/src/components/popover-next/popoverPopup.tsx
@@ -41,6 +41,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
         onClosing,
         onOpened,
         onOpening,
+        popoverId,
         popoverClassName,
         popoverRef,
         portalClassName,
@@ -140,7 +141,7 @@ export function PopoverPopup(props: PopoverPopupProps) {
                 ref={mergeRefs(floatingData.refs.setFloating, transitionContainerElement)}
                 {...popoverHandlers}
             >
-                <div className={popoverClasses} ref={popoverRef} style={{ transformOrigin }}>
+                <div className={popoverClasses} id={popoverId} ref={popoverRef} style={{ transformOrigin }}>
                     {arrow && (
                         <PopoverArrow
                             arrowProps={{ ref: arrowRef, style: arrowStyle }}

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -28,6 +28,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
         isControlled,
         isHoverInteractionKind,
         openOnTargetFocus = true,
+        popoverId,
         popupKind,
         renderTarget = undefined,
         targetProps,
@@ -87,6 +88,8 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
 
     // Ensure target is focusable if relevant prop enabled
     const targetTabIndex = !isContentEmpty && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
+    const targetAriaDescribedBy =
+        isOpen && isHoverInteractionKind && !isContentEmpty && !disabled ? popoverId : undefined;
 
     // Hover targets (including Tooltip) open via the mouse/focus handlers in `targetEventHandlers`, so
     // they must not receive Floating UI's reference props; those carry the `onClick`/keyboard click
@@ -113,6 +116,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
         ...targetEventHandlers,
     } satisfies React.HTMLProps<HTMLElement>;
     const childTargetProps = {
+        "aria-describedby": targetAriaDescribedBy,
         "aria-expanded": isHoverInteractionKind ? undefined : isOpen,
         "aria-haspopup":
             interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY ? undefined : (popupKind ?? "menu"),
@@ -158,6 +162,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
             {
                 ...ownTargetProps,
                 ...targetProps,
+                "aria-describedby": mergeAriaDescribedBy(targetProps?.["aria-describedby"], targetAriaDescribedBy),
                 // Apply Floating UI's interaction props to the wrapper element (same element that has the ref)
                 ...floatingProps,
             },
@@ -192,4 +197,14 @@ function isTooltipElement(element: React.ReactElement): boolean {
 function isTypeableElement(element: HTMLElement): boolean {
     const tagName = element.tagName;
     return tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT" || element.isContentEditable;
+}
+
+function mergeAriaDescribedBy(existingId: string | undefined, popoverId: string | undefined): string | undefined {
+    if (popoverId === undefined) {
+        return existingId;
+    }
+    if (existingId === undefined || existingId.length === 0) {
+        return popoverId;
+    }
+    return `${existingId} ${popoverId}`;
 }

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -153,6 +153,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
 
         const clonedTarget = cloneElement(childTarget, {
             ...childTargetProps,
+            "aria-describedby": mergeAriaDescribedBy(childTarget.props["aria-describedby"], targetAriaDescribedBy),
             className: classNames(childTarget.props.className, targetModifierClasses),
             disabled: (isOpen && isTooltipElement(childTarget)) || childTarget.props.disabled,
             tabIndex: childTarget.props.tabIndex ?? targetTabIndex,

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -94,6 +94,38 @@ describe("<Tooltip>", () => {
             expect(targetProps?.onClick).toBeUndefined();
             expect(targetProps?.onKeyDown).toBeUndefined();
         });
+
+        it("sets aria-describedby on the target when open", () => {
+            const { container } = render(
+                <Tooltip content="content" hoverOpenDelay={0} isOpen={true} usePortal={false}>
+                    <Button text="target" />
+                </Tooltip>,
+            );
+
+            const target = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+            const tooltip = container.querySelector(`.${Classes.TOOLTIP}`);
+
+            expect(target).toHaveAttribute("aria-describedby", tooltip?.id);
+        });
+
+        it("preserves existing target aria-describedby values", () => {
+            const { container } = render(
+                <Tooltip
+                    content="content"
+                    hoverOpenDelay={0}
+                    isOpen={true}
+                    targetProps={{ "aria-describedby": "external-description" }}
+                    usePortal={false}
+                >
+                    <Button text="target" />
+                </Tooltip>,
+            );
+
+            const target = container.querySelector(`.${Classes.POPOVER_TARGET}`);
+            const tooltip = container.querySelector(`.${Classes.TOOLTIP}`);
+
+            expect(target).toHaveAttribute("aria-describedby", `external-description ${tooltip?.id}`);
+        });
     });
 
     describe("basic functionality", () => {

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -126,6 +126,19 @@ describe("<Tooltip>", () => {
 
             expect(target).toHaveAttribute("aria-describedby", `external-description ${tooltip?.id}`);
         });
+
+        it("preserves aria-describedby values on the child target", () => {
+            const { container } = render(
+                <Tooltip content="content" hoverOpenDelay={0} isOpen={true} usePortal={false}>
+                    <Button aria-describedby="child-description" text="target" />
+                </Tooltip>,
+            );
+
+            const childTarget = container.querySelector(`.${Classes.BUTTON}`);
+            const tooltip = container.querySelector(`.${Classes.TOOLTIP}`);
+
+            expect(childTarget).toHaveAttribute("aria-describedby", `child-description ${tooltip?.id}`);
+        });
     });
 
     describe("basic functionality", () => {


### PR DESCRIPTION
#### Fixes #7672

#### Checklist

- [x] Includes tests
- [ ] Update documentation

Documentation update not included because this is an accessibility behavior fix for existing Tooltip/PopoverNext semantics rather than a new public API.

<!-- DO NOT enable CircleCI for your fork. Our build will run when you open this PR. -->

#### Changes proposed in this pull request:

- Adds a stable React-generated ID to PopoverNext popup content.
- Applies `aria-describedby` to open hover targets, including Tooltip targets, so assistive technologies can associate the target with the rendered tooltip content.
- Preserves consumer-provided `targetProps["aria-describedby"]` values by appending the popover ID.
- Adds Tooltip regression tests for the generated relationship and existing `aria-describedby` preservation.

#### Reviewers should focus on:

- Whether this relationship should remain scoped to open hover targets / Tooltip-style popovers.
- Whether the ID is best placed on the `.bp*-popover` element for the existing PopoverNext structure.

#### Screenshot

N/A; this is an accessibility attribute behavior change covered by tests.

---
Restored after an accidental fork deletion. Same commits as #8184.